### PR TITLE
[FIX] account: disable group create from AML Kanban

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -91,7 +91,7 @@
             <field name="name">account.move.line.kanban</field>
             <field name="model">account.move.line</field>
             <field name="arch" type="xml">
-                <kanban class="o_kanban_mobile" create="false">
+                <kanban class="o_kanban_mobile" create="false" group_create="false">
                     <field name="date_maturity"/>
                     <field name="move_id"/>
                     <field name="name"/>


### PR DESCRIPTION
This commit removes `Add a column` from Grouped 
Kanban view of Journal Items.

Creating new Records from `Add a column` should not be supported
from Journal Items and also it is not working for Journal/Account
as required fields are not set. (and also gives Traceback)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
