### PR TITLE
[FIX] mail: fix guest getting session expired warning on mention

### DIFF
--- a/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.xml
+++ b/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.xml
@@ -31,7 +31,7 @@
                                     <t t-esc="threadViewTopBar.thread.description"/>
                                 </div>
                             </t>
-                            <t t-if="!threadViewTopBar.thread.description and threadViewTopBar.thread.isChannelDescriptionChangeable">
+                            <t t-if="!messaging.isCurrentUserGuest and !threadViewTopBar.thread.description and threadViewTopBar.thread.isChannelDescriptionChangeable">
                                 <div class="o_ThreadViewTopbar_threadAddDescriptionEmptyLabel text-truncate" t-on-click="threadViewTopBar.onClickTopbarThreadDescription">
                                     Add a description
                                 </div>

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -809,6 +809,9 @@ function factory(dependencies) {
          * @private
          */
         _onChangeUpdateSuggestionList() {
+            if (this.messaging.isCurrentUserGuest) {
+                return;
+            }
             // Update the suggestion list immediately for a reactive UX...
             this._updateSuggestionList();
             // ...and then update it again after the server returned data.


### PR DESCRIPTION
When attempting to mention a user or a channel, an RPC is performed.
This uses a method on a model, which guests cannot perform as they don't
have a valid session cookie. This commit deactivates the mention
functionality for guests.