### PR TITLE
[FIX] correct the tax grid of UAE accounting localization

### DIFF
--- a/addons/l10n_ae/data/account_tax_template_data.xml
+++ b/addons/l10n_ae/data/account_tax_template_data.xml
@@ -346,40 +346,38 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base')],
-                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_base')]
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('uae_account_104041'),
-                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base'), ref('tax_report_line_supplies_reverse_charge_base')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
+                'account_id': ref('uae_account_104041'),
+                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
                 'account_id': ref('uae_account_201017'),
-                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base')],
-                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_base')]
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('uae_account_104041'),
-                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base'), ref('tax_report_line_supplies_reverse_charge_base')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
+                'account_id': ref('uae_account_104041'),
+                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
                 'account_id': ref('uae_account_201017'),
-                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
             }),
         ]"/>
     </record>
@@ -394,40 +392,38 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base')],
-                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_base')]
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('uae_account_104041'),
-                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base'), ref('tax_report_line_supplies_reverse_charge_base')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
+                'account_id': ref('uae_account_104041'),
+                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
                 'account_id': ref('uae_account_201017'),
-                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base')],
-                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_base')]
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('uae_account_104041'),
-                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base'), ref('tax_report_line_supplies_reverse_charge_base')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
+                'account_id': ref('uae_account_104041'),
+                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
                 'account_id': ref('uae_account_201017'),
-                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
             }),
         ]"/>
     </record>
@@ -442,40 +438,38 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base')],
-                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_base')]
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('uae_account_104041'),
-                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base'), ref('tax_report_line_supplies_reverse_charge_base')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
+                'account_id': ref('uae_account_104041'),
+                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
                 'account_id': ref('uae_account_201017'),
-                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base')],
-                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_base')]
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('uae_account_104041'),
-                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base'), ref('tax_report_line_supplies_reverse_charge_base')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
+                'account_id': ref('uae_account_104041'),
+                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
                 'account_id': ref('uae_account_201017'),
-                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
             }),
         ]"/>
     </record>
@@ -490,40 +484,38 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base')],
-                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_base')]
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('uae_account_104041'),
-                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base'), ref('tax_report_line_supplies_reverse_charge_base')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
+                'account_id': ref('uae_account_104041'),
+                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
                 'account_id': ref('uae_account_201017'),
-                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base')],
-                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_base')]
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('uae_account_104041'),
-                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base'), ref('tax_report_line_supplies_reverse_charge_base')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
+                'account_id': ref('uae_account_104041'),
+                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
                 'account_id': ref('uae_account_201017'),
-                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
             }),
         ]"/>
     </record>
@@ -538,40 +530,38 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base')],
-                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_base')]
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('uae_account_104041'),
-                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base'), ref('tax_report_line_supplies_reverse_charge_base')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
+                'account_id': ref('uae_account_104041'),
+                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
                 'account_id': ref('uae_account_201017'),
-                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base')],
-                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_base')]
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('uae_account_104041'),
-                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base'), ref('tax_report_line_supplies_reverse_charge_base')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
+                'account_id': ref('uae_account_104041'),
+                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
                 'account_id': ref('uae_account_201017'),
-                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
             }),
         ]"/>
     </record>
@@ -586,40 +576,38 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base')],
-                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_base')]
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('uae_account_104041'),
-                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base'), ref('tax_report_line_supplies_reverse_charge_base')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
+                'account_id': ref('uae_account_104041'),
+                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
                 'account_id': ref('uae_account_201017'),
-                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base')],
-                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_base')]
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('uae_account_104041'),
-                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base'), ref('tax_report_line_supplies_reverse_charge_base')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
+                'account_id': ref('uae_account_104041'),
+                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
                 'account_id': ref('uae_account_201017'),
-                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
             }),
         ]"/>
     </record>
@@ -634,40 +622,38 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base')],
-                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_base')]
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('uae_account_104041'),
-                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base'), ref('tax_report_line_supplies_reverse_charge_base')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
+                'account_id': ref('uae_account_104041'),
+                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
                 'account_id': ref('uae_account_201017'),
-                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base')],
-                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_base')]
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('uae_account_104041'),
-                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base'), ref('tax_report_line_supplies_reverse_charge_base')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
+                'account_id': ref('uae_account_104041'),
+                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
                 'account_id': ref('uae_account_201017'),
-                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
             }),
         ]"/>
     </record>
@@ -844,14 +830,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base')],
-                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_base')]
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('uae_account_201017'),
-                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base'), ref('tax_report_line_supplies_reverse_charge_base')],
             }),
             (0,0, {
                 'factor_percent': 100,
@@ -859,25 +838,30 @@
                 'account_id': ref('uae_account_104041'),
                 'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
             }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('uae_account_201017'),
+                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+            }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'plus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base')],
-                'minus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_base')]
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('uae_account_201017'),
-                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
+                'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_base'), ref('tax_report_line_supplies_reverse_charge_base')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('uae_account_104041'),
                 'minus_report_line_ids': [ref('tax_report_line_expense_supplies_reverse_vat')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('uae_account_201017'),
+                'plus_report_line_ids': [ref('tax_report_line_supplies_reverse_charge_vat')],
             }),
         ]"/>
     </record>


### PR DESCRIPTION
Correct The tax report for the tax grids 'Reverse Charge Provision' 

Description of the issue/feature this PR addresses:
Reverse Charge Provision taxes for the UAE were not using the right tax grids

Current behavior before PR:
![Screenshot from 2021-09-30 11-36-05](https://user-images.githubusercontent.com/15969250/135408276-1d5fbff8-64df-4103-9280-fcf11e479c54.png)





Desired behavior after PR is merged:
![image(1)](https://user-images.githubusercontent.com/15969250/135407789-f3918ef2-7b32-4483-87fd-dad0c5c1a56f.png)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
