### PR TITLE
[FIX] web_editor: remove lingering zero-width spaces

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
@@ -13,6 +13,7 @@ import {
     isMediaElement,
     getDeepRange,
     isUnbreakable,
+    isUnremovable
 } from './utils.js';
 
 const NOT_A_NUMBER = /[^\d]/g;
@@ -101,6 +102,28 @@ class Sanitize {
             moveNodes(...endPos(node.previousSibling), node);
             restoreCursor();
             node = nodeP;
+        }
+
+        // Remove zero-width spaces added by `fillEmpty` when there is content.
+        if (
+            node.nodeType === Node.TEXT_NODE &&
+            node.textContent.includes('\u200B') &&
+            (
+                node.textContent.length > 1 ||
+                // There can be multiple ajacent text nodes, in which case the
+                // zerro-width space is not needed either, despite being alone
+                // (length === 1) in its own text node.
+                (
+                    node.previousSibling &&
+                    node.previousSibling.nodeType === Node.TEXT_NODE
+                )
+            ) &&
+            isUnremovable(node.parentElement) &&
+            !isBlock(node.parentElement)
+        ) {
+            const restoreCursor = preserveCursor(this.root.ownerDocument);
+            node.textContent = node.textContent.replace('\u200B', '');
+            restoreCursor();
         }
 
         // Remove empty blocks in <li>

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -1357,6 +1357,8 @@ export function fillEmpty(el) {
         fillers.br = br;
     }
     if (!el.textContent.length && isUnremovable(el) && !isBlock(el)) {
+        // As soon as there is actual content in the node, the zero-width space
+        // is removed by the sanitize function.
         const zws = document.createTextNode('\u200B');
         el.appendChild(zws);
         fillers.zws = zws;


### PR DESCRIPTION
We add zero-width spaces in elements in certain cases where they would
not be correctly displayed by the browser if they were truly empty.
See the `fillEmpty` utils function.

However, we never remove those zero-width spaces when they are not
useful anymore. In particular, keeping those invisible characters in the
content prevents the ecommerce from saving the new price of a product if
the previous price was previously completely emptied during edition.
This commit fixes that.

The issue didn't happen with the previous editor because they were
using non-breaking space instead, which is removed by the text_content
method of lxml. However, non-breaking space were visible during edition,
which was weird on its own.