### PR TITLE
[FIX] sale: correctly get AML lines with downpayment

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -12,7 +12,7 @@ class AccountMove(models.Model):
     def action_post(self):
         #inherit of the function from account.move to validate a new tax and the priceunit of a downpayment
         res = super(AccountMove, self).action_post()
-        line_ids = self.mapped('line_ids').filtered(lambda line: line.sale_line_ids.is_downpayment)
+        line_ids = self.mapped('line_ids').filtered(lambda line: any(sol.is_downpayment for sol in line.sale_line_ids))
         for line in line_ids:
             try:
                 line.sale_line_ids.tax_id = line.tax_ids


### PR DESCRIPTION
Steps:
 - Create AML which is linked to multiple Down payment SO lines
 - Post Invoice

Issue:

 - Traeback due to accessing field on m2m `sale_line_ids` field

Fix:
- Filter the SO lines based on `is_downpayment` field.
Fixes: #77028

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
