### PR TITLE
Master decrease qty quwo

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -394,6 +394,10 @@ class StockMove(models.Model):
     def _prepare_merge_moves_distinct_fields(self):
         return super()._prepare_merge_moves_distinct_fields() + ['created_production_id', 'cost_share']
 
+    @api.model
+    def _prepare_merge_negative_moves_excluded_distinct_fields(self):
+        return super()._prepare_merge_negative_moves_excluded_distinct_fields() + ['created_production_id']
+
     def _merge_moves_fields(self):
         res = super()._merge_moves_fields()
         res['cost_share'] = sum(self.mapped('cost_share'))

--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -7,7 +7,7 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.osv import expression
 from odoo.addons.stock.models.stock_rule import ProcurementException
-from odoo.tools import OrderedSet
+from odoo.tools import float_compare, OrderedSet
 
 
 class StockRule(models.Model):
@@ -42,6 +42,9 @@ class StockRule(models.Model):
         productions_values_by_company = defaultdict(list)
         errors = []
         for procurement, rule in procurements:
+            if float_compare(procurement.product_qty, 0, precision_rounding=procurement.product_uom.rounding) <= 0:
+                # If procurement contains negative quantity, don't create a MO that would be for a negative value.
+                continue
             bom = rule._get_matching_bom(procurement.product_id, procurement.company_id, procurement.values)
 
             productions_values_by_company[procurement.company_id.id].append(rule._prepare_mo_vals(*procurement, bom))

--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -4,7 +4,7 @@ from markupsafe import Markup
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, SUPERUSER_ID, _
-from odoo.tools.float_utils import float_compare, float_round
+from odoo.tools.float_utils import float_compare, float_is_zero, float_round
 from odoo.exceptions import UserError
 
 from odoo.addons.purchase.models.purchase import PurchaseOrder as Purchase
@@ -462,7 +462,7 @@ class PurchaseOrderLine(models.Model):
         if float_compare(qty_to_attach, 0.0, precision_rounding=self.product_uom.rounding) > 0:
             product_uom_qty, product_uom = self.product_uom._adjust_uom_quantities(qty_to_attach, self.product_id.uom_id)
             res.append(self._prepare_stock_move_vals(picking, price_unit, product_uom_qty, product_uom))
-        if float_compare(qty_to_push, 0.0, precision_rounding=self.product_uom.rounding) > 0:
+        if not float_is_zero(qty_to_push, precision_rounding=self.product_uom.rounding):
             product_uom_qty, product_uom = self.product_uom._adjust_uom_quantities(qty_to_push, self.product_id.uom_id)
             extra_move_vals = self._prepare_stock_move_vals(picking, price_unit, product_uom_qty, product_uom)
             extra_move_vals['move_dest_ids'] = False  # don't attach

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -26,6 +26,10 @@ class StockMove(models.Model):
         distinct_fields += ['purchase_line_id', 'created_purchase_line_id']
         return distinct_fields
 
+    @api.model
+    def _prepare_merge_negative_moves_excluded_distinct_fields(self):
+        return super()._prepare_merge_negative_moves_excluded_distinct_fields() + ['created_purchase_line_id']
+
     def _get_price_unit(self):
         """ Returns the unit price for the move"""
         self.ensure_one()
@@ -88,7 +92,7 @@ class StockMove(models.Model):
         self.write({'created_purchase_line_id': False})
 
     def _get_upstream_documents_and_responsibles(self, visited):
-        if self.created_purchase_line_id and self.created_purchase_line_id.state not in ('done', 'cancel'):
+        if self.created_purchase_line_id and self.created_purchase_line_id.state not in ('draft', 'done', 'cancel'):
             return [(self.created_purchase_line_id.order_id, self.created_purchase_line_id.order_id.user_id, visited)]
         elif self.purchase_line_id and self.purchase_line_id.state not in ('done', 'cancel'):
             return[(self.purchase_line_id.order_id, self.purchase_line_id.order_id.user_id, visited)]

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -4,6 +4,7 @@
 from collections import defaultdict
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from odoo.tools import float_compare
 
 from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.addons.stock.models.stock_rule import ProcurementException
@@ -93,15 +94,17 @@ class StockRule(models.Model):
             po = self.env['purchase.order'].sudo().search([dom for dom in domain], limit=1)
             company_id = procurements[0].company_id
             if not po:
-                # We need a rule to generate the PO. However the rule generated
-                # the same domain for PO and the _prepare_purchase_order method
-                # should only uses the common rules's fields.
-                vals = rules[0]._prepare_purchase_order(company_id, origins, [p.values for p in procurements])
-                # The company_id is the same for all procurements since
-                # _make_po_get_domain add the company in the domain.
-                # We use SUPERUSER_ID since we don't want the current user to be follower of the PO.
-                # Indeed, the current user may be a user without access to Purchase, or even be a portal user.
-                po = self.env['purchase.order'].with_company(company_id).with_user(SUPERUSER_ID).create(vals)
+                positive_values = [p.values for p in procurements if float_compare(p.product_qty, 0.0, precision_rounding=p.product_uom.rounding) >= 0]
+                if positive_values:
+                    # We need a rule to generate the PO. However the rule generated
+                    # the same domain for PO and the _prepare_purchase_order method
+                    # should only uses the common rules's fields.
+                    vals = rules[0]._prepare_purchase_order(company_id, origins, positive_values)
+                    # The company_id is the same for all procurements since
+                    # _make_po_get_domain add the company in the domain.
+                    # We use SUPERUSER_ID since we don't want the current user to be follower of the PO.
+                    # Indeed, the current user may be a user without access to Purchase, or even be a portal user.
+                    po = self.env['purchase.order'].with_company(company_id).with_user(SUPERUSER_ID).create(vals)
             else:
                 # If a purchase order is found, adapt its `origin` field.
                 if po.origin:
@@ -131,6 +134,9 @@ class StockRule(models.Model):
                         procurement.values, po_line)
                     po_line.write(vals)
                 else:
+                    if float_compare(procurement.product_qty, 0, precision_rounding=procurement.product_uom.rounding) <= 0:
+                        # If procurement contains negative quantity, don't create a new line that would contain negative qty
+                        continue
                     # If it does not exist a PO line for current procurement.
                     # Generate the create values for it and add it to a list in
                     # order to create it in batch.

--- a/addons/purchase_stock/tests/test_create_picking.py
+++ b/addons/purchase_stock/tests/test_create_picking.py
@@ -515,3 +515,87 @@ class TestCreatePicking(common.TestProductCommon):
         po.order_line.product_qty += 2
         backorder = po.picking_ids.filtered(lambda picking: picking.state == 'assigned')
         self.assertEqual(backorder.move_lines.product_uom_qty, 9)
+
+    def test_08_check_update_qty_mto_chain(self):
+        """ Simulate a mto chain with a purchase order. Updating the
+        initial demand should also impact the initial move and the
+        purchase order if it wasn't yet confirmed.
+        """
+        def create_run_procurement(product, product_qty, values=None):
+            if not values:
+                values = {
+                    'warehouse_id': picking_type_out.warehouse_id,
+                    'action': 'pull_push',
+                    'group_id': procurement_group,
+                }
+            return self.env['procurement.group'].run([self.env['procurement.group'].Procurement(
+                product, product_qty, self.uom_unit, vendor.property_stock_customer,
+                product.name, '/', self.env.company, values)
+            ])
+
+        # Prepare procurement that replicates a sale order.
+        picking_type_out = self.env.ref('stock.picking_type_out')
+        partner = self.env['res.partner'].create({
+            'name': 'Jhon'
+        })
+        seller = self.env['product.supplierinfo'].create({
+            'name': partner.id,
+            'price': 12.0,
+        })
+        vendor = self.env['res.partner'].create({
+            'name': 'Roger'
+        })
+        # This needs to be tried with MTO route activated
+        self.env['stock.location.route'].browse(self.ref('stock.route_warehouse0_mto')).action_unarchive()
+        product = self.env['product.product'].create({
+            'name': 'product',
+            'type': 'product',
+            'route_ids': [(4, self.ref('stock.route_warehouse0_mto')), (4, self.ref('purchase_stock.route_warehouse0_buy'))],
+            'seller_ids': [(6, 0, [seller.id])],
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'supplier_taxes_id': [(6, 0, [])],
+        })
+
+        procurement_group = self.env['procurement.group'].create({
+            'move_type': 'direct',
+            'partner_id': vendor.id
+        })
+        # Create initial procurement that will generate the initial move and its picking.
+        create_run_procurement(product, 50, {
+            'group_id': procurement_group,
+            'warehouse_id': picking_type_out.warehouse_id,
+            'partner_id': vendor
+        })
+        customer_move = self.env['stock.move'].search([('group_id', '=', procurement_group.id)])
+        purchase_order = self.env['purchase.order'].search([('partner_id', '=', partner.id)])
+        self.assertTrue(purchase_order, 'No purchase order created.')
+
+        # Check purchase order line data.
+        purchase_order_line = purchase_order.order_line
+        self.assertEqual(purchase_order_line.product_id, product, 'The product on the purchase order line is not correct.')
+        self.assertEqual(purchase_order_line.product_qty, 50, 'The purchase order line qty should be the same as the move.')
+
+        # Create procurement to decrease quantity in the initial move and the related RFQ.
+        create_run_procurement(product, -10.00)
+        self.assertEqual(customer_move.product_uom_qty, 40, 'The demand on the initial move should have been decreased when merged with the procurement.')
+        self.assertEqual(purchase_order_line.product_qty, 40, 'The demand on the Purchase Order should have been decreased since it is still a RFQ.')
+
+        # Create procurement to increase quantity on the initial move and the related RFQ.
+        create_run_procurement(product, 5.00)
+        self.assertEqual(customer_move.product_uom_qty, 45, 'The demand on the initial move should have been increased when merged with the procurement.')
+        self.assertEqual(purchase_order_line.product_qty, 45, 'The demand on the Purchase Order should have been increased since it is still a RFQ.')
+
+        purchase_order.button_confirm()
+        # Create procurement to decrease quantity in the initial move but not the confirmed PO.
+        create_run_procurement(product, -10.00)
+        self.assertEqual(customer_move.product_uom_qty, 35, 'The demand on the initial move should have been decreased when merged with the procurement.')
+        self.assertEqual(purchase_order_line.product_qty, 45, 'The demand on the Purchase Order should not have been decreased since it is has been confirmed.')
+        purchase_orders = self.env['purchase.order'].search([('partner_id', '=', partner.id)])
+        self.assertEqual(len(purchase_orders), 1, 'No RFQ should have been created for a negative demand')
+
+        # Create procurement to increase quantity on the initial move that will create a new move and a new RFQ for missing demand.
+        create_run_procurement(product, 5.00)
+        self.assertEqual(customer_move.product_uom_qty, 35, 'The demand on the initial move should not have been increased since it should be a new move.')
+        self.assertEqual(purchase_order_line.product_qty, 45, 'The demand on the Purchase Order should not have been increased since it is has been confirmed.')
+        purchase_orders = self.env['purchase.order'].search([('partner_id', '=', partner.id)])
+        self.assertEqual(len(purchase_orders), 2, 'A new RFQ should have been created for missing demand.')

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1229,7 +1229,7 @@ class StockMove(models.Model):
 
         # call `_action_assign` on every confirmed move which location_id bypasses the reservation + those expected to be auto-assigned
         moves.filtered(lambda move: not move.picking_id.immediate_transfer
-                       and move.state == 'confirmed'
+                       and move.state in ('confirmed', 'partially_available')
                        and (move._should_bypass_reservation()
                             or move.picking_type_id.reservation_method == 'at_confirm'
                             or (move.reservation_date and move.reservation_date <= fields.Date.today())))\

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -807,6 +807,10 @@ class StockMove(models.Model):
             'product_packaging_id',
         ]
 
+    @api.model
+    def _prepare_merge_negative_moves_excluded_distinct_fields(self):
+        return []
+
     def _clean_merged(self):
         """Cleanup hook used when merging moves"""
         self.write({'propagate_cancel': False})
@@ -831,31 +835,51 @@ class StockMove(models.Model):
 
         # Move removed after merge
         moves_to_unlink = self.env['stock.move']
-        moves_to_merge = []
+        # Moves successfully merged
+        merged_moves = self.env['stock.move']
+
+        moves_by_neg_key = defaultdict(lambda: self.env['stock.move'])
+        # Need to check less fields for negative moves as some might not be set.
+        neg_qty_moves = self.filtered(lambda m: float_compare(m.product_qty, 0.0, precision_rounding=m.product_uom.rounding) < 0)
+        excluded_fields = self._prepare_merge_negative_moves_excluded_distinct_fields()
+        neg_key = itemgetter(*[field for field in distinct_fields if field not in excluded_fields])
+
         for candidate_moves in candidate_moves_list:
             # First step find move to merge.
-            candidate_moves = candidate_moves.with_context(prefetch_fields=False)
+            candidate_moves = candidate_moves.filtered(lambda m: m.state not in ('done', 'cancel', 'draft')) - neg_qty_moves
             for __, g in groupby(candidate_moves, key=itemgetter(*distinct_fields)):
-                moves = self.env['stock.move'].concat(*g).filtered(lambda m: m.state not in ('done', 'cancel', 'draft'))
-                # If we have multiple records we will merge then in a single one.
+                moves = self.env['stock.move'].concat(*g)
+                # Merge all positive moves together
                 if len(moves) > 1:
-                    moves_to_merge.append(moves)
+                    # link all move lines to record 0 (the one we will keep).
+                    moves.mapped('move_line_ids').write({'move_id': moves[0].id})
+                    # merge move data
+                    moves[0].write(moves._merge_moves_fields())
+                    # update merged moves dicts
+                    moves_to_unlink |= moves[1:]
+                    merged_moves |= moves[0]
+                # Add the now single positive move to its limited key record
+                moves_by_neg_key[neg_key(moves[0])] |= moves[0]
 
-        # second step merge its move lines, initial demand, ...
-        for moves in moves_to_merge:
-            # link all move lines to record 0 (the one we will keep).
-            moves.mapped('move_line_ids').write({'move_id': moves[0].id})
-            # merge move data
-            moves[0].write(moves._merge_moves_fields())
-            # update merged moves dicts
-            moves_to_unlink |= moves[1:]
+        for neg_move in neg_qty_moves:
+            # Check all the candidates that matches the same limited key, and adjust their quantites to absorb negative moves
+            for pos_move in moves_by_neg_key.get(neg_key(neg_move), []):
+                # If quantity can be fully absorbed by a single move, update its quantity and remove the negative move
+                if float_compare(pos_move.product_uom_qty, abs(neg_move.product_uom_qty), precision_rounding=pos_move.product_uom.rounding) >= 0:
+                    pos_move.product_uom_qty += neg_move.product_uom_qty
+                    merged_moves |= pos_move
+                    moves_to_unlink |= neg_move
+                    break
+                neg_move.product_uom_qty += pos_move.product_uom_qty
+                pos_move.product_uom_qty = 0
 
         if moves_to_unlink:
             # We are using propagate to False in order to not cancel destination moves merged in moves[0]
             moves_to_unlink._clean_merged()
             moves_to_unlink._action_cancel()
             moves_to_unlink.sudo().unlink()
-        return (self | self.env['stock.move'].concat(*moves_to_merge)) - moves_to_unlink
+
+        return (self | merged_moves) - moves_to_unlink
 
     def _get_relevant_state_among_moves(self):
         # We sort our moves by importance of state:
@@ -1035,6 +1059,11 @@ class StockMove(models.Model):
                         'origin': False,
                     })
             else:
+                # Don't create picking for negative moves since they will be
+                # reverse and assign to another picking
+                moves = moves.filtered(lambda m: float_compare(m.product_uom_qty, 0.0, precision_rounding=m.product_uom.rounding) >= 0)
+                if not moves:
+                    continue
                 new_picking = True
                 picking = Picking.create(moves._get_new_picking_values())
 
@@ -1185,6 +1214,18 @@ class StockMove(models.Model):
         moves = self
         if merge:
             moves = self._merge_moves(merge_into=merge_into)
+
+        # Transform remaining move in return in case of negative initial demand
+        neg_r_moves = moves.filtered(lambda move: float_compare(
+            move.product_uom_qty, 0, precision_rounding=move.product_uom.rounding) < 0)
+        for move in neg_r_moves:
+            move.location_id, move.location_dest_id = move.location_dest_id, move.location_id
+            move.product_uom_qty *= -1
+            if move.picking_type_id.return_picking_type_id:
+                move.picking_type_id = move.picking_type_id.return_picking_type_id
+        # detach their picking as we inverted the location and potentially picking type
+        neg_r_moves.picking_id = False
+        neg_r_moves._assign_picking()
 
         # call `_action_assign` on every confirmed move which location_id bypasses the reservation + those expected to be auto-assigned
         moves.filtered(lambda move: not move.picking_id.immediate_transfer
@@ -1733,7 +1774,7 @@ class StockMove(models.Model):
                         result.add((document, responsible, visited))
             return result
         else:
-            return [(self.picking_id, self.product_id.responsible_id, visited)]
+            return []
 
     def _set_quantity_done_prepare_vals(self, qty):
         res = []

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -238,16 +238,20 @@ class StockRule(models.Model):
             forecasted_qties_by_loc[location] = {product.id: product.free_qty for product in products}
 
         # Prepare the move values, adapt the `procure_method` if needed.
+        procurements = sorted(procurements, key=lambda proc: float_compare(proc[0].product_qty, 0.0, precision_rounding=proc[0].product_uom.rounding) > 0)
         for procurement, rule in procurements:
             procure_method = rule.procure_method
             if rule.procure_method == 'mts_else_mto':
                 qty_needed = procurement.product_uom._compute_quantity(procurement.product_qty, procurement.product_id.uom_id)
-                qty_available = forecasted_qties_by_loc[rule.location_src_id][procurement.product_id.id]
-                if float_compare(qty_needed, qty_available, precision_rounding=procurement.product_id.uom_id.rounding) <= 0:
-                    procure_method = 'make_to_stock'
+                if float_compare(qty_needed, 0, precision_rounding=procurement.product_id.uom_id.rounding) <= 0:
                     forecasted_qties_by_loc[rule.location_src_id][procurement.product_id.id] -= qty_needed
-                else:
                     procure_method = 'make_to_order'
+                elif float_compare(qty_needed, forecasted_qties_by_loc[rule.location_src_id][procurement.product_id.id],
+                                   precision_rounding=procurement.product_id.uom_id.rounding) > 0:
+                    procure_method = 'make_to_order'
+                else:
+                    forecasted_qties_by_loc[rule.location_src_id][procurement.product_id.id] -= qty_needed
+                    procure_method = 'make_to_stock'
 
             move_values = rule._get_stock_move_values(*procurement)
             move_values['procure_method'] = procure_method


### PR DESCRIPTION
Allows quantity decrease on Sale Orders to be propagated to their related pickings.
If the MTO route is used, the decrease can be propagated to a related RFQ if it wasn't confirmed yet.

Task-2513592

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Forward-Port-Of: #76752