### PR TITLE
[IMP] partial matches on reconciliation models

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -803,13 +803,13 @@ class AccountReconcileModel(models.Model):
         candidates, priorities = self._filter_candidates(candidates, aml_ids_to_exclude, reconciled_amls_ids)
 
         st_line_currency = st_line.foreign_currency_id or st_line.currency_id
-        candidate_currencies = set(candidate['aml_currency_id'] or st_line.company_id.currency_id.id for candidate in candidates)
+        candidate_currencies = set(candidate['aml_currency_id'] for candidate in candidates)
         kept_candidates = candidates
         if candidate_currencies == {st_line_currency.id}:
             kept_candidates = []
             sum_kept_candidates = 0
             for candidate in candidates:
-                candidate_residual = candidate['aml_amount_residual_currency'] if candidate['aml_currency_id'] else candidate['aml_amount_residual']
+                candidate_residual = candidate['aml_amount_residual_currency']
 
                 if st_line_currency.compare_amounts(candidate_residual, -st_line.amount_residual) == 0:
                     # Special case: the amounts are the same, submit the line directly.

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -818,12 +818,14 @@ class AccountChartTemplate(models.Model):
         for account_reconcile_model in account_reconcile_models:
             vals = self._prepare_reconcile_model_vals(company, account_reconcile_model, acc_template_ref, tax_template_ref)
             self.create_record_with_xmlid(company, account_reconcile_model, 'account.reconcile.model', vals)
-        # Create a default rule for the reconciliation widget matching invoices automatically.
+
+        # Create default rules for the reconciliation widget matching invoices automatically.
+
         self.env['account.reconcile.model'].sudo().create({
-            "name": _('Invoices Matching Rule'),
+            "name": _('Invoices/Bills Perfect Match'),
             "sequence": '1',
             "rule_type": 'invoice_matching',
-            "auto_reconcile": False,
+            "auto_reconcile": True,
             "match_nature": 'both',
             "match_same_currency": True,
             "allow_payment_tolerance": True,
@@ -832,6 +834,19 @@ class AccountChartTemplate(models.Model):
             "match_partner": True,
             "company_id": company.id,
         })
+
+        self.env['account.reconcile.model'].sudo().create({
+            "name": _('Invoices/Bills Partial Match if Underpaid'),
+            "sequence": '2',
+            "rule_type": 'invoice_matching',
+            "auto_reconcile": False,
+            "match_nature": 'both',
+            "match_same_currency": True,
+            "allow_payment_tolerance": False,
+            "match_partner": True,
+            "company_id": company.id,
+        })
+
         return True
 
     def _get_fp_vals(self, company, position):


### PR DESCRIPTION
[IMP] account: better default reconciliation models



[IMP] account: reconciliation models: don't suggest too many matches in case of partial mathing

- Create a statement line for partner A, amounting to 90€
- Make 5 invoices for partner A, of 10, 50, 100, 500 and 100 €
- create a reconciliation model (make sure it's the only one active for testing), with
>>> "invoice matching" selected
>>> "payment tolerance" disabled
>>> "partner should be set" enabled
>>> "same currency" enabled
>>> "auto-validate" disabled

Try to reconcile your statement. The reconciliation model associates your statement line to the 5 invoices, showing a partial match of 30 for the line of 100€, as only 30€ remain after matching 10 and 50. The following lines (500 and 100) are useless in the reconciliation and confusing for the user. They shouldn't be there.

After this commit, no useless line will be proposed anymore. In our example, only lines 10, 50 and 100 will be proposed.


Task 2652915