### PR TITLE
[FIX] mrp_subcontracting: Allow to create backorder for tracked products

### DIFF
--- a/addons/mrp_subcontracting/i18n/mrp_subcontracting.pot
+++ b/addons/mrp_subcontracting/i18n/mrp_subcontracting.pot
@@ -319,5 +319,11 @@ msgstr ""
 #. module: mrp_subcontracting
 #: code:addons/mrp_subcontracting/models/mrp_production.py:0
 #, python-format
+msgid "You must enter a serial number for %s"
+msgstr ""
+
+#. module: mrp_subcontracting
+#: code:addons/mrp_subcontracting/models/mrp_production.py:0
+#, python-format
 msgid "You must enter a serial number for each line of %s"
 msgstr ""

--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -39,6 +39,8 @@ class MrpProduction(models.Model):
         assert self.env.context.get('subcontract_move_id')
         if float_is_zero(self.qty_producing, precision_rounding=self.product_uom_id.rounding):
             return {'type': 'ir.actions.act_window_close'}
+        if self.product_tracking != 'none' and not self.lot_producing_id:
+            raise UserError(_('You must enter a serial number for %s') % self.product_id.name)
         for sml in self.move_raw_ids.move_line_ids:
             if sml.tracking != 'none' and not sml.lot_id:
                 raise UserError(_('You must enter a serial number for each line of %s') % sml.product_id.name)
@@ -58,6 +60,11 @@ class MrpProduction(models.Model):
             action = subcontract_move_id._action_record_components()
             action.update({'res_id': backorder.id})
             return action
+        return {'type': 'ir.actions.act_window_close'}
+
+    def action_subcontracting_discard_remaining_components(self):
+        self.ensure_one()
+        self.qty_producing = 0
         return {'type': 'ir.actions.act_window_close'}
 
     def _pre_button_mark_done(self):
@@ -135,7 +142,7 @@ class MrpProduction(models.Model):
                 return False
             if not all(line.lot_id for line in mo.move_raw_ids.filtered(lambda sm: sm.has_tracking != 'none').move_line_ids):
                 return False
-            if mo.product_id.tracking != 'none' and not mo.lot_producing_id:
+            if mo.product_tracking != 'none' and not mo.lot_producing_id:
                 return False
             return True
 

--- a/addons/mrp_subcontracting/views/mrp_production_views.xml
+++ b/addons/mrp_subcontracting/views/mrp_production_views.xml
@@ -18,7 +18,7 @@
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//field[@name='lot_producing_id']" position="attributes">
-                <attribute name="attrs">{'invisible': [('product_tracking', 'in', ('none', False))], 'required': [('product_tracking', 'not in', ('none', False))]}</attribute>
+                <attribute name="attrs">{'invisible': [('product_tracking', 'in', ('none', False))]}</attribute>
             </xpath>
             <xpath expr="//page[@name='miscellaneous']" position="attributes">
                 <attribute name="invisible">1</attribute>
@@ -48,7 +48,7 @@
                 <footer>
                     <button name="subcontracting_record_component" attrs="{'invisible': ['|', ('state', '=', 'to_close'), ('qty_producing', '&lt;', 0.001)]}" string="Continue" type="object" class="oe_highlight"/>
                     <button name="subcontracting_record_component" attrs="{'invisible': [('state', '!=', 'to_close')]}" string="Record Production" type="object" class="oe_highlight"/>
-                    <button string="Discard" special="cancel" />
+                    <button name="action_subcontracting_discard_remaining_components" string="Discard" type="object"/>
                 </footer>
             </xpath>
         </field>


### PR DESCRIPTION
This commit fixes the 'You need to supply a Lot/Serial Number...' message
when validating a receipt with backorder for subcontracted tracked products.

task: 2604664

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
