### PR TITLE
[FIX] website: less dynamic snippet refresh

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet/000.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/000.js
@@ -149,9 +149,12 @@ const DynamicSnippet = publicWidget.Widget.extend({
      */
     _prepareContent: function () {
         if (this.$target[0].dataset.numberOfElements && this.$target[0].dataset.numberOfElementsSmallDevices) {
-            this.renderedContent = core.qweb.render(
+            const oldRenderedContent = this.renderedContent;
+            const newRederedContent = core.qweb.render(
                 this.template_key,
                 this._getQWebRenderOptions());
+            this.noRerender = oldRenderedContent.localeCompare(newRederedContent) === 0;
+            this.renderedContent = newRederedContent;
         } else {
             this.renderedContent = '';
         }
@@ -182,6 +185,7 @@ const DynamicSnippet = publicWidget.Widget.extend({
         } else {
             this.renderedContent = '';
         }
+        if (this.noRerender) return;
         this._renderContent();
     },
     /**


### PR DESCRIPTION
Prior to this commit, any call to action would rerender the dynamic
snippet, making it flicker and in the case of the carousel, resetting
to page 1.

With this commit, if the content of the snippet is the same as
before, we don't rerender the content.

task-2654924
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
