### PR TITLE
Add l10n cl edi vendor bill doc type

### DIFF
--- a/addons/l10n_cl/data/account_tax_data.xml
+++ b/addons/l10n_cl/data/account_tax_data.xml
@@ -115,6 +115,44 @@
         ]"/>
     </record>
 
+    <record id="I_RTI" model="account.tax.template">
+        <field name="chart_template_id" ref="cl_chart_template"/>
+        <field name="name">Retención Total IVA</field>
+        <field name="description">Retención total IVA</field>
+        <field name="amount">-19.00</field>
+        <field name="sequence" eval="2"/>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="l10n_cl_sii_code">15</field>
+        <field name="tax_group_id" ref="tax_group_retenciones"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('tax_report_retencion_total_compras')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('account_210715'),
+                'plus_report_line_ids': [ref('tax_report_retencion_total_compras')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('tax_report_retencion_total_compras')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('account_210715'),
+                'minus_report_line_ids': [ref('tax_report_retencion_total_compras')],
+            }),
+        ]"/>
+    </record>
+
     <record id="especifico_compra" model="account.tax.template">
         <field name="chart_template_id" ref="cl_chart_template"/>
         <field name="name">Específico Compra</field>

--- a/addons/l10n_cl/data/account_tax_report_data.xml
+++ b/addons/l10n_cl/data/account_tax_report_data.xml
@@ -36,6 +36,13 @@
         <field name="parent_id" ref="tax_report_base_imponible_ventas"/>
     </record>
 
+    <record id="tax_report_retencion_total_compras" model="account.tax.report.line">
+        <field name="name">Retención Total (compras)</field>
+        <field name="tag_name">Retención Total (compras)</field>
+        <field name="report_id" ref="tax_report"/>
+        <field name="sequence" eval="1"/>
+    </record>
+
     <record id="tax_report_impuestos_originados_venta" model="account.tax.report.line">
         <field name="name">Impuesto Originado por la Venta</field>
         <field name="tag_name">Impuesto Originado por la Venta</field>

--- a/addons/l10n_cl/data/l10n_cl_chart_data.xml
+++ b/addons/l10n_cl/data/l10n_cl_chart_data.xml
@@ -944,6 +944,14 @@
         <field name="chart_template_id" ref="cl_chart_template"/>
     </record>
 
+    <record id="account_210715" model="account.account.template">
+        <field name="code">210715</field>
+        <field name="name">IVA Retenido a terceros</field>
+        <field ref="account.data_account_type_current_liabilities" name="user_type_id"/>
+        <field name="reconcile" eval="False"/>
+        <field name="chart_template_id" ref="cl_chart_template"/>
+    </record>
+
     <record id="account_210750" model="account.account.template">
         <field name="code">210750</field>
         <field name="name">Impuesto Renta 1a Categoría por Pagar</field>

--- a/addons/l10n_cl/data/l10n_latam.document.type.csv
+++ b/addons/l10n_cl/data/l10n_latam.document.type.csv
@@ -12,7 +12,7 @@ dc_y_f_dtn,10,32,Factura de Ventas y Servicios no Afectos o Exentos de IVA,F-EXE
 dc_l_f_dtn,10,40,Liquidación Factura,L-FACTURAM,invoice,FAL,base.cl,False
 dc_l_f_dte,10,43,Liquidación Factura Electrónica,L-FACTURAE,invoice,FAL,base.cl,False
 dc_fc_f_dtn,10,45,Factura de Compra,FACTURA,invoice_in,FAC,base.cl,False
-dc_fc_f_dte,10,46,Factura de Compra Electrónica,FACTURA,invoice_in,FAC,base.cl,False
+dc_fc_f_dte,10,46,Factura de Compra Electrónica,FACTURA,invoice_in,FAC,base.cl,True
 dc_nd_f_dtn,10,55,Nota de Débito,NOTA DE DEBITO,debit_note,N/D,base.cl,False
 dc_nc_f_dtn,10,60,Nota de Crédito,NOTA DE CREDITO,credit_note,N/C,base.cl,False
 dc_s_f_dtn,10,108,SRF Solicitud de Registro de Factura,SOL REGISTRO,,REG,base.cl,False

--- a/addons/l10n_cl/models/l10n_latam_document_type.py
+++ b/addons/l10n_cl/models/l10n_latam_document_type.py
@@ -28,3 +28,6 @@ class L10nLatamDocumentType(models.Model):
             return False
 
         return document_number.zfill(6)
+
+    def _is_doc_type_vendor(self):
+        return self.code == '46'

--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -74,12 +74,12 @@ class AccountMove(models.Model):
         """ Indicates if this document type uses a sequence or if the numbering is made manually """
         recs_with_journal_id = self.filtered(lambda x: x.journal_id and x.journal_id.l10n_latam_use_documents)
         for rec in recs_with_journal_id:
-            rec.l10n_latam_manual_document_number = self._is_manual_document_number(rec.journal_id)
+            rec.l10n_latam_manual_document_number = rec._is_manual_document_number()
         remaining = self - recs_with_journal_id
         remaining.l10n_latam_manual_document_number = False
 
-    def _is_manual_document_number(self, journal):
-        return True if journal.type == 'purchase' else False
+    def _is_manual_document_number(self):
+        return self.journal_id.type == 'purchase'
 
     @api.depends('name')
     def _compute_l10n_latam_document_number(self):

--- a/addons/l10n_latam_invoice_document/wizards/account_move_reversal.py
+++ b/addons/l10n_latam_invoice_document/wizards/account_move_reversal.py
@@ -19,7 +19,7 @@ class AccountMoveReversal(models.TransientModel):
         for rec in self.filtered('move_ids'):
             move = rec.move_ids[0]
             if move.journal_id and move.journal_id.l10n_latam_use_documents:
-                rec.l10n_latam_manual_document_number = self.env['account.move']._is_manual_document_number(move.journal_id)
+                rec.l10n_latam_manual_document_number = move._is_manual_document_number()
 
     @api.model
     def _reverse_type_map(self, move_type):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Modifications needed to create electronic vendor bill document type (46) since it is mandatory for some customers in Chile
Adds new account to withhold vat tax, and new vat tax
Enables document type 46
Allow electronic docs in purchase journals
[FIX] l10n_latam_invoice_document Consider doc type 46 as a vendor document
More information -> https://www.sii.cl/preguntas_frecuentes/catastro/001_012_3665.htm

Current behavior before PR:
Invoices type 46 (chile) cannot be used in vendor bills.
The taxes and account needed are not present in the plan

Desired behavior after PR is merged:
integrates with l10n_cl_edi allowing type 46

This replaces #75970






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
