### PR TITLE
[FIX] base: properly invalidate cache for external asset lazy loading

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -267,7 +267,7 @@ class IrQWeb(models.AbstractModel, QWeb):
         asset_nodes = self._get_asset_nodes(bundle, js=False)
         return [node[1]['href'] for node in asset_nodes if node[0] == 'link']
 
-    @tools.ormcache_context('bundle', 'nodeAttrs and nodeAttrs.get("media")', keys=("website_id", "lang"))
+    @tools.ormcache_context('bundle', 'nodeAttrs and nodeAttrs.get("media")', 'defer_load', 'lazy_load', keys=("website_id", "lang"))
     def _get_asset_content(self, bundle, nodeAttrs=None, defer_load=False, lazy_load=False):
         asset_paths = self.env['ir.asset']._get_asset_paths(bundle=bundle, css=True, js=True)
 


### PR DESCRIPTION
With [1], we allowed external assets to be lazy/defer loaded too
(especially automatically if part of lazy/defer loaded asset). Those
new parameters were not added to the cache invalidation system.

[1]: https://github.com/odoo/odoo/commit/8dd71bdc42c8d4ab3373a2a0601c93d1687aabca
