### PR TITLE
[IMP] base, *: allow html fields not to sanitize forms

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -158,7 +158,7 @@ class Slide(models.Model):
     document_id = fields.Char('Document ID', help="Youtube or Google Document ID")
     link_ids = fields.One2many('slide.slide.link', 'slide_id', string="External URL for this slide")
     mime_type = fields.Char('Mime-type')
-    html_content = fields.Html("HTML Content", help="Custom HTML content for slides of type 'Web Page'.", translate=True)
+    html_content = fields.Html("HTML Content", help="Custom HTML content for slides of type 'Web Page'.", translate=True, sanitize_form=False)
     # website
     website_id = fields.Many2one(related='channel_id.website_id', readonly=True)
     date_published = fields.Datetime('Publish Date', readonly=True, tracking=True)

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1628,6 +1628,7 @@ class Html(_String):
         'sanitize_style': False,        # whether to sanitize style attributes
         'strip_style': False,           # whether to strip style attributes (removed and therefore not sanitized)
         'strip_classes': False,         # whether to strip classes attributes
+        'sanitize_form': True,          # whether to sanitize forms
     }
 
     def _get_attrs(self, model, name):
@@ -1662,7 +1663,8 @@ class Html(_String):
                 sanitize_attributes=self.sanitize_attributes,
                 sanitize_style=self.sanitize_style,
                 strip_style=self.strip_style,
-                strip_classes=self.strip_classes)
+                strip_classes=self.strip_classes,
+                sanitize_form=self.sanitize_form)
         return value
 
     def convert_to_cache(self, value, record, validate=True):
@@ -1675,7 +1677,8 @@ class Html(_String):
                 sanitize_attributes=self.sanitize_attributes,
                 sanitize_style=self.sanitize_style,
                 strip_style=self.strip_style,
-                strip_classes=self.strip_classes)
+                strip_classes=self.strip_classes,
+                sanitize_form=self.sanitize_form)
         return value
 
 

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -177,7 +177,7 @@ class _Cleaner(clean.Cleaner):
                 del el.attrib['style']
 
 
-def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=False, sanitize_style=False, strip_style=False, strip_classes=False):
+def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=False, sanitize_style=False, strip_style=False, strip_classes=False, sanitize_form=True):
     if not src:
         return src
     src = ustr(src, errors='replace')
@@ -195,7 +195,7 @@ def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=Fals
         'page_structure': True,
         'style': strip_style,              # True = remove style tags/attrs
         'sanitize_style': sanitize_style,  # True = sanitize styling
-        'forms': True,                     # True = remove form tags
+        'forms': sanitize_form,            # True = remove form tags
         'remove_unknown_tags': False,
         'comments': False,
         'processing_instructions': False


### PR DESCRIPTION
\* = website_slides

The option to sanitize or not the forms was not available, this will
allow better flexibility on whether forms should be sanitized or not on
an HTML field.
Also we use this new param to allow forms to be added on an already
existing html field where the form was sanitized out.

This is a backport of 388c222c6c4bb7e2fe3e67009b248359ae0fd3db
adapted to the needs in 13.0