### PR TITLE
[FIX] base: fix qweb ast validation for python 3.8.4

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -422,10 +422,10 @@ class IrQWeb(models.AbstractModel, QWeb):
     def _get_attr_bool(self, attr, default=False):
         if attr:
             if attr is True:
-                return ast.Name(id='True', ctx=ast.Load())
+                return ast.NameConstant(True)
             attr = attr.lower()
             if attr in ('false', '0'):
-                return ast.Name(id='False', ctx=ast.Load())
+                return ast.NameConstant(False)
             elif attr in ('true', '1'):
-                return ast.Name(id='True', ctx=ast.Load())
-        return ast.Name(id=str(attr if attr is False else default), ctx=ast.Load())
+                return ast.NameConstant(True)
+        return ast.NameConstant(attr if attr is False else bool(default))

--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -613,12 +613,12 @@ class QWeb(object):
                         ast.Compare(
                             left=ast.Name(id='content', ctx=ast.Load()),
                             ops=[ast.IsNot()],
-                            comparators=[ast.Name(id='None', ctx=ast.Load())]
+                            comparators=[ast.NameConstant(None)]
                         ),
                         ast.Compare(
                             left=ast.Name(id='content', ctx=ast.Load()),
                             ops=[ast.IsNot()],
-                            comparators=[ast.Name(id='False', ctx=ast.Load())]
+                            comparators=[ast.NameConstant(False)]
                         )
                     ]
                 ),
@@ -1246,7 +1246,7 @@ class QWeb(object):
                         keywords=[], starargs=None, kwargs=None
                     ),
                     self._compile_expr0(expression),
-                    ast.Name(id='None', ctx=ast.Load()),
+                    ast.NameConstant(None),
                 ], ctx=ast.Load())
             )
         ]
@@ -1535,7 +1535,7 @@ class QWeb(object):
                     if isinstance(key, pycompat.string_types):
                         keys.append(ast.Str(s=key))
                     elif key is None:
-                        keys.append(ast.Name(id='None', ctx=ast.Load()))
+                        keys.append(ast.NameConstant(None))
                     values.append(ast.Str(s=value))
 
                 # {'nsmap': {None: 'xmlns def'}}


### PR DESCRIPTION
As of Python 3.8.4, when `ast.Name` is instantiated with either `True`,
`False` and `None`, a ValueError is raised [1][2].
Because of that, QWeb views processing will crash.

Replacing `ast.Name` with `ast.Constant` is the proper way to
instantiate those constants, and is supported since Python 3.6.0.

This fix was tested on Python 3.6, 3.7 and 3.8, and is in 14.0 already.

It is now considered for backport in 13.0 because:
- 13.0 still represented 75% of the new installations as of
  September 2020, so if left unpatched it will generate a large number
  of obscure errors and support tickets for our users.
- Ubuntu 20.04 has started to deploy Python 3.8.5 via unattended
  upgrades in October 2020, replacing 3.8.2, and thus triggers the
  problem [4].

1: https://docs.python.org/3/whatsnew/changelog.html#id7
2: https://bugs.python.org/issue40870
3: https://packages.ubuntu.com/focal/python3.8

backport of d73b44a46 using ast.NameConstant (available in python with
https://github.com/python/cpython/commit/442f20996dcd994d1024e5cad7f66a4
and deprecated in python 3.8) because python 3.5 doesn't have ast.Constant.