### PR TITLE
[ADD] loyalty, *: make loyalty available on eCommerce

### DIFF
--- a/addons/loyalty/__init__.py
+++ b/addons/loyalty/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models
+from . import wizard

--- a/addons/loyalty/__manifest__.py
+++ b/addons/loyalty/__manifest__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Loyalty Program',
+    'version': '1.0',
+    'category': 'Sales',
+    'summary': 'Loyalty Program',
+    'description': """
+
+This module allows you to define a loyalty program 
+where customers earn loyalty points and get rewards.
+
+""",
+    'depends': [
+        'base',
+    ],
+    'data': [
+        'views/loyalty_views.xml',
+        'security/ir.model.access.csv',
+    ],
+    'demo': [
+        'data/loyalty_demo.xml',
+    ],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/addons/loyalty/data/loyalty_demo.xml
+++ b/addons/loyalty/data/loyalty_demo.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="program" model="loyalty.program">
+        <field name="name">Loyalty Program</field>
+        <field name="points">10</field>
+    </record>
+</odoo>

--- a/addons/loyalty/models/__init__.py
+++ b/addons/loyalty/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import loyalty_program
+from . import loyalty_rule
+from . import res_partner

--- a/addons/loyalty/models/loyalty_program.py
+++ b/addons/loyalty/models/loyalty_program.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class LoyaltyProgram(models.Model):
+    _name = 'loyalty.program'
+    _description = 'Loyalty Program'
+
+    name = fields.Char(string='Loyalty Program Name', index=True, required=True, translate=True, help="An internal identification for the loyalty program configuration")
+    points = fields.Float(string='Point per $ spent', help="How many loyalty points are given to the customer by sold currency")
+    rule_ids = fields.One2many('loyalty.rule', 'loyalty_program_id', string='Rules')
+    active = fields.Boolean(default=True)

--- a/addons/loyalty/models/loyalty_rule.py
+++ b/addons/loyalty/models/loyalty_rule.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class LoyaltyRule(models.Model):
+    _name = 'loyalty.rule'
+    _description = 'Loyalty Rule'
+
+    name = fields.Char(index=True, required=True, help="An internal identification for this loyalty program rule")
+    loyalty_program_id = fields.Many2one('loyalty.program', ondelete='cascade', string='Loyalty Program', help='The Loyalty Program this exception belongs to')
+    points_quantity = fields.Float(string="Points per Unit")
+    points_currency = fields.Float(string="Points per $ spent")
+    rule_domain = fields.Char()

--- a/addons/loyalty/models/res_partner.py
+++ b/addons/loyalty/models/res_partner.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    loyalty_points = fields.Float(company_dependent=True, help='The loyalty points the user won as part of a Loyalty Program')
+
+    @api.constrains('loyalty_points')
+    def _check_loyalty_points(self):
+        for record in self:
+            if record.loyalty_points < 0:
+                raise ValidationError(
+                    _('Loyalty points cannot be negative')
+                )

--- a/addons/loyalty/security/ir.model.access.csv
+++ b/addons/loyalty/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_loyalty_program,loyalty.program.user,model_loyalty_program,base.group_user,1,0,0,0
+access_loyalty_program_manager,loyalty.program.manager,model_loyalty_program,base.group_system,1,1,1,1
+access_loyalty_rule,loyalty.rule.user,model_loyalty_rule,base.group_user,1,0,0,0
+access_loyalty_rule_manager,loyalty.rule.manager,model_loyalty_rule,base.group_system,1,1,1,1

--- a/addons/loyalty/views/loyalty_views.xml
+++ b/addons/loyalty/views/loyalty_views.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_loyalty_program_form" model="ir.ui.view">
+        <field name="name">loyalty.program.form</field>
+        <field name="model">loyalty.program</field>
+        <field name="arch" type="xml">
+            <form string="Loyalty Program">
+                <sheet>
+                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <field name="active" invisible="1"/>
+                    <div class="oe_title">
+                        <h1><field name="name" placeholder="Loyalty Program Name"/></h1>
+                    </div>
+
+                    <div>
+                        <label for="points"/>
+                        <field name="points"/>
+                    </div>
+
+                    <notebook>
+                        <page id="rules_ids" string="Points Rules">
+                            <p>Rules change how loyalty points are earned for specific products or categories</p>
+
+                            <field name="rule_ids" colspan="4" nolabel="1">
+                                <tree string="Rules">
+                                    <field name="name" />
+                                    <field name="points_quantity"/>
+                                    <field name="points_currency"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_loyalty_program_search" model="ir.ui.view">
+        <field name="name">loyalty.program.search</field>
+        <field name="model">loyalty.program</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name"/>
+                <filter string="Archived" name="active" domain="[('active', '=', False)]"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="view_loyalty_rule_form" model="ir.ui.view">
+        <field name="name">loyalty.rule.form</field>
+        <field name="model">loyalty.rule</field>
+        <field name="arch" type="xml">
+            <form string="Loyalty Rule">
+                <div class="oe_title">
+                    <label for="name" string="Rule Name"/>
+                    <h1><field name="name"/></h1>
+                </div>
+                <group col="2">
+                    <group col='2'>
+                        <field name="rule_domain" string="Based on Products" widget="domain" options="{'model': 'product.product', 'in_dialog': true}"/>
+                    </group>
+                    <group col='2'>
+                        <field name="points_quantity"/>
+                        <field name="points_currency"/>
+                    </group>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_loyalty_program_tree" model="ir.ui.view">
+        <field name="name">loyalty.program.form</field>
+        <field name="model">loyalty.program</field>
+        <field name="arch" type="xml">
+            <tree string="Loyalty Programs">
+                <field name="name" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_loyalty_program_kanban" model="ir.ui.view">
+        <field name="name">loyalty.program.kanban</field>
+        <field name="model">loyalty.program</field>
+        <field name="arch" type="xml">
+            <kanban class="o_kanban_mobile">
+                <field name="name"/>
+                <field name="points"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div t-attf-class="oe_kanban_global_click">
+                            <div class="mb4">
+                                <strong><field name="name"/></strong>
+                            </div>
+                            <div class="mb4" t-if="record.points.raw_value">
+                                <strong>Points:</strong>
+                                <span class="badge badge-pill float-right"><field name="points"/></span>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="action_loyalty_program_form" model="ir.actions.act_window">
+        <field name="name">Loyalty Programs</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">loyalty.program</field>
+        <field name="view_mode">tree,kanban,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a new loyalty program
+            </p><p>
+                Loyalty Programs allows you customer to earn points
+                and rewards when doing business at your shops.
+            </p>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/loyalty/wizard/__init__.py
+++ b/addons/loyalty/wizard/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import base_partner_merge

--- a/addons/loyalty/wizard/base_partner_merge.py
+++ b/addons/loyalty/wizard/base_partner_merge.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+class BasePartnerMergeAutomaticWizard(models.TransientModel):
+    _inherit = 'base.partner.merge.automatic.wizard'
+
+    def _get_summable_fields(self):
+        res = super(BasePartnerMergeAutomaticWizard, self)._get_summable_fields()
+        res.extend(['loyalty_points'])
+        return res

--- a/addons/loyalty_sales_team/__init__.py
+++ b/addons/loyalty_sales_team/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/addons/loyalty_sales_team/__manifest__.py
+++ b/addons/loyalty_sales_team/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Loyalty Program for Sales Team',
+    'version': '1.0',
+    'category': 'Sales',
+    'summary': 'Bridge Module for loyalty / sales_team',
+    'description': 'Bridge Module to allow sales team managers to define loyalty programs',
+    'depends': [
+        'loyalty',
+        'sales_team',
+    ],
+    'data': [
+        'security/ir.model.access.csv',
+    ],
+    'installable': True,
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/loyalty_sales_team/security/ir.model.access.csv
+++ b/addons/loyalty_sales_team/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_loyalty_program_manager,loyalty.program.manager,loyalty.model_loyalty_program,sales_team.group_sale_manager,1,1,1,1
+access_loyalty_program_salesman,loyalty.program.salesman,loyalty.model_loyalty_program,sales_team.group_sale_salesman,1,0,0,0
+access_loyalty_rule_manager,loyalty.rule.manager,loyalty.model_loyalty_rule,sales_team.group_sale_manager,1,1,1,1
+access_loyalty_rule_salesman,loyalty.rule.salesman,loyalty.model_loyalty_rule,sales_team.group_sale_salesman,1,0,0,0

--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -177,6 +177,7 @@ class CustomerPortal(portal.CustomerPortal):
             'partner_id': order_sudo.partner_id.id,
             'report_type': 'html',
             'action': order_sudo._get_portal_return_action(),
+            'page_name': kw.get('page_name'),
         }
         if order_sudo.company_id:
             values['res_company'] = order_sudo.company_id

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -3,15 +3,15 @@
 
     <template id="portal_my_home_menu_sale" name="Portal layout : sales menu entries" inherit_id="portal.portal_breadcrumbs" priority="20">
         <xpath expr="//ol[hasclass('o_portal_submenu')]" position="inside">
-            <li t-if="page_name == 'quote' or sale_order and sale_order.state in ('sent', 'cancel')" t-attf-class="breadcrumb-item #{'active ' if not sale_order else ''}">
+            <li t-if="page_name == 'quote' or sale_order and sale_order.state in ('sent', 'cancel') and not page_name" t-attf-class="breadcrumb-item #{'active ' if not sale_order else ''}">
                 <a t-if="sale_order" t-attf-href="/my/quotes?{{ keep_query() }}">Quotations</a>
                 <t t-else="">Quotations</t>
             </li>
-            <li t-if="page_name == 'order' or sale_order and sale_order.state not in ('sent', 'cancel')" t-attf-class="breadcrumb-item #{'active ' if not sale_order else ''}">
+            <li t-if="page_name == 'order' or sale_order and sale_order.state not in ('sent', 'cancel') and not page_name" t-attf-class="breadcrumb-item #{'active ' if not sale_order else ''}">
                 <a t-if="sale_order" t-attf-href="/my/orders?{{ keep_query() }}">Sales Orders</a>
                 <t t-else="">Sales Orders</t>
             </li>
-            <li t-if="sale_order" class="breadcrumb-item active">
+            <li t-if="sale_order" class="breadcrumb-item active o_portal_submenu_so">
                 <span t-field="sale_order.type_name"/>
                 <t t-esc="sale_order.name"/>
             </li>

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -24,6 +24,8 @@ class ResConfigSettings(models.TransientModel):
     module_website_sale_wishlist = fields.Boolean("Wishlists")
     module_website_sale_comparison = fields.Boolean("Product Comparison Tool")
     module_website_sale_gift_card = fields.Boolean("Gift Card")
+    module_website_sale_loyalty = fields.Boolean("Loyalty Program Module", help="Enables a loyalty program for this website")
+
     module_account = fields.Boolean("Invoicing")
 
     cart_recovery_mail_template = fields.Many2one('mail.template', string='Cart Recovery Email', domain="[('model', '=', 'sale.order')]",

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -188,6 +188,18 @@
                             </div>
                         </div>
                     </div>
+                    <div class="col-12 col-lg-6 o_setting_box" id="loyalty_settings">
+                        <div class="o_setting_left_pane">
+                            <field name="module_website_sale_loyalty" />
+                        </div>
+                        <div class="o_setting_right_pane" title="Loyalty program to use for this website.">
+                            <label for="module_website_sale_loyalty" string="Loyalty Program"/>
+                            <span class="fa fa-lg fa-globe" title="Values set here are website-specific." groups="website.group_multi_website"/>
+                            <div class="text-muted" id="loyalty_program">
+                                Give customer rewards, free samples, etc.
+                            </div>
+                        </div>
+                    </div>
                 </div>
 
                 <h2>Shipping</h2>

--- a/addons/website_sale_loyalty/__init__.py
+++ b/addons/website_sale_loyalty/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models
+from . import controllers

--- a/addons/website_sale_loyalty/__manifest__.py
+++ b/addons/website_sale_loyalty/__manifest__.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Loyalty - Ecommerce',
+    'summary': 'Bridge module loyalty using the website ecommerce.',
+    'description': 'Bridge module to allow website ecommerce to use loyalty programs.',
+    'category': 'Sale',
+    'depends': [
+        'loyalty',
+        'website_sale_gift_card',
+    ],
+    'data': [
+        'data/mail_data.xml',
+        'security/ir.model.access.csv',
+        'views/loyalty_views.xml',
+        'views/portal_templates.xml',
+        'views/res_config_settings_views.xml',
+        'views/res_partner_views.xml',
+        'views/sale_views.xml',
+        'views/website_sale_loyalty_views.xml',
+        'views/website_sale_templates.xml',
+    ],
+    'demo': [
+        'data/loyalty_demo.xml',
+    ],
+    'assets': {
+        'web.assets_frontend': [
+            '/website_sale_loyalty/static/src/scss/website_sale_loyalty.scss',
+            '/website_sale_loyalty/static/src/js/portal_loyalty.js',
+        ],
+        'web.assets_qweb': [
+            'website_sale_loyalty/static/src/xml/portal_loyalty.xml',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/addons/website_sale_loyalty/controllers/__init__.py
+++ b/addons/website_sale_loyalty/controllers/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import portal

--- a/addons/website_sale_loyalty/controllers/portal.py
+++ b/addons/website_sale_loyalty/controllers/portal.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import http, _
+from odoo.exceptions import UserError
+from odoo.http import request
+from odoo.addons.portal.controllers import portal
+from odoo.addons.portal.controllers.portal import pager as portal_pager
+
+
+class CustomerPortal(portal.CustomerPortal):
+
+    def _prepare_home_portal_values(self, counters):
+        values = super()._prepare_home_portal_values(counters)
+        partner = request.env.user.partner_id
+
+        if 'loyalty_points' in counters:
+            values['loyalty_points'] = int(partner.loyalty_points) if partner.loyalty_points.is_integer() else partner.loyalty_points
+        return values
+
+    # ------------------------------------------------------------
+    # My Loyalty
+    # ------------------------------------------------------------
+
+    @http.route(['/my/loyalty', '/my/loyalty/page/<int:page>'], type='http', auth="user", website=True)
+    def portal_my_loyalty(self, page=1, tab='rewards_catalog', **kw):
+        values = self._prepare_portal_layout_values()
+        partner = request.env.user.partner_id
+
+        if tab == 'rewards_catalog':
+            reward_ids = request.website.loyalty_id.website_reward_ids.sorted('point_cost')
+            # pager
+            pager = portal_pager(
+                url="/my/loyalty",
+                url_args={tab: 'rewards_catalog'},
+                total=len(reward_ids),
+                page=page,
+                step=self._items_per_page,
+            )
+            # content according to pager
+            reward_ids = reward_ids[pager['offset']:pager['offset'] + self._items_per_page]
+
+            values.update({
+                'rewards': reward_ids,
+            })
+        elif tab == 'won_points_history':
+            SaleOrder = request.env['sale.order']
+
+            domain = [
+                ('message_partner_ids', 'child_of', [partner.commercial_partner_id.id]),
+                ('state', 'in', ['sent', 'sale', 'done']),
+                ('website_id', '=', request.website.id),
+                ('won_loyalty_points', '>', 0),
+            ]
+
+            # count for pager
+            order_count = SaleOrder.search_count(domain)
+            # pager
+            pager = portal_pager(
+                url="/my/loyalty",
+                url_args={tab: 'won_points_history'},
+                total=order_count,
+                page=page,
+                step=self._items_per_page,
+            )
+            # content according to pager
+            orders = SaleOrder.search(domain, order='date_order desc', limit=self._items_per_page, offset=pager['offset'])
+            request.session['my_loyalty_history'] = orders.ids[:100]
+
+            values.update({
+                'orders': orders.sudo(),
+                'default_url': '/my/orders',
+            })
+        else:  # tab == 'redeem_history'
+            reward_ids = partner.sudo().loyalty_website_redeemed_reward_ids.filtered(
+                lambda reward: reward.website_id == request.website).sorted('create_date', reverse=True)
+            # pager
+            pager = portal_pager(
+                url="/my/loyalty",
+                url_args={tab: 'redeem_history'},
+                total=len(reward_ids),
+                page=page,
+                step=self._items_per_page,
+            )
+            # content according to pager
+            reward_ids = reward_ids[pager['offset']:pager['offset'] + self._items_per_page]
+
+            values.update({
+                'redeemed_rewards': reward_ids,
+            })
+
+        values.update({
+            'partner': partner,
+            'page_name': 'loyalty',
+            'pager': pager,
+            'tab': tab,
+        })
+        return request.render("website_sale_loyalty.portal_my_loyalty", values)
+
+    @http.route(['/my/loyalty/<int:order_id>'], type='http', auth="public", website=True)
+    def portal_loyalty_order_page(self, order_id, **kwargs):
+        kwargs['page_name'] = 'loyalty'
+        return self.portal_order_page(order_id=order_id, **kwargs)
+
+    @http.route('/my/loyalty/redeem', type='json', auth="user", website=True)
+    def portal_loyalty_redeem_reward(self, reward_id):
+        reward_id = request.env['loyalty.website.reward'].browse(int(reward_id)) if reward_id else None
+        if not reward_id or reward_id.loyalty_program_id != request.website.loyalty_id:
+            return {'error': _('Website has no such reward')}
+        try:
+            gift_card_id = reward_id._redeem_gift_card(request.website)
+            return {'code': gift_card_id.code}
+        except UserError as error:
+            return {'error': str(error)}

--- a/addons/website_sale_loyalty/data/loyalty_demo.xml
+++ b/addons/website_sale_loyalty/data/loyalty_demo.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record model="website" id="website.default_website">
+        <field name="has_loyalty">True</field>
+        <field name="loyalty_id" ref="loyalty.program" />
+    </record>
+
+    <record id="reward_01" model="loyalty.website.reward">
+        <field name="name">Gift Card</field>
+        <field name="loyalty_program_id" ref="loyalty.program"/>
+        <field name="point_cost">500</field>
+        <field name="gift_card_product_id" ref="gift_card.gift_card_product_50" />
+        <field name="validity">365</field>
+    </record>
+</odoo>

--- a/addons/website_sale_loyalty/data/mail_data.xml
+++ b/addons/website_sale_loyalty/data/mail_data.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="mail_template_card_info" model="mail.template">
+            <field name="name">Gift Card Info</field>
+            <field name="model_id" ref="website_sale_loyalty.model_loyalty_website_redeemed_reward" />
+            <field name="lang">{{ object.partner_id.lang }}</field>
+        </record>
+    </data>
+
+    <template id="website_sale_loyalty.card_info_mail_body" name="Gift card info mail">
+        <table border="0" cellpadding="0" style="background-color: white; padding: 0px; border-collapse:separate;">
+            <tr style="height: 48px;"><td valign="top"><span style="font-size: 24px; font-weight: bold;">
+                Gift Card Information
+            </span></td></tr>
+            <tr><td valign="top">
+                Dear <t t-out="reward.partner_id.name"/>,
+            </td></tr>
+            <tr><td valign="top">
+                <div style="margin: 16px 0px 16px 0px;">
+                    You just exchanged <span t-field="reward.point_used" t-options="{'widget': 'integer' if reward.point_used.is_integer() else 'float'}"/> loyalty points for a gift card.
+                    <br/>
+                    You can find all details in the table below.
+                    <br/>
+                    Regards.
+                </div>
+            </td></tr>
+            <tr><td valign="top">
+                <div style="margin: 16px 0px 16px 0px;">
+                    <table border="0" cellpadding="0" cellspacing="5" width="100%">
+                        <tr>
+                            <td><b>Redeemed Date:</b></td>
+                            <td><span t-out="reward.create_date.date()"/></td>
+                        </tr>
+                        <tr>
+                            <td><b>Loyalty Points Spent:</b></td>
+                            <td><span t-field="reward.point_used" t-options="{'widget': 'integer' if reward.point_used.is_integer() else 'float'}"/></td>
+                        </tr>
+                        <tr>
+                            <td><b>Gift Card Code:</b></td>
+                            <td><span t-out="reward.gift_card_id.code"/></td>
+                        </tr>
+                        <tr>
+                            <td><b>Initial Amount on Gift Card(<t t-out="reward.gift_card_id.currency_id.symbol"/>):</b></td>
+                            <td><span t-out="reward.gift_card_id.initial_amount"/></td>
+                        </tr>
+                        <tr>
+                            <td><b>Gift Card is valid until:</b></td>
+                            <td><span t-out="reward.gift_card_id.expired_date"/></td>
+                        </tr>
+                    </table>
+                </div>
+            </td></tr>
+        </table>
+    </template>
+</odoo>

--- a/addons/website_sale_loyalty/models/__init__.py
+++ b/addons/website_sale_loyalty/models/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import loyalty_program
+from . import loyalty_rule
+from . import loyalty_website_redeemed_reward
+from . import loyalty_website_reward
+from . import res_config_settings
+from . import res_partner
+from . import sale_order
+from . import website

--- a/addons/website_sale_loyalty/models/loyalty_program.py
+++ b/addons/website_sale_loyalty/models/loyalty_program.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class LoyaltyProgram(models.Model):
+    _name = 'loyalty.program'
+    _inherit = ['loyalty.program']
+
+    website_reward_ids = fields.One2many('loyalty.website.reward', 'loyalty_program_id', string='eCommerce Rewards')

--- a/addons/website_sale_loyalty/models/loyalty_rule.py
+++ b/addons/website_sale_loyalty/models/loyalty_rule.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+from odoo.tools.safe_eval import safe_eval
+
+
+class LoyaltyRule(models.Model):
+    _name = 'loyalty.rule'
+    _inherit = ['loyalty.rule']
+
+    valid_product_ids = fields.One2many('product.product', compute='_compute_valid_product_ids')
+
+    @api.depends('rule_domain')
+    def _compute_valid_product_ids(self):
+        for rule in self:
+            rule.valid_product_ids = self.env['product.product'].search(
+                safe_eval(rule.rule_domain) if rule.rule_domain else []
+            )
+
+    def is_product_valid(self, product_id):
+        """Avoid fetching the full product list if no domain is defined"""
+        if self.rule_domain:
+            return product_id in self.valid_product_ids
+        return True

--- a/addons/website_sale_loyalty/models/loyalty_website_redeemed_reward.py
+++ b/addons/website_sale_loyalty/models/loyalty_website_redeemed_reward.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+
+
+class LoyaltyWebsiteRedeemedReward(models.Model):
+    _name = 'loyalty.website.redeemed.reward'
+    _description = 'Loyalty Website Redeemed Reward'
+
+    partner_id = fields.Many2one('res.partner', required=True)
+    website_id = fields.Many2one('website', ondelete='cascade', required=True)
+    name = fields.Char(help="Name of the reward at redeemed time", required=True)
+    point_used = fields.Float(string='Points Used', help="Cost of the reward in points at redeemed time")
+    gift_card_id = fields.Many2one('gift.card', required=True)
+
+    def _send_gift_card_mail(self):
+        template = self.env.ref('sale_gift_card.mail_template_gift_card', raise_if_not_found=False)
+        if template:
+            template.send_mail(self.gift_card_id.id, notif_layout='mail.mail_notification_light',
+                force_send=True,
+                email_values={
+                    'email_to': self.partner_id.email,
+                    'email_from': self.website_id.company_id.email_formatted,
+                    'author_id': self.partner_id.id,
+                    'subject': _('Gift card information'),
+                },
+            )

--- a/addons/website_sale_loyalty/models/loyalty_website_reward.py
+++ b/addons/website_sale_loyalty/models/loyalty_website_reward.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError, ValidationError
+
+
+class LoyaltyWebsiteReward(models.Model):
+    _name = 'loyalty.website.reward'
+    _description = 'Loyalty Website Reward'
+
+    name = fields.Char(index=True, required=True, help='An internal identification for this loyalty reward')
+    loyalty_program_id = fields.Many2one('loyalty.program', string='Loyalty Program', help='The Loyalty Program this reward belongs to')
+    gift_card_product_id = fields.Many2one('product.product', required=True, string='Gift Card', help='The gift card given as a reward')
+    point_cost = fields.Float(default=100.0, string='Reward Cost', help="Cost of the gift card in points")
+    currency_id = fields.Many2one('res.currency', readonly=True, related='gift_card_product_id.currency_id')
+    initial_amount = fields.Float(readonly=True, related='gift_card_product_id.list_price')
+    validity = fields.Integer(required=True, default=365, string="Validity (days)", help="Number of days during which the card remains valid")
+
+    @api.constrains('gift_card_product_id')
+    def _check_gift_product(self):
+        if self.filtered(lambda reward: reward.gift_card_product_id.detailed_type != 'gift'):
+            raise ValidationError(_('The gift card product field must be a gift card'))
+
+    def _redeem_gift_card(self, website_id):
+        self.ensure_one()
+        if self.env.user.loyalty_points < self.point_cost:
+            raise UserError(_('Insufficient points'))
+        self.env.user.loyalty_points = self.env.user.loyalty_points - self.point_cost
+        gift_card_id = self.env['gift.card'].sudo().create({
+            'company_id': self.env.company.id,
+            'currency_id': self.currency_id.id,
+            'initial_amount': self.initial_amount,
+            'expired_date': fields.Date.add(fields.Date.today(), days=self.validity),
+        })
+        reward_id = self.env['loyalty.website.redeemed.reward'].sudo().create({
+            'partner_id': self.env.user.partner_id.id,
+            'website_id': website_id.id,
+            'name': self.name,
+            'point_used': self.point_cost,
+            'gift_card_id': gift_card_id.id,
+        })
+        reward_id._send_gift_card_mail()
+        return gift_card_id

--- a/addons/website_sale_loyalty/models/res_config_settings.py
+++ b/addons/website_sale_loyalty/models/res_config_settings.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    module_website_sale_loyalty = fields.Boolean(default=True)
+
+    has_loyalty = fields.Boolean("Has Loyalty Program", help="Enables a loyalty program for this website",
+        related='website_id.has_loyalty', readonly=False)
+    loyalty_id = fields.Many2one('loyalty.program', string='Loyalty Program', help='The loyalty program used by this website',
+        related='website_id.loyalty_id', readonly=False)

--- a/addons/website_sale_loyalty/models/res_partner.py
+++ b/addons/website_sale_loyalty/models/res_partner.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    loyalty_website_redeemed_reward_ids = fields.One2many('loyalty.website.redeemed.reward', "partner_id")
+    can_afford_reward = fields.Boolean(compute='_compute_can_afford_reward')
+
+    def _compute_can_afford_reward(self):
+        website = self.env['website'].get_current_website()
+        for partner in self:
+            if website.has_loyalty and website.loyalty_id.website_reward_ids:
+                cheapest_reward_cost = min(website.loyalty_id.website_reward_ids.mapped('point_cost'))
+                partner.can_afford_reward = cheapest_reward_cost <= self.loyalty_points
+            else:
+                partner.can_afford_reward = False

--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields, api, tools
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    won_loyalty_points = fields.Float(help='The amount of Loyalty points the customer won with this order', default=0.0)
+    reached_loyalty_points = fields.Float(help='The number of points that will be available to spend after this order completion', compute='_compute_reached_loyalty_points')
+
+    @api.depends('won_loyalty_points', 'state')
+    def _compute_reached_loyalty_points(self):
+        for order in self:
+            order.reached_loyalty_points = order.partner_id.loyalty_points
+            # Points are already received on balance if the order is paid
+            if order.state not in ('sale', 'done'):
+                order.reached_loyalty_points += max(0, order.won_loyalty_points)
+
+    def write(self, vals):
+        """Adjust partner's points on state transition:
+        - gain points only when payment is received
+        - restore points on cancel
+        """
+        new_state = vals.get('state')
+        if new_state:
+            for order in self.filtered(lambda order: order.partner_id):
+                if order.state in ('draft', 'sent') and new_state in ('sale', 'done') \
+                        and order.won_loyalty_points > 0:
+                    order.partner_id.loyalty_points += order.won_loyalty_points
+                if order.state in ('sale') and new_state == 'cancel' \
+                        and order.won_loyalty_points > 0:
+                    # Never remove more points than current balance.
+                    order.partner_id.loyalty_points -= min(order.partner_id.loyalty_points, order.won_loyalty_points)
+        return super(SaleOrder, self).write(vals)
+
+    def _cart_update(self, product_id=None, line_id=None, add_qty=0, set_qty=0, **kwargs):
+        values = super(SaleOrder, self)._cart_update(product_id, line_id, add_qty, set_qty, **kwargs)
+        website = self.env['website'].get_current_website()
+        if website.has_loyalty:
+            self.recompute_loyalty_points(website.loyalty_id.id)
+        return values
+
+    def _get_won_points(self, loyalty):
+        """The total of points won"""
+        if self.website_id.is_public_user() or not loyalty:
+            return 0
+        total_points = 0
+        for line in self.order_line:
+            line_points = 0
+            for rule in loyalty.rule_ids:
+                rule_points = 0
+                if rule.is_product_valid(line.product_id):
+                    rule_points += rule.points_quantity * line.product_uom_qty
+                    rule_points += rule.points_currency * line.price_total
+                if rule_points > line_points:
+                    line_points = rule_points
+
+            total_points += line_points
+
+        total_points += max(0, self.amount_total * loyalty.points)
+        return max(0, tools.float_round(total_points, 0, rounding_method='HALF-UP'))
+
+    def recompute_loyalty_points(self, loyalty_id):
+        loyalty = self.env['loyalty.program'].browse(loyalty_id) if loyalty_id else None
+        for order in self:
+            if loyalty and self.partner_id.active:
+                order.won_loyalty_points = order._get_won_points(loyalty)
+            else:
+                order.won_loyalty_points = 0
+
+    def get_portal_loyalty_url(self):
+        return self.get_portal_url().replace('orders', 'loyalty')

--- a/addons/website_sale_loyalty/models/website.py
+++ b/addons/website_sale_loyalty/models/website.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class Website(models.Model):
+    _inherit = 'website'
+
+    def _default_loyalty_program(self):
+        return self.env['loyalty.program'].search([], limit=1)
+
+    has_loyalty = fields.Boolean("Has Loyalty Program", help="Enables a loyalty program for this website", default=False)
+    loyalty_id = fields.Many2one('loyalty.program', string='Loyalty Program', help='The loyalty program used by this website', default=_default_loyalty_program)
+
+    @api.onchange('has_loyalty')
+    def _onchange_has_loyalty(self):
+        self.loyalty_id = self.has_loyalty and self._default_loyalty_program()

--- a/addons/website_sale_loyalty/security/ir.model.access.csv
+++ b/addons/website_sale_loyalty/security/ir.model.access.csv
@@ -1,0 +1,10 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_loyalty_program_portal,loyalty.program.portal,loyalty.model_loyalty_program,base.group_portal,1,0,0,0
+access_loyalty_rule_portal,loyalty.rule.portal,loyalty.model_loyalty_rule,base.group_portal,1,0,0,0
+access_loyalty_website_reward_portal,loyalty.website.reward.portal,model_loyalty_website_reward,base.group_portal,1,0,0,0
+access_loyalty_program_public,loyalty.program.public,loyalty.model_loyalty_program,base.group_public,1,0,0,0
+access_loyalty_rule_public,loyalty.rule.public,loyalty.model_loyalty_rule,base.group_public,1,0,0,0
+access_loyalty_website_reward_public,loyalty.website.reward.public,model_loyalty_website_reward,base.group_public,1,0,0,0
+access_loyalty_website_reward_admin,loyalty.website.reward.admin,model_loyalty_website_reward,base.group_system,1,1,1,1
+access_loyalty_website_reward_base,loyalty.website.reward.base,model_loyalty_website_reward,base.group_user,1,0,0,0
+access_loyalty_website_redeemed_reward,access_loyalty_website_redeemed_reward,website_sale_loyalty.model_loyalty_website_redeemed_reward,base.group_user,0,0,0,0

--- a/addons/website_sale_loyalty/static/src/js/portal_loyalty.js
+++ b/addons/website_sale_loyalty/static/src/js/portal_loyalty.js
@@ -1,0 +1,83 @@
+/** @odoo-module **/
+
+import {browser} from "@web/core/browser/browser";
+import publicWidget from 'web.public.widget';
+import Dialog from 'web.Dialog';
+import {_t, qweb} from 'web.core';
+
+publicWidget.registry.LoyaltyPortal = publicWidget.Widget.extend({
+    selector: '.o_portal_loyalty',
+    xmlDependencies: ['/website_sale_loyalty/static/src/xml/portal_loyalty.xml'],
+    events: {
+        'click .o_loyalty_redeem_reward_button': '_onClickRedeem',
+        'click .o_copy_gift_card_code': '_onClickCopy',
+    },
+
+    //----------------------------------------------------------------------
+    // Handlers
+    //----------------------------------------------------------------------
+
+    _onClickRedeem(ev) {
+        const rowEl = ev.target.closest('tr');
+        Dialog.confirm(this, _.str.sprintf(_t("Use %(points)s to get '%(name)s'"), {
+            points: rowEl.querySelector('.o_loyalty_reward_cost').innerText,
+            name: rowEl.querySelector('.o_loyalty_reward_name').innerText,
+        }), {
+            buttons: [{
+                text: _t("Confirm"),
+                close: true,
+                classes: 'btn-primary',
+                click: function () {
+                    const rewardId = ev.target.dataset.rewardId;
+                    return this._rpc({
+                        route: "/my/loyalty/redeem",
+                        params: {
+                            reward_id: rewardId,
+                        },
+                    }).then(function (data) {
+                        if (data.error) {
+                            Dialog.alert(this, data.error);
+                        } else {
+                            const $content = $('<div/>').append(qweb.render(
+                                'website_sale_loyalty.gift_card_info_dialog',
+                                data
+                            ));
+                            const $button = $content.find('button');
+                            $button.on('click', (ev) => {
+                                browser.navigator.clipboard.writeText(data.code);
+                                $button.addClass('disabled');
+                                $button.find('#copy_button_text').text(_t('Copied'));
+                                $button.off();
+                            });
+                            Dialog.alert(this, '', {
+                                title: _t('Gift card info'),
+                                buttons: [{
+                                    text: _t("Close"),
+                                    close: true,
+                                    click: function () {
+                                        window.location = '/my/loyalty?tab=redeem_history';
+                                    },
+                                }],
+                                $content: $content,
+                                onForceClose: function () {
+                                    window.location = '/my/loyalty?tab=redeem_history';
+                                },
+                            });
+                        }
+                    });
+                },
+            }, {
+                text: _t("Cancel"),
+                close: true,
+            }],
+        });
+    },
+    _onClickCopy(ev) {
+        browser.navigator.clipboard.writeText(ev.target.closest('button').dataset.code);
+        this.displayNotification({
+            title: _t("Copied"),
+            message: _t("The gift card code has been copied to the clipboard."),
+            type: 'success',
+        });
+    },
+});

--- a/addons/website_sale_loyalty/static/src/scss/website_sale_loyalty.scss
+++ b/addons/website_sale_loyalty/static/src/scss/website_sale_loyalty.scss
@@ -1,0 +1,10 @@
+table#rewards_catalog {
+    margin-bottom: 0;
+
+    td, th {
+        vertical-align: middle;
+    }
+    th:first-child {
+        padding-left: $grid-gutter-width*0.5;
+    }
+}

--- a/addons/website_sale_loyalty/static/src/xml/portal_loyalty.xml
+++ b/addons/website_sale_loyalty/static/src/xml/portal_loyalty.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <!-- Gift card info dialog -->
+    <t t-name="website_sale_loyalty.gift_card_info_dialog">
+        You will find below your gift card code.
+        <br/>
+        An email has been sent with it.
+        <br/>
+        You can use it starting now.
+        <br/>
+        <div class="button-row">
+            <span class="h5" t-out="code"/>
+            <button class='btn btn-primary ml-2'>
+                <i class="fa fa-clipboard mr8"/><span id="copy_button_text">Copy</span>
+            </button>
+        </div>
+        <br/>
+    </t>
+
+</templates>

--- a/addons/website_sale_loyalty/tests/__init__.py
+++ b/addons/website_sale_loyalty/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_website_sale_loyalty

--- a/addons/website_sale_loyalty/tests/test_website_sale_loyalty.py
+++ b/addons/website_sale_loyalty/tests/test_website_sale_loyalty.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from unittest.mock import patch
+
+from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
+from odoo.exceptions import UserError
+from odoo.fields import Command
+import odoo.tests
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestLoyalty(TransactionCaseWithUserDemo):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestLoyalty, cls).setUpClass()
+        cls.partner_id = cls.env['res.partner'].create({'name': 'My Test Customer'})
+        cls.product_gift_card = cls.env['product.product'].create({
+            'name': 'Gift Card',
+            'list_price': 50,
+            'detailed_type': 'gift',
+        })
+        cls.reward_id = cls.env['loyalty.website.reward'].create({
+            'name': 'Gift',
+            'point_cost': 75,
+            'gift_card_product_id': cls.product_gift_card.id,
+        })
+        cls.product_1 = cls.env['product.product'].create({'name': 'Product one'})
+        cls.product_2 = cls.env['product.product'].create({'name': 'Product two'})
+
+    def setUp(self):
+        super().setUp()
+        # Mock this method because no actual request is used to perform the test
+        def is_public_user(*args, **kwargs):
+            return False
+        patcher = patch('odoo.addons.website.models.website.Website.is_public_user', wraps=is_public_user)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_loyalty(self):
+        loyalty_id = self.env['loyalty.program'].create({
+            'name': 'Test Program',
+            'points': 0.01,
+        })
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_id.id,
+            'order_line': [Command.create({
+                'name': self.product_1.name,
+                'product_id': self.product_1.id,
+                'product_uom_qty': 2,
+                'price_unit': 750.00,
+            })],
+        })
+
+        sale_order.recompute_loyalty_points(loyalty_id.id)
+        self.assertEqual(17, sale_order.won_loyalty_points)
+
+        self.env['sale.order.line'].create({
+            'order_id': sale_order.id,
+            'name': self.product_2.name,
+            'product_id': self.product_2.id,
+            'product_uom_qty': 1,
+            'price_unit': 1000.0,
+        })
+
+        sale_order.recompute_loyalty_points(loyalty_id.id)
+        self.assertEqual(29, sale_order.won_loyalty_points)
+
+    def test_loyalty_rule(self):
+        loyalty_id = self.env['loyalty.program'].create({
+            'name': 'Test Program with rules',
+            'points': 0.00,
+            'rule_ids': [
+                Command.create({
+                    'name': 'Rule one',
+                    'points_quantity': 10.0,
+                    'points_currency': 0,
+                    'rule_domain': "[('name', '=', 'Product one')]",
+                }),
+                Command.create({
+                    'name': 'Rule two',
+                    'points_quantity': 0,
+                    'points_currency': 0.2,
+                    'rule_domain': "[('name', '=', 'Product two')]",
+                }),
+            ]
+        })
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_id.id,
+            'order_line': [Command.create({
+                'name': self.product_1.name,
+                'product_id': self.product_1.id,
+                'product_uom_qty': 7,
+                'price_unit': 100.00,
+            })],
+        })
+        sale_order.recompute_loyalty_points(loyalty_id.id)
+        self.assertEqual(70, sale_order.won_loyalty_points)
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_id.id,
+            'order_line': [Command.create({
+                'name': self.product_2.name,
+                'product_id': self.product_2.id,
+                'product_uom_qty': 2,
+                'price_unit': 150.00,
+            })],
+        })
+        # total price = (2*150)+tax = 300+15% = 345
+        sale_order.recompute_loyalty_points(loyalty_id.id)
+        self.assertEqual(69, sale_order.won_loyalty_points)
+
+    def test_loyalty_balance(self):
+        order_line = [Command.create({
+            'name': self.product_1.name,
+            'product_id': self.product_1.id,
+            'product_uom_qty': 1,
+            'price_unit': 100.00,
+        })]
+
+        # immediate payment get points
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_id.id,
+            'order_line': order_line,
+            'won_loyalty_points': 100,
+        })
+        self.assertEqual(self.partner_id.loyalty_points, 0)
+        sale_order.state = 'sale'
+        self.assertEqual(self.partner_id.loyalty_points, 100)
+
+        # immediate payment get and spend points
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_id.id,
+            'order_line': order_line,
+            'won_loyalty_points': 100,
+        })
+        self.assertEqual(self.partner_id.loyalty_points, 100)
+        sale_order.state = 'sale'
+        self.assertEqual(self.partner_id.loyalty_points, 200)
+        sale_order.state = 'cancel'
+        self.assertEqual(self.partner_id.loyalty_points, 100)
+
+        # delayed payment get and spend points
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_id.id,
+            'order_line': order_line,
+            'won_loyalty_points': 100,
+        })
+        self.assertEqual(self.partner_id.loyalty_points, 100)
+        sale_order.state = 'sent'
+        self.assertEqual(self.partner_id.loyalty_points, 100)
+        sale_order.state = 'sale'
+        self.assertEqual(self.partner_id.loyalty_points, 200)
+        sale_order.state = 'cancel'
+        self.assertEqual(self.partner_id.loyalty_points, 100)
+
+        self.env.user.partner_id = self.partner_id
+        gift_card = self.reward_id._redeem_gift_card(self.env['website'].get_current_website())
+        self.assertEqual(self.partner_id.loyalty_points, 25)
+        self.assertEqual(gift_card.balance, 50)
+        with self.assertRaises(UserError, msg="Insufficient points"):
+            self.reward_id._redeem_gift_card(self.env['website'].get_current_website())

--- a/addons/website_sale_loyalty/views/loyalty_views.xml
+++ b/addons/website_sale_loyalty/views/loyalty_views.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_loyalty_program_form" model="ir.ui.view">
+        <field name="name">loyalty.program.form</field>
+        <field name="model">loyalty.program</field>
+        <field name="inherit_id" ref="loyalty.view_loyalty_program_form"/>
+        <field name="arch" type="xml">
+            <notebook>
+                <page id="website_reward_ids" string="eCommerce Rewards">
+                    <p>Reward the eCommerce customer with gift cards for loyalty points</p>
+                    <field name="website_reward_ids" colspan="4" nolabel="1">
+                        <tree string="Rewards">
+                            <field name="name"/>
+                            <field name="initial_amount"/>
+                            <field name="validity"/>
+                            <field name="point_cost" />
+                        </tree>
+                    </field>
+                </page>
+            </notebook>
+        </field>
+    </record>
+
+    <record id="view_loyalty_website_reward_form" model="ir.ui.view">
+        <field name="name">loyalty.website.reward.form</field>
+        <field name="model">loyalty.website.reward</field>
+        <field name="arch" type="xml">
+            <form string="Loyalty eCommerce Reward">
+                <div class="oe_title">
+                    <label for="name" string="Reward Name"/>
+                    <h1><field name="name" placeholder="e.g. $50 Gift Card"/></h1>
+                </div>
+                <group>
+                    <field name="point_cost" />
+                    <field name="gift_card_product_id" domain="[('detailed_type', '=', 'gift')]" placeholder="Select reward gift card product"/>
+                    <field name="initial_amount" widget="monetary" options="{'currency_field': 'currency_id', 'field_digits': True}"/>
+                    <field name="currency_id"/>
+                    <field name="validity" />
+                </group>
+            </form>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/website_sale_loyalty/views/portal_templates.xml
+++ b/addons/website_sale_loyalty/views/portal_templates.xml
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="portal_my_home_menu_loyalty" name="Portal layout : loyalty menu entries" inherit_id="sale.portal_my_home_menu_sale" priority="35">
+        <xpath expr="//li[hasclass('o_portal_submenu_so')]" position="before">
+            <li t-if="page_name == 'loyalty'" t-attf-class="breadcrumb-item #{'active ' if not sale_order else ''}">
+                <a t-if="sale_order" t-attf-href="/my/loyalty?tab=won_points_history&amp;{{ keep_query() }}">Loyalty</a>
+                <t t-else="">Loyalty</t>
+            </li>
+        </xpath>
+    </template>
+
+    <template id="portal_my_home_loyalty" name="Show Loyalty" customize_show="True" inherit_id="portal.portal_my_home" priority="35">
+        <xpath expr="//div[hasclass('o_portal_docs')]" position="inside">
+            <t t-call="portal.portal_docs_entry" t-if="website.has_loyalty">
+                <t t-set="title">Loyalty</t>
+                <t t-set="url" t-value="'/my/loyalty'" />
+                <t t-set="placeholder_count" t-value="'loyalty_points'" />
+            </t>
+        </xpath>
+    </template>
+
+    <template id="portal_my_loyalty" name="Portal: My Loyalty">
+        <t t-call="portal.portal_layout">
+            <t t-set="breadcrumbs_searchbar" t-value="True" />
+
+            <t t-call="portal.portal_searchbar">
+                <t t-set="title">Loyalty</t>
+            </t>
+            <div class="o_portal_loyalty">
+                <p>
+                    You have <span t-field="partner.loyalty_points" t-options="{'widget': 'integer' if partner.loyalty_points.is_integer() else 'float'}"/> points available.
+                </p>
+                <ul class="nav nav-pills" role="tablist">
+                    <li class="nav-item">
+                        <a t-att-class="'nav-link active' if tab == 'rewards_catalog' else 'nav-link'" role="tab" href="/my/loyalty?tab=rewards_catalog">Rewards Catalog</a>
+                    </li>
+                    <li class="nav-item">
+                        <a t-att-class="'nav-link active' if tab == 'won_points_history' else 'nav-link'" role="tab" href="/my/loyalty?tab=won_points_history">Won Points History</a>
+                    </li>
+                    <li class="nav-item">
+                        <a t-att-class="'nav-link active' if tab == 'redeem_history' else 'nav-link'" role="tab" href="/my/loyalty?tab=redeem_history">Redeem History</a>
+                    </li>
+                </ul>
+                <br/>
+                <t t-if="tab == 'rewards_catalog'" t-call="website_sale_loyalty.portal_my_loyalty_reward_catalog"/>
+                <t t-elif="tab == 'won_points_history'" t-call="website_sale_loyalty.portal_my_loyalty_won_history"/>
+                <t t-elif="tab == 'redeem_history'" t-call="website_sale_loyalty.portal_my_loyalty_redeem_history"/>
+            </div>
+        </t>
+    </template>
+
+    <template id="portal_my_loyalty_reward_catalog" name="Portal: My Loyalty Reward Catalog">
+        <t t-if="rewards" t-call="portal.portal_table">
+            <thead>
+                <tr class="active">
+                    <th class="text-left">Reward</th>
+                    <th class="text-right">Value</th>
+                    <th class="text-right">Validity (days)</th>
+                    <th class="text-right">Points Cost</th>
+                    <th class="text-center"/>
+                </tr>
+            </thead>
+            <tbody>
+                <t t-foreach="rewards" t-as="reward">
+                    <tr>
+                        <td class="text-left o_loyalty_reward_name">
+                            <span t-field="reward.name"/>
+                        </td>
+                        <td class="text-right">
+                            <span t-field="reward.currency_id.symbol" t-if="reward.currency_id.position == 'before'"/>
+                            <span t-field="reward.initial_amount"/>
+                            <span t-field="reward.currency_id.symbol" t-if="reward.currency_id.position == 'after'"/>
+                        </td>
+                        <td class="text-right">
+                            <span t-field="reward.validity"/>
+                        </td>
+                        <td class="text-right o_loyalty_reward_cost">
+                            <span t-field="reward.point_cost" t-options="{'widget': 'integer' if reward.point_cost.is_integer() else 'float'}"/>
+                        </td>
+                        <td class="text-right">
+                            <a role="button" t-att-data-reward-id="reward.id"
+                                t-attf-class="btn btn-secondary o_loyalty_redeem_reward_button d-block d-sm-inline-block {{'disabled' if reward.point_cost > partner.loyalty_points else ''}}"
+                                aria-label="Redeem now" title="Redeem now" href="#">
+                                <i class="fa fa-shopping-basket mr-2"/>Redeem now
+                            </a>
+                        </td>
+                    </tr>
+                </t>
+            </tbody>
+        </t>
+        <t t-else="">
+            <p>There are currently no rewards defined in this loyalty program.</p>
+        </t>
+    </template>
+
+    <template id="portal_my_loyalty_won_history" name="Portal: My Loyalty Won History">
+        <div>
+            <t t-if="orders" t-call="portal.portal_table">
+                <thead>
+                    <tr class="active">
+                        <th>
+                            <span class='d-none d-md-inline'>Sales Order #</span>
+                            <span class='d-block d-md-none'>Ref.</span>
+                        </th>
+                        <th>Order Date</th>
+                        <th class="text-center" />
+                        <th class="text-right">Points Won</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <t t-foreach="orders" t-as="order">
+                        <tr>
+                            <td>
+                                <a t-att-href="order.get_portal_loyalty_url()">
+                                    <t t-esc="order.name" />
+                                </a>
+                            </td>
+                            <td>
+                                <span t-field="order.date_order" t-options="{'widget': 'date'}" />
+                                &amp;nbsp;
+                                <span class='d-none d-md-inline' t-field="order.date_order" t-options="{'time_only': True}" />
+                            </td>
+                            <td class="text-center">
+                                <span t-if="order.state in ['sale', 'done']" class="badge badge-pill badge-success">
+                                    <i class="fa fa-fw fa-check" role="img" aria-label="Done" title="Done" />
+                                    Done
+                                </span>
+                                <span t-elif="order.state == 'cancel'" class="badge badge-pill badge-error">
+                                    <i class="fa fa-fw fa-exclamation-triangle" role="img" aria-label="Cancelled" title="Cancelled" />
+                                    Cancelled
+                                </span>
+                                <span t-else="" class="badge badge-pill badge-warning">
+                                    <i class="fa fa-fw fa-hourglass-half" role="img" aria-label="Pending payment validation" title="Pending payment validation" />
+                                    Pending payment validation
+                                </span>
+                            </td>
+                            <td class="text-right">
+                                <span t-field="order.won_loyalty_points"
+                                    t-options="{'widget': 'integer' if order.won_loyalty_points.is_integer() else 'float'}"
+                                    t-att-class="'text-info' if order.state not in ('sale', 'done') else ''"
+                                />
+                            </td>
+                        </tr>
+                    </t>
+                </tbody>
+            </t>
+            <t t-else="">
+                <p>There are currently no orders for your account.</p>
+            </t>
+        </div>
+    </template>
+
+    <template id="portal_my_loyalty_redeem_history" name="Portal: My Loyalty Redeem History">
+        <div>
+            <t t-if="redeemed_rewards" t-call="portal.portal_table">
+                <thead>
+                    <tr class="active">
+                        <th>Redeem Date</th>
+                        <th>Reward</th>
+                        <th>Expiry Date</th>
+                        <th colspan="2">Code</th>
+                        <th>Status</th>
+                        <th class="text-right">Points Used</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <t t-foreach="redeemed_rewards" t-as="reward">
+                        <tr>
+                            <td>
+                                <span t-field="reward.create_date" t-options="{'widget': 'date'}" />
+                            </td>
+                            <td>
+                                <span t-field="reward.name" />
+                            </td>
+                            <td>
+                                <span t-field="reward.gift_card_id.expired_date" t-options="{'widget': 'date'}" />
+                            </td>
+                            <td>
+                                <span t-field="reward.gift_card_id.code" />
+                            </td>
+                            <td>
+                                <button t-if="reward.gift_card_id.state == 'valid' and reward.gift_card_id.balance > 0"
+                                        class='btn btn-primary ml-2 o_copy_gift_card_code' t-att-data-code="reward.gift_card_id.code">
+                                    <i class="fa fa-clipboard mr8"/>Copy
+                                </button>
+                            </td>
+                            <td>
+                                <span t-if="reward.gift_card_id.balance == 0" class="badge badge-pill badge-info">
+                                    <i class="fa fa-check" role="img" aria-label="Fully used" title="Fully used"/>
+                                    Fully used
+                                </span>
+                                <span t-elif="reward.gift_card_id.state == 'expired'" class="badge badge-pill badge-warning">
+                                    <i class="fa fa-hourglass-end" role="img" aria-label="Expired" title="Expired"/>
+                                    Expired
+                                </span>
+                                <span t-else="" class="badge badge-pill badge-success">
+                                    <i class="fa fa-credit-card" role="img" aria-label="Available" title="Available"/>
+                                    Available
+                                </span>
+                            </td>
+                            <td class="text-right">
+                                <span t-field="reward.point_used" t-options="{'widget': 'integer' if reward.point_used.is_integer() else 'float'}"/>
+                            </td>
+                        </tr>
+                    </t>
+                </tbody>
+            </t>
+            <t t-else="">
+                <p>There are no redeemed rewards for your account.</p>
+            </t>
+        </div>
+    </template>
+
+    <template id="sale_order_portal_content_loyalty" name="Loyalty Total Invoice" inherit_id="sale.sale_order_portal_content" priority="35">
+        <xpath expr="//section[@id='details']" position="after">
+            <section id="loyalty" style="page-break-inside: auto;" class="mt-5" t-if="(sale_order.won_loyalty_points > 0)">
+                <h3>Rewards Summary</h3>
+                <hr class="mt-0 mb-1"/>
+                <table>
+                    <tbody>
+                        <tr t-if='sale_order.won_loyalty_points > 0'>
+                            <td>Points Won:</td>
+                            <td class="text-right"><span class="ml16" t-field='sale_order.won_loyalty_points' t-options="{'widget': 'integer' if sale_order.won_loyalty_points.is_integer() else 'float'}"/></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </section>
+        </xpath>
+    </template>
+
+</odoo>

--- a/addons/website_sale_loyalty/views/res_config_settings_views.xml
+++ b/addons/website_sale_loyalty/views/res_config_settings_views.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.website</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="website.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <div id="loyalty_settings" position="replace">
+                <div class="col-12 col-lg-6 o_setting_box" id="loyalty_settings">
+                    <div class="o_setting_left_pane">
+                        <field name="has_loyalty"/>
+                    </div>
+                    <div class="o_setting_right_pane" title="Loyalty program to use for this website.">
+                        <label for="has_loyalty" string="Loyalty Program"/>
+                        <span class="fa fa-lg fa-globe" title="Values set here are website-specific." groups="website.group_multi_website"/>
+                        <div class="text-muted" id="loyalty_program">
+                            Give customer rewards
+                        </div>
+                        <div class="content-group" attrs="{'invisible': [('has_loyalty', '=', False)]}">
+                            <div class="row mt16">
+                                <label class="o_light_label col-lg-4" for="loyalty_id"/>
+                                <field name="loyalty_id"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/website_sale_loyalty/views/res_partner_views.xml
+++ b/addons/website_sale_loyalty/views/res_partner_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_loyalty_partner_property_form" model="ir.ui.view">
+        <field name="name">res.partner.pos.form.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="priority" eval="5"/>
+        <field name="arch" type="xml">
+
+            <group name="purchase" position="inside">
+                <field name="loyalty_points"/>
+            </group>
+
+        </field>
+    </record>
+
+</odoo>

--- a/addons/website_sale_loyalty/views/sale_views.xml
+++ b/addons/website_sale_loyalty/views/sale_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="name">sale.form.inherit.website.sale.loyalty</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="model">sale.order</field>
+        <field name="arch" type="xml">
+
+            <xpath expr="//page[@name='other_information']" position="inside">
+                <group>
+                    <group name="loyalty" string="Loyalty">
+                        <field name="won_loyalty_points" readonly="1"/>
+                    </group>
+                </group>
+            </xpath>
+
+        </field>
+    </record>
+
+</odoo>

--- a/addons/website_sale_loyalty/views/website_sale_loyalty_views.xml
+++ b/addons/website_sale_loyalty/views/website_sale_loyalty_views.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <menuitem
+        parent="website_sale.menu_ecommerce_settings"
+        action="loyalty.action_loyalty_program_form"
+        id="menu_loyalty_program"
+        sequence="30"
+        groups="sales_team.group_sale_manager,sales_team.group_sale_salesman" />
+
+</odoo>

--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="cart_total_loyalty" name="Loyalty Total Cart" inherit_id="website_sale.total">
+        <xpath expr="//table/tr[last()]" position="after">
+            <t t-set="is_connected" t-value="not user_id._is_public()"/>
+            <t t-if="is_connected and request.params.get('type') != 'popover'">
+                <t t-if="website_sale_order.won_loyalty_points > 0">
+                    <tr>
+                        <td class="text-right border-0">Points Won:</td>
+                        <td class="text-xl-right border-0"><span t-out="website_sale_order.won_loyalty_points" t-options="{'widget': 'integer' if website_sale_order.won_loyalty_points.is_integer() else 'float'}"/></td>
+                    </tr>
+                    <tr>
+                        <td class="text-right border-0">Total Points:</td>
+                        <td class="text-xl-right border-0"><span t-field="website_sale_order.reached_loyalty_points" t-options="{'widget': 'integer' if website_sale_order.reached_loyalty_points.is_integer() else 'float'}"/></td>
+                    </tr>
+                </t>
+                <tr t-if="request.params.get('type') != 'popover'">
+                    <td colspan="3" class="text-center text-xl-right border-0">
+                        <a href="/my/loyalty">
+                            <t t-if="website_sale_order.partner_id.can_afford_reward">You are eligible to a free reward!<br/>Click here to claim it.</t>
+                            <t t-else="">Track your loyalty points here</t>
+                        </a>
+                    </td>
+                </tr>
+            </t>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
This PR makes loyalty available on eCommerce:
- the general concept of loyalty points is extracted from pos_loyalty: loyalty points, loyalty programs and rules about gaining points
- rewards that can be obtained on the portal page are limited to gift cards

task-2319729

Related to https://github.com/odoo/enterprise/pull/21213
Related to https://github.com/odoo/upgrade/pull/2870

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
