### PR TITLE
[FIX] hr_timesheet, sale_timesheet, *: generic improvements

### DIFF
--- a/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
@@ -33,14 +33,24 @@
             </t>
             <t t-if="grouped_timesheets">
                 <t t-call="portal.portal_table">
+                    <thead>
+                        <tr>
+                            <th t-if="not groupby == 'date'">Date</th>
+                            <th t-if="not groupby == 'employee'">Employee</th>
+                            <th t-if="not groupby == 'project'">Project</th>
+                            <th t-if="not groupby == 'task'">Task</th>
+                            <th>Description</th>
+                            <th t-if="is_uom_day" class="text-right">Days Spent</th>
+                            <th t-else="" class="text-right">Hours Spent</th>
+                        </tr>
+                    </thead>
                     <t t-foreach="grouped_timesheets" t-as="timesheets_with_hours">
                         <t t-set="timesheets" t-value="timesheets_with_hours[0]"/>
                         <t t-set="hours_spent" t-value="timesheets_with_hours[1]"/>
-                        <thead style="font-size: 0.8rem">
-                            <tr t-if="not groupby =='none'" t-attf-class="{{'thead-light'}}">
+                        <tbody style="font-size: 0.8rem">
+                            <tr t-if="not groupby =='none'" class="thead-light">
                                 <t t-if="groupby == 'project'">
                                     <th t-if="groupby == 'project'" colspan="5">
-                                        <em class="font-weight-normal text-muted">Timesheets for project:</em>
                                         <span t-field="timesheets[0].project_id.name"/>
                                     </th>
                                     <th colspan="1" class="text-right text-muted">
@@ -54,7 +64,6 @@
                                 </t>
                                 <t t-elif="groupby == 'task'">
                                     <th colspan="5">
-                                        <em class="font-weight-normal text-muted">Timesheets for task:</em>
                                         <span t-field="timesheets[0].task_id.name"/>
                                     </th>
                                     <th colspan="1" class="text-right text-muted">
@@ -68,7 +77,6 @@
                                 </t>
                                 <t t-elif="groupby == 'date'">
                                     <th colspan="5">
-                                        <em class="font-weight-normal text-muted">Timesheets on </em>
                                         <span t-field="timesheets[0].date"/>
                                     </th>
                                     <th colspan="1" class="text-right text-muted">
@@ -82,7 +90,6 @@
                                 </t>
                                 <t t-elif="groupby == 'employee'">
                                     <th colspan="5">
-                                        <em class="font-weight-normal text-muted">Timesheets for employee:</em>
                                         <span t-field="timesheets[0].employee_id.name"/>
                                     </th>
                                     <th colspan="1" class="text-right text-muted">
@@ -105,16 +112,7 @@
                                     </t>
                                 </div>
                             </tr>
-                            <tr>
-                                <th t-if="not groupby == 'date'">Date</th>
-                                <th t-if="not groupby == 'employee'">Employee</th>
-                                <th t-if="not groupby == 'project'">Project</th>
-                                <th t-if="not groupby == 'task'">Task</th>
-                                <th>Description</th>
-                                <th t-if="is_uom_day" class="text-right">Days Spent</th>
-                                <th t-else="" class="text-right">Hours Spent</th>
-                            </tr>
-                        </thead>
+                        </tbody>
                         <tbody style="font-size: 0.8rem">
                             <t t-foreach="timesheets" t-as="timesheet">
                                 <tr>

--- a/addons/hr_timesheet/views/project_portal_templates.xml
+++ b/addons/hr_timesheet/views/project_portal_templates.xml
@@ -48,6 +48,9 @@
             <t t-set="timesheet_ids" t-value="task.sudo().timesheet_ids"/>
             <t t-set="is_uom_day" t-value="timesheet_ids._is_timesheet_encode_uom_day()"/>
         </xpath>
+        <xpath expr="//thead/tr/t[@t-set='number_of_header']" position="attributes">
+            <attribute name="t-value">8</attribute>
+        </xpath>
         <xpath expr="//thead/tr/th[@name='project_portal_assignees']" position="after">
             <th t-if="is_uom_day">Days Spent</th>
             <th t-else="">Hours Spent</th>

--- a/addons/project/views/project_portal_templates.xml
+++ b/addons/project/views/project_portal_templates.xml
@@ -97,33 +97,37 @@
     <template id="portal_tasks_list" name="Tasks List">
         <t t-if="grouped_tasks">
             <t t-call="portal.portal_table">
+                <thead>
+                    <tr>
+                        <!-- Allows overrides in modules -->
+                        <t t-set="group_by_in_header_list" t-value="['priority', 'status', 'project', 'stage']"></t>
+                        <t t-set="number_of_header" t-value="7"></t>
+                        <!-- Computes the right colspan once and use it everywhere -->
+                        <t t-set="grouped_tasks_colspan" t-value="number_of_header - 1 if groupby in group_by_in_header_list else number_of_header"></t>
+                        <th class="text-left">Ref</th>
+                        <th t-if="groupby != 'priority'">Priority</th>
+                        <th>Name</th>
+                        <th name="project_portal_assignees">Assignees</th>
+                        <th t-if="groupby != 'status'">Status</th>
+                        <th t-if="groupby != 'project'">Project</th>
+                        <th t-if="groupby != 'stage'">Stage</th>
+                    </tr>
+                </thead>
                 <t t-foreach="grouped_tasks" t-as="tasks">
-                    <thead>
-                        <tr t-attf-class="{{'thead-light' if not groupby == 'none' else ''}}">
-                            <th class="text-left">Ref</th>
-                            <th t-if="groupby != 'priority'">Priority</th>
-                            <th t-if="groupby == 'none'">Name</th>
-                            <th t-if="groupby == 'project'">
-                                <em class="font-weight-normal text-muted"><span t-field="tasks[0].sudo().project_id.label_tasks"/> for project:</em>
+                    <tbody>
+                        <tr t-if="not groupby == 'none'" class="thead-light">
+                            <th t-if="groupby == 'project'" t-attf-colspan="{{grouped_tasks_colspan}}">
                                 <span t-field="tasks[0].sudo().project_id.name"/></th>
-                            <th t-if="groupby == 'stage'">
-                                <em class="font-weight-normal text-muted"><span t-field="tasks[0].sudo().project_id.label_tasks"/> in stage:</em>
+                            <th t-if="groupby == 'stage'" t-attf-colspan="{{grouped_tasks_colspan}}">
                                 <span class="text-truncate" t-field="tasks[0].sudo().stage_id.name"/></th>
-                            <th t-if="groupby == 'priority'">
-                                <em class="font-weight-normal text-muted"><span t-field="tasks[0].sudo().project_id.label_tasks"/> in priority:</em>
+                            <th t-if="groupby == 'priority'" t-attf-colspan="{{grouped_tasks_colspan}}">
                                 <span class="text-truncate" t-field="tasks[0].sudo().priority"/></th>
-                            <th t-if="groupby == 'status'">
-                                <em class="font-weight-normal text-muted"><span t-field="tasks[0].sudo().project_id.label_tasks"/> in status:</em>
+                            <th t-if="groupby == 'status'" t-attf-colspan="{{grouped_tasks_colspan}}">
                                 <span class="text-truncate" t-field="tasks[0].sudo().kanban_state"/></th>
-                            <th t-if="groupby == 'customer'">
-                                <em class="font-weight-normal text-muted" t-if="tasks[0].sudo().partner_id"><span t-field="tasks[0].sudo().project_id.label_tasks"/> for customer:</em>
+                            <th t-if="groupby == 'customer'" t-attf-colspan="{{grouped_tasks_colspan}}">
                                 <span class="text-truncate" t-field="tasks[0].sudo().partner_id.name"/></th>
-                            <th name="project_portal_assignees">Assignees</th>
-                            <th t-if="groupby != 'status'">Status</th>
-                            <th t-if="groupby != 'project'">Project</th>
-                            <th t-if="groupby != 'stage'">Stage</th>
                         </tr>
-                    </thead>
+                    </tbody>
                     <tbody>
                         <t t-foreach="tasks" t-as="task">
                             <tr>

--- a/addons/sale_project/views/sale_project_portal_templates.xml
+++ b/addons/sale_project/views/sale_project_portal_templates.xml
@@ -2,16 +2,14 @@
 <odoo>
 
     <template id="portal_tasks_list_inherit" inherit_id="project.portal_tasks_list">
-        <xpath expr="//t[@t-call='portal.portal_table']//thead/tr/th[@name='project_portal_assignees']" position="before">
-            <th t-if="groupby == 'sale_order'">
-                <em class="font-weight-normal text-muted"><span t-field="tasks[0].sudo().project_id.label_tasks"/> for sale order:</em>
+        <xpath expr="//t[@t-foreach='grouped_tasks']/tbody/tr[hasclass('thead-light')]" position="inside">
+            <th t-if="groupby == 'sale_order'" t-attf-colspan="{{grouped_tasks_colspan}}">
                 <span t-if="tasks[0].sudo().sale_order_id" class="text-truncate" t-field="tasks[0].sudo().sale_order_id"/>
-                <span t-else="">None</span>
+                <span t-else="">No Sales Order</span>
             </th>
-            <th t-if="groupby == 'sale_line'">
-                <em class="font-weight-normal text-muted"><span t-field="tasks[0].sudo().project_id.label_tasks"/> for sale order item:</em>
+            <th t-if="groupby == 'sale_line'" t-attf-colspan="{{grouped_tasks_colspan}}">
                 <span t-if="tasks[0].sudo().sale_line_id" class="text-truncate" t-field="tasks[0].sudo().sale_line_id"/>
-                <span t-else="">None</span>
+                <span t-else="">No Sales Order Item</span>
             </th>
         </xpath>
     </template>

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -14,12 +14,11 @@
     </template>
 
     <template id="portal_my_timesheets_inherit" inherit_id="hr_timesheet.portal_my_timesheets">
-        <xpath expr="//thead/tr[contains(@t-attf-class, 'thead-light')]" position="inside">
+        <xpath expr="//t[@t-foreach='grouped_timesheets']/tbody/tr[hasclass('thead-light')]" position="inside">
             <t t-elif="groupby == 'sol'">
                 <t t-set="sol" t-value="timesheets[0].so_line"/>
                 <th colspan="5">
                     <t t-if="sol">
-                        <em class="font-weight-normal text-muted">Timesheets for sales order item:</em>
                         <span t-field="sol.display_name"/>
                         <t t-if="sol.remaining_hours_available">
                             <span class="text-muted font-weight-normal">
@@ -31,6 +30,9 @@
                                 </t>
                             </span>
                         </t>
+                    </t>
+                    <t t-else="">
+                        No Sales Order Item
                     </t>
                 </th>
                 <th colspan="1" class="text-right text-muted font-weight-normal">
@@ -46,8 +48,10 @@
                 <t t-set="so" t-value="timesheets[0].order_id"/>
                 <th colspan="6">
                     <t t-if="so">
-                        <em class="font-weight-normal text-muted">Timesheets for sales order:</em>
                         <span t-field="so.display_name"/>
+                    </t>
+                    <t t-else="">
+                        No Sales Order
                     </t>
                 </th>
                 <th colspan="1" class="text-right text-muted">
@@ -63,8 +67,10 @@
                 <t t-set="invoice" t-value="timesheets.timesheet_invoice_id"/>
                 <th colspan="6">
                     <t t-if="invoice">
-                        <em class="font-weight-normal text-muted">Timesheets for Invoice:</em>
                         <span t-field="invoice.display_name"/>
+                    </t>
+                    <t t-else="">
+                        No Invoice
                     </t>
                 </th>
                 <th colspan="1" class="text-right text-muted">


### PR DESCRIPTION
* = project, sale_project

Currently, the header is displayed above every group when the group by is applied.

In this commit, we move the header with the fields labels at the top of the
table. 

task-2655707

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
