### PR TITLE
[13.0][FIX] website_livechat: Remove hidden dependency with 'snailmail'

### DIFF
--- a/addons/mail/static/src/js/thread_widget.js
+++ b/addons/mail/static/src/js/thread_widget.js
@@ -134,6 +134,7 @@ var ThreadWidget = Widget.extend({
 
         // copy so that reverse do not alter order in the thread object
         var messages = _.clone(thread.getMessages({ domain: options.domain || [] }));
+        this._messages = messages;
 
         var modeOptions = options.isCreateMode ? this._disabledOptions :
                                                  this._enabledOptions;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
'website_livechat' has a hidden dependency with 'snailmail'. This PR moves "_messages" assign. from 'snailmail' to 'mail' module.
Conflict line in 'website_livechat': https://github.com/odoo/odoo/blob/13.0/addons/website_livechat/static/src/js/thread_window.js#L23

Current behavior before PR:
Can't close message chat popup when have website_livechat installed and snailmail uninstalled due to javascript error.

Desired behavior after PR is merged:
Can close message chat popup



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
