### PR TITLE
[FIX] website_sale(_stock): remove dead code

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -230,12 +230,10 @@ class Website(models.Model):
             'partner_shipping_id': addr['delivery'],
             'user_id': salesperson_id or self.salesperson_id.id or default_user_id,
             'website_id': self._context.get('website_id'),
+            'company_id': self.company_id.id,
         }
-        company = self.company_id or pricelist.company_id
-        if company:
-            values['company_id'] = company.id
-            if self.env['ir.config_parameter'].sudo().get_param('sale.use_sale_note'):
-                values['note'] = company.sale_note or ""
+        if self.env['ir.config_parameter'].sudo().get_param('sale.use_sale_note'):
+            values['note'] = self.company_id.sale_note or ""
 
         return values
 

--- a/addons/website_sale_stock/models/website.py
+++ b/addons/website_sale_stock/models/website.py
@@ -10,13 +10,12 @@ class Website(models.Model):
     def _prepare_sale_order_values(self, partner, pricelist):
         self.ensure_one()
         values = super(Website, self)._prepare_sale_order_values(partner, pricelist)
-        if values['company_id']:
-            warehouse_id = (
-                self.warehouse_id and self.warehouse_id.id or
-                self.env['ir.default'].get('sale.order', 'warehouse_id', company_id=values.get('company_id')) or
-                self.env['ir.default'].get('sale.order', 'warehouse_id') or
-                self.env['stock.warehouse'].sudo().search([('company_id', '=', values['company_id'])], limit=1).id
-            )
-            if warehouse_id:
-                values['warehouse_id'] = warehouse_id
+        warehouse_id = (
+            self.warehouse_id and self.warehouse_id.id or
+            self.env['ir.default'].get('sale.order', 'warehouse_id', company_id=self.company_id.id) or
+            self.env['ir.default'].get('sale.order', 'warehouse_id') or
+            self.env['stock.warehouse'].sudo().search([('company_id', '=', self.company_id.id)], limit=1).id
+        )
+        if warehouse_id:
+            values['warehouse_id'] = warehouse_id
         return values


### PR DESCRIPTION
When the `or` was introduced [1], the company_id was not required [2].
The required was added later somewhere between 11.0 and 12.0 [3].

Reaching the `or` condition was therefore not possible anymore.
Extracted from https://github.com/odoo/odoo/pull/77308

[1]: https://github.com/odoo/odoo/blame/10.0/addons/website_sale/models/sale_order.py#L350
[2]: https://github.com/odoo/odoo/blame/10.0/addons/website/models/website.py#L165
[3]: https://github.com/odoo/odoo/commit/2a9a514551ca951db656e139cb4d177657eb95e7
