### PR TITLE
[FIX] hr: mark offline employee status

### DIFF
--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -67,7 +67,7 @@ class HrEmployeeBase(models.AbstractModel):
         for employee in self:
             state = 'to_define'
             if check_login:
-                if employee.user_id.im_status == 'online' or employee.last_activity:
+                if employee.user_id.im_status == 'online':
                     state = 'present'
                 elif employee.user_id.im_status == 'offline' and employee.id not in working_now_list:
                     state = 'absent'


### PR DESCRIPTION
How to reproduce the problem:
- Install the Employees app
- Create a new user and create an employee form for this user
- Log in with this user, then log out
- On the user's Employees form, the employee still appears as connected

Cause of the problem : as soon as a user logs in,
the system saves the date of his last connection. That value was wrongly
used in the process of computing the user's status.

Now, if the user is offline, he is shown as "Not Available" or "Away"
(grey or orange).

opw-2623386