### PR TITLE
[IMP] l10n_latam_invoice_document, l10n_ar, l10n_cl: remove fields and compute methods

### DIFF
--- a/addons/l10n_ar/models/__init__.py
+++ b/addons/l10n_ar/models/__init__.py
@@ -15,3 +15,4 @@ from . import res_partner_bank
 from . import uom_uom
 from . import account_chart_template
 from . import account_move
+from . import account_move_line

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -2,7 +2,6 @@
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError, RedirectWarning, ValidationError
 from dateutil.relativedelta import relativedelta
-from lxml import etree
 import logging
 _logger = logging.getLogger(__name__)
 
@@ -294,3 +293,26 @@ class AccountMove(models.Model):
         if self.l10n_latam_use_documents and self.company_id.account_fiscal_country_id.code == 'AR':
             return 'l10n_ar.report_invoice_document'
         return super()._get_name_invoice_report()
+
+    def _l10n_ar_get_invoice_totals_for_report(self):
+        self.ensure_one()
+        tax_ids_filter = tax_line_id_filter = None
+        include_vat = self._l10n_ar_include_vat()
+
+        if include_vat:
+            tax_ids_filter = (lambda aml, tax: not bool(tax.tax_group_id.l10n_ar_vat_afip_code))
+            tax_line_id_filter = (lambda aml, tax: not bool(tax.tax_group_id.l10n_ar_vat_afip_code))
+
+        tax_lines_data = self._prepare_tax_lines_data_for_totals_from_invoice(
+            tax_ids_filter=tax_ids_filter, tax_line_id_filter=tax_line_id_filter)
+
+        if include_vat:
+            amount_untaxed = self.currency_id.round(
+                self.amount_total - sum([x['tax_amount'] for x in tax_lines_data if 'tax_amount' in x]))
+        else:
+            amount_untaxed = self.amount_untaxed
+        return self._get_tax_totals(self.partner_id, tax_lines_data, self.amount_total, amount_untaxed, self.currency_id)
+
+    def _l10n_ar_include_vat(self):
+        self.ensure_one()
+        return self.l10n_latam_document_type_id.l10n_ar_letter in ['B', 'C', 'X', 'R']

--- a/addons/l10n_ar/models/account_move_line.py
+++ b/addons/l10n_ar/models/account_move_line.py
@@ -1,0 +1,30 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+
+    _inherit = 'account.move.line'
+
+    def _l10n_ar_prices_and_taxes(self):
+        self.ensure_one()
+        invoice = self.move_id
+        included_taxes = self.tax_ids.filtered('tax_group_id.l10n_ar_vat_afip_code') if self.move_id._l10n_ar_include_vat() else self.tax_ids
+        if not included_taxes:
+            price_unit = self.tax_ids.with_context(round=False).compute_all(
+                self.price_unit, invoice.currency_id, 1.0, self.product_id, invoice.partner_id)
+            price_unit = price_unit['total_excluded']
+            price_subtotal = self.price_subtotal
+        else:
+            price_unit = included_taxes.compute_all(
+                self.price_unit, invoice.currency_id, 1.0, self.product_id, invoice.partner_id)['total_included']
+            price = self.price_unit * (1 - (self.discount or 0.0) / 100.0)
+            price_subtotal = included_taxes.compute_all(
+                price, invoice.currency_id, self.quantity, self.product_id, invoice.partner_id)['total_included']
+        price_net = price_unit * (1 - (self.discount or 0.0) / 100.0)
+
+        return {
+            'price_unit': price_unit,
+            'price_subtotal': price_subtotal,
+            'price_net': price_net,
+        }

--- a/addons/l10n_ar/models/l10n_latam_document_type.py
+++ b/addons/l10n_ar/models/l10n_latam_document_type.py
@@ -31,12 +31,6 @@ class L10nLatamDocumentType(models.Model):
             ('X', 'X'),
             ('I', 'I'),  # used for mapping of imports
         ]
-    def _filter_taxes_included(self, taxes):
-        """ In argentina we include taxes depending on document letter """
-        self.ensure_one()
-        if self.country_id.code == "AR" and self.l10n_ar_letter in ['B', 'C', 'X', 'R']:
-            return taxes.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)
-        return super()._filter_taxes_included(taxes)
 
     def _format_document_number(self, document_number):
         """ Make validation of Import Dispatch Number

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -114,33 +114,39 @@
         </td>
 
         <!-- use latam prices (to include/exclude VAT) -->
+        <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="before">
+            <t t-set="l10n_ar_values" t-value="line._l10n_ar_prices_and_taxes()"/>
+        </t>
         <xpath expr="//span[@t-field='line.price_unit']" position="attributes">
-            <attribute name="t-field">line.l10n_latam_price_unit</attribute>
-        </xpath>
-        <xpath expr="//span[@id='line_tax_ids']" position="attributes">
-            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), line.l10n_latam_tax_ids))</attribute>
+            <attribute name="t-field"></attribute>
+            <attribute name="t-esc">l10n_ar_values['price_unit']</attribute>
+            <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </xpath>
         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="attributes">
-            <attribute name="t-value">current_subtotal + line.l10n_latam_price_subtotal</attribute>
+            <attribute name="t-value">current_subtotal + l10n_ar_values['price_subtotal']</attribute>
         </t>
         <!-- if b2c we still wants the latam subtotal -->
         <t t-set="current_subtotal" t-value="current_subtotal + line.price_total" position="attributes">
-            <attribute name="t-value">current_subtotal + line.l10n_latam_price_subtotal</attribute>
+            <attribute name="t-value">current_subtotal + l10n_ar_values['price_subtotal']</attribute>
         </t>
         <!-- label amount for subtotal column on b2b and b2c -->
         <xpath expr="//th[@name='th_subtotal']/span[@groups='account.group_show_line_subtotals_tax_included']" position="replace">
             <span groups="account.group_show_line_subtotals_tax_included">Amount</span>
         </xpath>
         <span t-field="line.price_subtotal" position="attributes">
-            <attribute name="t-field">line.l10n_latam_price_subtotal</attribute>
+            <attribute name="t-field"></attribute>
+            <attribute name="t-esc">l10n_ar_values['price_subtotal']</attribute>
+            <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </span>
         <!-- if b2c we still wants the latam subtotal -->
         <span t-field="line.price_total" position="attributes">
-            <attribute name="t-field">line.l10n_latam_price_subtotal</attribute>
+            <attribute name="t-field"></attribute>
+            <attribute name="t-esc">l10n_ar_values['price_subtotal']</attribute>
+            <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </span>
 
         <t t-set="tax_totals" position="attributes">
-            <attribute name="t-value">o._get_tax_totals_for_latam_invoice_report()</attribute>
+            <attribute name="t-value">o._l10n_ar_get_invoice_totals_for_report()</attribute>
         </t>
 
         <!-- use column vat instead of taxes and only if vat discriminated -->
@@ -148,16 +154,15 @@
             <span>% VAT</span>
         </xpath>
 
-        <xpath expr="//th[@name='th_taxes']" position="attributes">
-            <attribute name="t-if">o.tax_totals_json</attribute>
-        </xpath>
-
         <!-- use column vat instead of taxes and only list vat taxes-->
+        <xpath expr="//th[@name='th_taxes']" position="attributes">
+            <attribute name="t-if">not o._l10n_ar_include_vat()</attribute>
+        </xpath>
         <xpath expr="//span[@id='line_tax_ids']/.." position="attributes">
-            <attribute name="t-if">o.tax_totals_json</attribute>
+            <attribute name="t-if">not o._l10n_ar_include_vat()</attribute>
         </xpath>
         <span id="line_tax_ids" position="attributes">
-            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), line.l10n_latam_tax_ids.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)))</attribute>
+            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), line.tax_ids.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)))</attribute>
         </span>
 
         <!-- remove payment reference that is not used in Argentina -->

--- a/addons/l10n_cl/models/__init__.py
+++ b/addons/l10n_cl/models/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import account_chart_template
 from . import account_move
+from . import account_move_line
 from . import account_tax
 from . import l10n_latam_document_type
 from . import res_company

--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -42,7 +42,6 @@ class AccountMove(models.Model):
             domain += [('code', 'in', [])]
         return domain
 
-
     def _check_document_types_post(self):
         for rec in self.filtered(
                 lambda r: r.company_id.account_fiscal_country_id.code == "CL" and
@@ -124,3 +123,26 @@ class AccountMove(models.Model):
         if self.l10n_latam_use_documents and self.company_id.account_fiscal_country_id.code == 'CL':
             return 'l10n_cl.report_invoice_document'
         return super()._get_name_invoice_report()
+
+    def _l10n_cl_get_invoice_totals_for_report(self):
+        self.ensure_one()
+        tax_ids_filter = tax_line_id_filter = None
+        include_sii = self._l10n_cl_include_sii()
+
+        if include_sii:
+            tax_ids_filter = (lambda aml, tax: bool(tax.l10n_cl_sii_code != 14))
+            tax_line_id_filter = (lambda aml, tax: bool(tax.l10n_cl_sii_code != 14))
+
+        tax_lines_data = self._prepare_tax_lines_data_for_totals_from_invoice(
+            tax_ids_filter=tax_ids_filter, tax_line_id_filter=tax_line_id_filter)
+
+        if include_sii:
+            amount_untaxed = self.currency_id.round(
+                self.amount_total - sum([x['tax_amount'] for x in tax_lines_data if 'tax_amount' in x]))
+        else:
+            amount_untaxed = self.amount_untaxed
+        return self._get_tax_totals(self.partner_id, tax_lines_data, self.amount_total, amount_untaxed, self.currency_id)
+
+    def _l10n_cl_include_sii(self):
+        self.ensure_one()
+        return self.l10n_latam_document_type_id.code in ['39', '41', '110', '111', '112', '34']

--- a/addons/l10n_cl/models/account_move_line.py
+++ b/addons/l10n_cl/models/account_move_line.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+
+    _inherit = 'account.move.line'
+
+    def _l10n_cl_prices_and_taxes(self):
+        self.ensure_one()
+        invoice = self.move_id
+        included_taxes = self.tax_ids.filtered(lambda x: x.l10n_cl_sii_code == 14) if self.move_id._l10n_cl_include_sii() else self.tax_ids
+        if not included_taxes:
+            price_unit = self.tax_ids.with_context(round=False).compute_all(
+                self.price_unit, invoice.currency_id, 1.0, self.product_id, invoice.partner_id)
+            price_unit = price_unit['total_excluded']
+            price_subtotal = self.price_subtotal
+        else:
+            price_unit = included_taxes.compute_all(
+                self.price_unit, invoice.currency_id, 1.0, self.product_id, invoice.partner_id)['total_included']
+            price = self.price_unit * (1 - (self.discount or 0.0) / 100.0)
+            price_subtotal = included_taxes.compute_all(
+                price, invoice.currency_id, self.quantity, self.product_id, invoice.partner_id)['total_included']
+        price_net = price_unit * (1 - (self.discount or 0.0) / 100.0)
+
+        return {
+            'price_unit': price_unit,
+            'price_subtotal': price_subtotal,
+            'price_net': price_net
+        }

--- a/addons/l10n_cl/models/l10n_latam_document_type.py
+++ b/addons/l10n_cl/models/l10n_latam_document_type.py
@@ -28,10 +28,3 @@ class L10nLatamDocumentType(models.Model):
             return False
 
         return document_number.zfill(6)
-
-    def _filter_taxes_included(self, taxes):
-        """ In Chile we include taxes depending on document type """
-        self.ensure_one()
-        if self.country_id.code == "CL" and self.code in ['39', '41', '110', '111', '112', '34']:
-            return taxes.filtered(lambda x: x.l10n_cl_sii_code == 14)
-        return super()._filter_taxes_included(taxes)

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -138,16 +138,22 @@
 
         <xpath expr="//h2" position="replace"/>
 
+        <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="before">
+            <t t-set="l10n_cl_values" t-value="line._l10n_cl_prices_and_taxes()"/>
+        </t>
+
         <xpath expr="//span[@t-field='line.price_unit']" position="attributes">
-            <attribute name="t-field">line.l10n_latam_price_unit</attribute>
+            <attribute name="t-field"></attribute>
+            <attribute name="t-esc">line.price_unit</attribute>
+            <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </xpath>
 
         <xpath expr="//span[@id='line_tax_ids']" position="attributes">
-            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), line.l10n_latam_tax_ids))</attribute>
+            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), line.tax_lines))</attribute>
         </xpath>
 
         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="attributes">
-            <attribute name="t-value">current_subtotal + line.l10n_latam_price_subtotal</attribute>
+            <attribute name="t-value">current_subtotal + l10n_cl_values['price_subtotal']</attribute>
         </t>
 
         <xpath expr="//th[@name='th_subtotal']/span[@groups='account.group_show_line_subtotals_tax_included']" position="replace">
@@ -155,11 +161,13 @@
         </xpath>
 
         <span t-field="line.price_subtotal" position="attributes">
-            <attribute name="t-field">line.l10n_latam_price_subtotal</attribute>
+            <attribute name="t-field"></attribute>
+            <attribute name="t-esc">current_subtotal + l10n_cl_values['price_subtotal']</attribute>
+            <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </span>
 
         <t t-set="tax_totals" position="attributes">
-            <attribute name="t-value">o._get_tax_totals_for_latam_invoice_report()</attribute>
+            <attribute name="t-value">o._l10n_cl_get_invoice_totals_for_report()</attribute>
         </t>
 
         <xpath expr="//th[@name='th_taxes']" position="replace"/>

--- a/addons/l10n_latam_invoice_document/models/account_move_line.py
+++ b/addons/l10n_latam_invoice_document/models/account_move_line.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, api, fields
+from odoo import models, fields
 from odoo.tools.sql import column_exists, create_column
 
 
@@ -17,39 +17,3 @@ class AccountMoveLine(models.Model):
 
     l10n_latam_document_type_id = fields.Many2one(
         related='move_id.l10n_latam_document_type_id', auto_join=True, store=True, index=True)
-    l10n_latam_price_unit = fields.Float(compute='compute_l10n_latam_prices_and_taxes', digits='Product Price')
-    l10n_latam_price_subtotal = fields.Monetary(compute='compute_l10n_latam_prices_and_taxes')
-    l10n_latam_price_net = fields.Float(compute='compute_l10n_latam_prices_and_taxes', digits='Product Price')
-    l10n_latam_tax_ids = fields.One2many(compute="compute_l10n_latam_prices_and_taxes", comodel_name='account.tax')
-
-    @api.depends('price_unit', 'price_subtotal', 'move_id.l10n_latam_document_type_id')
-    def compute_l10n_latam_prices_and_taxes(self):
-        for line in self:
-            invoice = line.move_id
-            included_taxes = \
-                invoice.l10n_latam_document_type_id and invoice.l10n_latam_document_type_id._filter_taxes_included(
-                    line.tax_ids)
-            # For the unit price, we need the number rounded based on the product price precision.
-            # The method compute_all uses the accuracy of the currency so, we multiply and divide for 10^(decimal accuracy of product price) to get the price correctly rounded.
-            price_digits = 10**self.env['decimal.precision'].precision_get('Product Price')
-            if not included_taxes:
-                price_unit = line.tax_ids.with_context(round=False, force_sign=invoice._get_tax_force_sign()).compute_all(
-                    line.price_unit * price_digits, invoice.currency_id, 1.0, line.product_id, invoice.partner_id)
-                l10n_latam_price_unit = price_unit['total_excluded'] / price_digits
-                l10n_latam_price_subtotal = line.price_subtotal
-                not_included_taxes = line.tax_ids
-                l10n_latam_price_net = l10n_latam_price_unit * (1 - (line.discount or 0.0) / 100.0)
-            else:
-                not_included_taxes = line.tax_ids - included_taxes
-                l10n_latam_price_unit = included_taxes.with_context(force_sign=invoice._get_tax_force_sign()).compute_all(
-                    line.price_unit * price_digits, invoice.currency_id, 1.0, line.product_id, invoice.partner_id)['total_included'] / price_digits
-                l10n_latam_price_net = l10n_latam_price_unit * (1 - (line.discount or 0.0) / 100.0)
-                price = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
-                l10n_latam_price_subtotal = included_taxes.with_context(force_sign=invoice._get_tax_force_sign()).compute_all(
-                    price, invoice.currency_id, line.quantity, line.product_id,
-                    invoice.partner_id)['total_included']
-
-            line.l10n_latam_price_subtotal = l10n_latam_price_subtotal
-            line.l10n_latam_price_unit = l10n_latam_price_unit
-            line.l10n_latam_price_net = l10n_latam_price_net
-            line.l10n_latam_tax_ids = not_included_taxes

--- a/addons/l10n_latam_invoice_document/models/l10n_latam_document_type.py
+++ b/addons/l10n_latam_invoice_document/models/l10n_latam_document_type.py
@@ -51,10 +51,3 @@ class L10nLatamDocumentType(models.Model):
         else:
             domain = ['|', ('name', 'ilike', name), ('code', 'ilike', name)]
         return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
-
-    def _filter_taxes_included(self, taxes):
-        """ This method is to be inherited by different localizations and must return filter the given taxes recordset
-        returning the taxes to be included on reports of this document type. All taxes are going to be discriminated
-        except the one returned by this method. """
-        self.ensure_one()
-        return self.env['account.tax']


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Fields removed from l10n_latam:
 * l10n_latam_amount_untaxed
 * l10n_latam_tax_ids
 * l10n_latam_price_unit
 * l10n_latam_price_subtotal
 * l10n_latam_price_net

Methods removed from l10n_latam:
 * compute_l10n_latam_prices_and_taxes
 * compute_l10n_latam_amount_and_taxes
 * _compute_invoice_taxes_by_group

Move the removed methods to l10n_ar and l10n_cl and now it returns a dictionary with the required values.

Also, adapt the invoices reports to get the required values from the new methods for each localization.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
