### PR TITLE
[FIX] account_check_printing: use correct name for checks layout block

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -176,7 +176,7 @@ class AccountPayment(models.Model):
         check_layout = self.company_id.account_check_printing_layout
         redirect_action = self.env.ref('account.action_account_config')
         if not check_layout or check_layout == 'disabled':
-            msg = _("You have to choose a check layout. For this, go in Invoicing/Accounting Settings, search for 'Checks layout' and set one.")
+            msg = _("You have to choose a check layout. For this, go in Invoicing/Accounting Settings, search for 'Check layout' and set one.")
             raise RedirectWarning(msg, redirect_action.id, _('Go to the configuration panel'))
         report_action = self.env.ref(check_layout, False)
         if not report_action:


### PR DESCRIPTION
Name of the block to set `Check layout` in Invoicing/Accounting Settings
 is `Check layout` not `Checks layout`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
