### PR TITLE
[FIX] mail: prevent traceback when the audio of a peer is loaded

### DIFF
--- a/addons/mail/static/src/models/rtc_session/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session/rtc_session.js
@@ -69,7 +69,6 @@ function factory(dependencies) {
          * @param {boolean} param0.isTalking
          */
         async setAudio({ audioStream, isMuted, isTalking }) {
-            this._removeAudio();
             const audioElement = this.audioElement || new window.Audio();
             try {
                 audioElement.srcObject = audioStream;


### PR DESCRIPTION
Before this commit, we would reset the audio of a peer before setting a
new one which is not necessary as the track remains the same for the
whole lifetime of the transceiver (and therefore the peerConnection).

Moreover, calling `pause` on the audioElement could lead to a race
condition with the following `play` and lead to a traceback.

