### PR TITLE
[FIX] point_of_sale: allow editing some fields in pos config

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -445,6 +445,11 @@ class PosConfig(models.Model):
         return result
 
     @api.model
+    def _get_allowed_change_fields(self):
+        allowed_keys = []
+        return allowed_keys
+
+    @api.model
     def create(self, values):
         IrSequence = self.env['ir.sequence'].sudo()
         val = {
@@ -467,7 +472,9 @@ class PosConfig(models.Model):
 
     def write(self, vals):
         opened_session = self.mapped('session_ids').filtered(lambda s: s.state != 'closed')
-        if opened_session:
+        allowed_change_fields = self._get_allowed_change_fields()
+        only_allowed_fields = all(val in allowed_change_fields for val in vals.keys())
+        if opened_session and not only_allowed_fields:
             raise UserError(_('Unable to modify this PoS Configuration because there is an open PoS Session based on it.'))
         result = super(PosConfig, self).write(vals)
 
@@ -528,10 +535,10 @@ class PosConfig(models.Model):
     # Methods to open the POS
     def open_ui(self):
         """Open the pos interface with config_id as an extra argument.
-    
+
         In vanilla PoS each user can only have one active session, therefore it was not needed to pass the config_id
         on opening a session. It is also possible to login to sessions created by other users.
-        
+
         :returns: dict
         """
         self.ensure_one()


### PR DESCRIPTION
When you have the belgian localisation installed, the sequence report
number should be incremented each time you print the report.

As you cannot write on the pos config when a pos session is opened, you
get a traceback when you try to print the Z reports and having a session
open.

So we are allowing writing on pos config only for the needed field

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
