### PR TITLE
[FIX] stock: avoid write on move when create return line

### DIFF
--- a/addons/stock/tests/__init__.py
+++ b/addons/stock/tests/__init__.py
@@ -14,6 +14,7 @@ from . import test_packing_neg
 from . import test_proc_rule
 from . import test_wise_operator
 from . import test_report
+from . import test_stock_return_picking
 
 # TODO enable this test: error on runbot to create asset and open the iframe
 # from . import test_ui

--- a/addons/stock/tests/test_stock_return_picking.py
+++ b/addons/stock/tests/test_stock_return_picking.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+from odoo.addons.stock.tests.common import TestStockCommon
+
+class TestReturnPicking(TestStockCommon):
+
+    def test_stock_return_picking_line_creation(self):
+        StockReturnObj = self.env['stock.return.picking']
+
+        picking_out = self.PickingObj.create({
+            'partner_id': self.partner_agrolite_id,
+            'picking_type_id': self.picking_type_out,
+            'location_id': self.stock_location,
+            'location_dest_id': self.customer_location})
+        move_1 = self.MoveObj.create({
+            'name': self.UnitA.name,
+            'product_id': self.UnitA.id,
+            'product_uom_qty': 2,
+            'product_uom': self.uom_unit.id,
+            'picking_id': picking_out.id,
+            'location_id': self.stock_location,
+            'location_dest_id': self.customer_location})
+        move_2 = self.MoveObj.create({
+            'name': self.UnitA.name,
+            'product_id': self.UnitA.id,
+            'product_uom_qty': 1,
+            'product_uom': self.uom_dozen.id,
+            'picking_id': picking_out.id,
+            'location_id': self.stock_location,
+            'location_dest_id': self.customer_location})
+        picking_out.action_confirm()
+        picking_out.action_assign()
+        move_1.quantity_done = 2
+        move_2.quantity_done = 1
+        picking_out.button_validate()
+        return_wizard = StockReturnObj.with_context(active_id=picking_out.id, active_ids=picking_out.ids).create({
+            'location_id': self.stock_location,
+            'picking_id': picking_out.id,
+        })
+        return_wizard._onchange_picking_id()
+
+        ReturnPickingLineObj = self.env['stock.return.picking.line']
+        # Check return line of uom_unit move
+        return_line = ReturnPickingLineObj.search([('move_id', '=', move_1.id), ('wizard_id.picking_id', '=', picking_out.id)], limit=1)
+        self.assertEqual(return_line.product_id.id, self.UnitA.id, 'Return line should have exact same product as outgoing move')
+        self.assertEqual(return_line.uom_id.id, self.uom_unit.id, 'Return line should have exact same uom as product uom')
+        # Check return line of uom_dozen move
+        return_line = ReturnPickingLineObj.search([('move_id', '=', move_2.id), ('wizard_id.picking_id', '=', picking_out.id)], limit=1)
+        self.assertEqual(return_line.product_id.id, self.UnitA.id, 'Return line should have exact same product as outgoing move')
+        self.assertEqual(return_line.uom_id.id, self.uom_unit.id, 'Return line should have exact same uom as product uom')
+

--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -14,7 +14,7 @@ class ReturnPickingLine(models.TransientModel):
 
     product_id = fields.Many2one('product.product', string="Product", required=True, domain="[('id', '=', product_id)]")
     quantity = fields.Float("Quantity", digits=dp.get_precision('Product Unit of Measure'), required=True)
-    uom_id = fields.Many2one('uom.uom', string='Unit of Measure', related='move_id.product_uom', readonly=False)
+    uom_id = fields.Many2one('uom.uom', string='Unit of Measure', related='product_id.uom_id')
     wizard_id = fields.Many2one('stock.return.picking', string="Wizard")
     move_id = fields.Many2one('stock.move', "Move")
 


### PR DESCRIPTION
When creating a wizard `stock.return.picking` and call
`_onchange_picking_id`, the creation of return picking line will perform
a write on move linked with it, due to `uom_id` being set as related with
`readonly=False`. Set `readonly` to `True` to avoid it

This starts with #76923

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
