### PR TITLE
[FIX] payment: compute methods shouldn't write

### DIFF
--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -157,7 +157,7 @@ class PaymentAcquirer(models.Model):
 
         :return: None
         """
-        self.write({
+        self.update({
             'show_credentials_page': True,
             'show_allow_tokenization': True,
             'show_payment_icon_ids': True,


### PR DESCRIPTION
`compute` shouldn't write things. This means `writes` can occur
just by reading records.

Instead, when you want to assign multiple compute fields at once,
`update` should be used.

```
2021-10-04 12:42:21,132 61 ERROR db_40421 odoo.upgrade.base.tests.test_mock_crawl: FAIL: TestCrawler.test_check
Traceback (most recent call last):
  File "/tmp/tmpn37k1zm_/migrations/testing.py", line 208, in test_check
    self.check(value)
  File "/tmp/tmpn37k1zm_/migrations/base/tests/test_mock_crawl.py", line 85, in check
    self.assertFalse(diff, msg)
AssertionError: [('payment.payment_acquirer_menu', 217, 'Accounting > Configuration > Payments > Payment Acquirers', 312)] is not false : At least one menu or view working before upgrade is not working after upgrade.

('payment.payment_acquirer_menu', 217, 'Accounting > Configuration > Payments > Payment Acquirers', 312):
 Traceback (most recent call last):
   File "/home/odoo/src/odoo/15.0/odoo/api.py", line 879, in get
    return field_cache[record._ids[0]]
 KeyError: 8

During handling of the above exception, another exception occurred:

 Traceback (most recent call last):
   File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1057, in __get__
    value = env.cache.get(record, self)
   File "/home/odoo/src/odoo/15.0/odoo/api.py", line 882, in get
    raise CacheMiss(record, field)
 odoo.exceptions.CacheMiss: 'payment.acquirer(8,).show_credentials_page'

During handling of the above exception, another exception occurred:

 Traceback (most recent call last):
   File "/tmp/tmpn37k1zm_/migrations/base/tests/test_mock_crawl.py", line 182, in crawl_menu
    self.mock_action(action_vals)
   File "/tmp/tmpn37k1zm_/migrations/base/tests/test_mock_crawl.py", line 293, in mock_action
    mock_method(model, view, fields_list, domain, group_by)
   File "/tmp/tmpn37k1zm_/migrations/base/tests/test_mock_crawl.py", line 319, in mock_view_form
    [data] = record.read(fields_list)
   File "/home/odoo/src/odoo/15.0/odoo/models.py", line 3227, in read
    return self._read_format(fnames=fields, load=load)
   File "/home/odoo/src/odoo/15.0/odoo/models.py", line 3247, in _read_format
    vals[name] = convert(record[name], record, use_name_get)
   File "/home/odoo/src/odoo/15.0/odoo/models.py", line 5867, in __getitem__
    return self._fields[key].__get__(self, type(self))
   File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1106, in __get__
    self.compute_value(recs)
   File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1265, in compute_value
    records._compute_field_value(self)
   File "/home/odoo/src/odoo/15.0/odoo/models.py", line 4249, in _compute_field_value
    getattr(self, field.compute)()
   File "/home/odoo/src/odoo/15.0/addons/payment_transfer/models/payment_acquirer.py", line 21, in _compute_view_configuration_fields
    super()._compute_view_configuration_fields()
   File "/home/odoo/src/odoo/15.0/addons/payment/models/payment_acquirer.py", line 168, in _compute_view_configuration_fields
    'show_cancel_msg': True,
   File "/home/odoo/src/odoo/15.0/addons/payment_transfer/models/payment_acquirer.py", line 41, in write
    res = super().write(values)
   File "/home/odoo/src/odoo/15.0/addons/payment/models/payment_acquirer.py", line 234, in write
    self._check_required_if_provider()
   File "/home/odoo/src/odoo/15.0/addons/payment/models/payment_acquirer.py", line 260, in _check_required_if_provider
    _("The following fields must be filled: %s", ", ".join(field_names))
 odoo.exceptions.ValidationError: The following fields must be filled: Email
```

upg-40421

closes odoo/odoo#77752