### PR TITLE
[FIX] website_event_booth: fix booth category image display

### DIFF
--- a/addons/website_event_booth/views/event_booth_templates.xml
+++ b/addons/website_event_booth/views/event_booth_templates.xml
@@ -61,7 +61,8 @@
                                         <div>
                                             <h5 name="booth_category_name" class="m-0 text-truncate" t-esc="booth_category.name"/>
                                             <span class="img img-responsive">
-                                                <img class="img img-fluid mt-2" t-att-title="booth_category.name" t-att-src="image_data_uri(booth_category.image_256)"/>
+                                                <img class="img img-fluid mt-2" t-att-title="booth_category.name"
+                                                     t-att-src="image_data_uri(booth_category.image_256) if booth_category.image_256 else '/web/static/img/placeholder.png'"/>
                                             </span>
                                         </div>
                                         <div t-if="booth_category_unavailable" class="o_ribbon_right bg-danger">


### PR DESCRIPTION
PURPOSE

Before this commit when a booth category doesn't have an image a
traceback is shown when accessing to the /booths route.
After this commit a default image is shown when the booth category
doesn't have an image.

LINKS

Task-2635461


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
