### PR TITLE
[FIX] web_editor: fix all temp hints being removed

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2257,7 +2257,7 @@ export class OdooEditor extends EventTarget {
             'CL LI': 'To-do',
         };
 
-        for (const hint of document.querySelectorAll('.oe-hint')) {
+        for (const hint of this.editable.querySelectorAll('.oe-hint')) {
             if (hint.classList.contains('oe-command-temporary-hint') || !isEmptyBlock(hint)) {
                 this.observerUnactive();
                 hint.classList.remove('oe-hint', 'oe-command-temporary-hint');


### PR DESCRIPTION
The temp hints removal was looking for all elements in the document
and not just the current editor