### PR TITLE
[FIX] accounting: have the right order for bank statement

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -207,7 +207,7 @@ class AccountBankStatement(models.Model):
             # will find the record itself, so we have to add a condition in the search to ignore self.id
             if not isinstance(st.id, models.NewId):
                 domain.extend(['|', '&', ('id', '<', st.id), ('date', '=', st.date), '&', ('id', '!=', st.id), ('date', '!=', st.date)])
-            previous_statement = self.search(domain, limit=1)
+            previous_statement = self.search(domain, limit=1, order='date desc, id desc')
             st.previous_statement_id = previous_statement.id
 
     name = fields.Char(string='Reference', states={'open': [('readonly', False)]}, copy=False, readonly=True)


### PR DESCRIPTION
Steps to reproduce:

- Go to Accounting -> Cash Registers
- Create a first statement named E, add a line with amount 100,
  set the Ending Balance (balance_end) to 100.
- Create a second statement named H, add a line with amount 50,
  set the Ending Balance (balance_end) to 150.
- Create a third statement named C, add a line with amount 1,
  set the Ending Balance (balance_end) to 151.
- Create a last statement named as you want.

Issue:

The Starting Balance of the last statement is compute from the
Ending Balance of statement H instead of statement C.

Cause:

Because of the _order = 'date desc, name desc, id desc', if several
statements have the same date, the name is taking into account to
classify the statements, which cause issue because the name doesn't
always reflect the chronological order of creation.

Solution:

Check if the previous statement's date is the same as the actual one,
then change the order to 'id desc', otherwise we don't touch anything.

opw-2635092

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
