### PR TITLE
[FIX] account: fix manual reconciliation widget

### DIFF
--- a/addons/account/static/src/js/reconciliation/reconciliation_model.js
+++ b/addons/account/static/src/js/reconciliation/reconciliation_model.js
@@ -686,7 +686,7 @@ var StatementModel = BasicModel.extend({
                 this._computeReconcileModels(handle, prop.reconcileModelId);
             }
         }
-        if ('account_id' in values || 'amount' in values || 'tax_id' in values  || 'force_tax_included' in values) {
+        if ('label' in values || 'account_id' in values || 'amount' in values || 'tax_id' in values  || 'force_tax_included' in values) {
             prop.__tax_to_recompute = true;
 
             if(values.tax_id){

--- a/addons/account/static/src/js/reconciliation/reconciliation_renderer.js
+++ b/addons/account/static/src/js/reconciliation/reconciliation_renderer.js
@@ -545,7 +545,7 @@ var LineRenderer = Widget.extend(FieldManagerMixin, {
             relation: 'account.journal',
             type: 'many2one',
             name: 'journal_id',
-            domain: [['company_id', '=', state.st_line.company_id]],
+            domain: [['company_id', '=', state.st_line.company_id], ['type', '=', 'general']],
         }, {
             relation: 'account.tax',
             type: 'many2one',

--- a/addons/account/views/account_view.xml
+++ b/addons/account/views/account_view.xml
@@ -906,7 +906,7 @@
                                     <field name="amount" class="oe_inline"/>
                                     <span class="o_form_label oe_inline" attrs="{'invisible':[('amount_type','!=','percentage')]}">%</span>
                                 </div>
-                                <field name="journal_id" domain="[('type', '!=', 'general'), ('company_id', '=', company_id)]" widget="selection"
+                                <field name="journal_id" domain="[('type', '=', 'general'), ('company_id', '=', company_id)]" widget="selection"
                                        attrs="{'invisible': [('rule_type', '!=', 'writeoff_button')]}"/>
                             </group>
                         </group>


### PR DESCRIPTION
- On “Manually create a write-off on clicked button.” type models, change counterpart value
  journal domain to show only journal with type general.
- Add domain to journal_id in manual create writeoff form to only show "general" type journals
- Add "label" to parameters that force tax recompute when changed on a line update.
  Needed because setting the label can change the "invalid" value of a proposition.
  If that is the case, taxes related to this proposition must also have their "invalid" updated.

Task: 2611348