### PR TITLE
[FIX] pos_gift_card: Remove useless CSS

### DIFF
--- a/addons/pos_gift_card/static/src/css/giftCard.css
+++ b/addons/pos_gift_card/static/src/css/giftCard.css
@@ -41,5 +41,3 @@
 .giftCardPopupConfirmButton {
     width: 40% !important;
 }
-
-.giftCardPopupIn


### PR DESCRIPTION
Remove useless CSS that lead to wrong behavior with popups.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
