### PR TITLE
[IMP] mail: keep url params in discuss public view

### DIFF
--- a/addons/mail/static/src/models/discuss_public_view/discuss_public_view.js
+++ b/addons/mail/static/src/models/discuss_public_view/discuss_public_view.js
@@ -28,7 +28,7 @@ function factory(dependencies) {
             });
             if (this.isChannelTokenSecret) {
                 // Change the URL to avoid leaking the invitation link.
-                window.history.replaceState(window.history.state, null, `/discuss/channel/${this.channel.id}`);
+                window.history.replaceState(window.history.state, null, `/discuss/channel/${this.channel.id}${window.location.search}`);
             }
             if (this.channel.defaultDisplayMode === 'video_full_screen') {
                 await this.channel.toggleCall({ startWithVideo: true });


### PR DESCRIPTION
This commit will change the way URLs are edited in discuss public view to preserve URL params in the resulting URL.

Context:
In order to avoid leaking invitation links, URLs are modified in discuss public view, but this can sometimes hide precious information such as the debug mode from the URL.
