### PR TITLE
[FIX] project: Use task object instead of self

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -771,7 +771,7 @@ class Task(models.Model):
     def _compute_recurrence_message(self):
         self.recurrence_message = False
         for task in self.filtered(lambda t: t.recurring_task and t._is_recurrence_valid()):
-            date = self._get_recurrence_start_date()
+            date = task._get_recurrence_start_date()
             number_occurrences = min(5, task.repeat_number if task.repeat_type == 'after' else 5)
             delta = task.repeat_interval if task.repeat_unit == 'day' else 1
             recurring_dates = self.env['project.task.recurrence']._get_next_recurring_dates(


### PR DESCRIPTION
Issue: Getting recurrence start date from self instead
of current task.

commit ref.: https://github.com/odoo/odoo/commit/b50f5f17ee7140160e72bd37241efb14e14a9484

opw-2628777