### PR TITLE
[IMP] barcode_gs1_nomenclature, stock: add/update demo data for GS1 demo data

### DIFF
--- a/addons/barcodes_gs1_nomenclature/data/barcodes_gs1_rules.xml
+++ b/addons/barcodes_gs1_nomenclature/data/barcodes_gs1_rules.xml
@@ -180,10 +180,22 @@
             <field name="gs1_decimal_usage">True</field>
         </record>
 
+        <record id="barcode_rule_gs1_316y" model="barcode.rule">
+            <field name="name">Net volume, cubic metres (variable measure trade item)</field>
+            <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
+            <field name="sequence">115</field>
+            <field name="encoding">gs1-128</field>
+            <field name="pattern">(316[0-5])(\d{6})</field>
+            <field name="associated_uom_id" ref="uom.product_uom_cubic_meter"/>
+            <field name="type">quantity</field>
+            <field name="gs1_content_type">measure</field>
+            <field name="gs1_decimal_usage">True</field>
+        </record>
+
         <record id="barcode_rule_gs1_321y" model="barcode.rule">
             <field name="name">Length or first dimension, inches (variable measure trade item)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">115</field>
+            <field name="sequence">116</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(321[0-5])(\d{6})</field>
             <field name="associated_uom_id" ref="uom.product_uom_inch"/>
@@ -195,10 +207,22 @@
         <record id="barcode_rule_gs1_357y" model="barcode.rule">
             <field name="name">Net weight (or volume), ounces (variable measure trade item)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">116</field>
+            <field name="sequence">117</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(357[0-5])(\d{6})</field>
             <field name="associated_uom_id" ref="uom.product_uom_oz"/>
+            <field name="type">quantity</field>
+            <field name="gs1_content_type">measure</field>
+            <field name="gs1_decimal_usage">True</field>
+        </record>
+
+        <record id="barcode_rule_gs1_365y" model="barcode.rule">
+            <field name="name">Net volume, cubic feet (variable measure trade item)</field>
+            <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
+            <field name="sequence">118</field>
+            <field name="encoding">gs1-128</field>
+            <field name="pattern">(365[0-5])(\d{6})</field>
+            <field name="associated_uom_id" ref="uom.product_uom_cubic_foot"/>
             <field name="type">quantity</field>
             <field name="gs1_content_type">measure</field>
             <field name="gs1_decimal_usage">True</field>

--- a/addons/stock/data/stock_demo.xml
+++ b/addons/stock/data/stock_demo.xml
@@ -14,7 +14,6 @@
         <record id="package_type_01" model="stock.package.type">
             <field name="name">Pallet</field>
             <field name="barcode">PAL</field>
-            <field name="company_id" ref="base.main_company"/>
             <field name="max_weight">4000</field>
             <field name="width">800</field>
             <field name="height">130</field>
@@ -24,7 +23,6 @@
         <record id="package_type_02" model="stock.package.type">
             <field name="name">Box</field>
             <field name="barcode">BOX</field>
-            <field name="company_id" ref="base.main_company"/>
             <field name="max_weight">30</field>
             <field name="width">362</field>
             <field name="height">374</field>


### PR DESCRIPTION
We want to add GS1 barcode demo data/flows. To support this, we tweak some small things:

- Add GS1 2 volume rules so we can match our demo data to the existing office furniture demo theme
- Make existing package types demo data company agnostic otherwise we cannot assign them in our demo (Put in Pack results in a package with no company until validation, which was making it so we couldn't choose the demo package types before validating)

Task: 2623434
ENT PR: odoo/enterprise#21179

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
