### PR TITLE
[14.0] [FIX]  l10n_ch: Restore line breaks in QR-Code

### DIFF
--- a/addons/l10n_ch/models/res_bank.py
+++ b/addons/l10n_ch/models/res_bank.py
@@ -230,7 +230,8 @@ class ResPartnerBank(models.Model):
 
     def _get_qr_vals(self, qr_method, amount, currency, debtor_partner, free_communication, structured_communication):
         if qr_method == 'ch_qr':
-            return self._l10n_ch_get_qr_vals(amount, currency, debtor_partner, free_communication, structured_communication)
+            qr_vals = self._l10n_ch_get_qr_vals(amount, currency, debtor_partner, free_communication, structured_communication)
+            return "\n".join(qr_vals)
         return super()._get_qr_vals(qr_method, amount, currency, debtor_partner, free_communication, structured_communication)
 
     def _get_qr_code_generation_params(self, qr_method, amount, currency, debtor_partner, free_communication, structured_communication):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The previous refactor at 73ca102e2b3bb2f8e8e69c6e8d3694a2ac5e45b0 removed the join of the list of values into a string

While the QR code can be generated it makes it unreadable by dedicated scanners.

**Current behavior before PR:**

(tested on todays runbot)

Before this change the content of the QR would be decoded as a pythonic list. Whereas we want a string with line break as
separators.

Inside QR-code:

```
[value1, value2, ...]
```


**Desired behavior after PR is merged:**

Same as before 73ca102e2b3bb2f8e8e69c6e8d3694a2ac5e45b0

Inside QR-code
```
value1
value2
...
```



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
