### PR TITLE
[FIX] hr_contract: make resource_calendar_id required

### DIFF
--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -212,7 +212,7 @@
                     <field name="name" readonly="1"/>
                     <field name="employee_id" readonly="1" widget="many2one_avatar_employee"/>
                     <field name="job_id"/>
-                    <field name="resource_calendar_id"/>
+                    <field name="resource_calendar_id" required="1"/>
                     <field name="date_start" readonly="1"/>
                     <field name="date_end" readonly="1"/>
                     <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state == 'close'" decoration-success="state == 'open'"/>


### PR DESCRIPTION
Before this commit, Field `resource_calendar_id` was not required
field in list view, due to which user was able to set it empty.
While same field `resource_calendar_id` is required on form view.

With this commit, Field `resource_calendar_id` is required in list and form view.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
