### PR TITLE
[FIX] sale: Use the company of the order instead of company related store in the soil when came from a onchange method.

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1601,7 +1601,7 @@ class SaleOrderLine(models.Model):
         self._compute_tax_id()
 
         if self.order_id.pricelist_id and self.order_id.partner_id:
-            vals['price_unit'] = self.env['account.tax']._fix_tax_included_price_company(self._get_display_price(product), product.taxes_id, self.tax_id, self.company_id)
+            vals['price_unit'] = self.env['account.tax']._fix_tax_included_price_company(self._get_display_price(product), product.taxes_id, self.tax_id, self.order_id.company_id)
         self.update(vals)
 
         title = False
@@ -1634,7 +1634,7 @@ class SaleOrderLine(models.Model):
                 uom=self.product_uom.id,
                 fiscal_position=self.env.context.get('fiscal_position')
             )
-            self.price_unit = self.env['account.tax']._fix_tax_included_price_company(self._get_display_price(product), product.taxes_id, self.tax_id, self.company_id)
+            self.price_unit = self.env['account.tax']._fix_tax_included_price_company(self._get_display_price(product), product.taxes_id, self.tax_id, self.order_id.company_id)
 
     def name_get(self):
         result = []


### PR DESCRIPTION
For multi-company environments, and you have more than one custom taxes for a product, and these taxes "all of them or more than one" have the
configuration "Included in Price" active. You have selected in companies tab all of these companies active and one selected to operate.
When you add a product in a sale order with one of the companies with the configuration above you notice that the price that is taken is not correct.
Due the company of the order line is not setting yet until you save the record, this cause then when the price is computed all taxes are taken not only the tax for
company of the order.

After that changes this will not happen, because we use directly the company of the order.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
