### PR TITLE
[FIX] web: remove the command palette from the frontend

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -213,8 +213,9 @@ This module provides the core of the Odoo Web Client.
             ('include', 'web._assets_bootstrap'),
 
             'web/static/src/env.js',
-            'web/static/src/core/utils/transitions.scss', # included early because used by other files
+            'web/static/src/core/utils/transitions.scss',  # included early because used by other files
             'web/static/src/core/**/*',
+            ('remove', 'web/static/src/core/commands/**/*'),
             'web/static/src/public/error_notifications.js',
 
             'web/static/src/legacy/scss/base_frontend.scss',

--- a/addons/web/static/src/core/debug/debug_menu.js
+++ b/addons/web/static/src/core/debug/debug_menu.js
@@ -1,18 +1,14 @@
 /** @odoo-module **/
 
+import { DebugMenuBasic } from "@web/core/debug/debug_menu_basic";
 import { useCommand } from "@web/core/commands/command_hook";
 import { useService } from "@web/core/utils/hooks";
 import { useEnvDebugContext } from "./debug_context";
 
-const { Component } = owl;
-
-export class DebugMenu extends Component {
+export class DebugMenu extends DebugMenuBasic {
     setup() {
+        super.setup();
         const debugContext = useEnvDebugContext();
-        // Needs to be bound to this for use in template
-        this.getElements = async () => {
-            this.elements = await debugContext.getItems(this.env);
-        };
         this.command = useService("command");
         useCommand(
             this.env._t("Debug tools..."),
@@ -57,4 +53,3 @@ export class DebugMenu extends Component {
         );
     }
 }
-DebugMenu.template = "web.DebugMenu";

--- a/addons/web/static/src/core/debug/debug_menu_basic.js
+++ b/addons/web/static/src/core/debug/debug_menu_basic.js
@@ -1,0 +1,16 @@
+/** @odoo-module **/
+
+import { useEnvDebugContext } from "./debug_context";
+
+const { Component } = owl;
+
+export class DebugMenuBasic extends Component {
+    setup() {
+        const debugContext = useEnvDebugContext();
+        // Needs to be bound to this for use in template
+        this.getElements = async () => {
+            this.elements = await debugContext.getItems(this.env);
+        };
+    }
+}
+DebugMenuBasic.template = "web.DebugMenu";

--- a/addons/website/static/src/js/menu/debug_menu.js
+++ b/addons/website/static/src/js/menu/debug_menu.js
@@ -1,16 +1,16 @@
 /** @odoo-module */
 import { registry } from "@web/core/registry";
-import { DebugMenu } from "@web/core/debug/debug_menu";
+import { DebugMenuBasic } from "@web/core/debug/debug_menu_basic";
 import { createDebugContext } from "@web/core/debug/debug_context";
 
 const debugMenuService = {
-    dependencies: ["command", "localization", "orm"],
+    dependencies: ["localization", "orm"],
     start(env) {
         if (env.debug) {
             const systray = document.querySelector('.o_menu_systray');
             if (systray) {
                 Object.assign(env, createDebugContext(env, {categories: ["default"]}));
-                owl.mount(DebugMenu, {
+                owl.mount(DebugMenuBasic, {
                     target: systray,
                     position: 'first-child',
                     env,


### PR DESCRIPTION
There is multiple issue with the palette in the frontend:

First, the command palette is bound to CTRL+K, which need to be bound to link
creation as this is an universal keybind, as CTRL+P CTRL+F are, as any other
edition app in the world does.
(Link creation is not only for edit mode but also for end user, eg forum post)
History:
1. Command palette was introduced with CTRL+K
2. The keybind was changed to CTRL+M to restore CTRL+K for link edition, see
   8727ed27667e
3. The keybind change was reverted and command back to CTRL+K, as CTRL+M can't
   be used on MAC

Second, the command palette do not work in the frontend, the menu are not
opened when an entry is selected, and the submenu are not shown in the palette
when the menu was opened before opening the palette.

Lastly, the CTRL+K in frontend does not only open the command palette but it
also create a link in the background of the palette being opened.. which
result in very bad usability..
The one expecting a link has to deal with a palette.
The one expecting a palette has had a link created without really noticing it.

task-2659885