### PR TITLE
[FIX] hr_attendance: fix missing context in kiosk mode

### DIFF
--- a/addons/hr_attendance/static/src/js/kiosk_confirm.js
+++ b/addons/hr_attendance/static/src/js/kiosk_confirm.js
@@ -6,6 +6,8 @@ var core = require('web.core');
 var field_utils = require('web.field_utils');
 var QWeb = core.qweb;
 
+const session = require('web.session');
+
 
 var KioskConfirm = AbstractAction.extend({
     events: {
@@ -16,6 +18,7 @@ var KioskConfirm = AbstractAction.extend({
                     model: 'hr.employee',
                     method: 'attendance_manual',
                     args: [[this.employee_id], this.next_action],
+                    context: session.user_context,
                 })
                 .then(function(result) {
                     if (result.action) {
@@ -43,6 +46,7 @@ var KioskConfirm = AbstractAction.extend({
                     model: 'hr.employee',
                     method: 'attendance_manual',
                     args: [[this.employee_id], this.next_action, this.$('.o_hr_attendance_PINbox').val()],
+                    context: session.user_context,
                 })
                 .then(function(result) {
                     if (result.action) {

--- a/addons/hr_attendance/static/src/js/my_attendances.js
+++ b/addons/hr_attendance/static/src/js/my_attendances.js
@@ -5,6 +5,7 @@ var AbstractAction = require('web.AbstractAction');
 var core = require('web.core');
 var field_utils = require('web.field_utils');
 
+const session = require('web.session');
 
 var MyAttendances = AbstractAction.extend({
     contentTemplate: 'HrAttendanceMyMainMenu',
@@ -21,6 +22,7 @@ var MyAttendances = AbstractAction.extend({
                 model: 'hr.employee',
                 method: 'search_read',
                 args: [[['user_id', '=', this.getSession().uid]], ['attendance_state', 'name', 'hours_today']],
+                context: session.user_context,
             })
             .then(function (res) {
                 self.employee = res.length && res[0];
@@ -38,6 +40,7 @@ var MyAttendances = AbstractAction.extend({
                 model: 'hr.employee',
                 method: 'attendance_manual',
                 args: [[self.employee.id], 'hr_attendance.hr_attendance_action_my_attendances'],
+                context: session.user_context,
             })
             .then(function(result) {
                 if (result.action) {


### PR DESCRIPTION
The context was missing from multiple RPC calls in the attendance's
kiosk modes resulting in the wrong employee being fetched for the
attendnace creation, all RPC calls related to attendances are now given
the context explicitely.

TaskId-2660772
