### PR TITLE
[FIX] missing if statement to avoid executing UAE related code when C…

### DIFF
--- a/addons/l10n_ae/models/account_chart_template.py
+++ b/addons/l10n_ae/models/account_chart_template.py
@@ -8,7 +8,7 @@ class AccountChartTemplate(models.Model):
 
     def _prepare_all_journals(self, acc_template_ref, company, journals_dict=None):
         """ If UAE chart, we add 2 new journals TA and IFRS"""
-        if company.country_id.code == "AE":
+        if self == self.env.ref('l10n_ae.uae_chart_template_standard'):
             if not journals_dict:
                 journals_dict = []
             journals_dict.extend(
@@ -23,16 +23,17 @@ class AccountChartTemplate(models.Model):
                                                                                   code_digits=code_digits,
                                                                                   account_ref=account_ref,
                                                                                   taxes_ref=taxes_ref)
-        ifrs_journal = self.env['account.journal'].search(
-            [('company_id', '=', company.id), ('code', '=', 'IFRS')]).id
-        if ifrs_journal:
-            ifrs_account_ids = [self.env.ref('l10n_ae.uae_account_100101').id,
-                                self.env.ref('l10n_ae.uae_account_100102').id,
-                                self.env.ref('l10n_ae.uae_account_400070').id]
-            ifrs_accounts = self.env['account.account'].browse([account_ref.get(id) for id in ifrs_account_ids])
-            for account in ifrs_accounts:
-                account.allowed_journal_ids = [(4, ifrs_journal, 0)]
-        self.env.ref('l10n_ae.ae_tax_group_5').write(
-            {'property_tax_payable_account_id': account_ref.get(self.env.ref('l10n_ae.uae_account_202003').id),
-             'property_tax_receivable_account_id': account_ref.get(self.env.ref('l10n_ae.uae_account_100103').id)})
+        if self == self.env.ref('l10n_ae.uae_chart_template_standard'):
+            ifrs_journal = self.env['account.journal'].search(
+                [('company_id', '=', company.id), ('code', '=', 'IFRS')]).id
+            if ifrs_journal:
+                ifrs_account_ids = [self.env.ref('l10n_ae.uae_account_100101').id,
+                                    self.env.ref('l10n_ae.uae_account_100102').id,
+                                    self.env.ref('l10n_ae.uae_account_400070').id]
+                ifrs_accounts = self.env['account.account'].browse([account_ref.get(id) for id in ifrs_account_ids])
+                for account in ifrs_accounts:
+                    account.allowed_journal_ids = [(4, ifrs_journal, 0)]
+            self.env.ref('l10n_ae.ae_tax_group_5').write(
+                {'property_tax_payable_account_id': account_ref.get(self.env.ref('l10n_ae.uae_account_202003').id),
+                 'property_tax_receivable_account_id': account_ref.get(self.env.ref('l10n_ae.uae_account_100103').id)})
         return account_ref, taxes_ref


### PR DESCRIPTION
Correcting and adding a if statement checking if we are currently using the right chart of account

Description of the issue/feature this PR addresses:
_load_template code was always executed

Current behavior before PR:
_load_template code was always executed

Desired behavior after PR is merged:
_load_template is now only executed when the COA is l10n_ae.uae_chart_template_standard



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
