### PR TITLE
[FIX] base: use tz in time only datetime field qweb

### DIFF
--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -266,7 +266,7 @@ class DateTimeConverter(models.AbstractModel):
 
         if options.get('time_only'):
             format_func = babel.dates.format_time
-            return pycompat.to_text(format_func(value, format=pattern, locale=locale))
+            return pycompat.to_text(format_func(value, format=pattern, tzinfo=tzinfo, locale=locale))
         if options.get('date_only'):
             format_func = babel.dates.format_date
             return pycompat.to_text(format_func(value, format=pattern, locale=locale))


### PR DESCRIPTION
We should also use the tzinfo to display only the time of a datetime.

task-2458013