### PR TITLE
[IMP] delivery: introduced new fields in stock picking.

### DIFF
--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -90,6 +90,8 @@ class StockPicking(models.Model):
     is_return_picking = fields.Boolean(compute='_compute_return_picking')
     return_label_ids = fields.One2many('ir.attachment', compute='_compute_return_label')
     destination_country_code = fields.Char(related='partner_id.country_id.code', string="Destination Country")
+    shipment_description = fields.Char(string='Shipment Description', compute='_compute_description', readonly=False)
+    shipment_declared_value = fields.Float(string='Declared Value', compute='_compute_declared_value', readonly=False)
 
     @api.depends('carrier_id', 'carrier_tracking_ref')
     def _compute_carrier_tracking_url(self):
@@ -110,6 +112,14 @@ class StockPicking(models.Model):
                 picking.return_label_ids = self.env['ir.attachment'].search([('res_model', '=', 'stock.picking'), ('res_id', '=', picking.id), ('name', 'like', '%s%%' % picking.carrier_id.get_return_label_prefix())])
             else:
                 picking.return_label_ids = False
+
+    def _compute_description(self):
+        for rec in self:
+            rec.shipment_description = self.sale_id.order_line.product_id[0].categ_id.name if self.sale_id else ""
+
+    def _compute_declared_value(self):
+        for rec in self:
+            rec.shipment_declared_value = self.sale_id.amount_total if self.sale_id else 0.0
 
     def get_multiple_carrier_tracking(self):
         self.ensure_one()

--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -115,11 +115,11 @@ class StockPicking(models.Model):
 
     def _compute_description(self):
         for rec in self:
-            rec.shipment_description = self.sale_id.order_line.product_id[0].categ_id.name if self.sale_id else ""
+            rec.shipment_description = rec.sale_id.order_line.product_id[0].categ_id.name if rec.sale_id else ""
 
     def _compute_declared_value(self):
         for rec in self:
-            rec.shipment_declared_value = self.sale_id.amount_total if self.sale_id else 0.0
+            rec.shipment_declared_value = rec.sale_id.amount_total if rec.sale_id else 0.0
 
     def get_multiple_carrier_tracking(self):
         self.ensure_one()

--- a/addons/delivery/views/delivery_view.xml
+++ b/addons/delivery/views/delivery_view.xml
@@ -213,6 +213,8 @@
                     <group name='carrier_data' string="Shipping Information">
                         <field name="is_return_picking" invisible="1"/>
                         <field name="carrier_id" attrs="{'readonly': [('state', 'in', ('done', 'cancel'))]}" options="{'no_create': True, 'no_open': True}"/>
+                        <field name="shipment_declared_value"/>
+                        <field name="shipment_description"/>
                         <field name="delivery_type" attrs="{'invisible':True}"/>
                         <label for="carrier_tracking_ref"/>
                         <div name="tracking">


### PR DESCRIPTION
In this commit:
===========================
Added two new fields in stock picking related to shipping

1. shipment_description
2. shipment_declared_value

Before this commit:
=========================

The value of shipment description was static `MY DESCRIPTION`
which might be rejected by customs so we added field to set the
description value default by taking the category name of the first
product from the sale order line.

The value of declared value was the total amount of movelines
which was not including shipping cost so in this commit we set
the value of declared field to total amount of sales order.

task-id: 2611210
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
