### PR TITLE
[FIX] event, website_event_track: fix registration email, template fix

### DIFF
--- a/addons/website_event_track/views/event_track_templates.xml
+++ b/addons/website_event_track/views/event_track_templates.xml
@@ -429,9 +429,9 @@
 
 <template id="event_track_proposal_success">
     <t t-call="website_event.event_details">
-        <p>
+        <p class="text-center mt-2">
             Thank you for your proposal.
-        </p><p>
+        </p><p class="text-center">
             We will evaluate your proposition and get back to you shortly.
         </p>
     </t>


### PR DESCRIPTION
Purpose
=======
Fix guest users receiving confirmation emails for events by "Public User" in 13.0.

Specifications
==============
Change confirmation message for events so that it's sent by Odoo Bot if the user is Guest else by the user itself or the Odoo bot.
Center confirmation text after sending track idea.

Task-2657588