### PR TITLE
[FIX] web_editor: restore column count snippet option

### DIFF
--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -26,6 +26,13 @@ for (const snippet of snippetsNames) {
     }, {
         content: `click on 'BLOCKS' tab (${snippet})`,
         trigger: ".o_we_add_snippet_btn",
+        run: function (actions) {
+            // FIXME cannot find the reason why this setTimeout is needed to
+            // after reverting ab7508393376075f95d6dd5925e7f4462936d2, to check
+            // (this commit is however reverted temporarily until a better
+            // solution is found).
+            setTimeout(() => actions.auto(), 0);
+        },
     }];
 
     if (snippet === 's_google_map') {


### PR DESCRIPTION
When decreasing the number of columns through the column count snippet
option, the editor entered a deadlock situation.

This reverts [1] which is the cause, trying to await the UI update
during a snippet removal. This commit first prevents the deadlock while
waiting for a better solution to be implemented.

[1]: https://github.com/odoo/odoo/commit/ab7508393376075f95d6dd5925e7f4462936d24e

task-2652904

X-original-commit: ae219ec06baf0280c76ae09b1453cc1481eece30
