### PR TITLE
[FIX] l10n_vn: Fix typo

### DIFF
--- a/addons/l10n_vn/i18n_extra/vi_VN.po
+++ b/addons/l10n_vn/i18n_extra/vi_VN.po
@@ -65,7 +65,7 @@ msgstr "Phụ trội trái phiếu"
 #: model:account.account.template,name:l10n_vn.chart1212
 #: model:account.account.template,name:l10n_vn.chart1282
 msgid "Bonds"
-msgstr "Trái phiế"
+msgstr "Trái phiếu"
 
 #. module: l10n_vn
 #: model:account.account.template,name:l10n_vn.chart3531


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Account vietnamese typing error

Current behavior before PR:
This word `Trái phiế` has no meaning

Desired behavior after PR is merged:
This is true `Trái phiếu`



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
