### PR TITLE
[FIX] web: graph view is not displayed in full height

### DIFF
--- a/addons/web/static/src/views/graph/graph_view.scss
+++ b/addons/web/static/src/views/graph/graph_view.scss
@@ -1,6 +1,7 @@
 .o_graph_view {
-  height: 100%;
-
+  .o_graph_renderer{
+    height: 100%;
+  }
   .o_graph_canvas_container {
     padding-top: 5px;
     position: relative;


### PR DESCRIPTION
PURPOSE
Graph view is not displayed in full space, it is squished instead, graph view should take full height.

SPEC
Graph view should use full height.

TASK 2654896


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
