### PR TITLE
[IMP] Add SM Scope KPIs digests

### DIFF
--- a/addons/calendar/__manifest__.py
+++ b/addons/calendar/__manifest__.py
@@ -5,7 +5,7 @@
     'name': 'Calendar',
     'version': '1.1',
     'sequence': 165,
-    'depends': ['base', 'mail'],
+    'depends': ['base', 'digest', 'mail'],
     'summary': "Schedule employees' meetings",
     'description': """
 This is a full-featured calendar system.
@@ -26,10 +26,12 @@ If you need to manage your meetings, you should install the CRM module.
         'security/ir.model.access.csv',
         'security/calendar_security.xml',
         'data/calendar_cron.xml',
+        'data/digest_data.xml',
         'data/mail_template_data.xml',
         'data/calendar_data.xml',
         'data/mail_activity_type_data.xml',
         'data/mail_message_subtype_data.xml',
+        'views/digest_views.xml',
         'views/mail_activity_views.xml',
         'views/calendar_templates.xml',
         'views/calendar_views.xml',

--- a/addons/calendar/data/digest_data.xml
+++ b/addons/calendar/data/digest_data.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="digest.digest_digest_default" model="digest.digest">
+            <field name="kpi_nbr_of_meetings_booked">True</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/calendar/models/__init__.py
+++ b/addons/calendar/models/__init__.py
@@ -10,6 +10,7 @@ from . import calendar_attendee
 from . import calendar_filter
 from . import calendar_event_type
 from . import calendar_recurrence
+from . import digest
 from . import mail_activity
 from . import mail_activity_mixin
 from . import mail_activity_type

--- a/addons/calendar/models/digest.py
+++ b/addons/calendar/models/digest.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class Digest(models.Model):
+    _inherit = 'digest.digest'
+
+    kpi_nbr_of_meetings_booked = fields.Boolean('# Meetings Booked')
+    kpi_nbr_of_meetings_booked_value = fields.Integer(compute='_compute_kpi_nbr_of_meetings_booked_value')
+
+    def _compute_kpi_nbr_of_meetings_booked_value(self):
+        for record in self:
+            start, end, _ = record._get_kpi_compute_parameters()
+            record.kpi_nbr_of_meetings_booked_value = self.env['calendar.event'].search_count([
+                ('create_date', '>=', start),
+                ('create_date', '<', end)
+            ])

--- a/addons/calendar/views/digest_views.xml
+++ b/addons/calendar/views/digest_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="digest_digest_view_form" model="ir.ui.view">
+        <field name="name">digest.digest.view.form.inherit.calendar.event</field>
+        <field name="model">digest.digest</field>
+        <field name="inherit_id" ref="digest.digest_digest_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='kpi_general']" position="after">
+                <group name="kpi_calendar" string="Calendar">
+                    <field name="kpi_nbr_of_meetings_booked"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/digest/__manifest__.py
+++ b/addons/digest/__manifest__.py
@@ -19,6 +19,7 @@ Send KPI Digests periodically
         'data/digest_tips_data.xml',
         'data/ir_cron_data.xml',
         'data/res_config_settings_data.xml',
+        'wizard/digest_preview_views.xml',
         'views/digest_views.xml',
         'views/digest_templates.xml',
         'views/res_config_settings_views.xml',

--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -143,7 +143,7 @@ class Digest(models.Model):
         for digest in to_slowdown:
             digest.periodicity = digest._get_next_periodicity()[0]
 
-    def _action_send_to_user(self, user, tips_count=1, consume_tips=True):
+    def _action_send_to_user(self, user, tips_count=1, consume_tips=True, force_send=False):
         unsubscribe_token = self._get_unsubscribe_token(user.id)
 
         rendered_body = self.env['mail.render.mixin']._render_template(
@@ -198,7 +198,9 @@ class Digest(models.Model):
             'state': 'outgoing',
             'subject': '%s: %s' % (user.company_id.name, self.name),
         }
-        self.env['mail.mail'].sudo().create(mail_values)
+        mail = self.env['mail.mail'].sudo().create(mail_values)
+        if force_send:
+            mail.send()
         return True
 
     @api.model

--- a/addons/digest/security/ir.model.access.csv
+++ b/addons/digest/security/ir.model.access.csv
@@ -1,5 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_digest_digest_system,digest.digest.administration,model_digest_digest,base.group_erp_manager,1,1,1,1
+access_digest_digest_preview,digest.digest.preview.administration,model_digest_digest_preview,base.group_erp_manager,1,1,1,0
 access_digest_digest_user,digest.digest.user,model_digest_digest,base.group_user,1,0,0,0
 access_digest_tip_system,digest.tip.administration,model_digest_tip,base.group_erp_manager,1,1,1,1
 access_digest_tip_user,digest.tip.user,model_digest_tip,base.group_user,1,0,0,0

--- a/addons/digest/views/digest_views.xml
+++ b/addons/digest/views/digest_views.xml
@@ -28,6 +28,7 @@
                     <button type="object" name="action_activate" string="Activate"
                         class="oe_highlight"
                         attrs="{'invisible': [('state','=','activated')]}" groups="base.group_system"/>
+                    <button type="action" name="%(action_open_digest_preview_wizard)d" string="Test" class="btn-secondary"/>
                     <field name="state" widget="statusbar" statusbar_visible="0"/>
                 </header>
                 <sheet>

--- a/addons/digest/wizard/__init__.py
+++ b/addons/digest/wizard/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import controllers
-from . import models
-from . import wizard
+from . import digest_preview

--- a/addons/digest/wizard/digest_preview.py
+++ b/addons/digest/wizard/digest_preview.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, tools
+
+
+class DigestPreview(models.TransientModel):
+    _name = 'digest.digest.preview'
+    _description = 'Digest Mail Preview Wizard'
+
+    digest_id = fields.Many2one('digest.digest', string='Digest', required=True, ondelete='cascade')
+    email_to = fields.Text(string='Recipients', required=True,
+        help='Carriage-return-separated list of email addresses.', default=lambda self: self.env.user.email_formatted)
+
+    def send_digest_preview(self):
+        self.ensure_one()
+
+        valid_emails = []
+        for candidate in self.email_to.splitlines():
+            parts = tools.email_split(candidate)
+            if parts:
+                valid_emails.append(parts[0])
+
+        users = self.env['res.users'].search([
+            ('partner_id.email_normalized', 'in', valid_emails)
+        ])
+
+        for user in users:
+            self.digest_id._action_send_to_user(user, consume_tips=False, force_send=True)

--- a/addons/digest/wizard/digest_preview_views.xml
+++ b/addons/digest/wizard/digest_preview_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="digest_digest_preview_view_form" model="ir.ui.view">
+        <field name="name">digest.digest.preview.form</field>
+        <field name="model">digest.digest.preview</field>
+        <field name="arch" type="xml">
+            <form string="Send a Digest Preview">
+                <p class="text-muted">Send a digest preview for testing purpose to the address below.</p>
+                <group>
+                    <field name="email_to" placeholder="email1@example.com&#10;email2@example.com"/>
+                </group>
+                <footer>
+                    <button string="Send" name="send_digest_preview" type="object" class="btn-primary" data-hotkey="q"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="z"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+    <record id="action_open_digest_preview_wizard" model="ir.actions.act_window">
+        <field name="name">Test Digest</field>
+        <field name="res_model">digest.digest.preview</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="context">{
+            'default_digest_id': active_id,
+            'dialog_size': 'medium',
+        }</field>
+    </record>
+</odoo>

--- a/addons/event/__manifest__.py
+++ b/addons/event/__manifest__.py
@@ -17,10 +17,11 @@ Key Features
 * Manage your Events and Registrations
 * Use emails to automatically confirm and send acknowledgments for any event registration
 """,
-    'depends': ['base_setup', 'mail', 'portal', 'utm'],
+    'depends': ['base_setup', 'digest', 'mail', 'portal', 'utm'],
     'data': [
         'security/event_security.xml',
         'security/ir.model.access.csv',
+        'views/digest_views.xml',
         'views/event_menu_views.xml',
         'views/event_ticket_views.xml',
         'views/event_mail_views.xml',
@@ -30,6 +31,7 @@ Key Features
         'views/event_stage_views.xml',
         'report/event_event_templates.xml',
         'report/event_event_reports.xml',
+        'data/digest_data.xml',
         'data/ir_cron_data.xml',
         'data/mail_template_data.xml',
         'data/event_data.xml',

--- a/addons/event/data/digest_data.xml
+++ b/addons/event/data/digest_data.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="digest.digest_digest_default" model="digest.digest">
+            <field name="kpi_nbr_of_registrations">True</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/event/models/__init__.py
+++ b/addons/event/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import digest
 from . import event_event
 from . import event_mail
 from . import event_registration

--- a/addons/event/models/digest.py
+++ b/addons/event/models/digest.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class Digest(models.Model):
+    _inherit = 'digest.digest'
+
+    kpi_nbr_of_registrations = fields.Boolean('# Registrations')
+    kpi_nbr_of_registrations_value = fields.Integer(compute='_compute_kpi_nbr_of_registrations_value')
+
+    def _compute_kpi_nbr_of_registrations_value(self):
+        for record in self:
+            start, end, company = record._get_kpi_compute_parameters()
+            record.kpi_nbr_of_registrations_value = self.env['event.registration'].search_count([
+                ('create_date', '>=', start),
+                ('create_date', '<', end),
+                ('company_id', '=', company.id)
+            ])
+
+    def _compute_kpis_actions(self, company, user):
+        res = super(Digest, self)._compute_kpis_actions(company, user)
+        res['kpi_nbr_of_registrations'] = 'event.action_registration'
+        return res

--- a/addons/event/views/digest_views.xml
+++ b/addons/event/views/digest_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="digest_digest_view_form" model="ir.ui.view">
+        <field name="name">digest.digest.view.form.inherit.event.registration</field>
+        <field name="model">digest.digest</field>
+        <field name="inherit_id" ref="digest.digest_digest_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='kpi_general']" position="after">
+                <group name="kpi_event" string="Event">
+                    <field name="kpi_nbr_of_registrations"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/survey/__manifest__.py
+++ b/addons/survey/__manifest__.py
@@ -18,6 +18,7 @@ sent mails with personal token for the invitation of the survey.
     'website': 'https://www.odoo.com/app/surveys',
     'depends': [
         'auth_signup',
+        'digest',
         'http_routing',
         'mail',
         'web_tour',
@@ -25,9 +26,11 @@ sent mails with personal token for the invitation of the survey.
     'data': [
         'views/survey_report_templates.xml',
         'views/survey_reports.xml',
+        'data/digest_data.xml',
         'data/mail_template_data.xml',
         'security/survey_security.xml',
         'security/ir.model.access.csv',
+        'views/digest_views.xml',
         'views/survey_menus.xml',
         'views/survey_survey_views.xml',
         'views/survey_user_views.xml',

--- a/addons/survey/data/digest_data.xml
+++ b/addons/survey/data/digest_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="digest.digest_digest_default" model="digest.digest">
+            <field name="kpi_nbr_of_answers">True</field>
+            <field name="kpi_nbr_of_certified_participants">True</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/survey/models/__init__.py
+++ b/addons/survey/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import digest
 from . import survey_survey
 from . import survey_survey_template
 from . import survey_question

--- a/addons/survey/models/digest.py
+++ b/addons/survey/models/digest.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class Digest(models.Model):
+    _inherit = 'digest.digest'
+
+    kpi_nbr_of_answers = fields.Boolean('# Answers')
+    kpi_nbr_of_answers_value = fields.Integer(compute='_compute_kpi_nbr_of_answers_value')
+    kpi_nbr_of_certified_participants = fields.Boolean('# Certified Participants')
+    kpi_nbr_of_certified_participants_value = fields.Integer(
+        compute='_compute_kpi_nbr_of_certified_participants_value'
+    )
+
+    def _compute_kpi_nbr_of_answers_value(self):
+        for record in self:
+            start, end, _ = record._get_kpi_compute_parameters()
+            record.kpi_nbr_of_answers_value = self.env['survey.user_input'].search_count([
+                ('create_date', '>=', start),
+                ('create_date', '<', end)
+            ])
+
+    def _compute_kpi_nbr_of_certified_participants_value(self):
+        for record in self:
+            start, end, _ = record._get_kpi_compute_parameters()
+            record.kpi_nbr_of_certified_participants_value = self.env['survey.user_input'].search_count([
+                ('end_datetime', '>=', start),
+                ('end_datetime', '<', end),
+                ('scoring_success', '=', True),
+                ('survey_id.certification', '=', True),
+            ])
+
+    def _compute_kpis_actions(self, company, user):
+        res = super(Digest, self)._compute_kpis_actions(company, user)
+        res['kpi_nbr_of_answers'] = 'survey.action_survey_user_input'
+        res['kpi_nbr_of_certified_participants'] = 'survey.action_show_certified_participants'
+        return res

--- a/addons/survey/views/digest_views.xml
+++ b/addons/survey/views/digest_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="digest_digest_view_form" model="ir.ui.view">
+        <field name="name">digest.digest.view.form.inherit.survey.user_input</field>
+        <field name="model">digest.digest</field>
+        <field name="inherit_id" ref="digest.digest_digest_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='kpi_general']" position="after">
+                <group name="kpi_survey" string="Survey">
+                    <field name="kpi_nbr_of_answers"/>
+                    <field name="kpi_nbr_of_certified_participants"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/survey/views/survey_user_views.xml
+++ b/addons/survey/views/survey_user_views.xml
@@ -19,6 +19,7 @@
                 <separator/>
                 <filter string="Quizz passed" name="scoring_success" domain="[('scoring_success','=', True)]"/>
                 <separator/>
+                <filter string="Certification" name="certification" domain="[('survey_id.certification', '=', True)]"/>
                 <filter string="Tests Only" name="test" domain="[('test_entry','=', True)]"/>
                 <filter string="Exclude Tests" name="not_test" domain="[('test_entry','=', False)]"/>
                 <group expand="0" string="Group By">
@@ -176,6 +177,26 @@
         <field name="view_id" ref="survey_user_input_view_tree"></field>
         <field name="search_view_id" ref="survey_user_input_view_search"/>
         <field name="context">{'search_default_group_by_survey': True}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_empty_folder">
+                No answers yet!
+            </p><p>
+                You can share your links through different means: email, invite shortcut, live presentation, ...
+            </p>
+        </field>
+    </record>
+
+    <record id="action_show_certified_participants" model="ir.actions.act_window">
+        <field name="name">Certified Participants</field>
+        <field name="res_model">survey.user_input</field>
+        <field name="view_mode">tree,kanban,form</field>
+        <field name="view_id" ref="survey_user_input_view_tree"></field>
+        <field name="search_view_id" ref="survey_user_input_view_search"/>
+        <field name="context">{
+            'search_default_group_by_survey': 1,
+            'search_default_scoring_success': 1,
+            'search_default_certification': 1
+        }</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
                 No answers yet!

--- a/addons/website_slides/__manifest__.py
+++ b/addons/website_slides/__manifest__.py
@@ -20,6 +20,7 @@ Featuring
  * Statistics
 """,
     'depends': [
+        'digest',
         'portal_rating',
         'website',
         'website_mail',
@@ -28,6 +29,7 @@ Featuring
     'data': [
         'security/website_slides_security.xml',
         'security/ir.model.access.csv',
+        'views/digest_views.xml',
         'views/res_config_settings_views.xml',
         'views/res_partner_views.xml',
         'views/rating_rating_views.xml',
@@ -50,6 +52,7 @@ Featuring
         'views/website_pages_views.xml',
         'views/slide_channel_add.xml',
         'wizard/slide_channel_invite_views.xml',
+        'data/digest_data.xml',
         'data/gamification_data.xml',
         'data/mail_activity_type_data.xml',
         'data/mail_message_subtype_data.xml',

--- a/addons/website_slides/data/digest_data.xml
+++ b/addons/website_slides/data/digest_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="digest.digest_digest_default" model="digest.digest">
+            <field name="kpi_nbr_of_new_attendees">True</field>
+            <field name="kpi_nbr_of_graduated_attendees">True</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/website_slides/models/__init__.py
+++ b/addons/website_slides/models/__init__.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import digest
 from . import gamification_challenge
 from . import slide_slide
 from . import slide_question

--- a/addons/website_slides/models/digest.py
+++ b/addons/website_slides/models/digest.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class Digest(models.Model):
+    _inherit = 'digest.digest'
+
+    kpi_nbr_of_graduated_attendees = fields.Boolean('# Graduated Attendees')
+    kpi_nbr_of_graduated_attendees_value = fields.Integer(
+        compute='_compute_kpi_nbr_of_graduated_attendees_value'
+    )
+    kpi_nbr_of_new_attendees = fields.Boolean('# New Attendees')
+    kpi_nbr_of_new_attendees_value = fields.Integer(compute='_compute_kpi_nbr_of_new_attendees_value')
+
+    def _compute_kpi_nbr_of_graduated_attendees_value(self):
+        for record in self:
+            start, end, _ = record._get_kpi_compute_parameters()
+            record.kpi_nbr_of_graduated_attendees_value = self.env['slide.channel.partner'].search_count([
+                ('completion_date', '>=', start),
+                ('completion_date', '<', end)
+            ])
+
+    def _compute_kpi_nbr_of_new_attendees_value(self):
+        for record in self:
+            start, end, _ = record._get_kpi_compute_parameters()
+            record.kpi_nbr_of_new_attendees_value = self.env['slide.channel.partner'].search_count([
+                ('create_date', '>=', start),
+                ('create_date', '<', end)
+            ])
+
+    def _compute_kpis_actions(self, company, user):
+        res = super(Digest, self)._compute_kpis_actions(company, user)
+        res['kpi_nbr_of_new_attendees'] = 'website_slides.slide_channel_partner_action_report'
+        res['kpi_nbr_of_graduated_attendees'] = 'website_slides.action_show_graduated_attendees'
+        return res

--- a/addons/website_slides/views/digest_views.xml
+++ b/addons/website_slides/views/digest_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="digest_digest_view_form" model="ir.ui.view">
+        <field name="name">digest.digest.view.form.inherit.slide.channel.partner</field>
+        <field name="model">digest.digest</field>
+        <field name="inherit_id" ref="digest.digest_digest_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='kpi_general']" position="after">
+                <group name="kpi_elearning" string="eLearning">
+                    <field name="kpi_nbr_of_new_attendees"/>
+                    <field name="kpi_nbr_of_graduated_attendees"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/website_slides/views/slide_channel_partner_views.xml
+++ b/addons/website_slides/views/slide_channel_partner_views.xml
@@ -94,7 +94,7 @@
             <field name="res_model">slide.channel.partner</field>
             <field name="view_mode">tree,form,kanban</field>
             <field name="search_view_id" ref="website_slides.slide_channel_partner_view_search"/>
-            <field name="context">{'search_default_groupby_channel': 1}</field>
+            <field name="context">{'search_default_groupby_channel_id': 1}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     <strong>No Attendees Yet!</strong>

--- a/addons/website_slides/views/slide_channel_partner_views.xml
+++ b/addons/website_slides/views/slide_channel_partner_views.xml
@@ -105,5 +105,23 @@
             </field>
         </record>
 
+        <record id="action_show_graduated_attendees" model="ir.actions.act_window">
+            <field name="name">Graduated Attendees</field>
+            <field name="res_model">slide.channel.partner</field>
+            <field name="view_mode">tree,form,kanban</field>
+            <field name="search_view_id" ref="website_slides.slide_channel_partner_view_search"/>
+            <field name="context">{
+                'search_default_groupby_channel_id': 1,
+                'search_default_filter_completed': 1,
+            }</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    <strong>No Attendees Yet!</strong>
+                </p>
+                <p>
+                    From here you'll be able to monitor attendees and to track their progress.
+                </p>
+            </field>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
This PR will add a few digests for the `appointment`, `event`, `survey` and `eLearning` modules. These digests will provide some statistics about the performance of the company (KPIs).

Here is the exhaustive list of new statistics that will be added:

`appointment`:
- Number of meeting booked over the last 24h / 7 days / 30 days

`event`:
- Number of registrations over the last 24h / 7 days / 30 days

`survey`:
- Number of answers over the last 24h / 7 days / 30 days
- Number of certified participants over the last 24h / 7 days / 30 days

`eLearning`:
- Number of new attendees over the last 24h / 7 days / 30 days
- Number of graduated attendees over the last 24h / 7 days / 30 days

This PR will also add a new button on the settings to allow the user to send a preview of the digest by email to one or several email addresses.

task-2647241

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
