### PR TITLE
[IMP] website: add ability to make mega menu transparent

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1193,6 +1193,7 @@ header {
     margin-top: 0;
     border-radius: 0;
     background-clip: unset; // Remove the 1px gap introduced by BS4
+    background-color: transparent; // In order to allow the mega menu to be transparent
 
     .container, .container-fluid {
         // Need to reforce those because they are removed since its a container


### PR DESCRIPTION
Make the transparency effect work on mega menus.
This effect was not working because the container that contains the mega menu was not transparent.

This comes with an upgrade script, see https://github.com/odoo/upgrade/pull/2929

**Task 2623335**
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
