### PR TITLE
[FIX] pos_sale: add delivery address when generating invoice

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -25,4 +25,6 @@ class PosOrder(models.Model):
     def _prepare_invoice_vals(self):
         invoice_vals = super(PosOrder, self)._prepare_invoice_vals()
         invoice_vals['team_id'] = self.crm_team_id
+        addr = self.partner_id.address_get(['delivery'])
+        invoice_vals['partner_shipping_id'] = addr['delivery']
         return invoice_vals


### PR DESCRIPTION
When invoicing via POS delivery address is missing on the invoice.
This value is needed in some localizations (i.e. l10n_co) to correctly
validate the invoice

opw-2653661

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
