### PR TITLE
[FIX] website: svg preview has been moved in theme repo

### DIFF
--- a/addons/test_website_modules/tests/test_configurator.py
+++ b/addons/test_website_modules/tests/test_configurator.py
@@ -27,7 +27,7 @@ class TestConfigurator(odoo.tests.HttpCase):
                     {"id": 4, "label": "abortion clinic"},
                     {"id": 5, "label": "abrasives supplier"},
                     {"id": 6, "label": "abundant life church"}]}
-            elif '/api/website/1/configurator/recommended_themes' in endpoint:
+            elif '/api/website/2/configurator/recommended_themes' in endpoint:
                 return []
             elif '/api/website/1/configurator/custom_resources/' in endpoint:
                 return {


### PR DESCRIPTION
Now, iap only return images urls and colors to use to process the svg.
We don't need to 'download' svg preprocess, we use the svg locally and make
the substitution our self.

It simplify the maintenance:
   Preview of theme are in theme repository
It make it blazing fast:
   Response contains a list of string, and not more a big string, the svg.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
