### PR TITLE
[FIX] lunch: Fixed e-mail sent at wrong time

### DIFF
--- a/addons/lunch/models/lunch_supplier.py
+++ b/addons/lunch/models/lunch_supplier.py
@@ -15,17 +15,14 @@ from odoo.addons.base.models.res_partner import _tz_get
 
 WEEKDAY_TO_NAME = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
 
-def float_to_time(hours, moment='am', tz=None):
+def float_to_time(hours, moment='am'):
     """ Convert a number of hours into a time object. """
     if hours == 12.0 and moment == 'pm':
         return time.max
     fractional, integral = math.modf(hours)
     if moment == 'pm':
         integral += 12
-    res = time(int(integral), int(float_round(60 * fractional, precision_digits=0)), 0)
-    if tz:
-        res = res.replace(tzinfo=pytz.timezone(tz))
-    return res
+    return time(int(integral), int(float_round(60 * fractional, precision_digits=0)), 0)
 
 def time_to_float(t):
     return float_round(t.hour + t.minute/60 + t.second/3600, precision_digits=2)
@@ -122,9 +119,10 @@ class LunchSupplier(models.Model):
         records = self.search([('send_by', '=', 'mail')])
 
         for supplier in records:
-            send_at = datetime.combine(fields.Date.today(),
-                                       float_to_time(supplier.automatic_email_time, supplier.moment, supplier.tz)).astimezone(pytz.UTC).replace(tzinfo=None)
-            if supplier.available_today and fields.Datetime.now() > send_at:
+            hours = float_to_time(supplier.automatic_email_time, supplier.moment)
+            date_tz = pytz.timezone(supplier.tz).localize(datetime.combine(fields.Date.today(), hours))
+            date_utc = date_tz.astimezone(pytz.UTC).replace(tzinfo=None)
+            if supplier.available_today and fields.Datetime.now() > date_utc:
                 lines = self.env['lunch.order'].search([('supplier_id', '=', supplier.id),
                                                              ('state', '=', 'ordered'), ('date', '=', fields.Date.today())])
 

--- a/addons/lunch/views/lunch_supplier_views.xml
+++ b/addons/lunch/views/lunch_supplier_views.xml
@@ -46,7 +46,6 @@
                     </group>
                     <group>
                         <group string="Availability">
-                            <field name="tz" groups="base.group_no_one"/>
                             <field name="recurrency_monday"/>
                             <field name="recurrency_tuesday"/>
                             <field name="recurrency_wednesday"/>
@@ -62,6 +61,7 @@
                             <field name="send_by" widget="radio"/>
                             <label for="automatic_email_time" attrs="{'invisible': [('send_by', '!=', 'mail')]}"/>
                             <div class="o_row" attrs="{'invisible': [('send_by', '!=', 'mail')]}"><field name="automatic_email_time" widget="float_time"/> <field name="moment"/></div>
+                            <field name="tz" groups="base.group_no_one"/>
                         </group>
                     </group>
                 </sheet>


### PR DESCRIPTION
Steps:
- Set a supplier's 'Timezone' at a different timezone from utc.
- Set 'Send Order By: Email' and set any 'Order Time'.

Result:
  E-mail will be sent at wrong time.

Explanation:
  According to pytz, using tzinfo arg in the standard datetime constructor "does not work" in combination with pytz. Yet lunch_supplier.float_to_time() calls time.replace() which calls this constructor.

Solution:
  Don't allow lunch_supplier.float_to_time() to modify tzinfo and use pytz.localize() in _auto_email_send() to specify the right tzinfo.

opw-2541132

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
