### PR TITLE
[FIX] crm: fix the rule based assignment

### DIFF
--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -280,8 +280,8 @@ class Team(models.Model):
         plaintext or html message at caller's will
         """
         # extract some statistics
-        assigned = sum(len(teams_data[team]['assigned']) + len(teams_data[team]['merged']) for team in self)
-        duplicates = sum(len(teams_data[team]['duplicates']) for team in self)
+        assigned = sum(len(teams_data[team]['assigned']) + len(teams_data[team]['merged']) for team in teams_data)
+        duplicates = sum(len(teams_data[team]['duplicates']) for team in teams_data)
         members = len(members_data)
         members_assigned = sum(len(member_data['assigned']) for member_data in members_data.values())
 


### PR DESCRIPTION
Bug
===
Since fe8c5b9b01c01ddb7cc516dfd1ad97bf537db655 , if you have a team
with set to `assignment_max` and you try to automatically assign the
leads an error is raised.

Technical: in `_allocate_leads` we skip a team if `assignment_max` is
Falsy. So when we prepare the values for the notifications, the key
might not be present in the dict an error is raised.

Task-2658696

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
