### PR TITLE
[FIX] project_timesheet_holidays: fix traceback when approving a time…

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_holidays.py
+++ b/addons/project_timesheet_holidays/models/hr_holidays.py
@@ -75,12 +75,13 @@ class Holidays(models.Model):
     def _timesheet_create_lines(self):
         self.ensure_one()
         vals_list = []
-        work_hours_data = self.employee_id.list_work_time_per_day(
-            self.date_from,
-            self.date_to,
-        )
-        for index, (day_date, work_hours_count) in enumerate(work_hours_data):
-            vals_list.append(self._timesheet_prepare_line_values(index, work_hours_data, day_date, work_hours_count))
+        if self.employee_id:
+            work_hours_data = self.employee_id.list_work_time_per_day(
+                self.date_from,
+                self.date_to,
+            )
+            for index, (day_date, work_hours_count) in enumerate(work_hours_data):
+                vals_list.append(self._timesheet_prepare_line_values(index, work_hours_data, day_date, work_hours_count))
         timesheets = self.env['account.analytic.line'].sudo().create(vals_list)
         return timesheets
 


### PR DESCRIPTION
… off with several employees

Description of the issue/feature this PR addresses:
A traceback appears when a time off is at the second approval stage and approved with several employees assigned to the time off.
https://www.awesomescreenshot.com/video/5408638

Current behavior before PR:
When validating a time off that is in the second approval stage with several employees assigned to, a traceback appears

Desired behavior after PR is merged:
No traceback appears when validating a time off that is in the second approval stage with several employees assigned to

task-2657656


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
