### PR TITLE
[FIX] base: update SQL expression

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -539,7 +539,7 @@ class Module(models.Model):
         known_deps = known_deps or self.browse()
         query = """ SELECT DISTINCT m.id
                     FROM ir_module_module_dependency d
-                    JOIN ir_module_module m ON (d.module_id=m.id)
+                    RIGHT JOIN ir_module_module m ON (d.module_id=m.id)
                     WHERE
                         m.name IN (SELECT name from ir_module_module_dependency where module_id in %s) AND
                         m.state NOT IN %s AND


### PR DESCRIPTION
base is the module which has no dependencies. So with the current
SQL expression, whenever upstream_dependencies is called with
module objects like (web, uom), the function returns a blank list, though
base is there as the only direct dependency in those modules.

After this commit, the function will return base module whenever it
is present as a direct dependency in any of the module.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
