### PR TITLE
[Fix] web: FieldFloatToggle use of format options

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -1352,7 +1352,8 @@ var FieldFloatToggle = AbstractField.extend({
         if (this.mode === 'edit') {
             ev.stopPropagation(); // only stop propagation in edit mode
             var next_val = this._nextValue();
-            next_val = field_utils.format['float'](next_val);
+            var options = _.extend({}, this.nodeOptions, this.formatOptions);
+            next_val = field_utils.format['float'](next_val, this.field, options);
             this._setValue(next_val); // will be parsed in _setValue
         }
     },


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Custom range attribute option to `float_toggle` or `timesheet_uom`  widgets with more than 2 decimals will be rounded to 2 decimal places, the float_toggle widget does not take into account `digit` options to format the display value. 

**Current behavior before PR:**
Set a `float_toggle` field with custom range and option to display multiple decimals (for example: `options="{'range': [0.0652, 0.1250], 'digits': [5,4]}"`)

In the screen the display will be with number of decimals allocated but the value is rounded to 2 decimals (in the above example the values will be: `0.0700`, `0.1300`).
![image](https://user-images.githubusercontent.com/41705642/134871616-371c92bd-4a6e-4a6e-842f-e30b727f29fe.png)


**Desired behavior after PR is merged:**
The display value should be with correct number of decimals as indicated in the `digits` option (in the above example: `0.0652`, `0.1250`).
![image](https://user-images.githubusercontent.com/41705642/134872016-b5a40753-c8e5-4ab1-bd71-f8f3f7df1694.png)



--
I confirm I have read the PR guidelines at www.odoo.com/submit-pr
