### PR TITLE
[FIX] account[_qr_code_sepa],l10n_ch: Use value as string in QR-code

### DIFF
--- a/addons/account/models/res_bank.py
+++ b/addons/account/models/res_bank.py
@@ -100,7 +100,6 @@ class ResPartnerBank(models.Model):
         """
         params = self._get_qr_code_generation_params(qr_method, amount, currency, debtor_partner, free_communication, structured_communication)
         if params:
-            params['value'] = '\n'.join(params['value'])
             params['type'] = params.pop('barcode_type')
             return '/report/barcode/?' + werkzeug.urls.url_encode(params)
         return None

--- a/addons/account_qr_code_sepa/models/res_bank.py
+++ b/addons/account_qr_code_sepa/models/res_bank.py
@@ -34,7 +34,7 @@ class ResPartnerBank(models.Model):
                 'width': 128,
                 'height': 128,
                 'humanreadable': 1,
-                'value': self._get_qr_vals(qr_method, amount, currency, debtor_partner, free_communication, structured_communication),
+                'value': '\n'.join(self._get_qr_vals(qr_method, amount, currency, debtor_partner, free_communication, structured_communication)),
             }
         return super()._get_qr_code_generation_params(qr_method, amount, currency, debtor_partner, free_communication, structured_communication)
 

--- a/addons/l10n_ch/models/res_bank.py
+++ b/addons/l10n_ch/models/res_bank.py
@@ -241,7 +241,7 @@ class ResPartnerBank(models.Model):
                 'height': 256,
                 'quiet': 1,
                 'mask': 'ch_cross',
-                'value': self._get_qr_vals(qr_method, amount, currency, debtor_partner, free_communication, structured_communication),
+                'value': '\n'.join(self._get_qr_vals(qr_method, amount, currency, debtor_partner, free_communication, structured_communication)),
             }
         return super()._get_qr_code_generation_params(qr_method, amount, currency, debtor_partner, free_communication, structured_communication)
 


### PR DESCRIPTION
Issue:

  When printing an invoice, the QR-code is generated but with the wrong
  params.

Cause:

  Using a List of String instead of a unique String.

Solution:

  Join values in the list with '\n'.

fix of commit https://github.com/odoo/odoo/commit/73ca102e2b3bb2f8e8e69c6e8d3694a2ac5e45b0

opw-2662581