### PR TITLE
[FIX] web_editor: properly display the state of list in the toolbar

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1422,6 +1422,7 @@ export class OdooEditor extends EventTarget {
             }
         }
         this.updateColorpickerLabels();
+        const listUIClasses = {UL: 'fa-list-ul', OL: 'fa-list-ol', CL: 'fa-tasks'};
         const block = closestBlock(sel.anchorNode);
         for (const [style, tag, isList] of [
             ['paragraph', 'P', false],
@@ -1446,6 +1447,15 @@ export class OdooEditor extends EventTarget {
                     : block.tagName === tag;
                 button.classList.toggle('active', isActive);
             }
+        }
+        const listMode = getListMode(block.parentElement);
+        const listDropdownButton = this.toolbar.querySelector('#listDropdownButton');
+        if (listDropdownButton) {
+            if (listMode) {
+                listDropdownButton.classList.remove('fa-list-ul', 'fa-list-ol', 'fa-tasks');
+                listDropdownButton.classList.add(listUIClasses[listMode]);
+            }
+            listDropdownButton.closest('button').classList.toggle('active', block.tagName === 'LI');
         }
         const linkNode = getInSelection(this.document, 'a');
         const linkButton = this.toolbar.querySelector('#createLink');

--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -118,7 +118,7 @@
                 <button type="button" class="btn dropdown-toggle"
                     data-toggle="dropdown" title="Toggle List" tabindex="-1"
                     data-original-title="List" aria-expanded="false">
-                    <i id="justifyDropdownButton" class="fa fa-list-ul fa-fw"></i>
+                    <i id="listDropdownButton" class="fa fa-list-ul fa-fw"></i>
                 </button>
                 <div class="dropdown-menu">
                     <div class="btn-group">


### PR DESCRIPTION
When selecting text in a list, the toolbar should show that a list is selected, and which type. It however failed to do that, which is fixed with this commit.

task-2638422

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
