### PR TITLE
[FIX] mail : traceback on Marketing Automation Mailings test send

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -90,6 +90,8 @@ class MailMail(models.Model):
         # To remove when automatic context propagation is removed in web client
         if self._context.get('default_type') not in type(self).message_type.base_field.selection:
             self = self.with_context(dict(self._context, default_type=None))
+        if self._context.get('default_state') not in type(self).state.base_field.selection:
+            self = self.with_context(dict(self._context, default_state='outgoing'))
         return super(MailMail, self).default_get(fields)
 
     def mark_outgoing(self):


### PR DESCRIPTION
Issue: When test sending a mail in Marketing Automation Mailings, there
is a traceback because we try to set the state of the mail to done,
even though there is no done in mail_mail.state

Steps to reproduce :
 1) Install Marketing Automation
 2) Create/select a campaign
 3) Access the templates of that campaign
 4) Create/select a template
 5) Click Test
 6) Send Sample Email
 -> Traceback

opw-2568210