### PR TITLE
[FIX] web: clickbot: correctly wait for next view

### DIFF
--- a/addons/web/static/src/webclient/clickbot/clickbot.js
+++ b/addons/web/static/src/webclient/clickbot/clickbot.js
@@ -295,7 +295,9 @@
                     triggerClick(target, `${viewType} view switcher`);
                 }
             }, 250);
-            await waitForCondition(() => document.querySelector(`.o_${viewType}_view`) !== null);
+            await waitForCondition(() => {
+                return document.querySelector(`.o_switch_view.o_${viewType}.active`) !== null;
+            });
             await testFilters();
         }
     }


### PR DESCRIPTION
Before this commit, the clickbot test failed when switching from
a dashboard view to a pivot, graph or cohort view, because the
condition to wait before toggling the filters in the next view was
wrong. As a consequence, we started to toggle the filters for the
next view on the dashboard view, so when we actually switched to
that view, the filter menu was closed and the tour was blocked.

The previous condition used the `.o_{view_type}_view` classname,
targetting the root node of the view (which appears in the DOM when
the view is loaded). Unfortunately, since [1] and the new
implementation of the graph and pivot views, we added root
classnames to graph and pivot (o_graph_view and o_pivot_view),
whereas it wasn't the case before. So when leaving a dashboard
view to a graph or pivot view, the former condition was directly
true (if the dashboard contained those views), and we didn't wait
for the next graph or pivot view to be loaded.

Note that the former implementatin of the cohort view already added
the "o_cohort_view" classname on its root node, but it didn't make
the clickbot test fail because we don't have cohort views next to
dashboard views in standard actions.

This commit changes the condition to use the view switcher icons
instead.

[1] 0134495ba55bea16c2d11d5eb5d832edad575694

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
