### PR TITLE
[FIX] website: don't show empty burger menu on mobile

### DIFF
--- a/addons/website/views/website_navbar_templates.xml
+++ b/addons/website/views/website_navbar_templates.xml
@@ -33,7 +33,7 @@
                     </li>
                 </ul>
 
-                <button type="button" class="fa fa-bars float-right d-block d-md-none o_mobile_menu_toggle" aria-label="Menu" title="Menu"/>
+                <button type="button" class="fa fa-bars float-right d-block d-md-none o_mobile_menu_toggle" aria-label="Menu" title="Menu" groups="website.group_website_designer"/>
 
                 <ul class="o_menu_sections" groups="website.group_website_designer">
                     <!-- Content -->


### PR DESCRIPTION
When the current app doesn't provide menu-items (or the user doesn't
have the rights to access them), the mobile burger menu should fallback
to the user menu instead of an empty one (like on the App Switcher).

task-2345001