### PR TITLE
[FIX] account: empty string is an empty sequence

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1242,7 +1242,7 @@ class AccountMove(models.Model):
         param = {'journal_id': self.journal_id.id}
 
         if not relaxed:
-            domain = [('journal_id', '=', self.journal_id.id), ('id', '!=', self.id or self._origin.id), ('name', 'not in', ('/', False))]
+            domain = [('journal_id', '=', self.journal_id.id), ('id', '!=', self.id or self._origin.id), ('name', 'not in', ('/', '', False))]
             if self.journal_id.refund_sequence:
                 refund_types = ('out_refund', 'in_refund')
                 domain += [('move_type', 'in' if self.move_type in refund_types else 'not in', refund_types)]


### PR DESCRIPTION
The empty string, the forward slash `/` and NULL are all to be
considered as without a sequence set on `account.move`.

While this is just true, it was detected because of non deterministic
bugs at the end of the month because the tax closing move was
explicitly set to an empty string on version 14.3 and higher.
See: https://github.com/odoo/enterprise/commit/4641825daa0ed3b8e407fb3817c582cb541e88a4
Most of the tests posting an entry in the MISC journal could then
randomly fail on the last day of the month.git 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
