### PR TITLE
packaging: add pyopenssl to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'psycopg2 >= 2.2',
         'pydot',
         'pypdf2',
+        'pyopenssl',
         'pyserial',
         'python-dateutil',
         'python-stdnum',
@@ -59,7 +60,6 @@ setup(
     python_requires='>=3.6',
     extras_require={
         'ldap': ['python-ldap'],
-        'SSL': ['pyopenssl'],
     },
     tests_require=[
         'freezegun',


### PR DESCRIPTION
pyopenssl is a required dependency of the base module (via ir_mail_server.py),
so add it to setup.py install_requires instead of an extra.

Description of the issue/feature this PR addresses:

Make Odoo saas-14.5 work out of the the box after a pip install in a fresh virtualenv.

@d-fence 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
