### PR TITLE
[13.0][FIX] stock: Use new cursor when running scheduler from a different thread

### DIFF
--- a/addons/stock/wizard/stock_scheduler_compute.py
+++ b/addons/stock/wizard/stock_scheduler_compute.py
@@ -37,7 +37,7 @@ class StockSchedulerCompute(models.TransientModel):
             for company in self.env.user.company_ids:
                 cids = (self.env.user.company_id | self.env.user.company_ids).ids
                 self.env['procurement.group'].with_context(allowed_company_ids=cids).run_scheduler(
-                    use_new_cursor=self._cr.dbname,
+                    use_new_cursor=True,
                     company_id=company.id)
             new_cr.close()
             return {}


### PR DESCRIPTION
The `use_new_cursor` parameter used should be a boolean.
Without this change, it was not behaving correctly and in some situations, an old cursor (already closed) was being used

@Tecnativa
TT32016

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
