### PR TITLE
[FIX] mail: fix crash when trying to catch result of play()

### DIFF
--- a/addons/mail/static/src/models/sound_effect/sound_effect.js
+++ b/addons/mail/static/src/models/sound_effect/sound_effect.js
@@ -30,7 +30,7 @@ function factory(dependencies) {
             this.audio.currentTime = 0;
             this.audio.loop = loop;
             this.audio.volume = volume;
-            this.audio.play().catch(()=>{});
+            Promise.resolve(this.audio.play()).catch(()=>{});
         }
 
         /**


### PR DESCRIPTION
Some browsers don't return a promise from mediaElement.play(), we wrap
it in promise.resolve to solve the issue.
