### PR TITLE
[MERGE][IMP] website_event: display the timezone when a datetime is used 

### DIFF
--- a/addons/event/data/mail_template_data.xml
+++ b/addons/event/data/mail_template_data.xml
@@ -126,7 +126,7 @@
                             <td style="padding: 0px 10px 0px 10px;width:50%;line-height:20px;vertical-align:top;">
                                 <div><strong>From</strong> <t t-out="object.event_id.date_begin_located or ''">May 4, 2021, 7:00:00 AM</t></div>
                                 <div><strong>To</strong> <t t-out="object.event_id.date_end_located or ''">May 6, 2021, 5:00:00 PM</t></div>
-                                <div style="font-size:12px;color:#9e9e9e"><i><strong>TZ</strong> <t t-out="object.event_id.date_tz or ''">Europe/Brussels</t></i></div>
+                                <div style="font-size:12px;color:#9e9e9e"><i>(<t t-out="object.event_id.date_tz or ''">Europe/Brussels</t>)</i></div>
                             </td>
                             <td style="vertical-align:top;">
                                 <t t-if="event_address">
@@ -353,7 +353,7 @@
                             <td style="padding: 0px 10px 0px 10px;width:50%;line-height:20px;vertical-align:top;">
                                 <div><strong>From</strong> <t t-out="object.event_id.date_begin_located or ''">May 4, 2021, 7:00:00 AM</t></div>
                                 <div><strong>To</strong> <t t-out="object.event_id.date_end_located or ''">May 6, 2021, 5:00:00 PM</t></div>
-                                <div style="font-size:12px;color:#9e9e9e"><i><strong>TZ</strong> <t t-out="object.event_id.date_tz or ''">Europe/Brussels</t></i></div>
+                                <div style="font-size:12px;color:#9e9e9e"><i><t t-out="object.event_id.date_tz or ''">Europe/Brussels</t></i></div>
                             </td>
                             <td style="vertical-align:top;">
                                 <t t-if="event_address">

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -581,8 +581,8 @@ class EventEvent(models.Model):
             cal_event = cal.add('vevent')
 
             cal_event.add('created').value = fields.Datetime.now().replace(tzinfo=pytz.timezone('UTC'))
-            cal_event.add('dtstart').value = fields.Datetime.from_string(event.date_begin).replace(tzinfo=pytz.timezone('UTC'))
-            cal_event.add('dtend').value = fields.Datetime.from_string(event.date_end).replace(tzinfo=pytz.timezone('UTC'))
+            cal_event.add('dtstart').value = event.date_begin.astimezone(pytz.timezone(event.date_tz))
+            cal_event.add('dtend').value = event.date_end.astimezone(pytz.timezone(event.date_tz))
             cal_event.add('summary').value = event.name
             if event.address_id:
                 cal_event.add('location').value = event.sudo().address_id.contact_address

--- a/addons/event/report/event_event_templates.xml
+++ b/addons/event/report/event_event_templates.xml
@@ -17,16 +17,16 @@
                     <div class="o_event_foldable_badge_ticket_wrapper_top page">
                         <h5 class="o_event_foldable_badge_event_name font-weight-bold text-center" t-field="event.name"/>
                         <div class="text-center o_event_foldable_badge_font_small">
-                            <span itemprop="startDate" t-esc="event.date_begin.date()"
+                            <span itemprop="startDate" t-out="event.date_begin.date()"
                                 class="font-weight-bold"/>
-                            <span itemprop="startDateTime" t-esc="event.date_begin"
+                            <span itemprop="startDateTime" t-out="event.date_begin"
                                 class="font-weight-bold"
                                 t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True}'/>
                             <span class="fa fa-arrow-right o_event_foldable_badge_font_faded"/>
                             <span t-if="not event.is_one_day"
-                                itemprop="endDate" t-esc="event.date_end.date()"
+                                itemprop="endDate" t-out="event.date_end.date()"
                                 class="font-weight-bold"/>
-                            <span itemprop="endDateTime" t-esc="event.date_end"
+                            <span itemprop="endDateTime" t-out="event.date_end"
                                 class="font-weight-bold"
                                 t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True}'/>
                         </div>
@@ -38,7 +38,7 @@
                             <h2 t-elif="not attendee"><span>John Doe</span></h2>
                             <t t-set="first_ticket" t-value="event.event_ticket_ids[0] if event.event_ticket_ids else None"/>
                             <div t-if="attendee" class="o_event_foldable_badge_font_faded" t-field="attendee.event_ticket_id"/>
-                            <div t-elif="first_ticket" t-esc="first_ticket.name"
+                            <div t-elif="first_ticket" t-out="first_ticket.name"
                                 class="o_event_foldable_badge_font_faded"/>
                         </div>
                     </div>
@@ -115,16 +115,16 @@
                                     Event Ticket For
                                 </div>
                                 <h5 class="o_event_full_page_ticket_event_name font-weight-bold py-0 my-0" t-field="event.name"/>
-                                <span itemprop="startDate" t-esc="event.date_begin.date()"
+                                <span itemprop="startDate" t-out="event.date_begin.date()"
                                     class="font-weight-bold"/>
-                                <span itemprop="startDateTime" t-esc="event.date_begin"
+                                <span itemprop="startDateTime" t-out="event.date_begin"
                                     class="font-weight-bold"
                                     t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True}'/>
                                 <span class="fa fa-arrow-right o_event_full_page_ticket_font_faded"/>
                                 <span t-if="not event.is_one_day"
-                                    itemprop="endDate" t-esc="event.date_end.date()"
+                                    itemprop="endDate" t-out="event.date_end.date()"
                                     class="font-weight-bold"/>
-                                <span itemprop="endDateTime" t-esc="event.date_end"
+                                <span itemprop="endDateTime" t-out="event.date_end"
                                     class="font-weight-bold"
                                     t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True}'/>
                                 <div t-if="event.address_id" class="o_event_full_page_ticket_font_faded">
@@ -135,7 +135,7 @@
                                 <h5 t-elif="not attendee"><span>John Doe</span></h5>
                                 <t t-set="first_ticket" t-value="event.event_ticket_ids[0] if event.event_ticket_ids else None"/>
                                 <div t-if="attendee" class="o_event_full_page_ticket_font_faded" t-field="attendee.event_ticket_id"/>
-                                <div t-elif="first_ticket" t-esc="first_ticket.name"
+                                <div t-elif="first_ticket" t-out="first_ticket.name"
                                     class="o_event_full_page_ticket_font_faded"/>
                             </div>
                             <div class="col-4 o_event_full_page_ticket_side_info page">
@@ -184,7 +184,7 @@
                 <span t-if="event.organizer_id.website" t-field="event.organizer_id.website"/>
             </t>
             <t t-else="">
-                <span t-esc="event.name"/> <!-- Force some content to avoid messing the layout -->
+                <span t-out="event.name"/> <!-- Force some content to avoid messing the layout -->
             </t>
         </div>
     </div>
@@ -225,7 +225,7 @@
         <t t-set="address_bits" t-value="event.address_id.contact_address.split('\n')"/>
         <t t-if="address_bits">
             <t t-set="partner_name" t-value="address_bits[0]"/>
-            <span t-esc="partner_name"/>
+            <span t-out="partner_name"/>
         </t>
         <t t-if="len(address_bits) > 1">
             <br/>
@@ -233,11 +233,11 @@
         <t t-set="remaining_bits" t-value="address_bits[1:]"/>
         <t t-foreach="remaining_bits" t-as="address_bit">
             <t t-if="address_bit and address_bit.strip()">
-                <span t-esc="address_bit"/>
+                <span t-out="address_bit"/>
             </t>
         </t>
     </t>
-    <t t-else="" t-esc="event.address_id.name"/>
+    <t t-else="" t-out="event.address_id.name"/>
 </template>
 
 </odoo>

--- a/addons/event/report/event_event_templates.xml
+++ b/addons/event/report/event_event_templates.xml
@@ -21,14 +21,17 @@
                                 class="font-weight-bold"/>
                             <span itemprop="startDateTime" t-out="event.date_begin"
                                 class="font-weight-bold"
-                                t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True}'/>
+                                t-options='{"widget": "datetime", "time_only": True, "tz_name": event.date_tz, "hide_seconds": True}'/>
                             <span class="fa fa-arrow-right o_event_foldable_badge_font_faded"/>
                             <span t-if="not event.is_one_day"
                                 itemprop="endDate" t-out="event.date_end.date()"
                                 class="font-weight-bold"/>
                             <span itemprop="endDateTime" t-out="event.date_end"
                                 class="font-weight-bold"
-                                t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True}'/>
+                                t-options='{"widget": "datetime", "time_only": True, "tz_name": event.date_tz, "hide_seconds": True}'/>
+                        </div>
+                        <div class="o_event_foldable_badge_font_faded o_event_foldable_badge_font_small text-center">
+                            (<span itemprop="timezone" t-out="event.date_tz"/>)
                         </div>
                         <div t-if="event.address_id" class="o_event_foldable_badge_font_faded o_event_foldable_badge_font_small text-center">
                             <t t-call="event.event_report_template_formatted_event_address"/>
@@ -119,14 +122,15 @@
                                     class="font-weight-bold"/>
                                 <span itemprop="startDateTime" t-out="event.date_begin"
                                     class="font-weight-bold"
-                                    t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True}'/>
+                                    t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True, "tz_name": event.date_tz}'/>
                                 <span class="fa fa-arrow-right o_event_full_page_ticket_font_faded"/>
                                 <span t-if="not event.is_one_day"
                                     itemprop="endDate" t-out="event.date_end.date()"
                                     class="font-weight-bold"/>
                                 <span itemprop="endDateTime" t-out="event.date_end"
                                     class="font-weight-bold"
-                                    t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True}'/>
+                                    t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True, "tz_name": event.date_tz}'/>
+                                <span itemprop="timeZone" class="o_event_full_page_ticket_font_faded small">(<t t-out="event.date_tz"/>)</span>
                                 <div t-if="event.address_id" class="o_event_full_page_ticket_font_faded">
                                     <t t-call="event.event_report_template_formatted_event_address"/>
                                 </div>

--- a/addons/event/views/event_ticket_views.xml
+++ b/addons/event/views/event_ticket_views.xml
@@ -120,11 +120,11 @@
                         <div t-attf-class="oe_kanban_card oe_kanban_global_click">
                             <div class="row">
                                 <div class="col-8">
-                                    <strong><t t-esc="record.name.value"/></strong>
+                                    <strong><t t-out="record.name.value"/></strong>
                                 </div>
                             </div>
                             <div><i>
-                            <t t-esc="record.seats_reserved.value"/> reserved + <t t-esc="record.seats_reserved.value"/> unconfirmed
+                            <t t-out="record.seats_reserved.value"/> reserved + <t t-out="record.seats_reserved.value"/> unconfirmed
                             </i></div>
                         </div>
                     </t>

--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -364,15 +364,15 @@
                             <div t-attf-class="d-flex flex-column p-0 oe_kanban_card oe_kanban_global_click">
                                 <div class="o_kanban_content p-0 m-0 position-relative row d-flex flex-fill">
                                     <div class="col-3 bg-primary p-2 text-center d-flex flex-column justify-content-center">
-                                        <div t-esc="record.date_begin.raw_value.getDate()" class="o_event_fontsize_20"/>
+                                        <div t-out="record.date_begin.raw_value.getDate()" class="o_event_fontsize_20"/>
                                         <div>
-                                            <t t-esc="moment(record.date_begin.raw_value).format('MMM')"/>
-                                            <t t-esc="record.date_begin.raw_value.getFullYear()"/>
+                                            <t t-out="moment(record.date_begin.raw_value).format('MMM')"/>
+                                            <t t-out="record.date_begin.raw_value.getFullYear()"/>
                                         </div>
-                                        <div><t t-esc="moment(record.date_begin.raw_value).format('LT')"/></div>
+                                        <div><t t-out="moment(record.date_begin.raw_value).format('LT')"/></div>
                                         <div t-if="moment(record.date_begin.raw_value).dayOfYear() !== moment(record.date_end.raw_value).dayOfYear()">
                                             <i class="fa fa-arrow-right o_event_fontsize_09" title="End date"/>
-                                            <t t-esc="moment(record.date_end.raw_value).format('D MMM')"/>
+                                            <t t-out="moment(record.date_end.raw_value).format('D MMM')"/>
                                          </div>
                                     </div>
                                     <div class="col-9 py-2 px-3 d-flex flex-column justify-content-between pt-3">
@@ -380,18 +380,18 @@
                                             <div class="o_kanban_record_title o_text_overflow" t-att-title="record.name.value">
                                                 <field name="name"/>
                                             </div>
-                                            <div t-if="record.address_id.value"><i class="fa fa-map-marker" title="Location"/> <span class="o_text_overflow o_event_kanban_location" t-esc="record.address_id.value"/></div>
+                                            <div t-if="record.address_id.value"><i class="fa fa-map-marker" title="Location"/> <span class="o_text_overflow o_event_kanban_location" t-out="record.address_id.value"/></div>
                                         </div>
                                         <h5 class="o_event_fontsize_11 p-0">
                                             <a name="%(act_event_registration_from_event)d"
                                                type="action"
                                                context="{'search_default_expected': True}">
-                                                <t t-esc="record.seats_expected.raw_value"/> Expected attendees
+                                                <t t-out="record.seats_expected.raw_value"/> Expected attendees
                                             </a>
                                             <t t-set="total_seats" t-value="record.seats_reserved.raw_value + record.seats_used.raw_value"/>
                                             <div  class="pt-2 pt-md-0" t-if="total_seats > 0 and ! record.auto_confirm.raw_value"><br/>
                                                 <a class="pl-2" name="%(act_event_registration_from_event)d" type="action" context="{'search_default_confirmed': True}">
-                                                    <i class="fa fa-level-up fa-rotate-90" title="Confirmed"/><span class="pl-2"><t t-esc="total_seats"/> Confirmed</span>
+                                                    <i class="fa fa-level-up fa-rotate-90" title="Confirmed"/><span class="pl-2"><t t-out="total_seats"/> Confirmed</span>
                                                 </a>
                                             </div>
                                         </h5>
@@ -666,7 +666,7 @@
                                                 <div id="event_ticket_id" class="o_field_many2manytags o_field_widget d-flex mt-auto">
                                                     <t t-if="record.event_ticket_id.raw_value">
                                                         <div t-attf-class="badge badge-pill o_tag_color_#{(record.event_ticket_id.raw_value % 11) + 1}" >
-                                                            <b><span class="o_badge_text o_text_overflow"><t t-esc="record.event_ticket_id.value"/></span></b>
+                                                            <b><span class="o_badge_text o_text_overflow"><t t-out="record.event_ticket_id.value"/></span></b>
                                                         </div>
                                                     </t>
                                                 </div>

--- a/addons/event_booth/data/mail_templates.xml
+++ b/addons/event_booth/data/mail_templates.xml
@@ -7,31 +7,31 @@
         <p>
             <span>
                 Booth
-                <a href="#" t-att-data-oe-model="booth._name" t-att-data-oe-id="booth.id" t-esc="booth.name"/>
+                <a href="#" t-att-data-oe-model="booth._name" t-att-data-oe-id="booth.id" t-out="booth.name"/>
             </span>
-            <span t-esc="'booked by' if booth.partner_id else 'has been reserved by'"/>
+            <span t-out="'booked by' if booth.partner_id else 'has been reserved by'"/>
             <span>
                 <a href="#" t-att-data-oe-model="booth.partner_id._name or booth.env.user.partner_id._name"
                    t-att-data-oe-id="booth.partner_id.id or booth.env.user.partner_id.id"
-                   t-esc="booth.partner_id.name or booth.env.user.partner_id.name"/>
+                   t-out="booth.partner_id.name or booth.env.user.partner_id.name"/>
             </span>
         </p>
         <ul t-if="booth.partner_id" name="contact_details">
             <t t-set="contact_name" t-value="booth.contact_name"/>
             <li t-if="contact_name">
-                <b>Renter Name</b>: <span t-esc="contact_name"/>
+                <b>Renter Name</b>: <span t-out="contact_name"/>
             </li>
             <t t-set="contact_email" t-value="booth.contact_email"/>
             <li t-if="contact_email">
-                <b>Renter Email</b>: <span t-esc="contact_email"/>
+                <b>Renter Email</b>: <span t-out="contact_email"/>
             </li>
             <t t-set="contact_mobile" t-value="booth.contact_mobile"/>
             <li t-if="contact_mobile">
-                <b>Renter Mobile</b>: <span t-esc="contact_mobile"/>
+                <b>Renter Mobile</b>: <span t-out="contact_mobile"/>
             </li>
             <t t-set="contact_phone" t-value="booth.contact_phone"/>
             <li t-if="contact_phone">
-                <b>Renter Phone</b>: <span t-esc="contact_phone"/>
+                <b>Renter Phone</b>: <span t-out="contact_phone"/>
             </li>
         </ul>
     </template>

--- a/addons/event_sale/data/mail_data.xml
+++ b/addons/event_sale/data/mail_data.xml
@@ -5,15 +5,15 @@
     <div>
         <p>
             <span>Registration modification for attendee:</span>
-            <a href="#" data-oe-model="event.registration" t-att-data-oe-id="registration.id"><t t-esc="registration.name"/></a>.
+            <a href="#" data-oe-model="event.registration" t-att-data-oe-id="registration.id"><t t-out="registration.name"/></a>.
             <span>Manual actions may be needed.</span>
         </p>
         <div class="mt16">
             <p>Exception:</p>
             <ul>
                 <li>
-                    <a href="#" data-oe-model="event.registration" t-att-data-oe-id="registration.id"><t t-esc="registration.name"/></a>:
-                    <span>Ticket changed from <strong><t t-esc="old_ticket_name"/></strong> to <strong><t t-esc="new_ticket_name"/></strong></span>
+                    <a href="#" data-oe-model="event.registration" t-att-data-oe-id="registration.id"><t t-out="registration.name"/></a>:
+                    <span>Ticket changed from <strong><t t-out="old_ticket_name"/></strong> to <strong><t t-out="new_ticket_name"/></strong></span>
                 </li>
             </ul>
         </div>

--- a/addons/event_sale/report/event_event_templates.xml
+++ b/addons/event_sale/report/event_event_templates.xml
@@ -10,7 +10,7 @@
         <xpath expr="//div[hasclass('o_event_full_page_ticket_side_info')]" position="inside">
             <div t-if="attendee and attendee.sale_order_id" class="mb-2">
                 <div class="o_event_full_page_ticket_font_faded o_event_full_page_ticket_small_caps font-weight-bold">Order Date</div>
-                <div class="o_event_full_page_ticket_small" t-esc="attendee.sale_order_id.date_order.date()"/>
+                <div class="o_event_full_page_ticket_small" t-out="attendee.sale_order_id.date_order.date()"/>
             </div>
             <div t-if="attendee and attendee.sale_order_line_id.price_total">
                 <div class="o_event_full_page_ticket_font_faded o_event_full_page_ticket_small_caps font-weight-bold">Price</div>

--- a/addons/event_sale/views/event_ticket_views.xml
+++ b/addons/event_sale/views/event_ticket_views.xml
@@ -75,10 +75,10 @@
                 <field name="price"/>
             </field>
             <xpath expr="//div[hasclass('col-8')]" position="after">
-                <div class="col-4 text-right"><strong> <t t-esc="record.price.value"/></strong></div>
+                <div class="col-4 text-right"><strong> <t t-out="record.price.value"/></strong></div>
             </xpath>
             <xpath expr="//div[hasclass('row')]" position="after">
-                <div t-esc="record.product_id.value"/>
+                <div t-out="record.product_id.value"/>
             </xpath>
         </field>
     </record>

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -7,7 +7,7 @@ from dateutil.relativedelta import relativedelta
 import json
 import werkzeug.urls
 
-from pytz import utc
+from pytz import utc, timezone
 
 from odoo import api, fields, models, _
 from odoo.addons.http_routing.models.ir_http import slug
@@ -407,12 +407,13 @@ class Event(models.Model):
         return super(Event, self)._track_subtype(init_values)
 
     def _get_event_resource_urls(self):
-        url_date_start = self.date_begin.strftime('%Y%m%dT%H%M%SZ')
-        url_date_stop = self.date_end.strftime('%Y%m%dT%H%M%SZ')
+        url_date_start = self.date_begin.astimezone(timezone(self.date_tz)).strftime('%Y%m%dT%H%M%S')
+        url_date_stop = self.date_end.astimezone(timezone(self.date_tz)).strftime('%Y%m%dT%H%M%S')
         params = {
             'action': 'TEMPLATE',
             'text': self.name,
             'dates': url_date_start + '/' + url_date_stop,
+            'ctz': self.date_tz,
             'details': self.name,
         }
         if self.address_id:

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -198,8 +198,11 @@
                             </h5>
                             <!-- Start Date & Time -->
                             <time itemprop="startDate" t-att-datetime="event.date_begin">
-                                <span t-field="event.with_context(tz=event.date_tz).date_begin" t-options="{'date_only': 'true', 'format': 'long'}"/> -
-                                <span t-field="event.with_context(tz=event.date_tz).date_begin" t-options="{'time_only': 'true', 'format': 'short'}" class="oe_hide_on_date_edit"/>
+                                <span t-field="event.with_context(tz=event.date_tz).date_begin"
+                                    t-options="{'date_only': 'true', 'format': 'long', 'tz_name': event.date_tz}"/> -
+                                <span t-field="event.with_context(tz=event.date_tz).date_begin" class="oe_hide_on_date_edit"
+                                    t-options="{'time_only': 'true', 'format': 'short', 'tz_name': event.date_tz}"/>
+                                (<span t-field="event.date_tz"/>)
                             </time>
                             <!-- Location -->
                             <div itemprop="location" t-field="event.address_id" t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': 'true'}"/>

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -54,14 +54,14 @@
                         <li t-if="category.is_published and category.tag_ids and any(tag.color for tag in category.tag_ids)" class="nav-item dropdown mr-2 my-1">
                             <a href="#" role="button" class="btn dropdown-toggle" data-toggle="dropdown">
                                 <i class="fa fa-folder-open"/>
-                                <t t-esc="category.name"/>
+                                <t t-out="category.name"/>
                             </a>
                             <div class="dropdown-menu">
                                 <t t-foreach="category.tag_ids" t-as="tag">
                                     <a t-if="tag.color"
                                         t-att-href="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids))"
                                         t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{'active' if tag in search_tags else ''}">
-                                        <t t-esc="tag.name"/>
+                                        <t t-out="tag.name"/>
                                     </a>
                                 </t>
                             </div>
@@ -81,7 +81,7 @@
         <t t-foreach="search_tags" t-as="tag">
             <span class="align-items-baseline border d-inline-flex pl-2 rounded ml16 mb-2 bg-white">
                 <i class="fa fa-tag mr-2 text-muted"/>
-                <t t-esc="tag.display_name"/>
+                <t t-out="tag.display_name"/>
                 <a t-att-href="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids))" class="btn border-0 py-1">&#215;</a>
             </span>
         </t>
@@ -94,15 +94,15 @@
         <li class="nav-item dropdown mr-2 my-1">
             <a href="#" role="button" class="btn dropdown-toggle" data-toggle="dropdown">
                 <i class="fa fa-calendar"/>
-                <t t-if="current_date" t-esc="current_date"/>
+                <t t-if="current_date" t-out="current_date"/>
                 <t t-else="">Upcoming Events</t>
             </a>
             <div class="dropdown-menu">
                 <t t-foreach="dates" t-as="date">
                     <t t-if="date[3] or (date[0] in ('old','upcoming','all'))">
                         <a t-att-href="keep('/event', date=date[0])" t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{searches.get('date') == date[0] and 'active'}">
-                            <t t-esc="date[1]"/>
-                            <span t-if="date[3]" t-esc="date[3]" class="badge badge-pill badge-primary ml-3"/>
+                            <t t-out="date[1]"/>
+                            <span t-if="date[3]" t-out="date[3]" class="badge badge-pill badge-primary ml-3"/>
                         </a>
                     </t>
                 </t>
@@ -117,21 +117,21 @@
         <li class="nav-item dropdown mr-2 my-1">
             <a href="#" role="button" class="btn dropdown-toggle" data-toggle="dropdown">
                 <i class="fa fa-map-marker"/>
-                <t t-if="current_country" t-esc="current_country.name"/>
+                <t t-if="current_country" t-out="current_country.name"/>
                 <t t-else="">All countries</t>
             </a>
             <div class="dropdown-menu">
                 <t t-foreach="countries" t-as="country">
                     <t t-if="country['country_id']">
                         <a t-att-href="keep('/event', country=country['country_id'][0])" t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{searches.get('country') == str(country['country_id'] and country['country_id'][0]) and 'active'}">
-                            <t t-esc="country['country_id'][1]"/>
-                            <span t-esc="country['country_id_count']" class="badge badge-pill badge-primary ml-auto"/>
+                            <t t-out="country['country_id'][1]"/>
+                            <span t-out="country['country_id_count']" class="badge badge-pill badge-primary ml-auto"/>
                         </a>
                     </t>
                     <t t-else="">
                         <a t-att-href="keep('/event', country='online')" t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{searches.get('country') == 'online' and 'active'}">
                             <span>Online Events</span>
-                            <span t-esc="country['country_id_count']" class="badge badge-pill badge-primary ml-3"/>
+                            <span t-out="country['country_id_count']" class="badge badge-pill badge-primary ml-3"/>
                         </a>
                     </t>
                 </t>
@@ -157,7 +157,7 @@
     </t>
     <!-- Fuzzy search -->
     <div t-if="event_ids and original_search" class="col-12 alert alert-warning mt8">
-        No results found for '<span t-esc="original_search"/>'. Showing results for '<span t-esc="searches['search']"/>'.
+        No results found for '<span t-out="original_search"/>'. Showing results for '<span t-out="searches['search']"/>'.
     </div>
     <!-- List -->
     <div t-foreach="event_ids" t-as="event" t-attf-class=" #{opt_event_size} mb-4">
@@ -207,7 +207,7 @@
                                 <t t-foreach="event.tag_ids.filtered(lambda tag: tag.category_id.is_published)" t-as="tag">
                                     <span t-if="tag.color"
                                         t-attf-class="badge mr4 #{'badge-primary' if tag in search_tags else 'badge-light'} #{'o_tag_color_%s' % tag.color if tag.color else ''}">
-                                        <span t-esc="tag.name"/>
+                                        <span t-out="tag.name"/>
                                     </span>
                                 </t>
                             </div>

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -61,7 +61,7 @@
                                 <span t-field="event.with_context(tz=event.date_tz).date_end" t-options="{'time_only': 'true', 'format': 'short'}"/>
                             </t>
                             <!-- Timezone -->
-                            <small t-esc="event.date_tz" class="d-block my-3 text-muted"/>
+                            <small t-out="event.date_tz" class="d-block my-3 text-muted"/>
 
                             <div class="dropdown">
                                 <i class="fa fa-calendar mr-1"/>
@@ -122,9 +122,9 @@
             <t t-if="not event.event_registrations_started">
                 <div class="col-md-8 d-flex">
                     <em class="mr-2">Ticket Sales starting on
-                        <span class="" t-esc="event.start_sale_datetime"
+                        <span class="" t-out="event.start_sale_datetime"
                             t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'short'}"/>
-                        <span t-esc="event.date_tz"/>
+                        <span t-out="event.date_tz"/>
                     </em>
                     <t t-call="website_event.registration_configure_tickets_button"
                         t-if="request.env.user.has_group('event.group_event_manager')"/>
@@ -178,15 +178,15 @@
                             </t>
                             <small t-if="ticket.end_sale_datetime and ticket.sale_available and not ticket.is_expired"
                                    class="text-muted mr-3" itemprop="availabilityEnds">Sales end on
-                                <span itemprop="priceValidUntil" t-esc="ticket.end_sale_datetime"
+                                <span itemprop="priceValidUntil" t-out="ticket.end_sale_datetime"
                                 t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'short'}"/>
-                                <span t-esc="ticket.event_id.date_tz"/>
+                                <span t-out="ticket.event_id.date_tz"/>
                             </small>
                             <small t-if="ticket.start_sale_datetime and not ticket.sale_available and not ticket.is_expired"
                                    class="text-muted mr-3" itemprop="availabilityEnds">
-                                Sales start on <span itemprop="priceValidUntil" t-esc="ticket.start_sale_datetime"
+                                Sales start on <span itemprop="priceValidUntil" t-out="ticket.start_sale_datetime"
                                 t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'short'}"/>
-                                <span t-esc="ticket.event_id.date_tz"/>
+                                <span t-out="ticket.event_id.date_tz"/>
                             </small>
                         </div>
                         <div class="col-md-4 col-xs-12 p-0 d-flex align-items-center justify-content-between">
@@ -199,7 +199,7 @@
                                     <t t-set="seats_max_event" t-value="(not event.seats_limited or event.seats_available &gt; 9) and 10 or event.seats_available + 1"/>
                                     <t t-set="seats_max" t-value="min(seats_max_ticket, seats_max_event)"/>
                                     <t t-foreach="range(0, seats_max)" t-as="nb">
-                                        <option t-esc="nb" t-att-selected="len(ticket) == 0 and nb == 0 and 'selected'"/>
+                                        <option t-out="nb" t-att-selected="len(ticket) == 0 and nb == 0 and 'selected'"/>
                                     </t>
                                 </select>
                                 <div t-else="" class="text-danger">
@@ -214,7 +214,7 @@
                             <button type="submit" class="btn btn-primary o_wait_lazy_js btn-block a-submit" disabled="" t-attf-id="#{event.id}">
                                 Register
                                 <t t-if="event.seats_limited and event.seats_max and event.seats_available &lt;= (event.seats_max * 0.2)">
-                                    (only <t t-esc="event.seats_available"/> available)
+                                    (only <t t-out="event.seats_available"/> available)
                                 </t>
                             </button>
                         </div>
@@ -229,9 +229,9 @@
                             <span t-else="">Registration</span>
                         </h6>
                         <small t-if="tickets.end_sale_datetime and tickets.sale_available and not tickets.is_expired" class="text-muted mr-3" itemprop="availabilityEnds">Sales end on
-                            <span itemprop="priceValidUntil" t-esc="tickets.end_sale_datetime"
+                            <span itemprop="priceValidUntil" t-out="tickets.end_sale_datetime"
                                 t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'short'}"/>
-                            <span t-esc="tickets.event_id.date_tz"/>
+                            <span t-out="tickets.event_id.date_tz"/>
                         </small>
                         <t t-call="website_event.registration_configure_tickets_button"
                         t-if="request.env.user.has_group('event.group_event_manager')"/>
@@ -244,7 +244,7 @@
                                     <t t-set="seats_max_event" t-value="(not event.seats_limited or event.seats_available &gt; 9) and 10 or event.seats_available + 1"/>
                                     <t t-set="seats_max" t-value="min(seats_max_ticket, seats_max_event) if tickets else seats_max_event"/>
                                     <t t-foreach="range(0, seats_max)" t-as="nb">
-                                        <option t-esc="nb" t-att-selected="nb == 1 and 'selected'"/>
+                                        <option t-out="nb" t-att-selected="nb == 1 and 'selected'"/>
                                     </t>
                                 </select>
                             </t>
@@ -259,7 +259,7 @@
                         <button type="submit" class="btn btn-primary o_wait_lazy_js btn-block a-submit" t-attf-id="#{event.id}">
                             Register
                             <t t-if="event.seats_limited and event.seats_max and event.seats_available &lt;= (event.seats_max * 0.2)">
-                                (only <t t-esc="event.seats_available"/> available)
+                                (only <t t-out="event.seats_available"/> available)
                             </t>
                         </button>
                     </div>
@@ -285,7 +285,7 @@
                         <t t-foreach="range(1, ticket['quantity'] + 1)" t-as="att_counter" name="attendee_loop">
                             <t t-set="counter" t-value="counter + 1"/>
                             <div class="modal-body bg-light border-bottom">
-                                <h5 class="mt-1 pb-2 border-bottom">Ticket #<span t-esc="counter"/> <small class="text-muted">- <span t-esc="ticket['name']"/></small></h5>
+                                <h5 class="mt-1 pb-2 border-bottom">Ticket #<span t-out="counter"/> <small class="text-muted">- <span t-out="ticket['name']"/></small></h5>
                                 <div class="row">
                                     <div class="col-lg my-2">
                                         <label>Name *</label>
@@ -329,31 +329,31 @@
             <div class="row mb-3">
                 <div class="col-12">
                     <h3>Registration confirmed!</h3>
-                    <span class="h4 text-muted" t-esc="event.name"/>
+                    <span class="h4 text-muted" t-out="event.name"/>
                 </div>
             </div>
             <div class="row mb-3 o_wereg_confirmed_attendees">
                 <div class="col-md-4 col-xs-12 mt-3" t-foreach="attendees" t-as="attendee">
                     <div class="d-flex flex-column">
                         <span class="font-weight-bold text-truncate">
-                            <t t-if="attendee.name" t-esc="attendee.name"/>
+                            <t t-if="attendee.name" t-out="attendee.name"/>
                             <t t-else="">N/A</t>
                         </span>
                         <span class="text-truncate">
                             <i class="fa fa-envelope mr-2   "></i>
-                            <t t-if="attendee.email" t-esc="attendee.email"/>
+                            <t t-if="attendee.email" t-out="attendee.email"/>
                             <t t-else="">N/A</t>
                         </span>
                         <span t-if="attendee.phone">
                             <i class="fa fa-phone mr-2"></i>
-                            <t t-esc="attendee.phone"/>
+                            <t t-out="attendee.phone"/>
                         </span>
                         <span>
                             <i class="fa fa-ticket mr-2"></i>
                             <t t-if="attendee.event_ticket_id">
-                                <t t-esc="attendee.event_ticket_id.name"/> (Ref: <t t-esc="attendee.id"/>)
+                                <t t-out="attendee.event_ticket_id.name"/> (Ref: <t t-out="attendee.id"/>)
                             </t>
-                            <t t-else="">Ref: <t t-esc="attendee.id"/></t>
+                            <t t-else="">Ref: <t t-out="attendee.id"/></t>
                         </span>
                     </div>
                 </div>
@@ -365,7 +365,7 @@
                             <b>Start</b>
                         </div>
                         <div class="col pl-0">
-                            <span itemprop="startDate" t-esc="event.date_begin_located"/>
+                            <span itemprop="startDate" t-out="event.date_begin_located"/>
                         </div>
                     </div>
                     <div class="row">
@@ -373,7 +373,7 @@
                             <b>End</b>
                         </div>
                         <div class="col pl-0">
-                            <span itemprop="endDate" t-esc="event.date_end_located"/>
+                            <span itemprop="endDate" t-out="event.date_end_located"/>
                         </div>
                     </div>
                     <div class="mt-4">

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -50,8 +50,10 @@
                             <t t-if="event.is_one_day">
                                 <i class="fa fa-long-arrow-right mx-1"/>
                                 <span t-field="event.with_context(tz=event.date_tz).date_end" t-options="{'time_only': 'true', 'format': 'short'}"/>
+                                (<span t-out="event.date_tz"/>)
                             </t>
                             <t t-else="">
+                                (<span t-out="event.date_tz"/>)
                                 <i class="fa fa-long-arrow-down d-block text-muted mx-3 my-2" style="font-size: 1.5rem"/>
                                 <div class="d-flex">
                                     <h5 t-field="event.with_context(tz=event.date_tz).date_end" class="my-1 mr-1 oe_hide_on_date_edit" t-options="{'date_only': 'true', 'format': 'EEEE'}"/>
@@ -59,9 +61,8 @@
                                 </div>
                                 <t t-if="not event.is_one_day">End -</t>
                                 <span t-field="event.with_context(tz=event.date_tz).date_end" t-options="{'time_only': 'true', 'format': 'short'}"/>
+                                (<span t-out="event.date_tz"/>)
                             </t>
-                            <!-- Timezone -->
-                            <small t-out="event.date_tz" class="d-block my-3 text-muted"/>
 
                             <div class="dropdown">
                                 <i class="fa fa-calendar mr-1"/>
@@ -180,13 +181,13 @@
                                    class="text-muted mr-3" itemprop="availabilityEnds">Sales end on
                                 <span itemprop="priceValidUntil" t-out="ticket.end_sale_datetime"
                                 t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'short'}"/>
-                                <span t-out="ticket.event_id.date_tz"/>
+                                (<span t-out="ticket.event_id.date_tz"/>)
                             </small>
                             <small t-if="ticket.start_sale_datetime and not ticket.sale_available and not ticket.is_expired"
                                    class="text-muted mr-3" itemprop="availabilityEnds">
                                 Sales start on <span itemprop="priceValidUntil" t-out="ticket.start_sale_datetime"
                                 t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'short'}"/>
-                                <span t-out="ticket.event_id.date_tz"/>
+                                (<span t-out="ticket.event_id.date_tz"/>)
                             </small>
                         </div>
                         <div class="col-md-4 col-xs-12 p-0 d-flex align-items-center justify-content-between">
@@ -228,10 +229,12 @@
                             <span t-if="tickets" t-field="tickets.name"/>
                             <span t-else="">Registration</span>
                         </h6>
-                        <small t-if="tickets.end_sale_datetime and tickets.sale_available and not tickets.is_expired" class="text-muted mr-3" itemprop="availabilityEnds">Sales end on
+                        <small t-if="tickets.end_sale_datetime and tickets.sale_available and not tickets.is_expired"
+                            class="text-muted ml-1 mr-3" itemprop="availabilityEnds">
+                            Sales end on
                             <span itemprop="priceValidUntil" t-out="tickets.end_sale_datetime"
                                 t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'short'}"/>
-                            <span t-out="tickets.event_id.date_tz"/>
+                            (<span t-out="tickets.event_id.date_tz"/>)
                         </small>
                         <t t-call="website_event.registration_configure_tickets_button"
                         t-if="request.env.user.has_group('event.group_event_manager')"/>
@@ -366,6 +369,7 @@
                         </div>
                         <div class="col pl-0">
                             <span itemprop="startDate" t-out="event.date_begin_located"/>
+                            (<span t-out="event.date_tz"/>)
                         </div>
                     </div>
                     <div class="row">
@@ -374,6 +378,7 @@
                         </div>
                         <div class="col pl-0">
                             <span itemprop="endDate" t-out="event.date_end_located"/>
+                            (<span t-out="event.date_tz"/>)
                         </div>
                     </div>
                     <div class="mt-4">

--- a/addons/website_event/views/event_templates_widgets.xml
+++ b/addons/website_event/views/event_templates_widgets.xml
@@ -50,7 +50,7 @@
          t-att-data-pre-countdown-text="pre_countdown_text">
         <t t-set="remaining_time" t-value="pre_remaining_time if pre_remaining_time else main_remaining_time"/>
         <span class="o_display_timer_countdown d-flex justify-content-center">
-            <span class="o_countdown_text pr-1" t-esc="pre_countdown_text if pre_countdown_text else main_countdown_text if not pre_countdown_display else ''"/>
+            <span class="o_countdown_text pr-1" t-out="pre_countdown_text if pre_countdown_text else main_countdown_text if not pre_countdown_display else ''"/>
             <div t-if="int(remaining_time) > 86400"
              class="o_countdown_metric_container"><span class="o_countdown_remaining o_timer_days pr-1">0</span><span class="o_countdown_metric pr-1">days</span></div>
             <div t-if="int(remaining_time) > 3600"

--- a/addons/website_event_booth/static/src/xml/event_booth_registration_templates.xml
+++ b/addons/website_event_booth/static/src/xml/event_booth_registration_templates.xml
@@ -5,22 +5,22 @@
             <div class="row mb-3">
                 <div class="col-12">
                     <h3>Booth Registration completed!</h3>
-                    <span class="h4 text-muted" t-esc="event_name"/>
+                    <span class="h4 text-muted" t-out="event_name"/>
                 </div>
             </div>
             <div class="d-flex flex-column">
-                <span t-if="contact.name" t-esc="contact.name" class="font-weight-bold"/>
+                <span t-if="contact.name" t-out="contact.name" class="font-weight-bold"/>
                 <span t-if="contact.email">
                     <i class="fa fa-fw fa-envelope mr-2"/>
-                    <t t-esc="contact.email"/>
+                    <t t-out="contact.email"/>
                 </span>
                 <span t-if="contact.phone">
                     <i class="fa fa-fw fa-phone mr-2"/>
-                    <t t-esc="contact.phone"/>
+                    <t t-out="contact.phone"/>
                 </span>
                 <span t-if="contact.mobile">
                     <i class="fa fa-fw fa-mobile mr-2"/>
-                    <t t-esc="contact.mobile"/>
+                    <t t-out="contact.mobile"/>
                 </span>
             </div>
         </div>

--- a/addons/website_event_booth/views/event_booth_templates.xml
+++ b/addons/website_event_booth/views/event_booth_templates.xml
@@ -59,7 +59,7 @@
                                         <input type="radio" name="booth_category_id" t-att-value="booth_category.id"
                                                t-att-disabled="booth_category_unavailable"/>
                                         <div>
-                                            <h5 name="booth_category_name" class="m-0 text-truncate" t-esc="booth_category.name"/>
+                                            <h5 name="booth_category_name" class="m-0 text-truncate" t-out="booth_category.name"/>
                                             <span class="img img-responsive">
                                                 <div t-field="booth_category.image_1920" t-options="{'widget': 'image', 'preview_image': 'image_256', 'class': 'mt-2'}"/>
                                             </span>

--- a/addons/website_event_booth_exhibitor/views/mail_templates.xml
+++ b/addons/website_event_booth_exhibitor/views/mail_templates.xml
@@ -5,7 +5,7 @@
         <ul name="contact_details" position="inside">
             <t t-set="renter_sponsor" t-value="booth.sponsor_id"/>
             <li t-if="renter_sponsor">
-                <b>Sponsor</b>: <a href="#" t-att-data-oe-model="booth.sponsor_id._name" t-att-data-oe-id="booth.sponsor_id.id" t-esc="booth.sponsor_id.name"/>
+                <b>Sponsor</b>: <a href="#" t-att-data-oe-model="booth.sponsor_id._name" t-att-data-oe-id="booth.sponsor_id.id" t-out="booth.sponsor_id.name"/>
             </li>
         </ul>
     </template>

--- a/addons/website_event_booth_sale/views/event_booth_templates.xml
+++ b/addons/website_event_booth_sale/views/event_booth_templates.xml
@@ -17,7 +17,7 @@
                     <span class="font-weight-bold">Total</span>
                 </div>
                 <div class="col-sm-6">
-                    <span class="font-weight-bold" t-esc="float(0)"
+                    <span class="font-weight-bold" t-out="float(0)"
                           t-options="{'widget': 'monetary', 'display_currency': website.pricelist_id.currency_id}"/>
                 </div>
             </div>

--- a/addons/website_event_exhibitor/controllers/website_event_main.py
+++ b/addons/website_event_exhibitor/controllers/website_event_main.py
@@ -15,7 +15,7 @@ class WebsiteEventController(main.WebsiteEventController):
         if "from_sponsor_id" in post and not event.is_ongoing:
             sponsor = request.env["event.sponsor"].browse(int(post["from_sponsor_id"])).exists()
             if sponsor:
-                date_begin = format_datetime(event.with_context(tz=event.date_tz).date_begin, format="medium")
+                date_begin = format_datetime(event.date_begin, format="medium", tzinfo=event.date_tz)
 
                 values["toast_message"] = (
                     _('The event %s starts on %s (%s). \nJoin us there to meet %s !')

--- a/addons/website_event_exhibitor/static/src/xml/event_exhibitor_connect.xml
+++ b/addons/website_event_exhibitor/static/src/xml/event_exhibitor_connect.xml
@@ -7,37 +7,37 @@
                 <t t-if="! widget.sponsorData.event_is_ongoing">
                     <div class="col-12 alert alert-warning text-center" role="alert"
                         t-if="widget.sponsorData.event_is_done">
-                        Event <span t-esc="widget.sponsorData.event_name" class="font-weight-bold"/> is over.
+                        Event <span t-out="widget.sponsorData.event_name" class="font-weight-bold"/> is over.
 
                         <br/>
-                        <span>Join us next time to meet <b t-esc="widget.sponsorData.name"/>!</span>
+                        <span>Join us next time to meet <b t-out="widget.sponsorData.name"/>!</span>
                     </div>
                     <div class="col-12 alert alert-warning text-center" role="alert"
                         t-else="">
-                        <span t-esc="widget.sponsorData.name" class="font-weight-bold"/> is not available right now.<br />
-                        Event <span t-esc="widget.sponsorData.event_name" class="font-weight-bold"/>
+                        <span t-out="widget.sponsorData.name" class="font-weight-bold"/> is not available right now.<br />
+                        Event <span t-out="widget.sponsorData.event_name" class="font-weight-bold"/>
                         <span t-if="widget.sponsorData.event_start_today">
                             starts in
-                            <span t-if="widget.sponsorData.event_start_remaining &gt;= 1" t-esc="widget.sponsorData.event_start_remaining"
+                            <span t-if="widget.sponsorData.event_start_remaining &gt;= 1" t-out="widget.sponsorData.event_start_remaining"
                                 t-options="{'widget': 'duration', 'digital': False, 'unit': 'minute', 'round': 'minute'}"/>
                             <t t-else="">
                                 a few seconds
                             </t>.
                         </span>
                         <span class="my-0" t-else="">
-                            starts on <span t-esc="widget.sponsorData.event_date_begin_located"/>
+                            starts on <span t-out="widget.sponsorData.event_date_begin_located"/>
                         </span>
                     </div>
                 </t>
                 <div class="col-12 alert alert-warning text-center" role="alert"
                     t-else="">
-                    <span t-esc="widget.sponsorData.name" class="font-weight-bold"/> is not available right now.<br />
+                    <span t-out="widget.sponsorData.name" class="font-weight-bold"/> is not available right now.<br />
                     Come back between
                     <strong>
-                        <t t-esc="widget.sponsorData.hour_from_str"/>
+                        <t t-out="widget.sponsorData.hour_from_str"/>
                         -
-                        <t t-esc="widget.sponsorData.hour_to_str"/>
-                    </strong> (<span t-esc="widget.sponsorData.event_date_tz"/>)
+                        <t t-out="widget.sponsorData.hour_to_str"/>
+                    </strong> (<span t-out="widget.sponsorData.event_date_tz"/>)
                     to meet them !
                 </div>
                 <div class="col-2">
@@ -49,19 +49,19 @@
                     <div class="d-flex align-items-top mb-3">
                         <div class="d-flex flex-column">
                             <div class="d-flex align-items-center">
-                                <h4 t-esc="widget.sponsorData.name" class="mb4"/>
+                                <h4 t-out="widget.sponsorData.name" class="mb4"/>
                                 <span class="badge badge-primary ml-2"
-                                    t-esc="widget.sponsorData.sponsor_type_name"/>
+                                    t-out="widget.sponsorData.sponsor_type_name"/>
                             </div>
-                            <span class="text-muted" t-if="widget.sponsorData.subtitle" t-esc="widget.sponsorData.subtitle"/>
+                            <span class="text-muted" t-if="widget.sponsorData.subtitle" t-out="widget.sponsorData.subtitle"/>
                             <span t-if="widget.sponsorData.url">
-                                <i class="fa fa-home mr-2"/><a t-att-href="widget.sponsorData.url"><span t-esc="widget.sponsorData.url"/></a>
+                                <i class="fa fa-home mr-2"/><a t-att-href="widget.sponsorData.url"><span t-out="widget.sponsorData.url"/></a>
                             </span>
                             <span t-if="widget.sponsorData.email">
-                                <i class="fa fa-envelope mr-2"/><a t-att-mailto="widget.sponsorData.email"><span t-esc="widget.sponsorData.email"/></a>
+                                <i class="fa fa-envelope mr-2"/><a t-att-mailto="widget.sponsorData.email"><span t-out="widget.sponsorData.email"/></a>
                             </span>
                             <span t-if="widget.sponsorData.phone">
-                                <i class="fa fa-phone mr-2"/><span t-esc="widget.sponsorData.phone"/>
+                                <i class="fa fa-phone mr-2"/><span t-out="widget.sponsorData.phone"/>
                             </span>
                         </div>
                         <img t-if="widget.sponsorData.country_flag_url"

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
@@ -70,7 +70,7 @@
                         <input class="d-none" type="checkbox" name="sponsor_country" multiple="multiple"
                             t-att-value="sponsor_country.id"
                             t-att-checked="'checked' if sponsor_country.id in search_countries.ids else None"/>
-                        <t t-esc="sponsor_country.name"/>
+                        <t t-out="sponsor_country.name"/>
                     </label>
                 </t>
             </div>
@@ -99,7 +99,7 @@
                         <input class="d-none" type="checkbox" name="sponsor_type" multiple="multiple"
                             t-att-value="sponsor_type.id"
                             t-att-checked="'checked' if sponsor_type.id in search_sponsorships.ids else None"/>
-                        <t t-esc="sponsor_type.name"/>
+                        <t t-out="sponsor_type.name"/>
                     </label>
                 </t>
             </div>
@@ -125,7 +125,7 @@
         <div class="col-12">
             <div class="h2 mb-3">No exhibitor found.</div>
             <div t-if="search_key" class="alert alert-info text-center">
-                <p class="m-0">We did not find any exhibitor matching your <strong t-esc="search_key"/> search.</p>
+                <p class="m-0">We did not find any exhibitor matching your <strong t-out="search_key"/> search.</p>
             </div>
             <div t-else="" class="alert alert-info text-center" groups="event.group_event_user">
                 <a target="_blank" t-att-href="'/web?#action=website_event_exhibitor.event_sponsor_action_from_event&amp;active_id=%s' % event.id">
@@ -142,7 +142,7 @@
 <template id="exhibitors_display_cards" name="Exhibitors Cards">
     <div t-foreach="sponsor_categories" t-as="sponsor_category" class="row mb-3">
         <div class="col-12">
-            <h2 class="m-0" t-esc="sponsor_category['sponsorship'].name"/>
+            <h2 class="m-0" t-out="sponsor_category['sponsorship'].name"/>
             <hr class="mt-2 pb-1 mb-1"/>
         </div>
         <div t-foreach="sponsor_category['sponsors']" t-as="sponsor" class="col-md-6 col-lg-3 mb-4">
@@ -191,7 +191,7 @@
                         </span>
                     </h5>
                     <!-- Catchy sentence -->
-                    <span class="text-muted" t-esc="sponsor.subtitle"/>
+                    <span class="text-muted" t-out="sponsor.subtitle"/>
                 </main>
             </div>
         </div>
@@ -238,7 +238,7 @@
     <span t-att-data-field="field" t-att-data-value="value"
         class="o_search_tag align-items-baseline border d-inline-flex pl-2 mt-3 rounded ml16 mb-2 bg-white">
         <i class="fa fa-tag mr-2 text-muted"/>
-        <t t-esc="label"/>
+        <t t-out="label"/>
         <span class="btn border-0 py-1">&#215;</span>
     </span>
 </template>

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
@@ -34,15 +34,15 @@
         <!-- EVENT NOT STARTED ALERTS -->
         <t t-if="not sponsor.event_id.is_ongoing">
             <div t-if="sponsor.event_id.is_done" class="alert alert-warning rounded-0 text-center" role="alert">
-                Event <span t-esc="sponsor.event_id.name" class="font-weight-bold"/> is over.
+                Event <span t-out="sponsor.event_id.name" class="font-weight-bold"/> is over.
                 <br/>
-                <span>Join us next time to meet <b t-esc="sponsor.partner_name"/>!</span>
+                <span>Join us next time to meet <b t-out="sponsor.partner_name"/>!</span>
             </div>
             <div t-else="" class="alert alert-warning rounded-0 text-center" role="alert">
-                Event <span t-esc="sponsor.event_id.name" class="font-weight-bold"/>
+                Event <span t-out="sponsor.event_id.name" class="font-weight-bold"/>
                 <span t-if="sponsor.event_id.start_today">
                     starts in
-                    <span t-if="sponsor.event_id.start_remaining &gt;= 1" t-esc="sponsor.event_id.start_remaining"
+                    <span t-if="sponsor.event_id.start_remaining &gt;= 1" t-out="sponsor.event_id.start_remaining"
                         t-options="{'widget': 'duration', 'digital': False, 'unit': 'minute', 'round': 'minute'}"/>
                     <t t-else="">
                         a few seconds
@@ -51,11 +51,11 @@
                 <span class="my-0" t-else="">
                     starts on
                     <span t-field="sponsor.event_id.with_context(tz=sponsor.event_id.date_tz).date_begin"
-                        t-options="{'format': 'medium'}"/> (<t t-esc="sponsor.event_id.date_tz"/>).
+                        t-options="{'format': 'medium'}"/> (<t t-out="sponsor.event_id.date_tz"/>).
                 </span>
                 <br/>
-                <span t-if="is_event_user">Attendees will be able to join to meet <b t-esc="sponsor.partner_name"/> .</span>
-                <span t-else="">Join us there to meet <b t-esc="sponsor.partner_name"/> !</span>
+                <span t-if="is_event_user">Attendees will be able to join to meet <b t-out="sponsor.partner_name"/> .</span>
+                <span t-else="">Join us there to meet <b t-out="sponsor.partner_name"/> !</span>
             </div>
         </t>
         <!-- SPONSOR JITSI + CLOSED/FULL ALERTS -->
@@ -65,10 +65,10 @@
                     <span>Oops! This room is currently closed</span><br />
                     Come back between
                     <strong>
-                        <t t-esc="sponsor.hour_from" t-options="{'widget': 'float_time'}"/>
+                        <t t-out="sponsor.hour_from" t-options="{'widget': 'float_time'}"/>
                         -
-                        <t t-esc="sponsor.hour_to" t-options="{'widget': 'float_time'}"/>
-                    </strong> (<span t-esc="sponsor.event_date_tz"/>)
+                        <t t-out="sponsor.hour_to" t-options="{'widget': 'float_time'}"/>
+                    </strong> (<span t-out="sponsor.event_date_tz"/>)
                     to meet them !
                 </div>
             </t>
@@ -95,7 +95,7 @@
         </div>
         <!-- SPONSOR DESCRIPTION -->
         <div class="h5 m-3">
-            About <t t-esc="sponsor.name"/>
+            About <t t-out="sponsor.name"/>
         </div>
         <hr class="my-0"/>
         <div class="ml-3 clearfix">
@@ -117,10 +117,10 @@
                     <div t-if="sponsor.hour_from and sponsor.hour_to"
                         t-att-class="'%s' % 'mb-3' if sponsor.hour_from and sponsor.hour_to else ''">
                         Available from
-                        <t t-esc="sponsor.hour_from" t-options="{'widget': 'float_time'}"/>
+                        <t t-out="sponsor.hour_from" t-options="{'widget': 'float_time'}"/>
                         -
-                        <t t-esc="sponsor.hour_to" t-options="{'widget': 'float_time'}"/>
-                        <span t-esc="sponsor.event_date_tz"/>
+                        <t t-out="sponsor.hour_to" t-options="{'widget': 'float_time'}"/>
+                        <span t-out="sponsor.event_date_tz"/>
                     </div>
                     <div t-if="sponsor.url" class="d-flex text-break align-items-baseline">
                         <i class="fa fa-home mr-2"/><a t-att-href="sponsor.url"><span t-field="sponsor.url"/></a>
@@ -175,16 +175,16 @@
                             t-att-alt="sponsor_other.partner_id.country_id.name"/>
                             <span t-if="sponsor_other.sponsor_type_id.display_ribbon_style not in [False, 'no_ribbon']"
                                 t-att-class="'badge badge-light mr-2 ribbon_%s' % sponsor_other.sponsor_type_id.display_ribbon_style"
-                                t-esc="sponsor_other.sponsor_type_id.name"/>
+                                t-out="sponsor_other.sponsor_type_id.name"/>
                             <span t-else="" class="badge badge-light mr-2"
-                                t-esc="sponsor_other.sponsor_type_id.name"/>
+                                t-out="sponsor_other.sponsor_type_id.name"/>
                         </div>
                         <div class="col flex-grow-1 overflow-auto">
                             <span class="d-flex align-items-baseline o_wesponsor_sponsor_name">
-                                <span class="d-inline-block text-truncate" t-esc="sponsor_other.name"/>
+                                <span class="d-inline-block text-truncate" t-out="sponsor_other.name"/>
 
                             </span>
-                            <small class="text-muted" t-esc="sponsor_other.subtitle"/>
+                            <small class="text-muted" t-out="sponsor_other.subtitle"/>
                             <div class="d-inline-block float-right" t-if="not sponsor_other.website_published">
                                 <small class="badge badge-danger">Unpublished</small>
                             </div>

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
@@ -65,9 +65,9 @@
                     <span>Oops! This room is currently closed</span><br />
                     Come back between
                     <strong>
-                        <t t-out="sponsor.hour_from" t-options="{'widget': 'float_time'}"/>
+                        <t t-out="sponsor.hour_from" t-options="{'widget': 'time'}"/>
                         -
-                        <t t-out="sponsor.hour_to" t-options="{'widget': 'float_time'}"/>
+                        <t t-out="sponsor.hour_to" t-options="{'widget': 'time'}"/>
                     </strong> (<span t-out="sponsor.event_date_tz"/>)
                     to meet them !
                 </div>
@@ -117,10 +117,10 @@
                     <div t-if="sponsor.hour_from and sponsor.hour_to"
                         t-att-class="'%s' % 'mb-3' if sponsor.hour_from and sponsor.hour_to else ''">
                         Available from
-                        <t t-out="sponsor.hour_from" t-options="{'widget': 'float_time'}"/>
+                        <t t-out="sponsor.hour_from" t-options="{'widget': 'time'}"/>
                         -
-                        <t t-out="sponsor.hour_to" t-options="{'widget': 'float_time'}"/>
-                        <span t-out="sponsor.event_date_tz"/>
+                        <t t-out="sponsor.hour_to" t-options="{'widget': 'time'}"/>
+                        (<span t-out="sponsor.event_date_tz"/>)
                     </div>
                     <div t-if="sponsor.url" class="d-flex text-break align-items-baseline">
                         <i class="fa fa-home mr-2"/><a t-att-href="sponsor.url"><span t-field="sponsor.url"/></a>

--- a/addons/website_event_exhibitor/views/event_sponsor_views.xml
+++ b/addons/website_event_exhibitor/views/event_sponsor_views.xml
@@ -183,8 +183,8 @@
                                     <h1 class="o_kanban_record_title"><field name="name"/></h1>
                                     <strong>Level: <field name="sponsor_type_id"/></strong>
                                     <span class="text-muted"><field name="exhibitor_type"/></span>
-                                    <span class="o_text_overflow" t-esc="record.partner_email.value"/>
-                                    <span class="o_text_overflow" t-esc="record.url.value"/>
+                                    <span class="o_text_overflow" t-out="record.partner_email.value"/>
+                                    <span class="o_text_overflow" t-out="record.url.value"/>
                                 </div>
                             </div>
                         </div>

--- a/addons/website_event_meet/controllers/website_event_main.py
+++ b/addons/website_event_meet/controllers/website_event_main.py
@@ -15,7 +15,7 @@ class WebsiteEventController(main.WebsiteEventController):
         if "from_room_id" in post and not event.is_ongoing:
             meeting_room = request.env["event.meeting.room"].browse(int(post["from_room_id"])).sudo().exists()
             if meeting_room and meeting_room.is_published:
-                date_begin = format_datetime(event.with_context(tz=event.date_tz).date_begin, format="medium")
+                date_begin = format_datetime(event.date_begin, format="medium", tzinfo=event.date_tz)
 
                 values["toast_message"] = (
                     _('The event %s starts on %s (%s). \nJoin us there to chat about "%s" !')

--- a/addons/website_event_meet/static/src/xml/website_event_meeting_room.xml
+++ b/addons/website_event_meet/static/src/xml/website_event_meeting_room.xml
@@ -26,7 +26,7 @@
                             <div class="row m-2">
                                 <label class="col-4 mt-2 text-left">Language</label>
                                 <select class="o_wevent_create_meeting_room_lang form-control col-8" name="lang_code" required="1">
-                                    <option t-foreach="langs" t-as="language" t-att-value="language[0]" t-esc="language[1]"
+                                    <option t-foreach="langs" t-as="language" t-att-value="language[0]" t-out="language[1]"
                                         t-att-selected="language[0] == defaultLangCode and 'selected' or None"/>
                                 </select>
                             </div>

--- a/addons/website_event_meet/views/event_meet_templates_list.xml
+++ b/addons/website_event_meet/views/event_meet_templates_list.xml
@@ -31,11 +31,11 @@
             <div class="dropdown">
                 <a class="dropdown-toggle o-no-caret btn p-0" title="Languages Menu"
                     aria-label="Dropdown menu" data-display="static" data-toggle="dropdown" href="#" role="button">
-                    <span t-esc="current_lang.name if current_lang else 'All Languages'"/> ▼</a>
+                    <span t-out="current_lang.name if current_lang else 'All Languages'"/> ▼</a>
                 <div class="dropdown-menu" role="menu">
                     <a class="dropdown-item" role="menuitem" t-attf-href="/event/#{slug(event)}/community">All Languages
                        </a>
-                    <a class="dropdown-item" role="menuitem" t-as="language" t-attf-href="/event/#{slug(event)}/community?lang=#{language.id}" t-esc="language.name" t-foreach="available_languages"/>
+                    <a class="dropdown-item" role="menuitem" t-as="language" t-attf-href="/event/#{slug(event)}/community?lang=#{language.id}" t-out="language.name" t-foreach="available_languages"/>
                 </div>
             </div>
         </h2>
@@ -78,9 +78,9 @@
                         to have a chat with us!
                     </t>
                     <t t-else="">
-                        Event <span t-esc="event.name" class="font-weight-bold"/> is over.
+                        Event <span t-out="event.name" class="font-weight-bold"/> is over.
                         <br/>
-                        <span>Join us next time to chat about <b t-esc="meeting_room.name"/>!</span>
+                        <span>Join us next time to chat about <b t-out="meeting_room.name"/>!</span>
                     </t>
                 </div>
 
@@ -89,8 +89,8 @@
                         <div class="w-100" t-attf-style="background-image: #{json.loads(event.cover_properties).get('background-image')}; min-height: 5rem; background-size: cover;"/>
                     </div>
                     <div class="col">
-                        <h5 t-esc="meeting_room.name"/>
-                        <div class="text-muted mb-2"><i class="fa fa-globe"/> <span t-esc="meeting_room.room_lang_id.name"/></div>
+                        <h5 t-out="meeting_room.name"/>
+                        <div class="text-muted mb-2"><i class="fa fa-globe"/> <span t-out="meeting_room.room_lang_id.name"/></div>
                         <span t-if="meeting_room.summary" t-field="meeting_room.summary"/>
                     </div>
                 </div>
@@ -126,7 +126,7 @@
             <div class="o_wevent_meeting_room_corner_ribbon" t-if="meeting_room.room_is_full">Full</div>
             <div class="d-flex flex-column">
                 <div class="d-flex flex-row">
-                    <h4 t-att-class="'text-break text-uppercase %s' % ('w-75' if meeting_room.website_published else 'w-50')" t-esc="meeting_room.name"/>
+                    <h4 t-att-class="'text-break text-uppercase %s' % ('w-75' if meeting_room.website_published else 'w-50')" t-out="meeting_room.name"/>
                     <div t-if="not meeting_room.is_published" class="w-25">
                         <span class="badge badge-danger">Unpublished</span>
                     </div>
@@ -134,11 +134,11 @@
                 <span class="text-muted" t-field="meeting_room.summary"/>
                 <div class="d-flex flex-row justify-content-between align-items-center">
                     <span class="h6 m-0 row">
-                        <span t-esc="meeting_room.room_participant_count"/>&amp;nbsp;
+                        <span t-out="meeting_room.room_participant_count"/>&amp;nbsp;
                         <span t-if="meeting_room.target_audience" class="text-uppercase" t-field="meeting_room.target_audience"/>
                         <span t-else="" class="text-uppercase">participant(s)</span>
                     </span>
-                    <div class="d-inline border py-1 px-2 bg-secondary" t-esc="meeting_room.room_lang_id.name"/>
+                    <div class="d-inline border py-1 px-2 bg-secondary" t-out="meeting_room.room_lang_id.name"/>
                 </div>
             </div>
         </div>

--- a/addons/website_event_meet/views/event_meet_templates_list.xml
+++ b/addons/website_event_meet/views/event_meet_templates_list.xml
@@ -75,6 +75,7 @@
                         <span>This room is not open right now!</span><br />
                         Join us here on the
                         <strong itemprop="startDate" t-field="event.with_context(tz=event.date_tz).date_begin" t-options="{'format': 'medium'}"/>
+                        <strong>(<t t-out="event.date_tz"/>)</strong>
                         to have a chat with us!
                     </t>
                     <t t-else="">
@@ -177,7 +178,11 @@
             <div t-else="" class="d-flex flex-column">
                 <button disabled="disabled" class="btn btn-primary align-self-start">Create a Room</button>
                 Room creation will be available when event starts at 
-                <span class="font-weight-bold" t-field="event.with_context(tz=event.date_tz).date_begin" t-options="{'format': 'medium'}"/>
+                <span>
+                    <span class="font-weight-bold" t-field="event.with_context(tz=event.date_tz).date_begin"
+                        t-options="{'format': 'medium'}"/>
+                    <span class="small">(<t t-out="event.date_tz"/>)</span>
+                </span>
             </div>
         </div>
     </div>

--- a/addons/website_event_meet/views/event_meet_templates_page.xml
+++ b/addons/website_event_meet/views/event_meet_templates_page.xml
@@ -34,15 +34,15 @@
         <!-- EVENT NOT STARTED ALERTS -->
         <t t-if="not meeting_room.event_id.is_ongoing">
             <div t-if="meeting_room.event_id.is_done" class="alert alert-warning text-center">
-                The event <span t-esc="meeting_room.event_id.name" class="font-weight-bold"/> is over.
+                The event <span t-out="meeting_room.event_id.name" class="font-weight-bold"/> is over.
                 <br/>
-                <span>Join us next time to chat about <b t-esc="meeting_room.name"/>!</span>
+                <span>Join us next time to chat about <b t-out="meeting_room.name"/>!</span>
             </div>
             <div t-else="" class="alert alert-warning text-center">
-                The event <span t-esc="meeting_room.event_id.name" class="font-weight-bold"/>
+                The event <span t-out="meeting_room.event_id.name" class="font-weight-bold"/>
                 <span t-if="meeting_room.event_id.start_today">
                     starts in
-                    <span t-if="meeting_room.event_id.start_remaining &gt;= 1" t-esc="meeting_room.event_id.start_remaining"
+                    <span t-if="meeting_room.event_id.start_remaining &gt;= 1" t-out="meeting_room.event_id.start_remaining"
                         t-options="{'widget': 'duration', 'digital': False, 'unit': 'minute', 'round': 'minute'}"/>
                     <t t-else="">
                         a few seconds
@@ -51,10 +51,10 @@
                 <span class="my-0" t-else="meeting_room.event_id.start_today">
                     starts on
                     <span t-field="meeting_room.event_id.with_context(tz=meeting_room.event_id.date_tz).date_begin"
-                        t-options="{'format': 'medium'}"/> (<t t-esc="meeting_room.event_id.date_tz"/>).
+                        t-options="{'format': 'medium'}"/> (<t t-out="meeting_room.event_id.date_tz"/>).
                 </span>
                 <br/>
-                <span>Join us there to chat about <b t-esc="meeting_room.name"/> !</span>
+                <span>Join us there to chat about <b t-out="meeting_room.name"/> !</span>
             </div>
         </t>
         <!-- ROOM CONTENT -->
@@ -86,9 +86,9 @@
         </div>
         <!-- ROOM DESCRIPTION -->
         <div class="mx-3">
-            <div class="h5 my-3" t-esc="meeting_room.name"/>
+            <div class="h5 my-3" t-out="meeting_room.name"/>
             <div t-if="meeting_room.room_participant_count > 0" class="text-muted mb-3">
-                A chat among <t t-esc="meeting_room.room_participant_count"/> <span class="font-weight-bold" t-esc="meeting_room.target_audience"/>
+                A chat among <t t-out="meeting_room.room_participant_count"/> <span class="font-weight-bold" t-out="meeting_room.target_audience"/>
             </div>
         </div>
         <hr class="my-0"/>
@@ -114,14 +114,14 @@
                     <a class="d-block w-100 h-100 px-2 pt-2 pb-1 text-decoration-none"
                         t-att-href="'/event/%s/meeting_room/%s' % (slug(event), slug(meeting_room_other))">
                         <div class="flex-grow-1 mw-100">
-                            <div class="text-truncate" t-esc="meeting_room_other.name"/>
-                            <span class="text-muted" t-esc="meeting_room_other.summary"></span>
+                            <div class="text-truncate" t-out="meeting_room_other.name"/>
+                            <span class="text-muted" t-out="meeting_room_other.summary"></span>
                             <div class="d-flex justify-content-between align-items-center">
                                 <div class="text-muted">
                                     <b>&amp;#9900;&amp;nbsp;</b>
-                                    <small><t t-esc="meeting_room_other.room_participant_count"/> <t t-esc="meeting_room_other.target_audience"/></small>
+                                    <small><t t-out="meeting_room_other.room_participant_count"/> <t t-out="meeting_room_other.target_audience"/></small>
                                 </div>
-                                <small t-if="meeting_room_other.room_lang_id" class="text-muted"><i class="fa fa-globe"/> <t t-esc="meeting_room_other.room_lang_id.name"/></small>
+                                <small t-if="meeting_room_other.room_lang_id" class="text-muted"><i class="fa fa-globe"/> <t t-out="meeting_room_other.room_lang_id.name"/></small>
                             </div>
                         </div>
                     </a>

--- a/addons/website_event_meet_quiz/views/event_meet_templates.xml
+++ b/addons/website_event_meet_quiz/views/event_meet_templates.xml
@@ -19,19 +19,19 @@
     <table class="w-100">
         <tr t-foreach="top3_visitors" t-as="visitor">
             <td><div class="d-flex align-items-center mb-3">
-                <b class="mr-2 text-muted" t-esc="visitor['position']"/>
+                <b class="mr-2 text-muted" t-out="visitor['position']"/>
                 <img class="rounded-circle float-left"
                     style="width: 32px; height: 32px; object-fit: cover;"
                     t-att-src="image_data_uri(visitor['visitor'].partner_image) if visitor['visitor'].partner_image else '/web/static/img/user_placeholder.jpg'"
                     t-att-alt="visitor['visitor'].display_name"/>
                 <div class="o_we_leaderboard_name">
                     <span t-if="visitor['visitor'] == current_visitor and not visitor['visitor'].name" class="font-weight-bold">You</span>
-                    <span t-else="" class="font-weight-bold" t-esc="visitor['visitor'].display_name"/>
+                    <span t-else="" class="font-weight-bold" t-out="visitor['visitor'].display_name"/>
                 </div>
             </div></td>
             <td class="text-right">
                 <div class="mb-3">
-                    <span class="text-nowrap"><t t-esc="visitor['points']"/> xp</span>
+                    <span class="text-nowrap"><t t-out="visitor['points']"/> xp</span>
                 </div>
             </td>
         </tr>

--- a/addons/website_event_questions/views/event_templates.xml
+++ b/addons/website_event_questions/views/event_templates.xml
@@ -31,14 +31,14 @@
 </template>
 
 <template id="registration_event_question" name="Registration Event Question">
-    <label t-esc="question.title"/>
+    <label t-out="question.title"/>
     <span t-if="question.is_mandatory_answer">*</span>
     <t t-if="question.question_type == 'simple_choice'">
         <select t-attf-name="question_answer-#{registration_index}-#{question.id}" class="custom-select"
                 t-att-required="question.is_mandatory_answer">
             <option value=""/>
             <t t-foreach="question.answer_ids" t-as="answer">
-                <option t-esc="answer.name" t-att-value="answer.id"/>
+                <option t-out="answer.name" t-att-value="answer.id"/>
             </t>
         </select>
     </t>

--- a/addons/website_event_sale/views/website_event_templates.xml
+++ b/addons/website_event_sale/views/website_event_templates.xml
@@ -10,8 +10,8 @@
             </t>
             <span t-field="ticket.price_reduce" t-options="{'widget': 'monetary', 'display_currency': website.pricelist_id.currency_id}" groups="account.group_show_line_subtotals_tax_excluded"/>
             <span t-field="ticket.price_reduce_taxinc" t-options="{'widget': 'monetary', 'display_currency': website.pricelist_id.currency_id}" groups="account.group_show_line_subtotals_tax_included"/>
-            <span itemprop="price" class="d-none" t-esc="ticket.price"/>
-            <span itemprop="priceCurrency" class="d-none" t-esc="website.pricelist_id.currency_id.name"/>
+            <span itemprop="price" class="d-none" t-out="ticket.price"/>
+            <span itemprop="priceCurrency" class="d-none" t-out="website.pricelist_id.currency_id.name"/>
         </t>
         <span t-else="" class="font-weight-bold text-uppercase">Free</span>
     </xpath>
@@ -19,10 +19,10 @@
         <t t-if="event.event_ticket_ids[-1].price_reduce > 0">
             <span class="text-dark">
                 From
-                <span t-esc="event.event_ticket_ids[0].price_reduce" t-options="{'widget': 'monetary', 'display_currency': website.pricelist_id.currency_id}"/>
+                <span t-out="event.event_ticket_ids[0].price_reduce" t-options="{'widget': 'monetary', 'display_currency': website.pricelist_id.currency_id}"/>
                 <t t-if="event.event_ticket_ids[-1].price_reduce != event.event_ticket_ids[0].price_reduce">
                     to
-                    <span t-esc="event.event_ticket_ids[-1].price_reduce" t-options="{'widget': 'monetary', 'display_currency': website.pricelist_id.currency_id}"/>
+                    <span t-out="event.event_ticket_ids[-1].price_reduce" t-options="{'widget': 'monetary', 'display_currency': website.pricelist_id.currency_id}"/>
                 </t>
             </span>
         </t>
@@ -36,8 +36,8 @@
                 </t>
                 <span t-field="tickets.price_reduce" t-options="{'widget': 'monetary', 'display_currency': website.pricelist_id.currency_id}" groups="account.group_show_line_subtotals_tax_excluded"/>
                 <span t-field="tickets.price_reduce_taxinc" t-options="{'widget': 'monetary', 'display_currency': website.pricelist_id.currency_id}" groups="account.group_show_line_subtotals_tax_included"/>
-                <span itemprop="price" class="d-none" t-esc="tickets.price"/>
-                <span itemprop="priceCurrency" class="d-none" t-esc="website.pricelist_id.currency_id.name"/>
+                <span itemprop="price" class="d-none" t-out="tickets.price"/>
+                <span itemprop="priceCurrency" class="d-none" t-out="website.pricelist_id.currency_id.name"/>
             </t>
             <span t-else="" class="font-weight-bold text-uppercase">Free</span>
         </div>

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -84,6 +84,9 @@
                     <span class="font-weight-bold" t-out="day"
                         t-options="{'widget': 'date', 'format': 'YYYY'}"/>
                 </div>
+                <div class="flex-column align-self-center ml-2">
+                    <span class="small font-weight-light">(<t t-out="event.date_tz"/>)</span>
+                </div>
             </div>
             <small class="float-right text-muted align-self-end"><t t-out="tracks_by_days[day]"/> tracks</small>
         </div>

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -63,7 +63,7 @@
     <div class="col-12" t-if="not tracks_by_days">
         <div class="h2 mb-3">No track found.</div>
         <div t-if="search_key" class="alert alert-info text-center">
-            <p class="m-0">We did not find any track matching your <strong t-esc="search_key"/> search.</p>
+            <p class="m-0">We did not find any track matching your <strong t-out="search_key"/> search.</p>
         </div>
         <div t-else="" class="alert alert-info text-center" groups="event.group_event_user">
             <a target="_blank" t-att-href="'/web?#action=website_event_track.action_event_track_from_event&amp;active_id=%s' % event.id">
@@ -76,16 +76,16 @@
         <!-- DAY HEADER -->
         <div class="o_we_track_day_header mt-3 w-100 d-flex justify-content-between align-items-center">
             <div class="d-flex">
-                <span class="h1 m-0 font-weight-bold" t-esc="day"
+                <span class="h1 m-0 font-weight-bold" t-out="day"
                     t-options="{'widget': 'date', 'format': 'EEEE dd'}"/>
                 <div class="d-flex flex-column ml-2">
-                    <span class="font-weight-bold" t-esc="day"
+                    <span class="font-weight-bold" t-out="day"
                         t-options="{'widget': 'date', 'format': 'MMMM'}"/>
-                    <span class="font-weight-bold" t-esc="day"
+                    <span class="font-weight-bold" t-out="day"
                         t-options="{'widget': 'date', 'format': 'YYYY'}"/>
                 </div>
             </div>
-            <small class="float-right text-muted align-self-end"><t t-esc="tracks_by_days[day]"/> tracks</small>
+            <small class="float-right text-muted align-self-end"><t t-out="tracks_by_days[day]"/> tracks</small>
         </div>
         <hr class="mt-2 pb-1 mb-1"/>
 
@@ -97,7 +97,7 @@
                 <th class="border-0 bg-white position-sticky"/>
                 <t t-foreach="locations" t-as="location">
                     <th t-if="location" class="active text-center">
-                        <span t-esc="location and location.name or 'Unknown'"/>
+                        <span t-out="location and location.name or 'Unknown'"/>
                     </th>
                 </t>
             </tr>
@@ -110,7 +110,7 @@
 
                 <tr t-att-class="'%s' % ('active' if is_round_hour else '')">
                     <td class="active">
-                        <b t-if="is_round_hour" t-esc="time_slots[day][time_slot]['formatted_time']"/>
+                        <b t-if="is_round_hour" t-out="time_slots[day][time_slot]['formatted_time']"/>
                     </td>
 
                     <t t-foreach="locations" t-as="location">
@@ -177,22 +177,22 @@
             <div class="o_we_agenda_card_title">
                 <t t-if="track.website_published or is_event_user">
                     <a t-att-href="'/event/%s/track/%s' % (slug(event), slug(track))" class="text-black text-bold">
-                        <t t-esc="track.name"/>
+                        <t t-out="track.name"/>
                     </a>
                 </t>
                 <t t-else="">
                     <span class="text-muted text-bold">
-                        <t t-esc="track.name"/>
+                        <t t-out="track.name"/>
                     </span>
                 </t>
             </div>
             <div class="text-muted text-center" t-if="track.partner_tag_line">
-                <small t-esc="track.partner_tag_line"/>
+                <small t-out="track.partner_tag_line"/>
             </div>
             <div class="d-flex justify-content-center flex-wrap">
                 <t t-foreach="track.tag_ids" t-as="tag">
                     <span t-if="tag.color" t-att-title="tag.name"
-                          t-attf-class="mr-1 mt-1 badge #{'o_tag_color_'+str(tag.color)}" t-esc="tag.name"
+                          t-attf-class="mr-1 mt-1 badge #{'o_tag_color_'+str(tag.color)}" t-out="tag.name"
                           t-attf-onclick="
                             var value = '#{tag.name}' ;
                             var target = $('#event_track_search');

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -182,6 +182,9 @@
                             <span class="font-weight-bold" t-out="tracks_date"
                                 t-options="{'widget': 'date', 'format': 'YYYY'}"/>
                         </div>
+                        <div class="flex-column align-self-center ml-2">
+                            <span class="small font-weight-light">(<t t-out="event.date_tz"/>)</span>
+                        </div>
                     </div>
                     <div class="d-flex flex-grow-1" t-elif="tracks_header_name">
                         <span class="h1 m-0 font-weight-bold"
@@ -203,7 +206,7 @@
                         t-att-class="'o_wesession_list_item px-2 py-2 event_color_%d' % (track.color)">
                         <!-- Side information in a floating div (desktop only) -->
                         <div t-if="not event.is_done and (not track.date or today_tz &lt;= tracks_date) and option_track_wishlist"
-                            class="float-right d-none d-md-block ml-2">
+                            class="float-right d-none d-md-block ml-2 py-1">
                             <t t-call="website_event_track.track_widget_reminder">
                                 <t t-set="reminder_small" t-value="False"/>
                                 <t t-set="reminder_light" t-value="False"/>
@@ -214,7 +217,7 @@
                             <div class="col-md-7">
                                 <!-- Reminder widget: directly in line to gain space, mobile only -->
                                 <div t-if="not event.is_done and (not track.date or today_tz &lt;= tracks_date) and option_track_wishlist"
-                                    class="float-right d-block d-md-none ml-2">
+                                    class="float-right d-block d-md-none ml-2 py-1">
                                     <t t-call="website_event_track.track_widget_reminder">
                                         <t t-set="reminder_small" t-value="True"/>
                                         <t t-set="reminder_light" t-value="False"/>
@@ -251,7 +254,7 @@
                                             <span t-elif="not track.is_track_done and not track.is_track_soon"
                                                 class="ml-2"
                                                 t-out="track.date"
-                                                t-options="{'widget': 'datetime', 'time_only': True, 'format': 'short'}"/>
+                                                t-options="{'widget': 'datetime', 'time_only': True, 'format': 'short', 'tz_name': track.event_id.date_tz}"/>
                                             <span t-else="" class="badge badge-info ml-2">Finished</span>
                                         </div>
                                         <!-- Duration (desktop only) -->
@@ -265,7 +268,7 @@
                                 </div>
                             </div>
                             <!-- Aside column: date, tags -->
-                            <div class="col-md-5">
+                            <div class="col-md-5 align-self-center">
                                 <!-- Hour: Live > Remaining > Hour: desktop only -->
                                 <div t-if="tracks_date and today_tz &lt;= tracks_date"
                                     class="d-none d-md-block float-right">
@@ -280,7 +283,7 @@
                                     <span t-elif="not track.is_track_done and not track.is_track_soon"
                                         class="ml-2"
                                         t-out="track.date"
-                                        t-options="{'widget': 'datetime', 'time_only': True, 'format': 'short'}"/>
+                                        t-options="{'widget': 'datetime', 'time_only': True, 'format': 'short', 'tz_name': event.date_tz}"/>
                                     <span t-else="" class="badge badge-info ml-2">Finished</span>
                                 </div>
                                 <!-- Tags: desktop only -->

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -81,7 +81,7 @@
             <li t-if="tag_category.tag_ids and any(tag.color for tag in tag_category.tag_ids)" class="nav-item dropdown mr-2 my-1">
                 <a href="#" role="button" class="btn dropdown-toggle" data-toggle="dropdown">
                     <i class="fa fa-folder-open"/>
-                    <t t-esc="tag_category.name"/>
+                    <t t-out="tag_category.name"/>
                 </a>
                 <div class="dropdown-menu">
                     <t t-foreach="tag_category.tag_ids" t-as="tag">
@@ -91,7 +91,7 @@
                             )"
                             t-if="tag.color"
                             t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{'active' if tag in search_tags else ''}">
-                            <t t-esc="tag.name"/>
+                            <t t-out="tag.name"/>
                         </a>
                     </t>
                 </div>
@@ -121,7 +121,7 @@
         <div class="col-12">
             <div class="h2 mb-3">No track found.</div>
             <div t-if="search_key" class="alert alert-info text-center">
-                <p class="m-0">We did not find any track matching your <strong t-esc="search_key"/> search.</p>
+                <p class="m-0">We did not find any track matching your <strong t-out="search_key"/> search.</p>
             </div>
             <div t-else="" class="alert alert-info text-center" groups="event.group_event_user">
                 <a target="_blank" t-att-href="'/web?#action=website_event_track.action_event_track_from_event&amp;active_id=%s' % event.id">
@@ -174,18 +174,18 @@
                 <!-- DAY HEADER -->
                 <div class="o_we_track_day_header d-flex">
                     <div class="d-flex flex-grow-1" t-if="tracks_date">
-                        <span class="h1 m-0 font-weight-bold" t-esc="tracks_date"
+                        <span class="h1 m-0 font-weight-bold" t-out="tracks_date"
                             t-options="{'widget': 'date', 'format': 'EEEE dd'}"/>
                         <div class="d-flex flex-column ml-2">
-                            <span class="font-weight-bold" t-esc="tracks_date"
+                            <span class="font-weight-bold" t-out="tracks_date"
                                 t-options="{'widget': 'date', 'format': 'MMMM'}"/>
-                            <span class="font-weight-bold" t-esc="tracks_date"
+                            <span class="font-weight-bold" t-out="tracks_date"
                                 t-options="{'widget': 'date', 'format': 'YYYY'}"/>
                         </div>
                     </div>
                     <div class="d-flex flex-grow-1" t-elif="tracks_header_name">
                         <span class="h1 m-0 font-weight-bold"
-                            t-esc="tracks_header_name"/>
+                            t-out="tracks_header_name"/>
                     </div>
                     <a t-attf-class="ml-auto align-self-start text-black {{ 'collapsed' if tracks_info['default_collapsed'] else '' }}"
                         t-attf-href="#collapse_session_list_{{ tracks_info_index }}"
@@ -235,7 +235,7 @@
                                     </span>
                                 </span>
                                 <div class="text-muted d-flex align-items-center">
-                                    <span class="text-muted" t-esc="track.partner_tag_line"/>
+                                    <span class="text-muted" t-out="track.partner_tag_line"/>
                                     <t t-if="tracks_date and today_tz &lt;= tracks_date">
                                         <!-- Hour: Live > Remaining > Hour: mobile only -->
                                         <div class="d-block d-md-none">
@@ -244,13 +244,13 @@
                                                 class="badge badge-danger ml-2">Live</span>
                                             <span t-elif="not track.is_track_done and track.is_track_soon"
                                                 class="ml-2">
-                                                <span t-esc="track.track_start_remaining"
+                                                <span t-out="track.track_start_remaining"
                                                     t-options="{'widget': 'duration', 'digital': False, 'format': 'narrow',
                                                                 'add_direction': True, 'unit': 'second', 'round': 'minute'}"/>
                                             </span>
                                             <span t-elif="not track.is_track_done and not track.is_track_soon"
                                                 class="ml-2"
-                                                t-esc="track.date"
+                                                t-out="track.date"
                                                 t-options="{'widget': 'datetime', 'time_only': True, 'format': 'short'}"/>
                                             <span t-else="" class="badge badge-info ml-2">Finished</span>
                                         </div>
@@ -258,7 +258,7 @@
                                         <t t-if="track.duration and not track.is_track_done and not track.is_track_done">
                                             <span class="d-none d-md-block ml-2">&amp;bull;</span>
                                             <span class="d-none d-md-block ml-2"
-                                                t-esc="track.duration"
+                                                t-out="track.duration"
                                                 t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'hour', 'round': 'minute'}"/>
                                         </t>
                                     </t>
@@ -273,13 +273,13 @@
                                         class="badge badge-danger ml-2">Live</span>
                                     <span t-elif="not track.is_track_done and track.is_track_soon"
                                         class="ml-2">
-                                        <span t-esc="track.track_start_remaining"
+                                        <span t-out="track.track_start_remaining"
                                             t-options="{'widget': 'duration', 'digital': False, 'format': 'narrow',
                                                         'add_direction': True, 'unit': 'second', 'round': 'minute'}"/>
                                     </span>
                                     <span t-elif="not track.is_track_done and not track.is_track_soon"
                                         class="ml-2"
-                                        t-esc="track.date"
+                                        t-out="track.date"
                                         t-options="{'widget': 'datetime', 'time_only': True, 'format': 'short'}"/>
                                     <span t-else="" class="badge badge-info ml-2">Finished</span>
                                 </div>
@@ -398,7 +398,7 @@
         <t t-foreach="search_tags" t-as="tag">
             <span class="align-items-baseline border d-inline-flex pl-2 mt-3 rounded ml16 mb-2 bg-white">
                 <i class="fa fa-tag mr-2 text-muted"/>
-                <t t-esc="tag.display_name"/>
+                <t t-out="tag.display_name"/>
                 <a t-att-href="'/event/%s/track?%s' % (slug(event), keep_query('*', tags=str((search_tags - tag).ids)))"
                     class="btn border-0 py-1">
                     &#215;
@@ -419,23 +419,23 @@
             keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids))
         )"
         t-att-class="'badge %s' % ('badge-primary' if tag in search_tags else 'o_tag_color_hovered_0')"
-        t-esc="tag.name"/>
+        t-out="tag.name"/>
     <a t-else=""
         t-att-href="'/event/%s/track?%s'% (
             slug(event),
             keep_query('*', tags=str(tag.ids))
         )"
         t-att-class="'badge o_tag_color_hovered_%s' % (tag.color)"
-        t-esc="tag.name"/>
+        t-out="tag.name"/>
 </template>
 
 <template id="track_tag_badge_info" name="Track: Tag Badge Info">
     <span t-if="search_tags"
         t-att-class="'badge %s' % ('badge-primary' if tag in search_tags else 'o_tag_color_0')"
-        t-esc="tag.name"/>
+        t-out="tag.name"/>
     <span t-else=""
         t-att-class="'badge o_tag_color_%s' % (tag.color)"
-        t-esc="tag.name"/>
+        t-out="tag.name"/>
 </template>
 
 </odoo>

--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -34,10 +34,10 @@
         <!-- LIVE INFORMATIONS -->
         <div t-if="not track.event_id.is_ongoing" class="pt-3">
             <div class="mx-3 alert alert-warning">
-                Event <span t-esc="track.event_id.name" class="font-weight-bold"/>
+                Event <span t-out="track.event_id.name" class="font-weight-bold"/>
                 <span t-if="track.event_id.start_today">
                     starts in
-                    <span t-if="track.event_id.start_remaining &gt;= 1" t-esc="track.event_id.start_remaining"
+                    <span t-if="track.event_id.start_remaining &gt;= 1" t-out="track.event_id.start_remaining"
                         t-options="{'widget': 'duration', 'digital': False, 'unit': 'minute', 'round': 'minute'}"/>
                     <t t-else="">
                         a few seconds
@@ -59,12 +59,12 @@
         <div class="o_wesession_track_main_description overflow-auto">
             <div class="mx-3 pt-3 mb-3 d-flex justify-content-between flex-column flex-md-row">
                 <div class="d-flex flex-column">
-                    <span class="h4 mb-0" t-esc="track.name"/>
+                    <span class="h4 mb-0" t-out="track.name"/>
                     <div>
                         <t t-foreach="track.tag_ids" t-as="tag">
                             <span t-if="tag.color"
                                 t-att-class="'badge o_tag_color_hovered_%s' % (tag.color)"
-                                t-esc="tag.name"/>
+                                t-out="tag.name"/>
                         </t>
                     </div>
                 </div>
@@ -109,9 +109,9 @@
                     <div class="pl-2 pr-0 pr-md-2 d-flex flex-column">
                         <span t-field="track.partner_name" class="font-weight-bold mb-2"/>
                         <span class="mb-1 d-flex align-items-baseline text-break" t-if="track.partner_function">
-                            <i class="fa fa-briefcase mr-2"/><span t-esc="track.partner_function"/>
+                            <i class="fa fa-briefcase mr-2"/><span t-out="track.partner_function"/>
                             <t t-if="track.partner_company_name">
-                                <span>&amp;nbsp;at&amp;nbsp;</span><span t-esc="track.partner_company_name"/>
+                                <span>&amp;nbsp;at&amp;nbsp;</span><span t-out="track.partner_company_name"/>
                             </t>
                         </span>
                         <span class="mb-1 d-flex align-items-baseline text-break" t-if="track.partner_id.website">
@@ -157,7 +157,7 @@
                     <a t-att-href="track.website_cta_url"
                         target="_blank"
                         class="btn btn-primary w-100 mb-3 mt-2 mt-md-0">
-                        <span t-esc="track.website_cta_title"/>
+                        <span t-out="track.website_cta_title"/>
                     </a>
                 </div>
             </div>
@@ -198,9 +198,9 @@
 </template>
 
 <template id="event_track_aside_other_track">
-    <span t-esc="track_other.name" class="w-100"/>
+    <span t-out="track_other.name" class="w-100"/>
     <div class="d-flex align-items-center">
-        <small class="text-muted" t-esc="track_other.partner_name"/>
+        <small class="text-muted" t-out="track_other.partner_name"/>
         <div class="d-inline-block ml-auto o_wesession_track_aside_info text-truncate">
             <small t-if="not track_other.website_published and user_event_manager"
                 class="badge badge-danger">Unpublished</small>
@@ -210,12 +210,12 @@
                 class="badge badge-light">Done</small>
             <small t-elif="track_other.is_track_today and track_other.track_start_remaining"
                 class="badge badge-light">
-                <span t-esc="track_other.track_start_remaining"
+                <span t-out="track_other.track_start_remaining"
                     t-options="{'widget': 'duration', 'digital': False, 'add_direction': True,
                                 'unit': 'second', 'round': 'minute', 'format': 'narrow'}"/>
             </small>
             <div t-elif="track_other.date" class="badge badge-light">
-                <span t-esc="track_other.date" t-options="{'widget': 'datetime', 'tz_name': track_other.event_id.date_tz, 'format': 'MMM. dd'}"/>
+                <span t-out="track_other.date" t-options="{'widget': 'datetime', 'tz_name': track_other.event_id.date_tz, 'format': 'MMM. dd'}"/>
             </div>
         </div>
     </div>

--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -46,7 +46,8 @@
                 <span t-else="">
                     starts on
                     <span t-field="track.event_id.with_context(tz=track.event_id.date_tz).date_begin"
-                        t-options="{'format': 'long', 'tz_name': track.event_id.date_tz, 'hide_seconds': True}"/>
+                        t-options="{'format': 'medium', 'tz_name': track.event_id.date_tz, 'hide_seconds': 'True'}"/>
+                    (<span t-out="track.event_id.date_tz"/>)
                 </span>
             </div>
         </div>
@@ -85,12 +86,12 @@
                 </t>
                 <t t-if="track.date">
                     <span t-field="track.date"
-                        t-options='{"hide_seconds":"True", "format": "short"}'/>
+                        t-options='{"hide_seconds":"True", "format": "short", "tz_name": event.date_tz}'/>
                     -
                     <span t-field="track.date_end"
-                        t-options='{"hide_seconds":"True", "format": "short"}'/>
+                        t-options='{"hide_seconds":"True", "format": "short", "tz_name": event.date_tz}'/>
                     <t t-if="event.date_tz">
-                        (<span t-field="track.date_end" t-options='{"format": "zzz"}'/>)
+                        (<span t-out="event.date_tz"/>)
                     </t>
                 </t>
                 <t t-if="track.duration">

--- a/addons/website_event_track/views/event_track_templates_proposal.xml
+++ b/addons/website_event_track/views/event_track_templates_proposal.xml
@@ -7,7 +7,7 @@
         <div class="container">
             <section class="pt48">
                 <h1 class="o_page_header">Call for Proposals</h1>
-                <h2 class="text-center text-secondary font-weight-bold my-4" t-esc="event.name"/>
+                <h2 class="text-center text-secondary font-weight-bold my-4" t-out="event.name"/>
             </section>
             <section id="forms" t-if="not event.website_track_proposal">
                 <h1>Proposals are closed!</h1>

--- a/addons/website_event_track/views/mail_templates.xml
+++ b/addons/website_event_track/views/mail_templates.xml
@@ -5,20 +5,20 @@
 <template id="event_track_template_new">
     <p>
         <span>New track proposal</span>
-        <a href="#" t-att-data-oe-model="track._name" t-att-data-oe-id="track.id" t-esc="track.name"/>
+        <a href="#" t-att-data-oe-model="track._name" t-att-data-oe-id="track.id" t-out="track.name"/>
     </p>
     <ul>
         <!-- "contact" information (the ones from partner_id) take precedence over public information -->
         <t t-set="speaker_name" t-value="track.partner_id.name or track.partner_name or track.partner_email" />
         <li t-if="speaker_name">
-            <b>Proposed By</b>: <span t-esc="speaker_name"/>
+            <b>Proposed By</b>: <span t-out="speaker_name"/>
         </li>
         <t t-set="speaker_email" t-value="track.contact_email or track.partner_email" />
         <li t-if="speaker_email">
-            <b>Mail</b>: <a t-attf-href="mailto:#{speaker_email}" t-esc="speaker_email"></a>
+            <b>Mail</b>: <a t-attf-href="mailto:#{speaker_email}" t-out="speaker_email"></a>
         </li>
         <li t-if="track.contact_phone or track.partner_phone">
-            <b>Phone</b>: <span t-esc="track.contact_phone or track.partner_phone"/>
+            <b>Phone</b>: <span t-out="track.contact_phone or track.partner_phone"/>
         </li>
         <li t-if="not is_html_empty(track.partner_biography)">
             <b>Speaker Biography</b>: <div t-field="track.partner_biography"/>

--- a/addons/website_event_track_live/static/src/xml/website_event_track_live_templates.xml
+++ b/addons/website_event_track_live/static/src/xml/website_event_track_live_templates.xml
@@ -7,7 +7,7 @@
     <div class="h-100 w-100 p-4 d-flex flex-column align-items-center owevent_track_suggestion_content">
         <div class="flex-grow-1 pt-5 d-flex flex-column align-items-center justify-content-center">
             <div class="text-white">You just watched:</div>
-            <div class="h1 text-white" t-esc="widget.currentTrack.name"/>
+            <div class="h1 text-white" t-out="widget.currentTrack.name"/>
             <div>
                 <a href="#" class="owevent_track_suggestion_replay font-weight-bold">
                     <span>Replay Video</span>
@@ -23,7 +23,7 @@
     <div class="h-100 w-100 p-4 d-flex flex-column align-items-center owevent_track_suggestion_content">
         <div class="flex-grow-1 pt-5 d-flex flex-column align-items-center justify-content-center">
             <div class="text-white">You just watched:</div>
-            <div class="h1 text-white" t-esc="widget.currentTrack.name"/>
+            <div class="h1 text-white" t-out="widget.currentTrack.name"/>
             <div>
                 <a href="#" class="owevent_track_suggestion_replay font-weight-bold">
                     <span>Replay Video</span>
@@ -36,7 +36,7 @@
                     <i class="fa fa-remove owevent_track_suggestion_close position-absolute"/>
                 </div>
                 <span class="text-white">Up Next:</span>
-                <span class="text-primary font-weight-bold pr-4" t-esc="widget.suggestion.name"/>
+                <span class="text-primary font-weight-bold pr-4" t-out="widget.suggestion.name"/>
                 <div class="text-white owevent_track_suggestion_timer_text_wrapper">
                     <span>Starts in</span>
                     <span class="owevent_track_suggestion_timer_text">30</span>

--- a/addons/website_event_track_quiz/static/src/xml/quiz_templates.xml
+++ b/addons/website_event_track_quiz/static/src/xml/quiz_templates.xml
@@ -7,7 +7,7 @@
                      t-attf-class="o_quiz_js_quiz_question mt-3 mb-4 #{widget.track.completed ? 'completed-disabled' : ''}"
                      t-att-data-question-id="question.id" t-att-data-title="question.question">
                     <div class="h4">
-                        <small class="text-muted"><span t-esc="question_index+1"/>. </small> <span t-esc="question.question"/>
+                        <small class="text-muted"><span t-out="question_index+1"/>. </small> <span t-out="question.question"/>
                     </div>
                     <div class="list-group">
                         <t t-foreach="question.answer_ids" t-as="answer">
@@ -24,7 +24,7 @@
                                     <i class="fa fa-times-circle text-danger d-none"></i>
                                     <i t-att-class="'fa fa-check-circle text-success' + (widget.track.completed &amp;&amp; answer.is_correct ? '' :  ' d-none')"></i>
                                 </label>
-                                <span t-esc="answer.text_value"/>
+                                <span t-out="answer.text_value"/>
                             </a>
                         </t>
                     </div>
@@ -35,7 +35,7 @@
 
     <t t-name="quiz.badge">
         <span class="badge badge-warning ml-2">
-            <span>+ <t t-esc="answer.awarded_points"/></span>
+            <span>+ <t t-out="answer.awarded_points"/></span>
             <span t-if="answer.awarded_points == 1">Point</span>
             <span t-else="">Points</span>
         </span>
@@ -48,17 +48,17 @@
                 Correct.
                 <t t-if="answer.comment">
                     <br/>
-                    <t t-esc="answer.comment"/>
+                    <t t-out="answer.comment"/>
                 </t>
             </div>
         </t>
         <t t-else="">
             <div class="o_quiz_quiz_answer_info list-group-item list-group-item-danger">
                 <i class="fa fa-info-circle"/>
-                Incorrect. <t t-if="answer.correct_answer">The correct answer was: <t t-esc="answer.correct_answer"/></t>
+                Incorrect. <t t-if="answer.correct_answer">The correct answer was: <t t-out="answer.correct_answer"/></t>
                 <t t-if="answer.comment">
                     <br/>
-                    <t t-esc="answer.comment"/>
+                    <t t-out="answer.comment"/>
                 </t>
             </div>
         </t>
@@ -73,7 +73,7 @@
                 </button>
                 <t t-else="">
                     <div t-if="widget.quiz.quizPointsGained > 0" class="alert alert-warning mr-md-3">
-                        Congratulations, you scored a total of <span t-esc="widget.quiz.quizPointsGained" class="font-weight-bold"/>
+                        Congratulations, you scored a total of <span t-out="widget.quiz.quizPointsGained" class="font-weight-bold"/>
                         <span t-if="widget.quiz.quizPointsGained == 1">point!</span>
                         <span t-else="">points!</span>
                     </div>

--- a/addons/website_event_track_quiz/views/event_leaderboard_templates.xml
+++ b/addons/website_event_track_quiz/views/event_leaderboard_templates.xml
@@ -24,7 +24,7 @@
         </div>
         <div t-if="not visitors and search" class="container mt32">
             <t t-call="website_event_track_quiz.leaderboard_search_bar"/>
-            <div class='alert alert-warning mt32'>No user found for <strong><t t-esc="search"/></strong>. Try another search.</div>
+            <div class='alert alert-warning mt32'>No user found for <strong><t t-out="search"/></strong>. Try another search.</div>
         </div>
         <div t-if="not visitors and not search" class="vh-100 bg-light d-flex justify-content-center align-items-center">
             <h4 class="text-muted font-weight-bold">There is currently no leaderboard available</h4>
@@ -62,17 +62,17 @@
                 <img class="position-absolute" t-attf-src="/website_profile/static/src/img/rank_#{visitor['position']}.svg" alt="User rank" style="bottom: 0; right: -10px"/>
             </div>
             <h3 t-if="visitor['visitor'] == current_visitor and not visitor['visitor'].name" class="mt-2 mb-0">You</h3>
-            <h3 t-else="" class="mt-2 mb-0" t-esc="visitor['visitor'].display_name"/>
+            <h3 t-else="" class="mt-2 mb-0" t-out="visitor['visitor'].display_name"/>
         </div>
         <div class="row mx-0 o_wprofile_top3_card_footer text-nowrap">
-            <div class="col py-3"><b t-esc="visitor['points']"/> <span class="text-muted">Points</span></div>
+            <div class="col py-3"><b t-out="visitor['points']"/> <span class="text-muted">Points</span></div>
         </div>
     </div>
 </template>
 
 <template id="all_visitor_card" name="All VIsitor Card">
     <td class="align-middle text-right text-muted" style="width: 0">
-        <span t-esc="visitor['position']"/>
+        <span t-out="visitor['position']"/>
     </td>
     <td class="align-middle d-none d-sm-table-cell">
         <img class="o_object_fit_cover rounded-circle o_wprofile_img_small"
@@ -82,10 +82,10 @@
     </td>
     <td class="align-middle w-md-75">
         <span t-if="visitor['visitor'] == current_visitor and not visitor['visitor'].name" class="font-weight-bold">You</span>
-        <span t-else="" class="font-weight-bold" t-esc="visitor['visitor'].display_name"/><br/>
+        <span t-else="" class="font-weight-bold" t-out="visitor['visitor'].display_name"/><br/>
     </td>
     <td class="align-middle font-weight-bold text-right text-nowrap">
-        <b t-esc="visitor['points']"/> <span class="text-muted small font-weight-bold">Points</span>
+        <b t-out="visitor['points']"/> <span class="text-muted small font-weight-bold">Points</span>
     </td>
 </template>
 

--- a/addons/website_event_track_quiz/views/event_quiz_templates.xml
+++ b/addons/website_event_track_quiz/views/event_quiz_templates.xml
@@ -23,7 +23,7 @@
             t-att-data-question-id="question['id']" t-att-data-title="question['name']" >
             <div class="row d-flex mb-2 mx-0">
                 <div class="h4">
-                    <span t-esc="question['name']"/>
+                    <span t-out="question['name']"/>
                 </div>
             </div>
             <div class="list-group">
@@ -41,7 +41,7 @@
                             <i class="fa fa-times-circle text-danger d-none"></i>
                             <i t-att-class="'fa fa-check-circle text-success %s' % ('d-none' if not (quiz_completed and answer['is_correct']) else '')"></i>
                         </label>
-                        <span t-esc="answer['text_value']"/>
+                        <span t-out="answer['text_value']"/>
                     </a>
                 </t>
             </div>

--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -33,6 +33,7 @@ from . import test_module
 from . import test_orm
 from . import test_ormcache
 from . import test_osv
+from . import test_qweb_field
 from . import test_qweb
 from . import test_res_config
 from . import test_res_lang

--- a/odoo/addons/base/tests/test_qweb_field.py
+++ b/odoo/addons/base/tests/test_qweb_field.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+from odoo.tests import common
+
+
+class TestQwebFieldTime(common.TransactionCase):
+    def value_to_html(self, value, options=None):
+        options = options or {}
+        return self.env['ir.qweb.field.time'].value_to_html(value, options)
+
+    def test_time_value_to_html(self):
+
+        self.assertEqual(
+            self.value_to_html(0),
+            "12:00 AM"
+        )
+
+        self.assertEqual(
+            self.value_to_html(11.75),
+            "11:45 AM"
+        )
+
+        self.assertEqual(
+            self.value_to_html(12),
+            "12:00 PM"
+        )
+
+        self.assertEqual(
+            self.value_to_html(14.25),
+            "2:15 PM"
+        )
+
+        self.assertEqual(
+            self.value_to_html(15.1, {'format': 'HH:mm:SS'}),
+            "15:06:00"
+        )
+
+        # Only positive values can be used
+        with self.assertRaises(ValueError):
+            self.value_to_html(-6.5)
+
+        # Only values inferior to 24 can be used
+        with self.assertRaises(ValueError):
+            self.value_to_html(24)


### PR DESCRIPTION
PURPOSE

Cleanup all the places where an hour or a datetime is been used to
display with the date the corresponding timezone.

SPECIFICATIONS

Display the timezone of the event  next to each datetime. For the event
main page and the track/agenda pages, we display the timezone next to
each date unless the timezone of the visitor is the same as the event.

We also introduce a new "time" qweb field converter. It is used to display
a float value into a real "time" (not duration).

Task-2458013
