### PR TITLE
[FIX] project: fix copy functionality of project

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -250,7 +250,7 @@ class Project(models.Model):
         ('yearly', 'Yearly')], 'Rating Frequency', required=True, default='monthly')
 
     update_ids = fields.One2many('project.update', 'project_id')
-    last_update_id = fields.Many2one('project.update', string='Last Update')
+    last_update_id = fields.Many2one('project.update', string='Last Update', copy=False)
     last_update_status = fields.Selection(selection=[
         ('on_track', 'On Track'),
         ('at_risk', 'At Risk'),


### PR DESCRIPTION
Purpose of this commit to do not copy progress of the project
update model when coping project.

So, In this commit make last_update_id field copy false
so default progress new created project update of copied
 project will be 0%.

TaskID-2664773

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
