### PR TITLE
[FIX] account_edi_ubl: Make UBL template EFFF-compatible

### DIFF
--- a/addons/account_edi_ubl/data/ubl_templates.xml
+++ b/addons/account_edi_ubl/data/ubl_templates.xml
@@ -123,8 +123,8 @@
                 </cac:AccountingCustomerParty>
                 <cac:PaymentMeans>
                     <cbc:PaymentMeansCode listID="UN/ECE 4461" t-esc="payment_means_code"/>
-                    <cbc:InstructionID t-esc="invoice.payment_reference"/>
                     <cbc:PaymentDueDate t-esc="invoice.invoice_date_due"/>
+                    <cbc:InstructionID t-esc="invoice.payment_reference"/>
                     <cac:PayeeFinancialAccount t-if="invoice.journal_id.bank_account_id">
                         <cbc:ID schemeName="IBAN" t-esc="invoice.journal_id.bank_account_id.acc_number"/>
                         <cac:FinancialInstitutionBranch t-if="invoice.journal_id.bank_account_id.bank_bic">


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/69124,the UBL template is wrong because of the order of the elements in `PaymentMeans` because it is a sequence
`PaymentDueDate` must be in second position (before `InstructionId`)

https://www.w3schools.com/xml/el_sequence.asp
https://docs.oasis-open.org/ubl/prd1-UBL-2.1/xsd/common/UBL-CommonAggregateComponents-2.1.xsd
see `<xsd: complexType name = "PaymentMeansType">`

OPW-2468492
