### PR TITLE
Fix delivery shipment rate error for unimplemented delivery types

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -157,6 +157,10 @@ class DeliveryCarrier(models.Model):
                 res['warning_message'] = _('The shipping is free since the order amount exceeds %.2f.') % (self.amount)
                 res['price'] = 0.0
             return res
+        else:
+            return {
+                'error_message': _("Shipment rate not found")
+            }
 
     def send_shipping(self, pickings):
         ''' Send the package to the service provider

--- a/doc/cla/individual/mjrk.md
+++ b/doc/cla/individual/mjrk.md
@@ -1,0 +1,11 @@
+Bulgaria, 27 September, 2021
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Michael Jurke m.jurke@gmx.de https://github.com/mjrk/


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Unimplemented delivery_types for delivery carriers lead to 500

Current behavior before PR: During an odoo version update or by replacing one delivery app by another, it can happen that the shipping method is not implemented (see delivery_carrier.py#rate_shipment method). This will lead to a 500 Internal Server Error when opening the checkout page that contains the delivery method select.

Desired behavior after PR is merged: Instead of a 500 Internal Server Error (full show stopper), the error message "Shipment rate not found" is returned. The interface displays the error messages like other errors and it is ensured, that the user cannot proceed when selecting an erroneous delivery carrier.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr