### PR TITLE
[FIX] product: `_prepare_seller` reuse the orm cache

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -590,11 +590,7 @@ class ProductProduct(models.Model):
                 'target': 'new'}
 
     def _prepare_sellers(self, params):
-        # This search is made to avoid retrieving seller_ids from the cache.
-        return self.env['product.supplierinfo']\
-                   .search([('product_tmpl_id', '=', self.product_tmpl_id.id)])\
-                   .filtered(lambda r: r.name.active)\
-                   .sorted(lambda s: (s.sequence, -s.min_qty, s.price, s.id))
+        return self.seller_ids.filtered(lambda s: s.name.active).sorted(lambda s: (s.sequence, -s.min_qty, s.price, s.id))
 
     def _select_seller(self, partner_id=False, quantity=0.0, date=None, uom_id=False, params=False):
         self.ensure_one()
@@ -729,7 +725,7 @@ class ProductPackaging(models.Model):
 class SupplierInfo(models.Model):
     _name = "product.supplierinfo"
     _description = "Supplier Pricelist"
-    _order = 'sequence, min_qty desc, price'
+    _order = 'sequence, min_qty DESC, price, id'
 
     name = fields.Many2one(
         'res.partner', 'Vendor',

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -123,7 +123,7 @@ class ProductTemplate(models.Model):
     packaging_ids = fields.One2many(
         'product.packaging', string="Product Packages", compute="_compute_packaging_ids", inverse="_set_packaging_ids",
         help="Gives the different ways to package the same product.")
-    seller_ids = fields.One2many('product.supplierinfo', 'product_tmpl_id', 'Vendors', help="Define vendor pricelists.")
+    seller_ids = fields.One2many('product.supplierinfo', 'product_tmpl_id', 'Vendors', depends_context=('company',), help="Define vendor pricelists.")
     variant_seller_ids = fields.One2many('product.supplierinfo', 'product_tmpl_id')
 
     active = fields.Boolean('Active', default=True, help="If unchecked, it will allow you to hide the product without removing it.")


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Apply a backport from 14, applied on #66621

Current behavior before PR:

If you have a lot of partners, selecting a product on a purchase order takes too long. For example, with 400.000, it takes 5 seconds.

Desired behavior after PR is merged:

Make it fast.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
