### PR TITLE
[FIX] mrp : operation of archived work center still available for search

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -354,7 +354,7 @@ class MrpBomLine(models.Model):
         help="BOM Product Variants needed to apply this line.")
     operation_id = fields.Many2one(
         'mrp.routing.workcenter', 'Consumed in Operation', check_company=True,
-        domain="[('routing_id', '=', routing_id), '|', ('company_id', '=', company_id), ('company_id', '=', False)]",
+        domain="[('workcenter_id.active', '=', True), ('routing_id', '=', routing_id), '|', ('company_id', '=', company_id), ('company_id', '=', False)]",
         help="The operation where the components are consumed, or the finished products created.")
     child_bom_id = fields.Many2one(
         'mrp.bom', 'Sub BoM', compute='_compute_child_bom_id')


### PR DESCRIPTION
Issue: When creating a BoM and selecting a certain routing for which
certain operations are done on an archived work center, we can still
select those operations, even though if we try to edit them, we cannot
save it on the current work center because it is archived

Steps to reproduce :
 1) Install MRP, enable work centers
 2) Create a work center WC
 3) Create a routing RO
 4) Create one or more operations with the work center set to WC
 5) Archive the Work Center
 6) Create a BoM, set the routing to RO, add a component with any
 product, try to add an operation_id (Consumed in Operation) for that
 line
-> The operation that uses an archived work center can still be used

Why is that a bug ?
As much as I do agree we should not archive the routing when a work
center is archived, I think we should not be able to create/edit a BoM
and explicitly set at the time of creation/edition an operation for
which the work center is archived.
IMO archiving means deprecated, so we cannot create new data referencing
archived data, and since the work center is archived, it means work
center deprecated, so all his operations should be deprecated too

Since mrp.routing.workcenter does not have an `active` field to archive
them when the work center is archived, I think this is a good way to
ensure we do not reference operations on an archived work center

opw-2658596
