### PR TITLE
[FIX] hr_timesheet: allow specific user to preview invoice

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -135,6 +135,9 @@ class AccountAnalyticLine(models.Model):
         return etree.tostring(doc, encoding='unicode')
 
     def _timesheet_get_portal_domain(self):
+        if self.env.user.has_group('hr_timesheet.group_hr_timesheet_user'):
+            # Then, he is internal user, and we take the domain for this current user
+            return self.env['ir.rule']._compute_domain(self._name)
         return ['&',
                     '|', '|', '|',
                     ('task_id.project_id.message_partner_ids', 'child_of', [self.env.user.partner_id.commercial_partner_id.id]),


### PR DESCRIPTION
How to reproduce the problem:
- Go to Settings -> Users -> choose any user (example Laurie Poiret)
- Note the ID of the res.user (example ID = 8)
- Go to Contacts -> open the contact with that same ID.
- Set that user as a company if not already one.
- Go back to Settings -> Users
- Open the related partner to the concerned user (visible in debug mode)
- Set the parent company of that user as the contact modified before
(contact with the ID = 8, in our example)
- Log in with that user.
- Go to Accounting -> Invoices -> open any invoice
- Click on the preview button -> it will load forever.

Cause of the problem : the system loops on a wrongly configured domain

Solution : the system uses another domain for internal users.
(fix inspired from
https://github.com/odoo/odoo/commit/3378ca8252d3ac0e22a8aa1632ffc436864b26b7)

opw-2543174