### PR TITLE
[saas-14.5] Fiscal position improvements

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -42,8 +42,8 @@
                         <group>
                             <field name="auto_apply"/>
                             <field name="vat_required" attrs="{'invisible': [('auto_apply', '!=', True)]}"/>
-                            <field name="country_group_id" attrs="{'invisible': [('auto_apply', '!=', True)]}"/>
                             <field name="foreign_vat"/>
+                            <field name="country_group_id" attrs="{'invisible': [('auto_apply', '!=', True)]}"/>
                             <field name="country_id"
                                 attrs="{'required': [('foreign_vat', '!=', False)]}"
                                 options="{'no_open': True, 'no_create': True}"/>


### PR DESCRIPTION
[IMP] account: improve fiscal positions' form view 

The 'Country Group' field should be displayed under the 'foreign VAT' one, so that it its grouped together with 'Country' and 'Federal states'.



[IMP] account: forbid creating multiple foreign VAT fiscal positions for the same region

Having the same VAT fiscal position for the same region multiple times doesn't make sense and is not supported by the report enfinge. We should prevent that.