### PR TITLE
[ADD] mail: quick-open related record from message

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -691,6 +691,17 @@ class Message(models.Model):
             self.update(attachement_values)
         thread._message_update_content_after_hook(self)
 
+    def action_open_document(self):
+        """ Opens the related record based on the model and ID """
+        self.ensure_one()
+        return {
+            'res_id': self.res_id,
+            'res_model': self.model,
+            'target': 'current',
+            'type': 'ir.actions.act_window',
+            'view_mode': 'form',
+        }
+
     # ------------------------------------------------------
     # DISCUSS API
     # ------------------------------------------------------

--- a/addons/mail/views/mail_message_views.xml
+++ b/addons/mail/views/mail_message_views.xml
@@ -25,6 +25,11 @@
             <field name="arch" type="xml">
                 <form string="Message">
                     <sheet>
+                        <div class="oe_button_box" name="button_box">
+                            <button name="action_open_document" string="Open Document"
+                                type="object" class="oe_link" icon="fa-file-text-o"
+                                attrs="{'invisible': ['|', ('model', '=', False), ('res_id', '=', 0)]}"/>
+                        </div>
                         <group>
                             <group>
                                 <field name="subject"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:  allow quick opening a record based on the message.

Current behavior before PR: You have to find the right menu/view and then take over the ID stored on the message to find back the record. This is annoying, painful and errorprone

Desired behavior after PR is merged:
By adding a smartbutton the user can quick-navigate to the related record in a second.
This allows for quickly finding and opening records which is usually handy when debugging things.
Sample:
![image](https://user-images.githubusercontent.com/6352350/135813266-09103124-1dfe-4f17-936e-70e033d10706.png)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
