### PR TITLE
[FIX] hr_holidays: fix displaying negative allocations

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -280,7 +280,7 @@ class HolidaysType(models.Model):
 
     @api.model
     def get_days_all_request(self):
-        leave_types = sorted(self.search([]).filtered(lambda x: ((x.virtual_remaining_leaves or x.max_leaves))), key=self._model_sorting_key, reverse=True)
+        leave_types = sorted(self.search([]).filtered(lambda x: ((x.virtual_remaining_leaves > 0 or x.max_leaves))), key=self._model_sorting_key, reverse=True)
         return [lt._get_days_request() for lt in leave_types]
 
     def _get_days_request(self):

--- a/addons/hr_holidays_attendance/static/src/xml/time_off_calendar.xml
+++ b/addons/hr_holidays_attendance/static/src/xml/time_off_calendar.xml
@@ -9,7 +9,7 @@
                     <img height="30px" t-attf-src="{{timeoff[1]['icon']}}"/>
                 </t>
                 <span t-esc="timeoff[1]['virtual_remaining_leaves']" class="o_timeoff_huge o_timeoff_purple font-weight-bold align-middle"/><br/>
-                <span class="o_timeoff_big o_timeoff_purple">HOURS AVAILABLE</span>
+                <span class="o_timeoff_purple">HOURS AVAILABLE</span>
             </t>
         </xpath>
         <!--change t-if to t-elif-->


### PR DESCRIPTION
When the attendance app is installed and the extra hours option is
enabled, it could happend that we have an allocation with negative
virtual_remaining_leaves, however it does not make sense to display it
to the user.
This commit filters out that possibility from showing on the dashboard.

TaskId-2655689
