### PR TITLE
[FIX] industry_fsm: fix locale for start hour displayed on the kanban

### DIFF
--- a/addons/project/static/src/js/project_kanban.js
+++ b/addons/project/static/src/js/project_kanban.js
@@ -68,7 +68,7 @@ const ProjectTaskKanbanColumn = KanbanColumn.extend({
     },
 });
 
-const ProjectTaskKanbanRenderer = KanbanRenderer.extend({
+export const ProjectTaskKanbanRenderer = KanbanRenderer.extend({
     config: Object.assign({}, KanbanRenderer.prototype.config, {
         KanbanColumn: ProjectTaskKanbanColumn,
     }),


### PR DESCRIPTION
... card

Description of the issue/feature this PR addresses:
In the kanban view of industry_fsm, the start time is hardcoded in 12 hours format.
The start time should be based on the user's time format

Current behavior before PR:
The start time is displayed in 12 hours format

Desired behavior after PR is merged:
The start time is displayed in 12 or 24 hours format according to the user's preferences.
The date is displayed according to user's preferences

task-2634340

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
