### PR TITLE
[FIX] event: stop sending confirmation email as public user 

### DIFF
--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -204,7 +204,21 @@ class EventMailRegistration(models.Model):
             reg_mail.scheduler_id.notification_type == 'mail'
         )
         for reg_mail in todo:
-            reg_mail.scheduler_id.template_id.send_mail(reg_mail.registration_id.id)
+            organizer = reg_mail.scheduler_id.event_id.organizer_id
+            company = self.env.company
+            author = self.env.ref('base.user_root')
+            if organizer.email:
+                author = organizer
+            elif company.email:
+                author = company.partner_id
+            elif self.env.user.email:
+                author = self.env.user
+            
+            email_values = {
+                'email_from': author.email_formatted,
+                'author_id': author.id,
+            }
+            reg_mail.scheduler_id.template_id.send_mail(reg_mail.registration_id.id, email_values=email_values)
         todo.write({'mail_sent': True})
 
     @api.depends('registration_id', 'scheduler_id.interval_unit', 'scheduler_id.interval_type')


### PR DESCRIPTION
Purpose
=======
Fix guest users receiving confirmation emails for events by "Public User"

Specifications
==============
Confirmation emails for events are sent by:
- Organizer (if set)
- Company email (if set)
- The users's email
- Odoo bot otherwise

Task-2657588