### PR TITLE
[BP][IMP] various: improves button titles for better command palette

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -624,6 +624,7 @@
                                 groups="account.group_account_invoice"/>
                         <!-- Preview (only customer invoices) -->
                         <button name="preview_invoice" type="object" string="Preview" data-hotkey="o"
+                                title="Preview invoice"
                                 attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund'))]}"/>
                         <!-- Reverse -->
                         <button name="%(action_view_account_move_reversal)d" string="Reverse Entry"

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -7,15 +7,15 @@
                 <form class="o_lead_opportunity_form" js_class="crm_form">
                     <header>
                         <button name="action_set_won_rainbowman" string="Won"
-                            type="object" class="oe_highlight" data-hotkey="w"
+                            type="object" class="oe_highlight" data-hotkey="w" title="Mark as won"
                             attrs="{'invisible': ['|','|', ('active','=',False), ('probability', '=', 100), ('type', '=', 'lead')]}"/>
-                        <button name="%(crm.crm_lead_lost_action)d" string="Lost" data-hotkey="l"
+                        <button name="%(crm.crm_lead_lost_action)d" string="Lost" data-hotkey="l" title="Mark as lost"
                             type="action" context="{'default_lead_id': active_id}" attrs="{'invisible': ['|', ('type', '=', 'lead'),('active', '=', False),('probability', '&lt;', 100)]}"/>
                         <button name="%(crm.action_crm_lead2opportunity_partner)d" string="Convert to Opportunity" type="action" help="Convert to Opportunity"
                             class="oe_highlight" attrs="{'invisible': ['|', ('type', '=', 'opportunity'), ('active', '=', False)]}" data-hotkey="v"/>
                         <button name="toggle_active" string="Restore" type="object" data-hotkey="z"
                             attrs="{'invisible': ['|', ('probability', '&gt;', 0), ('active', '=', True)]}"/>
-                        <button name="action_set_lost" string="Lost" type="object" data-hotkey="l"
+                        <button name="action_set_lost" string="Lost" type="object" data-hotkey="l" title="Mark as lost"
                             attrs="{'invisible': ['|', ('type', '=', 'opportunity'), '&amp;', ('probability', '=', 0), ('active', '=', False)]}"/>
                         <field name="stage_id" widget="statusbar"
                             options="{'clickable': '1', 'fold_field': 'fold'}"

--- a/addons/crm_iap_enrich/views/crm_lead_views.xml
+++ b/addons/crm_iap_enrich/views/crm_lead_views.xml
@@ -8,10 +8,10 @@
             <xpath expr="//button[@name='%(crm.action_crm_lead2opportunity_partner)d']" position="after">
                 <field name="show_enrich_button" invisible="1"/>
                 <button string="Enrich" name="iap_enrich" type="object" class="btn btn-secondary" data-hotkey="g"
-                title="Enrich this lead with company data based on the email address"
+                title="Enrich lead with company data"
                 attrs="{'invisible':['|',('show_enrich_button', '!=', True),('type','=','opportunity')]}"/>
                 <button string="Enrich" name="iap_enrich" type="object" class="btn btn-secondary" data-hotkey="g"
-                title="Enrich this opportunity with company data based on the email address"
+                title="Enrich opportunity with company data"
                 attrs="{'invisible':['|',('show_enrich_button', '!=', True),('type','=','lead')]}"/>
             </xpath>
         </field>

--- a/addons/sale_crm/views/crm_lead_views.xml
+++ b/addons/sale_crm/views/crm_lead_views.xml
@@ -8,6 +8,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//button[@name='action_set_won_rainbowman']" position="before">
                     <button string="New Quotation" name="action_sale_quotations_new" type="object" class="oe_highlight" data-hotkey="q"
+                        title="Create new quotation"
                         attrs="{'invisible': ['|', ('type', '=', 'lead'), '&amp;', ('probability', '=', 0), ('active', '=', False)]}"/>
                 </xpath>
                 <button name="action_set_won_rainbowman" position="attributes">


### PR DESCRIPTION
Backport of odoo/odoo@c1ea516aa701dde77149348d31fdd08f46550004 as we think this is important
to have in 14.5 to ease command palette usage.

Currently, in some of the important business objects' form views,
few header buttons are missing the title, and so the command palette
displays the button string which is not very clear/useful.

This commit improves the behavior by adding titles to the buttons. Below
are the model wise actions/methods linked with updated buttons:

 - preview_invoice (account.move)
 - action_sale_quotations_new (crm.lead)
 - action_set_lost (crm.lead)
 - action_set_won_rainbowman (crm.lead)
 - crm_lead_lost_action (crm.lead)
 - iap_enrich (crm.lead)

Task-2622266
