### PR TITLE
[IMP] mass_mailing: show body_arch in readonly, body_html in a debug tab

### DIFF
--- a/addons/mass_mailing/static/src/js/mailing_mailing_view_form_full_width.js
+++ b/addons/mass_mailing/static/src/js/mailing_mailing_view_form_full_width.js
@@ -40,7 +40,6 @@ const MassMailingFullWidthFormController = FormController.extend({
      * template is picked.
      *
      * @private
-     * @param {JQuery} $iframe
      */
     _resizeMailingEditorIframe() {
         const VERTICAL_OFFSET = 12; // Vertical offset picked for visual design purposes.
@@ -105,7 +104,7 @@ const MassMailingFullWidthFormController = FormController.extend({
      * @private
      */
     _onDomUpdated() {
-        const data = { $iframe: this.$('iframe.wysiwyg_iframe, iframe.o_readonly') };
+        const data = { $iframe: this.$('iframe.wysiwyg_iframe:visible, iframe.o_readonly:visible') };
         this._onIframeUpdated({ data });
     },
     /**

--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -170,13 +170,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
         }
         return this._super.apply(this, arguments);
     },
-    /**
-     * @override
-     */
-    _renderReadonly: function () {
-        this.value = this.recordData[this.nodeOptions['inline-field']];
-        return this._super.apply(this, arguments);
-    },
 
     /**
      * @override

--- a/addons/mass_mailing/views/assets.xml
+++ b/addons/mass_mailing/views/assets.xml
@@ -4,6 +4,12 @@
         <t t-call-assets="mass_mailing.assets_mail_themes" t-js="false"/>
         <t t-call="mass_mailing.mass_mailing_mail_style"/>
         <t t-call-assets="mass_mailing.assets_mail_themes_edition" t-js="false"/>
+        <!-- To view the body_arch field in readonly and have it display exactly
+        like in edit, load all the same css. TODO: move all this and the above
+        to a separate asset -->
+        <t t-call-assets="web.assets_common" t-js="false"/>
+        <t t-call-assets="web.assets_frontend" t-js="false"/>
+        <t t-call-assets="web_editor.assets_wysiwyg" t-js="false"/>
     </template>
 
     <template id="iframe_css_assets_readonly" groups="base.group_user">

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -199,13 +199,12 @@
                             <page string="Mail Body" name="mail_body">
                                 <div class="position-relative">
                                     <div class="mt-n2">
-                                        <field name="body_html" class="o_mail_body oe_read_only" widget="html"
-                                            options="{'cssReadonly': 'mass_mailing.iframe_css_assets_readonly'}"/>
-                                        <field name="body_arch" class="o_mail_body oe_edit_only" widget="mass_mailing_html"
+                                        <field name="body_arch" class="o_mail_body" widget="mass_mailing_html"
                                             options="{
                                                 'snippets': 'mass_mailing.email_designer_snippets',
                                                 'cssEdit': 'mass_mailing.iframe_css_assets_edit',
-                                                'inline-field': 'body_html'
+                                                'inline-field': 'body_html',
+                                                'cssReadonly': 'mass_mailing.iframe_css_assets_edit'
                                         }" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                     </div>
                                     <field name="is_body_empty" invisible="1"/>
@@ -416,6 +415,27 @@
                 </xpath>
                 <xpath expr="//notebook/page[@name='chat']" position="inside">
                     <xpath expr="//div[hasclass('oe_chatter')]" position="move"/>
+                </xpath>
+                <xpath expr="//notebook/page[@name='mail_body']" position="after">
+                    <page string="Mail Debug" name="mail_debug" groups="base.group_no_one">
+                        <div class="position-relative">
+                            <div class="mt-n2">
+                                <field name="body_html" class="o_mail_body" widget="html"
+                                    options="{'cssReadonly': 'mass_mailing.iframe_css_assets_readonly', 'notEditable': True}"/>
+                            </div>
+                            <field name="is_body_empty" invisible="1"/>
+                            <div class="o_view_nocontent oe_read_only" attrs="{'invisible': ['|', ('is_body_empty', '=', False), ('state', 'in', ('sending', 'done'))]}">
+                                <div class="o_nocontent_help">
+                                    <p class="o_view_nocontent_smiling_face">
+                                        No template picked yet.
+                                    </p>
+                                    <p>
+                                        Start editing your mailing to design something awesome.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </page>
                 </xpath>
                 <xpath expr="//notebook/page[@name='dynamic_placeholder_generator']" position="inside">
                     <group/>

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -118,6 +118,14 @@ function getMatchedCSSRules(a) {
         return a*100 + b*10 + c;
     }
     css.sort(function (a, b) { return specificity(a[0]) - specificity(b[0]); });
+    // Add inline styles at the highest specificity.
+    if (a.style.length) {
+        const inlineStyles = {};
+        for (const styleName of a.style) {
+            inlineStyles[styleName] = a.style[styleName];
+        }
+        css.push([a, inlineStyles]);
+    }
 
     style = {};
     _.each(css, function (v,k) {
@@ -210,10 +218,10 @@ function getMatchedCSSRules(a) {
             const camelCased = styleName.replace(/-(\w)/g, match => match[1].toUpperCase());
             node.style[camelCased] = style[styleName];
             for (const child of $(node).children()) {
-                const childStyle = $(child).css(styleName);
-                if (childStyle && childStyle !== 'inherit') {
-                    _styleDescendants(child, styleName);
+                if (child.style[camelCased] !== style[styleName]) {
+                    break;
                 }
+                _styleDescendants(child, styleName);
             }
         }
         if (style.color) {

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -87,7 +87,9 @@ function getMatchedCSSRules(a) {
     var style;
     a.matches = a.matches || a.webkitMatchesSelector || a.mozMatchesSelector || a.msMatchesSelector || a.oMatchesSelector;
     for (r = 0; r < rulesCache.length; r++) {
-        if (a.matches(rulesCache[r].selector)) {
+        // The top element of a mailing has the class 'o_layout'. Give it the
+        // body's styles so they can trickle down.
+        if (a.matches(rulesCache[r].selector) || (a.classList.contains('o_layout') && rulesCache[r].selector === 'body')) {
             style = rulesCache[r].style;
             if (style.parentRule) {
                 var style_obj = {};
@@ -363,15 +365,27 @@ const tableAttributes = {
 const tableStyles = {
     'border-collapse': 'collapse',
     'text-align': 'inherit',
+    'font-size': 'unset',
+    'line-height': 'unset',
 };
 function _createTable(attributes = []) {
     const $table = $('<table/>');
-    $table.attr(tableAttributes).css(tableStyles);
+    $table.attr(tableAttributes);
     $table[0].style.setProperty('width', '100%', 'important');
     for (const attr of attributes) {
-        if (attr.name !== 'width' && attr.value !== '100%') {
+        if (!(attr.name === 'width' && attr.value === '100%')) {
             $table.attr(attr.name, attr.value);
         }
+    }
+    if ($table.hasClass('o_layout')) {
+        // The top mailing element inherits the body's font size and line-height
+        // and should keep them.
+        const layoutStyles = {...tableStyles};
+        delete layoutStyles['font-size'];
+        delete layoutStyles['line-height'];
+        $table.css(layoutStyles);
+    } else {
+        $table.css(tableStyles);
     }
     return $table;
 }

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -309,7 +309,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
             resolver = resolve;
         });
         if (this.nodeOptions.cssReadonly) {
-            this.$iframe = $('<iframe class="o_readonly"/>');
+            this.$iframe = $('<iframe class="o_readonly d-none"/>');
             this.$iframe.appendTo(this.$el);
 
             var avoidDoubleLoad = 0; // this bug only appears on some computers with some chrome version.
@@ -378,6 +378,10 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
 
         def.then(function () {
             self.$content.on('click', 'ul.o_checklist > li', self._onReadonlyClickChecklist.bind(self));
+            if (self.$iframe) {
+                // Iframe is hidden until fully loaded to avoid glitches.
+                self.$iframe.removeClass('d-none');
+            }
         });
     },
     /**


### PR DESCRIPTION
The body of a mailing is saved in two fields: body_arch without modifications, and body_html with conversion for email client compatibility. Prior to this commit, we were showing body_html when opening the form view of a saved mailing in readonly. This was pretty strange and confusing as it's a sort of intermediary version that doesn't mean much: an in-browser rendering of html that is compiled for email clients.
With this commit, we change the view to always show body_arch instead.
A new tab is introduced in order to show body_html for debugging, which is therefore only visible in debug mode.

This made a pre-existing bug more visible, where the iframe glitches on load: when loading a field html iframe, there are sometimes display glitches due to the iframe's contents and assets loading lazily. This prevents those glitches by hiding the iframe until it is fully loaded, creating a better user experience.

A couple of obvious bad behaviors of the transpiler were also fixed.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
