### PR TITLE
[FIX] mail: add support for channel_type=group in mobile tabs

### DIFF
--- a/addons/im_livechat/static/src/models/discuss/discuss.js
+++ b/addons/im_livechat/static/src/models/discuss/discuss.js
@@ -14,6 +14,12 @@ registerInstancePatchModel('mail.discuss', 'im_livechat/static/src/models/discus
         }
         return this._super(value);
     },
+
+    channelTypeMapping() {
+        const map = this._super();
+        // map.livechat = 'livechat';
+        return map;
+    }
 });
 
 registerFieldPatchModel('mail.discuss', 'im_livechat/static/src/models/discuss/discuss.js', {

--- a/addons/mail/static/src/components/discuss/discuss.js
+++ b/addons/mail/static/src/components/discuss/discuss.js
@@ -26,7 +26,7 @@ export class Discuss extends Component {
         this.discuss.update({ isOpen: true });
         if (this.discuss.thread) {
             this.trigger('o-push-state-action-manager');
-        } else if (!this._activeThreadCache && this.discuss.messaging.isInitialized) {
+        } else if (!this._activeThreadCache && this.discuss.messaging.isInitialized && !this.discuss.messaging.device.isMobile) {
             this.discuss.openInitThread();
         }
         if (

--- a/addons/mail/static/src/models/discuss/discuss.js
+++ b/addons/mail/static/src/models/discuss/discuss.js
@@ -196,17 +196,22 @@ function factory(dependencies) {
                 return;
             }
             thread.open();
+            console.log(this.messaging.device.isMobile && thread.channel_type);
             if (this.messaging.device.isMobile && thread.channel_type) {
-                const channelTypeTab = {
-                    chat: 'chat',
-                    group: 'chat',
-                    channel: 'channel',
-                    livechat: 'livechat',
-                };
+                const channelTypeTab = this.channelTypeMapping();
+                console.log(channelTypeTab);
                 this.update({ activeMobileNavbarTabId: channelTypeTab[thread.channel_type] });
             }
         }
 
+        channelTypeMapping() {
+            return {
+                chat: 'chat',
+                group: 'chat',
+                channel: 'channel',
+                livechat: 'livechat',
+            };
+        }
 
         /**
          * Opens the given thread in Discuss, and opens Discuss if necessary.

--- a/addons/mail/static/src/models/discuss/discuss.js
+++ b/addons/mail/static/src/models/discuss/discuss.js
@@ -197,7 +197,13 @@ function factory(dependencies) {
             }
             thread.open();
             if (this.messaging.device.isMobile && thread.channel_type) {
-                this.update({ activeMobileNavbarTabId: thread.channel_type });
+                const channelTypeTab = {
+                    chat: 'chat',
+                    group: 'chat',
+                    channel: 'channel',
+                    livechat: 'livechat',
+                };
+                this.update({ activeMobileNavbarTabId: channelTypeTab[thread.channel_type] });
             }
         }
 


### PR DESCRIPTION
Before this commit, the tab list would crash trying to open a
channel_type=group.
To reproduce:
- open a group DM in discuss desktop, navigate to the group.
- Open the current URl on mobile.