### PR TITLE
[IMP] core: update the CDT runner to use an evented model

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -204,7 +204,6 @@
             ('include', 'web.frontend_legacy'),
         ],
         'point_of_sale.qunit_suite_tests': [
-            'web/static/tests/legacy/component_extension_tests.js',
             'point_of_sale/static/tests/unit/**/*',
         ],
         'point_of_sale.assets_backend_prod_only': [

--- a/addons/point_of_sale/tests/test_js.py
+++ b/addons/point_of_sale/tests/test_js.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import odoo.addons.web.tests.test_js
 import odoo.tests
 
 
@@ -17,6 +16,4 @@ class WebSuite(odoo.tests.HttpCase):
         self.main_pos_config.open_session_cb(check_coa=False)
 
         # point_of_sale desktop test suite
-        self.browser_js(
-            "/pos/ui/tests?mod=web&failfast", "", "", login="admin", timeout=1800
-        )
+        self.browser_js("/pos/ui/tests?mod=web", "", "", login="admin", timeout=1800)

--- a/addons/web/static/src/boot.js
+++ b/addons/web/static/src/boot.js
@@ -271,7 +271,7 @@
             unloaded: unloaded ? unloaded.map((mod) => mod.name) : [],
             cycle,
         };
-        didLogInfoResolve();
+        didLogInfoResolve(true);
     };
     odoo.processJobs = function (jobs, services) {
         var job;

--- a/addons/web/static/tests/legacy/views/calendar_tests.js
+++ b/addons/web/static/tests/legacy/views/calendar_tests.js
@@ -4094,12 +4094,9 @@ QUnit.module('Views', {
         var $initCell = calendar.$('.fc-time-grid .fc-minor[data-time="06:30:00"] .fc-widget-content:last-child');
         var $endCell = calendar.$('.fc-time-grid .fc-minor[data-time="10:30:00"] .fc-widget-content:last-child');
 
-        var left = $initCell.offset().left;
-        var top = $initCell.offset().top;
-        testUtils.dom.triggerPositionalMouseEvent(left, top, "mousedown");
-        top = $endCell.offset().top;
-        testUtils.dom.triggerPositionalMouseEvent(left, top, "mousemove");
-        testUtils.dom.triggerPositionalMouseEvent(left, top, "mouseup");
+        await testUtils.dom.triggerMouseEvent($initCell, "mousedown");
+        await testUtils.dom.triggerMouseEvent($endCell, "mousemove");
+        await testUtils.dom.triggerMouseEvent($endCell, "mouseup");
         await testUtils.nextTick();
 
         assert.verifySteps(['do_action']);

--- a/addons/web/static/tests/qunit.js
+++ b/addons/web/static/tests/qunit.js
@@ -215,8 +215,6 @@
         modulesAlert.classList.add("alert-info");
         modulesAlert.textContent = "Waiting for modules check...";
         document.getElementById("qunit").appendChild(modulesAlert);
-        // wait for the module system to end processing the JS modules
-        await odoo.__DEBUG__.didLogInfo;
         const info = odoo.__DEBUG__.jsModules;
         if (info.missing.length || info.failed.length || info.unloaded.length) {
             document.querySelector("#qunit-banner").classList.add("qunit-fail");
@@ -255,6 +253,7 @@
         }
     }
 
+    QUnit.begin(() => odoo.__DEBUG__.didLogInfo);
     /**
      * If we want to log several errors, we have to log all of them at once, as
      * browser_js is closed as soon as an error is logged.

--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -12,7 +12,7 @@ class WebSuite(odoo.tests.HttpCase):
 
     def test_js(self):
         # webclient desktop test suite
-        self.browser_js('/web/tests?mod=web&failfast', "", "", login='admin', timeout=1800)
+        self.browser_js('/web/tests?mod=web', "", "", login='admin', timeout=1800)
 
     def test_check_suite(self):
         # verify no js test is using `QUnit.only` as it forbid any other test to be executed
@@ -43,4 +43,4 @@ class MobileWebSuite(odoo.tests.HttpCase):
 
     def test_mobile_js(self):
         # webclient mobile test suite
-        self.browser_js('/web/tests/mobile?mod=web&failfast', "", "", login='admin', timeout=1800)
+        self.browser_js('/web/tests/mobile?mod=web', "", "", login='admin', timeout=1800)


### PR DESCRIPTION
Currently the runner kinda sorta tries to run the message pump when it needs a message, but it makes for messy and convoluted code as the "request/response" callers have to deal with a bunch of events they don't understand or care for, and can lose other people's events entirely.

Try to use a more evented model: the downstream from Chrome is handled by a separate thread which can handle all events and responses somewhat uniformly. Request/response callers can register their desire for feedback and get a nice `Future` to wait on (or add a callback to).

Also:

* removes the failfast mode of JS tests as that mostly just makes fixing tests more annoying (as only one failure is shown per run)
* fix a hitbox bug in calendar on Chrome 94
* fix a somewhat latent race condition in the qunit test suite / runner, which triggered during the POS qunit run (and is now a hard failure)