### PR TITLE
[FIX] web: fix documents tests failing randomly

### DIFF
--- a/addons/web/static/tests/helpers/cleanup.js
+++ b/addons/web/static/tests/helpers/cleanup.js
@@ -52,12 +52,18 @@ const validElements = [
     { tagName: "DIV", attr: "class", value: "tooltip fade bs-tooltip-auto" },
     { tagName: "DIV", attr: "class", value: "tooltip fade bs-tooltip-auto show" },
     { tagName: "SPAN", attr: "class", value: "select2-hidden-accessible" },
+
     // Due to a Document Kanban bug (already present in 12.0)
     { tagName: "DIV", attr: "class", value: "ui-helper-hidden-accessible" },
     {
         tagName: "UL",
         attr: "class",
         value: "ui-menu ui-widget ui-widget-content ui-autocomplete ui-front",
+    },
+    {
+        tagName: "UL",
+        attr: "class",
+        value: "ui-menu ui-widget ui-widget-content ui-autocomplete dropdown-menu ui-front", // many2ones
     },
 ];
 
@@ -72,7 +78,7 @@ QUnit.on("OdooAfterTestHook", function (info) {
     if (QUnit.config.debug) {
         return;
     }
-    const failed = info.testReport.getStatus() === 'failed';
+    const failed = info.testReport.getStatus() === "failed";
     const toRemove = [];
     // check for leftover elements in the body
     for (const bodyChild of document.body.children) {


### PR DESCRIPTION
Since commit [1], several tests from the "documents" addon failed
randomly, because there were leftovers in the DOM at the end of
the tests. Those leftovers were the many2one dropdowns. Since v12,
we whitelist jQuery autocomplete dropdowns in the leftover check.
However, since [1], the many2one autocomplete has an additionnal
className, and it thus didn't match the element in the whitelist
anymore. Note that we duplicated the entry in the whitelist
because we need both (there are several types of autocomplete
dropdowns in the "documents" view).

[1] 84715436d87bb05b421bc9ccaacda67d07571690

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
