### PR TITLE
[FIX] expression: avoid ORDER BY clause in subqueries

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1206,7 +1206,6 @@ class TestMany2one(TransactionCase):
                 SELECT "res_company".id
                 FROM "res_company"
                 WHERE ("res_company"."name"::text like %s)
-                ORDER BY "res_company"."id"
             ))
             ORDER BY "res_partner"."display_name"
         ''']):
@@ -1222,9 +1221,7 @@ class TestMany2one(TransactionCase):
                     SELECT "res_partner".id
                     FROM "res_partner"
                     WHERE ("res_partner"."name"::text LIKE %s)
-                    ORDER BY "res_partner"."id"
                 ))
-                ORDER BY "res_company"."id"
             ))
             ORDER BY "res_partner"."display_name"
         ''']):
@@ -1237,12 +1234,10 @@ class TestMany2one(TransactionCase):
                 SELECT "res_company".id
                 FROM "res_company"
                 WHERE ("res_company"."name"::text LIKE %s)
-                ORDER BY "res_company"."id"
             )) OR ("res_partner"."country_id" IN (
                 SELECT "res_country".id
                 FROM "res_country"
                 WHERE ("res_country"."code"::text LIKE %s)
-                ORDER BY "res_country"."id"
             )))
             ORDER BY "res_partner"."display_name"
         ''']):
@@ -1262,11 +1257,26 @@ class TestMany2one(TransactionCase):
                 SELECT "res_company".id
                 FROM "res_company"
                 WHERE ("res_company"."name"::text like %s)
-                ORDER BY "res_company"."id"
             ))
             ORDER BY "res_partner"."display_name"
         ''']):
             company_ids = self.company._search([('name', 'like', self.company.name)], order='id')
+            self.Partner.search([('company_id', 'in', company_ids)])
+
+        # special case, with a LIMIT to make ORDER BY necessary
+        with self.assertQueries(['''
+            SELECT "res_partner".id
+            FROM "res_partner"
+            WHERE ("res_partner"."company_id" IN (
+                SELECT "res_company".id
+                FROM "res_company"
+                WHERE ("res_company"."name"::text like %s)
+                ORDER BY "res_company"."id"
+                LIMIT 1
+            ))
+            ORDER BY "res_partner"."display_name"
+        ''']):
+            company_ids = self.company._search([('name', 'like', self.company.name)], order='id', limit=1)
             self.Partner.search([('company_id', 'in', company_ids)])
 
     def test_autojoin(self):
@@ -1294,7 +1304,6 @@ class TestMany2one(TransactionCase):
                 SELECT "res_partner".id
                 FROM "res_partner"
                 WHERE ("res_partner"."name"::text LIKE %s)
-                ORDER BY "res_partner"."id"
             ))
             ORDER BY "res_partner"."display_name"
         ''']):
@@ -1314,7 +1323,6 @@ class TestMany2one(TransactionCase):
                 LEFT JOIN "res_partner" AS "res_company__partner_id" ON
                     ("res_company"."partner_id" = "res_company__partner_id"."id")
                 WHERE ("res_company__partner_id"."name"::text LIKE %s)
-                ORDER BY "res_company"."id"
             ))
             ORDER BY "res_partner"."display_name"
         ''']):
@@ -1373,7 +1381,6 @@ class TestMany2one(TransactionCase):
                 SELECT "res_company".id
                 FROM "res_company"
                 WHERE ("res_company"."name"::text LIKE %s)
-                ORDER BY "res_company"."sequence", "res_company"."name"
             ))
             ORDER BY "res_partner"."display_name"
         ''']):
@@ -1415,7 +1422,6 @@ class TestOne2many(TransactionCase):
                 SELECT "res_partner_bank"."partner_id"
                 FROM "res_partner_bank"
                 WHERE ("res_partner_bank"."sanitized_acc_number"::text LIKE %s)
-                ORDER BY "res_partner_bank"."id"
             ))
             ORDER BY "res_partner"."display_name"
         ''']):
@@ -1431,9 +1437,7 @@ class TestOne2many(TransactionCase):
                     SELECT "res_partner_bank"."partner_id"
                     FROM "res_partner_bank"
                     WHERE ("res_partner_bank"."sanitized_acc_number"::text LIKE %s)
-                    ORDER BY "res_partner_bank"."id"
                 ))
-                ORDER BY "res_partner"."id"
             ))
             ORDER BY "res_partner"."display_name"
         ''']):
@@ -1569,7 +1573,6 @@ class TestOne2many(TransactionCase):
                 SELECT "res_partner_bank"."partner_id"
                 FROM "res_partner_bank"
                 WHERE ("res_partner_bank"."sanitized_acc_number"::text LIKE %s)
-                ORDER BY "res_partner_bank"."sequence", "res_partner_bank"."id"
             ))
             ORDER BY "res_partner"."display_name"
         ''']):
@@ -1608,7 +1611,6 @@ class TestMany2many(TransactionCase):
                     SELECT "res_groups".id
                     FROM "res_groups"
                     WHERE ("res_groups"."color" = %s)
-                    ORDER BY "res_groups"."id"
                 )
             ))
             ORDER BY "res_users"."id"
@@ -1627,10 +1629,8 @@ class TestMany2many(TransactionCase):
                             SELECT "ir_rule".id
                             FROM "ir_rule"
                             WHERE ("ir_rule"."name"::text LIKE %s)
-                            ORDER BY "ir_rule"."id"
                         )
                     ))
-                    ORDER BY "res_groups"."id"
                 )
             ))
             ORDER BY "res_users"."id"
@@ -1653,7 +1653,6 @@ class TestMany2many(TransactionCase):
                     SELECT "res_company".id
                     FROM "res_company"
                     WHERE ("res_company"."name"::text LIKE %s)
-                    ORDER BY "res_company"."sequence", "res_company"."name"
                 )
             ))
             ORDER BY "res_users"."id"

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -760,7 +760,7 @@ class expression(object):
 
                     if isinstance(ids2, Query) and comodel._fields[field.inverse_name].store:
                         op1 = 'not inselect' if operator in NEGATIVE_TERM_OPERATORS else 'inselect'
-                        subquery, subparams = ids2.select('"%s"."%s"' % (comodel._table, field.inverse_name))
+                        subquery, subparams = ids2.subselect('"%s"."%s"' % (comodel._table, field.inverse_name))
                         push(('id', op1, (subquery, subparams)), model, alias, internal=True)
                     elif ids2 and comodel._fields[field.inverse_name].store:
                         op1 = 'not inselect' if operator in NEGATIVE_TERM_OPERATORS else 'inselect'
@@ -823,7 +823,7 @@ class expression(object):
                     if isinstance(ids2, Query):
                         # rewrite condition in terms of ids2
                         subop = 'not inselect' if operator in NEGATIVE_TERM_OPERATORS else 'inselect'
-                        subquery, subparams = ids2.select()
+                        subquery, subparams = ids2.subselect()
                         query = 'SELECT "%s" FROM "%s" WHERE "%s" IN (%s)' % (rel_id1, rel_table, rel_id2, subquery)
                         push(('id', subop, (query, subparams)), model, alias, internal=True)
                     else:
@@ -981,7 +981,7 @@ class expression(object):
                     query = '(%s."%s" IS NULL)' % (table_alias, left)
                 params = []
             elif isinstance(right, Query):
-                subquery, subparams = right.select()
+                subquery, subparams = right.subselect()
                 query = '(%s."%s" %s (%s))' % (table_alias, left, operator, subquery)
                 params = subparams
             elif isinstance(right, (list, tuple)):

--- a/odoo/osv/query.py
+++ b/odoo/osv/query.py
@@ -130,6 +130,22 @@ class Query(object):
         )
         return query_str, params
 
+    def subselect(self, *args):
+        """ Similar to :meth:`.select`, but for sub-queries.
+            This one avoids the ORDER BY clause when possible.
+        """
+        if self.limit or self.offset:
+            # in this case, the ORDER BY clause is necessary
+            return self.select(*args)
+
+        from_clause, where_clause, params = self.get_sql()
+        query_str = 'SELECT {} FROM {} WHERE {}'.format(
+            ", ".join(args or [f'"{next(iter(self._tables))}".id']),
+            from_clause,
+            where_clause or "TRUE",
+        )
+        return query_str, params
+
     def get_sql(self):
         """ Returns (query_from, query_where, query_params). """
         tables = [_from_table(table, alias) for alias, table in self._tables.items()]


### PR DESCRIPTION
This fixes a performance issue: ORDER BY clauses in subqueries can make
the query unexpectedly slow.  We should avoid this situation, since
ORM-generated queries have an ORDER BY clause which is not relevant in
the context of a subquery.

The following example was found:

    SELECT "pos_payment"."id" AS "id"
      FROM "pos_payment"
     WHERE ("pos_payment"."pos_order_id" in
              (SELECT "pos_order".id
                 FROM "pos_order"
                WHERE ("pos_order"."company_id" in (1))
             ORDER BY "pos_order"."id"))
       AND "pos_payment".id IN (1285508)

Here are the query plans made by PostgreSQL on this query with and
without the ORDER BY clause.  The query time went from 1240ms to
0.402ms, which is 3000 times faster!

```
EXPLAIN ANALYZE SELECT "pos_payment"."id" as "id" FROM "pos_payment" WHERE ("pos_payment"."pos_order_id" in (SELECT "pos_order".id FROM "pos_order" WHERE ("pos_order"."company_id" in (1)) ORDER BY  "pos_order"."id"  )) AND "pos_payment".id IN (1285508);
                                                                    QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------
 Merge Semi Join  (cost=2.88..82726.85 rows=1 width=4) (actual time=1239.361..1239.364 rows=1 loops=1)
   Merge Cond: (pos_payment.pos_order_id = pos_order.id)
   ->  Sort  (cost=2.46..2.46 rows=1 width=8) (actual time=0.021..0.022 rows=1 loops=1)
         Sort Key: pos_payment.pos_order_id
         Sort Method: quicksort  Memory: 25kB
         ->  Index Scan using pos_payment_pkey on pos_payment  (cost=0.43..2.45 rows=1 width=8) (actual time=0.014..0.015 rows=1 loops=1)
               Index Cond: (id = 1285508)
   ->  Index Scan using pos_order_pkey on pos_order  (cost=0.43..66770.53 rows=1282120 width=4) (actual time=0.013..1148.194 rows=1182463 loops=1)
         Filter: (company_id = 1)
 Planning time: 0.272 ms
 Execution time: 1239.396 ms
(11 rows)

EXPLAIN ANALYZE SELECT "pos_payment"."id" as "id" FROM "pos_payment" WHERE ("pos_payment"."pos_order_id" in (SELECT "pos_order".id FROM "pos_order" WHERE ("pos_order
"."company_id" in (1)) )) AND "pos_payment".id IN (1285508);
                                                             QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=0.85..4.89 rows=1 width=4) (actual time=0.047..0.049 rows=1 loops=1)
   ->  Index Scan using pos_payment_pkey on pos_payment  (cost=0.43..2.45 rows=1 width=8) (actual time=0.027..0.028 rows=1 loops=1)
         Index Cond: (id = 1285508)
   ->  Index Scan using pos_order_pkey on pos_order  (cost=0.43..2.45 rows=1 width=4) (actual time=0.018..0.018 rows=1 loops=1)
         Index Cond: (id = pos_payment.pos_order_id)
         Filter: (company_id = 1)
 Planning time: 0.322 ms
 Execution time: 0.080 ms
(8 rows)
```

Co-authored-by: Stanislas Sobieski (sts@odoo.com)