### PR TITLE
Invoice: factur_x and send&print fixes

### DIFF
--- a/addons/account_edi_facturx/models/account_edi_format.py
+++ b/addons/account_edi_facturx/models/account_edi_format.py
@@ -149,7 +149,7 @@ class AccountEdiFormat(models.Model):
 
             partner_type = invoice_form.journal_id.type == 'purchase' and 'SellerTradeParty' or 'BuyerTradeParty'
             invoice_form.partner_id = self_ctx._retrieve_partner(
-                name=_find_value(f"/ram:{partner_type}/ram:Name"),
+                name=_find_value(f"//ram:{partner_type}/ram:Name"),
                 mail=_find_value(f"//ram:{partner_type}//ram:URIID[@schemeID='SMTP']"),
                 vat=_find_value(f"//ram:{partner_type}/ram:SpecifiedTaxRegistration/ram:ID"),
             )

--- a/addons/snailmail_account/i18n/snailmail_account.pot
+++ b/addons/snailmail_account/i18n/snailmail_account.pot
@@ -167,3 +167,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:snailmail_account.field_account_invoice_send__snailmail_cost
 msgid "Stamp(s)"
 msgstr ""
+
+#. module: snailmail_account
+#: code:addons/snailmail_account/wizard/account_invoice_send.py:0
+#, python-format
+msgid "You cannot send an invoice which has no partner assigned."
+msgstr ""


### PR DESCRIPTION
Fix two issues found out based on task id #2655365

Fix a space in factur_x which would fail to find the name of the partner, thus never finding it even where it should have been able to.

Raise a user error when trying to send&print an invoice that has no partner_id assigned.