### PR TITLE
[IMP] account: add debug menu to see tax groups

### DIFF
--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -68,6 +68,7 @@
                 <menuitem id="menu_action_currency_form" action="base.action_currency_form" name="Currencies" sequence="4"/>
                 <menuitem id="menu_action_account_fiscal_position_form" action="action_account_fiscal_position_form" sequence="5"/>
                 <menuitem id="menu_action_account_journal_group_list" action="action_account_journal_group_list" groups="account.group_account_manager" sequence="7"/>
+                <menuitem id="menu_action_tax_group" action="action_tax_group" sequence="8" groups="base.group_no_one"/>
             </menuitem>
             <menuitem id="root_payment_menu" name="Payments" groups="account.group_account_manager" sequence="4"/>
             <menuitem id="account_management_menu" name="Management" groups="account.group_account_manager" sequence="5">

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -234,5 +234,17 @@
             </field>
         </record>
 
+        <record id="action_tax_group" model="ir.actions.act_window">
+            <field name="name">Tax Groups</field>
+            <field name="res_model">account.tax.group</field>
+            <field name="view_mode">tree,form</field>
+            <field name="view_id" ref="view_tax_group_tree"/>
+            <field name="help" type="html">
+              <p class="o_view_nocontent_smiling_face">
+                Create a new tax group
+              </p>
+            </field>
+        </record>
+
     </data>
 </odoo>

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -230,6 +230,8 @@
                     <field name="property_advance_tax_payment_account_id"
                         domain="[('company_id', '=', context['force_account_company'])] if context.get('force_account_company') else []"
                     />
+
+                    <field name="preceding_subtotal" optional="hide"/>
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
No menu allowed viewing all tax groups at once before. With the new subtotals features, it could become painful for the user if he wanted to change the groups' sequence in order reorder subtotals on his invoices (he had to change the sequence manually on each group, accessing their form view through taxes using them). It is now possible in the tree view opened by our new menu, with the sequence widget.
