### PR TITLE
[FIX] account: manage multiple ids in _is_end_of_seq_chain

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -264,7 +264,7 @@ class SequenceMixin(models.AbstractModel):
         """
         batched = defaultdict(lambda: {'last_rec': self.browse(), 'seq_list': []})
         for record in self:
-            format, format_values = self._get_sequence_format_param(record[record._sequence_field])
+            format, format_values = record._get_sequence_format_param(record[record._sequence_field])
             seq = format_values.pop('seq')
             batch = batched[(format, frozendict(format_values))]
             batch['seq_list'].append(seq)


### PR DESCRIPTION
`_deduce_sequence_number_reset` should be used on maximum one record.
That function is called from `_get_sequence_format_param` in
`_is_end_of_seq_chain` but that function was possibly calling it on
multiple ids.

https://runbot.odoo.com/runbot/build/10315612




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
