### PR TITLE
[FIX] mail: remove the dataChannel entry when removing a peer.

### DIFF
--- a/addons/mail/static/src/models/rtc/rtc.js
+++ b/addons/mail/static/src/models/rtc/rtc.js
@@ -765,9 +765,12 @@ function factory(dependencies) {
             if (rtcSession) {
                 rtcSession.reset();
             }
-            const peerConnection = this._peerConnections[token];
             const dataChannel = this._dataChannels[token];
-            dataChannel.close();
+            if (dataChannel) {
+                dataChannel.close();
+            }
+            delete this._dataChannels[token];
+            const peerConnection = this._peerConnections[token];
             if (peerConnection) {
                 this._removeRemoteTracks(peerConnection);
                 peerConnection.close();


### PR DESCRIPTION
Before this commit, the entry in `mailRtc._dataChannels` was not removed
when removing a peer, which meant that `mailRtc._dataChannels` could
contain old closed dataChannels. Moreover, the call to `close()` on the
dataChannel was not guarded, which could lead to tracebacks.

For example, if a peer was removed before creating its dataChannel (like
in crashes or successive connection recovery attempts), `close()` was
called on `undefined`.

this commit fixes this issue.
