### PR TITLE
[FIX] website: prevent always showing debug icon in frontend

### DIFF
--- a/addons/website/static/src/js/menu/debug_menu.js
+++ b/addons/website/static/src/js/menu/debug_menu.js
@@ -6,15 +6,17 @@ import { createDebugContext } from "@web/core/debug/debug_context";
 const debugMenuService = {
     dependencies: ["command", "localization", "orm"],
     start(env) {
-        Object.assign(env, createDebugContext(env, { categories: ["default"] }));
-        const systray = document.querySelector('.o_menu_systray');
-        if (systray) {
-            owl.mount(DebugMenu, {
-                target: systray,
-                position: 'first-child',
-                env,
-            });
+        if (env.debug) {
+            const systray = document.querySelector('.o_menu_systray');
+            if (systray) {
+                Object.assign(env, createDebugContext(env, {categories: ["default"]}));
+                owl.mount(DebugMenu, {
+                    target: systray,
+                    position: 'first-child',
+                    env,
+                });
+            }
         }
     }
-}
+};
 registry.category("services").add("website_debug_menu", debugMenuService);


### PR DESCRIPTION
Commit [1] migrated the old debug manager to the new OWL one.
But is was missing a check, to actually ensure we are in debug mode before
showing the icon.
Without this fix, the debug icon is always shown, even if not in debug mode.

[1]: https://github.com/odoo/odoo/commit/ce5599926af8cf2d69d3abbff0cb212b4af04473
