### PR TITLE
[FIX] sale_timesheet: have the right value on project overview

### DIFF
--- a/addons/sale_timesheet/report/project_profitability_report_analysis.py
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis.py
@@ -37,159 +37,307 @@ class ProfitabilityAnalysis(models.Model):
         query = """
             CREATE VIEW %s AS (
                 SELECT
-                    ROW_NUMBER() OVER (ORDER BY P.id, SOL.id) AS id,
-                    P.id AS project_id,
-                    P.user_id AS user_id,
-                    SOL.id AS sale_line_id,
-                    P.analytic_account_id AS analytic_account_id,
-                    P.partner_id AS partner_id,
-                    C.id AS company_id,
-                    C.currency_id AS currency_id,
-                    S.id AS sale_order_id,
-                    S.date_order AS order_confirmation_date,
-                    SOL.product_id AS product_id,
-                    SOL.qty_delivered_method AS sale_qty_delivered_method,
-                    CASE
-                       WHEN SOL.qty_delivered_method = 'analytic' THEN (SOL.untaxed_amount_to_invoice / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
-                       ELSE 0.0
-                    END AS expense_amount_untaxed_to_invoice,
-                    CASE
-                       WHEN SOL.qty_delivered_method = 'analytic' AND SOL.invoice_status != 'no'
-                       THEN
-                            CASE
-                                WHEN T.expense_policy = 'sales_price'
-                                THEN (SOL.price_reduce / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END) * SOL.qty_invoiced
-                                ELSE -COST_SUMMARY.expense_cost
-                            END
-                       ELSE 0.0
-                    END AS expense_amount_untaxed_invoiced,
-                    CASE
-                       WHEN SOL.qty_delivered_method IN ('timesheet', 'manual', 'stock_move') THEN (SOL.untaxed_amount_to_invoice / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
-                       ELSE 0.0
-                    END AS amount_untaxed_to_invoice,
-                    CASE
-                       WHEN SOL.qty_delivered_method IN ('timesheet', 'manual', 'stock_move') THEN (COALESCE(SOL.untaxed_amount_invoiced, COST_SUMMARY.downpayment_invoiced) / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
-                       ELSE 0.0
-                    END AS amount_untaxed_invoiced,
-                    COST_SUMMARY.timesheet_unit_amount AS timesheet_unit_amount,
-                    COST_SUMMARY.timesheet_cost AS timesheet_cost,
-                    COST_SUMMARY.expense_cost AS expense_cost
-                FROM project_project P
-                    JOIN res_company C ON C.id = P.company_id
-                    LEFT JOIN (
-                        SELECT
-                            project_id,
-                            analytic_account_id,
-                            sale_line_id,
-                            SUM(timesheet_unit_amount) AS timesheet_unit_amount,
-                            SUM(timesheet_cost) AS timesheet_cost,
-                            SUM(expense_cost) AS expense_cost,
-                            SUM(downpayment_invoiced) AS downpayment_invoiced
-                        FROM (
+                    sub.id as id,
+                    sub.project_id as project_id,
+                    sub.user_id as user_id,
+                    sub.sale_line_id as sale_line_id,
+                    sub.analytic_account_id as analytic_account_id,
+                    sub.partner_id as partner_id,
+                    sub.company_id as company_id,
+                    sub.currency_id as currency_id,
+                    sub.sale_order_id as sale_order_id,
+                    sub.order_confirmation_date as order_confirmation_date,
+                    sub.product_id as product_id,
+                    sub.sale_qty_delivered_method as sale_qty_delivered_method,
+                    sub.expense_amount_untaxed_to_invoice as expense_amount_untaxed_to_invoice,
+                    sub.expense_amount_untaxed_invoiced as expense_amount_untaxed_invoiced,
+                    sub.amount_untaxed_to_invoice as amount_untaxed_to_invoice,
+                    sub.amount_untaxed_invoiced as amount_untaxed_invoiced,
+                    sub.timesheet_unit_amount as timesheet_unit_amount,
+                    sub.timesheet_cost as timesheet_cost,
+                    sub.expense_cost as expense_cost
+                FROM (
+                    SELECT
+                        ROW_NUMBER() OVER (ORDER BY P.id, SOL.id) AS id,
+                        P.id AS project_id,
+                        P.user_id AS user_id,
+                        SOL.id AS sale_line_id,
+                        P.analytic_account_id AS analytic_account_id,
+                        P.partner_id AS partner_id,
+                        C.id AS company_id,
+                        C.currency_id AS currency_id,
+                        S.id AS sale_order_id,
+                        S.date_order AS order_confirmation_date,
+                        SOL.product_id AS product_id,
+                        SOL.qty_delivered_method AS sale_qty_delivered_method,
+                        COST_SUMMARY.expense_amount_untaxed_to_invoice AS expense_amount_untaxed_to_invoice,
+                        COST_SUMMARY.expense_amount_untaxed_invoiced AS expense_amount_untaxed_invoiced,
+                        COST_SUMMARY.amount_untaxed_to_invoice AS amount_untaxed_to_invoice,
+                        COST_SUMMARY.amount_untaxed_invoiced AS amount_untaxed_invoiced,
+                        COST_SUMMARY.timesheet_unit_amount AS timesheet_unit_amount,
+                        COST_SUMMARY.timesheet_cost AS timesheet_cost,
+                        COST_SUMMARY.expense_cost AS expense_cost
+                    FROM project_project P
+                        JOIN res_company C ON C.id = P.company_id
+                        LEFT JOIN (
+                            -- Each costs and revenues will be retrieved individually by sub-requests
+                            -- This is required to able to get the date
                             SELECT
-                                P.id AS project_id,
-                                P.analytic_account_id AS analytic_account_id,
-                                TS.so_line AS sale_line_id,
-                                SUM(TS.unit_amount) AS timesheet_unit_amount,
-                                SUM(TS.amount) AS timesheet_cost,
-                                0.0 AS expense_cost,
-                                0.0 AS downpayment_invoiced
-                            FROM account_analytic_line TS, project_project P
-                            WHERE TS.project_id IS NOT NULL AND P.id = TS.project_id AND P.active = 't' AND P.allow_timesheets = 't'
-                            GROUP BY P.id, TS.so_line
+                                project_id,
+                                analytic_account_id,
+                                sale_line_id,
+                                SUM(timesheet_unit_amount) AS timesheet_unit_amount,
+                                SUM(timesheet_cost) AS timesheet_cost,
+                                SUM(expense_cost) AS expense_cost,
+                                SUM(downpayment_invoiced) AS downpayment_invoiced,
+                                SUM(expense_amount_untaxed_to_invoice) AS expense_amount_untaxed_to_invoice,
+                                SUM(expense_amount_untaxed_invoiced) AS expense_amount_untaxed_invoiced,
+                                SUM(amount_untaxed_to_invoice) AS amount_untaxed_to_invoice,
+                                SUM(amount_untaxed_invoiced) AS amount_untaxed_invoiced
+                            FROM (
+                                -- Get the timesheet costs
+                                SELECT
+                                    P.id AS project_id,
+                                    P.analytic_account_id AS analytic_account_id,
+                                    TS.so_line AS sale_line_id,
+                                    TS.unit_amount AS timesheet_unit_amount,
+                                    TS.amount AS timesheet_cost,
+                                    0.0 AS expense_cost,
+                                    0.0 AS downpayment_invoiced,
+                                    0.0 AS expense_amount_untaxed_to_invoice,
+                                    0.0 AS expense_amount_untaxed_invoiced,
+                                    0.0 AS amount_untaxed_to_invoice,
+                                    0.0 AS amount_untaxed_invoiced
+                                FROM account_analytic_line TS, project_project P
+                                WHERE TS.project_id IS NOT NULL AND P.id = TS.project_id AND P.active = 't' AND P.allow_timesheets = 't'
 
-                            UNION
+                                UNION ALL
 
-                            SELECT
-                                P.id AS project_id,
-                                P.analytic_account_id AS analytic_account_id,
-                                AAL.so_line AS sale_line_id,
-                                0.0 AS timesheet_unit_amount,
-                                0.0 AS timesheet_cost,
-                                CASE
-                                  WHEN AAL.product_id != CAST((COALESCE((SELECT value FROM ir_config_parameter WHERE key='sale.default_deposit_product_id'), '-1')) as INT)
-                                  THEN (SUM(AAL.amount))
-                                  ELSE 0.0
-                                END AS expense_cost,
-                                0.0 AS downpayment_invoiced
-                            FROM project_project P
-                                LEFT JOIN account_analytic_account AA ON P.analytic_account_id = AA.id
-                                LEFT JOIN account_analytic_line AAL ON AAL.account_id = AA.id
-                            WHERE AAL.amount < 0.0 AND AAL.project_id IS NULL AND P.active = 't' AND P.allow_timesheets = 't'
-                            GROUP BY P.id, AA.id, AAL.so_line, AAL.product_id
+                                -- Get the other revenues
+                                SELECT
+                                    P.id AS project_id,
+                                    P.analytic_account_id AS analytic_account_id,
+                                    AAL.so_line AS sale_line_id,
+                                    0.0 AS timesheet_unit_amount,
+                                    0.0 AS timesheet_cost,
+                                    0.0 AS expense_cost,
+                                    0.0 AS downpayment_invoiced,
+                                    0.0 AS expense_amount_untaxed_to_invoice,
+                                    0.0 AS expense_amount_untaxed_invoiced,
+                                    0.0 AS amount_untaxed_to_invoice,
+                                    0.0 AS amount_untaxed_invoiced
+                                FROM project_project P
+                                    JOIN account_analytic_account AA ON P.analytic_account_id = AA.id
+                                    JOIN account_analytic_line AAL ON AAL.account_id = AA.id
+                                    JOIN product_product PP ON PP.id = AAL.product_id
+                                    JOIN product_template PT ON PT.id = PP.product_tmpl_id
+                                    LEFT JOIN sale_order_line_invoice_rel SOINV ON SOINV.invoice_line_id = AAL.move_id
+                                    LEFT JOIN sale_order_line SOL ON SOINV.order_line_id = SOL.id
+                                WHERE AAL.amount > 0.0 AND AAL.project_id IS NULL AND P.active = 't'
+                                    AND P.allow_timesheets = 't'
+                                    AND PT.service_type = 'manual' -- default value or Milestone service for services products
+                                    AND PT.service_tracking = 'no' -- default value or not a tracking service for services products
+                                    AND (SOL.id IS NULL
+                                        OR (SOL.is_expense IS NOT TRUE AND SOL.is_downpayment IS NOT TRUE))
 
-                            UNION
+                                UNION ALL
 
-                            SELECT
-                                P.id AS project_id,
-                                P.analytic_account_id AS analytic_account_id,
-                                MY_SOLS.id AS sale_line_id,
-                                0.0 AS timesheet_unit_amount,
-                                0.0 AS timesheet_cost,
-                                0.0 AS expense_cost,
-                                CASE WHEN MY_SOLS.invoice_status = 'invoiced' THEN MY_SOLS.price_reduce ELSE 0.0 END AS downpayment_invoiced
-                            FROM project_project P
-                                LEFT JOIN sale_order_line MY_SOL ON P.sale_line_id = MY_SOL.id
-                                LEFT JOIN sale_order MY_S ON MY_SOL.order_id = MY_S.id
-                                LEFT JOIN sale_order_line MY_SOLS ON MY_SOLS.order_id = MY_S.id
-                            WHERE MY_SOLS.is_downpayment = 't'
-                            GROUP BY P.id, MY_SOLS.id
+                                -- Get the expense costs from account analytic line
+                                SELECT
+                                    P.id AS project_id,
+                                    P.analytic_account_id AS analytic_account_id,
+                                    AAL.so_line AS sale_line_id,
+                                    0.0 AS timesheet_unit_amount,
+                                    0.0 AS timesheet_cost,
+                                    AAL.amount AS expense_cost,
+                                    0.0 AS downpayment_invoiced,
+                                    0.0 AS expense_amount_untaxed_to_invoice,
+                                    0.0 AS expense_amount_untaxed_invoiced,
+                                    0.0 AS amount_untaxed_to_invoice,
+                                    0.0 AS amount_untaxed_invoiced
+                                FROM project_project P
+                                    LEFT JOIN account_analytic_account AA ON P.analytic_account_id = AA.id
+                                    LEFT JOIN account_analytic_line AAL ON AAL.account_id = AA.id
+                                WHERE AAL.amount < 0.0 AND AAL.project_id IS NULL AND P.active = 't' AND P.allow_timesheets = 't'
 
-                            UNION
+                                UNION ALL
 
-                            SELECT
-                                P.id AS project_id,
-                                P.analytic_account_id AS analytic_account_id,
-                                OLIS.id AS sale_line_id,
-                                0.0 AS timesheet_unit_amount,
-                                0.0 AS timesheet_cost,
-                                OLIS.price_reduce AS expense_cost,
-                                0.0 AS downpayment_invoiced
-                            FROM project_project P
-                                LEFT JOIN account_analytic_account ANAC ON P.analytic_account_id = ANAC.id
-                                LEFT JOIN account_analytic_line ANLI ON ANAC.id = ANLI.account_id
-                                LEFT JOIN sale_order_line OLI ON P.sale_line_id = OLI.id
-                                LEFT JOIN sale_order ORD ON OLI.order_id = ORD.id
-                                LEFT JOIN sale_order_line OLIS ON ORD.id = OLIS.order_id
-                            WHERE OLIS.product_id = ANLI.product_id AND OLIS.is_downpayment = 't' AND ANLI.amount < 0.0 AND ANLI.project_id IS NULL AND P.active = 't' AND P.allow_timesheets = 't'
-                            GROUP BY P.id, OLIS.id
+                                -- Get the invoiced downpayments
+                                SELECT
+                                    P.id AS project_id,
+                                    P.analytic_account_id AS analytic_account_id,
+                                    MY_SOLS.id AS sale_line_id,
+                                    0.0 AS timesheet_unit_amount,
+                                    0.0 AS timesheet_cost,
+                                    0.0 AS expense_cost,
+                                    CASE WHEN MY_SOLS.invoice_status = 'invoiced' THEN MY_SOLS.price_reduce ELSE 0.0 END AS downpayment_invoiced,
+                                    0.0 AS expense_amount_untaxed_to_invoice,
+                                    0.0 AS expense_amount_untaxed_invoiced,
+                                    0.0 AS amount_untaxed_to_invoice,
+                                    0.0 AS amount_untaxed_invoiced
+                                FROM project_project P
+                                    LEFT JOIN sale_order_line MY_SOL ON P.sale_line_id = MY_SOL.id
+                                    LEFT JOIN sale_order MY_S ON MY_SOL.order_id = MY_S.id
+                                    LEFT JOIN sale_order_line MY_SOLS ON MY_SOLS.order_id = MY_S.id
+                                WHERE MY_SOLS.is_downpayment = 't'
 
-                            UNION
+                                UNION ALL
 
-                            SELECT
-                                P.id AS project_id,
-                                P.analytic_account_id AS analytic_account_id,
-                                SOL.id AS sale_line_id,
-                                0.0 AS timesheet_unit_amount,
-                                0.0 AS timesheet_cost,
-                                0.0 AS expense_cost,
-                                0.0 AS downpayment_invoiced
-                            FROM sale_order_line SOL
-                                INNER JOIN project_project P ON SOL.project_id = P.id
-                            WHERE P.active = 't' AND P.allow_timesheets = 't'
+                                -- Get the expense costs from sale order line
+                                SELECT
+                                    P.id AS project_id,
+                                    P.analytic_account_id AS analytic_account_id,
+                                    OLIS.id AS sale_line_id,
+                                    0.0 AS timesheet_unit_amount,
+                                    0.0 AS timesheet_cost,
+                                    OLIS.price_reduce AS expense_cost,
+                                    0.0 AS downpayment_invoiced,
+                                    0.0 AS expense_amount_untaxed_to_invoice,
+                                    0.0 AS expense_amount_untaxed_invoiced,
+                                    0.0 AS amount_untaxed_to_invoice,
+                                    0.0 AS amount_untaxed_invoiced
+                                FROM project_project P
+                                    LEFT JOIN account_analytic_account ANAC ON P.analytic_account_id = ANAC.id
+                                    LEFT JOIN account_analytic_line ANLI ON ANAC.id = ANLI.account_id
+                                    LEFT JOIN sale_order_line OLI ON P.sale_line_id = OLI.id
+                                    LEFT JOIN sale_order ORD ON OLI.order_id = ORD.id
+                                    LEFT JOIN sale_order_line OLIS ON ORD.id = OLIS.order_id
+                                WHERE OLIS.product_id = ANLI.product_id AND OLIS.is_downpayment = 't' AND ANLI.amount < 0.0 AND ANLI.project_id IS NULL AND P.active = 't' AND P.allow_timesheets = 't'
 
-                            UNION
+                                UNION ALL
 
-                            SELECT
-                                P.id AS project_id,
-                                P.analytic_account_id AS analytic_account_id,
-                                SOL.id AS sale_line_id,
-                                0.0 AS timesheet_unit_amount,
-                                0.0 AS timesheet_cost,
-                                0.0 AS expense_cost,
-                                0.0 AS downpayment_invoiced
-                            FROM sale_order_line SOL
-                                INNER JOIN project_task T ON SOL.task_id = T.id
-                                INNER JOIN project_project P ON P.id = T.project_id
-                            WHERE P.active = 't' AND P.allow_timesheets = 't'
-                        ) SUB_COST_SUMMARY
-                        GROUP BY project_id, analytic_account_id, sale_line_id
-                    ) COST_SUMMARY ON COST_SUMMARY.project_id = P.id
-                    LEFT JOIN sale_order_line SOL ON COST_SUMMARY.sale_line_id = SOL.id
-                    LEFT JOIN sale_order S ON SOL.order_id = S.id
-                    LEFT JOIN product_product PP on (SOL.product_id=PP.id)
-                    LEFT JOIN product_template T on (PP.product_tmpl_id=T.id)
-                    WHERE P.active = 't' AND P.analytic_account_id IS NOT NULL
+                                -- Get the following values: expense amount untaxed to invoice/invoiced, amount untaxed to invoice/invoiced
+                                -- These values have to be computed from all the records retrieved just above but grouped by project and sale order line
+                                SELECT
+                                    AMOUNT_UNTAXED.project_id AS project_id,
+                                    AMOUNT_UNTAXED.analytic_account_id AS analytic_account_id,
+                                    AMOUNT_UNTAXED.sale_line_id AS sale_line_id,
+                                    0.0 AS timesheet_unit_amount,
+                                    0.0 AS timesheet_cost,
+                                    0.0 AS expense_cost,
+                                    0.0 AS downpayment_invoiced,
+                                    CASE
+                                        WHEN SOL.qty_delivered_method = 'analytic' THEN (SOL.untaxed_amount_to_invoice / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
+                                        ELSE 0.0
+                                    END AS expense_amount_untaxed_to_invoice,
+                                    CASE
+                                        WHEN SOL.qty_delivered_method = 'analytic' AND SOL.invoice_status != 'no'
+                                        THEN
+                                            CASE
+                                                WHEN T.expense_policy = 'sales_price'
+                                                THEN (SOL.price_reduce / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END) * SOL.qty_invoiced
+                                                ELSE -AMOUNT_UNTAXED.expense_cost
+                                            END
+                                        ELSE 0.0
+                                    END AS expense_amount_untaxed_invoiced,
+                                    CASE
+                                        WHEN SOL.qty_delivered_method IN ('timesheet', 'manual') THEN (SOL.untaxed_amount_to_invoice / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
+                                        ELSE 0.0
+                                    END AS amount_untaxed_to_invoice,
+                                    CASE
+                                        WHEN SOL.qty_delivered_method IN ('timesheet', 'manual') THEN (COALESCE(SOL.untaxed_amount_invoiced, AMOUNT_UNTAXED.downpayment_invoiced) / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
+                                        ELSE 0.0
+                                    END AS amount_untaxed_invoiced
+                                FROM project_project P
+                                    JOIN res_company C ON C.id = P.company_id
+                                    LEFT JOIN (
+                                        SELECT
+                                            P.id AS project_id,
+                                            P.analytic_account_id AS analytic_account_id,
+                                            AAL.so_line AS sale_line_id,
+                                            0.0 AS expense_cost,
+                                            0.0 AS downpayment_invoiced
+                                        FROM account_analytic_line AAL, project_project P
+                                        WHERE AAL.project_id IS NOT NULL AND P.id = AAL.project_id AND P.active = 't'
+                                        GROUP BY P.id, AAL.so_line
+
+                                        UNION
+
+                                        SELECT
+                                            P.id AS project_id,
+                                            P.analytic_account_id AS analytic_account_id,
+                                            AAL.so_line AS sale_line_id,
+                                            0.0 AS expense_cost,
+                                            0.0 AS downpayment_invoiced
+                                        FROM project_project P
+                                            LEFT JOIN account_analytic_account AA ON P.analytic_account_id = AA.id
+                                            LEFT JOIN account_analytic_line AAL ON AAL.account_id = AA.id
+                                        WHERE AAL.amount > 0.0 AND AAL.project_id IS NULL AND P.active = 't' AND P.allow_timesheets = 't'
+                                        GROUP BY P.id, AA.id, AAL.so_line
+                                        UNION
+                                        SELECT
+                                            P.id AS project_id,
+                                            P.analytic_account_id AS analytic_account_id,
+                                            AAL.so_line AS sale_line_id,
+                                            SUM(AAL.amount) AS expense_cost,
+                                            0.0 AS downpayment_invoiced
+                                        FROM project_project P
+                                            LEFT JOIN account_analytic_account AA ON P.analytic_account_id = AA.id
+                                            LEFT JOIN account_analytic_line AAL ON AAL.account_id = AA.id
+                                        WHERE AAL.amount < 0.0 AND AAL.project_id IS NULL AND P.active = 't' AND P.allow_timesheets = 't'
+                                        GROUP BY P.id, AA.id, AAL.so_line
+                                        UNION
+                                        SELECT
+                                            P.id AS project_id,
+                                            P.analytic_account_id AS analytic_account_id,
+                                            MY_SOLS.id AS sale_line_id,
+                                            0.0 AS expense_cost,
+                                            CASE WHEN MY_SOLS.invoice_status = 'invoiced' THEN MY_SOLS.price_reduce ELSE 0.0 END AS downpayment_invoiced
+                                        FROM project_project P
+                                            LEFT JOIN sale_order_line MY_SOL ON P.sale_line_id = MY_SOL.id
+                                            LEFT JOIN sale_order MY_S ON MY_SOL.order_id = MY_S.id
+                                            LEFT JOIN sale_order_line MY_SOLS ON MY_SOLS.order_id = MY_S.id
+                                        WHERE MY_SOLS.is_downpayment = 't'
+                                        GROUP BY P.id, MY_SOLS.id
+                                        UNION
+                                        SELECT
+                                            P.id AS project_id,
+                                            P.analytic_account_id AS analytic_account_id,
+                                            OLIS.id AS sale_line_id,
+                                            OLIS.price_reduce AS expense_cost,
+                                            0.0 AS downpayment_invoiced
+                                        FROM project_project P
+                                            LEFT JOIN account_analytic_account ANAC ON P.analytic_account_id = ANAC.id
+                                            LEFT JOIN account_analytic_line ANLI ON ANAC.id = ANLI.account_id
+                                            LEFT JOIN sale_order_line OLI ON P.sale_line_id = OLI.id
+                                            LEFT JOIN sale_order ORD ON OLI.order_id = ORD.id
+                                            LEFT JOIN sale_order_line OLIS ON ORD.id = OLIS.order_id
+                                        WHERE OLIS.product_id = ANLI.product_id AND OLIS.is_downpayment = 't' AND ANLI.amount < 0.0 AND ANLI.project_id IS NULL AND P.active = 't' AND P.allow_timesheets = 't'
+                                        GROUP BY P.id, OLIS.id
+                                        UNION
+                                        SELECT
+                                            P.id AS project_id,
+                                            P.analytic_account_id AS analytic_account_id,
+                                            SOL.id AS sale_line_id,
+                                            0.0 AS expense_cost,
+                                            0.0 AS downpayment_invoiced
+                                        FROM sale_order_line SOL
+                                            INNER JOIN project_project P ON SOL.project_id = P.id
+                                        WHERE P.active = 't' AND P.allow_timesheets = 't'
+                                        UNION
+                                        SELECT
+                                            P.id AS project_id,
+                                            P.analytic_account_id AS analytic_account_id,
+                                            SOL.id AS sale_line_id,
+                                            0.0 AS expense_cost,
+                                            0.0 AS downpayment_invoiced
+                                        FROM sale_order_line SOL
+                                            INNER JOIN project_task T ON SOL.task_id = T.id
+                                            INNER JOIN project_project P ON P.id = T.project_id
+                                        WHERE P.active = 't' AND P.allow_timesheets = 't'
+                                    ) AMOUNT_UNTAXED ON AMOUNT_UNTAXED.project_id = P.id
+                                    LEFT JOIN sale_order_line SOL ON AMOUNT_UNTAXED.sale_line_id = SOL.id
+                                    LEFT JOIN sale_order S ON SOL.order_id = S.id
+                                    LEFT JOIN product_product PP on (SOL.product_id = PP.id)
+                                    LEFT JOIN product_template T on (PP.product_tmpl_id = T.id)
+                                    WHERE P.active = 't' AND P.analytic_account_id IS NOT NULL
+                            ) SUB_COST_SUMMARY
+                            GROUP BY project_id, analytic_account_id, sale_line_id
+                        ) COST_SUMMARY ON COST_SUMMARY.project_id = P.id
+                        LEFT JOIN sale_order_line SOL ON COST_SUMMARY.sale_line_id = SOL.id
+                        LEFT JOIN sale_order S ON SOL.order_id = S.id
+                        WHERE P.active = 't' AND P.analytic_account_id IS NOT NULL
+                    ) AS sub
             )
         """ % self._table
         self._cr.execute(query)


### PR DESCRIPTION
Steps to reproduce:

- Go to sale
- Make a RFQ for a service product with service_policy set at
  delivered_timesheet (Timesheets on tasks), set quantity as 10
- Confirm order and create two invoices for 15%, confirm the two
  invoices
- Create a credit note for one of the invoice and confirm it
- Go back to the Sale Order and click on Project Overview

Issue:

the field expense_cost ("Other Costs") is not well calculated

Solution:

backport of 14.0, ignoring unused fields

opw-2596224

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
