### PR TITLE
[FIX] mail: prevent the server from sending outdated session state

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -377,7 +377,11 @@ class DiscussController(http.Controller):
                 ('id', '=', int(rtc_session_id)),
                 ('channel_partner_id', '=', channel_partner_sudo.id),
             ]).write({})  # update write_date
-        return {'rtcSessions': channel_partner_sudo._rtc_sync_sessions(check_rtc_session_ids=check_rtc_session_ids)}
+        current_rtc_sessions, outdated_rtc_sessions = channel_partner_sudo._rtc_sync_sessions(check_rtc_session_ids=check_rtc_session_ids)
+        return {'rtcSessions': [
+            ('insert', [rtc_session_sudo._mail_rtc_session_format(complete_info=False) for rtc_session_sudo in current_rtc_sessions]),
+            ('insert-and-unlink', [{'id': missing_rtc_session_sudo.id} for missing_rtc_session_sudo in outdated_rtc_sessions]),
+        ]}
 
     # --------------------------------------------------------------------------
     # Chatter API

--- a/addons/mail/models/mail_channel_rtc_session.py
+++ b/addons/mail/models/mail_channel_rtc_session.py
@@ -115,15 +115,18 @@ class MailRtcSession(models.Model):
             'payload': payload,
         }) for target, payload in payload_by_target.items()])
 
-    def _mail_rtc_session_format(self):
+    def _mail_rtc_session_format(self, complete_info=True):
         self.ensure_one()
         vals = {
             'id': self.id,
-            'isCameraOn': self.is_camera_on,
-            'isDeaf': self.is_deaf,
-            'isMuted': self.is_muted,
-            'isScreenSharingOn': self.is_screen_sharing_on,
         }
+        if complete_info:
+            vals.update({
+                'isCameraOn': self.is_camera_on,
+                'isDeaf': self.is_deaf,
+                'isMuted': self.is_muted,
+                'isScreenSharingOn': self.is_screen_sharing_on,
+            })
         if self.guest_id:
             vals['guest'] = [('insert', {
                 'id': self.guest_id.id,


### PR DESCRIPTION
Before this commit, the server could return outdated information to the
client about the state of their own rtc session.

The server should not return information about the client's own rtc
session as the source of truth is the client-side state.

A case in which this was causing an issue was when a user toggled their
mute state right before their client pinged the server and received
outdated session information before their most recent state could be
sent to the server.

This commit fixes this issue.