### PR TITLE
[FIX] stock: level package are not update

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1086,7 +1086,7 @@ class Picking(models.Model):
                     body=_('The backorder <a href=# data-oe-model=stock.picking data-oe-id=%d>%s</a> has been created.') % (
                         backorder_picking.id, backorder_picking.name))
                 moves_to_backorder.write({'picking_id': backorder_picking.id})
-                moves_to_backorder.mapped('package_level_id').write({'picking_id':backorder_picking.id})
+                moves_to_backorder.move_line_ids.package_level_id.write({'picking_id':backorder_picking.id})
                 moves_to_backorder.mapped('move_line_ids').write({'picking_id': backorder_picking.id})
                 backorders |= backorder_picking
         return backorders


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Install Stock, Sale, activate multi location and package. In the Pick (second step) config check "move full pack"
- In config of warehouse set delivery in 2 step
- Create a sale order with 1 x product A and 1 x product B
- In Pick picking, set 1 on qty_done of product A
- Put in pack
- In Pick picking, set 1 on qty_done of product B
- Put in pack
- Validate
- go to the out
- check is_done in the first package
- validate and create a backorder
--> Issue the level package is not move in the new picking

From this commit https://github.com/odoo/odoo/commit/9d758fa2e180b96d4b0f7046e7a75a202c4da7ff, package_level_id is not copied and during backorder the new stock.move have no package_level.

This PR fix this issue, but maybe the issue is more global.
@nim-odoo @amoyaux @simongoffin 

https://user-images.githubusercontent.com/16716992/135458916-b3a81f4c-639a-414f-a969-2147a0c08f6d.mov


