### PR TITLE
[FIX] website_slides: build a correct form in Courses

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -158,7 +158,7 @@ class Slide(models.Model):
     document_id = fields.Char('Document ID', help="Youtube or Google Document ID")
     link_ids = fields.One2many('slide.slide.link', 'slide_id', string="External URL for this slide")
     mime_type = fields.Char('Mime-type')
-    html_content = fields.Html("HTML Content", help="Custom HTML content for slides of type 'Web Page'.", translate=True, sanitize_form=False)
+    html_content = fields.Html("HTML Content", help="Custom HTML content for slides of type 'Web Page'.", translate=True, sanitize_attributes=False, sanitize_form=False)
     # website
     website_id = fields.Many2one(related='channel_id.website_id', readonly=True)
     date_published = fields.Datetime('Publish Date', readonly=True, tracking=True)


### PR DESCRIPTION
How to reproduce the problem:
- Install the website_slides modules
- Go to the website -> Courses -> choose a course -> Add Content (Webpage)
- In the new Webpage -> Edit -> Drag and drop a Form Builder -> Save
The form is unusable: you can't write in the form's fields.

Cause of the problem : usefull attributes and values of the form were
removed due to the sanitizing of the HTML component.

Solution : the HTML components in slide are not sanitized anymore,
in order to keep valuable information for building forms.

Huuuge thanks to @abz-odoo for his great help on finding the bug <3

opw-2588089