### PR TITLE
[FIX] One2many commands resolution

### DIFF
--- a/odoo/addons/test_performance/tests/test_performance.py
+++ b/odoo/addons/test_performance/tests/test_performance.py
@@ -167,24 +167,24 @@ class TestPerformance(SavepointCaseWithUserDemo):
 
         # link N lines from rec1 to rec2: O(1) queries
         rec1.invalidate_cache()
-        with self.assertQueryCount(2):
+        with self.assertQueryCount(3):
             rec2.write({'line_ids': [(4, line.id) for line in lines[0]]})
         self.assertEqual(rec1.line_ids, lines[1:])
         self.assertEqual(rec2.line_ids, lines[0])
 
         rec1.invalidate_cache()
-        with self.assertQueryCount(7):
+        with self.assertQueryCount(8):
             rec2.write({'line_ids': [(4, line.id) for line in lines[1:]]})
         self.assertFalse(rec1.line_ids)
         self.assertEqual(rec2.line_ids, lines)
 
         rec1.invalidate_cache()
-        with self.assertQueryCount(5):
+        with self.assertQueryCount(6):
             rec2.write({'line_ids': [(4, line.id) for line in lines[0]]})
         self.assertEqual(rec2.line_ids, lines)
 
         rec1.invalidate_cache()
-        with self.assertQueryCount(5):
+        with self.assertQueryCount(6):
             rec2.write({'line_ids': [(4, line.id) for line in lines[1:]]})
         self.assertEqual(rec2.line_ids, lines)
 

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3204,7 +3204,7 @@ class One2many(_RelationalMulti):
                     to_create.clear()
                 if to_inverse:
                     for record, inverse_ids in to_inverse.items():
-                        lines = comodel.browse(inverse_ids)
+                        lines = comodel.browse(inverse_ids).exists()
                         lines = lines.filtered(lambda line: int(line[inverse]) != record.id)
                         lines[inverse] = record
 


### PR DESCRIPTION
Fixes `MissingError` being raised when Odoo tries to link an already-deleted record to its inverse record.

For example, say we have a sale order with two order lines, the first being a simple product line, the second being a reward line which is applicable to the first one.
If we delete the product line, what happens is:
- a `write()` is called upon `sale.order` with vals `{"order_line": [(2, product_line.id), (4, reward_line.id)]}`
- the One2many `write_real()` is triggered: it will first delete the product line, then link the reward line to the sale order
- deleting the product line will make Odoo delete the reward line too
- when `write_real()` tries to execute the second command and link the reward line to the sale order, `MissingError` is raised because the reward line has already been deleted

[Test it with Runbot.](https://10397261-14-0-all.runbot80.odoo.com/web#action=827&cids=1&id=47&menu_id=587&model=sale.order&view_type=form)

Please note that what is written above is just an example of the current One2many field behaviour, so changing the sale_coupon module will only remove the symptoms, not the cause!

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
