### PR TITLE
[FIX] mrp_account: correct KIT cost even if bom line in different UOM

### DIFF
--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -56,7 +56,7 @@ class ProductProduct(models.Model):
             bom_line = move.bom_line_id
             if bom_line:
                 bom_line_data = bom_lines[bom_line]
-                line_qty = bom_line_data['qty']
+                line_qty = bom_line.product_uom_id._compute_quantity(bom_line_data['qty'], bom_line.product_id.uom_id)
             else:
                 # bom was altered (i.e. bom line removed) after being used
                 line_qty = move.product_qty

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -230,3 +230,69 @@ class TestSaleMrpKitBom(TransactionCase):
                 # The actual test, there should be no traceback here
                 order_line_change.product_id = product_variant_ids[1]
 
+    def test_sale_mrp_kit_cost(self):
+        """
+         Check the total cost of a KIT:
+            # BoM of Kit A:
+                # - BoM Type: Kit
+                # - Quantity: 1
+                # - Components:
+                # * 1 x Component A (Cost: $ 6, QTY: 1, UOM: Dozens)
+                # * 1 x Component B (Cost: $ 10, QTY: 2, UOM: Unit)
+            # cost of Kit A = (6 * 1 * 12) + (10 * 2) = $ 92
+        """
+        self.customer = self.env['res.partner'].create({
+            'name': 'customer'
+        })
+        
+        self.kit_product = self._create_product('Kit Product', 'product', 1.00)
+        # Creating components
+        self.component_a = self._create_product('Component A', 'product', 1.00)
+        self.component_a.product_tmpl_id.standard_price = 6
+        self.component_b = self._create_product('Component B', 'product', 1.00)
+        self.component_b.product_tmpl_id.standard_price = 10
+        
+        cat = self.env['product.category'].create({
+            'name': 'fifo',
+            'property_cost_method': 'fifo'
+        })
+        self.kit_product.product_tmpl_id.categ_id = cat
+        self.component_a.product_tmpl_id.categ_id = cat
+        self.component_b.product_tmpl_id.categ_id = cat
+        
+        self.bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': self.kit_product.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'type': 'phantom'
+        })
+        
+        self.env['mrp.bom.line'].create({
+                'product_id': self.component_a.id,
+                'product_qty': 1.0,
+                'bom_id': self.bom.id,
+                'product_uom_id': self.env.ref('uom.product_uom_dozen').id,
+        })
+        self.env['mrp.bom.line'].create({
+                'product_id': self.component_b.id,
+                'product_qty': 2.0,
+                'bom_id': self.bom.id,
+                'product_uom_id': self.env.ref('uom.product_uom_unit').id,
+        })
+    
+        # Create a SO with one unit of the kit product
+        so = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.kit_product.name,
+                    'product_id': self.kit_product.id,
+                    'product_uom_qty': 1.0,
+                    'product_uom': self.kit_product.uom_id.id,
+                })],
+        })
+        bom = self.env['mrp.bom'].sudo()._bom_find(product=self.kit_product)
+        so.action_confirm()
+        line = so.order_line
+        purchase_price = line.product_id.with_company(line.company_id)._compute_average_price(0, line.product_uom_qty, line.move_ids)
+        self.assertEqual(purchase_price, 92, "The purchase price must be the total cost of the components multiplied by their unit of measure")
+


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a Product A with Costing Method = FIFO
- Create a Product B with Costing Method = FIFO and cost of 10
- Create a BOM of product A > type = Kit
- Add product B in bom line, with qty = 1 and UoM = dozen
- Add product A in `sale.order`
- Confirm order

Problem:
The cost is 10 rather than 120 (10 * 12 = 120)

Solution:
The kit cost must be the total cost of the components multiplied by their unit of measure

opw-2631487

Co-authored-by: fmdl <florent.mirieu@gmail.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
