### PR TITLE
[IMP] test_mail_full: add a test model for both SMS and activities

### DIFF
--- a/addons/test_mail_full/models/test_mail_models.py
+++ b/addons/test_mail_full/models/test_mail_models.py
@@ -50,6 +50,19 @@ class MailTestSMSBL(models.Model):
         return ['phone_nbr', 'mobile_nbr']
 
 
+class MailTestSMSBLActivity(models.Model):
+    """ A model inheriting from mail.thread.phone allowing to test auto formatting
+    of phone numbers, blacklist, ... as well as activities management. """
+    _description = 'SMS Mailing Blacklist Enabled with activities'
+    _name = 'mail.test.sms.bl.activity'
+    _inherit = [
+        'mail.test.sms.bl',
+        'mail.activity.mixin',
+    ]
+    _mailing_enabled = True
+    _order = 'name asc, id asc'
+
+
 class MailTestSMSOptout(models.Model):
     """ Model using blacklist mechanism and a hijacked opt-out mechanism for
     mass mailing features. """

--- a/addons/test_mail_full/security/ir.model.access.csv
+++ b/addons/test_mail_full/security/ir.model.access.csv
@@ -3,6 +3,8 @@ access_mail_test_sms_all,mail.test.sms.all,model_mail_test_sms,,0,0,0,0
 access_mail_test_sms_user,mail.test.sms.user,model_mail_test_sms,base.group_user,1,1,1,1
 access_mail_test_sms_bl_all,mail.test.sms.bl.all,model_mail_test_sms_bl,,0,0,0,0
 access_mail_test_sms_bl_user,mail.test.sms.bl.user,model_mail_test_sms_bl,base.group_user,1,1,1,1
+access_mail_test_sms_bl_activity_all,mail.test.sms.bl.activity.all,model_mail_test_sms_bl_activity,,0,0,0,0
+access_mail_test_sms_bl_activity_user,mail.test.sms.bl.activity.user,model_mail_test_sms_bl_activity,base.group_user,1,1,1,1
 access_mail_test_sms_bl_optout_all,mail.test.sms.bl.optout.all,model_mail_test_sms_bl_optout,,0,0,0,0
 access_mail_test_sms_bl_optout_user,mail.test.sms.bl.optout.user,model_mail_test_sms_bl_optout,base.group_user,1,1,1,1
 access_mail_test_sms_partner_all,mail.test.sms.partner.all,model_mail_test_sms_partner,,0,0,0,0


### PR DESCRIPTION
Purpose is to ease future new tests about activities management
involving phone numbers and SMS sending.

Task-2657021