### PR TITLE
[FIX] stock: on_hand _search method perf improvement

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -134,8 +134,9 @@ class StockQuant(models.Model):
         """Handle the "on_hand" filter, indirectly calling `_get_domain_locations`."""
         if operator not in ['=', '!='] or not isinstance(value, bool):
             raise UserError(_('Operation not supported'))
-        domain_loc = self.env['product.product']._get_domain_locations()[0]
-        quant_ids = [l['id'] for l in self.env['stock.quant'].search_read(domain_loc, ['id'])]
+        domain_loc = self.env['product.product'].with_context(compute_child=False)._get_domain_locations()[0]
+        location_ids = self.env['stock.location']._search([('id', 'child_of', domain_loc[0][2])])
+        quant_ids = self.env['stock.quant']._search([('location_id', 'in', location_ids)])
         if (operator == '!=' and value is True) or (operator == '=' and value is False):
             domain_operator = 'not in'
         else:


### PR DESCRIPTION
The search method of `stock.quant.on_hand` currently 
gets the domain_locations from product.product before doing a search_read on stock.quant.

This is fine but searching on location_id is a bit slow because
it needs to pattern match on location_id.parent_path.

Indeed, when pattern matching on `parent_path`, the resulting query looks something like
`unaccent(location_id.parent_path::text) like unaccent('1/66/%')`. In psql (tested on 10.15)
this makes the query plan goes from _Nested Loop_ + _Index Scan_ -> _Hash Join_ + _Seq Scan_
when the number of records > 400.

Since there are usually more stock_quants than active stock_locations in a customer DB, this PR should
improve `_search_on_hand` overall performances on average.

#### speedup

In the ticket's customer DB, 400k stock_quants and 64 active stock_locations,
`stock_quant.search_read()` with `on_hand = True`: 8s -> 100ms.

In master, #76436 tackles this issue by removing `unaccent` for `parent_path`. So this branch doesn't need to be FP to master.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
