### PR TITLE
[FIX] base: AttributeError in check_view_fields

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2007,6 +2007,7 @@ class NameManager:
                     name=field, use=use,
                 )
                 view.handle_view_error(msg)
+                continue
             if corresponding_field.get('select') == 'multi':  # mainly for searchpanel, but can be a generic behaviour.
                 msg = _(
                     "Field %(name)s used in %(use)s is present in view but is in select multi.",


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

If corresponding_field is None, we need to avoid the "AttributeError: 'NoneType' object has no attribute 'get'" error.

**Current behavior before PR:**
If corresponding_field is None, then `corresponding_field.get('select')` gets AttributeError.

**Desired behavior after PR is merged:**
Everything works fine.

Note: I opted for the "continue" solution instead of the "elif" solution because later in v15 the corresponding_field is renamed. With the "elif" solution, the robodoo would get error when doing the v15 PR, and with the "continue" solution there is no problem.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr