### PR TITLE
75710 pos incorrect quantity first scenario fix

### DIFF
--- a/addons/point_of_sale/static/src/js/screens.js
+++ b/addons/point_of_sale/static/src/js/screens.js
@@ -65,6 +65,7 @@ var ScreenWidget = PosBaseWidget.extend({
             if (self.barcode_product_screen) {
                 self.gui.show_screen(self.barcode_product_screen, null, null, true);
             }
+            self.numpad.state.reset();
         } else {
             this.barcode_error_action(code);
         }
@@ -1051,7 +1052,10 @@ var ProductScreenWidget = ScreenWidget.extend({
         this.order_widget.replace(this.$('.placeholder-OrderWidget'));
 
         this.product_list_widget = new ProductListWidget(this,{
-            click_product_action: function(product){ self.click_product(product); },
+            click_product_action: function(product) {
+                self.click_product(product);
+                self.numpad.state.reset();
+            },
             product_list: this.pos.db.get_product_by_category(0)
         });
         this.product_list_widget.replace(this.$('.placeholder-ProductListWidget'));

--- a/doc/cla/individual/onorua.md
+++ b/doc/cla/individual/onorua.md
@@ -1,0 +1,11 @@
+Ukraine, 06.10.2021
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Yaroslav Molochko onorua@gmail.com https://github.com/onorua


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Fix for issue #75710, first part, case when the number is increased instead of setting. 

Current behavior before PR:

- scan 1 good
- press 2 as a quantity
- scan the same good second time
- press 2 as a quantity
- the resulting number is 22

Desired behavior after PR is merged:

- scan 1 good
- press 2 as a quantity
- scan the same good second time
- press 2 as a quantity
- the resulting number is 2

This will prevent people with multiple goods in different buckets from overpricing. 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
