### PR TITLE
[FIX] account: do not proceed if reference_move_name is false

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1255,9 +1255,9 @@ class AccountMove(models.Model):
             if self.journal_id.refund_sequence:
                 refund_types = ('out_refund', 'in_refund')
                 domain += [('move_type', 'in' if self.move_type in refund_types else 'not in', refund_types)]
-            reference_move_name = self.search(domain + [('date', '<=', self.date)], order='date desc', limit=1).name
+            reference_move_name = self.search(domain + [('date', '<=', self.date)], order='date desc', limit=1).name or self.search(domain, order='date asc', limit=1).name
             if not reference_move_name:
-                reference_move_name = self.search(domain, order='date asc', limit=1).name
+                return "WHERE FALSE", {}
             sequence_number_reset = self._deduce_sequence_number_reset(reference_move_name)
             if sequence_number_reset == 'year':
                 where_string += " AND date_trunc('year', date::timestamp without time zone) = date_trunc('year', %(date)s) "


### PR DESCRIPTION
Take into account that `reference_move_name` may not be set. In such case, https://github.com/odoo/odoo/blob/14.0/addons/account/models/account_move.py#L1261 is called with `reference_move_name=False`, which later results in https://github.com/odoo/odoo/blob/14.0/addons/account/models/sequence_mixin.py#L99 not matching and raising an error.


[upg-33883](https://upgrade.odoo.com/web#id=33883&action=150&model=upgrade.request&view_type=form&cids=1&menu_id=107)