### PR TITLE
[FIX] website_sale_stock: always select a warehouse

### DIFF
--- a/addons/website_sale_stock/models/product_template.py
+++ b/addons/website_sale_stock/models/product_template.py
@@ -27,7 +27,7 @@ class ProductTemplate(models.Model):
         if combination_info['product_id']:
             product = self.env['product.product'].sudo().browse(combination_info['product_id'])
             website = self.env['website'].get_current_website()
-            virtual_available = product.with_context(warehouse=website.warehouse_id.id).virtual_available
+            virtual_available = product.with_context(warehouse=website._get_warehouse_available()).virtual_available
             combination_info.update({
                 'virtual_available': virtual_available,
                 'virtual_available_formatted': self.env['ir.qweb.field.float'].value_to_html(virtual_available, {'decimal_precision': 'Product Unit of Measure'}),

--- a/addons/website_sale_stock/models/sale_order.py
+++ b/addons/website_sale_stock/models/sale_order.py
@@ -17,11 +17,8 @@ class SaleOrder(models.Model):
         for line in self.order_line:
             if line.product_id.type == 'product' and line.product_id.inventory_availability in ['always', 'threshold']:
                 cart_qty = sum(self.order_line.filtered(lambda p: p.product_id.id == line.product_id.id).mapped('product_uom_qty'))
-                # The quantity should be computed based on the warehouse of the website, not the
-                # warehouse of the SO.
-                website = self.env['website'].get_current_website()
-                if cart_qty > line.product_id.with_context(warehouse=website.warehouse_id.id).virtual_available and (line_id == line.id):
-                    qty = line.product_id.with_context(warehouse=website.warehouse_id.id).virtual_available - cart_qty
+                if cart_qty > line.product_id.with_context(warehouse=self.warehouse_id.id).virtual_available and (line_id == line.id):
+                    qty = line.product_id.with_context(warehouse=self.warehouse_id.id).virtual_available - cart_qty
                     new_val = super(SaleOrder, self)._cart_update(line.product_id.id, line.id, qty, 0, **kwargs)
                     values.update(new_val)
 

--- a/addons/website_sale_stock/models/website.py
+++ b/addons/website_sale_stock/models/website.py
@@ -11,12 +11,15 @@ class Website(models.Model):
         self.ensure_one()
         values = super(Website, self)._prepare_sale_order_values(partner, pricelist)
         if values['company_id']:
-            warehouse_id = (
-                self.warehouse_id and self.warehouse_id.id or
-                self.env['ir.default'].get('sale.order', 'warehouse_id', company_id=values.get('company_id')) or
-                self.env['ir.default'].get('sale.order', 'warehouse_id') or
-                self.env['stock.warehouse'].sudo().search([('company_id', '=', values['company_id'])], limit=1).id
-            )
+            warehouse_id = self._get_warehouse_available()
             if warehouse_id:
                 values['warehouse_id'] = warehouse_id
         return values
+
+    def _get_warehouse_available(self):
+        return (
+            self.warehouse_id and self.warehouse_id.id or
+            self.env['ir.default'].get('sale.order', 'warehouse_id', company_id=self.company_id.id) or
+            self.env['ir.default'].get('sale.order', 'warehouse_id') or
+            self.env['stock.warehouse'].sudo().search([('company_id', '=', self.company_id.id)], limit=1).id
+        )

--- a/addons/website_sale_stock/tests/test_website_sale_stock_product_warehouse.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_product_warehouse.py
@@ -78,3 +78,24 @@ class TestWebsiteSaleStockProductWarehouse(TestSaleProductAttributeValueSetup):
 
             # Check available quantity of product is according to warehouse
             self.assertEqual(combination_info['virtual_available'], qty_b, "%s units of Product B should be available in warehouse %s" % (qty_b, wh))
+
+    def test_02_update_cart_with_multi_warehouses(self):
+        """ When the user updates his cart and increases a product quantity, if
+        this quantity is not available in the SO's warehouse, a warning should
+        be returned and the quantity updated to its maximum. """
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.env.user.partner_id.id,
+            'order_line': [(0, 0, {
+                'name': self.product_A.name,
+                'product_id': self.product_A.id,
+                'product_uom_qty': 5,
+                'product_uom': self.product_A.uom_id.id,
+                'price_unit': self.product_A.list_price,
+            })]
+        })
+
+        with MockRequest(self.env, website=self.website, sale_order_id=so.id):
+            values = so._cart_update(product_id=self.product_A.id, line_id=so.order_line.id, set_qty=20)
+            self.assertTrue(values.get('warning', False))
+            self.assertEqual(values.get('quantity'), 10)

--- a/addons/website_sale_stock/tests/test_website_sale_stock_product_warehouse.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_product_warehouse.py
@@ -1,74 +1,80 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.website_sale.tests.test_website_sale_product_attribute_value_config import TestWebsiteSaleProductAttributeValueConfig
+from odoo.addons.website.tools import MockRequest
+from odoo.addons.sale.tests.test_sale_product_attribute_value_config import TestSaleProductAttributeValueSetup
+from odoo.tests import tagged
 
 
-class TestWebsiteSaleStockProductWarehouse(TestWebsiteSaleProductAttributeValueConfig):
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleStockProductWarehouse(TestSaleProductAttributeValueSetup):
 
-    def test_get_combination_info(self):
-        """ Checked that correct product quantity is shown in website according to the warehouse
-        which is set in current website.
-            - Create two warehouse
-            - Create two stockable products
-            - Update quantity of Product A in Warehouse 1
-            - Update quantity of Product B in Warehouse 2
-            - Set Warehouse 1 in website
-            - Check available quantity of Product A and Product B in website
-        Product A should be available in the website as it is available in warehouse 1 but Product B
-        should not be available in website as it is stored in warehouse 2.
-        """
-        # Create two warehouses
-        warehouse_1 = self.env['stock.warehouse'].create({
-            'name': 'Warehouse 1',
-            'code': 'WH1'
-        })
-        warehouse_2 = self.env['stock.warehouse'].create({
+    def setUp(self):
+        super().setUp()
+        # Run the tests in another company, so the tests do not rely on the
+        # database state (eg the default company's warehouse)
+        self.company = self.env['res.company'].create({'name': 'Company C'})
+        self.env.user.company_id = self.company
+        self.website = self.env['website'].create({'name': 'Website Company C'})
+        self.website.company_id = self.company
+
+        # Set two warehouses (one was created on company creation)
+        self.warehouse_1 = self.env['stock.warehouse'].search([('company_id', '=', self.company.id)])
+        self.warehouse_2 = self.env['stock.warehouse'].create({
             'name': 'Warehouse 2',
             'code': 'WH2'
         })
 
         # Create two stockable products
-        product_1 = self.env['product.product'].create({
+        self.product_A = self.env['product.product'].create({
             'name': 'Product A',
             'inventory_availability': 'always',
             'type': 'product',
             'default_code': 'E-COM1',
         })
 
-        product_2 = self.env['product.product'].create({
+        self.product_B = self.env['product.product'].create({
             'name': 'Product B',
             'inventory_availability': 'always',
             'type': 'product',
             'default_code': 'E-COM2',
         })
 
-        # Update quantity of Product A in Warehouse 1
+        # Add 10 Product A in WH1 and 15 Product 1 in WH2
+        self.env['stock.quant'].with_context(inventory_mode=True).create([{
+            'product_id': self.product_A.id,
+            'inventory_quantity': qty,
+            'location_id': wh.lot_stock_id.id,
+        } for wh, qty in [(self.warehouse_1, 10.0), (self.warehouse_2, 15.0)]])
+
+        # Add 10 Product 2 in WH2
         self.env['stock.quant'].with_context(inventory_mode=True).create({
-            'product_id': product_1.id,
+            'product_id': self.product_B.id,
             'inventory_quantity': 10.0,
-            'location_id': warehouse_1.lot_stock_id.id,
+            'location_id': self.warehouse_2.lot_stock_id.id,
         })
 
-        # Update quantity of Product B in Warehouse 2
-        self.env['stock.quant'].with_context(inventory_mode=True).create({
-            'product_id': product_2.id,
-            'inventory_quantity': 10.0,
-            'location_id': warehouse_2.lot_stock_id.id,
-        })
+    def test_01_get_combination_info(self):
+        """ Checked that correct product quantity is shown in website according
+        to the warehouse which is set in current website.
+          - Set Warehouse 1, Warehouse 2 or none in website and:
+            - Check available quantity of Product A and Product B in website
+        When the user doesn't set any warehouse, the module should still select
+        a default one.
+        """
 
-        # Get current website and set warehouse_id of Warehouse 1
-        current_website = self.env['website'].get_current_website()
-        current_website.warehouse_id = warehouse_1
+        for wh, qty_a, qty_b in [(self.warehouse_1, 10, 0), (self.warehouse_2, 15, 10), (False, 10, 0)]:
+            # set warehouse_id
+            self.website.warehouse_id = wh
 
-        product = product_1.with_context(website_id=current_website.id)
-        combination_info = product.product_tmpl_id.with_context(website_sale_stock_get_quantity=True)._get_combination_info()
+            product = self.product_A.with_context(website_id=self.website.id)
+            combination_info = product.product_tmpl_id.with_context(website_sale_stock_get_quantity=True)._get_combination_info()
 
-        # Check available quantity of product is according to warehouse
-        self.assertEqual(combination_info['virtual_available'], 10, "10 units of Product A should be available in warehouse 1.")
+            # Check available quantity of product is according to warehouse
+            self.assertEqual(combination_info['virtual_available'], qty_a, "%s units of Product A should be available in warehouse %s" % (qty_a, wh))
 
-        product = product_2.with_context(website_id=current_website.id)
-        combination_info = product.product_tmpl_id.with_context(website_sale_stock_get_quantity=True)._get_combination_info()
+            product = self.product_B.with_context(website_id=self.website.id)
+            combination_info = product.product_tmpl_id.with_context(website_sale_stock_get_quantity=True)._get_combination_info()
 
-        # Check available quantity of product is according to warehouse
-        self.assertEqual(combination_info['virtual_available'], 0, "Product B should not be available in warehouse 1.")
+            # Check available quantity of product is according to warehouse
+            self.assertEqual(combination_info['virtual_available'], qty_b, "%s units of Product B should be available in warehouse %s" % (qty_b, wh))


### PR DESCRIPTION
In a multi-warehouses configuration, the available quantities displayed
and the quantities that can actually be ordered are not the same

To reproduce the issue:
1. In Settings:
    - Enable 'Multi-Warehouses'
    - Make sure the option Website > Inventory > Warehouse in undefined
2. Create a second warehouse WH02
3. Update the quantity of "Storage Box":
    - 18 in first WH (should already be present)
    - 12 in WH02
4. Edit "Storage Box":
    - eCommerce > Availability: "Show inventory on website and prevent
sales if not enough stock"
5. On the eShop, go on "Storage Box"
    - Note that there are 30 units available
6. Add 22 "Storage Box" to the cart
7. Process checkout

Error: When trying to pay, a Server Error is raised: "We are not able to
redirect you to the payment form. You ask for 22.0 products but only
18.0 is available." This is confusing since the available quantity on
the product page is 30

When consulting the website, since we didn't define any warehouse (step
1), the quantities displayed are the sum of the quantities in each
warehouse. However, a sale order is always linked to one(!) warehouse.
So, when adding the Storage Box to the cart, there isn't any warehouse
defined. Therefore, a default one is selected:
https://github.com/odoo/odoo/blob/99fe3477fecc4948ac621fda82d93bf263933f02/addons/sale_stock/models/sale_order.py#L63-L67
When trying to pay, because of step 4, the server checks the quantity
available in the selected warehouse. This explains the error message

Considering the structure of `sale.order`, displaying the quantities in
several warehouses does not make sense.

OPW-2630804