### PR TITLE
[IMP] crm: redefine won/lost and apply rules in PLS frequencies and views

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -12,7 +12,7 @@ from odoo import api, fields, models, tools
 from odoo.addons.iap.tools import iap_tools
 from odoo.addons.mail.tools import mail_validation
 from odoo.addons.phone_validation.tools import phone_validation
-from odoo.exceptions import UserError, AccessError
+from odoo.exceptions import UserError, AccessError, ValidationError
 from odoo.osv import expression
 from odoo.tools.translate import _
 from odoo.tools import date_utils, email_split, is_html_empty, groupby, parse_contact_from_email, SQL
@@ -222,6 +222,8 @@ class CrmLead(models.Model):
     automated_probability = fields.Float('Automated Probability', compute='_compute_probabilities', readonly=True, store=True)
     is_automated_probability = fields.Boolean('Is automated probability?', compute="_compute_is_automated_probability")
     # Won/Lost
+    is_lost = fields.Boolean(string="Lost", compute='_compute_is_lost', search='_search_is_lost')
+    is_won = fields.Boolean(string="Won", compute='_compute_is_won', search='_search_is_won')
     lost_reason_id = fields.Many2one(
         'crm.lost.reason', string='Lost Reason',
         index=True, ondelete='restrict', tracking=True)
@@ -243,6 +245,12 @@ class CrmLead(models.Model):
     _sql_constraints = [
         ('check_probability', 'check(probability >= 0 and probability <= 100)', 'The probability of closing the deal should be between 0% and 100%!')
     ]
+
+    @api.constrains('probability', 'stage_id')
+    def _check_won_validity(self):
+        for lead in self:
+            if lead.stage_id.is_won and lead.probability != 100:
+                raise ValidationError(_("A lead in a Won stage cannot be lost. Move it to another stage first."))
 
     @api.depends('company_id')
     def _compute_user_company_ids(self):
@@ -498,6 +506,32 @@ class CrmLead(models.Model):
                 if was_automated:
                     lead.probability = lead.automated_probability
 
+    @api.depends('active', 'probability')
+    def _compute_is_lost(self):
+        for lead in self:
+            lead.is_lost = not lead.active and lead.probability == 0
+
+    @api.model
+    def _search_is_lost(self, operator, value):
+        if operator not in ['=', '!='] or not isinstance(value, bool):
+            raise NotImplementedError(_('Operation not supported'))
+        if (value and operator == '=') or (not value and operator == '!='):
+            return [('active', '=', False), ('probability', '=', 0)]
+        return ['|', ('active', '=', True), ('probability', '!=', 0)]
+
+    @api.depends('stage_id', 'probability')
+    def _compute_is_won(self):
+        for lead in self:
+            lead.is_won = lead.stage_id.is_won and lead.probability == 100
+
+    @api.model
+    def _search_is_won(self, operator, value):
+        if operator not in ['=', '!='] or not isinstance(value, bool):
+            raise NotImplementedError(_('Operation not supported'))
+        if (value and operator == '=') or (not value and operator == '!='):
+            return [('stage_id', 'any', [('is_won', '=', True)]), ('probability', '=', 100)]
+        return ['|', ('stage_id', 'not any', [('is_won', '=', True)]), ('probability', '!=', 100)]
+
     @api.depends('expected_revenue', 'probability')
     def _compute_prorated_revenue(self):
         for lead in self:
@@ -734,9 +768,12 @@ class CrmLead(models.Model):
                 vals['website'] = self.env['res.partner']._clean_website(vals['website'])
         leads = super().create(vals_list)
 
-        for lead, values in zip(leads, vals_list):
-            if any(field in ['active', 'stage_id'] for field in values):
-                lead._handle_won_lost(values)
+        leads._handle_won_lost({}, {
+            lead.id: {
+                'is_lost': lead.is_lost,
+                'is_won': lead.is_won,
+            } for lead in leads
+        })
 
         return leads
 
@@ -774,20 +811,34 @@ class CrmLead(models.Model):
         elif stage_updated and not stage_is_won and not 'probability' in vals:
             vals['date_closed'] = False
 
-        if any(field in ['active', 'stage_id'] for field in vals):
-            self._handle_won_lost(vals)
+        update_frequencies = any(field in ['active', 'stage_id', 'probability'] for field in vals)
+        old_status_by_lead = {
+            lead.id: {
+                'is_lost': lead.is_lost,
+                'is_won': lead.is_won,
+            } for lead in self
+        } if update_frequencies else {}
 
         if not stage_is_won:
-            return super().write(vals)
+            result = super().write(vals)
+        else:
+            # stage change between two won stages: does not change the date_closed
+            leads_already_won = self.filtered(lambda lead: lead.stage_id.is_won)
+            remaining = self - leads_already_won
+            if remaining:
+                result = super(CrmLead, remaining).write(vals)
+            if leads_already_won:
+                vals.pop('date_closed', False)
+                result = super(CrmLead, leads_already_won).write(vals)
 
-        # stage change between two won stages: does not change the date_closed
-        leads_already_won = self.filtered(lambda lead: lead.stage_id.is_won)
-        remaining = self - leads_already_won
-        if remaining:
-            result = super(CrmLead, remaining).write(vals)
-        if leads_already_won:
-            vals.pop('date_closed', False)
-            result = super(CrmLead, leads_already_won).write(vals)
+        if update_frequencies:
+            self._handle_won_lost(old_status_by_lead, {
+                lead.id: {
+                    'is_lost': lead.is_lost,
+                    'is_won': lead.is_won,
+                } for lead in self
+            })
+
         return result
 
     @api.model
@@ -870,40 +921,55 @@ class CrmLead(models.Model):
         )
         return self.browse(my_lead_ids_keep) + other_lead_res
 
-    def _handle_won_lost(self, vals):
-        """ This method handle the state changes :
-        - To lost : We need to increment corresponding lost count in scoring frequency table
-        - To won : We need to increment corresponding won count in scoring frequency table
-        - From lost to Won : We need to decrement corresponding lost count + increment corresponding won count
-        in scoring frequency table.
-        - From won to lost : We need to decrement corresponding won count + increment corresponding lost count
-        in scoring frequency table."""
-        CrmLead = self.env['crm.lead']
-        leads_reach_won = CrmLead
-        leads_leave_won = CrmLead
-        leads_reach_lost = CrmLead
-        leads_leave_lost = CrmLead
-        won_stage_ids = self.env['crm.stage'].search([('is_won', '=', True)]).ids
-        for lead in self:
-            if 'stage_id' in vals:
-                if vals['stage_id'] in won_stage_ids:
-                    if lead.probability == 0:
-                        leads_leave_lost += lead
-                    leads_reach_won += lead
-                elif lead.stage_id.id in won_stage_ids and lead.active:  # a lead can be lost at won_stage
-                    leads_leave_won += lead
-            if 'active' in vals:
-                if not vals['active'] and lead.active:  # archive lead
-                    if lead.stage_id.id in won_stage_ids and lead not in leads_leave_won:
-                        leads_leave_won += lead
-                    leads_reach_lost += lead
-                elif vals['active'] and not lead.active:  # restore lead
-                    leads_leave_lost += lead
+    def _handle_won_lost(self, old_status_by_lead, new_status_by_lead):
+        """ This method handles all changes of won / lost status of leads on creation / writing,
+        and update the scoring frequency table accordingly:
+        - To lost : Increment corresponding lost count
+        - To won : Increment corresponding won count
+        - Leaving lost : Decrement corresponding lost count
+        - Leaving won : Decrement corresponding won count
+        More than one operation can happen simultaneously, for instance, going from lost to won:
+        Decrement corresponding lost count + increment corresponding won count.
 
-        leads_reach_won._pls_increment_frequencies(to_state='won')
-        leads_leave_won._pls_increment_frequencies(from_state='won')
-        leads_reach_lost._pls_increment_frequencies(to_state='lost')
-        leads_leave_lost._pls_increment_frequencies(from_state='lost')
+        A lead is WON when in won stage (and probability = 100% but that is implied and constrained)
+        A lead is LOST when active = False AND probability = 0
+        In every other case, the lead is not won nor lost.
+
+        :param old_status_by_lead: dict of old status by lead: {lead.id: {'is_lost': ..., 'is_won': ...}}
+        :param new_status_by_lead: dict of new status by lead: {lead.id: {'is_lost': ..., 'is_won': ...}}
+        """
+        Lead = self.env['crm.lead']
+        leads_reach_won_ids = CrmLead
+        leads_leave_won_ids = CrmLead
+        leads_reach_lost_ids = CrmLead
+        leads_leave_lost_ids = CrmLead
+
+        for lead in self:
+            new_status = new_status_by_lead.get(
+                lead.id, {'is_lost': False, 'is_won': False}
+            )
+            old_status = old_status_by_lead.get(
+                lead.id, {'is_lost': False, 'is_won': False}
+            )
+            if new_status['is_lost'] and new_status['is_won']:
+                raise ValidationError(_("The lead %s cannot be won and lost at the same time.", lead))
+
+            if new_status['is_lost'] and not old_status['is_lost']:
+                leads_reach_lost_ids += lead
+            elif not new_status['is_lost'] and old_status['is_lost']:
+                leads_leave_lost_ids += lead
+
+            if new_status['is_won'] and not old_status['is_won']:
+                leads_reach_won_ids += lead
+            elif not new_status['is_won'] and old_status['is_won']:
+                leads_leave_won_ids += lead
+
+        leads_reach_won_ids._pls_increment_frequencies(to_state='won')
+        leads_leave_won_ids._pls_increment_frequencies(from_state='won')
+        leads_reach_lost_ids._pls_increment_frequencies(to_state='lost')
+        leads_leave_lost_ids._pls_increment_frequencies(from_state='lost')
+
+        return True
 
     def copy_data(self, default=None):
         # set default value in context, if not already set (Put stage to 'new' stage)
@@ -983,27 +1049,31 @@ class CrmLead(models.Model):
     # ------------------------------------------------------------
 
     def toggle_active(self):
-        """ When archiving: mark probability as 0. When re-activating
-        update probability again, for leads and opportunities. """
+        """ When archiving: do nothing more. A lead can be archived but not lost.
+        When re-activating, force update probability, for leads and opportunities. """
         res = super().toggle_active()
-        activated = self.filtered(lambda lead: lead.active)
-        archived = self.filtered(lambda lead: not lead.active)
-        if activated:
+        if activated := self.filtered(lambda lead: lead.active):
             activated.write({'lost_reason_id': False})
             activated._compute_probabilities()
-        if archived:
-            archived.write({'probability': 0, 'automated_probability': 0})
         return res
 
+    def action_restore(self):
+        """ Restoring a lost lead means that it should go back to its normal life cycle.
+        This should reactivate the lead but also force the recompute of its probability, for the stage where the lead
+        is currently at. During toggle_active, when reactivating a lost lead,only the automated probability will be
+        recomputed, because the probability is not automated anymore. Restore will reset this automation."""
+        self.toggle_active()
+        for lead in self:
+            lead.probability = lead.automated_probability
+
     def action_set_lost(self, **additional_values):
-        """ Lost semantic: probability = 0 or active = False """
+        """ Lost semantic: probability = 0 AND active = False """
         res = self.action_archive()
-        if additional_values:
-            self.write(dict(additional_values))
+        self.write({**additional_values, 'probability': 0, 'automated_probability': 0})
         return res
 
     def action_set_won(self):
-        """ Won semantic: probability = 100 (active untouched) """
+        """ Won semantic: stage.is_won (AND probability = 100 but implied) """
         self.action_unarchive()
         # group the leads by team_id, in order to write once by values couple (each write leads to frequency increment)
         leads_by_won_stage = {}
@@ -1063,7 +1133,7 @@ class CrmLead(models.Model):
             user_won_leads_count = self.search_count([
                 ('type', '=', 'opportunity'),
                 ('user_id', '=', self.user_id.id),
-                ('probability', '=', 100),
+                ('is_won', '=', True),
                 ('date_closed', '>=', date_utils.start_of(today, 'year')),
                 ('date_closed', '<', date_utils.end_of(today, 'year')),
             ])
@@ -1685,7 +1755,7 @@ class CrmLead(models.Model):
     def convert_opportunity(self, partner, user_ids=False, team_id=False):
         customer = partner if partner else self.env['res.partner']
         for lead in self:
-            if not lead.active or lead.probability == 100:
+            if not lead.active or lead.is_won:
                 continue
             vals = lead._convert_opportunity_data(customer, team_id)
             lead.write(vals)
@@ -1767,7 +1837,7 @@ class CrmLead(models.Model):
         if include_lost:
             domain += ['|', ('type', '=', 'opportunity'), ('active', '=', True)]
         else:
-            domain += ['&', ('active', '=', True), '|', ('stage_id', '=', False), ('stage_id.is_won', '=', False)]
+            domain += [('active', '=', True), ('is_won', '=', False)]
 
         return self.with_context(active_test=False).search(domain)
 
@@ -1909,15 +1979,15 @@ class CrmLead(models.Model):
 
     def _track_subtype(self, init_values):
         self.ensure_one()
-        if 'stage_id' in init_values and self.probability == 100 and self.stage_id:
+        if 'stage_id' in init_values and self.is_won:
             return self.env.ref('crm.mt_lead_won')
         elif 'lost_reason_id' in init_values and self.lost_reason_id:
             return self.env.ref('crm.mt_lead_lost')
         elif 'stage_id' in init_values:
             return self.env.ref('crm.mt_lead_stage')
-        elif 'active' in init_values and self.active:
+        elif 'is_lost' in init_values and not self.is_lost:
             return self.env.ref('crm.mt_lead_restored')
-        elif 'active' in init_values and not self.active:
+        elif 'is_lost' in init_values and self.is_lost:
             return self.env.ref('crm.mt_lead_lost')
         return super()._track_subtype(init_values)
 
@@ -2131,12 +2201,10 @@ class CrmLead(models.Model):
         domain = []
         if batch_mode:
             domain = [
-                '&',
-                    ('active', '=', True), ('id', 'in', self.ids),
-                    '|',
-                        ('probability', '=', None),
-                        '&',
-                            ('probability', '<', 100), ('probability', '>', 0)
+                ('active', '=', True),
+                ('id', 'in', self.ids),
+                ('is_won', '=', False),
+                ('is_lost', '=', False)
             ]
         leads_values_dict = self._pls_get_lead_pls_values(domain=domain)
 
@@ -2309,16 +2377,11 @@ class CrmLead(models.Model):
             return
 
         # 1. Get all the leads to recompute created after pls_start_date that are nor won nor lost
-        # (Won : probability = 100 | Lost : probability = 0 or inactive. Here, inactive won't be returned anyway)
-        # Get also all the lead without probability --> These are the new leads. Activate auto probability on them.
         pending_lead_domain = [
-            '&',
-                '&',
-                    ('stage_id', '!=', False), ('create_date', '>=', pls_start_date),
-                '|',
-                    ('probability', '=', False),
-                    '&',
-                        ('probability', '<', 100), ('probability', '>', 0)
+            ('stage_id', '!=', False),
+            ('create_date', '>=', pls_start_date),
+            ('is_won', '=', False),
+            ('is_lost', '=', False)
         ]
         leads_to_update = self.env['crm.lead'].search(pending_lead_domain)
         leads_to_update_count = len(leads_to_update)
@@ -2409,12 +2472,10 @@ class CrmLead(models.Model):
         # Extract target leads values
         if rebuild:  # rebuild is ok
             domain = [
-                '&',
-                    ('create_date', '>=', pls_start_date),
-                    '|',
-                        ('probability', '=', 100),
-                        '&',
-                            ('probability', '=', 0), ('active', '=', False)
+                ('create_date', '>=', pls_start_date),
+                '|',
+                    ('is_won', '=', True),
+                    ('is_lost', '=', True)
               ]
             team_ids = self.env['crm.team'].with_context(active_test=False).search([]).ids + [0]  # If team_id is unset, consider it as team 0
         else:  # increment
@@ -2611,7 +2672,7 @@ class CrmLead(models.Model):
 
     # Common PLS Tools
     # ----------------
-    def _pls_get_lead_pls_values(self, domain=[]):
+    def _pls_get_lead_pls_values(self, domain=None):
         """
         This methods builds a dict where, for each lead in self or matching the given domain,
         we will get a list of field/value couple.

--- a/addons/crm/models/crm_stage.py
+++ b/addons/crm/models/crm_stage.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 AVAILABLE_PRIORITIES = [
     ('0', 'Low'),
@@ -47,3 +47,30 @@ class CrmStage(models.Model):
     @api.depends('team_id')
     def _compute_team_count(self):
         self.team_count = self.env['crm.team'].search_count([])
+
+    @api.onchange('is_won')
+    def _onchange_is_won(self):
+        return {
+            'warning': {
+                'title': _("Do you really want to update this stage?"),
+                'message': _("Changing the value of 'Is Won Stage' may induce a large number of operations, "
+                            "as the probabilities of opportunities in this stage will be recomputed on saving."),
+            }
+        }
+
+    def write(self, vals):
+        """ Since leads that are in a won stage must have their
+        probability = 100%, this override ensures that setting a stage as won
+        will set all the leads in that stage to probability = 100%.
+        Inversely, if a won stage is not marked as won anymore, the lead
+        probability should be recomputed based on automated probability.
+        Note: If a user sets a stage as won and changes his mind right after,
+        the manual probability will be lost in the process."""
+        res = super().write(vals)
+        if 'is_won' in vals:
+            won_leads = self.env['crm.lead'].search([('stage_id', 'in', self.ids)])
+            if won_leads and vals.get('is_won'):
+                won_leads.write({'probability': 100, 'automated_probability': 100})
+            elif won_leads and not vals.get('is_won'):
+                won_leads._compute_probabilities()
+        return res

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -361,8 +361,7 @@ class CrmTeam(models.Model):
         Heuristic of this method is the following:
           * find unassigned leads for each team, aka leads being
             * without team, without user -> not assigned;
-            * not in a won stage, and not having False/0 (lost) or 100 (won)
-              probability) -> live leads;
+            * not won nor inactive -> live leads;
             * created in the last creation_delta_days (in the last week by default)
               This avoid to take into account old leads in the allocation.
             * if set, a delay after creation can be applied (see BUNDLE_HOURS_DELAY)
@@ -435,7 +434,7 @@ class CrmTeam(models.Model):
                 literal_eval(team.assignment_domain or '[]'),
                 [('create_date', '<=', max_create_dt)],
                 ['&', ('team_id', '=', False), ('user_id', '=', False)],
-                ['|', ('stage_id', '=', False), ('stage_id.is_won', '=', False)]
+                [('is_won', '=', False)]
             ])
             if creation_delta_days > 0:
                 lead_domain = expression.AND([

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -434,7 +434,7 @@ class CrmTeam(models.Model):
                 literal_eval(team.assignment_domain or '[]'),
                 [('create_date', '<=', max_create_dt)],
                 ['&', ('team_id', '=', False), ('user_id', '=', False)],
-                [('is_won', '=', False)]
+                [('won_status', '!=', 'won')]
             ])
             if creation_delta_days > 0:
                 lead_domain = expression.AND([

--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -113,7 +113,7 @@
                     <filter string="Inactive" name="filter_inactive"
                             domain="[('active', '=', False)]"/>
                     <filter string="Won" name="won"
-                            domain="[('probability', '=', 100)]"/>
+                            domain="[('is_won', '=', True)]"/>
                     <filter string="Lost" name="lost"
                             domain="[('probability', '=', 0), ('active', '=', False)]"/>
                     <field name="team_id" context="{'invisible_team': False}"/>

--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -113,7 +113,7 @@
                     <filter string="Inactive" name="filter_inactive"
                             domain="[('active', '=', False)]"/>
                     <filter string="Won" name="won"
-                            domain="[('is_won', '=', True)]"/>
+                            domain="[('won_status', '=', 'won')]"/>
                     <filter string="Lost" name="lost"
                             domain="[('probability', '=', 0), ('active', '=', False)]"/>
                     <field name="team_id" context="{'invisible_team': False}"/>

--- a/addons/crm/static/tests/tours/crm_forecast_tour.js
+++ b/addons/crm/static/tests/tours/crm_forecast_tour.js
@@ -68,9 +68,8 @@ registry.category("web_tour.tours").add('crm_forecast', {
         content: "complete expected closing",
         run: `edit ${today.plus({ months: 5 }).startOf("month").minus({ days: 1 }).toFormat("MM/dd/yyyy")} && press Escape`,
     }, {
-        trigger: ".o_field_widget[name=probability] input",
-        content: "max out probability",
-        run: "edit 100",
+        trigger: "button[name=action_set_won_rainbowman]",
+        content: "win the lead",
     }, {
         trigger: '.o_back_button',
         content: 'navigate back to the kanban view',

--- a/addons/crm/static/tests/tours/crm_forecast_tour.js
+++ b/addons/crm/static/tests/tours/crm_forecast_tour.js
@@ -70,6 +70,7 @@ registry.category("web_tour.tours").add('crm_forecast', {
     }, {
         trigger: "button[name=action_set_won_rainbowman]",
         content: "win the lead",
+        run: "click"
     }, {
         trigger: '.o_back_button',
         content: 'navigate back to the kanban view',

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -159,13 +159,18 @@ class TestCrmCommon(TestSalesCommon, MailCase):
         })
         cls.lead_team_1_won.action_set_won()
         cls.lead_team_1_lost = cls.env['crm.lead'].create({
-            'name': 'Already Won',
+            'name': 'Already Lost',
             'type': 'lead',
             'user_id': cls.user_sales_leads.id,
             'team_id': cls.sales_team_1.id,
         })
         cls.lead_team_1_lost.action_set_lost()
         (cls.lead_team_1_won + cls.lead_team_1_lost).flush_recordset()
+
+        # make lead 1 take team history into account for its automated proba.
+        # it should now be 50% as auto proba. (1 lost 1 won for team 1)
+        cls.lead_1._compute_probabilities()
+        cls.lead_1.flush_recordset()
 
         # email / phone data
         cls.test_email_data = [

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -11,7 +11,7 @@ from odoo.addons.crm.models.crm_lead import PARTNER_FIELDS_TO_SYNC, PARTNER_ADDR
 from odoo.addons.crm.tests.common import TestCrmCommon, INCOMING_EMAIL
 from odoo.addons.mail.tests.mail_tracking_duration_mixin_case import MailTrackingDurationMixinCase
 from odoo.addons.phone_validation.tools.phone_validation import phone_format
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests import Form, tagged, users
 from odoo.tools import mute_logger
 
@@ -981,6 +981,76 @@ class TestCRMLead(TestCrmCommon):
         self.assertEqual(lead.phone, self.test_phone_data[1])
         self.assertEqual(lead.mobile, self.test_phone_data[2])
         self.assertFalse(lead.phone_sanitized)
+
+    def test_won_lost_validity(self):
+        team_id = self.env['crm.team'].create([{'name': 'Team Test'}]).id
+        stage_new, stage_in_progress, stage_won = self.env['crm.stage'].create([{
+            'name': 'New Stage',
+            'sequence': 1,
+            'team_id': team_id,
+        }, {
+            'name': 'In Progress Stage',
+            'sequence': 2,
+            'team_id': team_id,
+        }, {
+            'is_won': True,
+            'name': 'Won Stage',
+            'sequence': 3,
+            'team_id': team_id,
+        }])
+        lead = self.env['crm.lead'].create([{
+            'active': True,
+            'name': 'Test Lead',
+            'probability': 50,
+            'stage_id': stage_new.id,
+            'team_id': team_id,
+        }])
+
+        # Probability 100 is not a sufficient condition to win the lead
+        lead.write({'probability': 100})
+        self.assertFalse(lead.is_lost)
+        self.assertFalse(lead.is_won, "A lead with proba = 100 is not won as needs to be in won stage.")
+
+        # Test won validity
+        lead.action_set_won()
+        self.assertEqual(lead.probability, 100)
+        self.assertFalse(lead.is_lost)
+        self.assertTrue(lead.is_won)
+        with self.assertRaises(ValidationError, msg='A won lead cannot be set as lost.'):
+            lead.action_set_lost()
+
+        # Won lead can be inactive
+        lead.write({'active': False})
+        self.assertTrue(lead.is_won)
+        with self.assertRaises(ValidationError, msg='A won lead cannot have a probability different than 100'):
+            lead.write({'probability': 50})
+
+        # Restore the lead in a non won stage. won_count = lost_count = 0.1 in frequency table. P = 50%
+        lead.write({'stage_id': stage_in_progress.id, 'active': True})
+        self.assertFalse(lead.probability == 100)
+        self.assertFalse(lead.is_won)
+
+        # Test lost validity
+        lead.action_set_lost()
+        self.assertEqual(lead.probability, 0)
+        self.assertFalse(lead.active)
+        self.assertTrue(lead.is_lost)
+        self.assertFalse(lead.is_won)
+
+        # Test won validity reaching won stage
+        lead.write({'stage_id': stage_won.id})
+        self.assertEqual(lead.probability, 100)
+        self.assertFalse(lead.is_lost)
+        self.assertTrue(lead.is_won)
+        self.assertFalse(lead.active)
+
+        # Back to lost
+        lead.write({'probability': 0, 'stage_id': stage_new.id})
+        self.assertTrue(lead.is_lost)
+
+        # Once active again, lead is not lost anymore
+        lead.write({'active': True})
+        self.assertFalse(lead.is_lost, "An active lead cannot be lost")
 
 
 @tagged('lead_internals')

--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -142,9 +142,9 @@ class TestLeadAssign(TestLeadAssignCommon):
             count=14,
             suffix='Existing')
         self.assertEqual(existing_leads.team_id, self.sales_team_1, "Team should have lower sequence")
-        existing_leads[0].active = False  # lost
-        existing_leads[1].probability = 100  # not won
-        existing_leads[2].probability = 0  # not lost
+        existing_leads[0].action_set_lost()  # lost
+        existing_leads[1].probability = 100  # not won as stage is not won.
+        existing_leads[2].probability = 0  # not lost as active
         existing_leads.flush_recordset()
 
         self.members.invalidate_model(['lead_month_count'])
@@ -176,8 +176,12 @@ class TestLeadAssign(TestLeadAssignCommon):
             ['TestLeadInitial_0003']
         )
 
+        # TestLeadInitial_0007 has same partner as TestLeadInitial_0003
         self.assertEqual(len(teams_data[self.sales_team_1]['duplicates']), 1)
 
+        # TestLeadInitial_0005 had a 0 auto_proba when its proba was set to 0.
+        # Therefore, it is auto_proba. At this point, its proba is 9x.xx %, and it is selected.
+        # These are the two leads with the highest probabilities, as they are sorted before assignment.
         self.assertEqual(
             sorted(members_data[self.sales_team_1_m3]['assigned'].mapped('name')),
             ['TestLeadInitial_0000', 'TestLeadInitial_0005']

--- a/addons/crm/tests/test_crm_lead_lost.py
+++ b/addons/crm/tests/test_crm_lead_lost.py
@@ -59,7 +59,7 @@ class TestLeadConvert(crm_common.TestCrmCommon):
         self.assertEqual(len(lead.message_ids), 3, 'Should have logged a tracking message for lost lead with reason')
         update_message = lead.message_ids[0]
         self.assertEqual(update_message.subtype_id, self.env.ref('crm.mt_lead_lost'))
-        self.assertEqual(len(update_message.tracking_value_ids), 2, 'Tracking: active, lost reason')
+        self.assertEqual(len(update_message.tracking_value_ids), 2, 'Tracking: active, lost reason, is_lost')
         self.assertTracking(
             update_message,
             [('active', 'boolean', True, False),

--- a/addons/crm/tests/test_crm_lead_lost.py
+++ b/addons/crm/tests/test_crm_lead_lost.py
@@ -59,7 +59,7 @@ class TestLeadConvert(crm_common.TestCrmCommon):
         self.assertEqual(len(lead.message_ids), 3, 'Should have logged a tracking message for lost lead with reason')
         update_message = lead.message_ids[0]
         self.assertEqual(update_message.subtype_id, self.env.ref('crm.mt_lead_lost'))
-        self.assertEqual(len(update_message.tracking_value_ids), 2, 'Tracking: active, lost reason, is_lost')
+        self.assertEqual(len(update_message.tracking_value_ids), 2, 'Tracking: active, lost reason')
         self.assertTracking(
             update_message,
             [('active', 'boolean', True, False),

--- a/addons/crm/tests/test_crm_lead_merge.py
+++ b/addons/crm/tests/test_crm_lead_merge.py
@@ -63,6 +63,9 @@ class TestLeadMerge(TestLeadMergeCommon):
         self.assertEqual(self.lead_1.user_id, self.user_sales_leads)
         self.assertEqual(self.lead_1.team_id, self.sales_team_1)
         self.assertEqual(self.lead_1.stage_id, self.stage_team1_1)
+        self.assertEqual(self.lead_1.probability, 20)
+        self.assertTrue(self.lead_1.automated_probability > 0)
+        self.assertFalse(self.lead_1.is_automated_probability)
 
         self.assertEqual(self.lead_w_partner.stage_id, self.env['crm.stage'])
         self.assertEqual(self.lead_w_partner.user_id, self.env['res.users'])
@@ -284,6 +287,7 @@ class TestLeadMerge(TestLeadMergeCommon):
         leads = self.env['crm.lead'].browse((self.lead_1 + self.lead_w_partner + self.lead_w_partner_company).ids)
         merged_lead = self._run_merge_wizard(leads)
         self.assertEqual(merged_lead, self.lead_1)
+        self.assertTrue(self.lead_1.automated_probability > 0)
         self.assertEqual(merged_lead.probability, 0, "Manual Probability should remain the same after the merge")
         self.assertFalse(merged_lead.is_automated_probability)
 

--- a/addons/crm/tests/test_crm_pls.py
+++ b/addons/crm/tests/test_crm_pls.py
@@ -284,8 +284,7 @@ class TestCRMPLS(TransactionCase):
 
         # Restore -> Should decrease lost
         leads[4].toggle_active()
-        self.assertFalse(leads[4].is_lost)
-        self.assertFalse(leads[4].is_won)
+        self.assertEqual(leads[4].won_status, 'pending')
         self.assertEqual(lead_4_stage_0_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_stage_won_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_country_freq.won_count, 0.1)  # unchanged
@@ -306,8 +305,7 @@ class TestCRMPLS(TransactionCase):
 
         # set to won stage -> Should increase won
         leads[4].stage_id = won_stage_id
-        self.assertTrue(leads[4].is_won)
-        self.assertFalse(leads[4].is_lost)
+        self.assertEqual(leads[4].won_status, 'won')
         self.assertEqual(lead_4_stage_0_freq.won_count, 2.1)  # + 1
         self.assertEqual(lead_4_stage_won_freq.won_count, 2.1)  # + 1
         self.assertEqual(lead_4_country_freq.won_count, 1.1)  # + 1
@@ -320,8 +318,7 @@ class TestCRMPLS(TransactionCase):
         # Archive in won stage -> Should NOT decrease won NOR increase lost
         # as lost = archived + 0% and WON = won_stage (+ 100%)
         leads[4].toggle_active()
-        self.assertTrue(leads[4].is_won)
-        self.assertFalse(leads[4].is_lost)
+        self.assertEqual(leads[4].won_status, 'won')
         self.assertEqual(lead_4_stage_0_freq.won_count, 2.1)  # unchanged
         self.assertEqual(lead_4_stage_won_freq.won_count, 2.1)  # unchanged
         self.assertEqual(lead_4_country_freq.won_count, 1.1)  # unchanged
@@ -333,8 +330,7 @@ class TestCRMPLS(TransactionCase):
 
         # Move to original stage -> lead is not won anymore but not lost as probability != 0
         leads[4].stage_id = stage_ids[0]
-        self.assertFalse(leads[4].is_won)
-        self.assertFalse(leads[4].is_lost)
+        self.assertEqual(leads[4].won_status, 'pending')
         self.assertEqual(lead_4_stage_0_freq.won_count, 1.1)  # -1
         self.assertEqual(lead_4_stage_won_freq.won_count, 1.1)  # -1
         self.assertEqual(lead_4_country_freq.won_count, 0.1)  # -1
@@ -346,8 +342,7 @@ class TestCRMPLS(TransactionCase):
 
         # force proba to 0% -> as already archived, will be lost (lost = archived AND 0%)
         leads[4].probability = 0
-        self.assertTrue(leads[4].is_lost)
-        self.assertFalse(leads[4].is_won)
+        self.assertEqual(leads[4].won_status, 'lost')
         self.assertEqual(lead_4_stage_0_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_stage_won_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_country_freq.won_count, 0.1)  # unchanged
@@ -359,8 +354,7 @@ class TestCRMPLS(TransactionCase):
 
         # Restore -> Should decrease lost - at the end, frequencies should be like first frequencyes tests (except for 0.0 -> 0.1)
         leads[4].toggle_active()
-        self.assertFalse(leads[4].is_lost)
-        self.assertFalse(leads[4].is_won)
+        self.assertEqual(leads[4].won_status, 'pending')
         self.assertEqual(lead_4_stage_0_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_stage_won_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_country_freq.won_count, 0.1)  # unchanged

--- a/addons/crm/tests/test_crm_pls.py
+++ b/addons/crm/tests/test_crm_pls.py
@@ -284,6 +284,8 @@ class TestCRMPLS(TransactionCase):
 
         # Restore -> Should decrease lost
         leads[4].toggle_active()
+        self.assertFalse(leads[4].is_lost)
+        self.assertFalse(leads[4].is_won)
         self.assertEqual(lead_4_stage_0_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_stage_won_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_country_freq.won_count, 0.1)  # unchanged
@@ -304,6 +306,8 @@ class TestCRMPLS(TransactionCase):
 
         # set to won stage -> Should increase won
         leads[4].stage_id = won_stage_id
+        self.assertTrue(leads[4].is_won)
+        self.assertFalse(leads[4].is_lost)
         self.assertEqual(lead_4_stage_0_freq.won_count, 2.1)  # + 1
         self.assertEqual(lead_4_stage_won_freq.won_count, 2.1)  # + 1
         self.assertEqual(lead_4_country_freq.won_count, 1.1)  # + 1
@@ -313,36 +317,56 @@ class TestCRMPLS(TransactionCase):
         self.assertEqual(lead_4_country_freq.lost_count, 1.1)  # unchanged
         self.assertEqual(lead_4_email_state_freq.lost_count, 2.1)  # unchanged
 
-        # Archive (was won, now lost) -> Should decrease won and increase lost
+        # Archive in won stage -> Should NOT decrease won NOR increase lost
+        # as lost = archived + 0% and WON = won_stage (+ 100%)
         leads[4].toggle_active()
-        self.assertEqual(lead_4_stage_0_freq.won_count, 1.1)  # - 1
-        self.assertEqual(lead_4_stage_won_freq.won_count, 1.1)  # - 1
-        self.assertEqual(lead_4_country_freq.won_count, 0.1)  # - 1
-        self.assertEqual(lead_4_email_state_freq.won_count, 1.1)  # - 1
-        self.assertEqual(lead_4_stage_0_freq.lost_count, 3.1)  # + 1
-        self.assertEqual(lead_4_stage_won_freq.lost_count, 1.1)  # consider stages with <= sequence when lostand as stage is won.. even won_stage lost_count is increased by 1
-        self.assertEqual(lead_4_country_freq.lost_count, 2.1)  # + 1
-        self.assertEqual(lead_4_email_state_freq.lost_count, 3.1)  # + 1
+        self.assertTrue(leads[4].is_won)
+        self.assertFalse(leads[4].is_lost)
+        self.assertEqual(lead_4_stage_0_freq.won_count, 2.1)  # unchanged
+        self.assertEqual(lead_4_stage_won_freq.won_count, 2.1)  # unchanged
+        self.assertEqual(lead_4_country_freq.won_count, 1.1)  # unchanged
+        self.assertEqual(lead_4_email_state_freq.won_count, 2.1)  # unchanged
+        self.assertEqual(lead_4_stage_0_freq.lost_count, 2.1)  # unchanged
+        self.assertEqual(lead_4_stage_won_freq.lost_count, 0.1)  # unchanged
+        self.assertEqual(lead_4_country_freq.lost_count, 1.1)  # unchanged
+        self.assertEqual(lead_4_email_state_freq.lost_count, 2.1)  # unchanged
 
-        # Move to original stage -> Should do nothing (as lead is still lost)
+        # Move to original stage -> lead is not won anymore but not lost as probability != 0
         leads[4].stage_id = stage_ids[0]
+        self.assertFalse(leads[4].is_won)
+        self.assertFalse(leads[4].is_lost)
+        self.assertEqual(lead_4_stage_0_freq.won_count, 1.1)  # -1
+        self.assertEqual(lead_4_stage_won_freq.won_count, 1.1)  # -1
+        self.assertEqual(lead_4_country_freq.won_count, 0.1)  # -1
+        self.assertEqual(lead_4_email_state_freq.won_count, 1.1)  # -1
+        self.assertEqual(lead_4_stage_0_freq.lost_count, 2.1)  # unchanged
+        self.assertEqual(lead_4_stage_won_freq.lost_count, 0.1)  # unchanged
+        self.assertEqual(lead_4_country_freq.lost_count, 1.1)  # unchanged
+        self.assertEqual(lead_4_email_state_freq.lost_count, 2.1)  # unchanged
+
+        # force proba to 0% -> as already archived, will be lost (lost = archived AND 0%)
+        leads[4].probability = 0
+        self.assertTrue(leads[4].is_lost)
+        self.assertFalse(leads[4].is_won)
         self.assertEqual(lead_4_stage_0_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_stage_won_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_country_freq.won_count, 0.1)  # unchanged
         self.assertEqual(lead_4_email_state_freq.won_count, 1.1)  # unchanged
-        self.assertEqual(lead_4_stage_0_freq.lost_count, 3.1)  # unchanged
-        self.assertEqual(lead_4_stage_won_freq.lost_count, 1.1)  # unchanged
-        self.assertEqual(lead_4_country_freq.lost_count, 2.1)  # unchanged
-        self.assertEqual(lead_4_email_state_freq.lost_count, 3.1)  # unchanged
+        self.assertEqual(lead_4_stage_0_freq.lost_count, 3.1)  # +1
+        self.assertEqual(lead_4_stage_won_freq.lost_count, 0.1)  # unchanged - should not increase lost frequency of won stage.
+        self.assertEqual(lead_4_country_freq.lost_count, 2.1)  # +1
+        self.assertEqual(lead_4_email_state_freq.lost_count, 3.1)  # +1
 
         # Restore -> Should decrease lost - at the end, frequencies should be like first frequencyes tests (except for 0.0 -> 0.1)
         leads[4].toggle_active()
+        self.assertFalse(leads[4].is_lost)
+        self.assertFalse(leads[4].is_won)
         self.assertEqual(lead_4_stage_0_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_stage_won_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_country_freq.won_count, 0.1)  # unchanged
         self.assertEqual(lead_4_email_state_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_stage_0_freq.lost_count, 2.1)  # - 1
-        self.assertEqual(lead_4_stage_won_freq.lost_count, 1.1)  # unchanged - consider stages with <= sequence when lost
+        self.assertEqual(lead_4_stage_won_freq.lost_count, 0.1)  # unchanged - consider stages with <= sequence when lost
         self.assertEqual(lead_4_country_freq.lost_count, 1.1)  # - 1
         self.assertEqual(lead_4_email_state_freq.lost_count, 2.1)  # - 1
 
@@ -356,7 +380,7 @@ class TestCRMPLS(TransactionCase):
         self.assertEqual(lead_4_country_freq.won_count, 0.1)  # unchanged
         self.assertEqual(lead_4_email_state_freq.won_count, 1.1)  # unchanged
         self.assertEqual(lead_4_stage_0_freq.lost_count, 2.1)  # unchanged
-        self.assertEqual(lead_4_stage_won_freq.lost_count, 1.1)  # unchanged
+        self.assertEqual(lead_4_stage_won_freq.lost_count, 0.1)  # unchanged
         self.assertEqual(lead_4_country_freq.lost_count, 1.1)  # unchanged
         self.assertEqual(lead_4_email_state_freq.lost_count, 2.1)  # unchanged
 

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -8,21 +8,21 @@
                     <header>
                         <button name="action_set_won_rainbowman" string="Won"
                             type="object" class="oe_highlight" data-hotkey="w" title="Mark as won"
-                            invisible="not active or probability == 100 or type == 'lead'"/>
-                        <button name="%(crm.crm_lead_lost_action)d" string="Lost" data-hotkey="l" title="Mark as lost"
-                            type="action" invisible="type == 'lead' or not active and probability &lt; 100"/>
+                            invisible="is_won or type == 'lead' or not active"/>
                         <button name="%(crm.action_crm_lead2opportunity_partner)d" string="Convert to Opportunity" type="action"
                             class="oe_highlight" invisible="type == 'opportunity' or not active" data-hotkey="v"/>
-                        <button name="toggle_active" string="Restore" type="object" data-hotkey="x"
-                            invisible="probability &gt; 0 or active"/>
-                        <button name="%(crm.crm_lead_lost_action)d" string="Lost" type="action"  data-hotkey="l" title="Mark as lost"
-                            invisible="type == 'opportunity' or probability == 0 and not active"/>
+                        <button name="action_restore" string="Restore" type="object" data-hotkey="x"
+                            invisible="not is_lost"/>
+                        <button name="%(crm.crm_lead_lost_action)d" string="Lost" type="action" data-hotkey="l" title="Mark as lost"
+                            invisible="is_lost or is_won or not active"/>
                         <field name="stage_id" widget="statusbar_duration"
                             options="{'clickable': '1', 'fold_field': 'fold'}"
                             domain="['|', ('team_id', '=', team_id), ('team_id', '=', False)]"
-                            invisible="not active or type == 'lead'"/>
+                            invisible="type == 'lead'" readonly="is_lost"/>
                     </header>
                     <sheet>
+                        <field name="is_lost" invisible="1"/>
+                        <field name="is_won" invisible="1"/>
                         <field name="active" invisible="1"/>
                         <field name="company_id" invisible="1"/>
                         <div class="oe_button_box" name="button_box">
@@ -45,8 +45,9 @@
                                 </div>
                             </button>
                         </div>
-                        <widget name="web_ribbon" title="Lost" bg_color="text-bg-danger" invisible="probability &gt; 0 or active"/>
-                        <widget name="web_ribbon" title="Won" invisible="probability &lt; 100" />
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active or is_lost or is_won"/>
+                        <widget name="web_ribbon" title="Lost" bg_color="text-bg-danger" invisible="not is_lost"/>
+                        <widget name="web_ribbon" title="Won" invisible="not is_won" />
                         <div class="oe_title">
                             <h1><field class="text-break" options="{'line_breaks': False}" widget="text" name="name" placeholder="e.g. Product Pricing"/></h1>
                             <h2 class="row g-0 pb-3 pb-sm-4">
@@ -78,7 +79,7 @@
                                     </small>
                                     <div id="probability" class="d-flex align-items-baseline">
                                         <field name="is_automated_probability" invisible="1"/>
-                                        <field name="probability" widget="float" class="oe_inline o_input_6ch"/>
+                                        <field name="probability" widget="float" class="oe_inline o_input_6ch" readonly="is_won"/>
                                         <span class="oe_grey p-2"> %</span>
                                     </div>
                                 </div>
@@ -181,7 +182,7 @@
                                         title="By saving this change, the customer phone number will also be updated."
                                         invisible="not partner_phone_update"/>
                                 </div>
-                                <field name="lost_reason_id" invisible="active"/>
+                                <field name="lost_reason_id" invisible="not is_lost"/>
                                 <field name="date_conversion" invisible="1"/>
                                 <field name="user_company_ids" invisible="1"/>
                             </group>
@@ -523,6 +524,8 @@
                     <field name="company_currency"/>
                     <field name="recurring_revenue_monthly"/>
                     <field name="team_id"/>
+                    <field name="is_lost"/>
+                    <field name="is_won"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'
                         sum_field="expected_revenue" recurring_revenue_sum_field="recurring_revenue_monthly"
                         help="This bar allows to filter the opportunities based on scheduled activities."/>
@@ -533,8 +536,7 @@
                             <field name="color" widget="kanban_color_picker"/>
                         </t>
                         <t t-name="card">
-                            <t t-set="lost_ribbon" t-value="!record.active.raw_value and record.probability and record.probability.raw_value == 0"/>
-                            <widget name="web_ribbon" title="lost" bg_color="text-bg-danger" invisible="probability &gt; 0 or active"/>
+                            <widget name="web_ribbon" title="Lost" bg_color="text-bg-danger" invisible="not is_lost"/>
                             <field class="fw-bold fs-5" name="name"/>
                             <div>
                                 <t t-if="record.expected_revenue.raw_value">
@@ -575,6 +577,7 @@
                 </xpath>
                 <xpath expr="//kanban" position="inside">
                     <field name="date_deadline"/>
+                    <field name="is_won"/>
                 </xpath>
                 <xpath expr="//field[@name='expected_revenue']" position="replace">
                     <field name="prorated_revenue"/>
@@ -587,12 +590,9 @@
                     <attribute name="sum_field">prorated_revenue</attribute>
                     <attribute name="recurring_revenue_sum_field">recurring_revenue_monthly_prorated</attribute>
                 </xpath>
-                <xpath expr="//t[@t-set='lost_ribbon']" position="after">
-                    <t t-set="won_ribbon" t-value="record.active.raw_value and record.probability and record.probability.raw_value == 100"/>
-                </xpath>
                 <xpath expr="//widget" position="replace">
-                    <widget t-if="won_ribbon" name="web_ribbon" title="Won" bg_color="text-bg-success" invisible="(probability &gt; 0 or active) and (probability &lt; 100 or not active)"/>
-                    <widget t-if="lost_ribbon" name="web_ribbon" title="Lost" bg_color="text-bg-danger" invisible="(probability &gt; 0 or active) and (probability &lt; 100 or not active)"/>
+                    <widget t-if="record.is_won.raw_value" name="web_ribbon" title="Won" bg_color="text-bg-success"/>
+                    <widget t-elif="record.is_lost.raw_value" name="web_ribbon" title="Lost" bg_color="text-bg-danger"/>
                 </xpath>
                 <xpath expr="//div" position="replace">
                     <div>
@@ -955,9 +955,9 @@
                     <filter string="Creation Date" name="creation_date" date="create_date"/>
                     <filter string="Closed Date" name="close_date" date="date_closed"/>
                     <separator/>
-                    <filter string="Won" name="filter_won" domain="['&amp;', ('active', '=', True), ('stage_id.is_won', '=', True)]"/>
-                    <filter string="Ongoing" name="filter_ongoing" domain="['&amp;', ('active', '=', True), ('stage_id.is_won', '=', False)]"/>
-                    <filter string="Lost" name="filter_lost" domain="['&amp;', ('active', '=', False), ('probability', '=', 0)]"/>
+                    <filter string="Won" name="filter_won" domain="[('is_won', '=', True)]"/>
+                    <filter string="Ongoing" name="filter_ongoing" domain="['&amp;', ('is_lost', '=', False), ('is_won', '=', False)]"/>
+                    <filter string="Lost" name="filter_lost" context="{'active_test': False}" domain="[('is_lost', '=', True)]"/>
                     <separator/>
                     <filter invisible="1" string="Overdue Opportunities" name="overdue_opp" domain="['&amp;', ('date_closed', '=', False), ('date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"/>
                     <filter invisible="1" string="Late Activities" name="activities_overdue"

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -8,21 +8,20 @@
                     <header>
                         <button name="action_set_won_rainbowman" string="Won"
                             type="object" class="oe_highlight" data-hotkey="w" title="Mark as won"
-                            invisible="is_won or type == 'lead' or not active"/>
+                            invisible="won_status == 'won' or type == 'lead' or not active"/>
                         <button name="%(crm.action_crm_lead2opportunity_partner)d" string="Convert to Opportunity" type="action"
                             class="oe_highlight" invisible="type == 'opportunity' or not active" data-hotkey="v"/>
                         <button name="action_restore" string="Restore" type="object" data-hotkey="x"
-                            invisible="not is_lost"/>
+                            invisible="won_status != 'lost'"/>
                         <button name="%(crm.crm_lead_lost_action)d" string="Lost" type="action" data-hotkey="l" title="Mark as lost"
-                            invisible="is_lost or is_won or not active"/>
+                            invisible="won_status != 'pending' or not active"/>
                         <field name="stage_id" widget="statusbar_duration"
                             options="{'clickable': '1', 'fold_field': 'fold'}"
                             domain="['|', ('team_id', '=', team_id), ('team_id', '=', False)]"
-                            invisible="type == 'lead'" readonly="is_lost"/>
+                            invisible="type == 'lead'" readonly="won_status == 'lost'"/>
                     </header>
                     <sheet>
-                        <field name="is_lost" invisible="1"/>
-                        <field name="is_won" invisible="1"/>
+                        <field name="won_status" invisible="1"/>
                         <field name="active" invisible="1"/>
                         <field name="company_id" invisible="1"/>
                         <div class="oe_button_box" name="button_box">
@@ -45,9 +44,9 @@
                                 </div>
                             </button>
                         </div>
-                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active or is_lost or is_won"/>
-                        <widget name="web_ribbon" title="Lost" bg_color="text-bg-danger" invisible="not is_lost"/>
-                        <widget name="web_ribbon" title="Won" invisible="not is_won" />
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active or won_status != 'pending'"/>
+                        <widget name="web_ribbon" title="Lost" bg_color="text-bg-danger" invisible="won_status != 'lost'"/>
+                        <widget name="web_ribbon" title="Won" invisible="won_status != 'won'" />
                         <div class="oe_title">
                             <h1><field class="text-break" options="{'line_breaks': False}" widget="text" name="name" placeholder="e.g. Product Pricing"/></h1>
                             <h2 class="row g-0 pb-3 pb-sm-4">
@@ -79,7 +78,7 @@
                                     </small>
                                     <div id="probability" class="d-flex align-items-baseline">
                                         <field name="is_automated_probability" invisible="1"/>
-                                        <field name="probability" widget="float" class="oe_inline o_input_6ch" readonly="is_won"/>
+                                        <field name="probability" widget="float" class="oe_inline o_input_6ch" readonly="won_status == 'won'"/>
                                         <span class="oe_grey p-2"> %</span>
                                     </div>
                                 </div>
@@ -182,7 +181,7 @@
                                         title="By saving this change, the customer phone number will also be updated."
                                         invisible="not partner_phone_update"/>
                                 </div>
-                                <field name="lost_reason_id" invisible="not is_lost"/>
+                                <field name="lost_reason_id" invisible="won_status != 'lost'"/>
                                 <field name="date_conversion" invisible="1"/>
                                 <field name="user_company_ids" invisible="1"/>
                             </group>
@@ -524,8 +523,7 @@
                     <field name="company_currency"/>
                     <field name="recurring_revenue_monthly"/>
                     <field name="team_id"/>
-                    <field name="is_lost"/>
-                    <field name="is_won"/>
+                    <field name="won_status"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'
                         sum_field="expected_revenue" recurring_revenue_sum_field="recurring_revenue_monthly"
                         help="This bar allows to filter the opportunities based on scheduled activities."/>
@@ -536,7 +534,7 @@
                             <field name="color" widget="kanban_color_picker"/>
                         </t>
                         <t t-name="card">
-                            <widget name="web_ribbon" title="Lost" bg_color="text-bg-danger" invisible="not is_lost"/>
+                            <widget name="web_ribbon" title="Lost" bg_color="text-bg-danger" invisible="won_status != 'lost'"/>
                             <field class="fw-bold fs-5" name="name"/>
                             <div>
                                 <t t-if="record.expected_revenue.raw_value">
@@ -577,7 +575,7 @@
                 </xpath>
                 <xpath expr="//kanban" position="inside">
                     <field name="date_deadline"/>
-                    <field name="is_won"/>
+                    <field name="won_status"/>
                 </xpath>
                 <xpath expr="//field[@name='expected_revenue']" position="replace">
                     <field name="prorated_revenue"/>
@@ -591,8 +589,8 @@
                     <attribute name="recurring_revenue_sum_field">recurring_revenue_monthly_prorated</attribute>
                 </xpath>
                 <xpath expr="//widget" position="replace">
-                    <widget t-if="record.is_won.raw_value" name="web_ribbon" title="Won" bg_color="text-bg-success"/>
-                    <widget t-elif="record.is_lost.raw_value" name="web_ribbon" title="Lost" bg_color="text-bg-danger"/>
+                    <widget t-if="record.won_status.raw_value === 'won'" name="web_ribbon" title="Won" bg_color="text-bg-success"/>
+                    <widget t-elif="record.won_status.raw_value === 'lost'" name="web_ribbon" title="Lost" bg_color="text-bg-danger"/>
                 </xpath>
                 <xpath expr="//div" position="replace">
                     <div>
@@ -955,9 +953,9 @@
                     <filter string="Creation Date" name="creation_date" date="create_date"/>
                     <filter string="Closed Date" name="close_date" date="date_closed"/>
                     <separator/>
-                    <filter string="Won" name="filter_won" domain="[('is_won', '=', True)]"/>
-                    <filter string="Ongoing" name="filter_ongoing" domain="['&amp;', ('is_lost', '=', False), ('is_won', '=', False)]"/>
-                    <filter string="Lost" name="filter_lost" context="{'active_test': False}" domain="[('is_lost', '=', True)]"/>
+                    <filter string="Won" name="filter_won" domain="[('won_status', '=', 'won')]"/>
+                    <filter string="Ongoing" name="filter_ongoing" domain="[('won_status', '=', 'pending')]"/>
+                    <filter string="Lost" name="filter_lost" context="{'active_test': False}" domain="[('won_status', '=', 'lost')]"/>
                     <separator/>
                     <filter invisible="1" string="Overdue Opportunities" name="overdue_opp" domain="['&amp;', ('date_closed', '=', False), ('date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"/>
                     <filter invisible="1" string="Late Activities" name="activities_overdue"

--- a/addons/crm/wizard/crm_lead_lost.py
+++ b/addons/crm/wizard/crm_lead_lost.py
@@ -9,7 +9,7 @@ from odoo.tools.mail import is_html_empty
 class CrmLeadLost(models.TransientModel):
     _description = 'Get Lost Reason'
 
-    lead_ids = fields.Many2many('crm.lead', string='Leads')
+    lead_ids = fields.Many2many('crm.lead', string='Leads', context={"active_test": False})
     lost_reason_id = fields.Many2one('crm.lost.reason', 'Lost Reason')
     lost_feedback = fields.Html(
         'Closing Note', sanitize=True

--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -106,8 +106,8 @@ class WebsiteAccount(CustomerPortal):
             'overdue': {'label': _('Late Activities'), 'domain': [('activity_date_deadline', '<', today)]},
             'today': {'label': _('Today Activities'), 'domain': [('activity_date_deadline', '=', today)]},
             'future': {'label': _('Future Activities'), 'domain': [('activity_date_deadline', '>', today)]},
-            'won': {'label': _('Won'), 'domain': [('stage_id.is_won', '=', True)]},
-            'lost': {'label': _('Lost'), 'domain': [('active', '=', False), ('probability', '=', 0)]},
+            'won': {'label': _('Won'), 'domain': [('is_won', '=', True)]},
+            'lost': {'label': _('Lost'), 'domain': [('is_lost', '=', True)]},
         }
         searchbar_sortings = {
             'date': {'label': _('Newest'), 'order': 'create_date desc'},

--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -106,8 +106,8 @@ class WebsiteAccount(CustomerPortal):
             'overdue': {'label': _('Late Activities'), 'domain': [('activity_date_deadline', '<', today)]},
             'today': {'label': _('Today Activities'), 'domain': [('activity_date_deadline', '=', today)]},
             'future': {'label': _('Future Activities'), 'domain': [('activity_date_deadline', '>', today)]},
-            'won': {'label': _('Won'), 'domain': [('is_won', '=', True)]},
-            'lost': {'label': _('Lost'), 'domain': [('is_lost', '=', True)]},
+            'won': {'label': _('Won'), 'domain': [('won_status', '=', 'won')]},
+            'lost': {'label': _('Lost'), 'domain': [('won_status', '=', 'lost')]},
         }
         searchbar_sortings = {
             'date': {'label': _('Newest'), 'order': 'create_date desc'},


### PR DESCRIPTION
BEFORE:

LOST:     0% and not active
WON:    100% and active


NOW:  

LOST:     0% and not active
WON:    stage won and 100% proba (!this should be implied!)



Purpose
=======
Ribbons and buttons display + PLS won/lost frequency rules should be aligned.
 --> Redefine Won / Lost heuristic and apply it everywhere.

Specification
=============

"New heuristic":
Lost: Proba = 0 AND archived (and not in won stage)
Won: won stage AND 100% (was previously: won stage and active)
	(Won stage implies 100%.)

That means that even if a lead is archived, it is still considered as won if
he is in won stage. That also mean that we should block the edition of
probability in won stage as it should always be 100%.
In the same way, we should block edition on probability if the lead is lost.

Won / lost ribbons display rules should be aligned.

That also implies to change a bit the rules to handle won/lost frequencies

- Set to Won Stage (>WS) : Reach Won
	If probability was 0 and active was False: Leave Lost
- Move out from Won stage (<WS) : Leave Won
	If active was False and Proba = 0 -> This should never happen
- Archive: If set proba=0 or proba was 0: Reach Lost
- Restore: Leave Lost

Special cases :
- Out of WS (Won Stage) + Archive : "Leave Won"
	Later, if set P = 0% -> trigger "Reach Lost".
- In WS + Archive : Reach Won
	If proba set to 0 -> Should never happen
- Out of WS + Restore: Leave Won
- In WS + Restore: Reach Won
	If proba was 0 : Leave Lost

This commit adds two fields on crm.lead to ease domains to display/hide 
fields, buttons and ribbons:
- is_lost: computed on active=False AND proba = 0. Tracking enbaled to follow
	the state of the lead in the chatter. (when it was lost or restored)
- is_won: related to the stage_id.won_stage. Used to know if the lead is won.
	As won = in won stage.

Review the Restore vs Unarchive:
- Unarchive = set active=True
- Restore = Unarchive + force automated probability (and it's recomputation).
Restore button is displayed only on lost leads.

Probabilty is set to readonly mode when the lead is won or lost. This is to
avoid inconsistencies between the state of the lead and it's probability.

Why oh why ?
============

Before this change, the old won/lost rules where the following:
Lost: Proba = 0 OR archived
Won: won stage AND active

Which means that both rules could have coexisted. If the lead were in won stage,
active but probability = 0%. (that should not happens but was still allowed).
The objective with the new rules is to use the probability as a necessary
but not sufficient criteriat. Probability makes it impossible to be both
lost and won. But probability is not sufficient to classify a lead as won or
lost.
0% does not mean it's lost, it must also be archived.
100% does not mean it's won, it must also be in won stage.

That will avoid having automatically lost or won leads.
If Predictive lead scoring computes 0% or 100% chance of winning, the lead will
not be flagged yet as lost or won and the user will still need to take action to
correctly classify the lead.

Task-2654916