### PR TITLE
[FIX] survey: avoid returning empty navigation template

### DIFF
--- a/addons/survey/views/survey_templates_management.xml
+++ b/addons/survey/views/survey_templates_management.xml
@@ -137,14 +137,17 @@
     </template>
 
     <template id="survey_navigation" name="Survey: Navigation">
-        <button t-if="can_go_back"
-            type="submit" class="btn p-0 shadow-none o_survey_navigation_submit" name="button_submit" value="previous" t-att-data-previous-page-id="previous_page_id">
-            <i class="border-left fa fa-chevron-left p-2" />
-        </button>
-        <button t-if="survey and survey.questions_layout in ['page_per_question', 'page_per_section'] and answer and answer.state != 'done' and not answer.is_session_answer"
-            type="submit" class="btn p-0 shadow-none o_survey_navigation_submit" t-att-value="'next' if not survey_last else 'finish'">
-            <i class="border-left fa fa-chevron-right p-2" />
-        </button>
+        <!-- Keep this enclosing div so that the template always returns valid HTML content, no matter the use case -->
+        <div class="d-inline-block">
+            <button t-if="can_go_back"
+                type="submit" class="btn p-0 shadow-none o_survey_navigation_submit" name="button_submit" value="previous" t-att-data-previous-page-id="previous_page_id">
+                <i class="border-left fa fa-chevron-left p-2" />
+            </button>
+            <button t-if="survey and survey.questions_layout in ['page_per_question', 'page_per_section'] and answer and answer.state != 'done' and not answer.is_session_answer"
+                type="submit" class="btn p-0 shadow-none o_survey_navigation_submit" t-att-value="'next' if not survey_last else 'finish'">
+                <i class="border-left fa fa-chevron-right p-2" />
+            </button>
+        </div>
     </template>
 
 </data>


### PR DESCRIPTION
This commit fixes the survey navigation rendering by always returning valid
HTML even when no buttons are displayed.

Indeed, in some cases, such as on the "thank you" page, we don't display any
buttons, meaning that the returned template will be an empty string, which in
turn prevents the re-rendering of this part of the page in the JS part of the
survey form management.

To avoid this issue, we simply add an empty span tag into the template so that
the template always returns valid HTML no matter the use case.

Task-2642787

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
