### PR TITLE
[FIX] mrp: Add variant to delivery slips.

### DIFF
--- a/addons/mrp/report/report_deliveryslip.xml
+++ b/addons/mrp/report/report_deliveryslip.xml
@@ -5,10 +5,11 @@
         <xpath expr="//t[@name='has_packages']" position="before">
             <!-- get only the top level kits' (i.e. no subkit) move lines for easier mapping later on + we ignore subkit groupings-->
             <!-- note that move.name uses top level kit's product.template.display_name value instead of product.template.name -->
-            <t t-set="has_kits" t-value="o.move_line_ids.filtered(lambda l: l.move_id.bom_line_id and l.move_id.bom_line_id.bom_id.product_tmpl_id.display_name == l.move_id.name)"/>
+            <!-- Product template for non-variant and product id for variant bom -->
+            <t t-set="has_kits" t-value="o.move_line_ids.filtered(lambda l: l.move_id.bom_line_id and (l.move_id.bom_line_id.bom_id.product_tmpl_id.display_name == l.move_id.name or l.move_id.bom_line_id.bom_id.product_id.display_name == l.move_id.name))"/>
         </xpath>
         <xpath expr="//t[@name='no_package_section']" position="before">
-            <t t-set="has_kits" t-value="move_lines.filtered(lambda l: l.move_id.bom_line_id and l.move_id.bom_line_id.bom_id.product_tmpl_id.display_name == l.move_id.name)"/>
+            <t t-set="has_kits" t-value="move_lines.filtered(lambda l: l.move_id.bom_line_id and (l.move_id.bom_line_id.bom_id.product_tmpl_id.display_name == l.move_id.name or l.move_id.bom_line_id.bom_id.product_id.display_name == l.move_id.name))"/>
             <t t-if="has_kits">
                 <!-- print the products not in a package or kit first -->
                 <t t-set="move_lines" t-value="move_lines.filtered(lambda m: not m.move_id.bom_line_id)"/>
@@ -28,8 +29,16 @@
 
     <template id="stock_report_delivery_kit_sections">
         <!-- do another map to get unique top level kits -->
-        <t t-set="kits" t-value="has_kits.mapped('move_id.bom_line_id.bom_id.product_tmpl_id')"/>
+        <t t-set="kits" t-value="has_kits.mapped('move_id.bom_line_id.bom_id')"/>
         <t t-foreach="kits" t-as="kit">
+            <!-- Separate porduct.product from template for variants-->
+            <t t-if="kit.product_id">
+                <!--                -->
+                <t t-set="kit" t-value="kit.product_id"/>
+            </t>
+            <t t-else="">
+                <t t-set="kit" t-value="kit.product_tmpl_id"/>
+            </t>
             <tr t-att-class="'bg-200 font-weight-bold o_line_section'">
                 <td colspan="99">
                     <span t-esc="kit.display_name"/>
@@ -39,7 +48,7 @@
             <t t-if="has_serial_number">
                 <tr t-foreach="kit_move_lines" t-as="move_line">
                     <t t-set="description" t-as="move_line.move_id.description_picking"/>
-                    <t t-if="description == kit.name">
+                    <t t-if="description == kit.display_name">
                         <t t-set="description" t-value=""/>
                     </t>
                     <t t-call="stock.stock_report_delivery_has_serial_move_line"/>
@@ -47,7 +56,7 @@
             </t>
             <t t-else="">
                 <!-- move line description by default is the product_template.name (kit name), instead of display_name-->
-                <t t-set="aggregated_lines" t-value="kit_move_lines._get_aggregated_product_quantities(kit_name=kit.name)"/>
+                <t t-set="aggregated_lines" t-value="kit_move_lines._get_aggregated_product_quantities(kit_name=kit.display_name)"/>
                 <t t-if="aggregated_lines">
                     <t t-call="stock.stock_report_delivery_aggregated_move_lines"/>
                 </t>


### PR DESCRIPTION
Problem : Variant where not shown in delivery slips reports.

Cause : Product where linked via their description to the variant name but then compared to the product template name.
Solution : Compare to product name if it exist and compare to template name.

opw-2603829

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
