### PR TITLE
[FIX] product_expiry, stock: choose the correct lot in FEFO

### DIFF
--- a/addons/product_expiry/tests/test_stock_production_lot.py
+++ b/addons/product_expiry/tests/test_stock_production_lot.py
@@ -360,9 +360,9 @@ class TestStockProductionLot(TestStockCommon):
             msg="Must be define even if the product's `expiration_time` isn't set.")
         self.assertAlmostEqual(
             apple_lot.use_date, expiration_date + timedelta(days=5), delta=time_gap)
-        self.assertEqual(
-            apple_lot.removal_date, False,
-            "Must be false as the `removal_time` isn't set on product.")
+        self.assertAlmostEqual(
+            apple_lot.removal_date, expiration_date + timedelta(days=self.apple_product.removal_time), delta=time_gap,
+            msg="`removal_date` should always be calculated when an expiration date is defined")
         self.assertAlmostEqual(
             apple_lot.alert_date, expiration_date + timedelta(days=4), delta=time_gap)
 


### PR DESCRIPTION
Steps to reproduce the bug:
- Install product_expiry and inventory
- Go to inventory settings and enable “Expiration date”
- Create a product with tracking by lots and an expiration date
- Set on the product category: Force Removal Strategy = FEFO
- Create a PO for the product > Receive product and set expiration date to “30/10” for LOT 1
- Create another PO for LOT 2 with an expiration date set to “29/10”
- Create a sales order for this product > Go to delivery

Problem:
Lot1 will be chosen on the delivery linked to the SO while lot2 must be selected
because it has an expiration date before lot 1

The lot is chosen based on the date defined in the removal_date field,
so this field should always be calculated when an expiration date is defined

Solution:
Set the fields ("use_date", "removal_date", "alert_date") when an expiration date is defined

opw-2613711



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
