### PR TITLE
[FIX] mrp_subcontracting: qty incorrect

### DIFF
--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -31,8 +31,6 @@ class StockPicking(models.Model):
     # Action methods
     # -------------------------------------------------------------------------
     def _action_done(self):
-        res = super(StockPicking, self)._action_done()
-
         for move in self.move_lines.filtered(lambda move: move.is_subcontract):
             # Auto set qty_producing/lot_producing_id of MO if there isn't tracked component
             # If there is tracked component, the flow use subcontracting_record_component instead
@@ -74,7 +72,7 @@ class StockPicking(models.Model):
             production_moves = productions_to_done.move_raw_ids | productions_to_done.move_finished_ids
             production_moves.write({'date': minimum_date - timedelta(seconds=1)})
             production_moves.move_line_ids.write({'date': minimum_date - timedelta(seconds=1)})
-        return res
+        return super(StockPicking, self)._action_done()
 
     def action_record_components(self):
         self.ensure_one()


### PR DESCRIPTION
To have the correct qty in the subcontract location when validating incoming receipt firstly needs mark related subcontracting MO (hidden) as done and then only process receipt stock moves. Now it process receipt moves from subcontracting to stock location even MO is finished/done [later](https://github.com/odoo/odoo/blob/c13087da4c8084e7401af688ab0f382ad2a868b0/addons/mrp_subcontracting/models/stock_picking.py#L70) which is not the right flow.

Issue was identified with an additional community addon that prevents negative amounts in internal stock quantities. 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
