### PR TITLE
[FIX] web_editor: restore column count snippet option

### DIFF
--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -26,6 +26,13 @@ for (const snippet of snippetsNames) {
     }, {
         content: `click on 'BLOCKS' tab (${snippet})`,
         trigger: ".o_we_add_snippet_btn",
+        run: function (actions) {
+            // FIXME cannot find the reason why this setTimeout is needed to
+            // after reverting ab7508393376075f95d6dd5925e7f4462936d2, to check
+            // (this commit is however reverted temporarily until a better
+            // solution is found).
+            setTimeout(() => actions.auto(), 0);
+        },
     }];
 
     if (snippet === 's_google_map') {


### PR DESCRIPTION
When decreasing the number of columns through the column count snippet
option, the editor entered a deadlock situation. This was because of [1]
which started awaiting the UI update during a snippet removal.

This commit fixes the problem by again not awaiting that UI update. It
probably should be though but a more complex refactoring is needed to
achieve that. This commit first prevents the deadlock while waiting for
a better solution to be implemented.

[1]: https://github.com/odoo/odoo/commit/ab7508393376075f95d6dd5925e7f4462936d24e

task-2652904
