### PR TITLE
[FIX] purchase_mrp: allow basic users to confirm PO

### DIFF
--- a/addons/purchase_mrp/models/purchase_mrp.py
+++ b/addons/purchase_mrp/models/purchase_mrp.py
@@ -45,7 +45,7 @@ class PurchaseOrderLine(models.Model):
         # We don't try to be too smart and keep a simple approach: we compare the quantity before
         # and after update, and return the difference. We don't take into account what was already
         # sent, or any other exceptional case.
-        bom = self.env['mrp.bom']._bom_find(product=self.product_id)
+        bom = self.env['mrp.bom'].sudo()._bom_find(product=self.product_id)
         if bom and bom.type == 'phantom' and 'previous_product_qty' in self.env.context:
             return self.env.context['previous_product_qty'].get(self.id, 0.0)
         return super()._get_qty_procurement()


### PR DESCRIPTION
Bug introduced by this commit: https://github.com/odoo/odoo/pull/76965/commits/509db2371f9122a47af867e3b90841e115c712cf

Steps to reproduce the bug:
- Install purchase and mrp
- Add to “Marc Demo”, user access rights only for purchase app
- As demo, Create a PO and add any product
- Confirm the PO

Problem:
An access error is triggered when searching for a BOM linked to the selected product in the POL




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
