### PR TITLE
[FIX] event_sale: fix ticket default product type

### DIFF
--- a/addons/event_sale/views/event_ticket_views.xml
+++ b/addons/event_sale/views/event_ticket_views.xml
@@ -43,7 +43,7 @@
                 <attribute name="string">Sales End</attribute>
             </field>
             <field name="name" position="after">
-                <field name="product_id" context="{'default_detailed_type': 'event'}"/>
+                <field name="product_id" context="{'default_detailed_type': 'event', 'default_type': 'service'}"/>
             </field>
             <field name="description" position="after">
                 <field name="price"/>
@@ -57,7 +57,7 @@
         <field name="inherit_id" ref="event.event_event_ticket_view_form_from_event"/>
         <field name="arch" type="xml">
             <field name="name" position="after">
-                <field name="product_id" context="{'default_detailed_type': 'event'}"/>
+                <field name="product_id" context="{'default_detailed_type': 'event', 'default_type': 'service'}"/>
             </field>
             <field name="description" position="after">
                 <field name="price"/>


### PR DESCRIPTION
When creating a new ticket for an event, the default associated product type
was "consumable" which made a notification appear. It is now set to "service",
such that the notification about consumable products does not appear anymore.

Similar to #76801

Task-2655226
