### PR TITLE
[FIX] website: prevent snippet drop in product_catalog

### DIFF
--- a/addons/website/views/snippets/s_product_catalog.xml
+++ b/addons/website/views/snippets/s_product_catalog.xml
@@ -70,11 +70,10 @@
                 <!-- Note: no need of extra dependency thanks to the apply-to -->
             </t>
         </div>
-        <div data-selector=".s_product_catalog_dish"/>
+        <div data-selector=".s_product_catalog_dish" data-drop-near=".s_product_catalog_dish"/>
     </xpath>
     <xpath expr="//div[@data-js='SnippetMove']" position="attributes">
         <attribute name="data-selector" add=".s_product_catalog_dish" separator=","/>
-        <attribute name="data-drop-near" add=".s_product_catalog_dish" separator=","/>
     </xpath>
 </template>
 


### PR DESCRIPTION
Before this commit, a user would be able to drop pretty much any
snippet inside the product_catalog (pricelist) snippet.
This was not ideal as the snippet wasn't designed to receive
any other snippets inside of it.

With this commit, the configuration of the snippet is closer
to snippets such as timeline, allowing lines to be moved around
without allowing snippets to be dropped inside it.

task-2655171

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
