### PR TITLE
[FIX] payment_(adyen, authorize): fix traceback and tune the refund

### DIFF
--- a/addons/payment/tests/test_transactions.py
+++ b/addons/payment/tests/test_transactions.py
@@ -74,7 +74,7 @@ class TestTransactions(PaymentCommon):
         )
 
         # Test the values of a partial refund transaction with custom refund amount
-        partial_refund_tx = tx._create_refund_transaction(refund_amount=11.11)
+        partial_refund_tx = tx._create_refund_transaction(amount_to_refund=11.11)
         self.assertAlmostEqual(
             partial_refund_tx.amount,
             -11.11,


### PR DESCRIPTION
- This replaces the name of `refund_amount` to `amount_to_refund`
for a variable that was renamed elsewhere, which caused a traceback.
- Adyen and authorized `_send_refund_request` now have their return,
as their parent.
- When a refund is initiated from Adyen, it's now easier to change
the merchant reference, thus, we can't count on it anymore to get
the source transaction.
- Fix the automatic refund for authorize.net with the manual capture

task-2634184