### PR TITLE
[FIX] mail: make possible to search on channel_partner_id

### DIFF
--- a/addons/mail/models/mail_channel_partner.py
+++ b/addons/mail/models/mail_channel_partner.py
@@ -34,6 +34,14 @@ class ChannelPartner(models.Model):
     def name_get(self):
         return [(record.id, record.partner_id.name or record.guest_id.name) for record in self]
 
+    def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
+        domain = [[('partner_id', operator, name)], [('guest_id', operator, name)]]
+        if '!' in operator or 'not' in operator:
+            domain = expression.AND(domain)
+        else:
+            domain = expression.OR(domain)
+        return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
+
     def init(self):
         self.env.cr.execute("CREATE UNIQUE INDEX IF NOT EXISTS mail_channel_partner_partner_unique ON %s (channel_id, partner_id) WHERE partner_id IS NOT NULL" % self._table)
         self.env.cr.execute("CREATE UNIQUE INDEX IF NOT EXISTS mail_channel_partner_guest_unique ON %s (channel_id, guest_id) WHERE guest_id IS NOT NULL" % self._table)


### PR DESCRIPTION
Issue
-----
Adding ('channel_partner_id', 'ilike', name) when searching for
mail.channel.rtc.session does not filter out any record

because the model mail.channel.partner does not define any _rec_name
only the name_get

Solution
-------
Implement a _name_search method consistent with the name_get



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
