### PR TITLE
[FIX] web: keep context on form dialog save&new by default

### DIFF
--- a/addons/web/static/src/js/views/view_dialogs.js
+++ b/addons/web/static/src/js/views/view_dialogs.js
@@ -144,7 +144,7 @@ var FormViewDialog = ViewDialog.extend({
                                 .then(function () {
                                     // reset default name field from context when Save & New is clicked, pass additional
                                     // context so that when getContext is called additional context resets it
-                                    var additionalContext = self._createContext && self._createContext(false) || {};
+                                    const additionalContext = self._createContext && self._createContext(false);
                                     self.form_view.createRecord(self.parentID, additionalContext);
                                 })
                                 .then(function () {


### PR DESCRIPTION
ISSUE ADDRESSED
- Open Project > Tasks > Gantt view
- Click on the button "Create"  of any cell to open a form dialog 
- Fill the form and click on SAVE&NEW button
- Fill again the form and click on SAVE&CLOSE button
- Both tasks are created, but only the first has been planned, because the second one has lost a part of the context (plan dates...)

BEFORE
Opening a form view dialog without passing a _createContext method (see commit c14b17c485 where it was introduced) was still passing an empty object additionalContext argument when save&new was hit.
This was leading to not take into account the full context (see BasicModel._getContext).

AFTER
If no _createContext method is passed to a form view dialog, then no empty object additionalContext is passed to evaluate the context, resulting in the full context being used.

Cherry-pick of: https://github.com/odoo/odoo/pull/75795/commits/73d1321268224e25ba4ac9927c95a83e5cd3c400
opw-2655195

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
