### PR TITLE
[FIX] website: fix non-full layouts combined with footer scroll effect

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1258,7 +1258,12 @@ header {
     @include media-breakpoint-up(lg) {
         #wrapwrap.o_footer_effect_enable {
             > main {
-                background-color: $body-bg;
+                @if o-website-value('layout') == 'full' {
+                    // Ensure a transparent snippet at the end of the content
+                    // still appears with the same background when hovering the
+                    // footer during the scroll effect.
+                    background-color: $body-bg;
+                }
                 @if o-website-value('footer-effect') == 'slideout_shadow' {
                     box-shadow: $box-shadow;
                 }


### PR DESCRIPTION
Since [1], a footer effect option has been introduced which allows to
have the content hovering the footer to then reveal it when reaching the
bottom of the page (instead of having the footer to scroll like the rest
of the content).

To achieve that, the body color was forced on the snippet container (the
`<main/>`) so that the transparent snippet still appear with a
background color for the time they go over the footer.
That background color should however not have been forced in non-full
layouts as another is already forced in that case. In those non-full
layout, the "full" body background (= background of color combination 1)
is applied on the snippet container but the "body" color is another
color which is customizable by the user too.

[1]: https://github.com/odoo/odoo/commit/5879e40445f0176d545b4a50f7f7ec33b2e171c8

Related to task-2590182
