### PR TITLE
[FW][FIX] l10n_ar: return vat info grouped by tax

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -271,11 +271,12 @@ class AccountMove(models.Model):
         for line in self.line_ids:
             if any(tax.tax_group_id.l10n_ar_vat_afip_code and tax.tax_group_id.l10n_ar_vat_afip_code not in ['0', '1', '2'] for tax in line.tax_line_id) and line['price_subtotal']:
                 vat_taxable |= line
-        for vat in vat_taxable:
-            base_imp = sum(self.invoice_line_ids.filtered(lambda x: x.tax_ids.filtered(lambda y: y.tax_group_id.l10n_ar_vat_afip_code == vat.tax_line_id.tax_group_id.l10n_ar_vat_afip_code)).mapped('price_subtotal'))
-            res += [{'Id': vat.tax_line_id.tax_group_id.l10n_ar_vat_afip_code,
+        for tax_group in vat_taxable.mapped('tax_group_id'):
+            base_imp = sum(self.invoice_line_ids.filtered(lambda x: x.tax_ids.filtered(lambda y: y.tax_group_id.l10n_ar_vat_afip_code == tax_group.l10n_ar_vat_afip_code)).mapped('price_subtotal'))
+            imp = sum(vat_taxable.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code == tax_group.l10n_ar_vat_afip_code).mapped('price_subtotal'))
+            res += [{'Id': tax_group.l10n_ar_vat_afip_code,
                      'BaseImp': base_imp,
-                     'Importe': vat['price_subtotal']}]
+                     'Importe': imp}]
 
         # Report vat 0%
         vat_base_0 = sum(self.invoice_line_ids.filtered(lambda x: x.tax_ids.filtered(lambda y: y.tax_group_id.l10n_ar_vat_afip_code == '3')).mapped('price_subtotal'))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In the method _get_vat(), used to inform AFIP about the vat taxes of an
invoice, we were assuming that in the journal items of the invoices
there is always one line per tax group, but if the user enables the
option "Include in Analytic Cost" of the tax, then it could create more
than one line per tax so it will return an error if you try to validate
the invoice in AFIP or upload the vat book.

Steps to replicate the error:

In a database with l10n_ar localization installed.
Move to a company with the Argentinean char of accounts.
Create a tax with the following configuration:
- Tax Computation: Percentage of Price
- Include in Analytic Cost: enabled
Create an electronic journal.
Create an invoice with the electronic journal and multiple lines adding the tax created before and differents analytic accounts.
Try to validate.
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Forward-Port-Of: #75802
