### PR TITLE
[IMP] l10n_ar: add missing report name to document types

### DIFF
--- a/addons/l10n_ar/data/l10n_latam.document.type.csv
+++ b/addons/l10n_ar/data/l10n_latam.document.type.csv
@@ -140,8 +140,8 @@ dc_cvl_sp_a,1370,180,CUENTA DE VENTA Y LÍQUIDO PRODUCTO A - SECTOR PECUARIO,A,,
 dc_cvl_sp_b,1380,182,CUENTA DE VENTA Y LÍQUIDO PRODUCTO B - SECTOR PECUARIO,B,,invoice,CVP-B,base.ar,zero,False
 dc_liq_c_sp_a,1390,183,LIQUIDACIÓN DE COMPRA A - SECTOR PECUARIO,A,,invoice,LCP-A,base.ar,not_zero,False
 dc_liq_c_sp_b,1400,185,LIQUIDACIÓN DE COMPRA B - SECTOR PECUARIO,B,,invoice,LCP-B,base.ar,zero,False
-dc_liq_cd_sp_a,1410,186,LIQUIDACIÓN DE COMPRA DIRECTA A - SECTOR PECUARIO,A,,invoice,LCDP-A,base.ar,not_zero,False
-dc_liq_cd_sp_b,1420,188,LIQUIDACIÓN DE COMPRA DIRECTA B - SECTOR PECUARIO,B,,invoice,LCDP-B,base.ar,zero,False
-dc_liq_cd_sp_c,1430,189,LIQUIDACIÓN DE COMPRA DIRECTA C - SECTOR PECUARIO,C,,invoice,LCDP-C,base.ar,zero,False
-dc_liq_vd_sp_a,1440,190,LIQUIDACIÓN DE VENTA DIRECTA A - SECTOR PECUARIO,A,,invoice,LVDP-A,base.ar,not_zero,False
-dc_liq_vd_sp_b,1450,191,LIQUIDACIÓN DE VENTA DIRECTA B - SECTOR PECUARIO,B,,invoice,LVDP-B,base.ar,zero,False
+dc_liq_cd_sp_a,1410,186,LIQUIDACIÓN DE COMPRA DIRECTA A - SECTOR PECUARIO,A,LIQ. COMPRA DIRT. A,invoice,LCDP-A,base.ar,not_zero,False
+dc_liq_cd_sp_b,1420,188,LIQUIDACIÓN DE COMPRA DIRECTA B - SECTOR PECUARIO,B,LIQ. COMPRA DIRT. B,invoice,LCDP-B,base.ar,zero,False
+dc_liq_cd_sp_c,1430,189,LIQUIDACIÓN DE COMPRA DIRECTA C - SECTOR PECUARIO,C,LIQ. COMPRA DIRT. C,invoice,LCDP-C,base.ar,zero,False
+dc_liq_vd_sp_a,1440,190,LIQUIDACIÓN DE VENTA DIRECTA A - SECTOR PECUARIO,A,LIQ. VENTA DIRT. A,invoice,LVDP-A,base.ar,not_zero,False
+dc_liq_vd_sp_b,1450,191,LIQUIDACIÓN DE VENTA DIRECTA B - SECTOR PECUARIO,B,LIQ. VWNRA DIRT. B,invoice,LVDP-B,base.ar,zero,False


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

If the user activates any of the "Liquidacion ventas/compras directas ..." document types and want it to print them then the report will show no document name. This was not important since the user was only adding these types of documents for vendor bills where the report is not printed, But now we have the case "Liquido product" were we need to print the report.

### Current behavior before PR:

Print the invoice report but without the document name.

### Desired behavior after PR is merged:

Print the invoice report but without the correct document name.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
