### PR TITLE
[FIX] web_editor: restore overlay padding controls

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4178,6 +4178,10 @@ registry.sizing = SnippetOptionWidget.extend({
             $body.on('mouseup', bodyMouseUp);
         });
 
+        _.each(resizeValues, (value, key) => {
+            this.$handles.filter('.' + key).toggleClass('readonly', !value);
+        });
+
         return def;
     },
     /**
@@ -4185,12 +4189,6 @@ registry.sizing = SnippetOptionWidget.extend({
      */
     onFocus: function () {
         this._onResize();
-    },
-    /**
-     * @override
-     */
-    onBlur: function () {
-        this.$handles.addClass('readonly');
     },
 
     //--------------------------------------------------------------------------
@@ -4203,16 +4201,6 @@ registry.sizing = SnippetOptionWidget.extend({
     setTarget: function () {
         this._super(...arguments);
         this._onResize();
-    },
-    /**
-     * @override
-     */
-    updateUI: async function () {
-        await this._super(...arguments);
-        const resizeValues = this._getSize();
-        _.each(resizeValues, (value, key) => {
-            this.$handles.filter('.' + key).toggleClass('readonly', !value);
-        });
     },
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Sometimes the padding controls disappeared for no apparent reason. This
was when going from a child element to a parent element -> following
BVR's investigation, it apparently appears that the UI is not updated
anymore since already visible and nothing should have to be updated
since [1].

While waiting for a deeper investigation about the onFocus / ui update
flows, this commit restores the padding controls another way: by simply
not hiding them and showing them again at each blur / focus. It does not
seem needed indeed... or at least I cannot find a reason why right now.
Indeed, it was not the case before [2] which changed the system without
any explanation. With [3], the onFocus part was later moved to updateUI
since each onFocus calls are now followed by an UI update. But in this
case, like before [2], it only seems needed to show or not the padding
controls at option initialization.

Deeper investigation and refactoring will follow.

[1]: https://github.com/odoo/odoo/commit/806a8db35b5e0e6a461422f5bba7c97180c3ef29
[2]: https://github.com/odoo/odoo/commit/4f27e52cabb77b8b1a9637a11185ddf882adc9af
[3]: https://github.com/odoo/odoo/commit/3be9ae5672f76f85cd747f57539e7bc2919850f8
