### PR TITLE
[FIX] web_tour: display rainbowman at end of tours

### DIFF
--- a/addons/web_tour/static/src/js/tour_manager.js
+++ b/addons/web_tour/static/src/js/tour_manager.js
@@ -434,7 +434,7 @@ return core.Class.extend(mixins.EventDispatcherMixin, ServicesMixin, {
             }
             const fadeout = this.tours[tour_name].fadeout;
             core.bus.trigger('show-effect', {
-                type: "rainbowman",
+                type: "rainbow_man",
                 message,
                 fadeout,
                 messageIsHtml: true,


### PR DESCRIPTION
Since commit [1], it crashed when, at the end of a tour, we tried
to display a rainbow man, because we forgot to update the "type"
key.

74dc3f654ee5849982b494e46eefb1fc2b4e0c74

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
