### PR TITLE
[FIX] web_editor: save codeview changes

### DIFF
--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -146,7 +146,12 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
      * @override
      */
     _getValue: function () {
-        var value = this.wysiwyg.getValue();
+        let value;
+        if (!this._$codeview || this._$codeview.hasClass('d-none')) {
+           value = this.wysiwyg.getValue();
+        } else {
+            value = this._$codeview.val();
+        }
         if (this.nodeOptions.wrapper) {
             return this._unWrap(value);
         }
@@ -520,10 +525,10 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
                     </button>
                 </div>
             `);
-            const $codeview = $('<textarea class="o_codeview d-none"/>');
-            this.wysiwyg.$editable.after($codeview);
+            this._$codeview = $('<textarea class="o_codeview d-none"/>');
+            this.wysiwyg.$editable.after(this._$codeview);
             this.wysiwyg.toolbar.$el.append($codeviewButton);
-            $codeviewButton.click(() => this._toggleCodeView($codeview, $codeviewButton));
+            $codeviewButton.click(() => this._toggleCodeView(this._$codeview, $codeviewButton));
         }
     },
     /**


### PR DESCRIPTION
Before this commit, if there were a change in the codeview of the
field html and the record was saved while the codeview was still open,
the changes made in the codeview were not saved.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
