### PR TITLE
[FIX] account: update taxes on changing fiscal positions

### DIFF
--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -643,67 +643,6 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertInvoiceValues(self.invoice, [
             {
                 **self.product_line_vals_1,
-                'partner_id': self.partner_b.id,
-            },
-            {
-                **self.product_line_vals_2,
-                'partner_id': self.partner_b.id,
-            },
-            {
-                **self.tax_line_vals_1,
-                'partner_id': self.partner_b.id,
-            },
-            {
-                **self.tax_line_vals_2,
-                'partner_id': self.partner_b.id,
-            },
-            {
-                **self.term_line_vals_1,
-                'name': 'turlututu',
-                'partner_id': self.partner_b.id,
-                'account_id': self.partner_b.property_account_payable_id.id,
-                'price_unit': -789.6,
-                'price_subtotal': -789.6,
-                'price_total': -789.6,
-                'amount_currency': -789.6,
-                'credit': 789.6,
-                'date_maturity': fields.Date.from_string('2019-02-28'),
-            },
-            {
-                **self.term_line_vals_1,
-                'name': 'turlututu',
-                'partner_id': self.partner_b.id,
-                'account_id': self.partner_b.property_account_payable_id.id,
-                'price_unit': -338.4,
-                'price_subtotal': -338.4,
-                'price_total': -338.4,
-                'amount_currency': -338.4,
-                'credit': 338.4,
-            },
-        ], {
-            **self.move_vals,
-            'partner_id': self.partner_b.id,
-            'payment_reference': 'turlututu',
-            'fiscal_position_id': self.fiscal_pos_a.id,
-            'invoice_payment_term_id': self.pay_terms_b.id,
-            'amount_untaxed': 960.0,
-            'amount_tax': 168.0,
-            'amount_total': 1128.0,
-        })
-
-        # Remove lines and recreate them to apply the fiscal position.
-        move_form = Form(self.invoice)
-        move_form.invoice_line_ids.remove(0)
-        move_form.invoice_line_ids.remove(0)
-        with move_form.invoice_line_ids.new() as line_form:
-            line_form.product_id = self.product_a
-        with move_form.invoice_line_ids.new() as line_form:
-            line_form.product_id = self.product_b
-        move_form.save()
-
-        self.assertInvoiceValues(self.invoice, [
-            {
-                **self.product_line_vals_1,
                 'account_id': self.product_b.property_account_expense_id.id,
                 'partner_id': self.partner_b.id,
                 'tax_ids': self.tax_purchase_b.ids,
@@ -749,6 +688,47 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'payment_reference': 'turlututu',
             'fiscal_position_id': self.fiscal_pos_a.id,
             'invoice_payment_term_id': self.pay_terms_b.id,
+            'amount_untaxed': 960.0,
+            'amount_tax': 144.0,
+            'amount_total': 1104.0,
+        })
+
+    def test_in_invoice_line_onchange_fiscal_position_1(self):
+
+        move_form = Form(self.invoice)
+
+        # Change from no fiscal position to fiscal position a
+        move_form.fiscal_position_id = self.fiscal_pos_a
+        move_form.save()
+
+        self.assertInvoiceValues(self.invoice, [
+            {
+                **self.product_line_vals_1,
+                'account_id': self.product_b.property_account_expense_id.id,
+                'tax_ids': self.tax_purchase_b.ids,
+            },
+            {
+                **self.product_line_vals_2,
+                'price_total': 184.0,
+                'tax_ids': self.tax_purchase_b.ids,
+            },
+            {
+                **self.tax_line_vals_1,
+                'name': self.tax_purchase_b.name,
+                'tax_line_id': self.tax_purchase_b.id,
+            },
+            {
+                **self.term_line_vals_1,
+                'price_unit': -1104.0,
+                'price_subtotal': -1104.0,
+                'price_total': -1104.0,
+                'amount_currency': -1104.0,
+                'credit': 1104.0,
+                'date_maturity': fields.Date.from_string('2019-01-01'),
+            },
+        ], {
+            **self.move_vals,
+            'fiscal_position_id': self.fiscal_pos_a.id,
             'amount_untaxed': 960.0,
             'amount_tax': 144.0,
             'amount_total': 1104.0,

--- a/addons/account/tests/test_account_move_in_refund.py
+++ b/addons/account/tests/test_account_move_in_refund.py
@@ -326,67 +326,6 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
         self.assertInvoiceValues(self.invoice, [
             {
                 **self.product_line_vals_1,
-                'partner_id': self.partner_b.id,
-            },
-            {
-                **self.product_line_vals_2,
-                'partner_id': self.partner_b.id,
-            },
-            {
-                **self.tax_line_vals_1,
-                'partner_id': self.partner_b.id,
-            },
-            {
-                **self.tax_line_vals_2,
-                'partner_id': self.partner_b.id,
-            },
-            {
-                **self.term_line_vals_1,
-                'name': 'turlututu',
-                'partner_id': self.partner_b.id,
-                'account_id': self.partner_b.property_account_payable_id.id,
-                'price_unit': -338.4,
-                'price_subtotal': -338.4,
-                'price_total': -338.4,
-                'amount_currency': 338.4,
-                'debit': 338.4,
-            },
-            {
-                **self.term_line_vals_1,
-                'name': 'turlututu',
-                'partner_id': self.partner_b.id,
-                'account_id': self.partner_b.property_account_payable_id.id,
-                'price_unit': -789.6,
-                'price_subtotal': -789.6,
-                'price_total': -789.6,
-                'amount_currency': 789.6,
-                'debit': 789.6,
-                'date_maturity': fields.Date.from_string('2019-02-28'),
-            },
-        ], {
-            **self.move_vals,
-            'partner_id': self.partner_b.id,
-            'payment_reference': 'turlututu',
-            'fiscal_position_id': self.fiscal_pos_a.id,
-            'invoice_payment_term_id': self.pay_terms_b.id,
-            'amount_untaxed': 960.0,
-            'amount_tax': 168.0,
-            'amount_total': 1128.0,
-        })
-
-        # Remove lines and recreate them to apply the fiscal position.
-        move_form = Form(self.invoice)
-        move_form.invoice_line_ids.remove(0)
-        move_form.invoice_line_ids.remove(0)
-        with move_form.invoice_line_ids.new() as line_form:
-            line_form.product_id = self.product_a
-        with move_form.invoice_line_ids.new() as line_form:
-            line_form.product_id = self.product_b
-        move_form.save()
-
-        self.assertInvoiceValues(self.invoice, [
-            {
-                **self.product_line_vals_1,
                 'account_id': self.product_b.property_account_expense_id.id,
                 'partner_id': self.partner_b.id,
                 'tax_ids': self.tax_purchase_b.ids,
@@ -432,6 +371,47 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'payment_reference': 'turlututu',
             'fiscal_position_id': self.fiscal_pos_a.id,
             'invoice_payment_term_id': self.pay_terms_b.id,
+            'amount_untaxed': 960.0,
+            'amount_tax': 144.0,
+            'amount_total': 1104.0,
+        })
+
+    def test_in_refund_line_onchange_fiscal_position_1(self):
+
+        move_form = Form(self.invoice)
+
+        # Change from no fiscal position to fiscal position a
+        move_form.fiscal_position_id = self.fiscal_pos_a
+        move_form.save()
+
+        self.assertInvoiceValues(self.invoice, [
+            {
+                **self.product_line_vals_1,
+                'account_id': self.product_b.property_account_expense_id.id,
+                'tax_ids': self.tax_purchase_b.ids,
+            },
+            {
+                **self.product_line_vals_2,
+                'price_total': 184.0,
+                'tax_ids': self.tax_purchase_b.ids,
+            },
+            {
+                **self.tax_line_vals_1,
+                'name': self.tax_purchase_b.name,
+                'tax_line_id': self.tax_purchase_b.id,
+            },
+            {
+                **self.term_line_vals_1,
+                'price_unit': -1104.0,
+                'price_subtotal': -1104.0,
+                'price_total': -1104.0,
+                'amount_currency': 1104.0,
+                'debit': 1104.0,
+                'date_maturity': fields.Date.from_string('2019-01-01'),
+            },
+        ], {
+            **self.move_vals,
+            'fiscal_position_id': self.fiscal_pos_a.id,
             'amount_untaxed': 960.0,
             'amount_tax': 144.0,
             'amount_total': 1104.0,

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -631,67 +631,6 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertInvoiceValues(self.invoice, [
             {
                 **self.product_line_vals_1,
-                'partner_id': self.partner_b.id,
-            },
-            {
-                **self.product_line_vals_2,
-                'partner_id': self.partner_b.id,
-            },
-            {
-                **self.tax_line_vals_1,
-                'partner_id': self.partner_b.id,
-            },
-            {
-                **self.tax_line_vals_2,
-                'partner_id': self.partner_b.id,
-            },
-            {
-                **self.term_line_vals_1,
-                'name': 'turlututu',
-                'account_id': self.partner_b.property_account_receivable_id.id,
-                'partner_id': self.partner_b.id,
-                'price_unit': -423.0,
-                'price_subtotal': -423.0,
-                'price_total': -423.0,
-                'amount_currency': 423.0,
-                'debit': 423.0,
-            },
-            {
-                **self.term_line_vals_1,
-                'name': 'turlututu',
-                'account_id': self.partner_b.property_account_receivable_id.id,
-                'partner_id': self.partner_b.id,
-                'price_unit': -987.0,
-                'price_subtotal': -987.0,
-                'price_total': -987.0,
-                'amount_currency': 987.0,
-                'debit': 987.0,
-                'date_maturity': fields.Date.from_string('2019-02-28'),
-            },
-        ], {
-            **self.move_vals,
-            'partner_id': self.partner_b.id,
-            'payment_reference': 'turlututu',
-            'fiscal_position_id': self.fiscal_pos_a.id,
-            'invoice_payment_term_id': self.pay_terms_b.id,
-            'amount_untaxed': 1200.0,
-            'amount_tax': 210.0,
-            'amount_total': 1410.0,
-        })
-
-        # Remove lines and recreate them to apply the fiscal position.
-        move_form = Form(self.invoice)
-        move_form.invoice_line_ids.remove(0)
-        move_form.invoice_line_ids.remove(0)
-        with move_form.invoice_line_ids.new() as line_form:
-            line_form.product_id = self.product_a
-        with move_form.invoice_line_ids.new() as line_form:
-            line_form.product_id = self.product_b
-        move_form.save()
-
-        self.assertInvoiceValues(self.invoice, [
-            {
-                **self.product_line_vals_1,
                 'account_id': self.product_b.property_account_income_id.id,
                 'partner_id': self.partner_b.id,
                 'tax_ids': self.tax_sale_b.ids,
@@ -737,6 +676,46 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'payment_reference': 'turlututu',
             'fiscal_position_id': self.fiscal_pos_a.id,
             'invoice_payment_term_id': self.pay_terms_b.id,
+            'amount_untaxed': 1200.0,
+            'amount_tax': 180.0,
+            'amount_total': 1380.0,
+        })
+
+    def test_out_invoice_line_onchange_fiscal_position_1(self):
+
+        move_form = Form(self.invoice)
+
+        # Change from no fiscal position to fiscal position a
+        move_form.fiscal_position_id = self.fiscal_pos_a
+        move_form.save()
+
+        self.assertInvoiceValues(self.invoice, [
+            {
+                **self.product_line_vals_1,
+                'account_id': self.product_b.property_account_income_id.id,
+                'tax_ids': self.tax_sale_b.ids,
+            },
+            {
+                **self.product_line_vals_2,
+                'price_total': 230.0,
+                'tax_ids': self.tax_sale_b.ids,
+            },
+            {
+                **self.tax_line_vals_1,
+                'name': self.tax_sale_b.name,
+                'tax_line_id': self.tax_sale_b.id,
+            },
+            {
+                **self.term_line_vals_1,
+                'price_unit': -1380.0,
+                'price_subtotal': -1380.0,
+                'price_total': -1380.0,
+                'amount_currency': 1380.0,
+                'debit': 1380.0,
+            },
+        ], {
+            **self.move_vals,
+            'fiscal_position_id': self.fiscal_pos_a.id,
             'amount_untaxed': 1200.0,
             'amount_tax': 180.0,
             'amount_total': 1380.0,

--- a/addons/account/tests/test_account_move_out_refund.py
+++ b/addons/account/tests/test_account_move_out_refund.py
@@ -326,67 +326,6 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
         self.assertInvoiceValues(self.invoice, [
             {
                 **self.product_line_vals_1,
-                'partner_id': self.partner_b.id,
-            },
-            {
-                **self.product_line_vals_2,
-                'partner_id': self.partner_b.id,
-            },
-            {
-                **self.tax_line_vals_1,
-                'partner_id': self.partner_b.id,
-            },
-            {
-                **self.tax_line_vals_2,
-                'partner_id': self.partner_b.id,
-            },
-            {
-                **self.term_line_vals_1,
-                'name': 'turlututu',
-                'partner_id': self.partner_b.id,
-                'account_id': self.partner_b.property_account_receivable_id.id,
-                'price_unit': -987.0,
-                'price_subtotal': -987.0,
-                'price_total': -987.0,
-                'amount_currency': -987.0,
-                'credit': 987.0,
-                'date_maturity': fields.Date.from_string('2019-02-28'),
-            },
-            {
-                **self.term_line_vals_1,
-                'name': 'turlututu',
-                'partner_id': self.partner_b.id,
-                'account_id': self.partner_b.property_account_receivable_id.id,
-                'price_unit': -423.0,
-                'price_subtotal': -423.0,
-                'price_total': -423.0,
-                'amount_currency': -423.0,
-                'credit': 423.0,
-            },
-        ], {
-            **self.move_vals,
-            'partner_id': self.partner_b.id,
-            'payment_reference': 'turlututu',
-            'fiscal_position_id': self.fiscal_pos_a.id,
-            'invoice_payment_term_id': self.pay_terms_b.id,
-            'amount_untaxed': 1200.0,
-            'amount_tax': 210.0,
-            'amount_total': 1410.0,
-        })
-
-        # Remove lines and recreate them to apply the fiscal position.
-        move_form = Form(self.invoice)
-        move_form.invoice_line_ids.remove(0)
-        move_form.invoice_line_ids.remove(0)
-        with move_form.invoice_line_ids.new() as line_form:
-            line_form.product_id = self.product_a
-        with move_form.invoice_line_ids.new() as line_form:
-            line_form.product_id = self.product_b
-        move_form.save()
-
-        self.assertInvoiceValues(self.invoice, [
-            {
-                **self.product_line_vals_1,
                 'account_id': self.product_b.property_account_income_id.id,
                 'partner_id': self.partner_b.id,
                 'tax_ids': self.tax_sale_b.ids,
@@ -432,6 +371,46 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'payment_reference': 'turlututu',
             'fiscal_position_id': self.fiscal_pos_a.id,
             'invoice_payment_term_id': self.pay_terms_b.id,
+            'amount_untaxed': 1200.0,
+            'amount_tax': 180.0,
+            'amount_total': 1380.0,
+        })
+
+    def test_out_refund_line_onchange_fiscal_position_1(self):
+
+        move_form = Form(self.invoice)
+
+        # Change from no fiscal position to fiscal position a
+        move_form.fiscal_position_id = self.fiscal_pos_a
+        move_form.save()
+
+        self.assertInvoiceValues(self.invoice, [
+            {
+                **self.product_line_vals_1,
+                'account_id': self.product_b.property_account_income_id.id,
+                'tax_ids': self.tax_sale_b.ids,
+            },
+            {
+                **self.product_line_vals_2,
+                'price_total': 230.0,
+                'tax_ids': self.tax_sale_b.ids,
+            },
+            {
+                **self.tax_line_vals_1,
+                'name': self.tax_sale_b.name,
+                'tax_line_id': self.tax_sale_b.id,
+            },
+            {
+                **self.term_line_vals_1,
+                'price_unit': -1380,
+                'price_subtotal': -1380.0,
+                'price_total': -1380.0,
+                'amount_currency': -1380.0,
+                'credit': 1380.0,
+            },
+        ], {
+            **self.move_vals,
+            'fiscal_position_id': self.fiscal_pos_a.id,
             'amount_untaxed': 1200.0,
             'amount_tax': 180.0,
             'amount_total': 1380.0,


### PR DESCRIPTION
In account_move when partner_id is changed, if the fiscal position has also changed, then the taxes on the account move lines should be updated. This only occurs on lines with products with taxes defined on them (this is the behaviour in the sale order). For lines without a product the fiscal position is not applied on the tax, since one might not be able to return to the original tax using the fiscal position.

task_id: 2647101