### PR TITLE
[FIX] mail: exclude portal user from the DM search

### DIFF
--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -237,6 +237,7 @@ class Partner(models.Model):
                 WHERE P.name ILIKE %s
                     AND P.id NOT IN %s
                     AND U.active = 't'
+                    AND U.share IS NOT TRUE
                 ORDER BY P.name ASC, P.id ASC
                 LIMIT %s
             """, ("%s seconds" % DISCONNECTION_TIMER, "%s seconds" % AWAY_TIMER, name, tuple(excluded_partner_ids), limit))


### PR DESCRIPTION
Before this commit, a user could DM a portal user.
Portal user are not supported and can't chat.

task-2632874