### PR TITLE
[FIX]/[IMP] mrp{_account}, stock_account: MRP UX fixes

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -94,6 +94,13 @@ class MrpRoutingWorkcenter(models.Model):
             bom_id = self.env.context.get('bom_id')
             for operation in self:
                 operation.copy({'name': _("%s (copy)", operation.name), 'bom_id': bom_id})
+            return {
+                'view_mode': 'form',
+                'res_model': 'mrp.bom',
+                'views': [(False, 'form')],
+                'type': 'ir.actions.act_window',
+                'res_id': bom_id,
+            }
 
     def _skip_operation_line(self, product):
         """ Control if a operation should be processed, can be inherited to add

--- a/addons/mrp/static/src/js/mrp_field_one2many_with_copy.js
+++ b/addons/mrp/static/src/js/mrp_field_one2many_with_copy.js
@@ -55,21 +55,15 @@ var MrpFieldOne2ManyWithCopy = FieldOne2Many.extend({
             this.displayNotification({ message: _t('Please click on the "save" button first'), type: 'danger' });
             return;
         }
-        var self = this;
         this.do_action({
             name: _t('Select Operations to Copy'),
             type: 'ir.actions.act_window',
             res_model: 'mrp.routing.workcenter',
-            views: [[false, 'list']],
+            views: [[false, 'list'], [false, 'form']],
             context: {
                 tree_view_ref: 'mrp.mrp_routing_workcenter_copy_to_bom_tree_view',
                 bom_id: this.recordData.id,
             },
-            target: 'new',
-        }, {
-            on_close: function () {
-                self.trigger_up('reload');
-        }
         });
 
     },

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -6,7 +6,7 @@
             <field name="name">mrp.production.tree</field>
             <field name="model">mrp.production</field>
             <field name="arch" type="xml">
-                <tree string="Manufacturing Orders" js_class="lazy_column_list" default_order="priority desc, date_planned_start desc" multi_edit="1" sample="1">
+                <tree string="Manufacturing Orders" js_class="lazy_column_list" default_order="priority desc, date_planned_start desc" multi_edit="1" sample="1" decoration-info="state == 'draft'">
                     <header>
                         <button name="button_plan" type="object" string="Plan"/>
                         <button name="do_unreserve" type="object" string="Unreserve"/>
@@ -19,7 +19,7 @@
                     <field name="product_id" readonly="1" optional="show"/>
                     <field name="lot_producing_id" optional="hide"/>
                     <field name="bom_id" readonly="1" optional="hide"/>
-                    <field name="activity_ids" widget="list_activity" optional="show"/>
+                    <field name="activity_ids" string="Next Activity" widget="list_activity" optional="show" nolabel="1"/>
                     <field name="origin" optional="show"/>
                     <field name="user_id" optional="hide" widget="many2one_avatar_user"/>
                     <field name="components_availability_state" invisible="1" options='{"lazy": true}'/>
@@ -37,8 +37,8 @@
                     <field name="company_id" readonly="1" groups="base.group_multi_company" optional="show"/>
                     <field name="state" 
                            decoration-success="state in ('done', 'to_close')"
-                           decoration-warning="state == 'draft'"
-                           decoration-info="state in ('confirmed', 'progress')"
+                           decoration-warning="state == 'progress'"
+                           decoration-info="state in ('confirmed', 'draft')"
                            optional="show" widget="badge"/>
                     <field name="activity_exception_decoration" widget="activity_exception"/>
                     <field name="delay_alert_date" invisible="1"/>

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -54,7 +54,9 @@
             <field name="arch" type="xml">
                 <xpath expr="//tree" position="attributes">
                     <attribute name="create">0</attribute>
+                    <attribute name="delete">0</attribute>
                     <attribute name="export_xlsx">0</attribute>
+                    <attribute name="multi_edit">0</attribute>
                 </xpath>
                 <xpath expr="//field[@name='name']" position="before">
                     <header>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -84,7 +84,7 @@
                 <field name="duration_expected" widget="float_time" sum="expected duration"/>
                 <field name="duration" widget="mrp_time_counter"
                   attrs="{'invisible': [('production_state','=', 'draft')], 'readonly': [('is_user_working', '=', True)]}" sum="real duration"/>
-                <field name="state" widget="badge" decoration-warning="state == 'waiting'" decoration-success="state == 'done'" decoration-info="state not in ('waiting', 'done', 'cancel')" 
+                <field name="state" widget="badge" decoration-warning="state == 'progress'" decoration-success="state == 'done'" decoration-info="state not in ('progress', 'done', 'cancel')"
                   attrs="{'invisible': [('production_state', '=', 'draft')], 'column_invisible': [('parent.state', '=', 'draft')]}"/>
                 <button name="button_start" type="object" string="Start" class="btn-success"
                   attrs="{'invisible': ['|', '|', '|', ('production_state','in', ('draft', 'done', 'cancel')), ('working_state', '=', 'blocked'), ('state', '=', 'done'), ('is_user_working', '!=', False)]}"/>

--- a/addons/mrp_account/models/__init__.py
+++ b/addons/mrp_account/models/__init__.py
@@ -7,3 +7,4 @@ from . import mrp_workorder
 from . import mrp_production
 from . import product
 from . import stock_move
+from . import stock_rule

--- a/addons/mrp_account/models/mrp_workorder.py
+++ b/addons/mrp_account/models/mrp_workorder.py
@@ -33,7 +33,7 @@ class MrpWorkorder(models.Model):
             'account_id': account.id,
             'unit_amount': unit_amount,
             'product_id': self.product_id.id,
-            'product_uom_id': self.product_id.uom_id.id,
+            'product_uom_id': self.env.ref('uom.product_uom_hour').id,
             'company_id': self.company_id.id,
             'ref': self.production_id.name,
             'category': 'manufacturing_order',

--- a/addons/mrp_account/models/stock_rule.py
+++ b/addons/mrp_account/models/stock_rule.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = 'stock.rule'
+
+    def _prepare_mo_vals(self, product_id, product_qty, product_uom, location_id, name, origin, company_id, values, bom):
+        res = super()._prepare_mo_vals(product_id, product_qty, product_uom, location_id, name, origin, company_id, values, bom)
+        if not bom.analytic_account_id and values.get('analytic_account_id'):
+            res['analytic_account_id'] = values.get('analytic_account_id').id
+        return res

--- a/addons/sale_mrp/models/stock_move.py
+++ b/addons/sale_mrp/models/stock_move.py
@@ -4,6 +4,14 @@
 from odoo import models
 
 
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    def _prepare_procurement_values(self):
+        res = super()._prepare_procurement_values()
+        res['analytic_account_id'] = self.sale_line_id.order_id.analytic_account_id
+        return res
+
 
 class StockMoveLine(models.Model):
     _inherit = 'stock.move.line'

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -400,15 +400,15 @@ class StockMove(models.Model):
         elif self.product_id.valuation == 'real_time':
             accounts_data = self.product_id.product_tmpl_id.get_product_accounts()
             account_valuation = accounts_data.get('stock_valuation', False)
-            analalytic_line_vals = self.stock_valuation_layer_ids.account_move_id.line_ids.filtered(
+            analytic_line_vals = self.stock_valuation_layer_ids.account_move_id.line_ids.filtered(
                 lambda l: l.account_id == account_valuation)._prepare_analytic_line()
-            amount = - sum(vals['amount'] for vals in analalytic_line_vals)
-            unit_amount = - sum(vals['unit_amount'] for vals in analalytic_line_vals)
+            amount = - sum(vals['amount'] for vals in analytic_line_vals)
+            unit_amount = - sum(vals['unit_amount'] for vals in analytic_line_vals)
         elif sum(self.stock_valuation_layer_ids.mapped('quantity')):
             amount = sum(self.stock_valuation_layer_ids.mapped('value'))
-            unit_amount = sum(self.stock_valuation_layer_ids.mapped('quantity'))
+            unit_amount = - sum(self.stock_valuation_layer_ids.mapped('quantity'))
         if self.analytic_account_line_id:
-            self.analytic_account_line_id.unit_amount = - unit_amount
+            self.analytic_account_line_id.unit_amount = unit_amount
             self.analytic_account_line_id.amount = amount
             return False
         elif amount:


### PR DESCRIPTION
[IMP] Propagate the analytic account of a MTO triggered MO from a SO if:
- SO has an analytic account set
- MO does NOT have a BoM with an analytic account set

[FIX] a bunch of small things:
- update MO list status colors: draft = blue, in progress = yellow +
  make the WO status colors match (waiting = blue, in progress = yellow)
- cleanup Activity in tree view (no label in tree + "Next Activity" in
  column selection dropdown)
- make units of analytic accounting for WO = hours
- make quantity for move_raw_ids products (i.e. components for MOs)
  always have positive analytic_account_line.unit_amount (i.e. when
  changing a done move's quantity + changing a quantity twice made this
  value negative)
- make "Copy Operations" on BOM open the list view in "current" instead
  of "new" due to lack of hook to prevent form view (i.e. open BoM in
  current view) changing when clicking on lines in the new window's
  operations (also ends up being a better UX anyways since being able to
  view the operations form view is desired).

Task: 2648460
Related ENT PR: https://github.com/odoo/enterprise/pull/21322

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
