### PR TITLE
[IMP] account: partner_id not required in payment form view

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -241,12 +241,10 @@
                                         attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                                 <field name="partner_id" context="{'default_is_company': True}" string="Customer"
                                        attrs="{'readonly':[('state', '!=', 'draft')],
-                                             'invisible':['|', ('partner_type','!=','customer'), ('is_internal_transfer', '=', True)],
-                                             'required': [('partner_type','=','customer')]}"/>
+                                             'invisible':['|', ('partner_type','!=','customer'), ('is_internal_transfer', '=', True)]}"/>
                                 <field name="partner_id" context="{'default_is_company': True}" string="Vendor"
                                        attrs="{'readonly':[('state', '!=', 'draft')],
-                                               'invisible':['|', ('partner_type','!=','supplier'), ('is_internal_transfer', '=', True)],
-                                               'required': [('partner_type','=','supplier')]}"/>
+                                               'invisible':['|', ('partner_type','!=','supplier'), ('is_internal_transfer', '=', True)]}"/>
                                 <label for="amount"/>
                                 <div name="amount_div" class="o_row">
                                     <field name="amount"


### PR DESCRIPTION
Create a payment without a partner for a receipt
Go to the form view
Click on the stats button.
=> Error, 'partner_id' is required

In some cases, having the partner not required on the view is needed.

task: 2610780

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
