### PR TITLE
[FIX] base,website_crm_partner_assign: fix `exists()` model with `_table_query`

### DIFF
--- a/addons/website_crm_partner_assign/report/crm_partner_report.py
+++ b/addons/website_crm_partner_assign/report/crm_partner_report.py
@@ -37,7 +37,7 @@ class CrmPartnerReportAssign(models.Model):
         """
         return """
                 SELECT
-                    coalesce(i.id, p.id - 1000000000) as id,
+                    COALESCE(2 * i.id, 2 * p.id + 1) AS id,
                     p.id as partner_id,
                     (SELECT country_id FROM res_partner a WHERE a.parent_id=p.id AND country_id is not null limit 1) as country_id,
                     p.grade_id,

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -55,7 +55,7 @@ from .exceptions import AccessError, MissingError, ValidationError, UserError
 from .osv.query import Query
 from .tools import frozendict, lazy_classproperty, ormcache, \
                    Collector, LastOrderedSet, OrderedSet, IterableGenerator, \
-                   groupby
+                   groupby, partition
 from .tools.config import config
 from .tools.func import frame_codeinfo
 from .tools.misc import CountingStream, clean_context, DEFAULT_SERVER_DATETIME_FORMAT, DEFAULT_SERVER_DATE_FORMAT, get_lang
@@ -4675,13 +4675,13 @@ Fields:
 
         By convention, new records are returned as existing.
         """
-        ids, new_ids = [], []
-        for i in self._ids:
-            (new_ids if isinstance(i, NewId) else ids).append(i)
+        new_ids, ids = partition(lambda i: isinstance(i, NewId), self._ids)
         if not ids:
             return self
-        query = """SELECT id FROM "%s" WHERE id IN %%s""" % self._table
-        self._cr.execute(query, [tuple(ids)])
+        query = Query(self.env.cr, self._table, self._table_query)
+        query.add_where(f'"{self._table}".id IN %s', [tuple(ids)])
+        query_str, params = query.select()
+        self.env.cr.execute(query_str, params)
         valid_ids = set([r[0] for r in self._cr.fetchall()] + new_ids)
         return self.browse(i for i in self._ids if i in valid_ids)
 


### PR DESCRIPTION
The exists method (of BaseModel) doesn't work with model
without SQL table but with a table query (see
f2ceef0)
This method is call when we try to read a forbidden
record (`forbidden = missing.exists()` in `_read`)

- Fix it by using a Query object (which able the case).
- Also use a partition method instead of duplicate it in the method.
- Fix the CRM Lead Report which can return a Falsy id

task-2633558
