### PR TITLE
[FIX] web: set "data-tooltip" as translatable attr in owl

### DIFF
--- a/addons/web/static/src/core/l10n/localization_service.js
+++ b/addons/web/static/src/core/l10n/localization_service.js
@@ -10,6 +10,9 @@ import { session } from "@web/session";
 export const localizationService = {
     dependencies: ["user"],
     start: async (env, { user }) => {
+        // add "data-toolip" to the list of translatable attributes in owl templates
+        owl.config.translatableAttributes.push("data-tooltip");
+
         const cacheHashes = session.cache_hashes || {};
         const translationsHash = cacheHashes.translations || new Date().getTime().toString();
         const lang = user.lang || null;


### PR DESCRIPTION
With this, tooltips specified with the "data-tooltip" attribute in
owl templates will be translated.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
