### PR TITLE
[FIX] mail: fix threaded layout on Mobile

### DIFF
--- a/addons/mail/static/src/components/discuss/discuss.scss
+++ b/addons/mail/static/src/components/discuss/discuss.scss
@@ -82,7 +82,7 @@
 }
 
 .o_Discuss_thread {
-    flex: 1 1 auto;
+    flex: 1 1 0;
 
     &.o-mobile {
         width: 100%;


### PR DESCRIPTION
As a followup of commit odoo/odoo@06081d2e8d86ec695f68c155b882d6a15a3fce9f,
the CSS rule `flex: 1 1 0` should also be applied to `.o_Discuss_thread`
to avoid the same kind of issue.

Steps to reproduce:
* Open Discuss
* Select History => BUG the `.o_Discuss_mobileNavbar` is not visible

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
