### PR TITLE
[FIX] website_sale: restore the block ui loading on pay now click

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_payment.js
+++ b/addons/website_sale/static/src/js/website_sale_payment.js
@@ -49,10 +49,30 @@ odoo.define('website_sale.payment', require => {
             'change #checkbox_tc': '_onClickTCCheckbox',
         }),
 
-        //--------------------------------------------------------------------------
+        //----------------------------------------------------------------------
         // Private
-        //--------------------------------------------------------------------------
+        //----------------------------------------------------------------------
 
+        /**
+         * @override
+         */
+        _disableButton(showLoadingAnimation = true) {
+            $("body").block({
+                message: false,
+                overlayCSS: {backgroundColor: "#000", opacity: 0, zIndex: 1050},
+            });
+            this._super(...arguments);
+        },
+        /**
+         * @override
+         */
+        _enableButton() {
+            const res = this._super(...arguments);
+            if (res) {
+                $('body').unblock();
+            }
+            return res;
+        },
         /**
          * Verify that the Terms and Condition checkbox is checked.
          *


### PR DESCRIPTION
The cart UX was improved with [1] at payment step by adding a block ui when the
user had clicked on "Pay now".
Indeed, that step could take some (long) time, and preventing the user to click
on anything would limit the possible issues: changing a delivery, a payment
provider or anything.
Also, it would be even clearer to the user that something is being processed,
even if the Pay now button was already spinning.

The payment refactoring [2] did not correctly adapt that behavior.
This commit restores it.

[1]: https://github.com/odoo/odoo/commit/eb3ed89f8440050fc32f9a7b29fb2b6ab8fd6b59
[2]: https://github.com/odoo/odoo/commit/573ed74c121c1572b3fab6f9553ed7f93f7b3f99

task-2659450