### PR TITLE
[FIX] digest: fix spelling mistake and duplicate code, add unsubscribe

### DIFF
--- a/addons/account/views/digest_views.xml
+++ b/addons/account/views/digest_views.xml
@@ -3,9 +3,10 @@
     <record id="digest_digest_view_form" model="ir.ui.view">
         <field name="name">digest.digest.view.form.inherit.account.account</field>
         <field name="model">digest.digest</field>
+        <field name="priority">30</field>
         <field name="inherit_id" ref="digest.digest_digest_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='kpi_general']" position="after">
+            <xpath expr="//group[@name='kpis']/group[last()]" position="before">
                 <group name="kpi_account" string="Invoicing" groups="account.group_account_manager">
                     <field name="kpi_account_total_revenue"/>
                 </group>

--- a/addons/crm/models/digest.py
+++ b/addons/crm/models/digest.py
@@ -8,7 +8,7 @@ from odoo.exceptions import AccessError
 class Digest(models.Model):
     _inherit = 'digest.digest'
 
-    kpi_crm_lead_created = fields.Boolean('New Leads/Opportunities')
+    kpi_crm_lead_created = fields.Boolean('New Leads')
     kpi_crm_lead_created_value = fields.Integer(compute='_compute_kpi_crm_lead_created_value')
     kpi_crm_opportunities_won = fields.Boolean('Opportunities Won')
     kpi_crm_opportunities_won_value = fields.Integer(compute='_compute_kpi_crm_opportunities_won_value')

--- a/addons/crm/views/digest_views.xml
+++ b/addons/crm/views/digest_views.xml
@@ -3,9 +3,10 @@
     <record id="digest_digest_view_form" model="ir.ui.view">
         <field name="name">digest.digest.view.form.inherit.crm.lead</field>
         <field name="model">digest.digest</field>
+        <field name="priority">20</field>
         <field name="inherit_id" ref="digest.digest_digest_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='kpi_general']" position="after">
+            <xpath expr="//group[@name='kpis']/group[last()]" position="before">
                 <group name="kpi_crm" string="CRM" groups="sales_team.group_sale_salesman_all_leads">
                     <field name="kpi_crm_lead_created"/>
                     <field name="kpi_crm_opportunities_won"/>

--- a/addons/digest/controllers/portal.py
+++ b/addons/digest/controllers/portal.py
@@ -23,7 +23,7 @@ class DigestController(Controller):
             digest_sudo._action_unsubscribe_users(request.env['res.users'].sudo().browse(int(user_id)))
         # old route was given without any token or user_id but only for auth users
         elif digest_sudo and not token and not user_id and not request.env.user.share:
-            digest_sudo.action_unsubcribe()
+            digest_sudo.action_unsubscribe()
         else:
             raise NotFound()
 

--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -94,7 +94,7 @@ class Digest(models.Model):
         computation and avoid ACLs issues. """
         self.sudo().user_ids |= users
 
-    def action_unsubcribe(self):
+    def action_unsubscribe(self):
         if self.env.user.has_group('base.group_user') and self.env.user in self.user_ids:
             self._action_unsubscribe_users(self.env.user)
 

--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -28,7 +28,7 @@ class Digest(models.Model):
                                     ('monthly', 'Monthly'),
                                     ('quarterly', 'Quarterly')],
                                    string='Periodicity', default='daily', required=True)
-    next_run_date = fields.Date(string='Next Send Date')
+    next_run_date = fields.Date(string='Next Mailing Date')
     currency_id = fields.Many2one(related="company_id.currency_id", string='Currency', readonly=False)
     company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company.id)
     available_fields = fields.Char(compute='_compute_available_fields')
@@ -37,7 +37,7 @@ class Digest(models.Model):
     # First base-related KPIs
     kpi_res_users_connected = fields.Boolean('Connected Users')
     kpi_res_users_connected_value = fields.Integer(compute='_compute_kpi_res_users_connected_value')
-    kpi_mail_message_total = fields.Boolean('Messages')
+    kpi_mail_message_total = fields.Boolean('Messages Sent')
     kpi_mail_message_total_value = fields.Integer(compute='_compute_kpi_mail_message_total_value')
 
     @api.depends('user_ids')

--- a/addons/digest/views/digest_templates.xml
+++ b/addons/digest/views/digest_templates.xml
@@ -6,7 +6,8 @@
                     <div class="col-lg-6 offset-lg-3">
                         <h3>Digest Subscriptions</h3>
                         <div class="alert alert-success text-center" role="status">
-                            <p>You have been successfully unsubscribed from <strong t-field="digest.name"/></p>
+                            <p>You have been successfully unsubscribed from:<br/>
+                            <strong t-field="digest.name"/></p>
                         </div>
                     </div>
                 </div>

--- a/addons/digest/views/digest_views.xml
+++ b/addons/digest/views/digest_views.xml
@@ -22,7 +22,7 @@
                     <button type="object" name="action_subscribe" string="Subscribe"
                         class="oe_highlight"
                         attrs="{'invisible': ['|',('is_subscribed', '=', True), ('state','=','deactivated')]}"/>
-                    <button type="object" name="action_unsubcribe" string="Unsubscribe me"
+                    <button type="object" name="action_unsubscribe" string="Unsubscribe me"
                         class="oe_highlight"
                         attrs="{'invisible': ['|',('is_subscribed', '=', False), ('state','=','deactivated')]}"/>
                     <button type="object" name="action_deactivate" string="Deactivate for everyone"

--- a/addons/digest/views/digest_views.xml
+++ b/addons/digest/views/digest_views.xml
@@ -5,10 +5,11 @@
         <field name="model">digest.digest</field>
         <field name="arch" type="xml">
             <tree string="KPI Digest">
-                <field name="name"/>
+                <field name="name" string="Title"/>
                 <field name="periodicity"/>
                 <field name="next_run_date" groups="base.group_no_one"/>
                 <field name="company_id" groups="base.group_multi_company"/>
+                <field name="state" groups="base.group_no_one" widget="badge" decoration-success="state == 'activated'"/>
             </tree>
         </field>
     </record>
@@ -19,26 +20,19 @@
             <form string="KPI Digest">
                 <field name="is_subscribed" invisible="1"/>
                 <header>
-                    <button type="object" name="action_subscribe" string="Subscribe"
+                    <button type="object" name="action_send" string="Send Now"
                         class="oe_highlight"
-                        attrs="{'invisible': ['|',('is_subscribed', '=', True), ('state','=','deactivated')]}"/>
-                    <button type="object" name="action_unsubscribe" string="Unsubscribe me"
-                        class="oe_highlight"
-                        attrs="{'invisible': ['|',('is_subscribed', '=', False), ('state','=','deactivated')]}"/>
-                    <button type="object" name="action_deactivate" string="Deactivate for everyone"
-                        class="oe_highlight"
+                        attrs="{'invisible': [('state','=','deactivated')]}" groups="base.group_system"/>
+                    <button type="object" name="action_deactivate" string="Deactivate"
                         attrs="{'invisible': [('state','=','deactivated')]}" groups="base.group_system"/>
                     <button type="object" name="action_activate" string="Activate"
                         class="oe_highlight"
                         attrs="{'invisible': [('state','=','activated')]}" groups="base.group_system"/>
-                    <button type="object" name="action_send" string="Send Now"
-                        class="oe_highlight"
-                        attrs="{'invisible': [('state','=','deactivated')]}" groups="base.group_system"/>
-                    <field name="state" widget="statusbar"/>
+                    <field name="state" widget="statusbar" statusbar_visible="0"/>
                 </header>
                 <sheet>
                     <div class="oe_title">
-                        <label for="name" string="Digest Name"/>
+                        <label for="name" string="Digest Title"/>
                         <h1>
                             <field name="name" placeholder="e.g. Your Weekly Digest"/>
                         </h1>
@@ -46,8 +40,10 @@
                     <group>
                         <group>
                             <field name="periodicity" widget="radio" options="{'horizontal': true}"/>
-                            <field name="next_run_date" groups="base.group_system"/>
                             <field name="company_id" options="{'no_create': True}" invisible="1"/>
+                        </group>
+                        <group>
+                            <field name="next_run_date" groups="base.group_system"/>
                         </group>
                     </group>
                     <notebook>
@@ -58,51 +54,20 @@
                                     <field name="kpi_mail_message_total"/>
                                 </group>
                                 <group name="kpi_sales"/>
+                                <group name="custom" string="Custom" groups="base.group_system">
+                                    <p>Want to add your own KPIs?<br />
+                                    <!-- TODO: change to actual documentation link!!! -->
+                                    <a href="https://www.odoo.com/documentation/" target="_blank"><i class="fa fa-arrow-right"></i> Check our Documentation</a></p>
+                                </group>
                             </group>
                         </page>
                         <page name="recipients" string="Recipients" groups="base.group_system">
-                            <group>
-                                <field name="user_ids" options="{'no_create': True}">
-                                    <tree string="Recipients">
-                                        <field name="name"/>
-                                        <field name="email"/>
-                                    </tree>
-                                </field>
-                            </group>
-                        </page>
-                        <page name="how_to" string="How to customize your digest?" groups="base.group_no_one">
-                            <div class="alert alert-info" role="alert">
-                                In order to build your customized digest, follow these steps:
-                                <ol>
-                                    <li>
-                                        You may want to add new computed fields with Odoo Studio:
-                                        <ul>
-                                            <li>
-                                                you must create 2 fields on the
-                                                <code>digest</code>
-                                                object:
-                                            </li>
-                                            <li>
-                                                first create a boolean field called
-                                                <code>kpi_myfield</code>
-                                                and display it in the KPI's tab;
-                                            </li>
-                                            <li>
-                                                then create a computed field called
-                                                <code>kpi_myfield_value</code>
-                                                that will compute your customized KPI.
-                                            </li>
-                                        </ul>
-                                    </li>
-                                    <li>Select your KPIs in the KPI's tab.</li>
-                                    <li>
-                                        Create or edit the mail template: you may get computed KPI's value using these fields:
-                                        <code>
-                                            <field name="available_fields" class="oe_inline" />
-                                        </code>
-                                    </li>
-                                </ol>
-                            </div>
+                            <field name="user_ids" options="{'no_create': True}">
+                                <tree string="Recipients">
+                                    <field name="name"/>
+                                    <field name="email" string="Email Address" />
+                                </tree>
+                            </field>
                         </page>
                     </notebook>
                 </sheet>
@@ -116,6 +81,8 @@
             <search>
                 <field name="name"/>
                 <field name="user_ids"/>
+                <filter name="filter_activated" string="Activated" domain="[('state', '=', 'activated')]"/>
+                <filter name="filter_deactivated" string="Deactivated" domain="[('state', '=', 'deactivated')]"/>
                 <group expand="1" string="Group by">
                     <filter string="Periodicity" name="periodicity" context="{'group_by': 'periodicity'}"/>
                 </group>
@@ -125,6 +92,7 @@
     <record id="digest_digest_action" model="ir.actions.act_window">
         <field name="name">Digest Emails</field>
         <field name="res_model">digest.digest</field>
+        <field name="context">{'search_default_filter_activated': 1}</field>
         <field name="search_view_id" ref="digest_digest_view_search"/>
     </record>
 

--- a/addons/hr_recruitment/models/digest.py
+++ b/addons/hr_recruitment/models/digest.py
@@ -8,7 +8,7 @@ from odoo.exceptions import AccessError
 class Digest(models.Model):
     _inherit = 'digest.digest'
 
-    kpi_hr_recruitment_new_colleagues = fields.Boolean('Employees')
+    kpi_hr_recruitment_new_colleagues = fields.Boolean('New Employees')
     kpi_hr_recruitment_new_colleagues_value = fields.Integer(compute='_compute_kpi_hr_recruitment_new_colleagues_value')
 
     def _compute_kpi_hr_recruitment_new_colleagues_value(self):

--- a/addons/hr_recruitment/views/digest_views.xml
+++ b/addons/hr_recruitment/views/digest_views.xml
@@ -3,9 +3,10 @@
     <record id="digest_digest_view_form" model="ir.ui.view">
         <field name="name">digest.digest.view.form.inherit.hr.recruitment</field>
         <field name="model">digest.digest</field>
+        <field name="priority">70</field>
         <field name="inherit_id" ref="digest.digest_digest_view_form" />
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='kpi_general']" position="after">
+            <xpath expr="//group[@name='kpis']/group[last()]" position="before">
                 <group name="kpi_hr" string="Recruitment" groups="hr_recruitment.group_hr_recruitment_user">
                     <field name="kpi_hr_recruitment_new_colleagues"/>
                 </group>

--- a/addons/im_livechat/models/digest.py
+++ b/addons/im_livechat/models/digest.py
@@ -11,7 +11,7 @@ class Digest(models.Model):
     kpi_livechat_rating_value = fields.Float(digits=(16, 2), compute='_compute_kpi_livechat_rating_value')
     kpi_livechat_conversations = fields.Boolean('Conversations handled')
     kpi_livechat_conversations_value = fields.Integer(compute='_compute_kpi_livechat_conversations_value')
-    kpi_livechat_response = fields.Boolean('Time to answer(sec)', help="Time to answer the user in second.")
+    kpi_livechat_response = fields.Boolean('Time to answer (sec)', help="Time to answer the user in second.")
     kpi_livechat_response_value = fields.Float(compute='_compute_kpi_livechat_response_value')
 
     def _compute_kpi_livechat_rating_value(self):

--- a/addons/im_livechat/views/digest_views.xml
+++ b/addons/im_livechat/views/digest_views.xml
@@ -3,9 +3,10 @@
     <record id="im_livechat.digest_digest_view_form_inherit" model="ir.ui.view">
         <field name="name">im.livechat.digest.digest.view.form.inherit</field>
         <field name="model">digest.digest</field>
+        <field name="priority">80</field>
         <field name="inherit_id" ref="digest.digest_digest_view_form" />
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='kpi_general']" position="after">
+            <xpath expr="//group[@name='kpis']/group[last()]" position="before">
                 <group name="kpi_im_livechat" string="Live Chat">
                     <field name="kpi_livechat_rating"/>
                     <field name="kpi_livechat_conversations"/>

--- a/addons/point_of_sale/views/digest_views.xml
+++ b/addons/point_of_sale/views/digest_views.xml
@@ -3,9 +3,10 @@
     <record id="digest_digest_view_form" model="ir.ui.view">
         <field name="name">digest.digest.view.form.inherit.sale.order</field>
         <field name="model">digest.digest</field>
+        <field name="priority">50</field>
         <field name="inherit_id" ref="digest.digest_digest_view_form" />
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='kpi_general']" position="after">
+            <xpath expr="//group[@name='kpis']/group[last()]" position="before">
                 <group name="kpi_pos" string="Point of Sale">
                     <field name="kpi_pos_total"/>
                 </group>

--- a/addons/project/views/digest_views.xml
+++ b/addons/project/views/digest_views.xml
@@ -3,9 +3,10 @@
     <record id="digest_digest_view_form" model="ir.ui.view">
         <field name="name">digest.digest.view.form.inherit.project.task</field>
         <field name="model">digest.digest</field>
+        <field name="priority">40</field>
         <field name="inherit_id" ref="digest.digest_digest_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='kpi_general']" position="after">
+            <xpath expr="//group[@name='kpis']/group[last()]" position="before">
                 <group name="kpi_project" string="Project" groups="project.group_project_user">
                     <field name="kpi_project_task_opened"/>
                 </group>

--- a/addons/sale_management/views/digest_views.xml
+++ b/addons/sale_management/views/digest_views.xml
@@ -3,6 +3,7 @@
     <record id="digest_digest_view_form" model="ir.ui.view">
         <field name="name">digest.digest.view.form.inherit.sale.order</field>
         <field name="model">digest.digest</field>
+        <field name="priority">10</field>
         <field name="inherit_id" ref="digest.digest_digest_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//group[@name='kpi_sales']" position="attributes">

--- a/addons/website_sale/views/digest_views.xml
+++ b/addons/website_sale/views/digest_views.xml
@@ -3,6 +3,7 @@
     <record id="digest_digest_view_form" model="ir.ui.view">
         <field name="name">digest.digest.view.form.inherit.website.sale.order</field>
         <field name="model">digest.digest</field>
+        <field name="priority">10</field>
         <field name="inherit_id" ref="digest.digest_digest_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//group[@name='kpi_sales']" position="attributes">


### PR DESCRIPTION
Purpose
======
Give the user a more organised view of the digest KPIs in the backend,
let any user unsubscribe to the digest.

Specifications
==========
Organise order of kpi in digest view, change few typos, move buttons in
list and form view.
Add token to unsubscribe link to avoid possible issue of someone
redirecting user to unsubscribe (token is generated in the backend with
superuser right).
