### PR TITLE
13.0 fix pos entry tax edition oco

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -548,7 +548,7 @@ class AccountMove(models.Model):
             if move.type == 'entry':
                 repartition_field = is_refund and 'refund_repartition_line_ids' or 'invoice_repartition_line_ids'
                 repartition_tags = base_line.tax_ids.flatten_taxes_hierarchy().mapped(repartition_field).filtered(lambda x: x.repartition_type == 'base').tag_ids
-                tags_need_inversion = (tax_type == 'sale' and not is_refund) or (tax_type == 'purchase' and is_refund)
+                tags_need_inversion = self._tax_tags_need_inversion(move, is_refund, tax_type)
                 if tags_need_inversion:
                     balance_taxes_res['base_tags'] = base_line._revert_signed_tags(repartition_tags).ids
                     for tax_res in balance_taxes_res['taxes']:
@@ -569,7 +569,7 @@ class AccountMove(models.Model):
                 if move.type == 'entry':
                     repartition_field = is_refund and 'refund_repartition_line_ids' or 'invoice_repartition_line_ids'
                     repartition_tags = base_line.tax_ids.mapped(repartition_field).filtered(lambda x: x.repartition_type == 'base').tag_ids
-                    tags_need_inversion = (tax_type == 'sale' and not is_refund) or (tax_type == 'purchase' and is_refund)
+                    tags_need_inversion = self._tax_tags_need_inversion(move, is_refund, tax_type)
                     if tags_need_inversion:
                         balance_taxes_res['base_tags'] = base_line._revert_signed_tags(repartition_tags).ids
                         for tax_res in balance_taxes_res['taxes']:
@@ -697,6 +697,19 @@ class AccountMove(models.Model):
             if tax_line and in_draft_mode:
                 tax_line._onchange_amount_currency()
                 tax_line._onchange_balance()
+
+    def _tax_tags_need_inversion(self, move, is_refund, tax_type):
+        """ Tells whether the tax tags need to be inverted for a given move.
+
+        :param move: the move for which we want to check inversion
+        :param is_refund: whether or not the operation we want the inversion value for is a refund
+        :param tax_type: the tax type of the operation we want the inversion value for
+
+        :return: True if the tags need to be inverted
+        """
+        if move.type == 'entry':
+            return (tax_type == 'sale' and not is_refund) or (tax_type == 'purchase' and is_refund)
+        return False
 
     @api.model
     def _get_base_amount_to_display(self, base_amount, tax_rep_ln, parent_tax_group=None):

--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -23,6 +23,16 @@ class AccountMove(models.Model):
             if inv.type in ['out_invoice', 'out_refund'] and inv.pos_order_ids and any(s != 'closed' for s in inv.pos_order_ids.mapped('session_id.state')):
                 inv.invoice_payment_state = 'paid'
 
+    def _tax_tags_need_inversion(self, move, is_refund, tax_type):
+        # POS order operations are handled by the tax report just like invoices ;
+        # we should never invert their tags.
+        if move.type == 'entry':
+            orders_count = self.env['pos.order'].search_count([('account_move', '=', move._origin.id)])
+            sessions_count = self.env['pos.session'].search_count([('move_id', '=', move._origin.id)])
+            if orders_count + sessions_count:
+                return False
+        return super()._tax_tags_need_inversion(move, is_refund, tax_type)
+
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 

--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -55,5 +55,7 @@ class AccountMoveLine(models.Model):
             # is linked to it ; we know that the invoice type tells us whether it's a refund
             return rslt
 
+        sessions_count = self.env['pos.session'].search_count([('move_id', '=', aml.move_id.id)])
         pos_orders_count = self.env['pos.order'].search_count([('account_move', '=', aml.move_id.id)])
-        return rslt or (pos_orders_count and aml.debit > 0)
+
+        return rslt or (sessions_count + pos_orders_count and aml.debit > 0)


### PR DESCRIPTION
[FIX] account, point_of_sale: don't invert tags when editing entry from POS

Miscellaneous entries created by POS are handled like invoices by the tax report engine. They hence differ from regular miscellaneous entries, as they don't require inverting their tag signs under any circumstances.

Before this fix, manually editing and entry from POS in such a way that the tax lines were recomputed did not take that into account, and the signs were inverted on every line, causing a sign inversion in the tax report.


OPW 2653923



[FIX] point_of_sale: also consider pos.sessions when guessing if an account.move comes from pos to compute tax_audit

In every other place doing that, both models are checked. See here, for example https://github.com/odoo/enterprise/blob/13.0/pos_account_reports/models/account_generic_tax_report.py#L14 .