### PR TITLE
[FIX] account, point_of_sale: starting balance in one PoS is affected by

### DIFF
--- a/addons/point_of_sale/models/account_bank_statement.py
+++ b/addons/point_of_sale/models/account_bank_statement.py
@@ -24,6 +24,17 @@ class AccountBankStatement(models.Model):
                 raise UserError(_("You cannot delete a bank statement linked to Point of Sale session."))
         return super( AccountBankStatement, self).unlink()
 
+    @api.depends('previous_statement_id', 'previous_statement_id.balance_end_real')
+    def _compute_starting_balance(self):
+        statement_ids = self.env['account.bank.statement']
+        for statement in self:
+            if statement.pos_session_id.config_id == statement.previous_statement_id.pos_session_id.config_id:
+                statement_ids |= statement
+            else:
+                # Need default value
+                statement.balance_start = statement.balance_start or 0.0
+        return super(AccountBankStatement, statement_ids)._compute_starting_balance()
+
 class AccountBankStatementLine(models.Model):
     _inherit = 'account.bank.statement.line'
 


### PR DESCRIPTION
other PoS

Prevent the starting balance in cash control affect by other PoS session

Before the fix, when opening two PoS sessions with different starting
balance, if we close one pos session, the value of "Starting Balance" in
another opening session changes to the value of "Actual in Cash" in
closing session

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
