### PR TITLE
[FIX] mrp: make MO date_planned_start default=now again

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -65,7 +65,7 @@ class MrpProduction(models.Model):
     def _get_default_date_planned_start(self):
         if self.env.context.get('default_date_deadline'):
             return fields.Datetime.to_datetime(self.env.context.get('default_date_deadline'))
-        return fields.Datetime.now().replace(minute=0, second=0, microsecond=0) + datetime.timedelta(hours=1)
+        return datetime.datetime.now()
 
     @api.model
     def _get_default_is_locked(self):


### PR DESCRIPTION
In PR: #74540 the MO.date_planned_start default was updated to
round up to the next hour. It was later decided this would be too
confusing so this commit reverts it back to the original default of now
(i.e. without any hour rounding)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
