### PR TITLE
[IMP] Warn for open carts when changing the partner pricelist

### DIFF
--- a/addons/website_sale/models/res_partner.py
+++ b/addons/website_sale/models/res_partner.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 from odoo.addons.website.models import ir_http
 
 
@@ -18,8 +18,29 @@ class ResPartner(models.Model):
             if website and not is_public:
                 partner.last_website_so_id = SaleOrder.search([
                     ('partner_id', '=', partner.id),
+                    ('pricelist_id', '=', partner.property_product_pricelist.id),
                     ('website_id', '=', website.id),
                     ('state', '=', 'draft'),
                 ], order='write_date desc', limit=1)
             else:
                 partner.last_website_so_id = SaleOrder  # Not in a website context or public User
+
+    @api.onchange('property_product_pricelist')
+    def _onchange_property_product_pricelist(self):
+        open_order = self.env['sale.order'].search([
+            ('partner_id', '=', self._origin.id),
+            ('pricelist_id', '=', self._origin.property_product_pricelist.id),
+            ('pricelist_id', '!=', self.property_product_pricelist.id),
+            ('website_id', '!=', False),
+            ('state', '=', 'draft'),
+        ], limit=1)
+
+        if open_order:
+            return {'warning': {
+                'title': _('Open Sale Orders'),
+                'message': _(
+                    "This partner has an open cart. "
+                    "Please note that the pricelist will not be updated on that cart. "
+                    "Also, the cart might not be visible for the customer until you update the pricelist of that cart."
+                ),
+            }}


### PR DESCRIPTION
It is not always immediately clear to the end user that changing the pricelist on a partner will not change the pricelist for any open carts related to this partner. To clarify, this commit introduces a warning message, indicating that the end user should change the pricelists of these open carts manually if this is the desired effect.
    
Any open carts that already have the same pricelist as the new partner pricelist are excluded from the search and will not trigger the warning message.

task-2635067