### PR TITLE
[FIX] http_routing: hide the traceback by default on error 500 page

### DIFF
--- a/addons/http_routing/views/http_routing_template.xml
+++ b/addons/http_routing/views/http_routing_template.xml
@@ -69,7 +69,7 @@
                     <h1 class="mt-5">Oops! Something went wrong.</h1>
                     <p>Take a look at the error message below.</p>
                 </div>
-                <t t-if="editable or request.session.debug">
+                <t t-if="editable or debug">
                     <t t-call="http_routing.http_error_debug"/>
                 </t>
                 <t t-else="">
@@ -88,7 +88,7 @@
                     <h1 class="mt-5">403: Forbidden</h1>
                     <p>The page you were looking for could not be authorized.</p>
                 </div>
-                    <t t-if="editable or request.session.debug">
+                    <t t-if="editable or debug">
                         <t t-call="http_routing.http_error_debug"/>
                     </t>
                     <t t-else="">
@@ -145,7 +145,6 @@
         <html>
             <head>
                 <title t-esc="status_message">Internal Server Error</title>
-                <t t-set="debug" t-value="True"/>
 
                 <link rel="stylesheet" href="/web/static/lib/bootstrap/css/bootstrap.css"/>
                 <script src="/web/static/lib/jquery/jquery.js" type="text/javascript"/>

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -19,6 +19,7 @@ class Menu(models.Model):
         menu = self.search([], limit=1, order="sequence DESC")
         return menu.sequence or 0
 
+    @api.depends('mega_menu_content')
     def _compute_field_is_mega_menu(self):
         for menu in self:
             menu.is_mega_menu = bool(menu.mega_menu_content)

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2283,7 +2283,7 @@
     </xpath>
     <xpath expr="//div[@id='error_message']" position="after">
         <div class="container" t-if="view and editable">
-            <div class="alert alert-danger" t-if="debug" role="alert">
+            <div class="alert alert-danger" role="alert">
                 <h4>Template fallback</h4>
                 <p>An error occured while rendering the template <code t-esc="qweb_exception.name"/>.</p>
                 <p>If this error is caused by a change of yours in the templates, you have the possibility to reset the template to its <strong>factory settings</strong>.</p>


### PR DESCRIPTION
Before this commit, the error 500 page would always shows the full traceback
even if it is supposed to only show it in debug mode (or if editable).

That behavior was probably broken by the debug refactoring [1], which
introduced side effect with [2] (see template `http_error` which was moved with
[3]).

[1]: d7cd97a
[2]: 24a20cd
[3]: 423402f