### PR TITLE
[FIX] mrp: Wrong production location in multi company

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -171,7 +171,7 @@ class MrpProduction(models.Model):
                                 readonly=True, states={'confirmed': [('readonly', False)]}, default='1')
     is_locked = fields.Boolean('Is Locked', default=True, copy=False)
     show_final_lots = fields.Boolean('Show Final Lots', compute='_compute_show_lots')
-    production_location_id = fields.Many2one('stock.location', "Production Location", related='product_id.property_stock_production', readonly=False)
+    production_location_id = fields.Many2one('stock.location', "Production Location", related='product_id.property_stock_production', readonly=False, related_sudo=False)
     picking_ids = fields.Many2many('stock.picking', compute='_compute_picking_ids', string='Picking associated to this manufacturing order')
     delivery_count = fields.Integer(string='Delivery Orders', compute='_compute_picking_ids')
 


### PR DESCRIPTION
_Manual backport of #45307_

Steps to reproduce the bug:

- Let's consider two companies C1 and C2
- Let's consider two production locations L1 in C1 and L2 in C2
- Let's consider that the company of SUPERUSER is C1
- Add the field Production location in the form view of mrp.production
- Log in C2
- Create a product P with a BOM in C2 with L2 as production location
- Create a MO for P

Bug:

The production location of P was L1 instead L2

PS: related_sudo is set to True by default.

opw:2196707
