### PR TITLE
[FIX] stock: assign digits attribute to scrap_qty field

### DIFF
--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -4,6 +4,7 @@
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.tools import float_compare
+from odoo.addons import decimal_precision as dp
 
 
 class StockScrap(models.Model):
@@ -48,7 +49,7 @@ class StockScrap(models.Model):
     scrap_location_id = fields.Many2one(
         'stock.location', 'Scrap Location', default=_get_default_scrap_location_id,
         domain="[('scrap_location', '=', True)]", required=True, states={'done': [('readonly', True)]})
-    scrap_qty = fields.Float('Quantity', default=1.0, required=True, states={'done': [('readonly', True)]})
+    scrap_qty = fields.Float('Quantity', default=1.0, required=True, states={'done': [('readonly', True)]}, digits=dp.get_precision('Product Unit of Measure'))
     state = fields.Selection([
         ('draft', 'Draft'),
         ('done', 'Done')], string='Status', default="draft")


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

`scrap_qty` field is currently missing the digits attribute.

### Current behavior before PR:

Cannot create a scrap with a quantity with more than two decimal places.

### Desired behavior after PR is merged:

`scrap_qty` will follow the 'Product Unit of Measure' precision setting, just like any other quantity fields.

@qrtl

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
