### PR TITLE
[IMP] mail: updated attachment design to display file size

### DIFF
--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -57,6 +57,7 @@ class IrAttachment(models.Model):
                 'filename': attachment.name,
                 'name': attachment.name,
                 'mimetype': 'application/octet-stream' if safari and attachment.mimetype and 'video' in attachment.mimetype else attachment.mimetype,
+                'size': attachment.file_size,
             }
             if commands:
                 res['originThread'] = [('insert', {

--- a/addons/mail/static/src/components/attachment_card/attachment_card.scss
+++ b/addons/mail/static/src/components/attachment_card/attachment_card.scss
@@ -52,7 +52,8 @@
 // ------------------------------------------------------------------
 
 .o_AttachmentCard.o-has-card-details {
-    background-color: gray('300');
+    max-width: 300px;
+    background-color: gray('200');
     border-radius: 5px;
 }
 
@@ -90,7 +91,7 @@
     color: $o-brand-primary;
 }
 
-.o_AttachmentCard_extension {
+.o_AttachmentCard_detailsItem {
     font-size: 80%;
     font-weight: 400;
 }

--- a/addons/mail/static/src/components/attachment_card/attachment_card.xml
+++ b/addons/mail/static/src/components/attachment_card/attachment_card.xml
@@ -12,24 +12,32 @@
                 >
                     <!-- Image style-->
                     <!-- o_image from mimetype.scss -->
-                    <div class="o_AttachmentCard_image o_image" t-on-click="attachmentCard.onClickImage" t-att-class="{'o-attachment-viewable': attachmentCard.attachment.isViewable,}" t-att-data-mimetype="attachmentCard.attachment.mimetype">
+                    <div class="o_AttachmentCard_image o_image m-2" t-on-click="attachmentCard.onClickImage" t-att-class="{'o-attachment-viewable': attachmentCard.attachment.isViewable,}" t-att-data-mimetype="attachmentCard.attachment.mimetype">
                     </div>
                     <!-- Attachment details -->
-                    <div class="o_AttachmentCard_details d-flex justify-content-center">
+                    <div class="o_AttachmentCard_details d-flex m-2 justify-content-center">
                         <t t-if="attachmentCard.attachment.displayName">
                             <div class="o_AttachmentCard_filename overflow-hidden text-nowrap">
                                 <t t-esc="attachmentCard.attachment.displayName"/>
                             </div>
                         </t>
-                        <t t-if="attachmentCard.attachment.extension">
-                            <div class="o_AttachmentCard_extension text-uppercase">
-                                <t t-esc="attachmentCard.attachment.extension"/>
-                            </div>
-                        </t>
+                        <div class="d-flex mx-1">
+                            <t t-if="attachmentCard.attachment.extension">
+                                <div class="o_AttachmentCard_extension o_AttachmentCard_detailsItem text-uppercase">
+                                    <t t-esc="attachmentCard.attachment.extension"/>
+                                </div>
+                            </t>
+                            <div t-if="attachmentCard.attachment.extension and attachmentCard.attachment.size" class="o_AttachmentCard_detailsItem mx-1">-</div>
+                            <t t-if="attachmentCard.attachment.size">
+                                <div class="o_AttachmentCard_formattedSize o_AttachmentCard_detailsItem text-uppercase">
+                                    <t t-esc="attachmentCard.attachment.formattedSize"/>
+                                </div>
+                            </t>
+                        </div>
                     </div>
                     <!-- Attachment aside -->
                     <t t-if="(!attachmentCard.attachmentList.composerView or attachmentCard.attachment.isEditable)">
-                        <div class="o_AttachmentCard_aside position-relative overflow-hidden" t-att-class="{ 'o-has-multiple-action d-flex flex-column': !attachmentCard.attachmentList.composerView and attachmentCard.attachment.isEditable }">
+                        <div class="o_AttachmentCard_aside position-relative ml-2 overflow-hidden fa-lg" t-att-class="{ 'o-has-multiple-action d-flex flex-column': !attachmentCard.attachmentList.composerView and attachmentCard.attachment.isEditable }">
                             <!-- Uploading icon -->
                             <t t-if="attachmentCard.attachment.isUploading and attachmentCard.attachmentList.composerView">
                                 <div class="o_AttachmentCard_asideItem o_AttachmentCard_asideItemUploading d-flex justify-content-center align-items-center" title="Uploading">

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -3,6 +3,7 @@
 import { registerNewModel } from '@mail/model/model_core';
 import { attr, many2many, many2one, one2many } from '@mail/model/model_field';
 import { clear, insert } from '@mail/model/model_field_command';
+import { human_size } from '@web/core/utils/sizes';
 
 function factory(dependencies) {
 
@@ -49,6 +50,9 @@ function factory(dependencies) {
             }
             if ('originThread' in data) {
                 data2.originThread = data.originThread;
+            }
+            if ('size' in data) {
+                data2.size = data.size;
             }
             return data2;
         }
@@ -152,14 +156,27 @@ function factory(dependencies) {
 
         /**
          * @private
-         * @returns {string|undefined}
+         * @returns {string}
          */
         _computeExtension() {
-            const extension = this.filename && this.filename.split('.').pop();
-            if (extension) {
-                return extension;
+            if (this.filename && this.filename.includes('.')){
+                const extension = this.filename.split('.').pop();
+                if (extension) {
+                    return extension;
+                }
             }
             return clear();
+        }
+
+        /**
+         * @private
+         * @returns {string}
+         */
+        _computeFormattedSize() {
+            if (!this.size) {
+                return clear();
+            }
+            return human_size(this.size);
         }
 
         /**
@@ -339,6 +356,12 @@ function factory(dependencies) {
             compute: '_computeExtension',
         }),
         filename: attr(),
+        /**
+         * States a human-way to display the size of the attachment (e.g. 5 kb).
+         */
+        formattedSize: attr({
+            compute: '_computeFormattedSize',
+        }),
         id: attr({
             readonly: true,
             required: true,

--- a/addons/web/static/src/core/utils/sizes.js
+++ b/addons/web/static/src/core/utils/sizes.js
@@ -1,0 +1,21 @@
+/** @odoo-module */
+
+/**
+ * Returns a human readable size
+ * e.g. 167 => 167 Bytes and 1311 => 1.28 Kb
+ *
+ * @param {Number} size value in Bytes
+ */
+export function human_size(size) {
+    const units = [ '%s Bytes', '%s Kb', '%s Mb', '%s Gb', '%s Tb' ];
+    let i = 0;
+    while (size >= 1024 && i < units.length - 1) {
+        size /= 1024;
+        ++i;
+    }
+    return _.str.sprintf(
+        units[i],
+        Number.isInteger(size) ? size : size.toFixed(2)
+    );
+}
+    


### PR DESCRIPTION
This commit improves the attachment design in the chatter. Increased padding and visibility of file size if available

Description of the issue/feature this PR addresses:
https://www.odoo.com/my/task/2377947

Current behavior before PR:
Attachments are packed and have a small padding. The file size is not displayed

Desired behavior after PR is merged:
Attachments have more padding and space inside. It is also possible to view file size next to the file type when available


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
