### PR TITLE
[FIX] Allow disabling themes with custom layout headers

### DIFF
--- a/addons/website/models/theme_models.py
+++ b/addons/website/models/theme_models.py
@@ -225,7 +225,6 @@ class Theme(models.AbstractModel):
         self.disable_asset('website.ripple_effect_js')
 
         # Reinitialize header templates
-        self.enable_view('website.template_header_default')
         self.disable_view('website.template_header_hamburger')
         self.disable_view('website.template_header_vertical')
         self.disable_view('website.template_header_sidebar')
@@ -236,9 +235,9 @@ class Theme(models.AbstractModel):
         self.disable_view('website.template_header_image')
         self.disable_view('website.template_header_hamburger_full')
         self.disable_view('website.template_header_magazine')
+        self.enable_view('website.template_header_default')
 
         # Reinitialize footer templates
-        self.enable_view('website.footer_custom')
         self.disable_view('website.template_footer_descriptive')
         self.disable_view('website.template_footer_centered')
         self.disable_view('website.template_footer_links')
@@ -246,6 +245,7 @@ class Theme(models.AbstractModel):
         self.disable_view('website.template_footer_contact')
         self.disable_view('website.template_footer_call_to_action')
         self.disable_view('website.template_footer_headline')
+        self.enable_view('website.footer_custom')
 
         # Reinitialize footer scrolltop template
         self.disable_view('website.option_footer_scrolltop')


### PR DESCRIPTION
Switching between themes sometimes fails with the following error message:

> Element `<xpath expr="//header//nav">` cannot be located in parent view

Reproducing the problem can be achieved by enabling the Beauty theme and switching to any other theme afterwards. The problem occurs when the Beauty theme is being disabled, just before activating the new theme.

The Beauty theme (and other themes as well) replace the `website.template_header_default` template in the website layout. This poses a problem when changing to another theme afterwards because of the interaction between the website templates and the `_reset_default_config` method:

1) Since version 15.0 the `nav` tag inside the header templates was abstracted into a separate template (`website.navbar`) and added to each header layout through `t-call`.

2) The `_reset_default_config` deactivates or reactivates views that were enabled or disabled by the currently active theme. However, when doing so, the default header is activated before the custom header is deactivated.

As a consequence, after toggling the default header, there are temporarily two header extensions in the `website.layout` template. They both replace the `//header//nav` element. Because of the abstraction of the `nav` element into a separate template by the header extensions, only the first replacement will work.

task-2662497