### PR TITLE
[FIX] event_sale: create tickets with default product type "service" 

### DIFF
--- a/addons/event_sale/views/event_views.xml
+++ b/addons/event_sale/views/event_views.xml
@@ -71,7 +71,7 @@
                                     <field name="event_ticket_ids">
                                         <tree string="Tickets" editable="bottom">
                                             <field name="name"/>
-                                            <field name="product_id"/>
+                                            <field name="product_id" context="{'default_type': 'service'}"/>
                                             <field name="price"/>
                                         </tree>
                                     </field>
@@ -93,7 +93,7 @@
                         <field name="event_ticket_ids" context="{'default_name': name}" mode="tree,kanban">
                             <tree string="Tickets" editable="bottom">
                                 <field name="name"/>
-                                <field name="product_id" context="{'default_event_ok':1}"/>
+                                <field name="product_id" context="{'default_event_ok':1, 'default_type': 'service'}"/>
                                 <field name="deadline"/>
                                 <field name="price"/>
                                 <field name="seats_max"/>


### PR DESCRIPTION
In some cases when creating a new ticket, the default product
type shown is a "Consumable". It should rather be handled as a
"Service". In later versions, a detailed type is created, but the
base product type should be set to service too.

This commit uses the `product_id` `context` to set the default
type to "service".

Task-2655226
