### PR TITLE
[14.0] account: Fix usage of self in loop of payment register compute method

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -226,7 +226,7 @@ class AccountPaymentRegister(models.TransientModel):
         # it's a compute editable field and then, should be computed in a separated method.
         for wizard in self:
             if wizard.can_edit_wizard:
-                batches = self._get_batches()
+                batches = wizard._get_batches()
                 wizard.communication = wizard._get_batch_communication(batches[0])
             else:
                 wizard.communication = False


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Ugly usage of self inside a for loop.

Current behavior before PR:

`_get_batches` is called on `self`

Desired behavior after PR is merged:

`_get_batches` is called on `wizard`


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
