### PR TITLE
[FIX] mail: avoid crashing on partner created from lead

### DIFF
--- a/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.xml
+++ b/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.ComposerSuggestedRecipient" owl="1">
-        <div class="o_ComposerSuggestedRecipient" t-att-data-partner-id="suggestedRecipientInfo.partner and suggestedRecipientInfo.partner.id ? suggestedRecipientInfo.partner.id : false" t-att-title="ADD_AS_RECIPIENT_AND_FOLLOWER_REASON">
+        <div class="o_ComposerSuggestedRecipient" t-att-data-partner-id="suggestedRecipientInfo and suggestedRecipientInfo.partner and suggestedRecipientInfo.partner.id ? suggestedRecipientInfo.partner.id : false" t-att-title="ADD_AS_RECIPIENT_AND_FOLLOWER_REASON">
             <t t-if="suggestedRecipientInfo">
                 <div class="custom-control custom-checkbox">
                     <input t-attf-id="{{ id }}_checkbox" class="custom-control-input" type="checkbox" t-att-checked="suggestedRecipientInfo.isSelected ? 'checked' : undefined" t-on-change="_onChangeCheckbox" t-ref="checkbox" />

--- a/addons/mail/static/src/models/suggested_recipient_info/suggested_recipient_info.js
+++ b/addons/mail/static/src/models/suggested_recipient_info/suggested_recipient_info.js
@@ -78,6 +78,7 @@ function factory(dependencies) {
          */
         thread: many2one('mail.thread', {
             inverse: 'suggestedRecipientInfoList',
+            required: true,
         }),
     };
     SuggestedRecipientInfo.identifyingFields = ['id'];

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -2440,6 +2440,7 @@ function factory(dependencies) {
          */
         suggestedRecipientInfoList: one2many('mail.suggested_recipient_info', {
             inverse: 'thread',
+            isCausal: true,
         }),
         /**
          * Determines the last content of the last composer related to this


### PR DESCRIPTION
Delete obsolete suggested_recipient_info with isCausal and ensure thread is
required on it.

This is intended to prevent crashing when creating a new partner from a
lead.

Task-2654859