### PR TITLE
[MERGE] survey: improve survey views, especially kanban

### DIFF
--- a/addons/mail/static/src/js/m2x_avatar_user.js
+++ b/addons/mail/static/src/js/m2x_avatar_user.js
@@ -194,6 +194,11 @@ export const Many2OneAvatarUser = Many2OneAvatar.extend(M2XAvatarMixin, {
 
 export const KanbanMany2OneAvatarUser = Many2OneAvatarUser.extend({
     _template: 'mail.KanbanMany2OneAvatarUser',
+
+    init() {
+        this._super(...arguments);
+        this.displayAvatarName = this.nodeOptions.display_avatar_name || false;
+    },
 });
 
 const M2MAvatarMixin = Object.assign(M2XAvatarMixin, {

--- a/addons/mail/static/src/xml/many2one_avatar_user.xml
+++ b/addons/mail/static/src/xml/many2one_avatar_user.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <!-- MailMany2OneAvatar: do not display the display_name in kanban views -->
+    <!-- MailMany2OneAvatar: do not display the display_name in kanban views unless requested -->
     <t t-name="mail.KanbanMany2OneAvatarUser" t-extend="web.Many2OneAvatar">
         <t t-jquery="img" t-operation="attributes">
             <attribute name="t-att-title">value</attribute>
         </t>
-        <t t-jquery="span" t-operation="replace"/>
+        <t t-jquery="span[t-if*='widget.mode']" t-operation="attributes">
+            <attribute name="t-if">widget.mode === 'readonly' &amp;&amp; widget.displayAvatarName</attribute>
+        </t>
     </t>
 
 </templates>

--- a/addons/survey/static/src/scss/survey_survey_views.scss
+++ b/addons/survey/static/src/scss/survey_survey_views.scss
@@ -1,26 +1,148 @@
-.o_kanban_card_survey {
-    & > .row {
-    min-height: 60px;
+// KANBAN VIEW
+.o_survey_survey_view_kanban {
+    // Common: left semi-trophy icon for certifications
+    .o_survey_kanban_card_certification {
+        background-image:
+            linear-gradient(rgba(255,255,255,.9),
+                            rgba(255,255,255,.9)),
+            url(/survey/static/src/img/trophy-solid.svg);
+        background-repeat: no-repeat;
+        background-position: bottom 6px left -45px;
+        background-size: 100%, 100px;
+    }
+
+    // Grouped / Ungrouped sections hidding
+    &.o_kanban_grouped {
+        .o_survey_kanban_card_ungrouped {
+            display:none !important;
+        }
+    }
+    &.o_kanban_ungrouped {
+        .o_survey_kanban_card_grouped {
+            display:none !important;
+        }
+    }
+
+    // Ungrouped display: whole length (kanban-list)
+    &.o_kanban_ungrouped {
+        padding: 0px;
+
+        .o_survey_kanban_card {
+            width: 100%;
+            margin: 0px;
+            border-top: 0px !important;
+            &:first-child {
+                border-bottom: 1px solid #dee2e6 !important;
+            }
+        }
+    }
+
+    // Grouped specific
+    &.o_kanban_grouped {
+        // Set a minimal height otherwise display may have different card sized
+        .o_survey_kanban_card_grouped {
+            & > .row {
+                min-height: 60px;
+            }
+        }
+
+        // Due to activity widget crashing if present twice, have to set absolute and tweak
+        .o_survey_kanban_card_bottom {
+            position: absolute;
+            bottom: 10px;
+            right: 10px;
+        }
+    }
+
+    // Ungrouped specific
+    &.o_kanban_ungrouped {
+        // Set a minimal height otherwise display may have different card sized
+        .o_survey_kanban_card_ungrouped {
+            &.row {
+                min-height: 60px;
+            }
+        }
+
+        // Left semi-trophy icon for certifications: tweak display for list view
+        .o_survey_kanban_card_certification {
+            background-position: bottom 6px left -30px;
+            background-size: 100%, 65px;
+        }
+
+        // Due to activity widget crashing if present twice, have to set absolute and tweak
+        .o_survey_kanban_card_bottom {
+            position: absolute;
+            bottom: 4px;
+            right: 19px;
+        }
+    }
+
+    // RIBBON: Kanban specific
+    // Ungrouped specific
+    .o_survey_kanban_card_ungrouped {
+        .ribbon {
+            // Desktop: finishes on next kanban card line
+            height: 77px;
+            width: 130px;
+
+            // Mobile: is in a corner, takes more place
+            @include media-breakpoint-down(sm) {
+                height: 100px;
+                width: 100px;
+            }
+
+            &-top-right {
+                margin-top: -$o-kanban-inside-vgutter;
+                right: 0;
+
+                & span {
+                    left: -8px;
+                    top: 24px;
+                }
+            }
+
+            & span {
+                font-size: 1rem;
+                width: 150px;
+                height: 32px;
+            }
+        }
+    }
+    // Grouped specific
+    .o_survey_kanban_card_grouped {
+        .ribbon {
+            height: 90px;
+            width: 98px;
+
+            &-top-right {
+                margin-top: -$o-kanban-inside-vgutter;
+                right: 0;
+
+                & span {
+                    left: -8px;
+                    top: 16px;
+                }
+            }
+
+            & span {
+                font-size: 1rem;
+                width: 150px;
+                height: 32px;
+                padding: 0 8px;
+            }
+        }
     }
 }
 
-.o_kanban_card_survey_successed{
-    background-image:
-        linear-gradient(rgba(255,255,255,.9), 
-                        rgba(255,255,255,.9)),
-        url(/survey/static/src/img/trophy-solid.svg);
-    background-repeat: no-repeat;
-    background-position: bottom 6px left -45px;
-    background-size: 100%, 100px;
-}
-
-table.o_section_list_view tr.o_data_row.o_is_section {
+// FORM view
+.o_survey_form table.o_section_list_view tr.o_data_row.o_is_section {
     font-weight: bold;
     background-color: #DDD;
     border-top: 1px solid #BBB;
     border-bottom: 1px solid #BBB;
 }
 
+// TOOLS
 .icon_rotates {
     transform: rotate(180deg);
 }

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -192,73 +192,162 @@
         <field name="name">survey.survey.view.kanban</field>
         <field name="model">survey.survey</field>
         <field name="arch" type="xml">
-            <kanban sample="1">
-                <field name="title" />
-                <field name="answer_done_count" />
-                <field name="certification" />
-                <field name="scoring_type" />
-                <field name="color" />
-                <field name="access_mode"/>
-                <field name="activity_ids" />
-                <field name="activity_state" />
-                <field name="success_count"/>
+            <kanban class="o_survey_survey_view_kanban" sample="1">
+                <field name="active"/>
+                <field name="certification"/>
+                <field name="color"/>
+                <field name="create_date"/>
+                <field name="scoring_type"/>
+                <field name="session_state"/>
                 <field name="success_ratio"/>
-                <field name='active'/>
                 <templates>
                     <div t-name="kanban-box" 
-                        t-attf-class="oe_kanban_color_#{kanban_getcolor(record.color.raw_value)} oe_kanban_card oe_kanban_global_click o_kanban_card_survey 
-                            #{record.certification.raw_value ? 'o_kanban_card_survey_successed' : ''}">
-                        <div class="o_dropdown_kanban dropdown" t-if="widget.editable">
-
-                            <a role="button" class="dropdown-toggle o-no-caret btn" data-toggle="dropdown" data-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
-                                <span class="fa fa-ellipsis-v"/>
-                            </a>
-                            <div class="dropdown-menu" role="menu">
-                                <a role="menuitem" type="edit" class="dropdown-item">Edit Survey</a>
-                                <a t-if="record.active.raw_value" role="menuitem" type="object" class="dropdown-item" name="action_send_survey">Share</a>
-                                <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item">Delete</a>
-                                <div role="separator" class="dropdown-divider"/>
-                                <div role="separator" class="dropdown-item-text">Color</div>
-                                <ul class="oe_kanban_colorpicker" data-field="color"/>
+                        t-attf-class="oe_kanban_color_#{kanban_getcolor(record.color.raw_value)}
+                                      oe_kanban_card oe_kanban_global_click
+                                      o_survey_kanban_card #{record.certification.raw_value ? 'o_survey_kanban_card_certification' : ''}">
+                        <!-- displayed in ungrouped mode -->
+                        <div class="o_survey_kanban_card_ungrouped row mx-0">
+                            <div class="col-lg-2 col-sm-8 col-12 py-0 my-2 my-lg-0">
+                                <div class="d-flex flex-grow-1 flex-column my-0 my-lg-2">
+                                    <span class="font-weight-bold"><field name="title"/></span>
+                                    <span>
+                                        <field name="user_id" widget="many2one_avatar_user"
+                                            options="{'display_avatar_name': True}"/>
+                                        -
+                                        <t t-esc="moment(record.create_date.raw_value).format('MMM YYYY')"/>
+                                    </span>
+                                </div>
                             </div>
+                            <div class="col-lg-1 col-sm-4 col-6 py-0 my-2">
+                                <span class="font-weight-bold"><field name="question_count"/></span><br />
+                                <span class="text-muted">Questions</span>
+                            </div>
+                            <div class="col-lg-1 col-sm-4 col-6 py-0 my-2">
+                                <span class="font-weight-bold">
+                                    <field name="answer_duration_avg" widget="float_time"/>
+                                </span><br />
+                                <span class="text-muted">Average Duration</span>
+                            </div>
+                            <div class="col-lg-1 col-sm-4 col-6 py-0 my-2">
+                                <a type="object"
+                                   name="action_survey_user_input"
+                                   class="font-weight-bold">
+                                    <field name="answer_count"/><br />
+                                    <span class="text-muted">Registered</span>
+                                </a>
+                            </div>
+                            <div class="col-lg-1 col-sm-4 col-6 py-0 my-2">
+                                <a type="object"
+                                   name="action_survey_user_input_completed"
+                                   class="font-weight-bold">
+                                    <field name="answer_done_count"/><br />
+                                    <span class="text-muted">Completed</span>
+                                </a>
+                            </div>
+                            <div class="col-lg-1 col-sm-4 col-6 py-0 my-2"
+                                 name="o_survey_kanban_card_section_success">
+                                 <a t-if="record.scoring_type.raw_value != 'no_scoring'"
+                                   type="object"
+                                   name="action_survey_user_input_certified"
+                                   class="font-weight-bold">
+                                    <field name="success_ratio" widget="progressbar"
+                                           options="{'current_value': 'success_ratio',
+                                                     'max_value': 100,
+                                                     'editable': false}"/>
+                                    <span class="text-muted" t-if="!record.certification.raw_value">Passed</span>
+                                    <span class="text-muted" t-else="">Certified</span>
+                                </a>
+                            </div>
+                            <div class="col-lg-3 col-sm-12 py-0 my-2 ml-auto text-lg-right">
+                                <button name="action_send_survey"
+                                        string="Share" type="object"
+                                        class="btn btn-secondary border"
+                                        attrs="{'invisible': [('active', '=', False)]}">
+                                    Share
+                                </button>
+                                <button name="action_test_survey"
+                                        string="Test" type="object"
+                                        class="btn btn-secondary border"
+                                        attrs="{'invisible': [('active', '=', False)]}">
+                                    Test
+                                </button>
+                                <button name="action_result_survey"
+                                        string="See results" type="object"
+                                        class="btn btn-secondary border"
+                                        attrs="{'invisible': [('active', '=', False)]}">
+                                    See results
+                                </button>
+                                <button name="action_start_session"
+                                        string="Start Live Session" type="object"
+                                        class="btn btn-secondary border"
+                                        attrs="{'invisible': ['|', '|', ('session_state', '!=', False), ('certification', '=', True), ('active', '=', False)]}">
+                                    Start Live Session
+                                </button>
+                                <button name="action_end_session"
+                                        string="End Live Session" type="object"
+                                        class="btn btn-secondary border"
+                                        attrs="{'invisible': ['|', ('session_state', 'not in', ['ready', 'in_progress']), ('active', '=', False)]}">
+                                    End Live Session
+                                </button>
+                            </div>
+                            <widget name="web_ribbon" title="Archived"
+                                bg_color="bg-danger"
+                                attrs="{'invisible': [('active', '=', True)]}"/>
                         </div>
-                        <div class="o_kanban_record_top">
+                        <!-- displayed in grouped mode -->
+                        <div class="o_survey_kanban_card_grouped">
+                            <widget name="web_ribbon" title="Archived"
+                                bg_color="bg-danger"
+                                attrs="{'invisible': [('active', '=', True)]}"/>
+                            <div class="o_dropdown_kanban dropdown" t-if="widget.editable">
+                                <a href="#" role="button"
+                                    class="dropdown-toggle o-no-caret btn"
+                                    data-toggle="dropdown" data-display="static"
+                                    aria-label="Dropdown menu" title="Dropdown menu">
+                                    <span class="fa fa-ellipsis-v"/>
+                                </a>
+                                <div class="dropdown-menu" role="menu">
+                                    <a role="menuitem" type="edit" class="dropdown-item">Edit Survey</a>
+                                    <a t-if="record.active.raw_value" role="menuitem" type="object" class="dropdown-item" name="action_send_survey">Share</a>
+                                    <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item">Delete</a>
+                                    <div role="separator" class="dropdown-divider"/>
+                                    <div role="separator" class="dropdown-item-text">Color</div>
+                                    <ul class="oe_kanban_colorpicker" data-field="color"/>
+                                </div>
+                            </div>
+                            <div class="o_kanban_record_top">
                                 <h4 class="o_kanban_record_title p-0 mb4"><field name="title" /></h4>
+                            </div>
+                            <div class="row">
+                                <div class="col-10 p-0 pb-1">
+                                    <div class="container o_kanban_card_content" t-if="record.answer_count.raw_value != 0">
+                                        <div class="row mt-4 ml-5">
+                                            <div class="col-4 p-0">
+                                                <a name="action_survey_user_input" type="object" class="d-flex flex-column align-items-center">
+                                                    <span class="font-weight-bold"><field name="answer_count"/></span>
+                                                    <span class="text-muted">Registered</span>
+                                                </a>
+                                            </div>
+                                            <div class="col-4 p-0 border-left">
+                                                <a name="action_survey_user_input_completed" type="object" class="d-flex flex-column align-items-center">
+                                                    <span class="font-weight-bold"><field name="answer_done_count"/></span>
+                                                    <span class="text-muted">Completed</span>
+                                                </a>
+                                            </div>
+                                            <div class="col-4 p-0 border-left" t-if="record.scoring_type.raw_value != 'no_scoring'" >
+                                                <a name="action_survey_user_input_certified" type="object" class="d-flex flex-column align-items-center">
+                                                    <span class="font-weight-bold"> <t t-esc="Math.round(record.success_ratio.raw_value)"></t> %</span>
+                                                    <span class="text-muted" >Success</span>
+                                                </a> 
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                        <div class="row">
-                            <div class="col-10 p-0 pb-1">
-                                <div class="container o_kanban_card_content" t-if="record.answer_done_count.raw_value != 0">
-                                    <div class="row mt-4 ml-5">
-                                        <div class="col-4 p-0">
-                                            <a name="action_result_survey" type="object" class="d-flex flex-column align-items-center">
-                                                <span class="font-weight-bold"><field name="answer_done_count"/></span>
-                                                <span class="text-muted">Answers</span>
-                                            </a>
-                                        </div>
-                                        <div class="col-4 p-0 border-left" t-if="record.scoring_type.raw_value != 'no_scoring'" >
-                                            <a name="action_survey_user_input_certified" type="object" class="d-flex flex-column align-items-center">
-                                                <span class="font-weight-bold"><field name="success_count"/></span>
-                                                <span class="text-muted" t-if="!record.certification.raw_value">Passed</span>
-                                                <span class="text-muted" t-else="">Certified</span>
-                                            </a>
-                                        </div>
-                                        <div class="col-4 p-0 border-left" t-if="record.scoring_type.raw_value != 'no_scoring'" >
-                                            <a name="action_survey_user_input_completed" type="object" class="d-flex flex-column align-items-center">
-                                                <span class="font-weight-bold"> <t t-esc="Math.round(record.success_ratio.raw_value)"></t> %</span>
-                                                <span class="text-muted" >Success</span>
-                                            </a> 
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-2 align-self-end">
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_left"/>
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="activity_ids" widget="kanban_activity"/>
-                                    </div>
-                                </div>
-                            </div>
+                        <!-- Generic -->
+                        <div class="o_survey_kanban_card_bottom">
+                            <field name="activity_ids" widget="kanban_activity"/>
                         </div>
                     </div>
                 </templates>
@@ -282,6 +371,10 @@
                     domain="[('my_activity_date_deadline', '=', context_today().strftime('%Y-%m-%d'))]"/>
                 <filter invisible="1" string="Upcoming Activities" name="activities_upcoming_all"
                     domain="[('my_activity_date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Responsible" name="group_by_responsible"
+                        context="{'group_by': 'user_id'}"/>
+                </group>
             </search>
         </field>
     </record>

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 <data>
-    <record id="survey_form" model="ir.ui.view">
+    <record id="survey_survey_view_form" model="ir.ui.view">
         <field name="name">survey.survey.view.form</field>
         <field name="model">survey.survey</field>
         <field name="arch" type="xml">
@@ -166,7 +166,7 @@
             </form>
         </field>
     </record>
-    <record id="survey_tree" model="ir.ui.view">
+    <record id="survey_survey_view_tree" model="ir.ui.view">
         <field name="name">survey.survey.view.tree</field>
         <field name="model">survey.survey</field>
         <field name="arch" type="xml">
@@ -188,7 +188,7 @@
             </tree>
         </field>
     </record>
-    <record id="survey_kanban" model="ir.ui.view">
+    <record id="survey_survey_view_kanban" model="ir.ui.view">
         <field name="name">survey.survey.view.kanban</field>
         <field name="model">survey.survey</field>
         <field name="arch" type="xml">

--- a/addons/website_slides_survey/models/survey_survey.py
+++ b/addons/website_slides_survey/models/survey_survey.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import ast
+
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
 
@@ -37,6 +39,9 @@ class Survey(models.Model):
     # ---------------------------------------------------------
 
     def action_survey_view_slide_channels(self):
+        """ Redirect to the channels using the survey as a certification. Open
+        in no-create as link between those two comes through a slide, hard to
+        keep as default values. """
         action = self.env["ir.actions.actions"]._for_xml_id("website_slides.slide_channel_action_overview")
         action['display_name'] = _("Courses")
         if self.slide_channel_count == 1:
@@ -45,6 +50,10 @@ class Survey(models.Model):
         else:
             action.update({'views': [[False, 'tree'], [False, 'form']],
                            'domain': [('id', 'in', self.slide_channel_ids.ids)]})
+        action['context'] = dict(
+            ast.literal_eval(action.get('context') or '{}'),  # sufficient in most cases
+            create=False
+        )
         return action
 
     # ---------------------------------------------------------

--- a/addons/website_slides_survey/views/survey_survey_views.xml
+++ b/addons/website_slides_survey/views/survey_survey_views.xml
@@ -32,7 +32,7 @@
     </record>
 
     <record id="survey_survey_view_form" model="ir.ui.view">
-        <field name="name">survey.survey.view.form.inherit.website_slides</field>
+        <field name="name">survey.survey.view.form.inherit.website.slides</field>
         <field name="model">survey.survey</field>
         <field name="inherit_id" ref="survey.survey_survey_view_form"/>
         <field name="arch" type="xml">
@@ -45,6 +45,28 @@
                     groups="website_slides.group_website_slides_officer">
                     <field string="Courses" name="slide_channel_count" widget="statinfo"/>
                 </button>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="survey_survey_view_kanban" model="ir.ui.view">
+        <field name="name">survey.survey.view.kanban.inherit.website.slides</field>
+        <field name="model">survey.survey</field>
+        <field name="inherit_id" ref="survey.survey_survey_view_kanban"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='session_state']" position="after">
+                <field name="slide_channel_count"/>
+            </xpath>
+            <xpath expr="//div[@name='o_survey_kanban_card_section_success']" position="after">
+                <div class="col-lg-1 col-sm-4 col-6 py-0 my-2">
+                    <a t-if="record.slide_channel_count.raw_value"
+                       type="object"
+                       name="action_survey_view_slide_channels"
+                       class="font-weight-bold">
+                        <field name="slide_channel_count"/><br />
+                        <span class="text-muted">Courses</span>
+                    </a>
+                </div>
             </xpath>
         </field>
     </record>

--- a/addons/website_slides_survey/views/survey_survey_views.xml
+++ b/addons/website_slides_survey/views/survey_survey_views.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <record id="survey_view_tree_slides" model="ir.ui.view">
-        <field name="name">survey.view.tree.slides</field>
+    <record id="survey_survey_view_tree_slides" model="ir.ui.view">
+        <field name="name">survey.survey.view.tree.slides</field>
         <field name="model">survey.survey</field>
-        <field name="inherit_id" ref="survey.survey_tree"/>
+        <field name="inherit_id" ref="survey.survey_survey_view_tree"/>
         <field name="mode">primary</field>
         <field name="priority" eval="20"/>
         <field name="arch" type="xml">
@@ -21,8 +21,8 @@
         </field>
     </record>
 
-    <record id="survey_survey_inherit_view_search" model="ir.ui.view">
-        <field name="name">survey.survey.search.inherit.website_slides</field>
+    <record id="survey_survey_view_search_slides" model="ir.ui.view">
+        <field name="name">survey.survey.view.search.slides</field>
         <field name="model">survey.survey</field>
         <field name="inherit_id" ref="survey.survey_survey_view_search"/>
         <field name="mode">primary</field>
@@ -34,7 +34,7 @@
     <record id="survey_survey_view_form" model="ir.ui.view">
         <field name="name">survey.survey.view.form.inherit.website_slides</field>
         <field name="model">survey.survey</field>
-        <field name="inherit_id" ref="survey.survey_form"/>
+        <field name="inherit_id" ref="survey.survey_survey_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//button[@name='action_survey_user_input_certified']" position="before">
                 <button name="action_survey_view_slide_channels"
@@ -54,7 +54,7 @@
         <field name="res_model">survey.survey</field>
         <field name="view_mode">kanban,tree,pivot,graph,form</field>
         <field name="domain">[('certification', '=', True)]</field>
-        <field name="search_view_id" ref="survey_survey_inherit_view_search"/>
+        <field name="search_view_id" ref="survey_survey_view_search_slides"/>
         <field name="context">{'default_certification': True, 'default_scoring_type': 'scoring_with_answers'}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
@@ -69,19 +69,19 @@
     <record id="survey_survey_action_slides_view_kanban" model="ir.actions.act_window.view">
          <field name="sequence" eval="0"/>
          <field name="view_mode">kanban</field>
-         <field name="view_id" ref="survey.survey_kanban"/>
+         <field name="view_id" ref="survey.survey_survey_view_kanban"/>
          <field name="act_window_id" ref="survey_survey_action_slides"/>
      </record>
      <record id="survey_survey_action_slides_view_tree" model="ir.actions.act_window.view">
          <field name="sequence" eval="1"/>
          <field name="view_mode">tree</field>
-         <field name="view_id" ref="survey_view_tree_slides"/>
+         <field name="view_id" ref="survey_survey_view_tree_slides"/>
          <field name="act_window_id" ref="survey_survey_action_slides"/>
      </record>
      <record id="survey_survey_action_slides_view_form" model="ir.actions.act_window.view">
          <field name="sequence" eval="4"/>
          <field name="view_mode">form</field>
-         <field name="view_id" ref="survey.survey_form"/>
+         <field name="view_id" ref="survey.survey_survey_view_form"/>
          <field name="act_window_id" ref="survey_survey_action_slides"/>
      </record>
 </odoo>


### PR DESCRIPTION
PURPOSE

When dealing with lot of surveys kanban view is not really optimal and its
state based grouping is not really helpful. Indeed we do not have total of
each coumn and there is not point adding new states, meaning most surveys
hang in the same column. This is not an optimal display.

SPECIFICATIONS

Improve ungrouped display as this is the main usage of surveys. It should
be displayed like a global list view: each card should take the whole
screen (like ``Visitor`` kanban view). Each line contains some "columns"
holding statistics. We notably use a progressbar to display a nice passed
ratio, as well as a many2one avatar widget to make survey enters the era
of amazing wow kanban views.

When grouped, display should be the old one, aka a standard card.

This is done using a small CSS hack: card template actually consists in main
templates related to two displays. Each card style is hidden depending on being
groups or ungrouped. This triggers a class that is used using CSS to hide
irrelevant content.

A ribbon is also added on kanban cards displaying an Archived danger ribbon
when survey is not active anymore. It is therefore coherent with the form
view display that also has a ribbon defined.

An override in website_slides_survey is added to add number of courses using
the survey.

Order is updated so that new surveys are on top. No need to be bloated by
old ongoing surveys when creating new one.

Finally, some labelling is done with answers to be clearer: registered (number
of raw user inputs), completed (finished answers), certified or passed (quiz
with certification activated or not).

Task-2388785