### PR TITLE
[IMP] hr: make Plan company dependent

### DIFF
--- a/addons/hr/models/hr_plan.py
+++ b/addons/hr/models/hr_plan.py
@@ -9,8 +9,9 @@ class HrPlanActivityType(models.Model):
     _name = 'hr.plan.activity.type'
     _description = 'Plan activity type'
     _rec_name = 'summary'
+    _check_company_auto = True
 
-
+    company_id = fields.Many2one('res.company', default=lambda self: self.env.company)
     activity_type_id = fields.Many2one(
         'mail.activity.type', 'Activity Type',
         default=lambda self: self.env.ref('mail.mail_activity_data_todo'),
@@ -23,7 +24,7 @@ class HrPlanActivityType(models.Model):
         ('manager', 'Manager'),
         ('employee', 'Employee'),
         ('other', 'Other')], default='employee', string='Responsible', required=True)
-    responsible_id = fields.Many2one('res.users', 'Name', help='Specific responsible of activity if not linked to the employee.')
+    responsible_id = fields.Many2one('res.users', 'Name', help='Specific responsible of activity if not linked to the employee.', check_company=True)
     note = fields.Html('Note')
 
 
@@ -62,5 +63,6 @@ class HrPlan(models.Model):
     _description = 'plan'
 
     name = fields.Char('Name', required=True)
-    plan_activity_type_ids = fields.Many2many('hr.plan.activity.type', string='Activities')
+    company_id = fields.Many2one('res.company', default=lambda self: self.env.company)
+    plan_activity_type_ids = fields.Many2many('hr.plan.activity.type', string='Activities', domain="[('company_id', '=', company_id)]")
     active = fields.Boolean(default=True)

--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -49,5 +49,17 @@
         <field name="model_id" ref="model_hr_job"/>
         <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
     </record>
+
+    <record id="hr_plan_company_rule" model="ir.rule">
+        <field name="name">Plan multi-company rule</field>
+        <field name="model_id" ref="model_hr_plan"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+    </record>
+
+    <record id="hr_plan_activity_type_company_rule" model="ir.rule">
+        <field name="name">Plan Activity Type multi-company rule</field>
+        <field name="model_id" ref="model_hr_plan_activity_type"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+    </record>
 </data>
 </odoo>

--- a/addons/hr/views/hr_plan_views.xml
+++ b/addons/hr/views/hr_plan_views.xml
@@ -20,6 +20,7 @@
             <field name="arch" type="xml">
                 <tree string="Planning">
                     <field name="name"/>
+                    <field name="company_id" groups="base.group_multi_company"/>
                 </tree>
             </field>
         </record>
@@ -37,10 +38,12 @@
                                 <field name="name" placeholder="e.g. Onboarding"/>
                             </h1>
                         </div>
+                        <field name="company_id" groups="base.group_multi_company"/>
                         <group string="Activities">
                             <field name="active" invisible="1"/>
                             <field name="plan_activity_type_ids" nolabel="1">
                                 <tree editable="bottom">
+                                    <field name="company_id" invisible="1"/>
                                     <field name="activity_type_id"/>
                                     <field name="summary"/>
                                     <field name="responsible"/>
@@ -61,6 +64,7 @@
                     <field name="activity_type_id"/>
                     <field name="summary"/>
                     <field name="responsible"/>
+                    <field name="company_id" groups="base.group_multi_company"/>
                 </tree>
             </field>
         </record>
@@ -74,6 +78,7 @@
                         <group>
                             <field name="activity_type_id"/>
                             <field name="summary"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                             <field name="responsible"/>
                             <field name="responsible_id" attrs="{'invisible': [('responsible', '!=', 'other')]}"/>
                             <field name="note"/>

--- a/addons/hr/wizard/hr_plan_wizard.py
+++ b/addons/hr/wizard/hr_plan_wizard.py
@@ -8,11 +8,16 @@ class HrPlanWizard(models.TransientModel):
     _name = 'hr.plan.wizard'
     _description = 'Plan Wizard'
 
-    plan_id = fields.Many2one('hr.plan', default=lambda self: self.env['hr.plan'].search([], limit=1))
+    def _default_plan_id(self):
+        employee = self.env['hr.employee'].browse(self.env.context.get('active_id'))
+        return self.env['hr.plan'].search([('company_id', '=', employee.company_id.id)], limit=1)
+
+    plan_id = fields.Many2one('hr.plan', default=_default_plan_id, domain="[('company_id', '=', company_id)]")
     employee_id = fields.Many2one(
         'hr.employee', string='Employee', required=True,
         default=lambda self: self.env.context.get('active_id', None),
     )
+    company_id = fields.Many2one(related='employee_id.company_id')
 
     def action_launch(self):
         for activity_type in self.plan_id.plan_activity_type_ids:

--- a/addons/hr/wizard/hr_plan_wizard_views.xml
+++ b/addons/hr/wizard/hr_plan_wizard_views.xml
@@ -10,6 +10,7 @@
                         <group>
                             <field name="plan_id"/>
                             <field name="employee_id" invisible="1"/>
+                            <field name="company_id" invisible="1"/>
                         </group>
                     </sheet>
                     <footer>


### PR DESCRIPTION
It was possible to assign a user that was not part of the same company
as the employee's for an activity which is misleading.

Make hr.plan and hr.plan.activity.type company dependent.

TaskID: 2658773

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
