### PR TITLE
[FIX] web: localization: add a docstring

### DIFF
--- a/addons/web/static/src/core/l10n/localization.js
+++ b/addons/web/static/src/core/l10n/localization.js
@@ -7,6 +7,16 @@ const notReadyError = new Error(
     "Localization parameters not ready yet. Maybe add 'localization' to your dependencies?"
 );
 
+/**
+ * This is the main object holding user specific data about the localization. Its basically
+ * the JS counterpart of the "res.lang" model.
+ * It is useful to directly access those data anywhere, even outside Components.
+ *
+ * Important Note: its data are actually loaded by the localization_service,
+ * so a code like the following would not work:
+ *   import { localization } from "@web/core/l10n/localization";
+ *   const dateFormat = localization.dateFormat; // dateFormat isn't set yet
+ */
 export const localization = {
     dateFormat: notReadyError,
     dateTimeFormat: notReadyError,


### PR DESCRIPTION
This commit just adds a comment to enlighten a developper on how the actual
data of localization is loaded.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
