### PR TITLE
[FIX] product : Improved error message for variant attribute value de…

### DIFF
--- a/addons/product/i18n/product.pot
+++ b/addons/product/i18n/product.pot
@@ -2803,7 +2803,15 @@ msgstr ""
 #, python-format
 msgid ""
 "You cannot delete the value %s because it is used on the following products:\n"
-"%s"
+"%s\n"
+"If the value has been associated to a product in the past, you will not be able to delete it."
+msgstr ""
+
+#. module: product
+#: code:addons/product/models/product_attribute.py:0
+#, python-format
+msgid ""
+"You cannot delete value %s because it was used in some products."
 msgstr ""
 
 #. module: product


### PR DESCRIPTION
…letion

What are the steps to reproduce your issue?
- Create a product with more than one attribute.
Let say color White, black and purple
- Create a 'draft' invoice for the purple product variant
- Remove the 'purple' attribute value from the product
- It will archive that variant (because the account.move linked to it)
- Try to delete the attribute value from menu Sales > Cofinfiguration > Attribute

What is the current behavior that you observe?
- technical error message

What would be your expected behavior in this case?
- non-technical message for end-users

Solution : 
- Change both message to tell user he cannot delete the value if the value has been referenced somewhere else.

opw-2623583

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
