### PR TITLE
[FIX] l10n_pe: demo data should have correct invoice names

### DIFF
--- a/addons/l10n_pe/demo/account_demo.py
+++ b/addons/l10n_pe/demo/account_demo.py
@@ -12,9 +12,13 @@ class AccountChartTemplate(models.Model):
         model, data = super()._get_demo_data_move()
         document_type = self.env.ref('l10n_pe.document_type01')
         data[f'{cid}_demo_invoice_1']['l10n_latam_document_type_id'] = document_type.id
+        data[f'{cid}_demo_invoice_1']['l10n_latam_document_number'] = 'FFI-000001'
         data[f'{cid}_demo_invoice_2']['l10n_latam_document_type_id'] = document_type.id
+        data[f'{cid}_demo_invoice_2']['l10n_latam_document_number'] = 'FFI-000002'
         data[f'{cid}_demo_invoice_3']['l10n_latam_document_type_id'] = document_type.id
+        data[f'{cid}_demo_invoice_3']['l10n_latam_document_number'] = 'FFI-000003'
         data[f'{cid}_demo_invoice_followup']['l10n_latam_document_type_id'] = document_type.id
+        data[f'{cid}_demo_invoice_followup']['l10n_latam_document_number'] = 'FFI-000004'
         data[f'{cid}_demo_invoice_5']['l10n_latam_document_number'] = '1'
-        data[f'{cid}_demo_invoice_equipment_purchase']['l10n_latam_document_number'] = '2'
+        data[f'{cid}_demo_invoice_equipment_purchase']['l10n_latam_document_number'] = 'INV-000089'
         return model, data


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Somehow we missed the FFI prefix. 

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
