### PR TITLE
[FIX] hr: fix avatar generation on employee rename

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -146,7 +146,7 @@ class HrEmployeePrivate(models.Model):
 
     def _compute_avatar(self, avatar_field, image_field):
         for employee in self:
-            avatar = employee[image_field]
+            avatar = employee._origin[image_field]
             if not avatar:
                 if employee.user_id:
                     avatar = employee.user_id[avatar_field]


### PR DESCRIPTION
It was not possible to rename an employee with an existing image
profile, as it was trying to assign the size of the avatar (coming from
the webclient) as the avatar itself.

TaskID: 2660773

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
