### PR TITLE
[FIX] account: fix model reconciliation recognized as refund

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -277,7 +277,7 @@ class AccountReconcileModel(models.Model):
         self.ensure_one()
         balance = base_line_dict['balance']
         tax_type = tax.type_tax_use
-        is_refund = (tax_type == 'sale' and balance < 0) or (tax_type == 'purchase' and balance > 0)
+        is_refund = (tax_type == 'sale' and balance > 0) or (tax_type == 'purchase' and balance < 0)
 
         res = tax.compute_all(balance, is_refund=is_refund)
 


### PR DESCRIPTION
- Belgian accounting installed and active in currenct company
- Create a bank statement with a negative amount.
- Post it and reconcile using model "Frais bancaires TVA21"

Back to the bank statement, under Journal entries, the tax grids are
wrong: it reports "+82", "-85" and "-63" but it should be
"+82" and "+59"
This occur because the system interpret the move as a refund.

opw-2646291

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
