### PR TITLE
[FIX] Commit transient model vacuuming directly

### DIFF
--- a/odoo/addons/base/models/ir_autovacuum.py
+++ b/odoo/addons/base/models/ir_autovacuum.py
@@ -22,6 +22,7 @@ class AutoVacuum(models.AbstractModel):
                 try:
                     with self._cr.savepoint():
                         model._transient_vacuum(force=True)
+                    self._cr.commit()
                 except Exception as e:
                     _logger.warning("Failed to clean transient model %s\n%s", model, str(e))
 


### PR DESCRIPTION
Before this commit:
If the "Base: Auto-vacuum internal data" Scheduled action is archived since a long time, auto-vacuuming models may timeout. As the commit was previously done at the end of the cron, the process wouldn't have been applied. As a consequence the Scheduled action will timeout every time

After this commit:
The commit is done right after each model vacuuming

OPW-2638706

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
