### PR TITLE
[FIX] mrp: trigger RR after change product qty

### DIFF
--- a/addons/mrp/wizard/change_production_qty.py
+++ b/addons/mrp/wizard/change_production_qty.py
@@ -100,4 +100,8 @@ class ChangeProductionQty(models.TransientModel):
                 moves_finished = production.move_finished_ids.filtered(lambda move: move.operation_id == operation) #TODO: code does nothing, unless maybe by_products?
                 moves_raw.mapped('move_line_ids').write({'workorder_id': wo.id})
                 (moves_finished + moves_raw).write({'workorder_id': wo.id})
+
+        # run scheduler for moves forecasted to not have enough in stock
+        self.mo_id.filtered(lambda mo: mo.state in ['confirmed', 'progress']).move_raw_ids._trigger_scheduler()
+
         return {}


### PR DESCRIPTION
In 1e93c161ca454313436b65427542db961f6ddcdd we trigger RR when
confirming a MO. Same thing should be done if we changed the product qty
for a confirmed MO.

Task-2653116

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
