### PR TITLE
[IMP] New date_utils function added: next_weekday

### DIFF
--- a/addons/account/data/account_data.xml
+++ b/addons/account/data/account_data.xml
@@ -82,6 +82,12 @@
                     (0, 0, {'value': 'balance', 'value_amount': 0.0, 'sequence': 500, 'days': 60, 'option': 'day_after_invoice_date'})]"/>
         </record>
 
+        <record id="account_payment_term_next_thursday" model="account.payment.term">
+            <field name="name">Next week Thursday</field>
+            <field name="note">Payment terms: next Thursday</field>
+            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'balance', 'value_amount': 0.0, 'sequence': 500, 'days': 3, 'option': 'day_from_the_week_start', 'weeks_count': 1})]"/>
+        </record>
+
         <!--
         Account Statement Sequences
         -->

--- a/addons/account/views/account_payment_term_views.xml
+++ b/addons/account/views/account_payment_term_views.xml
@@ -13,6 +13,7 @@
                     <field name="days"/>
                     <field name="option" string=""/>
                     <field name="day_of_the_month" string="Day of the month"/>
+                    <field name="weeks_count" attrs="{'invisible': [('option', '!=', 'day_from_the_week_start')]}"/>
                 </tree>
             </field>
         </record>
@@ -52,6 +53,12 @@
                         <field name="day_of_the_month" class="oe_inline"/>
                         <span class="o_form_label">of the month</span>
                     </div>
+
+                    <div colspan="2" attrs="{'invisible': [('option','!=', 'day_from_the_week_start')]}">
+                        <label for="weeks_count" string="Weeks to be passed"/>
+                        <field name="weeks_count" class="oe_inline"/>
+                    </div>
+
                 </form>
             </field>
         </record>

--- a/doc/cla/individual/SkiBY.md
+++ b/doc/cla/individual/SkiBY.md
@@ -1,0 +1,9 @@
+Belarus, 2021-10-04
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Sergei Ruzki sergei.ruzki@gmail.com https://github.com/SkiBY

--- a/odoo/tools/date_utils.py
+++ b/odoo/tools/date_utils.py
@@ -252,3 +252,49 @@ def date_range(start, end, step=relativedelta(months=1)):
     while dt <= end:
         yield localize(dt)
         dt = dt + step
+
+
+
+WEEKDAYS_MAPPING = [
+    (0, 'M', 'MD', 'Monday'),
+    (1, 'T', 'TD', 'Tuesday'),
+    (2, 'W', 'WD', 'Wednesday'),
+    (3, 'R', 'TH', 'Thursday'),
+    (4, 'F', 'FR', 'Friday'),
+    (5, 'S', 'SA', 'Saturday'),
+    (6, 'U', 'SU', 'Sunday'),
+]
+
+
+def next_weekday(value, weekday, weeks_correction=1):
+    """
+    Return the next needed weekday from ``value``
+    I.e. if you need
+    "Next Week Friday" you should use
+    >> next_weekday(today, 4)
+    "Thursday in 2 weeks":
+    >> next_weekday(today, 'TH', 2)
+
+    :param value: initial date or datetime.
+    :param weekday: choice of
+        ['MD', 'TD', 'WD', 'TH', 'FR', 'SA', 'SU']
+        ['M', 'T', 'W', 'R', 'F', 'S', 'U']
+        [1, 2, 3, 4, 5, 6, 0]
+    :param weeks_correction: how many weeks we should pass. By default - one.
+    :return: the resulting date/datetime.
+    """
+
+    if isinstance(weekday, int):
+        tuple_index = 0
+    elif isinstance(weekday, str) and len(weekday) == 1:
+        tuple_index = 1
+    elif isinstance(weekday, str) and len(weekday) == 2:
+        tuple_index = 2
+    else:
+        raise ValueError("Wrong weekday definition!")
+    if weekday not in (x[tuple_index] for x in WEEKDAYS_MAPPING):
+        raise ValueError("Wrong weekday definition!")
+
+    weekday_tuple = next((x for x in WEEKDAYS_MAPPING if x[tuple_index] == weekday), 0)
+
+    return add(start_of(add(value, weeks=weeks_correction), 'week'), days=weekday_tuple[0])


### PR DESCRIPTION
New possibility in invoice payment terms added: weekday in N weeks after date

Description of the issue/feature this PR addresses:
In date_utils new functionality added: next_weekday(value, weekday, weeks_correction).
Functionality can be used in Invoice Payment Terms if we need term like "Next Friday" and in some other places in the future - planning in activities(auto), controlling, reports etc.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
