### PR TITLE
[FIX] sale_mrp: fix manufacturing order smart button

### DIFF
--- a/addons/sale_mrp/models/sale.py
+++ b/addons/sale_mrp/models/sale.py
@@ -14,16 +14,12 @@ class SaleOrder(models.Model):
 
     @api.depends('procurement_group_id.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids')
     def _compute_mrp_production_count(self):
-        data = self.env['procurement.group'].read_group([('sale_id', 'in', self.ids), ('mrp_production_ids', '!=', False)], ['id'], ['sale_id'])
-        mrp_count = dict()
-        for item in data:
-            mrp_count[item['sale_id'][0]] = item['sale_id_count']
         for sale in self:
-            sale.mrp_production_count = mrp_count.get(sale.id)
+            sale.mrp_production_count = len(sale.picking_ids.move_lines.created_production_id)
 
     def action_view_mrp_production(self):
         self.ensure_one()
-        mrp_production_ids = self.env['mrp.production'].search([('procurement_group_id.sale_id', '=', self.id)]).ids
+        mrp_production_ids = self.picking_ids.move_lines.created_production_id.ids
         action = {
             'res_model': 'mrp.production',
             'type': 'ir.actions.act_window',

--- a/addons/sale_mrp/tests/test_sale_mrp_procurement.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_procurement.py
@@ -65,6 +65,8 @@ class TestSaleMrpProcurement(TransactionCase):
         # I confirm the sale order
         sale_order_so0.action_confirm()
 
+        self.assertEqual(sale_order_so0.mrp_production_count, 1, "Smart button should show 1 manufacture order")
+
         # I verify that a manufacturing order has been generated, and that its name and reference are correct
         mo = self.env['mrp.production'].search([('origin', 'like', sale_order_so0.name)], limit=1)
         self.assertTrue(mo, 'Manufacturing order has not been generated')
@@ -163,6 +165,9 @@ class TestSaleMrpProcurement(TransactionCase):
         sale_order_so0.action_confirm()
 
         pickings = sale_order_so0.picking_ids
+
+        # Two MO for final production and manufactured component
+        self.assertEqual(sale_order_so0.mrp_production_count, 2, "Smart button should show 2 manufacture orders")
 
         # One delivery...
         self.assertEqual(len(pickings), 1)


### PR DESCRIPTION
Commit
https://github.com/odoo/odoo/commit/96b56ea350c283d824468c591d42e4aeeada0d69
managed to fix 3-step manufacturing smart button in sale order
but 1-step and 2-step manufacturing are having the same issue now

opw-2645042

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
