### PR TITLE
[FIX] web_editor: handle gradient styles only when gradients allowed

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -3115,7 +3115,7 @@ const SnippetOptionWidget = Widget.extend({
         // method with background-color as property too, so it is automatically
         // reset anyway).
         let bgImageParts = undefined;
-        if (params.cssProperty === 'background-color') {
+        if (params.withGradients && params.cssProperty === 'background-color') {
             const styles = getComputedStyle(this.$target[0]);
             bgImageParts = backgroundImageCssToParts(styles['background-image']);
             delete bgImageParts.gradient;
@@ -3166,7 +3166,7 @@ const SnippetOptionWidget = Widget.extend({
         // In case of background-color edition, we could receive a gradient, in
         // which case the value has to be combined with the potential background
         // image (real image).
-        if (params.cssProperty === 'background-color' && weUtils.isColorGradient(widgetValue)) {
+        if (params.withGradients && params.cssProperty === 'background-color' && weUtils.isColorGradient(widgetValue)) {
             cssProps = ['background-image'];
             bgImageParts.gradient = widgetValue;
             widgetValue = backgroundImagePartsToCss(bgImageParts);
@@ -3531,7 +3531,7 @@ const SnippetOptionWidget = Widget.extend({
 
                 const styles = window.getComputedStyle(this.$target[0]);
 
-                if (params.cssProperty === 'background-color') {
+                if (params.withGradients && params.cssProperty === 'background-color') {
                     // Check if there is a gradient, in that case this is the
                     // value to be returned, we normally not allow color and
                     // gradient at the same time (the option would remove one


### PR DESCRIPTION
Before this commit the progress bar options were broken because the
stripe effect is achieved by a gradient in the CSS, but
`SnippetOptionWidget` recognized it as a manually selected gradient, and
thus applied the gradient specific handling (such as neutralizing the
background-image when a color is selected).

After this commit the special handling for gradients is only applied
where gradients are expected to be selected manually (i.e. when the
`withGradients` parameter is set).

task-2662401

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
