### PR TITLE
[FIX] mail: prevents frozen video elements

### DIFF
--- a/addons/mail/static/src/models/rtc_session/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session/rtc_session.js
@@ -46,13 +46,9 @@ function factory(dependencies) {
 
         /**
          * cleanly removes the video stream of the session
-         *
-         * @param {Object} [param0]
-         * @param {Object} [param0.stopTracks] true if tracks have to be stopped,
-         * it is optional as tracks can be removed but still necessary for transceivers.
          */
-        removeVideo({ stopTracks = true } = {}) {
-            if (this.videoStream && stopTracks) {
+        removeVideo() {
+            if (this.videoStream) {
                 for (const track of this.videoStream.getTracks() || []) {
                     track.stop();
                 }


### PR DESCRIPTION
Before this commit, when a video track ended unexpectedly, the peers
were not notified that the remote track ended, which made it so that
inactive video elements remained on screen.

This commit fixes this issue.
