### PR TITLE
[FIX] stock: save correctly the selected SN in stock move

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -503,6 +503,9 @@ class StockMove(models.Model):
                     move_line_vals['product_uom_id'] = move.product_id.uom_id.id
                     move_line_vals['qty_done'] = 1
                     move_lines_commands.append((0, 0, move_line_vals))
+                else:
+                    move_line = move.move_line_ids.filtered(lambda line: line.lot_id.id == lot.id)
+                    move_line.qty_done = 1
             move.write({'move_line_ids': move_lines_commands})
 
     @api.constrains('product_uom')


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a product and enable serial number option
- Create one “on hand qty” with SN e.g: “001”
- Create a SO for SN product
- Confirm SO and check the delivery order
- In the Operations tab > Enable Serial Number field
- “001” SN is already reserved in Detailed Operations and the qty done is 0 but the Serial Number field in “stock.move” is empty
- Edit and add “001” in the SN field
- save

Problem:
The SN is deleted and the quantity done in the `”stock.move.line”` is not updated

Solution:
Update the quantity done in the `“stock.move.line”` linked to the selected SN

opw-2623101




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
