### PR TITLE
[IMP] web: add url_parse in report download to get data from URL

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -26,7 +26,7 @@ import werkzeug.wrappers
 import werkzeug.wsgi
 from lxml import etree, html
 from markupsafe import Markup
-from werkzeug.urls import url_encode, url_decode, iri_to_uri
+from werkzeug.urls import url_encode, url_parse, iri_to_uri
 
 import odoo
 import odoo.modules.registry
@@ -1998,7 +1998,7 @@ class ReportController(http.Controller):
                     response = self.report_routes(reportname, docids=docids, converter=converter, context=context)
                 else:
                     # Particular report:
-                    data = dict(url_decode(url.split('?')[1]).items())  # decoding the args represented in JSON
+                    data = url_parse(url).decode_query(cls=dict)  # decoding the args represented in JSON
                     if 'context' in data:
                         context, data_context = json.loads(context or '{}'), json.loads(data.pop('context'))
                         context = json.dumps({**context, **data_context})


### PR DESCRIPTION
When printing particular reports without specified record IDs, an indexError occurs, therefore preventing the printing. This PR changes the way the data is get from the url by using url_parse instead of string.split('?'), which sets the data to an empty dictionary if no params exist in the url.

task-2552160

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
