### PR TITLE
Improve overtime displays overall

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -140,7 +140,6 @@ class HrAttendance(models.Model):
         for emp, attendance_dates in employee_attendance_dates.items():
             # get_attendances_dates returns the date translated from the local timezone without tzinfo,
             # and contains all the date which we need to check for overtime
-            emp_tz = pytz.timezone(emp._get_tz())
             attendance_domain = []
             for attendance_date in attendance_dates:
                 attendance_domain = OR([attendance_domain, [

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -165,6 +165,9 @@ class HrEmployee(models.Model):
             modified_attendance = employee._attendance_action_change()
         action_message['attendance'] = modified_attendance.read()[0]
         action_message['total_overtime'] = employee.total_overtime
+        # Overtime have an unique constraint on the day, no need for limit=1
+        action_message['overtime_today'] = self.env['hr.attendance.overtime'].sudo().search([
+            ('employee_id', '=', employee.id), ('date', '=', fields.Date.context_today(self)), ('adjustment', '=', False)]).duration or 0
         return {'action': action_message}
 
     def _attendance_action_change(self):

--- a/addons/hr_attendance/static/src/js/greeting_message.js
+++ b/addons/hr_attendance/static/src/js/greeting_message.js
@@ -55,7 +55,9 @@ var GreetingMessage = AbstractAction.extend({
 
         // extra hours amount displayed in the greeting message template.
         this.total_overtime_float = action.total_overtime; // Used for comparison in template
-        this.total_overtime = field_utils.format.float_time(this.total_overtime_float)
+        this.total_overtime = field_utils.format.float_time(this.total_overtime_float);
+        this.today_overtime_float = action.overtime_today;
+        this.today_overtime = field_utils.format.float_time(this.today_overtime_float);
 
         if (action.hours_today) {
             var duration = moment.duration(action.hours_today, "hours");

--- a/addons/hr_attendance/static/src/xml/attendance.xml
+++ b/addons/hr_attendance/static/src/xml/attendance.xml
@@ -118,17 +118,12 @@
                             Checked out at <b><t t-esc="widget.attendance.check_out_time"/></b>
                             <br/><b><t t-esc="widget.hours_today"/></b>
                         </div>
+                        <div t-att-class="'alert ' + (widget.today_overtime_float &gt;= 0 ? 'alert-success' : 'alert-danger') + ' h3 mt0'" role="status">
+                            Extra hours today:
+                            <span t-esc="widget.today_overtime"/>
+                        </div>
                         <t t-if="widget.total_overtime_float &gt; 0">
-                            <div class="alert alert-success h3 mt0" role="status">
-                                Total extra hours:
-                                <span t-esc="widget.total_overtime"/>
-                            </div>
-                        </t>
-                        <t t-if="widget.total_overtime_float &lt; 0">
-                            <div class="alert alert-danger h3 mt0" role="status">
-                                Total extra hours:
-                                <span t-esc="widget.total_overtime"/>
-                            </div>
+                            Total extra hours: <span t-esc="widget.total_overtime"/>
                         </t>
                         <h3 class="o_hr_attendance_random_message mb24"/>
                         <div class="o_hr_attendance_warning_message mt24 alert alert-warning" style="display:none" role="alert"/>

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -710,6 +710,14 @@ class HolidaysRequest(models.Model):
     # ORM Overrides methods
     ####################################################
 
+    def onchange(self, values, field_name, field_onchange):
+        # Try to force the leave_type name_get when creating new records
+        # This is called right after pressing create and returns the name_get for
+        # most fields in the view.
+        if 'employee_id' in field_onchange:
+            self = self.with_context(employee_id=int(field_onchange['employee_id']))
+        return super().onchange(values, field_name, field_onchange)
+
     def name_get(self):
         res = []
         for leave in self:

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -460,6 +460,14 @@ class HolidaysAllocation(models.Model):
     # ORM Overrides methods
     ####################################################
 
+    def onchange(self, values, field_name, field_onchange):
+        # Try to force the leave_type name_get when creating new records
+        # This is called right after pressing create and returns the name_get for
+        # most fields in the view.
+        if 'employee_id' in field_onchange:
+            self = self.with_context(employee_id=int(field_onchange['employee_id']))
+        return super().onchange(values, field_name, field_onchange)
+
     def name_get(self):
         res = []
         for allocation in self:

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -373,8 +373,11 @@ class HolidaysType(models.Model):
         for leave_type in self:
             leave_type.accrual_count = mapped_data.get(leave_type.id, 0)
 
+    def requested_name_get(self):
+        return self._context.get('holiday_status_name_get', True) and self._context.get('employee_id')
+
     def name_get(self):
-        if not self._context.get('employee_id'):
+        if not self.requested_name_get():
             # leave counts is based on employee_id, would be inaccurate if not based on correct employee
             return super(HolidaysType, self).name_get()
         res = []

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -97,7 +97,7 @@
                     <group>
                         <group>
                             <field name="type_request_unit" invisible="1"/>
-                            <field name="holiday_status_id" context="{'employee_id':employee_id, 'default_date_from':current_date}"/>
+                            <field name="holiday_status_id" context="{'employee_id':employee_id, 'default_date_from':current_date, 'request_type':'allocation'}"/>
 
                             <field name="allocation_type" invisible="1" widget="radio"
                                 attrs="{'readonly': ['|', ('is_officer', '=', False), ('state', 'not in', ('draft', 'confirm'))]}"/>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -231,7 +231,7 @@
                 </div>
                 <group>
                     <group name="col_left">
-                        <field name="holiday_status_id" force_save="1" domain="['|', ('requires_allocation', '=', 'no'), '&amp;', ('has_valid_allocation', '=', True), '&amp;', ('virtual_remaining_leaves', '&gt;', 0), ('max_leaves', '>', '0')]" context="{'employee_id':employee_id, 'default_date_from':date_from}" options="{'no_create': True, 'no_open': True}" class="w-100"/>
+                        <field name="holiday_status_id" force_save="1" domain="['|', ('requires_allocation', '=', 'no'), '&amp;', ('has_valid_allocation', '=', True), '&amp;', ('virtual_remaining_leaves', '&gt;', 0), ('max_leaves', '>', '0')]" context="{'employee_id':employee_id, 'default_date_from':date_from}" options="{'no_create': True, 'no_open': True, 'request_type':'leave'}" class="w-100"/>
                         <label for="request_date_from" string="Dates" id="label_dates"/>
                         <div>
                             <field name="date_from" invisible="1" widget="daterange"/>
@@ -408,7 +408,7 @@
             <field name="holiday_status_id" position="replace"/>
             <div name="title" position="inside">
                 <h1 class="d-flex flex-row justify-content-between">
-                    <field name="holiday_status_id" options="{'no_open': True}"/>
+                    <field name="holiday_status_id" options="{'no_open': True}" context="{'request_type':'leave'}"/>
                 </h1>
             </div>
             <field name="employee_id" position="replace"/>
@@ -660,7 +660,8 @@
             'search_default_my_team': 2,
             'search_default_active_employee': 3,
             'search_default_active_time_off': 4,
-            'hide_employee_name': 1}
+            'hide_employee_name': 1,
+            'holiday_status_name_get': False}
         </field>
         <field name="domain">[]</field>
         <field name="help" type="html">
@@ -678,7 +679,8 @@
         <field name="view_mode">tree,kanban,form,calendar,activity</field>
         <field name="search_view_id" ref="hr_holidays.hr_leave_view_search_manager"/>
         <field name="context">{
-            'hide_employee_name': 1}
+            'hide_employee_name': 1,
+            'holiday_status_name_get': False}
         </field>
         <field name="domain">[('holiday_allocation_id', '=', active_id)]</field>
         <field name="help" type="html">

--- a/addons/hr_holidays_attendance/models/hr_leave_type.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_type.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo.tools.misc import format_duration
+from odoo import _, api, fields, models
 
 
 class HRLeaveType(models.Model):
@@ -11,6 +12,28 @@ class HRLeaveType(models.Model):
     overtime_deductible = fields.Boolean(
         "Deduct Extra Hours", default=False,
         help="Once a time off of this type is approved, extra hours in attendances will be deducted.")
+
+    def name_get(self):
+        # Exclude hours available in allocation contexts, it might be confusing otherwise
+        if not self.requested_name_get() or self._context.get('request_type', 'leave') == 'allocation':
+            return super().name_get()
+        employee_id = False
+        overtime_leaves = self.env['hr.leave.type']
+        res = []
+        for leave_type in self:
+            if leave_type.overtime_deductible and leave_type.requires_allocation == 'no':
+                if not employee_id:
+                    employee_id = self.env['hr.employee'].browse(self._context.get('employee_id')).sudo()
+                if employee_id.total_overtime > 0:
+                    overtime_leaves |= leave_type
+                    name = "%(name)s (%(count)s)" % {
+                        'name': leave_type.name,
+                        'count': _('%s hours available',
+                            format_duration(employee_id.total_overtime)),
+                    }
+                    res.append((leave_type.id, name))
+        res += super(HRLeaveType, self - overtime_leaves).name_get()
+        return res
 
     def get_employees_days(self, employee_ids, date=None):
         res = super().get_employees_days(employee_ids, date)

--- a/addons/hr_holidays_attendance/views/hr_leave_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_leave_views.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="hr_leave_view_form" model="ir.ui.view">
         <field name="model">hr.leave</field>
-        <field name="inherit_id" ref="hr_holidays.hr_leave_view_form" />
+        <field name="inherit_id" ref="hr_holidays.hr_leave_view_form_manager" />
         <field name="arch" type="xml">
             <xpath expr="(//div[@name='duration_display']/div)[last()]" position="after">
                 <field name="overtime_deductible" invisible="1" />


### PR DESCRIPTION
Adds more ways for the user to see his overtime hours.

The name_get for leaves types would previously not show the number of
hours available to the user for the extra hours time off type.
This commit adds that special case of time off type.

Improves on the display when closing an attendance to display today's
overtime aswell as the total overtime the employee has.