### PR TITLE
 [FIX] stock_landed_costs: traceback division by 0 when no quantity

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -212,7 +212,7 @@ class LandedCost(models.Model):
 
         for move in self.mapped('picking_ids').mapped('move_lines'):
             # it doesn't make sense to make a landed cost for a product that isn't set as being valuated in real time at real cost
-            if move.product_id.valuation != 'real_time' or move.product_id.cost_method not in ('fifo', 'average') or move.state == 'cancel':
+            if move.product_id.valuation != 'real_time' or move.product_id.cost_method not in ('fifo', 'average') or move.state == 'cancel' or not move.product_qty:
                 continue
             vals = {
                 'product_id': move.product_id.id,

--- a/doc/cla/corporate/biktrix.md
+++ b/doc/cla/corporate/biktrix.md
@@ -1,0 +1,15 @@
+Canada, 2021-09-03
+
+Biktrix Electric Bikes agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Andrew Tremblay 69811674+atremblay-biktrix@users.noreply.github.com https://github.com/atremblay-biktrix
+
+List of contributors:
+
+Andrew Tremblay 69811674+atremblay-biktrix@users.noreply.github.com https://github.com/atremblay-biktrix


### PR DESCRIPTION
Issue:
When computing the landed cost for a transfer with quantity 0, the validation of the LC wasn't working since there was a quantity 0

Steps to reproduce :
Create a PO for some items
Confirm, validate the delivery
Edit and unlock the delivery, set one quantity to 0, save
Create a landed cost for that transfer
Compute it
Validate -> Traceback

Why is that a bug:
There should not be a traceback, this is caused by trying to validate a landed cost for a product where there is no quantity, if there is no quantity, it should be part of the landed cost computation

Background:
Following the fix recently applied in 14.0 and replicating for 13.0.

opw-2599799

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
