### PR TITLE
Improve user interface of cash in/out

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -3659,9 +3659,15 @@ td {
 }
 
 .cash-move .input-amount .input-type.highlight {
-    background: #6EC89B !important;
-    border: solid 1px #64AF8A !important;
-    color: white !important;
+    background: #6EC89B;
+    border: solid 1px #64AF8A;
+    color: white;
+}
+
+.cash-move .input-amount .input-type.red-background {
+    background: #d53b15;
+    border: solid 1px #aa3e00;
+    color: white;
 }
 
 .cash-move .input-amount input {
@@ -3669,6 +3675,12 @@ td {
     min-height: auto;
     text-align: right;
     padding-right: 30px;
+}
+
+.cash-move .input-amount span.sign {
+    position: relative;
+    left: 15px;
+    top: 10px;
 }
 
 .cash-move .input-amount .input-field span.currency {

--- a/addons/point_of_sale/static/src/js/Popups/CashMovePopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/CashMovePopup.js
@@ -36,6 +36,12 @@ odoo.define('point_of_sale.CashMovePopup', function (require) {
             this.state.inputHasError = false;
             this.inputAmountRef.el && this.inputAmountRef.el.focus();
         }
+        onEditInputAmount(event) {
+            if (['-', '+'].includes(event.key)) {
+                this.state.inputType = { '-': 'out', '+': 'in' }[event.key];
+                event.preventDefault();
+            }
+        }
         getPayload() {
             return {
                 amount: parse.float(this.state.inputAmount),

--- a/addons/point_of_sale/static/src/xml/Popups/CashMovePopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/CashMovePopup.xml
@@ -14,12 +14,12 @@
                                 <span t-on-click="onClickButton('out')" class="input-type" t-att-class="{ highlight: state.inputType == 'out' }">
                                     Cash Out
                                 </span>
-                                <div class="input-field">
+                                <div class="input-field" t-on-mousedown.stop="" t-on-touchstart.stop="">
                                     <input type="text" name="amount" t-model="state.inputAmount" t-ref="input-amount-ref"/>
                                     <span class="currency" t-esc="env.pos.currency.symbol" />
                                 </div>
                             </div>
-                            <textarea name="reason" t-model="state.inputReason" placeholder="Reason"></textarea>
+                            <textarea name="reason" t-model="state.inputReason" placeholder="Reason" t-on-mousedown.stop="" t-on-touchstart.stop="" ></textarea>
                             <span t-if="state.inputHasError" class="error-message">
                                 <t t-esc="errorMessage" />
                             </span>

--- a/addons/point_of_sale/static/src/xml/Popups/CashMovePopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/CashMovePopup.xml
@@ -11,11 +11,12 @@
                                 <span t-on-click="onClickButton('in')" class="input-type" t-att-class="{ highlight: state.inputType == 'in' }">
                                     Cash In
                                 </span>
-                                <span t-on-click="onClickButton('out')" class="input-type" t-att-class="{ highlight: state.inputType == 'out' }">
+                                <span t-on-click="onClickButton('out')" class="input-type" t-att-class="{ 'red-background': state.inputType == 'out' }">
                                     Cash Out
                                 </span>
+                                <span class="sign" t-att-class="{ oe_invisible: state.inputType != 'out' }">-</span>
                                 <div class="input-field" t-on-mousedown.stop="" t-on-touchstart.stop="">
-                                    <input type="text" name="amount" t-model="state.inputAmount" t-ref="input-amount-ref"/>
+                                    <input type="text" name="amount" t-model="state.inputAmount" t-ref="input-amount-ref" t-on-keydown="onEditInputAmount" />
                                     <span class="currency" t-esc="env.pos.currency.symbol" />
                                 </div>
                             </div>


### PR DESCRIPTION
In the text field to input amount, when "minus" or "plus" is pressed,
the corresponding type is automatically selected -- "minus" -> cash out,
"plus" -> cash in.

"Minus" sign is also shown at the beginning part of the amount input
field. Furthermore, color of cash out button is changed to red.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
