### PR TITLE
[IMP] l10n_it_edi_sdicoop: created a test_mode, fixed Base64 issues

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -17,6 +17,8 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
+# IAP Server address.
+# Customize this address if you want to use the IAP Test Server
 SERVER_URL = 'https://l10n-it-edi.api.odoo.com'
 TIMEOUT = 30
 
@@ -129,12 +131,13 @@ class AccountEdiProxyClientUser(models.Model):
             response = {'id_client': 'demo', 'refresh_token': 'demo'}
         else:
             try:
+                # b64encode returns a bytestring, we need it as a string
                 response = self._make_request(SERVER_URL + '/iap/account_edi/1/create_user', params={
                     'dbuuid': company.env['ir.config_parameter'].get_param('database.uuid'),
                     'company_id': company.id,
                     'edi_format_code': edi_format.code,
                     'edi_identification': edi_identification,
-                    'public_key': base64.b64encode(public_pem)
+                    'public_key': base64.b64encode(public_pem).decode()
                 })
             except AccountEdiProxyError as e:
                 raise UserError(e.message)

--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -17,9 +17,7 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
-# IAP Server address.
-# Customize this address if you want to use the IAP Test Server
-SERVER_URL = 'https://l10n-it-edi.api.odoo.com'
+DEFAULT_SERVER_URL = 'https://l10n-it-edi.api.odoo.com'
 TIMEOUT = 30
 
 
@@ -132,7 +130,8 @@ class AccountEdiProxyClientUser(models.Model):
         else:
             try:
                 # b64encode returns a bytestring, we need it as a string
-                response = self._make_request(SERVER_URL + '/iap/account_edi/1/create_user', params={
+                server_url = self.env['ir.config_parameter'].get_param('account_edi_proxy_client.edi_server_url', DEFAULT_SERVER_URL)
+                response = self._make_request(server_url + '/iap/account_edi/1/create_user', params={
                     'dbuuid': company.env['ir.config_parameter'].get_param('database.uuid'),
                     'company_id': company.id,
                     'edi_format_code': edi_format.code,
@@ -160,7 +159,8 @@ class AccountEdiProxyClientUser(models.Model):
         that multiple database use the same credentials. When receiving an error for an expired refresh_token,
         This method makes a request to get a new refresh token.
         '''
-        response = self._make_request(SERVER_URL + '/iap/account_edi/1/renew_token')
+        server_url = self.env['ir.config_parameter'].get_param('account_edi_proxy_client.edi_server_url', DEFAULT_SERVER_URL)
+        response = self._make_request(server_url + '/iap/account_edi/1/renew_token')
         if 'error' in response:
             # can happen if the database was duplicated and the refresh_token was refreshed by the other database.
             # we don't want two database to be able to query the proxy with the same user

--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -143,8 +143,10 @@ class AccountMove(models.Model):
         else:
             document_type = 'TD0X'
 
+        # b64encode returns a bytestring, the template tries to turn it to string,
+        # but only gets the repr(pdf) --> "b'<base64_data>'"
         pdf = self.env.ref('account.account_invoices')._render_qweb_pdf(self.id)[0]
-        pdf = base64.b64encode(pdf)
+        pdf = base64.b64encode(pdf).decode()
         pdf_name = re.sub(r'\W+', '', self.name) + '.pdf'
 
         # tax map for 0% taxes which have no tax_line_id

--- a/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
+++ b/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
@@ -3,7 +3,7 @@
 
 from odoo import models, _, _lt
 from odoo.exceptions import UserError
-from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError, SERVER_URL
+from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError, DEFAULT_SERVER_URL
 
 from lxml import etree
 import base64
@@ -25,11 +25,12 @@ class AccountEdiFormat(models.Model):
         if self.env['ir.config_parameter'].get_param('account_edi_proxy_client.demo', False):
             return
 
+        server_url = self.env['ir.config_parameter'].get_param('account_edi_proxy_client.edi_server_url', DEFAULT_SERVER_URL)
         proxy_users = self.env['account_edi_proxy_client.user'].search([('edi_format_id', '=', self.env.ref('l10n_it_edi.edi_fatturaPA').id)])
         for proxy_user in proxy_users:
             company = proxy_user.company_id
             try:
-                res = proxy_user._make_request(SERVER_URL + '/api/l10n_it_edi/1/in/RicezioneInvoice',
+                res = proxy_user._make_request(server_url + '/api/l10n_it_edi/1/in/RicezioneInvoice',
                                                params={'recipient_codice_fiscale': company.l10n_it_codice_fiscale})
             except AccountEdiProxyError as e:
                 _logger.error('Error while receiving file from SdiCoop: %s', e)
@@ -64,7 +65,7 @@ class AccountEdiFormat(models.Model):
 
             if proxy_acks:
                 try:
-                    proxy_user._make_request(SERVER_URL + '/api/l10n_it_edi/1/ack',
+                    proxy_user._make_request(server_url + '/api/l10n_it_edi/1/ack',
                                             params={'transaction_ids': proxy_acks})
                 except AccountEdiProxyError as e:
                     _logger.error('Error while receiving file from SdiCoop: %s', e)
@@ -116,7 +117,7 @@ class AccountEdiFormat(models.Model):
                 'name': filename,
                 'res_id': invoice.id,
                 'res_model': invoice._name,
-                'datas': base64.b64encode(xml.encode()),
+                'raw': xml.encode(),
                 'description': _('Italian invoice: %s', invoice.move_type),
                 'type': 'binary',
             })
@@ -161,6 +162,7 @@ class AccountEdiFormat(models.Model):
     def _l10n_it_post_invoices_step_2(self, invoices):
         ''' Check if the sent invoices have been processed by FatturaPA.
         '''
+        server_url = self.env['ir.config_parameter'].get_param('account_edi_proxy_client.edi_server_url', DEFAULT_SERVER_URL)
         to_check = {i.l10n_it_edi_transaction: i for i in invoices}
         to_return = {}
         company = invoices.company_id
@@ -175,7 +177,7 @@ class AccountEdiFormat(models.Model):
             return {invoice: {'attachment': invoice.l10n_it_edi_attachment_id} for invoice in invoices}
         else:
             try:
-                responses = proxy_user._make_request(SERVER_URL + '/api/l10n_it_edi/1/in/TrasmissioneFatture',
+                responses = proxy_user._make_request(server_url + '/api/l10n_it_edi/1/in/TrasmissioneFatture',
                                                     params={'ids_transaction': list(to_check.keys())})
             except AccountEdiProxyError as e:
                 return {invoice: {'error': e.message, 'blocking_level': 'error'} for invoice in invoices}
@@ -227,7 +229,7 @@ class AccountEdiFormat(models.Model):
             proxy_acks.append(id_transaction)
 
         try:
-            proxy_user._make_request(SERVER_URL + '/api/l10n_it_edi/1/ack',
+            proxy_user._make_request(server_url + '/api/l10n_it_edi/1/ack',
                                      params={'transaction_ids': proxy_acks})
         except AccountEdiProxyError as e:
             # Will be ignored and acked again next time.
@@ -271,7 +273,8 @@ class AccountEdiFormat(models.Model):
             'EI03': {'error': _lt('Unauthorized user'), 'blocking_level': 'error'},
         }
 
-        result = proxy_user._make_request(SERVER_URL + '/api/l10n_it_edi/1/out/SdiRiceviFile', params={'files': files})
+        server_url = self.env['ir.config_parameter'].get_param('account_edi_proxy_client.edi_server_url', DEFAULT_SERVER_URL)
+        result = proxy_user._make_request(server_url + '/api/l10n_it_edi/1/out/SdiRiceviFile', params={'files': files})
 
         # Translate the errors.
         for filename in result.keys():

--- a/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
+++ b/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
@@ -116,7 +116,7 @@ class AccountEdiFormat(models.Model):
                 'name': filename,
                 'res_id': invoice.id,
                 'res_model': invoice._name,
-                'datas': base64.encodebytes(xml),
+                'datas': base64.b64encode(xml.encode()),
                 'description': _('Italian invoice: %s', invoice.move_type),
                 'type': 'binary',
             })
@@ -130,7 +130,7 @@ class AccountEdiFormat(models.Model):
             else:
                 to_send[filename] = {
                     'invoice': invoice,
-                    'data': {'filename': filename, 'xml': base64.b64encode(xml)}}
+                    'data': {'filename': filename, 'xml': base64.b64encode(xml.encode()).decode()}}
 
         company = invoices.company_id
         proxy_user = self._get_proxy_user(company)


### PR DESCRIPTION
1) A test_mode is now created to allow experimentation on the IAP server.
    The SERVER_URL pointing to the IAP is now just a DEFAULT_SERVER_URL and it can be configured through a new ir.config_parameter: `account_edi_proxy_client.edi_server_url`
    This parameter is not shown in the configuration, so that it can only be created manually.

2) When encoding a string or bytes with base64, the resulting byte string must be decoded to get the string back.