### PR TITLE
[IMP] Prevent clicking navbar buttons while starting the editor

### DIFF
--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -69,7 +69,7 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
      *
      * @override
      */
-    start: function () {
+    start() {
         var def = this._super.apply(this, arguments);
 
         // If we auto start the editor, do not show a welcome message
@@ -205,6 +205,13 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         if (this.editModeEnable) {
             return;
         }
+
+        $.blockUI({overlayCSS: {
+            backgroundColor: '#000',
+            opacity: 0,
+            zIndex: 1050
+        }, message: false});
+
         this.trigger_up('widgets_stop_request', {
             $target: this._targetForEdition(),
         });
@@ -227,6 +234,8 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         if ($loader) {
             $loader.remove();
         }
+
+        $.unblockUI();
 
         return res;
     },


### PR DESCRIPTION
When visiting a page with enable_editor set to true, the web editor will be automatically started. However, while the editor is loading, the end user can still click other buttons in the navbar.

For example, some changes in the web editor require a save and reload of the current page being edited. After saving, the same page will be reloaded with enable_editor.

This PR blocks any clicks while the editor is being loaded.

task-2607755