### PR TITLE
[FIX] account: fix manual reconciliation widget

### DIFF
--- a/addons/account/static/src/js/reconciliation/reconciliation_model.js
+++ b/addons/account/static/src/js/reconciliation/reconciliation_model.js
@@ -686,7 +686,7 @@ var StatementModel = BasicModel.extend({
                 this._computeReconcileModels(handle, prop.reconcileModelId);
             }
         }
-        if ('account_id' in values || 'amount' in values || 'tax_id' in values  || 'force_tax_included' in values) {
+        if ('label' in values || 'account_id' in values || 'amount' in values || 'tax_id' in values  || 'force_tax_included' in values) {
             prop.__tax_to_recompute = true;
 
             if(values.tax_id){

--- a/addons/account/static/src/js/reconciliation/reconciliation_renderer.js
+++ b/addons/account/static/src/js/reconciliation/reconciliation_renderer.js
@@ -545,7 +545,7 @@ var LineRenderer = Widget.extend(FieldManagerMixin, {
             relation: 'account.journal',
             type: 'many2one',
             name: 'journal_id',
-            domain: [['company_id', '=', state.st_line.company_id]],
+            domain: [['company_id', '=', state.st_line.company_id], ['type', '=', 'general']],
         }, {
             relation: 'account.tax',
             type: 'many2one',

--- a/addons/account/static/tests/reconciliation_tests.js
+++ b/addons/account/static/tests/reconciliation_tests.js
@@ -113,10 +113,11 @@ var db = {
         fields: {
             id: {string: "ID", type: 'integer'},
             display_name: {string: "Displayed name", type: 'char'},
+            type: {string: "Type", type: 'char'},
             company_id: {string: "Company", type: 'many2one', relation: 'res.company'},
         },
         records: [
-            {id: 8, display_name: "company 1 journal", company_id: 1}
+            {id: 8, display_name: "company 1 journal", type:'general', company_id: 1}
         ]
     },
     'account.analytic.account': {
@@ -1739,7 +1740,7 @@ QUnit.module('account', {
                     assert.deepEqual(
                         _.pick(args.args[0][0].new_mv_line_dicts[1 - idx],
                                'account_id', 'name', 'credit', 'debit', 'tax_line_id'),
-                        {account_id: 287, name: "Tax 20.00%", credit: 0, debit: 36, tax_line_id: 6},
+                        {account_id: 287, name: "dummy text Tax 20.00%", credit: 0, debit: 36, tax_line_id: 6},
                         "Reconciliation rpc payload, new_mv_line_dicts.tax is correct"
                     );
                 }
@@ -1802,7 +1803,7 @@ QUnit.module('account', {
             "Tax line account number is valid");
         assert.equal($($newLineTaxeTds[2]).text().trim(), "New",
             "Tax line is flagged as new");
-        assert.equal($($newLineTaxeTds[3]).text().trim(), "Tax 20.00%",
+        assert.equal($($newLineTaxeTds[3]).text().trim(), "dummy text Tax 20.00%",
             "Tax line has the correct label");
         assert.equal($($newLineTaxeTds[4]).text().trim(), "36.00",
             "Tax line has the correct left amount");

--- a/addons/account/views/account_view.xml
+++ b/addons/account/views/account_view.xml
@@ -906,7 +906,7 @@
                                     <field name="amount" class="oe_inline"/>
                                     <span class="o_form_label oe_inline" attrs="{'invisible':[('amount_type','!=','percentage')]}">%</span>
                                 </div>
-                                <field name="journal_id" domain="[('type', '!=', 'general'), ('company_id', '=', company_id)]" widget="selection"
+                                <field name="journal_id" domain="[('type', '=', 'general'), ('company_id', '=', company_id)]" widget="selection"
                                        attrs="{'invisible': [('rule_type', '!=', 'writeoff_button')]}"/>
                             </group>
                         </group>


### PR DESCRIPTION
- On “Manually create a write-off on clicked button.” type models, change counterpart value
  journal domain to show only journal with type general.
- Add domain to journal_id in manual create writeoff form to only show "general" type journals
- Add "label" to parameters that force tax recompute when changed on a line update.
  Needed because setting the label can change the "invalid" value of a proposition.
  If that is the case, taxes related to this proposition must also have their "invalid" updated.

Task: 2611348