### PR TITLE
[FIX][13.0] fleet: fix some warning in console log that have same label

### DIFF
--- a/addons/fleet/i18n/af.po
+++ b/addons/fleet/i18n/af.po
@@ -1961,6 +1961,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/am.po
+++ b/addons/fleet/i18n/am.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/en_GB.po
+++ b/addons/fleet/i18n/en_GB.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/es_BO.po
+++ b/addons/fleet/i18n/es_BO.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/es_CL.po
+++ b/addons/fleet/i18n/es_CL.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/es_CO.po
+++ b/addons/fleet/i18n/es_CO.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/es_CR.po
+++ b/addons/fleet/i18n/es_CR.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/es_DO.po
+++ b/addons/fleet/i18n/es_DO.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/es_EC.po
+++ b/addons/fleet/i18n/es_EC.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/es_PE.po
+++ b/addons/fleet/i18n/es_PE.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/es_PY.po
+++ b/addons/fleet/i18n/es_PY.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/es_VE.po
+++ b/addons/fleet/i18n/es_VE.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/fo.po
+++ b/addons/fleet/i18n/fo.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/fr_CA.po
+++ b/addons/fleet/i18n/fr_CA.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/gl.po
+++ b/addons/fleet/i18n/gl.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/ka.po
+++ b/addons/fleet/i18n/ka.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/kab.po
+++ b/addons/fleet/i18n/kab.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/mk.po
+++ b/addons/fleet/i18n/mk.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/ne.po
+++ b/addons/fleet/i18n/ne.po
@@ -1957,6 +1957,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/nl_BE.po
+++ b/addons/fleet/i18n/nl_BE.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/i18n/sq.po
+++ b/addons/fleet/i18n/sq.po
@@ -1960,6 +1960,10 @@ msgstr ""
 
 #. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract_insurer_id
+msgid "Insurer"
+msgstr ""
+
+#. module: fleet
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_fuel_vendor_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_services_vendor_id
 msgid "Vendor"

--- a/addons/fleet/models/fleet_vehicle_cost.py
+++ b/addons/fleet/models/fleet_vehicle_cost.py
@@ -111,7 +111,7 @@ class FleetVehicleLogContract(models.Model):
         self.compute_next_year_date(fields.Date.context_today(self)),
         help='Date when the coverage of the contract expirates (by default, one year after begin date)')
     days_left = fields.Integer(compute='_compute_days_left', string='Warning Date')
-    insurer_id = fields.Many2one('res.partner', 'Vendor')
+    insurer_id = fields.Many2one('res.partner', 'Insurer')
     purchaser_id = fields.Many2one('res.partner', 'Driver', default=lambda self: self.env.user.partner_id.id,
         help='Person to which the contract is signed for')
     ins_ref = fields.Char('Contract Reference', size=64, copy=False)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

**Current behavior before PR:**
Two fields (vendor_id, insurer_id) of fleet.vehicle.log.contract() have the same label: Vendor.

**Desired behavior after PR is merged:**
The field vendor_id of fleet.vehicle.log.contract() have the label: Vendor.
The field insurer_id of fleet.vehicle.log.contract() have the label: Insurer.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
