### PR TITLE
[FIX] web: expanded search item

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -324,7 +324,7 @@ export class SearchBar extends Component {
      * @param {number} index
      */
     onItemMousemove(focusedIndex) {
-        this.computeState({ focusedIndex }); /** @todo review that */
+        this.state.focusedIndex = focusedIndex;
         this.inputRef.el.focus();
     }
 
@@ -342,7 +342,7 @@ export class SearchBar extends Component {
             case "ArrowDown":
                 ev.preventDefault();
                 if (this.items.length) {
-                    if (this.state.focusedIndex === this.items.length - 1) {
+                    if (this.state.focusedIndex >= this.items.length - 1) {
                         focusedIndex = 0;
                     } else {
                         focusedIndex = this.state.focusedIndex + 1;
@@ -354,7 +354,10 @@ export class SearchBar extends Component {
             case "ArrowUp":
                 ev.preventDefault();
                 if (this.items.length) {
-                    if (this.state.focusedIndex === 0) {
+                    if (
+                        this.state.focusedIndex === 0 ||
+                        this.state.focusedIndex > this.items.length - 1
+                    ) {
                         focusedIndex = this.items.length - 1;
                     } else {
                         focusedIndex = this.state.focusedIndex - 1;
@@ -421,7 +424,7 @@ export class SearchBar extends Component {
         }
 
         if (focusedIndex !== undefined) {
-            this.computeState({ focusedIndex });
+            this.state.focusedIndex = focusedIndex;
         }
     }
 


### PR DESCRIPTION
Before this commit, in the search bar menu, an item did not expanded if you moved the mouse or navigated with the arrows before it was expanded.
This is the steps to reproduce the problem:
1. Click on the caret of an item
2. Move the mouse before the menu is expanded
3. The item did not expand.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
