### PR TITLE
[FIX] web_editor: fix img being removed on copy/paste

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -1234,7 +1234,11 @@ export function isEmptyBlock(blockEl) {
  * @returns {boolean}
  */
 export function isShrunkBlock(blockEl) {
-    return isEmptyBlock(blockEl) && !blockEl.querySelector('br');
+    return (
+        isEmptyBlock(blockEl) &&
+        !blockEl.querySelector('br') &&
+        blockEl.nodeName !== "IMG"
+    );
 }
 
 /**


### PR DESCRIPTION
The img nodes where being wrongly considered empty by isShrunkNode
because the image was not loaded yet.