### PR TITLE
[FIX] hr_holidays: no creation of allocations for specific Time Off Types

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -97,7 +97,7 @@
                     <group>
                         <group>
                             <field name="type_request_unit" invisible="1"/>
-                            <field name="holiday_status_id" context="{'employee_id':employee_id, 'default_date_from':current_date, 'request_type':'allocation'}"/>
+                            <field name="holiday_status_id" domain="[('requires_allocation', '=', 'yes')]" context="{'employee_id':employee_id, 'default_date_from':current_date, 'request_type':'allocation'}"/>
 
                             <field name="allocation_type" invisible="1" widget="radio"
                                 attrs="{'readonly': ['|', ('is_officer', '=', False), ('state', 'not in', ('draft', 'confirm'))]}"/>


### PR DESCRIPTION
User should not be able to create allocations for Time Off Types that does not
requires allocation ('requires_allocation' is not 'yes').

task - 2658250

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
