### PR TITLE
[14.0][mail_bot_hr][fix] inherit from correct view to avoid error.

### DIFF
--- a/addons/mail_bot_hr/views/res_users_views.xml
+++ b/addons/mail_bot_hr/views/res_users_views.xml
@@ -11,14 +11,27 @@
             </field>
         </record>
 
-        <record id="res_users_view_form_profile" model="ir.ui.view">
+        <record id="res_users_view_form_preferences" model="ir.ui.view">
             <field name="name">res.users.preferences.form.inherit</field>
             <field name="model">res.users</field>
-            <field name="inherit_id" ref="hr.res_users_view_form_profile" />
+            <field name="inherit_id"
+                   ref="mail_bot.res_users_view_form_preferences" />
             <field name="arch" type="xml">
+                <field name="odoobot_state" position="before">
+                    <field name="can_edit" invisible="1"/>
+                </field>
                 <xpath expr="//field[@name='odoobot_state']" position="attributes">
                     <attribute name="attrs">{'readonly': [('can_edit', '=', False)]}</attribute>
                 </xpath>
+            </field>
+        </record>
+
+        <record id="res_users_view_form_profile" model="ir.ui.view">
+            <field name="name">res.users.profile.form.inherit</field>
+            <field name="model">res.users</field>
+            <field name="inherit_id"
+                   ref="hr.res_users_view_form_profile" />
+            <field name="arch" type="xml">
                 <sheet position="before">
                     <widget name="notification_alert" class="mb-0" />
                 </sheet>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The field 'odoobot_state' is defined in view 'res_users_view_form_preferences' of mail_bot. Otheriwse an error is raised 'odoobot_state' cannot be located in parent view.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
