### PR TITLE
[IMP] pos_gift_card: fix usability

### DIFF
--- a/addons/gift_card/models/gift_card.py
+++ b/addons/gift_card/models/gift_card.py
@@ -13,7 +13,8 @@ class GiftCard(models.Model):
 
     @api.model
     def _generate_code(self):
-        return '044' + str(uuid4())[4:-8][3:]
+        # 044 is used for the barcode scanner.
+        return '044' + str(uuid4())[7:-8]
 
     name = fields.Char(compute='_compute_name')
     code = fields.Char(default=lambda x: x._generate_code(), required=True, readonly=True, copy=False)

--- a/addons/pos_gift_card/data/gift_card_data.xml
+++ b/addons/pos_gift_card/data/gift_card_data.xml
@@ -15,6 +15,15 @@
             <field name="binding_model_id" ref="model_gift_card"/>
         </record>
 
+        <record id="barcode_rule_giftcard" model="barcode.rule">
+            <field name="name">Gift Card Barcodes</field>
+            <field name="barcode_nomenclature_id" ref="barcodes.default_barcode_nomenclature"/>
+            <field name="sequence">51</field>
+            <field name="type">gift_card</field>
+            <field name="encoding">any</field>
+            <field name="pattern">044</field>
+        </record>
+
         <template id="gift_card_template">
             <t t-call="web.html_container">
                 <t t-foreach="docs" t-as="o">

--- a/addons/pos_gift_card/security/ir.model.access.csv
+++ b/addons/pos_gift_card/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
-access_gift_card_sales,Gift Card Program Salesman,model_gift_card,point_of_sale.group_pos_manager,1,0,0,0
+access_gift_card_sales,Gift Card Program Salesman,model_gift_card,point_of_sale.group_pos_user,1,1,1,0
 access_pos_gift_card_manager,Gift Card Program Sale Manager,model_gift_card,point_of_sale.group_pos_manager,1,1,1,1

--- a/addons/pos_gift_card/static/src/css/giftCard.css
+++ b/addons/pos_gift_card/static/src/css/giftCard.css
@@ -1,43 +1,62 @@
-.giftCardPopupMain {
+.pos .popups .giftCardPopupMain {
     display: flex;
     flex-wrap: wrap;
-
     justify-content: space-around;
-
     text-align: center;
-    padding: 1em;
+    margin: 1em;
 }
 
-.giftCardPopupContainer {
+.pos .popups .giftCardPopupMain .giftCardPopupContainer {
     display: flex;
-    justify-content: center;
-    flex-wrap: wrap;
     padding: 5px;
-
     font-weight: bold;
     text-align: center;
     width: 100%;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
 }
 
-.giftCardPopupFooter {
-    display: flex;
-    justify-content: space-evenly;
-
+.pos .popups .giftCardPopupFooter {
     text-align: center;
 }
 
-.giftCardPopupInput {
-    border-bottom: 1px solid !important;
-    background-color: #F0EEEE !important;
-    box-shadow: none !important;
-    text-align: right !important;
+.pos .popups .giftCardPopupMain .giftCardPopupInputAmount {
+    border-bottom: 1px solid;
+    background-color: #F0EEEE;
+    box-shadow: none;
+    text-align: right;
+    width: 80%;
 }
 
-.giftCardPopupButton {
-    width: 50% !important;
+.pos .popups .giftCardPopupMain .giftCardPopupInputBarcode {
+    border-bottom: 1px solid;
+    background-color: #F0EEEE;
+    box-shadow: none;
+    text-align: center;
+    width: 80%;
+}
+
+.pos .popups .giftCardPopupButton {
+    width: 100%;
     margin: 6px;
 }
 
-.giftCardPopupConfirmButton {
-    width: 40% !important;
+.pos .popups .giftCardPopupConfirmButton {
+    width: 47%;
+    margin: 0px;
+}
+
+.pos .popups .giftCardPopupMain .giftCardPopupInputContainer {
+    width: 80%;
+}
+
+.pos .popups .footer .GiftCardFooterButton {
+    margin-left: 5px;
+    width: 70px;
+}
+
+.pos .popups .giftCardError {
+    width: 100%;
+    background-color: rgba(255, 76, 76, 0.5);
 }

--- a/addons/pos_gift_card/static/src/js/PaymentScreen.js
+++ b/addons/pos_gift_card/static/src/js/PaymentScreen.js
@@ -45,7 +45,6 @@ odoo.define('pos_gift_card.PaymentScreen', function(require) {
                                     });
                                     return;
                                 }
-                                this.env.pos.giftCard.find(gift => gift.id === gift_card[0].id).balance += line.price;
                             }
                         }
                     } catch (e) {

--- a/addons/pos_gift_card/static/src/xml/GiftCardPopup.xml
+++ b/addons/pos_gift_card/static/src/xml/GiftCardPopup.xml
@@ -10,115 +10,83 @@
                     </header>
 
                     <main class="giftCardPopupMain">
-                        <div class="giftCardPopupContainer" t-if="!state.showBarcodeGeneration">
+                        <div class="giftCardError" t-if="state.error != ''">
+                            <span t-esc="state.error"/>
+                        </div>
+                        <div t-if="state.showMenu" class="giftCardPopupContainer">
                             <span t-if="state.giftCardConfig == 'create_set'"
                                   class="giftCardPopupButton button"
-                                  t-on-click="switchBarcodeView">Generate barcode</span>
+                                  t-on-click="switchToBarcode">Generate barcode</span>
                             <span t-if="state.giftCardConfig == 'scan_set'"
                                   class="giftCardPopupButton button"
-                                  t-on-click="switchBarcodeView">Scan and set price on gift card</span>
+                                  t-on-click="switchToBarcode">Scan and set price on gift card</span>
                             <span t-if="state.giftCardConfig == 'scan_use'"
                                   class="giftCardPopupButton button"
-                                  t-on-click="switchBarcodeView">Scan gift card</span>
+                                  t-on-click="switchToBarcode">Scan gift card</span>
                         </div>
 
-                        <div t-if="!state.showUseGiftCardMenu &amp;&amp; !state.showGiftCardDetails">
-                            <div class="giftCardPopupContainer"
-                                 t-if="state.showBarcodeGeneration &amp;&amp; state.giftCardConfig == 'create_set'">
-                                <div>
-                                    <span>Amount of the gift card:</span><br/>
-                                    <div>
-                                        <input t-model.number="state.amountToSet" class="giftCardPopupInput" type="text"/>
-                                        <span class="currency">
-                                            <t t-esc="env.pos.getCurrencySymbol()" />
-                                        </span>
-                                    </div>
-                                </div>
-                                <div>
-                                    <div class="button confirm" t-on-click="generateBarcode">
-                                        Confirm
-                                    </div>
-                                        <div class="button confirm" t-on-click="switchBarcodeView">
-                                        Cancel
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="giftCardPopupContainer"
-                                 t-if="state.showBarcodeGeneration &amp;&amp; state.giftCardConfig == 'scan_set'">
-                                <div>
-                                    Gift Card Barcode: <br/>
-                                    <input t-model="state.giftCardBarcode" class="giftCardPopupInput" type="text"/>
-                                </div>
-                                <div>
-                                    Amount of the gift card: <br/>
-                                    <input t-model.number="state.amountToSet" class="giftCardPopupInput" type="text"/>
-                                </div>
-                                <div>
-                                    <span class="button confirm" t-on-click="scanAndUseGiftCard">
-                                        Confirm
-                                    </span>
-                                    <span class="button cancel" t-on-click="switchBarcodeView">
-                                        Discard
+                        <div t-if="!state.showMenu" class="giftCardPopupContainer">
+                            <div class="giftCardPopupContainer" t-if="state.command == 'create_set'">
+                                <span>Amount of the gift card:</span>
+                                <div class="giftCardPopupInputContainer">
+                                    <input t-model.number="state.amountToSet" class="giftCardPopupInputAmount" type="text"/>
+                                    <span class="currency">
+                                        <t t-esc="env.pos.getCurrencySymbol()" />
                                     </span>
                                 </div>
                             </div>
 
-                            <div class="giftCardPopupContainer"
-                                 t-if="state.showBarcodeGeneration &amp;&amp; state.giftCardConfig == 'scan_use'">
-                                <div>
+                            <div class="giftCardPopupContainer" t-if="state.command == 'scan_set'">
+                                <div class="giftCardPopupInputContainer" style="margin: 10px">
                                     Gift Card Barcode:
-                                    <input t-model="state.giftCardBarcode" class="giftCardPopupInput" type="text"/>
+                                    <input t-model="state.giftCardBarcode" class="giftCardPopupInputBarcode" type="text"/>
+                                </div>
+                                <div class="giftCardPopupInputContainer">
+                                    Amount of the gift card:
+                                    <input t-model.number="state.amountToSet" class="giftCardPopupInputAmount" type="text"/>
+                                    <span class="currency">
+                                        <t t-esc="env.pos.getCurrencySymbol()" />
+                                    </span>
+                                </div>
+                            </div>
+
+                            <div class="giftCardPopupContainer" t-if="state.command == 'scan_use'">
+                                <div class="giftCardPopupInputContainer">
+                                    Gift Card Barcode:
+                                    <input t-model="state.giftCardBarcode" class="giftCardPopupInputBarcode" type="text"/>
+                                </div>
+                            </div>
+
+                            <div class="giftCardPopupContainer" t-if="state.command == 'pay'">
+                                <div class="giftCardPopupInputContainer">
+                                    Gift Card Barcode:
+                                    <input t-model="state.giftCardBarcode" class="giftCardPopupInputBarcode" type="text"/>
+                                </div>
+                            </div>
+
+                            <div class="giftCardPopupContainer" t-if="state.command == 'showAmount'">
+                                <div class="giftCardPopupInputContainer" style="margin: 10px">
+                                    Gift Card Barcode:
+                                    <input t-model="state.giftCardBarcode" class="giftCardPopupInputBarcode" type="text"/>
                                 </div>
                                 <div>
-                                    <span class="button confirm" t-on-click="scanAndUseGiftCard">
-                                        Confirm
-                                    </span>
-                                    <span class="button cancel" t-on-click="switchBarcodeView">
-                                        Discard
-                                    </span>
+                                    Remaining amount of the gift card:
+                                    <t t-esc="env.pos.format_currency(state.remainingAmount)"/>
+                                </div>
+                            </div>
+
+                            <div class="giftCardPopupContainer" t-if="state.showMenu" style="flex-direction: row;">
+                                <div class="button giftCardPopupConfirmButton" t-on-click="switchToPay">
+                                    Use a gift card
+                                </div>
+                                    <div class="button giftCardPopupConfirmButton" t-on-click="switchToShowGiftCardDetails">
+                                    Check a gift card
                                 </div>
                             </div>
                         </div>
 
-                        <div class="giftCardPopupContainer"
-                             t-if="state.showBarcodeGeneration &amp;&amp; state.showUseGiftCardMenu">
-                            <div>
-                                Gift Card Barcode:
-                                <input t-model="state.giftCardBarcode" class="giftCardPopupInput" type="text"/>
-                            </div>
-                            <div>
-                                <span class="button confirm" t-on-click="payWithGiftCard">
-                                    Confirm
-                                </span>
-                                <span class="button cancel" t-on-click="switchBarcodeView">
-                                    Discard
-                                </span>
-                            </div>
-                        </div>
-
-                        <div class="giftCardPopupContainer"
-                             t-if="state.showBarcodeGeneration &amp;&amp; state.showGiftCardDetails">
-                            <div>
-                                Gift Card Barcode:
-                                <input t-model="state.giftCardBarcode" class="giftCardPopupInput" type="text"/>
-                            </div>
-                            <div>
-                                Remaining amount of the gift card:
-                                <t t-esc="state.amountToSet"/>
-                            </div>
-                            <div>
-                                <span class="button confirm" t-on-click="ShowRemainingAmount">
-                                    Confirm
-                                </span>
-                                <span class="button cancel" t-on-click="switchBarcodeView">
-                                    Discard
-                                </span>
-                            </div>
-                        </div>
-
-                        <div class="giftCardPopupContainer" t-if="!state.showBarcodeGeneration">
-                            <div class="button giftCardPopupConfirmButton" t-on-click="switchToUseGiftCardMenu">
+                        <div class="giftCardPopupContainer" t-if="state.showMenu" style="flex-direction: row;">
+                            <div class="button giftCardPopupConfirmButton" t-on-click="switchToPay">
                                 Use a gift card
                             </div>
                                 <div class="button giftCardPopupConfirmButton" t-on-click="switchToShowGiftCardDetails">
@@ -128,8 +96,14 @@
                     </main>
 
                     <footer class="footer giftCardPopupFooter">
-                        <div class="button cancel" t-on-click="cancel">
-                            Cancel
+                        <div class="button cancel GiftCardFooterButton" t-on-click="cancel">
+                            Close
+                        </div>
+                        <div t-if="!state.showMenu" class="button cancel GiftCardFooterButton" t-on-click="backToMenu">
+                            Back
+                        </div>
+                        <div t-if="!state.showMenu" class="button confirm GiftCardFooterButton" t-on-click="clickConfirm">
+                            Confirm
                         </div>
                     </footer>
                 </div>

--- a/addons/pos_gift_card/views/gift_card_views.xml
+++ b/addons/pos_gift_card/views/gift_card_views.xml
@@ -15,7 +15,7 @@
         <field name="inherit_id" ref="gift_card.gift_card_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='code']" position="after">
-                <field name="buy_pos_order_line_id" options="{'no_create': True}"/>
+                <field name="buy_pos_order_line_id" options="{'no_create': True}" string="Pos Order Line"/>
             </xpath>
             <xpath expr="//group[@name='gift_card']" position="after">
                 <group>

--- a/addons/sale_gift_card/views/sale_order_view.xml
+++ b/addons/sale_gift_card/views/sale_order_view.xml
@@ -31,7 +31,7 @@
         <field name="inherit_id" ref="gift_card.gift_card_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='code']" position="after">
-                <field name="buy_line_id" options="{'no_create': True}"/>
+                <field name="buy_line_id" string="Sale Order" options="{'no_create': True}"/>
             </xpath>
             <xpath expr="//group[@name='gift_card']" position="after">
                 <group>


### PR DESCRIPTION
Allow to use the bar code in the popup gift card properly.
Small change of the gift card code generation.
Add a missing label in the view for sale gift card and pos gift card
Change the logic of the view to be able to use a context.

Change the access right for the POS user. Before he didn't have access
to the gift card. Now he can read/write/create.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
