### PR TITLE
[IMP] account: align the label of fields narration in both

### DIFF
--- a/addons/account/views/account_bank_statement_views.xml
+++ b/addons/account/views/account_bank_statement_views.xml
@@ -208,15 +208,15 @@
                                            attrs="{'readonly': [('parent.state', '!=', 'open')]}"
                                            domain="['|', ('parent_id','=', False), ('is_company','=',True)]"/>
                                     <field name="ref" optional="hidden"/>
-                                    <field name="transaction_type" optional="hidden"/>
                                     <field name="narration" string="Notes" optional="hidden"/>
-                                    <field name="amount"
-                                           attrs="{'readonly': [('parent.state', '!=', 'open')]}"/>
+                                    <field name="transaction_type" optional="hidden"/>
                                     <field name="amount_currency" optional="hidden" groups="base.group_multi_currency"
                                            attrs="{'readonly': [('parent.state', '!=', 'open')]}"/>
-                                    <field name="account_number" optional="hidden"/>
                                     <field name="foreign_currency_id" optional="hidden" groups="base.group_multi_currency"
                                            attrs="{'readonly': [('parent.state', '!=', 'open')]}"/>
+                                    <field name="amount"
+                                           attrs="{'readonly': [('parent.state', '!=', 'open')]}"/>
+                                    <field name="account_number" optional="hidden"/>
 
                                     <!-- Buttons -->
                                     <button name="button_undo_reconciliation" type="object"
@@ -290,6 +290,7 @@
                     <field name="transaction_type"/>
                     <field name="move_id"/>
                     <field name="amount"/>
+                    <filter name="statement" string="Statement" context="{'group_by':'statement_id'}"/>
                 </search>
             </field>
         </record>
@@ -342,14 +343,14 @@
                     <field name="move_id"/>
                     <field name="date"/>
                     <field name="payment_ref"/>
-                    <field name="ref" groups="base.group_no_one"/>
                     <field name="partner_id"/>
-                    <field name="amount"/>
+                    <field name="ref" groups="base.group_no_one" optional="hidden"/>
+                    <field name="narration" string="Notes" optional="hidden"/>
+                    <field name="transaction_type" optional="hidden"/>
                     <field name="amount_currency" optional="hidden" groups="base.group_multi_currency"/>
                     <field name="foreign_currency_id" optional="hidden" groups="base.group_multi_currency"/>
+                    <field name="amount"/>
                     <field name="account_number" optional="hidden"/>
-                    <field name="transaction_type" optional="hidden"/>
-                    <field name="narration" optional="hidden"/>
 
                     <!-- Buttons -->
                     <button name="button_undo_reconciliation" type="object"

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -64,7 +64,7 @@
                                     <a t-if="journal_type == 'cash'" role="menuitem" type="object" name="open_action_with_context" context="{'action_name': 'action_view_bank_statement_tree', 'search_default_journal': True}">Statements</a>
                                 </div>
                                 <div>
-                                    <a role="menuitem" type="object" name="open_action_with_context" context="{'action_name': 'action_bank_statement_line', 'search_default_journal': True}">Operations</a>
+                                    <a role="menuitem" type="object" name="open_action_with_context" context="{'action_name': 'action_bank_statement_line', 'search_default_journal': True,'search_default_statement': 1}">Operations</a>
                                 </div>
                                 <div>
                                     <a role="menuitem" type="object" name="open_collect_money">Cust. Payments</a>


### PR DESCRIPTION
Purpose of the task is to:
1) Label becomes "Notes" rather than "Terms & Conditions".
2) Fields reorganization from left to right.

So in this commit, Updated Label "Terms & Conditions" to "Notes", Fields
reorganization from left to right in 'account.bank.statement' and
'accont.bank.statement.line' model and make group_by bank statement.

Links
PR #77336
Task - 2613132
