### PR TITLE
[FIX] web: company_menu menu always shown by default (in community)

### DIFF
--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
@@ -40,11 +40,11 @@ export class SwitchCompanyMenu extends Component {
 SwitchCompanyMenu.template = "web.SwitchCompanyMenu";
 SwitchCompanyMenu.toggleDelay = 1000;
 
-const systrayItem = {
+export const systrayItem = {
     Component: SwitchCompanyMenu,
     isDisplayed(env) {
         const { availableCompanies } = env.services.company;
-        return Object.keys(availableCompanies).length > 1 && !env.isSmall;
+        return Object.keys(availableCompanies).length > 1;
     },
 };
 


### PR DESCRIPTION
Before: the company menu would disapear when the screen was smaller than
some threshold. It is expected in enterprise, but not in community as
it doesn't have the burger menu.

After: The menu is set to always be displayed. To remove it becomes
an enterprise reponsability.

Enterprise: https://github.com/odoo/enterprise/pull/21398
