### PR TITLE
[FIX] mail: ensure guest is in the context

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -75,7 +75,10 @@ class DiscussController(http.Controller):
             'isChannelTokenSecret': is_channel_token_secret,
         }
         add_guest_cookie = False
-        if not channel_sudo.env['mail.channel.partner']._get_as_sudo_from_request(request=request, channel_id=channel_sudo.id):
+        channel_partner_sudo = channel_sudo.env['mail.channel.partner']._get_as_sudo_from_request(request=request, channel_id=channel_sudo.id)
+        if channel_partner_sudo:
+            channel_sudo = channel_partner_sudo.channel_id  # ensure guest is in context
+        else:
             if not channel_sudo.env.user._is_public():
                 channel_sudo.add_members([channel_sudo.env.user.partner_id.id])
             else:


### PR DESCRIPTION
Update a specific flow to ensure the record on which session_info is called has guest in its context. This is needed because session_info performs some checks on guest to determine if it should add translations data.