### PR TITLE
[FIX] mail: do not crash when sending notification with a False subject

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2258,7 +2258,7 @@ class MailThread(models.AbstractModel):
 
         mail_subject = message.subject or (message.record_name and 'Re: %s' % message.record_name) # in cache, no queries
         # Replace new lines by spaces to conform to email headers requirements
-        mail_subject = ' '.join(mail_subject.splitlines())
+        mail_subject = ' '.join((mail_subject or '').splitlines())
         # prepare notification mail values
         base_mail_values = {
             'mail_message_id': message.id,


### PR DESCRIPTION
Followup of odoo/odoo@a794a482009cea440a11ee60e195b75b46ec27eb
