### PR TITLE
[FIX] sale_coupon: Prommotional program applied on canceled SO

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -31,7 +31,8 @@ class SaleOrder(models.Model):
     def recompute_coupon_lines(self):
         for order in self:
             order._remove_invalid_reward_lines()
-            order._create_new_no_code_promo_reward_lines()
+            if order.state != 'cancel':
+                order._create_new_no_code_promo_reward_lines()
             order._update_existing_reward_lines()
 
     @api.multi


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a promotional program P with 'Fixed amount' discount of $50 and 'Automatically applied' on current order
- Create SO and cancel it

Bug:

P was applied on the canceled SO

opw:2579344