### PR TITLE
Running tours / JS tests under firefox

### DIFF
--- a/addons/bus/static/src/js/longpolling_bus.js
+++ b/addons/bus/static/src/js/longpolling_bus.js
@@ -179,19 +179,19 @@ var LongpollingBus = Bus.extend(ServicesMixin, {
         var data = {channels: this._channels, last: this._lastNotificationID, options: options};
         // The backend has a maximum cycle time of 50 seconds so give +10 seconds
         this._pollRpc = this._makePoll(data);
-        this._pollRpc.then(function (result) {
-            self._pollRpc = false;
-            self._onPoll(result);
-            self._poll();
-        }).guardedCatch(function (result) {
-            self._pollRpc = false;
+        this._pollRpc.then(result => {
+            this._pollRpc = false;
+            this._onPoll(result);
+            this._poll();
+        }, reject => {
+            this._pollRpc = false;
             // no error popup if request is interrupted or fails for any reason
-            result.event.preventDefault();
-            if (result.message === "XmlHttpRequestError abort") {
-                self._poll();
+            reject.event.preventDefault();
+            if (reject.message === "XmlHttpRequestError abort") {
+                this._poll();
             } else {
                 // random delay to avoid massive longpolling
-                self._pollRetryTimeout = setTimeout(self._poll, self.ERROR_RETRY_DELAY + (Math.floor((Math.random()*20)+1)*1000));
+                this._pollRetryTimeout = setTimeout(this._poll, this.ERROR_RETRY_DELAY + (Math.floor((Math.random()*20)+1)*1000));
             }
         });
     },

--- a/addons/mail/static/tests/tours/mail_full_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_full_composer_test_tour.js
@@ -6,6 +6,7 @@ import {
 } from 'web.test_utils_file';
 
 import tour from 'web_tour.tour';
+import { hasLegacyFilesystem } from "@web/core/browser/feature_detection";
 
 /**
  * This tour depends on data created by python test in charge of launching it.
@@ -15,7 +16,11 @@ import tour from 'web_tour.tour';
  */
 tour.register('mail/static/tests/tours/mail_full_composer_test_tour.js', {
     test: true,
-}, [{
+}, !hasLegacyFilesystem() ? [{
+    content: "Has a Send Message",
+    trigger: '.o_ChatterTopbar_buttonSendMessage',
+    run() {},
+}] : [{
     content: "Click on Send Message",
     trigger: '.o_ChatterTopbar_buttonSendMessage',
 }, {

--- a/addons/point_of_sale/tests/test_js.py
+++ b/addons/point_of_sale/tests/test_js.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import odoo.addons.web.tests.test_js
+import os
+
 import odoo.tests
 
 
@@ -16,7 +17,8 @@ class WebSuite(odoo.tests.HttpCase):
         # open a session, the /pos/ui controller will redirect to it
         self.main_pos_config.open_session_cb(check_coa=False)
 
+        failfast = '&failfast' if 'ODOO_QWEB_FAILFAST' in os.environ else ''
         # point_of_sale desktop test suite
         self.browser_js(
-            "/pos/ui/tests?mod=web&failfast", "", "", login="admin", timeout=1800
+            f"/pos/ui/tests?mod=web{failfast}", "", "", login="admin", timeout=1800
         )

--- a/addons/web/static/lib/qunit/qunit-2.9.1.js
+++ b/addons/web/static/lib/qunit/qunit-2.9.1.js
@@ -3036,8 +3036,10 @@
   		try {
   			runTest(this);
   		} catch (e) {
-  			lastError = e;
-  			this.pushFailure("Died on test #" + (this.assertions.length + 1) + " " + this.stack + ": " + (e.message || e), extractStacktrace(e, 0));
+		    if (!(e instanceof QUnit.Skip)) {
+				lastError = e;
+				this.pushFailure("Died on test #" + (this.assertions.length + 1) + " " + this.stack + ": " + (e.message || e), extractStacktrace(e, 0));
+			}
 
   			// Else next test will carry the responsibility
   			saveGlobal();
@@ -3379,9 +3381,11 @@
   					then.call(promise, function () {
   						resume();
   					}, function (error) {
-  						lastError = error;
-  						message = "Promise rejected " + (!phase ? "during" : phase.replace(/Each$/, "")) + " \"" + test.testName + "\": " + (error && error.message || error);
-  						test.pushFailure(message, extractStacktrace(error, 0));
+					    if (!(error instanceof QUnit.Skip)) {
+							lastError = error;
+							message = "Promise rejected " + (!phase ? "during" : phase.replace(/Each$/, "")) + " \"" + test.testName + "\": " + (error && error.message || error);
+							test.pushFailure(message, extractStacktrace(error, 0));
+						}
 
   						// Else next test will carry the responsibility
   						saveGlobal();
@@ -3928,8 +3932,8 @@
   		value: function deepEqual(actual, expected, message) {
   			this.pushResult({
   				result: equiv(actual, expected),
-  				actual: actual,
-  				expected: expected,
+  				actual: JSON.stringify(actual),
+  				expected: JSON.stringify(expected),
   				message: message
   			});
   		}
@@ -4279,6 +4283,14 @@
   	todo: todo,
 
   	skip: skip,
+	skipIf(test, ...args) {
+		if (test) {
+			return skip(...args);
+		} else {
+			return test(...args);
+		}
+	},
+	Skip: function Skip() {},
 
   	only: only,
 

--- a/addons/web/static/lib/qunit/qunit-2.9.1.js
+++ b/addons/web/static/lib/qunit/qunit-2.9.1.js
@@ -4283,8 +4283,8 @@
   	todo: todo,
 
   	skip: skip,
-	skipIf(test, ...args) {
-		if (test) {
+	skipIf(assertion, ...args) {
+		if (assertion) {
 			return skip(...args);
 		} else {
 			return test(...args);

--- a/addons/web/static/src/core/browser/feature_detection.js
+++ b/addons/web/static/src/core/browser/feature_detection.js
@@ -15,6 +15,10 @@ export function isBrowserChrome() {
     return browser.navigator.userAgent.includes("Chrome");
 }
 
+export function isBrowserFirefox() {
+    return browser.navigator.userAgent.includes("Firefox");
+}
+
 export function isMacOS() {
     return Boolean(browser.navigator.userAgent.match(/Mac/i));
 }
@@ -37,4 +41,8 @@ export function isIosApp() {
 
 export function hasTouch() {
     return "ontouchstart" in window || "onmsgesturechange" in window;
+}
+
+export function hasLegacyFilesystem() {
+    return window['requestFileSystem'] || window['webkitRequestFileSystem'];
 }

--- a/addons/web/static/tests/core/dialog_service_tests.js
+++ b/addons/web/static/tests/core/dialog_service_tests.js
@@ -12,6 +12,7 @@ import { clearRegistryWithCleanup, makeTestEnv } from "../helpers/mock_env";
 import { makeFakeLocalizationService, makeFakeRPCService } from "../helpers/mock_services";
 import { click, getFixture, makeDeferred, nextTick, patchWithCleanup } from "../helpers/utils";
 import { Dialog } from "../../src/core/dialog/dialog";
+import {isBrowserFirefox} from "../../src/core/browser/feature_detection";
 
 const { Component, mount, tags } = owl;
 
@@ -209,7 +210,7 @@ QUnit.test("Interactions between multiple dialogs", async (assert) => {
     assert.containsOnce(target, ".o_dialog_container");
 });
 
-QUnit.test("dialog component crashes", async (assert) => {
+QUnit.skipIf(isBrowserFirefox(), "dialog component crashes", async (assert) => {
     assert.expect(4);
 
     class FailingDialog extends Dialog {

--- a/addons/web/static/tests/legacy/helpers/test_utils_file.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_file.js
@@ -54,7 +54,7 @@ function createFile(data) {
     return new Promise(function (resolve, reject) {
         var requestFileSystem = window.requestFileSystem || window.webkitRequestFileSystem;
         if (!requestFileSystem) {
-            throw new Error('FileSystem API is not supported');
+            throw new QUnit.Skip();
         }
         requestFileSystem(window.TEMPORARY, 1024 * 1024, function (fileSystem) {
             fileSystem.root.getFile(data.name, { create: true }, function (fileEntry) {

--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import os
 import re
 import odoo.tests
 
@@ -11,8 +12,9 @@ RE_ONLY = re.compile(r'QUnit\.(only|debug)\(')
 class WebSuite(odoo.tests.HttpCase):
 
     def test_js(self):
+        failfast = '&failfast' if 'ODOO_QWEB_FAILFAST' in os.environ else ''
         # webclient desktop test suite
-        self.browser_js('/web/tests?mod=web&failfast', "", "", login='admin', timeout=1800)
+        self.browser_js(f'/web/tests?mod=web{failfast}', "", "", login='admin', timeout=1800)
 
     def test_check_suite(self):
         # verify no js test is using `QUnit.only` as it forbid any other test to be executed
@@ -42,5 +44,6 @@ class MobileWebSuite(odoo.tests.HttpCase):
     browser_size = '375x667'
 
     def test_mobile_js(self):
+        failfast = '&failfast' if 'ODOO_QWEB_FAILFAST' in os.environ else ''
         # webclient mobile test suite
-        self.browser_js('/web/tests/mobile?mod=web&failfast', "", "", login='admin', timeout=1800)
+        self.browser_js(f'/web/tests/mobile?mod=web{failfast}', "", "", login='admin', timeout=1800)

--- a/odoo/addons/base/tests/test_http_case.py
+++ b/odoo/addons/base/tests/test_http_case.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from unittest import skipIf
 
-from odoo.tests.common import HttpCase, tagged
+from odoo.tests.common import HttpCase, tagged, USE_CHROME
 from odoo.tools import mute_logger, logging
 from unittest.mock import patch
 
@@ -16,6 +17,7 @@ class TestHttpCase(HttpCase):
         # second line must contains error message
         self.assertEqual(error_catcher.exception.args[0].splitlines()[1], "test error message")
 
+    @skipIf(not USE_CHROME, "Firefox can not serialize exceptions, also probably non-portable stacktrace details")
     def test_console_error_object(self):
         with self.assertRaises(AssertionError) as error_catcher:
             code = "console.error(TypeError('test error message'))"

--- a/odoo/addons/base/tests/test_http_case.py
+++ b/odoo/addons/base/tests/test_http_case.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 
 @tagged('-at_install', 'post_install')
 class TestHttpCase(HttpCase):
-
     def test_console_error_string(self):
         with self.assertRaises(AssertionError) as error_catcher:
             code = "console.error('test error','message')"

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -952,9 +952,10 @@ class ChromeBrowser():
         switches = [
             '--headless',
             '--profile', self.user_data_dir,
-            '--window-size', self.window_size,
             '--remote-debugging-port', '0',
         ]
+        os.environ['MOZ_HEADLESS_WIDTH'], os.environ['MOZ_HEADLESS_HEIGHT'] = \
+            self.window_size.split('x')
         cmd = [
             executable,
             *switches,

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1137,9 +1137,21 @@ class ChromeBrowser():
         'info': logging.INFO,
         'warning': logging.WARNING,
         'error': logging.ERROR,
-        # TODO: what do with
-        # dir, dirxml, table, trace, clear, startGroup, startGroupCollapsed,
-        # endGroup, assert, profile, profileEnd, count, timeEnd
+        # event is only sent if the assertion fails, pretty cool
+        'assert': logging.ERROR,
+        # same as log but in the browser console objects are expanded by default
+        'dir': logging.INFO,
+        # same as log except always dumps a stacktrace (or links an async stack
+        # really?), useless in FF as it never sends stacktraces anyway
+        'trace': logging.INFO,
+        # count: sends a `count` console event with the label as arg, not really
+        #        useable: chrome sends formatted value while firefox only sends
+        #        label
+        # 'count': logging.WARNING,
+        # countReset: resets counter
+        # time: N/A, never sent to client
+        # timeLog, timeEnd: sends event for corresponding timer, use timestamp
+        # startGroup/startGroupCollapsed/endGroup: sub-logger?
     }
 
     def _websocket_wait_id(self, awaited_id, timeout=10):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1106,6 +1106,13 @@ class ChromeBrowser():
         if res.get('method') == 'Runtime.exceptionThrown':
             details = res['params']['exceptionDetails']
             message = details['text']
+            if re.match('uncaught exception: (Object|undefined)$', message):
+                # workaround: `PromiseRejectionEvent.preventDefault()`
+                # currently does not work in firefox (issue 1642147), and the
+                # CDP serialisation of errors is dreary (basically just a
+                # `text`, which is also pretty shite). so the first time a bus
+                # request is cancelled due to no bus in test mode, firefox fails
+                return {}
             exception = details.get('exception')
             if exception:
                 message += str(self._from_remoteobject(exception))

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1322,6 +1322,9 @@ class ChromeBrowser():
             self._websocket_wait_event('Page.frameStoppedLoading', params={'frameId': frame_id})
 
     def clear(self):
+        if not USE_CHROME:
+            return
+
         self._websocket_send('Page.stopScreencast')
         if self.screencasts_dir and os.path.isdir(self.screencasts_frames_dir):
             shutil.rmtree(self.screencasts_frames_dir)

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -946,7 +946,7 @@ class ChromeBrowser():
     def _find_websocket(self):
         version = self._json_command('version')
         self._logger.info('Browser version: %s', version['Browser'])
-        infos = self._json_command('', get_key=0)  # Infos about the first tab
+        infos = self._json_command('list', get_key=0)  # Infos about the first tab
         self.ws_url = infos['webSocketDebuggerUrl']
         self._logger.info('Chrome headless temporary user profile dir: %s', self.user_data_dir)
 


### PR DESCRIPTION
The runbot can not currently test JS on Firefox, because it uses the Chrome DevTools Protocol to interact with and drive the browser. This means Odoo is way under-tested on Firefox (though there's a similar issue with various Python versions).

This branch looks to:

* adapt the runner so it can use firefox at all
* see if there are upstream blockers and what they are, and / or adapt to the common subset if that's possible

## Blockers

* ~~https://bugzilla.mozilla.org/show_bug.cgi?id=1706581 the runner retrieves the port by reading `DevToolsActivePort`, Firefox currently doesn't create one~~ should be fixed in FF 95
* https://bugzilla.mozilla.org/show_bug.cgi?id=1642147 can't suppress `unhandledrejection` global errors

## Not sure

* https://bugzilla.mozilla.org/show_bug.cgi?id=1548480 Firefox currently has very limited support for exceptions reporting (no stack traces), not sure it's a huge issue: the only thing which tests that is something testing the console reporting itself?
* https://bugzilla.mozilla.org/show_bug.cgi?id=1734587 Firefox currently has very limited for RemoteObject information (just value, no className, properties, subtype)

## Others

[Page with all CDP bugs](https://bugzilla.mozilla.org/buglist.cgi?product=Remote%20Protocol&component=CDP&resolution=---&list_id=15861314)