### PR TITLE
[FIX] website: allow to disable cache page based on content

### DIFF
--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -204,7 +204,7 @@
             <field name="url">/contactus</field>
             <field name="is_published">True</field>
             <field name="view_id" ref="contactus"/>
-            <field name="cache_key_expr">('cached' if not request.params else None,)</field>
+            <field name="cache_time">0</field>
             <field name="track">True</field>
         </record>
         <!-- Default Menu to store module menus for new website -->

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -208,6 +208,15 @@ class Page(models.Model):
         self.ensure_one()
         return self.view_id.get_website_meta()
 
+    @staticmethod
+    def _get_cached_blacklist():
+        return ('data-snippet="s_website_form"', 'data-no-page-cache=', )
+
+    def _can_be_cached(self, response):
+        """ return False if at least one blacklisted's word is present in content """
+        blacklist = self._get_cached_blacklist()
+        return not any(black in str(response) for black in blacklist)
+
     def _get_cache_key(self, req):
         # Always call me with super() AT THE END to have cache_key_expr appended as last element
         # It is the only way for end user to not use cache via expr.


### PR DESCRIPTION
In some case, we know that page will contains dynamic content and that cache
can be ignored whatever the cachetime.

E.g. as soon as a s_snippet_form will be present in page, we know that we need
the real csrf, and so we cannot use the cached response from another user.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
