### PR TITLE
[FIX] hr_expense: Expense is refused when account move is cancelled

### DIFF
--- a/addons/hr_expense/i18n/hr_expense.pot
+++ b/addons/hr_expense/i18n/hr_expense.pot
@@ -1785,3 +1785,10 @@ msgstr ""
 #, python-format
 msgid "or send receipts by email to %s."
 msgstr ""
+
+
+#. module: hr_expense
+#: code:addons/hr_expense/models/account_move.py:0
+#, python-format
+msgid "Payment Cancelled"
+msgstr ""

--- a/addons/hr_expense/models/__init__.py
+++ b/addons/hr_expense/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from . import hr_employee
+from . import account_move
 from . import account_move_line
 from . import hr_department
 from . import hr_expense

--- a/addons/hr_expense/models/account_move.py
+++ b/addons/hr_expense/models/account_move.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, _
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def button_cancel(self):
+        for l in self.line_ids:
+            if l.expense_id:
+                l.expense_id.refuse_expense(reason=_("Payment Cancelled"))
+        return super().button_cancel()


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

When an expense was accepted and then the account move related to the expense was reset to draft/cancelled, the expense's state stayed as payed.

Current behavior before PR:\

The expense's state stayed as payed.

Desired behavior after PR is merged:

 Change the expense's state to refused with the reason 'Payment Cancelled'.

opw-2559225


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
