### PR TITLE
[IMP] stock: add index on the serial name

### DIFF
--- a/addons/stock/models/stock_production_lot.py
+++ b/addons/stock/models/stock_production_lot.py
@@ -17,7 +17,7 @@ class ProductionLot(models.Model):
 
     name = fields.Char(
         'Lot/Serial Number', default=lambda self: self.env['ir.sequence'].next_by_code('stock.lot.serial'),
-        required=True, help="Unique Lot/Serial Number")
+        required=True, help="Unique Lot/Serial Number", index=True)
     ref = fields.Char('Internal Reference', help="Internal reference number in case it differs from the manufacturer's lot/serial number")
     product_id = fields.Many2one(
         'product.product', 'Product', index=True,


### PR DESCRIPTION
In large database with unique serial number. The index add performance during search of lot.

@Whenrow 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
