### PR TITLE
[FIX] mrp: remove 'gantt' from view type

### DIFF
--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -5,7 +5,7 @@
             <field name="context">{'search_default_confirmed': 1}</field>
             <field name="name">Manufacturing Orders</field>
             <field name="res_model">mrp.production</field>
-            <field name="view_mode">tree,kanban,form,gantt</field>
+            <field name="view_mode">tree,kanban,form</field>
             <field name="domain">[('bom_id', '!=', False), ('bom_id.operation_ids.workcenter_id', '=', active_id)]</field>
         </record>
 


### PR DESCRIPTION
commit https://github.com/odoo/odoo/commit/876c2c33e8f1f50799cf2af5dfebca13a0c4cd4c
removes the production order gantt view but did not removed 'gantt' from
the view_type of the window action.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
