### PR TITLE
[FIX] mail: Cannot read property "rtc" of undefined

### DIFF
--- a/addons/mail/static/src/components/rtc_activity_notice/rtc_activity_notice.xml
+++ b/addons/mail/static/src/components/rtc_activity_notice/rtc_activity_notice.xml
@@ -3,19 +3,21 @@
 
     <t t-name="mail.RtcActivityNotice" owl="1">
         <li class="o_RtcActivityNotice">
-            <RtcInvitations/>
-            <t t-if="messaging.rtc.channel">
-                <t t-set="title">Open conference: <t t-esc="messaging.rtc.channel.displayName"/></t>
-                <a class="o_RtcActivityNotice_button" t-att-title="title" role="button" t-on-click="_onClick">
-                    <div class="o_RtcActivityNotice_buttonContent">
-                        <span class="o_RtcActivityNotice_buttonTitle" t-esc="messaging.rtc.channel.displayName"/>
-                        <i class="o_RtcActivityNotice_outputIndicator fa" t-att-class="{
-                            'fa-microphone': !messaging.rtc.sendDisplay and !messaging.rtc.sendUserVideo,
-                            'fa-video-camera': messaging.rtc.sendUserVideo,
-                            'fa-desktop': messaging.rtc.sendDisplay,
-                        }"/>
-                    </div>
-                </a>
+            <t t-if="messaging">
+                <RtcInvitations/>
+                <t t-if="messaging.rtc.channel">
+                    <t t-set="title">Open conference: <t t-esc="messaging.rtc.channel.displayName"/></t>
+                    <a class="o_RtcActivityNotice_button" t-att-title="title" role="button" t-on-click="_onClick">
+                        <div class="o_RtcActivityNotice_buttonContent">
+                            <span class="o_RtcActivityNotice_buttonTitle" t-esc="messaging.rtc.channel.displayName"/>
+                            <i class="o_RtcActivityNotice_outputIndicator fa" t-att-class="{
+                                'fa-microphone': !messaging.rtc.sendDisplay and !messaging.rtc.sendUserVideo,
+                                'fa-video-camera': messaging.rtc.sendUserVideo,
+                                'fa-desktop': messaging.rtc.sendDisplay,
+                            }"/>
+                        </div>
+                    </a>
+                </t>
             </t>
         </li>
     </t>

--- a/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
+++ b/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.RtcController" owl="1">
         <div class="o_RtcController">
-            <t t-if="rtcController">
+            <t t-if="rtcController and messaging">
                 <div class="o_RtcController_buttons">
                     <t t-if="rtcController.callViewer.threadView.thread.rtc and messaging.rtc.currentRtcSession">
                         <t t-if="messaging.rtc.currentRtcSession.isMuted"><t t-set="microphoneTitle">Unmute</t></t>


### PR DESCRIPTION
Also resulted in crash `Cannot read property 'sel' of undefined`.

This commit adds some guards in some component templates
that access model records and their fields, to avoid crashes.

These guards are necessary due to the asynchronous rendering of OWL,
which makes it vulnerable to risky changes in models such as
record deletion or any modification in any relational fields.

Introduced with odoo@9bf4b6c