### PR TITLE
[FIX] sale_stock: improve module installation

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
+from odoo.tools.sql import column_exists, create_column
 
 
 class StockLocationRoute(models.Model):
@@ -68,6 +69,17 @@ class StockPicking(models.Model):
 
     sale_id = fields.Many2one(related="group_id.sale_id", string="Sales Order", store=True, readonly=False)
 
+    def _auto_init(self):
+        """
+        Create related field here, too slow
+        when computing it afterwards through _compute_related.
+
+        Since group_id.sale_id is created in this module,
+        no need for an UPDATE statement.
+        """
+        if not column_exists(self.env.cr, 'stock_picking', 'sale_id'):
+            create_column(self.env.cr, 'stock_picking', 'sale_id', 'int4')
+        return super()._auto_init()
 
     def _log_less_quantities_than_expected(self, moves):
         """ Log an activity on sale order that are linked to moves. The


### PR DESCRIPTION
Add _auto_init for stock_picking.sale_id
to speedup the module installation.

Since its related field, group_id.sale_id is also
created in sale_stock, adding the sale_id column is
enough (i.e. no UPDATE needed).

#### speedup

After PR, installation time not correlated to number of stock_picking records.
In customer DB with 1.5M pickings, installation time goes from timeout to a few seconds.

opw-2638554

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
