### PR TITLE
[FIX] partner_autocomplete: slice options when there are too many opt…

### DIFF
--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
@@ -31,6 +31,21 @@ var PartnerField = FieldMany2One.extend(AutocompleteMixin, {
     // Private
     //--------------------------------------------------------------------------
 
+    _concatenateAutocompleteResults() {
+        let result = this._super(...arguments);
+
+        const documentHeight = document.documentElement.clientHeight;
+        if (documentHeight <= 570) {
+            result = result.slice(0, 9);
+        } else if (documentHeight <= 620) {
+            result = result.slice(0, 10);
+        } else if (documentHeight <= 700) {
+            result = result.slice(0, 11);
+        } else {
+            result = result.slice(0, 14);
+        }
+        return result;
+    },
     /**
      * Action : create popup form with pre-filled values from Autocomplete
      *

--- a/addons/partner_autocomplete/static/src/scss/partner_autocomplete.scss
+++ b/addons/partner_autocomplete/static/src/scss/partner_autocomplete.scss
@@ -17,9 +17,6 @@
 }
 
 .ui-autocomplete.o_partner_autocomplete_dropdown {
-    > .ui-menu-item:nth-of-type(1n+16) {
-        display: none;
-    }
     > .o_partner_autocomplete_dropdown_item {
         > a {
             white-space: nowrap;
@@ -40,27 +37,5 @@
     }
     > .ui-menu-item > a.ui-state-active .text-muted {
         color: white !important;
-    }
-}
-
-@media (max-height: 700px) {
-    .ui-autocomplete.o_partner_autocomplete_dropdown {
-        > .ui-menu-item:nth-of-type(1n+13) {
-            display: none;
-        }
-    }
-}
-@media (max-height: 620px) {
-    .ui-autocomplete.o_partner_autocomplete_dropdown {
-        > .ui-menu-item:nth-of-type(1n+12) {
-            display: none;
-        }
-    }
-}
-@media (max-height: 570px) {
-    .ui-autocomplete.o_partner_autocomplete_dropdown {
-        > .ui-menu-item:nth-of-type(1n+11) {
-            display: none;
-        }
     }
 }


### PR DESCRIPTION
PURPOSE
Navigation on partner_autocomplete should be smooth.

SPEC
Do not hide autocomplete item instead remove it from autocomplete so that it is not considered while navigating through keyboard.

TASK 2531294

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
