### PR TITLE
[FIX] website_forum: fix forum back button visibility

### DIFF
--- a/addons/website_forum/controllers/main.py
+++ b/addons/website_forum/controllers/main.py
@@ -261,7 +261,7 @@ class WebsiteForum(WebsiteProfile):
             'reversed': reversed,
         })
         if (request.httprequest.referrer or "").startswith(request.httprequest.url_root):
-            values['back_button_url'] = request.httprequest.referrer
+            values['has_back_button_url'] = True
 
         # increment view counter
         question.sudo()._set_viewed()

--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -634,4 +634,22 @@ publicWidget.registry.websiteForumSpam = publicWidget.Widget.extend({
     },
 });
 
+publicWidget.registry.WebsiteForumBackButton = publicWidget.Widget.extend({
+    selector: '.o_back_button',
+    events: {
+        'click': '_onBackButtonClick',
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * @private
+     */
+    _onBackButtonClick() {
+        window.history.back();
+    },
+});
+
 });

--- a/addons/website_forum/views/website_forum.xml
+++ b/addons/website_forum/views/website_forum.xml
@@ -128,7 +128,7 @@
 <template id="forum_nav_header">
     <div class="navbar navbar-expand-sm navbar-light">
         <div class="container flex-wrap flex-md-nowrap">
-            <a t-if="back_button_url" class="btn btn-light border mr-2" t-attf-href="#{back_button_url}" title="Back">
+            <a t-if="has_back_button_url" class="btn btn-light border mr-2 o_back_button" title="Back">
                 <i class="fa fa-chevron-left mr-1"/>Back
             </a>
             <!-- Desktop -->


### PR DESCRIPTION
purpose of this commit is to remove the back button of the forum
page when the user opens the question from helpdesk ticket

before this commit, the back button displays on the forum page
when the user opens the question from the helpdesk ticket.

Task-2602604
Related: odoo/enterprise#21219
