### PR TITLE
[FIX] mail: fix settings crashes

### DIFF
--- a/addons/mail/static/src/components/rtc_configuration_menu/rtc_configuration_menu.js
+++ b/addons/mail/static/src/components/rtc_configuration_menu/rtc_configuration_menu.js
@@ -32,7 +32,7 @@ export class RtcConfigurationMenu extends Component {
      * @param {Event} ev
      */
     _onChangeDelay(ev) {
-        this.messaging.rtcConfigurationMenu.onChangeDelay(ev.target.value);
+        this.messaging.userSetting.rtcConfigurationMenu.onChangeDelay(ev.target.value);
     }
 
     /**
@@ -40,7 +40,7 @@ export class RtcConfigurationMenu extends Component {
      * @param {Event} ev
      */
     _onChangePushToTalk(ev) {
-        this.messaging.rtcConfigurationMenu.onChangePushToTalk();
+        this.messaging.userSetting.rtcConfigurationMenu.onChangePushToTalk();
     }
 
     /**
@@ -48,7 +48,7 @@ export class RtcConfigurationMenu extends Component {
      * @param {Event} ev
      */
     _onChangeSelectAudioInput(ev) {
-        this.messaging.rtcConfigurationMenu.onChangeSelectAudioInput(ev.target.value);
+        this.messaging.userSetting.rtcConfigurationMenu.onChangeSelectAudioInput(ev.target.value);
     }
 
     /**
@@ -56,7 +56,7 @@ export class RtcConfigurationMenu extends Component {
      * @param {Event} ev
      */
     _onChangeThreshold(ev) {
-        this.messaging.rtcConfigurationMenu.onChangeThreshold(ev.target.value);
+        this.messaging.userSetting.rtcConfigurationMenu.onChangeThreshold(ev.target.value);
     }
 
     /**
@@ -64,7 +64,7 @@ export class RtcConfigurationMenu extends Component {
      * @param {MouseEvent} ev
      */
     _onClickRegisterKeyButton() {
-        this.messaging.rtcConfigurationMenu.onClickRegisterKeyButton();
+        this.messaging.userSetting.rtcConfigurationMenu.onClickRegisterKeyButton();
     }
 }
 

--- a/addons/mail/static/src/models/user_setting/user_setting.js
+++ b/addons/mail/static/src/models/user_setting/user_setting.js
@@ -127,7 +127,9 @@ function factory(dependencies) {
         setDelayValue(value) {
             const voiceActiveDuration = parseInt(value, 10);
             this.update({ voiceActiveDuration });
-            this._saveSettings();
+            if (!this.messaging.isCurrentUserGuest) {
+                this._saveSettings();
+            }
         }
 
         /**
@@ -136,7 +138,9 @@ function factory(dependencies) {
         async setPushToTalkKey(ev) {
             const pushToTalkKey = `${ev.shiftKey || ''}.${ev.ctrlKey || ev.metaKey || ''}.${ev.altKey || ''}.${ev.key}`;
             this.update({ pushToTalkKey });
-            this._saveSettings();
+            if (!this.messaging.isCurrentUserGuest) {
+                this._saveSettings();
+            }
         }
 
         /**
@@ -172,7 +176,9 @@ function factory(dependencies) {
         async togglePushToTalk() {
             this.update({ usePushToTalk: !this.usePushToTalk });
             await this.messaging.rtc.updateVoiceActivation();
-            this._saveSettings();
+            if (!this.messaging.isCurrentUserGuest) {
+                this._saveSettings();
+            }
         }
 
         toggleLayoutSettingsWindow() {


### PR DESCRIPTION
In odoo/odoo#76941 some getters were removed but the code using those
getters was not entirely adapted, causing crashes.

This commit also fixes an unrelated crash, where we were attempting to
save the push-to-talk settings for guests, which cannot work as they do
not have a correspoding user.
