### PR TITLE
[FIX] account: fix manual reconciliation widget

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -293,10 +293,10 @@ class AccountReconcileModel(models.Model):
         for tax_res in res['taxes']:
             tax = self.env['account.tax'].browse(tax_res['id'])
             balance = tax_res['amount']
-
+            name = ' '.join([x for x in [base_line_dict.get('name', ''), tax_res['name']] if x])
             new_aml_dicts.append({
                 'account_id': tax_res['account_id'] or base_line_dict['account_id'],
-                'name': tax_res['name'],
+                'name': name,
                 'partner_id': base_line_dict.get('partner_id'),
                 'balance': balance,
                 'debit': balance > 0 and balance or 0,
@@ -366,6 +366,7 @@ class AccountReconcileModel(models.Model):
                 'analytic_account_id': line.analytic_account_id.id,
                 'analytic_tag_ids': [(6, 0, line.analytic_tag_ids.ids)],
                 'reconcile_model_id': self.id,
+                'journal_id': line.journal_id.id,
             }
             lines_vals_list.append(writeoff_line)
 

--- a/addons/account/views/account_reconcile_model_views.xml
+++ b/addons/account/views/account_reconcile_model_views.xml
@@ -180,13 +180,13 @@
                                 <tree editable="bottom">
                                     <field name="account_id"/>
                                     <field name="amount_type"/>
-                                    <field name="journal_id" attrs="{'column_invisible': [('parent.rule_type', '!=', 'writeoff_button')]}"/>
+                                    <field name="journal_id" attrs="{'column_invisible': [('parent.rule_type', '!=', 'writeoff_button')]}" optional="hide"/>
                                     <field name="amount_string"/>
-                                    <field name="tax_ids" widget="many2many_tags"/>
-                                    <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
-                                    <field name="analytic_tag_ids" groups="analytic.group_analytic_tags" widget="many2many_tags"/>
+                                    <field name="tax_ids" widget="many2many_tags" optional="hide"/>
+                                    <field name="analytic_account_id" groups="analytic.group_analytic_accounting" optional="hide"/>
+                                    <field name="analytic_tag_ids" groups="analytic.group_analytic_tags" widget="many2many_tags"  optional="hide"/>
                                     <field name="show_force_tax_included" invisible="1"/>
-                                    <field name="force_tax_included" attrs="{'invisible': [('show_force_tax_included', '=', False)]}" widget="boolean_toggle"/>
+                                    <field name="force_tax_included" attrs="{'invisible': [('show_force_tax_included', '=', False)]}" widget="boolean_toggle" optional="hide"/>
                                     <field name="company_id" invisible="1"/>
                                     <field name="label"/>
                                 </tree>


### PR DESCRIPTION
- set journal_id, tax_ids, analytic_account_id, analytic_tag_ids & force_tax_included as optional hide
- fix _get_write_off_move_lines_dict to make clicking a reconciliation model button have the same result as doing the operation manually :
    - add journal_id parameter
    - use reco line label in new aml name

Task: 2611348