### PR TITLE
[FIX] website: use snippet lists from theme manifest

### DIFF
--- a/addons/test_website_modules/tests/test_configurator.py
+++ b/addons/test_website_modules/tests/test_configurator.py
@@ -29,12 +29,8 @@ class TestConfigurator(odoo.tests.HttpCase):
                     {"id": 6, "label": "abundant life church"}]}
             elif '/api/website/2/configurator/recommended_themes' in endpoint:
                 return []
-            elif '/api/website/1/configurator/custom_resources/' in endpoint:
-                return {
-                    'pages': {
-                        'pricing': ['website.s_comparisons'],
-                        'homepage': ['website.s_cover', 'website.s_text_image', 'website.s_numbers']},
-                    'images': {}}
+            elif '/api/website/2/configurator/custom_resources/' in endpoint:
+                return {'images': {}}
 
             iap_jsonrpc_mocked()
 

--- a/addons/theme_default/__manifest__.py
+++ b/addons/theme_default/__manifest__.py
@@ -13,6 +13,13 @@
         'static/description/cover.png',
         'static/description/theme_default_screenshot.jpg',
     ],
+    'snippet_lists': {
+        'homepage': ['s_cover', 's_text_image', 's_numbers'],
+        'about_us': ['s_text_image', 's_image_text', 's_title', 's_company_team'],
+        'our_services': ['s_three_columns', 's_quotes_carousel', 's_references'],
+        'pricing': ['s_comparisons'],
+        'privacy_policy': ['s_faq_collapse'],
+    },
     'application': False,
     'auto_install': False,
     'license': 'LGPL-3',


### PR DESCRIPTION
Previously the configurator retrieved the snippet lists
needed to build the website pages from IAP. These lists
have been put in the theme manifests and can be accessed
from it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
