### PR TITLE
[FIX] - calendar: exclude recurring event manually edited

### DIFF
--- a/addons/calendar/models/calendar.py
+++ b/addons/calendar/models/calendar.py
@@ -647,7 +647,7 @@ class Meeting(models.Model):
                         recurring_date = pytz.UTC.localize(recurring_date)
                     recurring_date = recurring_date.astimezone(timezone).replace(tzinfo=None)
                 if date_field == "stop":
-                    recurring_date += timedelta(hours=self.duration)
+                    recurring_date += timedelta(hours=self.duration, seconds=-1)
                 rset1.exdate(recurring_date)
             invalidate = True
 


### PR DESCRIPTION
#### Affected version:
12, 13

#### Description of the issue/feature this PR addresses:
when calculating the recurring dates per event, the stop date, of a recurring
event manually edited, is not correctly excluded due to a difference of 1 sec
between the event stop date and the calculated recurring date

#### Current behavior before PR:
1. create a recurring event
2. remove a recurrence
--> in the calendar view, in week mode, all the recurrences after the one removed are not displayed
--> if you change to month mode or list view, you can see them



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
