### PR TITLE
[IMP] {purchase,sale}_stock: Update warnings for decreased quantity on MTO sale orders

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -68,25 +68,6 @@ class PurchaseOrder(models.Model):
             self.picking_type_id = self._get_picking_type(self.company_id.id)
 
     # --------------------------------------------------
-    # CRUD
-    # --------------------------------------------------
-
-    def write(self, vals):
-        if vals.get('order_line') and self.state == 'purchase':
-            for order in self:
-                pre_order_line_qty = {order_line: order_line.product_qty for order_line in order.mapped('order_line')}
-        res = super(PurchaseOrder, self).write(vals)
-        if vals.get('order_line') and self.state == 'purchase':
-            for order in self:
-                to_log = {}
-                for order_line in order.order_line:
-                    if pre_order_line_qty.get(order_line, False) and float_compare(pre_order_line_qty[order_line], order_line.product_qty, precision_rounding=order_line.product_uom.rounding) > 0:
-                        to_log[order_line] = (order_line.product_qty, pre_order_line_qty[order_line])
-                if to_log:
-                    order._log_decrease_ordered_quantity(to_log)
-        return res
-
-    # --------------------------------------------------
     # Actions
     # --------------------------------------------------
 

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -591,11 +591,3 @@ class SaleOrderLine(models.Model):
                 # Trigger the Scheduler for Pickings
                 pickings_to_confirm.action_confirm()
         return True
-
-    def _update_line_quantity(self, values):
-        precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
-        line_products = self.filtered(lambda l: l.product_id.type in ['product', 'consu'])
-        if line_products.mapped('qty_delivered') and float_compare(values['product_uom_qty'], max(line_products.mapped('qty_delivered')), precision_digits=precision) == -1:
-            raise UserError(_('You cannot decrease the ordered quantity below the delivered quantity.\n'
-                              'Create a return first.'))
-        super(SaleOrderLine, self)._update_line_quantity(values)

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -495,6 +495,7 @@ class SaleOrderLine(models.Model):
             'company_id': self.order_id.company_id,
             'product_packaging_id': self.product_packaging_id,
             'sequence': self.sequence,
+            'to_refund': float_compare(self.product_uom_qty, 0, precision_rounding=self.product_uom.rounding) < 0,
         })
         return values
 

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -59,7 +59,7 @@ class StockRule(models.Model):
 
     def _get_custom_move_fields(self):
         fields = super(StockRule, self)._get_custom_move_fields()
-        fields += ['sale_line_id', 'partner_id', 'sequence']
+        fields += ['sale_line_id', 'partner_id', 'sequence', 'to_refund']
         return fields
 
 


### PR DESCRIPTION
Related to #76752

Alters notifications made in MTO Sale Orders, following modifications made in linked PR.
- Remove warning in chatter of sale order's related MTO purchase order in case of quantity decrease for a MTO product
- Update delivered quantity in SO when validating a return
- Remove warning for decreasing the quantity of a SO line under the delivered quantity, as it would create a return for the missing quantity automatically.

Task-2659807

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr