### PR TITLE
[FIX] account: only display qr code if residual > 0

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -179,7 +179,7 @@
                     <p t-if="o.fiscal_position_id.note" name="note">
                         <span t-field="o.fiscal_position_id.note"/>
                     </p>
-                    <div id="qrcode" t-if="(o.company_id.qr_code) and (o.currency_id.name == 'EUR') and (o.invoice_partner_bank_id.acc_number != False)">
+                    <div id="qrcode" t-if="(o.company_id.qr_code) and (o.currency_id.name == 'EUR') and (o.invoice_partner_bank_id.acc_number != False) and o.amount_residual > 0">
                         <p t-if="(o.invoice_partner_bank_id.qr_code_valid)">
                             <strong class="text-center">Scan me with your banking app.</strong><br /><br />
                             <img class="border border-dark rounded" t-att-src="o.invoice_partner_bank_id.build_qr_code_base64(o.amount_residual, o.invoice_payment_ref or o.ref or o.name)"/>


### PR DESCRIPTION
In case an invoice is already paid it is useless to provide
a QR Code for scanning to pay a residual of zero.

**Description of the issue/feature this PR addresses:**
If an invoice is already settled the QR Code is taking useless space on an invoice (report).

**Current behavior before PR:**
QR Code is always shown if the bank account is linked and has a valid QR Code

**Desired behavior after PR is merged:**
Only if the invoice is unpaid or has a residual it is shown on the invoice report.

Info: @wt-io-it

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
