### PR TITLE
[FIX] repair: display create invoices action to valid users

### DIFF
--- a/addons/repair/wizard/repair_make_invoice_views.xml
+++ b/addons/repair/wizard/repair_make_invoice_views.xml
@@ -27,6 +27,7 @@
             <field name="target">new</field>
             <field name="binding_model_id" ref="model_repair_order"/>
             <field name="binding_view_types">list</field>
+            <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
         </record>
 
     </data>


### PR DESCRIPTION
Before this commit, Create invoices action was displayed
to all users.

With this commit, Create invoices action is displayed to
accounting users only.

This commit makes Invoicing flow consistent as 'Create Invoice' button
is visible to accounting users only on Repair order form view.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
