### PR TITLE
[FIX] mail: add attachment deleted notification

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -257,7 +257,8 @@ class DiscussController(http.Controller):
             raise NotFound()
         if not request.env.user.share:
             # Check through standard access rights/rules for internal users.
-            return attachment_sudo.sudo(False).unlink()
+            attachment_sudo.sudo(False)._delete_and_notify()
+            return
         # For non-internal users 2 cases are supported:
         #   - Either the attachment is linked to a message: verify the request is made by the author of the message (portal user or guest).
         #   - Either a valid access token is given: also verify the message is pending (because unfortunately in portal a token is also provided to guest for viewing others' attachments).
@@ -271,7 +272,7 @@ class DiscussController(http.Controller):
                 raise NotFound()
             if attachment_sudo.res_model != 'mail.compose.message' or attachment_sudo.res_id != 0:
                 raise NotFound()
-        return attachment_sudo.unlink()
+        attachment_sudo._delete_and_notify()
 
     @http.route('/mail/message/add_reaction', methods=['POST'], type='json', auth='public')
     def mail_message_add_reaction(self, message_id, content):

--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -36,6 +36,17 @@ class IrAttachment(models.Model):
                 except AccessError:
                     pass
 
+    def _delete_and_notify(self):
+        for attachment in self:
+            if attachment.res_model == 'mail.channel':
+                self.env['bus.bus'].sendone((self._cr.dbname, 'mail.channel', attachment.res_id), {
+                    'type': 'mail.attachment_delete',
+                    'payload': {
+                        'id': attachment.id,
+                    },
+                })
+        self.unlink()
+
     def _attachment_format(self, commands=False):
         safari = request and request.httprequest.user_agent and request.httprequest.user_agent.browser == 'safari'
         res_list = []

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -79,6 +79,8 @@ function factory(dependencies) {
                 }
                 if (typeof message === 'object') {
                     switch (message.type) {
+                        case 'mail.attachment_delete':
+                            return this._handleNotificationAttachmentDelete(message.payload);
                         case 'mail.channel_description_change':
                             return this._handleNotificationChannelDescriptionChanged(message.payload);
                         case 'mail.channel_joined':
@@ -124,6 +126,19 @@ function factory(dependencies) {
                 }
             });
             await this.async(() => Promise.all(proms));
+        }
+
+
+        /**
+         * @private
+         * @param {Object} payload
+         * @param {integer} [payload.id]
+         */
+        _handleNotificationAttachmentDelete(payload) {
+            const attachment = this.messaging.models['mail.attachment'].findFromIdentifyingData(payload);
+            if (attachment) {
+                attachment.delete();
+            }
         }
 
         /**


### PR DESCRIPTION
Before this commite, when an attachment is deleted, there is no notification and
other client do not update the attachment status.

task-2635516