### PR TITLE
[FIX] web: avoid scroll on mobile form view

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown.scss
+++ b/addons/web/static/src/core/dropdown/dropdown.scss
@@ -129,10 +129,6 @@
 }
 
 button.o_dropdown_toggler {
-  > span {
-    min-width: max-content;
-  }
-
   &%--state-active {
     outline: none;
     box-shadow: none !important;


### PR DESCRIPTION
On mobile, due to a mix of two CSS rules, the '.o_dropdown_title'
produce an unwanted scroll in the form view when there is a dropdown
at the right of the control panel like 'Actions' dropdown.

```css
.o_dropdown_title {
    @include sr-only;
}

button.o_dropdown_toggler > span {
    min-width: max-content;
}
```

This commit remove the min-width.

Steps to reproduce:
* Open Odoo on Mobile
* Go to the Contact app
* Select a contact
* Scroll to the left/right => BUG

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
