### PR TITLE
[FIX] mail: restore the scroll behaviour of control panel on Mobile

### DIFF
--- a/addons/mail/static/src/components/discuss/discuss.scss
+++ b/addons/mail/static/src/components/discuss/discuss.scss
@@ -2,11 +2,6 @@
 // Layout
 // ------------------------------------------------------------------
 
-.o_action_manager {
-    // bug with scrollable inside discuss mobile without this...
-    min-height: 0;
-}
-
 .o-autogrow {
     flex: 1 1 auto;
 }
@@ -96,7 +91,7 @@
 
 .o_Discuss_notificationList {
     width: 100%;
-    flex: 1 1 auto;
+    flex: 1 1 0;
 }
 // ------------------------------------------------------------------
 // Style


### PR DESCRIPTION
Given that we have a viewport of 320px and, to simplify the explanation,
we discard the height of the `<header>` (aka. the top navbar).

Since the refactoring of Discuss [1], a global rule was added to the
'.o_action_manager' to allow the flex to shrink the discussion's list
in Discuss on Mobile.

But this rule change the box sizing of '.o_action_manager' as now it
takes the minimum size (e.g. before 3000px became now 320px +/- the
height of the viewport).
Therefore a limit for the sticky-scroll behaviour of control panel is
set at the end of the height of the element.
Then when the viewport goes outside this limit the sticky doesn't work
anymore until the viewport returns before this limit.
(e.g. <= 320px ok, > 320px ko).

The fix is to change the flex basis of the '.o_Discuss_notificationList'
to be 0 which avoids to alter the global '.o_action_manager' and scopes
rules to Discuss' specific classes.

DOM before this commit:
```
┌───────────────────────────────────────────────────────┐
│ '.o_action_manager'                                ▲  │
│                                                    │  │
│                                                    │  │
│                                                    │  │
│                                                    │  │
│                                                    │  │
│                                     ELEMENT HEIGHT │  │
│                                       = 'VIEWPORT' │  │
│                                              320px │  │
│ ┌────────────────────────────────────────────────┐ │  │
│ │                                                │ │  │
│ │                                                │ │  │
│ │                                                │ │  │
│ │        Control Panel                           │ │  │
│ │                                                │ │  │
│ │                                                │ │  │
│ │                                                │ │  │
│ │                                                │ │  │
│ └────────────────────────────────────────────────┘ ▼  │
│ - - - - - - - - LIMIT OF STICKY ELEMENT - - - - - - - │ <- 320px
│                                                    ▲  │
│                                                    │  │
│                                        OVERFLOW    │  │
│                                        VISIBLE     │  │
│                                                    │  │
│                                                    ▼  │
└───────────────────────────────────────────────────────┘
```

DOM after this commit:
```
┌───────────────────────────────────────────────────────┐
│ '.o_action_manager'                                ▲  │
│                                                    │  │
│                                                    │  │
│                                                    │  │
│                                                    │  │
│                                                    │  │
│                                                    │  │
│                                                    │  │
│                                                    │  │
│                                     ELEMENT HEIGHT │  │ <- 320px
│                                     >=  'VIEWPORT' │  │
│                                             3000px │  │
│ ┌────────────────────────────────────────────────┐ │  │
│ │                                                │ │  │
│ │                                                │ │  │
│ │                                                │ │  │
│ │        Control Panel                           │ │  │
│ │                                                │ │  │
│ │                                                │ │  │
│ │                                                │ │  │
│ │                                                │ │  │
│ └────────────────────────────────────────────────┘ ▼  │
└───────────────────────────────────────────────────────┘
```

Steps to reproduce:
* Open Odoo on Mobile
* Go to a Kanban view with list height at least twice the screen height
* Scroll to the end of the page (the control panel is hidden)
* Scroll a bit upper => BUG the control panel is not visible until we
scroll in the 'box' of the '.o_action_manager'

Note this behaviour is maybe related to an issue from CSS3 [2]
from MDN [3]

Ref:
[1] 3fea5b2
[2] Issue 865 on https://github.com/w3c/csswg-drafts
[3] https://developer.mozilla.org/en-US/docs/Web/CSS/position

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
