### PR TITLE
[FIX] website: dynamic snippets fixes

### DIFF
--- a/addons/website/models/website_snippet_filter.py
+++ b/addons/website/models/website_snippet_filter.py
@@ -93,7 +93,7 @@ class WebsiteSnippetFilter(models.Model):
             if search_domain:
                 domain = expression.AND([domain, search_domain])
             try:
-                records = self.env[filter_sudo.model_id].search(
+                records = self.env[filter_sudo.model_id].with_context(**literal_eval(filter_sudo.context)).search(
                     domain,
                     order=','.join(literal_eval(filter_sudo.sort)) or None,
                     limit=limit

--- a/addons/website/static/src/snippets/s_dynamic_snippet/options.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/options.js
@@ -63,6 +63,20 @@ const dynamicSnippetOptions = options.Class.extend({
     //--------------------------------------------------------------------------
 
     /**
+     * See from updateUI in s_website_form
+     * 
+     * @override
+     */
+    async updateUI() {
+        if (this.rerender) {
+            this.rerender = false;
+            await this._rerenderXML();
+            return;
+        }
+        await this._super(...arguments);
+    },
+
+    /**
      * @override
      */
     async updateUIVisibility() {
@@ -252,7 +266,7 @@ const dynamicSnippetOptions = options.Class.extend({
     _filterUpdated: function (filter) {
         if (filter && this.currentModelName !== filter.model_name) {
             this.currentModelName = filter.model_name;
-            this._rerenderXML();
+            this.rerender = true;
         }
     },
     /**

--- a/addons/website_sale/data/data.xml
+++ b/addons/website_sale/data/data.xml
@@ -64,7 +64,7 @@
             <field name="model_id">product.product</field>
             <field name="user_id" eval="False" />
             <field name="domain">[('website_published', '=', True)]</field>
-            <field name="context">{'display_default_code': False}</field>
+            <field name="context">{'display_default_code': False, 'add2cart_rerender': False}</field>
             <field name="sort">['create_date desc']</field>
             <field name="action_id" ref="website.action_website"/>
         </record>

--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -5,7 +5,7 @@
         <template id="dynamic_filter_template_product_product_add_to_cart" name="Classic Card">
             <t t-foreach="records" t-as="data">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="o_carousel_product_card card h-100 w-100">
+                <div class="o_carousel_product_card card h-100 w-100" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <input type="hidden" name="product-id" t-att-data-product-id="record.id"/>
                     <a class="o_carousel_product_img_link" t-att-href="record.website_url">
@@ -39,7 +39,7 @@
         <template id="dynamic_filter_template_product_product_view_detail" name="Detailed Product">
             <t t-foreach="records" t-as="data">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="o_carousel_product_card card h-100 w-100" t-att-data-url="record.website_url">
+                <div class="o_carousel_product_card card h-100 w-100" t-att-data-url="record.website_url" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <a class="o_carousel_product_img_link" t-att-href="record.website_url">
                         <img class="card-img-top p-3" loading="lazy" t-att-src="data['image_512']" t-att-alt="record.display_name"/>
@@ -117,7 +117,7 @@
         <template id="dynamic_filter_template_product_product_centered" name="Centered Product">
             <t t-foreach="records" t-as="data">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="o_carousel_product_card card w-100">
+                <div class="o_carousel_product_card card w-100" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <input type="hidden" name="product-id" t-att-data-product-id="record.id"/>
                     <a class="o_carousel_product_img_link position-absolute mx-auto" t-att-href="record.website_url">
@@ -179,7 +179,7 @@
         <template id="dynamic_filter_template_product_product_borderless_2" name="Borderless Product n°2">
             <t t-foreach="records" t-as="data">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="o_carousel_product_card card w-100 border-0">
+                <div class="o_carousel_product_card card w-100 border-0" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <input type="hidden" name="product-id" t-att-data-product-id="record.id"/>
                     <a class="o_carousel_product_img_link o_dynamic_product_hovered" t-att-href="record.website_url">
@@ -211,7 +211,7 @@
         <template id="dynamic_filter_template_product_product_banner" name="Large Banner">
             <t t-foreach="records" t-as="data" data-number-of-elements="1" data-number-of-elements-sm="1">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="o_carousel_product_card card w-100 p-3">
+                <div class="o_carousel_product_card card w-100 p-3" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <input type="hidden" name="product-id" t-att-data-product-id="record.id"/>
                     <div class="row flex-row-reverse">
@@ -249,7 +249,7 @@
         <template id="dynamic_filter_template_product_product_horizontal_card" name="Horizontal Card">
             <t t-foreach="records" t-as="data" data-number-of-elements="3" data-number-of-elements-sm="1">
                 <t t-set="record" t-value="data['_record']"/>
-                <div class="o_carousel_product_card card w-100 border-0 bg-light p-3">
+                <div class="o_carousel_product_card card w-100 border-0 bg-light p-3" t-att-data-add2cart-rerender="data.get('_add2cart_rerender')">
                     <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                     <input type="hidden" name="product-id" t-att-data-product-id="record.id"/>
                     <div class="row h-100">

--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -59,6 +59,8 @@ class WebsiteSnippetFilter(models.Model):
                 product = res_product.get('_record')
                 if not is_sample:
                     res_product.update(product._get_combination_info_variant())
+                    if records.env.context.get('add2cart_rerender'):
+                        res_product['_add2cart_rerender'] = True
         return res_products
 
     @api.model
@@ -108,7 +110,7 @@ class WebsiteSnippetFilter(models.Model):
                     domain,
                     [('id', 'in', products_ids)],
                 ])
-                products = self.env['product.product'].with_context(display_default_code=False).search(domain, limit=limit)
+                products = self.env['product.product'].with_context(display_default_code=False, add2cart_rerender=True).search(domain, limit=limit)
         return products
 
     def _get_products_recently_sold_with(self, website, limit, domain, context):

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
@@ -97,11 +97,20 @@ const DynamicSnippetProducts = DynamicSnippetCarousel.extend({
             var animation = wSaleUtils.animateClone($navButton, $(ev.currentTarget).parents('.card'), 25, 40);
             Promise.all([fetch, animation]).then(function (values) {
                 wSaleUtils.updateCartNavBar(data);
-                self._render();
+                if (self.add2cartRerender) {
+                     self._render();
+                }
             });
         });
     },
-
+    /**
+     * @override 
+     * @private
+     */
+    _renderContent() {
+        this._super(...arguments);
+        this.add2cartRerender = !!this.el.querySelector('[data-add2cart-rerender="True"]');
+    },
     /**
      * Remove product from recently viewed products.
      * @private


### PR DESCRIPTION
This pull request handles a bunch of fixes for the dynamic snippets.

The intial goal was to prevent refreshing on add2cart on snippets that didn't need to, but while doing so, some more bugs surfaced.

task-2654924

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
