### PR TITLE
[FIX] mail: open attachment viewer in public views

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -150,8 +150,11 @@ class DiscussController(http.Controller):
             raise NotFound()
         return channel_partner_sudo.env['ir.http']._get_content_common(res_id=int(attachment_id), download=True)
 
-    @http.route('/mail/channel/<int:channel_id>/image/<int:attachment_id>/<int:width>x<int:height>', methods=['GET'], type='http', auth='public')
-    def fetch_image(self, channel_id, attachment_id, width, height, **kwargs):
+    @http.route([
+        '/mail/channel/<int:channel_id>/image/<int:attachment_id>',
+        '/mail/channel/<int:channel_id>/image/<int:attachment_id>/<int:width>x<int:height>',
+    ], methods=['GET'], type='http', auth='public')
+    def fetch_image(self, channel_id, attachment_id, width=0, height=0, **kwargs):
         channel_partner_sudo = request.env['mail.channel.partner']._get_as_sudo_from_request_or_raise(request=request, channel_id=int(channel_id))
         if not channel_partner_sudo.env['ir.attachment'].search([('id', '=', int(attachment_id)), ('res_id', '=', int(channel_id)), ('res_model', '=', 'mail.channel')], limit=1):
             raise NotFound()

--- a/addons/mail/static/src/components/attachment_viewer/attachment_viewer.xml
+++ b/addons/mail/static/src/components/attachment_viewer/attachment_viewer.xml
@@ -43,7 +43,7 @@
                                     <i class="fa fa-3x fa-circle-o-notch fa-fw fa-spin" role="img" title="Loading"/>
                                 </div>
                             </t>
-                            <img class="o_AttachmentViewer_view o_AttachmentViewer_viewImage" t-on-click="_onClickImage" t-on-mousedown="_onMousedownImage" t-on-wheel="_onWheelImage" t-on-load="_onLoadImage" t-att-src="attachmentViewer.attachment.defaultSource" t-att-style="imageStyle" draggable="false" alt="Viewer" t-key="'image_' + attachmentViewer.attachment.id" t-ref="image_{{ attachmentViewer.attachment.id }}"/>
+                            <img class="o_AttachmentViewer_view o_AttachmentViewer_viewImage" t-on-click="_onClickImage" t-on-mousedown="_onMousedownImage" t-on-wheel="_onWheelImage" t-on-load="_onLoadImage" t-att-src="attachmentViewer.imageUrl" t-att-style="imageStyle" draggable="false" alt="Viewer" t-key="'image_' + attachmentViewer.attachment.id" t-ref="image_{{ attachmentViewer.attachment.id }}"/>
                         </div>
                     </t>
                     <t t-if="attachmentViewer.attachment.isPdf">

--- a/addons/mail/static/src/models/attachment_viewer/attachment_viewer.js
+++ b/addons/mail/static/src/models/attachment_viewer/attachment_viewer.js
@@ -20,6 +20,25 @@ function factory(dependencies) {
                 dialog.delete();
             }
         }
+
+        //----------------------------------------------------------------------
+        // Private
+        //----------------------------------------------------------------------
+
+        /**
+         * @private
+         * @returns {string}
+         */
+        _computeImageUrl() {
+            if (!this.attachment) {
+                return;
+            }
+            if (!this.attachment.accessToken && this.attachment.originThread && this.attachment.originThread.model === 'mail.channel') {
+                return `/mail/channel/${this.attachment.originThread.id}/image/${this.attachment.id}`;
+            }
+            const accessToken = this.attachment.accessToken ? `?access_token=${this.attachment.accessToken}` : '';
+            return `/web/image/${this.attachment.id}${accessToken}`;
+        }
     }
 
     AttachmentViewer.fields = {
@@ -45,6 +64,13 @@ function factory(dependencies) {
         dialog: one2one('mail.dialog', {
             inverse: 'attachmentViewer',
             isCausal: true,
+            readonly: true,
+        }),
+        /**
+         * Determines the source URL to use for the image.
+         */
+        imageUrl: attr({
+            compute: '_computeImageUrl',
             readonly: true,
         }),
         /**

--- a/addons/mail/static/src/public/discuss_public_boot.js
+++ b/addons/mail/static/src/public/discuss_public_boot.js
@@ -66,6 +66,10 @@ owl.Component.env = legacyEnv;
 
 async function createAndMountDiscussPublicView() {
     const messaging = await owl.Component.env.services.messaging.get();
+    // needed by the attachment viewer
+    const DialogManager = getMessagingComponent('DialogManager');
+    const dialogManagerComponent = new DialogManager(null, {});
+    await dialogManagerComponent.mount(document.body);
     messaging.models['mail.thread'].insert(messaging.models['mail.thread'].convertData(data.channelData));
     const discussPublicView = messaging.models['mail.discuss_public_view'].create(data.discussPublicViewData);
     if (discussPublicView.shouldDisplayWelcomeViewInitially) {


### PR DESCRIPTION
Click on an attachment from a public thread view will now open it in an attachment viewer.
