### PR TITLE
[FIX] purchase: open orderpoint same date than confirmation

### DIFF
--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -3,6 +3,7 @@
 
 from datetime import datetime as dt
 from datetime import timedelta as td
+from freezegun import freeze_time
 
 from odoo import SUPERUSER_ID
 from odoo.tests import Form
@@ -10,6 +11,7 @@ from odoo.tests.common import SavepointCase
 from odoo.exceptions import UserError
 
 
+@freeze_time("2021-01-14 09:12:15")
 class TestReorderingRule(SavepointCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Testing orderpoint generation assumes the whole test is done the same
day. The assert could failed if the test is run right before midnight
and end the day after.

This commit ensure the time is frozen during all the tests about
orderpoints generation

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
