### PR TITLE
[FIX] website: correctly display overlay on a new slide

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -313,8 +313,10 @@ options.registry.carousel = options.Class.extend({
         this.$('.carousel-control-prev, .carousel-control-next, .carousel-indicators').removeClass('d-none');
         // we added a space after the <li> in the line below to keep the same space between the indicators
         this.$indicators.append('<li data-target="#' + this.id + '" data-slide-to="' + cycle + '"></li> ');
-        var $clone = $active.clone(true);
-        $clone.removeClass('active').insertAfter($active);
+        // Need to remove editor data from the clone so it gets its own.
+        $active.clone(false)
+            .removeClass('active')
+            .insertAfter($active);
         _.defer(function () {
             self.$target.carousel().carousel(++index);
             self._rebindEvents();


### PR DESCRIPTION
Before this commit, selecting elements on a newly added slide of the
carousel was not displaying the editor overlay.
It was due to the fact that adding a new slide to the carousel was done
making a deep clone of the slide, and therefore of its editor.
Now, the slide is cloned without its editor.

task-2657532




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
