### PR TITLE
[FIX] stock: fix blocking generate lots name

### DIFF
--- a/addons/stock/models/stock_production_lot.py
+++ b/addons/stock/models/stock_production_lot.py
@@ -40,8 +40,8 @@ class ProductionLot(models.Model):
         # We look if the first lot contains at least one digit.
         caught_initial_number = regex_findall(r"\d+", first_lot)
         if not caught_initial_number:
-            raise UserError(_('The lot name must contain at least one digit.'))
-        # We base the serie on the last number found in the base lot.
+            return self.generate_lot_names(first_lot + "0", count)
+        # We base the series on the last number found in the base lot.
         initial_number = caught_initial_number[-1]
         padding = len(initial_number)
         # We split the lot name to get the prefix and suffix.

--- a/addons/stock/tests/test_generate_serial_numbers.py
+++ b/addons/stock/tests/test_generate_serial_numbers.py
@@ -191,14 +191,16 @@ class StockGenerate(TransactionCase):
             default_move_id=move.id,
             default_next_serial_number='code-xxx',
         ))
-        wiz = form_wizard.save()
-        with self.assertRaises(UserError):
-            wiz.generate_serial_numbers()
 
         form_wizard.next_serial_count = 0
         # Must raise an exception because `next_serial_count` must be greater than 0.
         with self.assertRaises(ValidationError):
             form_wizard.save()
+
+        form_wizard.next_serial_count = 3
+        wiz = form_wizard.save()
+        wiz.generate_serial_numbers()
+        self.assertEqual(move.move_line_nosuggest_ids.mapped('lot_name'), ["code-xxx0", "code-xxx1", "code-xxx2"])
 
     def test_generate_04_generate_in_multiple_time(self):
         """ Generates a Serial Number for each move lines (except the last one)


### PR DESCRIPTION
Issue, to reproduce:
- Create a product A tracked by serial
- Reciept one product A with a lot without digit
- validate this receipt, Ok
- Create a other receipt for product A,
- You cannot anymore open the detail wizard to enter a
SN/lot : get 'The lot name must contain at least one digit.'

Fix:
Remove the constraint and add the possibility to generate only alpha barcode if no digit is found.
Try firts with the uppercase alphabet, then with the lowercase alphabet, and
fallback by adding "0" at the end (if there only special character).

task-2652292