### PR TITLE
[FIX] maintenance: allow to search using serial_no

### DIFF
--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -104,9 +104,9 @@ class MaintenanceEquipment(models.Model):
         args = args or []
         equipment_ids = []
         if name:
-            equipment_ids = self._search([('name', '=', name)] + args, limit=limit, access_rights_uid=name_get_uid)
+            equipment_ids = self._search(['|', ('name', '=', name), ('serial_no', '=', name)] + args, limit=limit, access_rights_uid=name_get_uid)
         if not equipment_ids:
-            equipment_ids = self._search([('name', operator, name)] + args, limit=limit, access_rights_uid=name_get_uid)
+            equipment_ids = self._search(['|', ('name', operator, name), ('serial_no', operator, name)] + args, limit=limit, access_rights_uid=name_get_uid)
         return equipment_ids
 
     name = fields.Char('Equipment Name', required=True, translate=True)


### PR DESCRIPTION
Before this commit, we were displaying `serial_no` for Equipment
in `name_get` but search using `serial_no` was not implemented.

With this commit, we are allowing to search using `serial_no` as well.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
