### PR TITLE
[FIX] stock_landed_costs: round using the currency rounding

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -220,9 +220,9 @@ class StockLandedCost(models.Model):
         AdjustementLines = self.env['stock.valuation.adjustment.lines']
         AdjustementLines.search([('cost_id', 'in', self.ids)]).unlink()
 
-        digits = self.env['decimal.precision'].precision_get('Product Price')
         towrite_dict = {}
         for cost in self.filtered(lambda cost: cost._get_targeted_move_ids()):
+            rounding = cost.currency_id.rounding
             total_qty = 0.0
             total_cost = 0.0
             total_weight = 0.0
@@ -239,7 +239,7 @@ class StockLandedCost(models.Model):
 
                 former_cost = val_line_values.get('former_cost', 0.0)
                 # round this because former_cost on the valuation lines is also rounded
-                total_cost += tools.float_round(former_cost, precision_digits=digits) if digits else former_cost
+                total_cost += cost.currency_id.round(former_cost)
 
                 total_line += 1
 
@@ -265,8 +265,8 @@ class StockLandedCost(models.Model):
                         else:
                             value = (line.price_unit / total_line)
 
-                        if digits:
-                            value = tools.float_round(value, precision_digits=digits, rounding_method='UP')
+                        if rounding:
+                            value = tools.float_round(value, precision_rounding=rounding, rounding_method='UP')
                             fnc = min if line.price_unit > 0 else max
                             value = fnc(value, line.price_unit - value_split)
                             value_split += value


### PR DESCRIPTION
In some cases, it is impossible to validate some landed costs ("Cost and
adjustments lines do not match.[...]")

To reproduce the issue:
(Enable debug mode)
1. Set the Decimal Accuracy of Product Price to 4
2. Create a Product Category PC:
    - Costing Method: FIFO
3. Create 4 storable products (category PC)
4. Create a service product (landed cost)
5. Create a PO with the 4 products:
    - 6 x $0.92
    - 6 x $0.92
    - 3 x $75.17
    - 6 x $20.54
6. Process the delivery D
7. Create a Landed Cost:
    - Delivery: D
    - Product: the service product
        - Split Method: By Quantity
        - Cost: $1000
8. Compute the landed costs + Validate

Error: a User Error is raised "Cost and adjustments lines do not match.
You should maybe recompute the landed costs.". The sum of the additional
landed cost equals $999.99 instead of $1000

From version 14, `additional_landed_cost` is a Monetary field and its
rounding property is no more based on "Product Price":
https://github.com/odoo/odoo/blob/800433bde03a36ead40a78bc6d53cbb95c24f97b/addons/stock_landed_costs/models/stock_landed_cost.py#L371-L372
Therefore, we should use the rounding of the associated currency to
round its value

OPW-2637701
OPW-2631718
OPW-2649348