### PR TITLE
[FIX]l10n_be: vat due tag on vat due rep line

### DIFF
--- a/addons/l10n_be/data/account_tax_template_data.xml
+++ b/addons/l10n_be/data/account_tax_template_data.xml
@@ -1214,13 +1214,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_56'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451056'),
+                    'minus_report_line_ids': [ref('tax_report_line_56')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1267,13 +1268,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_56'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451056'),
+                    'minus_report_line_ids': [ref('tax_report_line_56')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1320,13 +1322,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_56'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451056'),
+                    'minus_report_line_ids': [ref('tax_report_line_56')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1411,13 +1414,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_56'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451056'),
+                    'minus_report_line_ids': [ref('tax_report_line_56')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1464,13 +1468,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_56'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451056'),
+                    'minus_report_line_ids': [ref('tax_report_line_56')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1517,13 +1522,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_56'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451056'),
+                    'minus_report_line_ids': [ref('tax_report_line_56')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1608,13 +1614,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_56'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451056'),
+                    'minus_report_line_ids': [ref('tax_report_line_56')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1661,13 +1668,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_56'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451056'),
+                    'minus_report_line_ids': [ref('tax_report_line_56')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1714,13 +1722,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_56'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451056'),
+                    'minus_report_line_ids': [ref('tax_report_line_56')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1860,13 +1869,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_55'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451055'),
+                    'minus_report_line_ids': [ref('tax_report_line_55')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1913,13 +1923,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_55'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451055'),
+                    'minus_report_line_ids': [ref('tax_report_line_55')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1966,13 +1977,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_55'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451055'),
+                    'minus_report_line_ids': [ref('tax_report_line_55')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2057,13 +2069,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_55'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451055'),
+                    'minus_report_line_ids': [ref('tax_report_line_55')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2110,13 +2123,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_55'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451055'),
+                    'minus_report_line_ids': [ref('tax_report_line_55')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2163,13 +2177,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_55'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451055'),
+                    'minus_report_line_ids': [ref('tax_report_line_55')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2216,13 +2231,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_55'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451055'),
+                    'minus_report_line_ids': [ref('tax_report_line_55')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2269,13 +2285,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_55'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451055'),
+                    'minus_report_line_ids': [ref('tax_report_line_55')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2322,13 +2339,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_55'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451055'),
+                    'minus_report_line_ids': [ref('tax_report_line_55')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2413,13 +2431,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_55'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451055'),
+                    'minus_report_line_ids': [ref('tax_report_line_55')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2504,13 +2523,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_55'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451055'),
+                    'minus_report_line_ids': [ref('tax_report_line_55')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2557,13 +2577,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_55'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451055'),
+                    'minus_report_line_ids': [ref('tax_report_line_55')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2647,13 +2668,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_57'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451057'),
+                    'minus_report_line_ids': [ref('tax_report_line_57')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2700,13 +2722,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_57'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451057'),
+                    'minus_report_line_ids': [ref('tax_report_line_57')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2753,13 +2776,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_57'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451057'),
+                    'minus_report_line_ids': [ref('tax_report_line_57')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2844,13 +2868,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_57'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451057'),
+                    'minus_report_line_ids': [ref('tax_report_line_57')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2897,13 +2922,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_57'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451057'),
+                    'minus_report_line_ids': [ref('tax_report_line_57')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2950,13 +2976,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_57'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451057'),
+                    'minus_report_line_ids': [ref('tax_report_line_57')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -3041,13 +3068,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_57'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451057'),
+                    'minus_report_line_ids': [ref('tax_report_line_57')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -3094,13 +3122,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_57'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451057'),
+                    'minus_report_line_ids': [ref('tax_report_line_57')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -3147,13 +3176,14 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('a411059'),
-                    'plus_report_line_ids': [ref('tax_report_line_57'), ref('tax_report_line_59')],
+                    'plus_report_line_ids': [ref('tax_report_line_59')],
                 }),
 
                 (0,0, {
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a451057'),
+                    'minus_report_line_ids': [ref('tax_report_line_57')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

This commit aims to make the "due and deduced" taxes more consistent by
assigning the "VAT due" tags to the "VAT due" repartition line.
This way the tag representing the due VAT will be set on the account
move line that represents the due VAT instead of the account move line
that represents the deductible VAT.

## Current behavior before PR:

Due VAT tags is assigned on VAT to deduce account_move_line.

## Desired behavior after PR is merged:

Due VAT tags is assigned to the due VAT account_move_line.

task: 2658974

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
