### PR TITLE
[IMP] doc: update links to V15

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ TL;DR
 * If you [make a pull request](https://github.com/odoo/odoo/wiki/Contributing#making-pull-requests),
   do not create an issue! Use the PR description for that
 * Issues are handled with a much lower priority than pull requests
-* Use this [template](https://github.com/odoo/odoo/tree/14.0/.github/ISSUE_TEMPLATE.md)
+* Use this [template](https://github.com/odoo/odoo/tree/15.0/.github/ISSUE_TEMPLATE.md)
   when reporting issues. Please search for duplicates first!
 * Pull requests must be made against the [correct version](https://github.com/odoo/odoo/wiki/Contributing#against-which-version-should-i-submit-a-patch)
 * There are restrictions on the kind of [changes allowed in stable series](https://github.com/odoo/odoo/wiki/Contributing#what-does-stable-mean)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,10 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 15.0    | :white_check_mark: |
 | 14.0    | :white_check_mark: |
 | 13.0    | :white_check_mark: |
-| 12.0    | :white_check_mark: |
-| <=11.0  | :x:                |
+| <=12.0  | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Map to right URL's

Current behavior before PR: Some URL's point to 14.0

Desired behavior after PR is merged: The URL's point to 15.0



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
