### PR TITLE
[REF] stock*,mrp*: clean `setUp` vs `setUpClass` [PHASE1]

### DIFF
--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -12,13 +12,10 @@ class TestMrpProductionBackorder(TestMrpCommon):
     def setUpClass(cls):
         super().setUpClass()
         cls.stock_location = cls.env.ref('stock.stock_location_stock')
-
-    def setUp(self):
-        super().setUp()
-        warehouse_form = Form(self.env['stock.warehouse'])
+        warehouse_form = Form(cls.env['stock.warehouse'])
         warehouse_form.name = 'Test Warehouse'
         warehouse_form.code = 'TWH'
-        self.warehouse = warehouse_form.save()
+        cls.warehouse = warehouse_form.save()
 
     def test_no_tracking_1(self):
         """Create a MO for 4 product. Produce 4. The backorder button should

--- a/addons/mrp/tests/test_byproduct.py
+++ b/addons/mrp/tests/test_byproduct.py
@@ -7,24 +7,25 @@ from odoo.tests import common
 
 class TestMrpByProduct(common.TransactionCase):
 
-    def setUp(self):
-        super(TestMrpByProduct, self).setUp()
-        self.MrpBom = self.env['mrp.bom']
-        self.warehouse = self.env.ref('stock.warehouse0')
-        route_manufacture = self.warehouse.manufacture_pull_id.route_id.id
-        route_mto = self.warehouse.mto_pull_id.route_id.id
-        self.uom_unit_id = self.ref('uom.product_uom_unit')
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.MrpBom = cls.env['mrp.bom']
+        cls.warehouse = cls.env.ref('stock.warehouse0')
+        route_manufacture = cls.warehouse.manufacture_pull_id.route_id.id
+        route_mto = cls.warehouse.mto_pull_id.route_id.id
+        cls.uom_unit_id = cls.env.ref('uom.product_uom_unit').id
         def create_product(name, route_ids=[]):
-            return self.env['product.product'].create({
+            return cls.env['product.product'].create({
                 'name': name,
                 'type': 'product',
                 'route_ids': route_ids})
 
         # Create product A, B, C.
         # --------------------------
-        self.product_a = create_product('Product A', route_ids=[(6, 0, [route_manufacture, route_mto])])
-        self.product_b = create_product('Product B', route_ids=[(6, 0, [route_manufacture, route_mto])])
-        self.product_c_id = create_product('Product C', route_ids=[]).id
+        cls.product_a = create_product('Product A', route_ids=[(6, 0, [route_manufacture, route_mto])])
+        cls.product_b = create_product('Product B', route_ids=[(6, 0, [route_manufacture, route_mto])])
+        cls.product_c_id = create_product('Product C', route_ids=[]).id
 
     def test_00_mrp_byproduct(self):
         """ Test by product with production order."""

--- a/addons/mrp/tests/test_multicompany.py
+++ b/addons/mrp/tests/test_multicompany.py
@@ -7,31 +7,32 @@ from odoo.exceptions import UserError
 
 class TestMrpMulticompany(common.TransactionCase):
 
-    def setUp(self):
-        super(TestMrpMulticompany, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        group_user = self.env.ref('base.group_user')
-        group_mrp_manager = self.env.ref('mrp.group_mrp_manager')
-        self.company_a = self.env['res.company'].create({'name': 'Company A'})
-        self.company_b = self.env['res.company'].create({'name': 'Company B'})
-        self.warehouse_a = self.env['stock.warehouse'].search([('company_id', '=', self.company_a.id)], limit=1)
-        self.warehouse_b = self.env['stock.warehouse'].search([('company_id', '=', self.company_b.id)], limit=1)
-        self.stock_location_a = self.warehouse_a.lot_stock_id
-        self.stock_location_b = self.warehouse_b.lot_stock_id
+        group_user = cls.env.ref('base.group_user')
+        group_mrp_manager = cls.env.ref('mrp.group_mrp_manager')
+        cls.company_a = cls.env['res.company'].create({'name': 'Company A'})
+        cls.company_b = cls.env['res.company'].create({'name': 'Company B'})
+        cls.warehouse_a = cls.env['stock.warehouse'].search([('company_id', '=', cls.company_a.id)], limit=1)
+        cls.warehouse_b = cls.env['stock.warehouse'].search([('company_id', '=', cls.company_b.id)], limit=1)
+        cls.stock_location_a = cls.warehouse_a.lot_stock_id
+        cls.stock_location_b = cls.warehouse_b.lot_stock_id
 
-        self.user_a = self.env['res.users'].create({
+        cls.user_a = cls.env['res.users'].create({
             'name': 'user company a with access to company b',
             'login': 'user a',
             'groups_id': [(6, 0, [group_user.id, group_mrp_manager.id])],
-            'company_id': self.company_a.id,
-            'company_ids': [(6, 0, [self.company_a.id, self.company_b.id])]
+            'company_id': cls.company_a.id,
+            'company_ids': [(6, 0, [cls.company_a.id, cls.company_b.id])]
         })
-        self.user_b = self.env['res.users'].create({
+        cls.user_b = cls.env['res.users'].create({
             'name': 'user company a with access to company b',
             'login': 'user b',
             'groups_id': [(6, 0, [group_user.id, group_mrp_manager.id])],
-            'company_id': self.company_b.id,
-            'company_ids': [(6, 0, [self.company_a.id, self.company_b.id])]
+            'company_id': cls.company_b.id,
+            'company_ids': [(6, 0, [cls.company_a.id, cls.company_b.id])]
         })
 
     def test_bom_1(self):

--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -6,44 +6,45 @@ from odoo.exceptions import UserError
 from odoo.tests import Form
 
 
-class TestWarehouse(common.TestMrpCommon):
-    def setUp(self):
-        super(TestWarehouse, self).setUp()
+class TestWarehouseMrp(common.TestMrpCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        unit = self.env.ref("uom.product_uom_unit")
-        self.stock_location = self.env.ref('stock.stock_location_stock')
-        self.depot_location = self.env['stock.location'].create({
+        unit = cls.env.ref("uom.product_uom_unit")
+        cls.stock_location = cls.env.ref('stock.stock_location_stock')
+        cls.depot_location = cls.env['stock.location'].create({
             'name': 'Depot',
             'usage': 'internal',
-            'location_id': self.stock_location.id,
+            'location_id': cls.stock_location.id,
         })
-        self.env["stock.putaway.rule"].create({
-            "location_in_id": self.stock_location.id,
-            "location_out_id": self.depot_location.id,
-            'category_id': self.env.ref('product.product_category_all').id,
+        cls.env["stock.putaway.rule"].create({
+            "location_in_id": cls.stock_location.id,
+            "location_out_id": cls.depot_location.id,
+            'category_id': cls.env.ref('product.product_category_all').id,
         })
-        mrp_workcenter = self.env['mrp.workcenter'].create({
+        cls.env['mrp.workcenter'].create({
             'name': 'Assembly Line 1',
-            'resource_calendar_id': self.env.ref('resource.resource_calendar_std').id,
+            'resource_calendar_id': cls.env.ref('resource.resource_calendar_std').id,
         })
-        self.env['stock.quant'].create({
-            'location_id': self.stock_location_14.id,
-            'product_id': self.graphics_card.id,
+        cls.env['stock.quant'].create({
+            'location_id': cls.stock_location_14.id,
+            'product_id': cls.graphics_card.id,
             'inventory_quantity': 16.0
         }).action_apply_inventory()
 
-        self.bom_laptop = self.env['mrp.bom'].create({
-            'product_tmpl_id': self.laptop.product_tmpl_id.id,
+        cls.bom_laptop = cls.env['mrp.bom'].create({
+            'product_tmpl_id': cls.laptop.product_tmpl_id.id,
             'product_qty': 1,
             'product_uom_id': unit.id,
             'consumption': 'flexible',
             'bom_line_ids': [(0, 0, {
-                'product_id': self.graphics_card.id,
+                'product_id': cls.graphics_card.id,
                 'product_qty': 1,
                 'product_uom_id': unit.id
             })],
             'operation_ids': [
-                (0, 0, {'name': 'Cutting Machine', 'workcenter_id': self.workcenter_1.id, 'time_cycle': 12, 'sequence': 1}),
+                (0, 0, {'name': 'Cutting Machine', 'workcenter_id': cls.workcenter_1.id, 'time_cycle': 12, 'sequence': 1}),
             ],
         })
 
@@ -173,11 +174,12 @@ class TestWarehouse(common.TestMrpCommon):
         self.assertNotEqual(location_dest.id, self.stock_location.id)
 
 class TestKitPicking(common.TestMrpCommon):
-    def setUp(self):
-        super(TestKitPicking, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
         def create_product(name):
-            p = Form(self.env['product.product'])
+            p = Form(cls.env['product.product'])
             p.name = name
             p.type = 'product'
             return p.save()
@@ -206,13 +208,13 @@ class TestKitPicking(common.TestMrpCommon):
         kit_1 = create_product('Kit 1')
         kit_2 = create_product('Kit 2')
         kit_3 = create_product('kit 3')
-        self.kit_parent = create_product('Kit Parent')
+        cls.kit_parent = create_product('Kit Parent')
         # Linking the kits and the components via some 'phantom' BoMs
-        bom_kit_1 = self.env['mrp.bom'].create({
+        bom_kit_1 = cls.env['mrp.bom'].create({
             'product_tmpl_id': kit_1.product_tmpl_id.id,
             'product_qty': 1.0,
             'type': 'phantom'})
-        BomLine = self.env['mrp.bom.line']
+        BomLine = cls.env['mrp.bom.line']
         BomLine.create({
             'product_id': component_a.id,
             'product_qty': 2.0,
@@ -225,7 +227,7 @@ class TestKitPicking(common.TestMrpCommon):
             'product_id': component_c.id,
             'product_qty': 3.0,
             'bom_id': bom_kit_1.id})
-        bom_kit_2 = self.env['mrp.bom'].create({
+        bom_kit_2 = cls.env['mrp.bom'].create({
             'product_tmpl_id': kit_2.product_tmpl_id.id,
             'product_qty': 1.0,
             'type': 'phantom'})
@@ -237,8 +239,8 @@ class TestKitPicking(common.TestMrpCommon):
             'product_id': kit_1.id,
             'product_qty': 2.0,
             'bom_id': bom_kit_2.id})
-        bom_kit_parent = self.env['mrp.bom'].create({
-            'product_tmpl_id': self.kit_parent.product_tmpl_id.id,
+        bom_kit_parent = cls.env['mrp.bom'].create({
+            'product_tmpl_id': cls.kit_parent.product_tmpl_id.id,
             'product_qty': 1.0,
             'type': 'phantom'})
         BomLine.create({
@@ -249,7 +251,7 @@ class TestKitPicking(common.TestMrpCommon):
             'product_id': kit_2.id,
             'product_qty': 2.0,
             'bom_id': bom_kit_parent.id})
-        bom_kit_3 = self.env['mrp.bom'].create({
+        bom_kit_3 = cls.env['mrp.bom'].create({
             'product_tmpl_id': kit_3.product_tmpl_id.id,
             'product_qty': 1.0,
             'type': 'phantom'})
@@ -267,16 +269,16 @@ class TestKitPicking(common.TestMrpCommon):
             'bom_id': bom_kit_parent.id})
 
         # We create an 'immediate transfer' receipt for x3 kit_parent
-        self.test_partner = self.env['res.partner'].create({
+        cls.test_partner = cls.env['res.partner'].create({
             'name': 'Notthat Guyagain',
         })
-        self.test_supplier = self.env['stock.location'].create({
+        cls.test_supplier = cls.env['stock.location'].create({
             'name': 'supplier',
             'usage': 'supplier',
-            'location_id': self.env.ref('stock.stock_location_stock').id,
+            'location_id': cls.env.ref('stock.stock_location_stock').id,
         })
 
-        self.expected_quantities = {
+        cls.expected_quantities = {
             component_a: 24,
             component_b: 12,
             component_c: 36,

--- a/addons/mrp/tests/test_stock_report.py
+++ b/addons/mrp/tests/test_stock_report.py
@@ -5,7 +5,7 @@ from odoo.tests.common import Form
 from odoo.addons.stock.tests.test_report import TestReportsCommon
 
 
-class TestSaleStockReports(TestReportsCommon):
+class TestMrpStockReports(TestReportsCommon):
     def test_report_forecast_1_mo_count(self):
         """ Creates and configures a product who could be produce and could be a component.
         Plans some producing and consumming MO and check the report values.

--- a/addons/mrp/tests/test_unbuild.py
+++ b/addons/mrp/tests/test_unbuild.py
@@ -7,11 +7,12 @@ from odoo.exceptions import UserError
 
 
 class TestUnbuild(TestMrpCommon):
-    def setUp(self):
-        super(TestUnbuild, self).setUp()
-        self.stock_location = self.env.ref('stock.stock_location_stock')
-        self.env.ref('base.group_user').write({
-            'implied_ids': [(4, self.env.ref('stock.group_production_lot').id)]
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.stock_location = cls.env.ref('stock.stock_location_stock')
+        cls.env.ref('base.group_user').write({
+            'implied_ids': [(4, cls.env.ref('stock.group_production_lot').id)]
         })
 
     def test_unbuild_standart(self):

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -8,47 +8,48 @@ from odoo.addons.mrp.tests.common import TestMrpCommon
 @tagged('post_install', '-at_install')
 class TestMultistepManufacturingWarehouse(TestMrpCommon):
 
-    def setUp(self):
-        super(TestMultistepManufacturingWarehouse, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         # Create warehouse
-        self.customer_location = self.env['ir.model.data']._xmlid_to_res_id('stock.stock_location_customers')
-        warehouse_form = Form(self.env['stock.warehouse'])
+        cls.customer_location = cls.env['ir.model.data']._xmlid_to_res_id('stock.stock_location_customers')
+        warehouse_form = Form(cls.env['stock.warehouse'])
         warehouse_form.name = 'Test Warehouse'
         warehouse_form.code = 'TWH'
-        self.warehouse = warehouse_form.save()
+        cls.warehouse = warehouse_form.save()
 
-        self.uom_unit = self.env.ref('uom.product_uom_unit')
+        cls.uom_unit = cls.env.ref('uom.product_uom_unit')
 
         # Create manufactured product
-        product_form = Form(self.env['product.product'])
+        product_form = Form(cls.env['product.product'])
         product_form.name = 'Stick'
-        product_form.uom_id = self.uom_unit
-        product_form.uom_po_id = self.uom_unit
+        product_form.uom_id = cls.uom_unit
+        product_form.uom_po_id = cls.uom_unit
         product_form.detailed_type = 'product'
         product_form.route_ids.clear()
-        product_form.route_ids.add(self.warehouse.manufacture_pull_id.route_id)
-        product_form.route_ids.add(self.warehouse.mto_pull_id.route_id)
-        self.finished_product = product_form.save()
+        product_form.route_ids.add(cls.warehouse.manufacture_pull_id.route_id)
+        product_form.route_ids.add(cls.warehouse.mto_pull_id.route_id)
+        cls.finished_product = product_form.save()
 
         # Create raw product for manufactured product
-        product_form = Form(self.env['product.product'])
+        product_form = Form(cls.env['product.product'])
         product_form.name = 'Raw Stick'
         product_form.detailed_type = 'product'
-        product_form.uom_id = self.uom_unit
-        product_form.uom_po_id = self.uom_unit
-        self.raw_product = product_form.save()
+        product_form.uom_id = cls.uom_unit
+        product_form.uom_po_id = cls.uom_unit
+        cls.raw_product = product_form.save()
 
         # Create bom for manufactured product
-        bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = self.finished_product
-        bom_product_form.product_tmpl_id = self.finished_product.product_tmpl_id
+        bom_product_form = Form(cls.env['mrp.bom'])
+        bom_product_form.product_id = cls.finished_product
+        bom_product_form.product_tmpl_id = cls.finished_product.product_tmpl_id
         bom_product_form.product_qty = 1.0
         bom_product_form.type = 'normal'
         with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = self.raw_product
+            bom_line.product_id = cls.raw_product
             bom_line.product_qty = 2.0
 
-        self.bom = bom_product_form.save()
+        cls.bom = bom_product_form.save()
 
     def _check_location_and_routes(self):
         # Check manufacturing pull rule.

--- a/addons/mrp_account/tests/test_bom_price.py
+++ b/addons/mrp_account/tests/test_bom_price.py
@@ -8,28 +8,30 @@ from odoo.tools.float_utils import float_round, float_compare
 
 class TestBomPrice(common.TransactionCase):
 
-    def _create_product(self, name, price):
-        return self.Product.create({
+    @classmethod
+    def _create_product(cls, name, price):
+        return cls.Product.create({
             'name': name,
             'type': 'product',
             'standard_price': price,
         })
 
-    def setUp(self):
-        super(TestBomPrice, self).setUp()
-        self.Product = self.env['product.product']
-        self.Bom = self.env['mrp.bom']
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Product = cls.env['product.product']
+        cls.Bom = cls.env['mrp.bom']
 
         # Products.
-        self.dining_table = self._create_product('Dining Table', 1000)
-        self.table_head = self._create_product('Table Head', 300)
-        self.screw = self._create_product('Screw', 10)
-        self.leg = self._create_product('Leg', 25)
-        self.glass = self._create_product('Glass', 100)
+        cls.dining_table = cls._create_product('Dining Table', 1000)
+        cls.table_head = cls._create_product('Table Head', 300)
+        cls.screw = cls._create_product('Screw', 10)
+        cls.leg = cls._create_product('Leg', 25)
+        cls.glass = cls._create_product('Glass', 100)
 
         # Unit of Measure.
-        self.unit = self.env.ref("uom.product_uom_unit")
-        self.dozen = self.env.ref("uom.product_uom_dozen")
+        cls.unit = cls.env.ref("uom.product_uom_unit")
+        cls.dozen = cls.env.ref("uom.product_uom_dozen")
 
         # Bills Of Materials.
         # -------------------------------------------------------------------------------
@@ -41,31 +43,31 @@ class TestBomPrice(common.TransactionCase):
         # Total = 550 [718.75 if components of Table Head considered] (for 1 Unit)
         # -------------------------------------------------------------------------------
 
-        bom_form = Form(self.Bom)
-        bom_form.product_id = self.dining_table
-        bom_form.product_tmpl_id = self.dining_table.product_tmpl_id
+        bom_form = Form(cls.Bom)
+        bom_form.product_id = cls.dining_table
+        bom_form.product_tmpl_id = cls.dining_table.product_tmpl_id
         bom_form.product_qty = 1.0
-        bom_form.product_uom_id = self.unit
+        bom_form.product_uom_id = cls.unit
         bom_form.type = 'normal'
         with bom_form.bom_line_ids.new() as line:
-            line.product_id = self.table_head
+            line.product_id = cls.table_head
             line.product_qty = 1
         with bom_form.bom_line_ids.new() as line:
-            line.product_id = self.screw
+            line.product_id = cls.screw
             line.product_qty = 5
         with bom_form.bom_line_ids.new() as line:
-            line.product_id = self.leg
+            line.product_id = cls.leg
             line.product_qty = 4
         with bom_form.bom_line_ids.new() as line:
-            line.product_id = self.glass
+            line.product_id = cls.glass
             line.product_qty = 1
-        self.bom_1 = bom_form.save()
+        cls.bom_1 = bom_form.save()
 
         # Table Head's components.
-        self.plywood_sheet = self._create_product('Plywood Sheet', 200)
-        self.bolt = self._create_product('Bolt', 10)
-        self.colour = self._create_product('Colour', 100)
-        self.corner_slide = self._create_product('Corner Slide', 25)
+        cls.plywood_sheet = cls._create_product('Plywood Sheet', 200)
+        cls.bolt = cls._create_product('Bolt', 10)
+        cls.colour = cls._create_product('Colour', 100)
+        cls.corner_slide = cls._create_product('Corner Slide', 25)
 
         # -----------------------------------------------------------------
         # Cost of BoM (Table Head 1 Dozen)
@@ -77,25 +79,25 @@ class TestBomPrice(common.TransactionCase):
         #                          1 Unit price (5625/12) =  468.75
         # -----------------------------------------------------------------
 
-        bom_form2 = Form(self.Bom)
-        bom_form2.product_id = self.table_head
-        bom_form2.product_tmpl_id = self.table_head.product_tmpl_id
+        bom_form2 = Form(cls.Bom)
+        bom_form2.product_id = cls.table_head
+        bom_form2.product_tmpl_id = cls.table_head.product_tmpl_id
         bom_form2.product_qty = 1.0
-        bom_form2.product_uom_id = self.dozen
+        bom_form2.product_uom_id = cls.dozen
         bom_form2.type = 'phantom'
         with bom_form2.bom_line_ids.new() as line:
-            line.product_id = self.plywood_sheet
+            line.product_id = cls.plywood_sheet
             line.product_qty = 12
         with bom_form2.bom_line_ids.new() as line:
-            line.product_id = self.bolt
+            line.product_id = cls.bolt
             line.product_qty = 60
         with bom_form2.bom_line_ids.new() as line:
-            line.product_id = self.colour
+            line.product_id = cls.colour
             line.product_qty = 12
         with bom_form2.bom_line_ids.new() as line:
-            line.product_id = self.corner_slide
+            line.product_id = cls.corner_slide
             line.product_qty = 57
-        self.bom_2 = bom_form2.save()
+        cls.bom_2 = bom_form2.save()
 
     def test_00_compute_price(self):
         """Test multi-level BoM cost"""

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -592,49 +592,51 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
 
 
 class TestSubcontractingTracking(TransactionCase):
-    def setUp(self):
-        super(TestSubcontractingTracking, self).setUp()
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         # 1: Create a subcontracting partner
-        main_company_1 = self.env['res.partner'].create({'name': 'main_partner'})
-        self.subcontractor_partner1 = self.env['res.partner'].create({
+        main_company_1 = cls.env['res.partner'].create({'name': 'main_partner'})
+        cls.subcontractor_partner1 = cls.env['res.partner'].create({
             'name': 'Subcontractor 1',
             'parent_id': main_company_1.id,
-            'company_id': self.env.ref('base.main_company').id
+            'company_id': cls.env.ref('base.main_company').id
         })
 
         # 2. Create a BOM of subcontracting type
         # 2.1. Comp1 has tracking by lot
-        self.comp1_sn = self.env['product.product'].create({
+        cls.comp1_sn = cls.env['product.product'].create({
             'name': 'Component1',
             'type': 'product',
-            'categ_id': self.env.ref('product.product_category_all').id,
+            'categ_id': cls.env.ref('product.product_category_all').id,
             'tracking': 'serial'
         })
-        self.comp2 = self.env['product.product'].create({
+        cls.comp2 = cls.env['product.product'].create({
             'name': 'Component2',
             'type': 'product',
-            'categ_id': self.env.ref('product.product_category_all').id,
+            'categ_id': cls.env.ref('product.product_category_all').id,
         })
 
         # 2.2. Finished prodcut has tracking by serial number
-        self.finished_product = self.env['product.product'].create({
+        cls.finished_product = cls.env['product.product'].create({
             'name': 'finished',
             'type': 'product',
-            'categ_id': self.env.ref('product.product_category_all').id,
+            'categ_id': cls.env.ref('product.product_category_all').id,
             'tracking': 'lot'
         })
-        bom_form = Form(self.env['mrp.bom'])
+        bom_form = Form(cls.env['mrp.bom'])
         bom_form.type = 'subcontract'
         bom_form.consumption = 'strict'
-        bom_form.subcontractor_ids.add(self.subcontractor_partner1)
-        bom_form.product_tmpl_id = self.finished_product.product_tmpl_id
+        bom_form.subcontractor_ids.add(cls.subcontractor_partner1)
+        bom_form.product_tmpl_id = cls.finished_product.product_tmpl_id
         with bom_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = self.comp1_sn
+            bom_line.product_id = cls.comp1_sn
             bom_line.product_qty = 1
         with bom_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = self.comp2
+            bom_line.product_id = cls.comp2
             bom_line.product_qty = 1
-        self.bom_tracked = bom_form.save()
+        cls.bom_tracked = bom_form.save()
 
     def test_flow_tracked_1(self):
         """ This test mimics test_flow_1 but with a BoM that has tracking included in it.

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -7,48 +7,49 @@ from odoo import fields
 
 
 @tagged('post_install', '-at_install')
-class TestSaleMrpFlow(TransactionCase):
+class TestPurchaseMrpFlow(TransactionCase):
 
-    def setUp(self):
-        super(TestSaleMrpFlow, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         # Useful models
-        self.UoM = self.env['uom.uom']
-        self.categ_unit = self.env.ref('uom.product_uom_categ_unit')
-        self.categ_kgm = self.env.ref('uom.product_uom_categ_kgm')
-        self.stock_location = self.env.ref('stock.stock_location_stock')
-        self.warehouse = self.env.ref('stock.warehouse0')
+        cls.UoM = cls.env['uom.uom']
+        cls.categ_unit = cls.env.ref('uom.product_uom_categ_unit')
+        cls.categ_kgm = cls.env.ref('uom.product_uom_categ_kgm')
+        cls.stock_location = cls.env.ref('stock.stock_location_stock')
+        cls.warehouse = cls.env.ref('stock.warehouse0')
 
-        self.uom_kg = self.env['uom.uom'].search([('category_id', '=', self.categ_kgm.id), ('uom_type', '=', 'reference')],
+        cls.uom_kg = cls.env['uom.uom'].search([('category_id', '=', cls.categ_kgm.id), ('uom_type', '=', 'reference')],
                                                  limit=1)
-        self.uom_kg.write({
+        cls.uom_kg.write({
             'name': 'Test-KG',
             'rounding': 0.000001})
-        self.uom_gm = self.UoM.create({
+        cls.uom_gm = cls.UoM.create({
             'name': 'Test-G',
-            'category_id': self.categ_kgm.id,
+            'category_id': cls.categ_kgm.id,
             'uom_type': 'smaller',
             'factor': 1000.0,
             'rounding': 0.001})
-        self.uom_unit = self.env['uom.uom'].search(
-            [('category_id', '=', self.categ_unit.id), ('uom_type', '=', 'reference')], limit=1)
-        self.uom_unit.write({
+        cls.uom_unit = cls.env['uom.uom'].search(
+            [('category_id', '=', cls.categ_unit.id), ('uom_type', '=', 'reference')], limit=1)
+        cls.uom_unit.write({
             'name': 'Test-Unit',
             'rounding': 0.01})
-        self.uom_dozen = self.UoM.create({
+        cls.uom_dozen = cls.UoM.create({
             'name': 'Test-DozenA',
-            'category_id': self.categ_unit.id,
+            'category_id': cls.categ_unit.id,
             'factor_inv': 12,
             'uom_type': 'bigger',
             'rounding': 0.001})
 
         # Creating all components
-        self.component_a = self._create_product('Comp A', self.uom_unit)
-        self.component_b = self._create_product('Comp B', self.uom_unit)
-        self.component_c = self._create_product('Comp C', self.uom_unit)
-        self.component_d = self._create_product('Comp D', self.uom_unit)
-        self.component_e = self._create_product('Comp E', self.uom_unit)
-        self.component_f = self._create_product('Comp F', self.uom_unit)
-        self.component_g = self._create_product('Comp G', self.uom_unit)
+        cls.component_a = cls._create_product('Comp A', cls.uom_unit)
+        cls.component_b = cls._create_product('Comp B', cls.uom_unit)
+        cls.component_c = cls._create_product('Comp C', cls.uom_unit)
+        cls.component_d = cls._create_product('Comp D', cls.uom_unit)
+        cls.component_e = cls._create_product('Comp E', cls.uom_unit)
+        cls.component_f = cls._create_product('Comp F', cls.uom_unit)
+        cls.component_g = cls._create_product('Comp G', cls.uom_unit)
 
         # Create a kit 'kit_1' :
         # -----------------------
@@ -57,26 +58,26 @@ class TestSaleMrpFlow(TransactionCase):
         #         |- component_b   x1
         #         |- component_c   x3
 
-        self.kit_1 = self._create_product('Kit 1', self.uom_unit)
+        cls.kit_1 = cls._create_product('Kit 1', cls.uom_unit)
 
-        self.bom_kit_1 = self.env['mrp.bom'].create({
-            'product_tmpl_id': self.kit_1.product_tmpl_id.id,
+        cls.bom_kit_1 = cls.env['mrp.bom'].create({
+            'product_tmpl_id': cls.kit_1.product_tmpl_id.id,
             'product_qty': 1.0,
             'type': 'phantom'})
 
-        BomLine = self.env['mrp.bom.line']
+        BomLine = cls.env['mrp.bom.line']
         BomLine.create({
-            'product_id': self.component_a.id,
+            'product_id': cls.component_a.id,
             'product_qty': 2.0,
-            'bom_id': self.bom_kit_1.id})
+            'bom_id': cls.bom_kit_1.id})
         BomLine.create({
-            'product_id': self.component_b.id,
+            'product_id': cls.component_b.id,
             'product_qty': 1.0,
-            'bom_id': self.bom_kit_1.id})
+            'bom_id': cls.bom_kit_1.id})
         BomLine.create({
-            'product_id': self.component_c.id,
+            'product_id': cls.component_c.id,
             'product_qty': 3.0,
-            'bom_id': self.bom_kit_1.id})
+            'bom_id': cls.bom_kit_1.id})
 
         # Create a kit 'kit_parent' :
         # ---------------------------
@@ -92,60 +93,61 @@ class TestSaleMrpFlow(TransactionCase):
         #              |- component_e x1
 
         # Creating all kits
-        self.kit_2 = self._create_product('Kit 2', self.uom_unit)
-        self.kit_3 = self._create_product('kit 3', self.uom_unit)
-        self.kit_parent = self._create_product('Kit Parent', self.uom_unit)
+        cls.kit_2 = cls._create_product('Kit 2', cls.uom_unit)
+        cls.kit_3 = cls._create_product('kit 3', cls.uom_unit)
+        cls.kit_parent = cls._create_product('Kit Parent', cls.uom_unit)
 
         # Linking the kits and the components via some 'phantom' BoMs
-        bom_kit_2 = self.env['mrp.bom'].create({
-            'product_tmpl_id': self.kit_2.product_tmpl_id.id,
+        bom_kit_2 = cls.env['mrp.bom'].create({
+            'product_tmpl_id': cls.kit_2.product_tmpl_id.id,
             'product_qty': 1.0,
             'type': 'phantom'})
 
         BomLine.create({
-            'product_id': self.component_d.id,
+            'product_id': cls.component_d.id,
             'product_qty': 1.0,
             'bom_id': bom_kit_2.id})
         BomLine.create({
-            'product_id': self.kit_1.id,
+            'product_id': cls.kit_1.id,
             'product_qty': 2.0,
             'bom_id': bom_kit_2.id})
 
-        bom_kit_parent = self.env['mrp.bom'].create({
-            'product_tmpl_id': self.kit_parent.product_tmpl_id.id,
+        bom_kit_parent = cls.env['mrp.bom'].create({
+            'product_tmpl_id': cls.kit_parent.product_tmpl_id.id,
             'product_qty': 1.0,
             'type': 'phantom'})
 
         BomLine.create({
-            'product_id': self.component_e.id,
+            'product_id': cls.component_e.id,
             'product_qty': 1.0,
             'bom_id': bom_kit_parent.id})
         BomLine.create({
-            'product_id': self.kit_2.id,
+            'product_id': cls.kit_2.id,
             'product_qty': 2.0,
             'bom_id': bom_kit_parent.id})
 
-        bom_kit_3 = self.env['mrp.bom'].create({
-            'product_tmpl_id': self.kit_3.product_tmpl_id.id,
+        bom_kit_3 = cls.env['mrp.bom'].create({
+            'product_tmpl_id': cls.kit_3.product_tmpl_id.id,
             'product_qty': 1.0,
             'type': 'phantom'})
 
         BomLine.create({
-            'product_id': self.component_f.id,
+            'product_id': cls.component_f.id,
             'product_qty': 1.0,
             'bom_id': bom_kit_3.id})
         BomLine.create({
-            'product_id': self.component_g.id,
+            'product_id': cls.component_g.id,
             'product_qty': 2.0,
             'bom_id': bom_kit_3.id})
 
         BomLine.create({
-            'product_id': self.kit_3.id,
+            'product_id': cls.kit_3.id,
             'product_qty': 2.0,
             'bom_id': bom_kit_parent.id})
 
-    def _create_product(self, name, uom_id, routes=()):
-        p = Form(self.env['product.product'])
+    @classmethod
+    def _create_product(cls, name, uom_id, routes=()):
+        p = Form(cls.env['product.product'])
         p.name = name
         p.type = 'product'
         p.uom_id = uom_id

--- a/addons/purchase_stock/tests/test_create_picking.py
+++ b/addons/purchase_stock/tests/test_create_picking.py
@@ -11,14 +11,15 @@ from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 
 class TestCreatePicking(common.TestProductCommon):
 
-    def setUp(self):
-        super(TestCreatePicking, self).setUp()
-        self.partner_id = self.env['res.partner'].create({'name': 'Wood Corner Partner'})
-        self.product_id_1 = self.env['product.product'].create({'name': 'Large Desk'})
-        self.product_id_2 = self.env['product.product'].create({'name': 'Conference Chair'})
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner_id = cls.env['res.partner'].create({'name': 'Wood Corner Partner'})
+        cls.product_id_1 = cls.env['product.product'].create({'name': 'Large Desk'})
+        cls.product_id_2 = cls.env['product.product'].create({'name': 'Conference Chair'})
 
-        self.user_purchase_user = mail_new_test_user(
-            self.env,
+        cls.user_purchase_user = mail_new_test_user(
+            cls.env,
             name='Pauline Poivraisselle',
             login='pauline',
             email='pur@example.com',
@@ -26,14 +27,14 @@ class TestCreatePicking(common.TestProductCommon):
             groups='purchase.group_purchase_user',
         )
 
-        self.po_vals = {
-            'partner_id': self.partner_id.id,
+        cls.po_vals = {
+            'partner_id': cls.partner_id.id,
             'order_line': [
                 (0, 0, {
-                    'name': self.product_id_1.name,
-                    'product_id': self.product_id_1.id,
+                    'name': cls.product_id_1.name,
+                    'product_id': cls.product_id_1.id,
                     'product_qty': 5.0,
-                    'product_uom': self.product_id_1.uom_po_id.id,
+                    'product_uom': cls.product_id_1.uom_po_id.id,
                     'price_unit': 500.0,
                     'date_planned': datetime.today().strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                 })],

--- a/addons/purchase_stock/tests/test_move_cancel_propagation.py
+++ b/addons/purchase_stock/tests/test_move_cancel_propagation.py
@@ -6,37 +6,38 @@ from .common import PurchaseTestCommon
 
 class TestMoveCancelPropagation(PurchaseTestCommon):
 
-    def setUp(self):
-        super(TestMoveCancelPropagation, self).setUp()
-        self.customer = self.env['res.partner'].create({'name': 'abc'})
-        self.group = self.env['procurement.group'].create({'partner_id': self.customer.id, 'name': 'New Group'})
-        self.warehouse = self.env.ref('stock.warehouse0')
-        cust_location = self.env.ref('stock.stock_location_customers')
-        seller = self.env['product.supplierinfo'].create({
-            'name': self.customer.id,
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.customer = cls.env['res.partner'].create({'name': 'abc'})
+        cls.group = cls.env['procurement.group'].create({'partner_id': cls.customer.id, 'name': 'New Group'})
+        cls.warehouse = cls.env.ref('stock.warehouse0')
+        cust_location = cls.env.ref('stock.stock_location_customers')
+        seller = cls.env['product.supplierinfo'].create({
+            'name': cls.customer.id,
             'price': 100.0,
         })
-        product = self.env['product.product'].create({
+        product = cls.env['product.product'].create({
             'name': 'Geyser',
             'type': 'product',
-            'route_ids': [(4, self.route_mto), (4, self.route_buy)],
+            'route_ids': [(4, cls.route_mto), (4, cls.route_buy)],
             'seller_ids': [(6, 0, [seller.id])],
         })
-        self.picking_out = self.env['stock.picking'].create({
-            'location_id': self.warehouse.out_type_id.default_location_src_id.id,
+        cls.picking_out = cls.env['stock.picking'].create({
+            'location_id': cls.warehouse.out_type_id.default_location_src_id.id,
             'location_dest_id': cust_location.id,
-            'partner_id': self.customer.id,
-            'group_id': self.group.id,
-            'picking_type_id': self.ref('stock.picking_type_out'),
+            'partner_id': cls.customer.id,
+            'group_id': cls.group.id,
+            'picking_type_id': cls.env.ref('stock.picking_type_out').id,
         })
-        self.move = self.env['stock.move'].create({
+        cls.move = cls.env['stock.move'].create({
             'name': product.name,
             'product_id': product.id,
             'product_uom_qty': 10,
             'product_uom': product.uom_id.id,
-            'picking_id': self.picking_out.id,
-            'group_id': self.group.id,
-            'location_id': self.warehouse.out_type_id.default_location_src_id.id,
+            'picking_id': cls.picking_out.id,
+            'group_id': cls.group.id,
+            'location_id': cls.warehouse.out_type_id.default_location_src_id.id,
             'location_dest_id': cust_location.id,
             'procure_method': 'make_to_order',
         })

--- a/addons/purchase_stock/tests/test_onchange_product.py
+++ b/addons/purchase_stock/tests/test_onchange_product.py
@@ -12,18 +12,19 @@ class TestOnchangeProductId(TransactionCase):
     subtracted to the price of the product.
     """
 
-    def setUp(self):
-        super(TestOnchangeProductId, self).setUp()
-        self.fiscal_position_model = self.env['account.fiscal.position']
-        self.fiscal_position_tax_model = self.env['account.fiscal.position.tax']
-        self.tax_model = self.env['account.tax']
-        self.po_model = self.env['purchase.order']
-        self.po_line_model = self.env['purchase.order.line']
-        self.res_partner_model = self.env['res.partner']
-        self.product_tmpl_model = self.env['product.template']
-        self.product_model = self.env['product.product']
-        self.product_uom_model = self.env['uom.uom']
-        self.supplierinfo_model = self.env["product.supplierinfo"]
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.fiscal_position_model = cls.env['account.fiscal.position']
+        cls.fiscal_position_tax_model = cls.env['account.fiscal.position.tax']
+        cls.tax_model = cls.env['account.tax']
+        cls.po_model = cls.env['purchase.order']
+        cls.po_line_model = cls.env['purchase.order.line']
+        cls.res_partner_model = cls.env['res.partner']
+        cls.product_tmpl_model = cls.env['product.template']
+        cls.product_model = cls.env['product.product']
+        cls.product_uom_model = cls.env['uom.uom']
+        cls.supplierinfo_model = cls.env["product.supplierinfo"]
 
     def test_onchange_product_id(self):
 

--- a/addons/purchase_stock/tests/test_replenish_wizard.py
+++ b/addons/purchase_stock/tests/test_replenish_wizard.py
@@ -4,30 +4,31 @@ from odoo.addons.stock.tests.common import TestStockCommon
 
 
 class TestReplenishWizard(TestStockCommon):
-    def setUp(self):
-        super(TestReplenishWizard, self).setUp()
-        self.vendor = self.env['res.partner'].create(dict(name='The Replenisher'))
-        self.product1_price = 500
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.vendor = cls.env['res.partner'].create(dict(name='The Replenisher'))
+        cls.product1_price = 500
 
         # Create a supplier info witch the previous vendor
-        self.supplierinfo = self.env['product.supplierinfo'].create({
-            'name': self.vendor.id,
-            'price': self.product1_price,
+        cls.supplierinfo = cls.env['product.supplierinfo'].create({
+            'name': cls.vendor.id,
+            'price': cls.product1_price,
         })
 
         # Create a product with the 'buy' route and
         # the 'supplierinfo' prevously created
-        self.product1 = self.env['product.product'].create({
+        cls.product1 = cls.env['product.product'].create({
             'name': 'product a',
             'type': 'product',
-            'categ_id': self.env.ref('product.product_category_all').id,
-            'seller_ids': [(4, self.supplierinfo.id, 0)],
-            'route_ids': [(4, self.env.ref('purchase_stock.route_warehouse0_buy').id, 0)],
+            'categ_id': cls.env.ref('product.product_category_all').id,
+            'seller_ids': [(4, cls.supplierinfo.id, 0)],
+            'route_ids': [(4, cls.env.ref('purchase_stock.route_warehouse0_buy').id, 0)],
         })
 
         # Additional Values required by the replenish wizard
-        self.uom_unit = self.env.ref('uom.product_uom_unit')
-        self.wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        cls.uom_unit = cls.env.ref('uom.product_uom_unit')
+        cls.wh = cls.env['stock.warehouse'].search([('company_id', '=', cls.env.user.id)], limit=1)
 
     def test_replenish_buy_1(self):
         """ Set a quantity to replenish via the "Buy" route and check if

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -13,48 +13,49 @@ from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 
 
 class TestStockValuation(TransactionCase):
-    def setUp(self):
-        super(TestStockValuation, self).setUp()
-        self.supplier_location = self.env.ref('stock.stock_location_suppliers')
-        self.stock_location = self.env.ref('stock.stock_location_stock')
-        self.partner_id = self.env['res.partner'].create({
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.supplier_location = cls.env.ref('stock.stock_location_suppliers')
+        cls.stock_location = cls.env.ref('stock.stock_location_stock')
+        cls.partner_id = cls.env['res.partner'].create({
             'name': 'Wood Corner Partner',
-            'company_id': self.env.user.company_id.id,
+            'company_id': cls.env.user.company_id.id,
         })
-        self.product1 = self.env['product.product'].create({
+        cls.product1 = cls.env['product.product'].create({
             'name': 'Large Desk',
             'standard_price': 1299.0,
             'list_price': 1799.0,
             'type': 'product',
         })
-        Account = self.env['account.account']
-        self.stock_input_account = Account.create({
+        Account = cls.env['account.account']
+        cls.stock_input_account = Account.create({
             'name': 'Stock Input',
             'code': 'StockIn',
-            'user_type_id': self.env.ref('account.data_account_type_current_assets').id,
+            'user_type_id': cls.env.ref('account.data_account_type_current_assets').id,
             'reconcile': True,
         })
-        self.stock_output_account = Account.create({
+        cls.stock_output_account = Account.create({
             'name': 'Stock Output',
             'code': 'StockOut',
-            'user_type_id': self.env.ref('account.data_account_type_current_assets').id,
+            'user_type_id': cls.env.ref('account.data_account_type_current_assets').id,
             'reconcile': True,
         })
-        self.stock_valuation_account = Account.create({
+        cls.stock_valuation_account = Account.create({
             'name': 'Stock Valuation',
             'code': 'Stock Valuation',
-            'user_type_id': self.env.ref('account.data_account_type_current_assets').id,
+            'user_type_id': cls.env.ref('account.data_account_type_current_assets').id,
         })
-        self.stock_journal = self.env['account.journal'].create({
+        cls.stock_journal = cls.env['account.journal'].create({
             'name': 'Stock Journal',
             'code': 'STJTEST',
             'type': 'general',
         })
-        self.product1.categ_id.write({
-            'property_stock_account_input_categ_id': self.stock_input_account.id,
-            'property_stock_account_output_categ_id': self.stock_output_account.id,
-            'property_stock_valuation_account_id': self.stock_valuation_account.id,
-            'property_stock_journal': self.stock_journal.id,
+        cls.product1.categ_id.write({
+            'property_stock_account_input_categ_id': cls.stock_input_account.id,
+            'property_stock_account_output_categ_id': cls.stock_output_account.id,
+            'property_stock_valuation_account_id': cls.stock_valuation_account.id,
+            'property_stock_journal': cls.stock_journal.id,
         })
 
     def test_change_unit_cost_average_1(self):

--- a/addons/sale_mrp/tests/test_multistep_manufacturing.py
+++ b/addons/sale_mrp/tests/test_multistep_manufacturing.py
@@ -7,59 +7,60 @@ from odoo.addons.mrp.tests.common import TestMrpCommon
 
 class TestMultistepManufacturing(TestMrpCommon):
 
-    def setUp(self):
-        super(TestMultistepManufacturing, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        self.env.ref('stock.route_warehouse0_mto').active = True
-        self.MrpProduction = self.env['mrp.production']
+        cls.env.ref('stock.route_warehouse0_mto').active = True
+        cls.MrpProduction = cls.env['mrp.production']
         # Create warehouse
-        warehouse_form = Form(self.env['stock.warehouse'])
+        warehouse_form = Form(cls.env['stock.warehouse'])
         warehouse_form.name = 'Test'
         warehouse_form.code = 'Test'
-        self.warehouse = warehouse_form.save()
+        cls.warehouse = warehouse_form.save()
 
-        self.uom_unit = self.env.ref('uom.product_uom_unit')
+        cls.uom_unit = cls.env.ref('uom.product_uom_unit')
 
         # Create manufactured product
-        product_form = Form(self.env['product.product'])
+        product_form = Form(cls.env['product.product'])
         product_form.name = 'Stick'
-        product_form.uom_id = self.uom_unit
-        product_form.uom_po_id = self.uom_unit
+        product_form.uom_id = cls.uom_unit
+        product_form.uom_po_id = cls.uom_unit
         product_form.route_ids.clear()
-        product_form.route_ids.add(self.warehouse.manufacture_pull_id.route_id)
-        product_form.route_ids.add(self.warehouse.mto_pull_id.route_id)
-        self.product_manu = product_form.save()
+        product_form.route_ids.add(cls.warehouse.manufacture_pull_id.route_id)
+        product_form.route_ids.add(cls.warehouse.mto_pull_id.route_id)
+        cls.product_manu = product_form.save()
 
         # Create raw product for manufactured product
-        product_form = Form(self.env['product.product'])
+        product_form = Form(cls.env['product.product'])
         product_form.name = 'Raw Stick'
-        product_form.uom_id = self.uom_unit
-        product_form.uom_po_id = self.uom_unit
-        self.product_raw = product_form.save()
+        product_form.uom_id = cls.uom_unit
+        product_form.uom_po_id = cls.uom_unit
+        cls.product_raw = product_form.save()
 
         # Create bom for manufactured product
-        bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = self.product_manu
-        bom_product_form.product_tmpl_id = self.product_manu.product_tmpl_id
+        bom_product_form = Form(cls.env['mrp.bom'])
+        bom_product_form.product_id = cls.product_manu
+        bom_product_form.product_tmpl_id = cls.product_manu.product_tmpl_id
         bom_product_form.product_qty = 1.0
         bom_product_form.type = 'normal'
         with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = self.product_raw
+            bom_line.product_id = cls.product_raw
             bom_line.product_qty = 2.0
-        self.bom_prod_manu = bom_product_form.save()
+        cls.bom_prod_manu = bom_product_form.save()
 
         # Create sale order
-        sale_form = Form(self.env['sale.order'])
-        sale_form.partner_id = self.env['res.partner'].create({'name': 'My Test Partner'})
+        sale_form = Form(cls.env['sale.order'])
+        sale_form.partner_id = cls.env['res.partner'].create({'name': 'My Test Partner'})
         sale_form.picking_policy = 'direct'
-        sale_form.warehouse_id = self.warehouse
+        sale_form.warehouse_id = cls.warehouse
         with sale_form.order_line.new() as line:
-            line.name = self.product_manu.name
-            line.product_id = self.product_manu
+            line.name = cls.product_manu.name
+            line.product_id = cls.product_manu
             line.product_uom_qty = 1.0
-            line.product_uom = self.uom_unit
+            line.product_uom = cls.uom_unit
             line.price_unit = 10.0
-        self.sale_order = sale_form.save()
+        cls.sale_order = sale_form.save()
 
     def test_00_manufacturing_step_one(self):
         """ Testing for Step-1 """

--- a/addons/sale_mrp/tests/test_sale_mrp_lead_time.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_lead_time.py
@@ -11,28 +11,29 @@ from odoo.tests import Form
 
 class TestSaleMrpLeadTime(TestStockCommon):
 
-    def setUp(self):
-        super(TestSaleMrpLeadTime, self).setUp()
-        self.env.ref('stock.route_warehouse0_mto').active = True
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.ref('stock.route_warehouse0_mto').active = True
         # Update the product_1 with type, route, Manufacturing Lead Time and Customer Lead Time
-        with Form(self.product_1) as p1:
+        with Form(cls.product_1) as p1:
             p1.type = 'product'
             p1.produce_delay = 5.0
             p1.sale_delay = 5.0
             p1.route_ids.clear()
-            p1.route_ids.add(self.warehouse_1.manufacture_pull_id.route_id)
-            p1.route_ids.add(self.warehouse_1.mto_pull_id.route_id)
+            p1.route_ids.add(cls.warehouse_1.manufacture_pull_id.route_id)
+            p1.route_ids.add(cls.warehouse_1.mto_pull_id.route_id)
 
         # Update the product_2 with type
-        with Form(self.product_2) as p2:
+        with Form(cls.product_2) as p2:
             p2.type = 'consu'
 
         # Create Bill of materials for product_1
-        with Form(self.env['mrp.bom']) as bom:
-            bom.product_tmpl_id = self.product_1.product_tmpl_id
+        with Form(cls.env['mrp.bom']) as bom:
+            bom.product_tmpl_id = cls.product_1.product_tmpl_id
             bom.product_qty = 2
             with bom.bom_line_ids.new() as line:
-                line.product_id = self.product_2
+                line.product_id = cls.product_2
                 line.product_qty = 4
 
     def test_00_product_company_level_delays(self):

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -2146,9 +2146,10 @@ class TestSinglePicking(TestStockCommon):
 
 
 class TestStockUOM(TestStockCommon):
-    def setUp(self):
-        super(TestStockUOM, self).setUp()
-        dp = self.env.ref('product.decimal_product_uom')
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        dp = cls.env.ref('product.decimal_product_uom')
         dp.digits = 7
 
     def test_pickings_transfer_with_different_uom_and_back_orders(self):
@@ -2398,15 +2399,16 @@ class TestStockUOM(TestStockCommon):
 
 
 class TestRoutes(TestStockCommon):
-    def setUp(self):
-        super(TestRoutes, self).setUp()
-        self.product1 = self.env['product.product'].create({
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product1 = cls.env['product.product'].create({
             'name': 'product a',
             'type': 'product',
-            'categ_id': self.env.ref('product.product_category_all').id,
+            'categ_id': cls.env.ref('product.product_category_all').id,
         })
-        self.uom_unit = self.env.ref('uom.product_uom_unit')
-        self.partner = self.env['res.partner'].create({'name': 'Partner'})
+        cls.uom_unit = cls.env.ref('uom.product_uom_unit')
+        cls.partner = cls.env['res.partner'].create({'name': 'Partner'})
 
     def _enable_pick_ship(self):
         self.wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)

--- a/addons/stock/tests/test_proc_rule.py
+++ b/addons/stock/tests/test_proc_rule.py
@@ -9,15 +9,16 @@ from odoo.tools import mute_logger
 
 class TestProcRule(TransactionCase):
 
-    def setUp(self):
-        super(TestProcRule, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        self.uom_unit = self.env.ref('uom.product_uom_unit')
-        self.product = self.env['product.product'].create({
+        cls.uom_unit = cls.env.ref('uom.product_uom_unit')
+        cls.product = cls.env['product.product'].create({
             'name': 'Desk Combination',
             'type': 'consu',
         })
-        self.partner = self.env['res.partner'].create({'name': 'Partner'})
+        cls.partner = cls.env['res.partner'].create({'name': 'Partner'})
 
     def test_proc_rule(self):
         # Create a product route containing a stock rule that will

--- a/addons/stock/tests/test_product.py
+++ b/addons/stock/tests/test_product.py
@@ -9,51 +9,52 @@ from odoo.tests.common import Form
 
 
 class TestVirtualAvailable(TestStockCommon):
-    def setUp(self):
-        super(TestVirtualAvailable, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
         # Make `product3` a storable product for this test. Indeed, creating quants
         # and playing with owners is not possible for consumables.
-        self.product_3.type = 'product'
-        self.env['stock.picking.type'].browse(self.ref('stock.picking_type_out')).reservation_method = 'manual'
+        cls.product_3.type = 'product'
+        cls.env['stock.picking.type'].browse(cls.env.ref('stock.picking_type_out').id).reservation_method = 'manual'
 
-        self.env['stock.quant'].create({
-            'product_id': self.product_3.id,
-            'location_id': self.env.ref('stock.stock_location_stock').id,
+        cls.env['stock.quant'].create({
+            'product_id': cls.product_3.id,
+            'location_id': cls.env.ref('stock.stock_location_stock').id,
             'quantity': 30.0})
 
-        self.env['stock.quant'].create({
-            'product_id': self.product_3.id,
-            'location_id': self.env.ref('stock.stock_location_stock').id,
+        cls.env['stock.quant'].create({
+            'product_id': cls.product_3.id,
+            'location_id': cls.env.ref('stock.stock_location_stock').id,
             'quantity': 10.0,
-            'owner_id': self.user_stock_user.partner_id.id})
+            'owner_id': cls.user_stock_user.partner_id.id})
 
-        self.picking_out = self.env['stock.picking'].create({
-            'picking_type_id': self.ref('stock.picking_type_out'),
-            'location_id': self.env.ref('stock.stock_location_stock').id,
-            'location_dest_id': self.env.ref('stock.stock_location_customers').id})
-        self.env['stock.move'].create({
+        cls.picking_out = cls.env['stock.picking'].create({
+            'picking_type_id': cls.env.ref('stock.picking_type_out').id,
+            'location_id': cls.env.ref('stock.stock_location_stock').id,
+            'location_dest_id': cls.env.ref('stock.stock_location_customers').id})
+        cls.env['stock.move'].create({
             'name': 'a move',
-            'product_id': self.product_3.id,
+            'product_id': cls.product_3.id,
             'product_uom_qty': 3.0,
-            'product_uom': self.product_3.uom_id.id,
-            'picking_id': self.picking_out.id,
-            'location_id': self.env.ref('stock.stock_location_stock').id,
-            'location_dest_id': self.env.ref('stock.stock_location_customers').id})
+            'product_uom': cls.product_3.uom_id.id,
+            'picking_id': cls.picking_out.id,
+            'location_id': cls.env.ref('stock.stock_location_stock').id,
+            'location_dest_id': cls.env.ref('stock.stock_location_customers').id})
 
-        self.picking_out_2 = self.env['stock.picking'].create({
-            'picking_type_id': self.ref('stock.picking_type_out'),
-            'location_id': self.env.ref('stock.stock_location_stock').id,
-            'location_dest_id': self.env.ref('stock.stock_location_customers').id})
-        self.env['stock.move'].create({
-            'restrict_partner_id': self.user_stock_user.partner_id.id,
+        cls.picking_out_2 = cls.env['stock.picking'].create({
+            'picking_type_id': cls.env.ref('stock.picking_type_out').id,
+            'location_id': cls.env.ref('stock.stock_location_stock').id,
+            'location_dest_id': cls.env.ref('stock.stock_location_customers').id})
+        cls.env['stock.move'].create({
+            'restrict_partner_id': cls.user_stock_user.partner_id.id,
             'name': 'another move',
-            'product_id': self.product_3.id,
+            'product_id': cls.product_3.id,
             'product_uom_qty': 5.0,
-            'product_uom': self.product_3.uom_id.id,
-            'picking_id': self.picking_out_2.id,
-            'location_id': self.env.ref('stock.stock_location_stock').id,
-            'location_dest_id': self.env.ref('stock.stock_location_customers').id})
+            'product_uom': cls.product_3.uom_id.id,
+            'picking_id': cls.picking_out_2.id,
+            'location_id': cls.env.ref('stock.stock_location_stock').id,
+            'location_dest_id': cls.env.ref('stock.stock_location_customers').id})
 
     def test_without_owner(self):
         self.assertAlmostEqual(40.0, self.product_3.virtual_available)

--- a/addons/stock/tests/test_report_stock_quantity.py
+++ b/addons/stock/tests/test_report_stock_quantity.py
@@ -8,53 +8,54 @@ from odoo.tests.common import Form
 
 
 class TestReportStockQuantity(tests.TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.product1 = self.env['product.product'].create({
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product1 = cls.env['product.product'].create({
             'name': 'Mellohi',
             'default_code': 'C418',
             'type': 'product',
-            'categ_id': self.env.ref('product.product_category_all').id,
+            'categ_id': cls.env.ref('product.product_category_all').id,
             'tracking': 'lot',
             'barcode': 'scan_me'
         })
-        self.wh = self.env['stock.warehouse'].create({
+        cls.wh = cls.env['stock.warehouse'].create({
             'name': 'Base Warehouse',
             'code': 'TESTWH'
         })
-        self.categ_unit = self.env.ref('uom.product_uom_categ_unit')
-        self.uom_unit = self.env['uom.uom'].search([('category_id', '=', self.categ_unit.id), ('uom_type', '=', 'reference')], limit=1)
-        self.customer_location = self.env.ref('stock.stock_location_customers')
-        self.supplier_location = self.env.ref('stock.stock_location_suppliers')
+        cls.categ_unit = cls.env.ref('uom.product_uom_categ_unit')
+        cls.uom_unit = cls.env['uom.uom'].search([('category_id', '=', cls.categ_unit.id), ('uom_type', '=', 'reference')], limit=1)
+        cls.customer_location = cls.env.ref('stock.stock_location_customers')
+        cls.supplier_location = cls.env.ref('stock.stock_location_suppliers')
         # replenish
-        self.move1 = self.env['stock.move'].create({
+        cls.move1 = cls.env['stock.move'].create({
             'name': 'test_in_1',
-            'location_id': self.supplier_location.id,
-            'location_dest_id': self.wh.lot_stock_id.id,
-            'product_id': self.product1.id,
-            'product_uom': self.uom_unit.id,
+            'location_id': cls.supplier_location.id,
+            'location_dest_id': cls.wh.lot_stock_id.id,
+            'product_id': cls.product1.id,
+            'product_uom': cls.uom_unit.id,
             'product_uom_qty': 100.0,
             'state': 'done',
             'date': fields.Datetime.now(),
         })
-        self.quant1 = self.env['stock.quant'].create({
-            'product_id': self.product1.id,
-            'location_id': self.wh.lot_stock_id.id,
+        cls.quant1 = cls.env['stock.quant'].create({
+            'product_id': cls.product1.id,
+            'location_id': cls.wh.lot_stock_id.id,
             'quantity': 100.0,
         })
         # ship
-        self.move2 = self.env['stock.move'].create({
+        cls.move2 = cls.env['stock.move'].create({
             'name': 'test_out_1',
-            'location_id': self.wh.lot_stock_id.id,
-            'location_dest_id': self.customer_location.id,
-            'product_id': self.product1.id,
-            'product_uom': self.uom_unit.id,
+            'location_id': cls.wh.lot_stock_id.id,
+            'location_dest_id': cls.customer_location.id,
+            'product_id': cls.product1.id,
+            'product_uom': cls.uom_unit.id,
             'product_uom_qty': 120.0,
             'state': 'partially_available',
             'date': fields.Datetime.add(fields.Datetime.now(), days=3),
             'date_deadline': fields.Datetime.add(fields.Datetime.now(), days=3),
         })
-        self.env['base'].flush()
 
     def test_report_stock_quantity(self):
         from_date = fields.Date.to_string(fields.Date.add(fields.Date.today(), days=-1))

--- a/addons/stock/tests/test_report_tours.py
+++ b/addons/stock/tests/test_report_tours.py
@@ -5,12 +5,9 @@ from odoo.tests import Form, HttpCase, tagged
 
 @tagged('-at_install', 'post_install')
 class TestStockReportTour(HttpCase):
-    def setUp(self):
-        super().setUp()
 
     def _get_report_url(self):
         return '/web#&model=product.template&action=stock.product_template_action_product'
-
 
     def test_stock_route_diagram_report(self):
         """ Open the route diagram report."""

--- a/addons/stock/tests/test_stock_flow.py
+++ b/addons/stock/tests/test_stock_flow.py
@@ -7,8 +7,9 @@ from odoo import fields
 
 
 class TestStockFlow(TestStockCommon):
-    def setUp(cls):
-        super(TestStockFlow, cls).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         decimal_product_uom = cls.env.ref('product.decimal_product_uom')
         decimal_product_uom.digits = 3
         cls.partner_company2 = cls.env['res.partner'].create({

--- a/addons/stock/tests/test_stock_location_search.py
+++ b/addons/stock/tests/test_stock_location_search.py
@@ -4,18 +4,19 @@ from odoo.tests import common
 
 
 class TestStockLocationSearch(common.TransactionCase):
-    def setUp(self):
-        super(TestStockLocationSearch, self).setUp()
-        self.location = self.env['stock.location']
-        self.stock_location = self.env.ref('stock.stock_location_stock')
-        self.sublocation = self.env['stock.location'].create({
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.location = cls.env['stock.location']
+        cls.stock_location = cls.env.ref('stock.stock_location_stock')
+        cls.sublocation = cls.env['stock.location'].create({
             'name': 'Shelf 2',
             'barcode': 1201985,
-            'location_id': self.stock_location.id
+            'location_id': cls.stock_location.id
         })
-        self.location_barcode_id = self.sublocation.id
-        self.barcode = self.sublocation.barcode
-        self.name = self.sublocation.name
+        cls.location_barcode_id = cls.sublocation.id
+        cls.barcode = cls.sublocation.barcode
+        cls.name = cls.sublocation.name
 
     def test_10_location_search_by_barcode(self):
         """Search stock location by barcode"""

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -8,9 +8,10 @@ from odoo.tools import mute_logger
 
 class TestWarehouse(TestStockCommon):
 
-    def setUp(self):
-        super(TestWarehouse, self).setUp()
-        self.partner = self.env['res.partner'].create({'name': 'Deco Addict'})
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env['res.partner'].create({'name': 'Deco Addict'})
 
     def test_inventory_product(self):
         self.product_1.type = 'product'

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -129,10 +129,11 @@ class TestStockValuationCommon(TransactionCase):
 
 
 class TestStockValuationStandard(TestStockValuationCommon):
-    def setUp(self):
-        super(TestStockValuationStandard, self).setUp()
-        self.product1.product_tmpl_id.categ_id.property_cost_method = 'standard'
-        self.product1.product_tmpl_id.standard_price = 10
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product1.product_tmpl_id.categ_id.property_cost_method = 'standard'
+        cls.product1.product_tmpl_id.standard_price = 10
 
     def test_normal_1(self):
         self.product1.product_tmpl_id.categ_id.property_valuation = 'manual_periodic'
@@ -302,9 +303,10 @@ class TestStockValuationStandard(TestStockValuationCommon):
 
 
 class TestStockValuationAVCO(TestStockValuationCommon):
-    def setUp(self):
-        super(TestStockValuationAVCO, self).setUp()
-        self.product1.product_tmpl_id.categ_id.property_cost_method = 'average'
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product1.product_tmpl_id.categ_id.property_cost_method = 'average'
 
     def test_normal_1(self):
         self.product1.product_tmpl_id.categ_id.property_valuation = 'manual_periodic'
@@ -518,9 +520,10 @@ class TestStockValuationAVCO(TestStockValuationCommon):
 
 
 class TestStockValuationFIFO(TestStockValuationCommon):
-    def setUp(self):
-        super(TestStockValuationFIFO, self).setUp()
-        self.product1.product_tmpl_id.categ_id.property_cost_method = 'fifo'
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product1.product_tmpl_id.categ_id.property_cost_method = 'fifo'
 
     def test_normal_1(self):
         self.product1.product_tmpl_id.categ_id.property_valuation = 'manual_periodic'

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -11,44 +11,45 @@ from odoo.tests import tagged, Form
 @tagged('post_install', '-at_install')
 class TestLandedCosts(TestStockLandedCostsCommon):
 
-    def setUp(self):
-        super(TestLandedCosts, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         # Create picking incoming shipment
-        self.picking_in = self.Picking.create({
-            'partner_id': self.supplier_id,
-            'picking_type_id': self.warehouse.in_type_id.id,
-            'location_id': self.supplier_location_id,
-            'location_dest_id': self.warehouse.lot_stock_id.id})
-        self.Move.create({
-            'name': self.product_refrigerator.name,
-            'product_id': self.product_refrigerator.id,
+        cls.picking_in = cls.Picking.create({
+            'partner_id': cls.supplier_id,
+            'picking_type_id': cls.warehouse.in_type_id.id,
+            'location_id': cls.supplier_location_id,
+            'location_dest_id': cls.warehouse.lot_stock_id.id})
+        cls.Move.create({
+            'name': cls.product_refrigerator.name,
+            'product_id': cls.product_refrigerator.id,
             'product_uom_qty': 5,
-            'product_uom': self.product_refrigerator.uom_id.id,
-            'picking_id': self.picking_in.id,
-            'location_id': self.supplier_location_id,
-            'location_dest_id': self.warehouse.lot_stock_id.id})
-        self.Move.create({
-            'name': self.product_oven.name,
-            'product_id': self.product_oven.id,
+            'product_uom': cls.product_refrigerator.uom_id.id,
+            'picking_id': cls.picking_in.id,
+            'location_id': cls.supplier_location_id,
+            'location_dest_id': cls.warehouse.lot_stock_id.id})
+        cls.Move.create({
+            'name': cls.product_oven.name,
+            'product_id': cls.product_oven.id,
             'product_uom_qty': 10,
-            'product_uom': self.product_oven.uom_id.id,
-            'picking_id': self.picking_in.id,
-            'location_id': self.supplier_location_id,
-            'location_dest_id': self.warehouse.lot_stock_id.id})
+            'product_uom': cls.product_oven.uom_id.id,
+            'picking_id': cls.picking_in.id,
+            'location_id': cls.supplier_location_id,
+            'location_dest_id': cls.warehouse.lot_stock_id.id})
         # Create picking outgoing shipment
-        self.picking_out = self.Picking.create({
-            'partner_id': self.customer_id,
-            'picking_type_id': self.warehouse.out_type_id.id,
-            'location_id': self.warehouse.lot_stock_id.id,
-            'location_dest_id': self.customer_location_id})
-        self.Move.create({
-            'name': self.product_refrigerator.name,
-            'product_id': self.product_refrigerator.id,
+        cls.picking_out = cls.Picking.create({
+            'partner_id': cls.customer_id,
+            'picking_type_id': cls.warehouse.out_type_id.id,
+            'location_id': cls.warehouse.lot_stock_id.id,
+            'location_dest_id': cls.customer_location_id})
+        cls.Move.create({
+            'name': cls.product_refrigerator.name,
+            'product_id': cls.product_refrigerator.id,
             'product_uom_qty': 2,
-            'product_uom': self.product_refrigerator.uom_id.id,
-            'picking_id': self.picking_out.id,
-            'location_id': self.warehouse.lot_stock_id.id,
-            'location_dest_id': self.customer_location_id})
+            'product_uom': cls.product_refrigerator.uom_id.id,
+            'picking_id': cls.picking_out.id,
+            'location_id': cls.warehouse.lot_stock_id.id,
+            'location_dest_id': cls.customer_location_id})
 
     def test_00_landed_costs_on_incoming_shipment(self):
         """ Test landed cost on incoming shipment """

--- a/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
+++ b/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
@@ -137,10 +137,11 @@ class TestStockValuationLCCommon(TestStockLandedCostsCommon):
 
 @tagged('-at_install', 'post_install')
 class TestStockValuationLCFIFO(TestStockValuationLCCommon):
-    def setUp(self):
-        super(TestStockValuationLCFIFO, self).setUp()
-        self.product1.product_tmpl_id.categ_id.property_cost_method = 'fifo'
-        self.product1.product_tmpl_id.categ_id.property_valuation = 'real_time'
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product1.product_tmpl_id.categ_id.property_cost_method = 'fifo'
+        cls.product1.product_tmpl_id.categ_id.property_valuation = 'real_time'
 
     def test_normal_1(self):
         move1 = self._make_in_move(self.product1, 10, unit_cost=10, create_picking=True)
@@ -253,10 +254,11 @@ class TestStockValuationLCFIFO(TestStockValuationLCCommon):
 
 @tagged('-at_install', 'post_install')
 class TestStockValuationLCAVCO(TestStockValuationLCCommon):
-    def setUp(self):
-        super(TestStockValuationLCAVCO, self).setUp()
-        self.product1.product_tmpl_id.categ_id.property_cost_method = 'average'
-        self.product1.product_tmpl_id.categ_id.property_valuation = 'real_time'
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product1.product_tmpl_id.categ_id.property_cost_method = 'average'
+        cls.product1.product_tmpl_id.categ_id.property_valuation = 'real_time'
 
     def test_normal_1(self):
         move1 = self._make_in_move(self.product1, 10, unit_cost=10, create_picking=True)

--- a/addons/stock_picking_batch/tests/test_batch_picking.py
+++ b/addons/stock_picking_batch/tests/test_batch_picking.py
@@ -10,79 +10,80 @@ from odoo.tests.common import TransactionCase
 
 class TestBatchPicking(TransactionCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """ Create a picking batch with two pickings from stock to customer """
-        super(TestBatchPicking, self).setUp()
-        self.stock_location = self.env.ref('stock.stock_location_stock')
-        self.customer_location = self.env.ref('stock.stock_location_customers')
-        self.picking_type_out = self.env['ir.model.data']._xmlid_to_res_id('stock.picking_type_out')
-        self.env['stock.picking.type'].browse(self.picking_type_out).reservation_method = 'manual'
-        self.productA = self.env['product.product'].create({
+        super().setUpClass()
+        cls.stock_location = cls.env.ref('stock.stock_location_stock')
+        cls.customer_location = cls.env.ref('stock.stock_location_customers')
+        cls.picking_type_out = cls.env['ir.model.data']._xmlid_to_res_id('stock.picking_type_out')
+        cls.env['stock.picking.type'].browse(cls.picking_type_out).reservation_method = 'manual'
+        cls.productA = cls.env['product.product'].create({
             'name': 'Product A',
             'type': 'product',
-            'categ_id': self.env.ref('product.product_category_all').id,
+            'categ_id': cls.env.ref('product.product_category_all').id,
         })
-        self.productB = self.env['product.product'].create({
+        cls.productB = cls.env['product.product'].create({
             'name': 'Product B',
             'type': 'product',
-            'categ_id': self.env.ref('product.product_category_all').id,
+            'categ_id': cls.env.ref('product.product_category_all').id,
         })
 
-        self.picking_client_1 = self.env['stock.picking'].create({
-            'location_id': self.stock_location.id,
-            'location_dest_id': self.customer_location.id,
-            'picking_type_id': self.picking_type_out,
-            'company_id': self.env.company.id,
+        cls.picking_client_1 = cls.env['stock.picking'].create({
+            'location_id': cls.stock_location.id,
+            'location_dest_id': cls.customer_location.id,
+            'picking_type_id': cls.picking_type_out,
+            'company_id': cls.env.company.id,
         })
 
-        self.env['stock.move'].create({
-            'name': self.productA.name,
-            'product_id': self.productA.id,
+        cls.env['stock.move'].create({
+            'name': cls.productA.name,
+            'product_id': cls.productA.id,
             'product_uom_qty': 10,
-            'product_uom': self.productA.uom_id.id,
-            'picking_id': self.picking_client_1.id,
-            'location_id': self.stock_location.id,
-            'location_dest_id': self.customer_location.id,
+            'product_uom': cls.productA.uom_id.id,
+            'picking_id': cls.picking_client_1.id,
+            'location_id': cls.stock_location.id,
+            'location_dest_id': cls.customer_location.id,
         })
 
-        self.picking_client_2 = self.env['stock.picking'].create({
-            'location_id': self.stock_location.id,
-            'location_dest_id': self.customer_location.id,
-            'picking_type_id': self.picking_type_out,
-            'company_id': self.env.company.id,
+        cls.picking_client_2 = cls.env['stock.picking'].create({
+            'location_id': cls.stock_location.id,
+            'location_dest_id': cls.customer_location.id,
+            'picking_type_id': cls.picking_type_out,
+            'company_id': cls.env.company.id,
         })
 
-        self.env['stock.move'].create({
-            'name': self.productB.name,
-            'product_id': self.productB.id,
+        cls.env['stock.move'].create({
+            'name': cls.productB.name,
+            'product_id': cls.productB.id,
             'product_uom_qty': 10,
-            'product_uom': self.productA.uom_id.id,
-            'picking_id': self.picking_client_2.id,
-            'location_id': self.stock_location.id,
-            'location_dest_id': self.customer_location.id,
+            'product_uom': cls.productA.uom_id.id,
+            'picking_id': cls.picking_client_2.id,
+            'location_id': cls.stock_location.id,
+            'location_dest_id': cls.customer_location.id,
         })
 
-        self.picking_client_3 = self.env['stock.picking'].create({
-            'location_id': self.stock_location.id,
-            'location_dest_id': self.customer_location.id,
-            'picking_type_id': self.picking_type_out,
-            'company_id': self.env.company.id,
+        cls.picking_client_3 = cls.env['stock.picking'].create({
+            'location_id': cls.stock_location.id,
+            'location_dest_id': cls.customer_location.id,
+            'picking_type_id': cls.picking_type_out,
+            'company_id': cls.env.company.id,
         })
 
-        self.env['stock.move'].create({
-            'name': self.productB.name,
-            'product_id': self.productB.id,
+        cls.env['stock.move'].create({
+            'name': cls.productB.name,
+            'product_id': cls.productB.id,
             'product_uom_qty': 10,
-            'product_uom': self.productA.uom_id.id,
-            'picking_id': self.picking_client_3.id,
-            'location_id': self.stock_location.id,
-            'location_dest_id': self.customer_location.id,
+            'product_uom': cls.productA.uom_id.id,
+            'picking_id': cls.picking_client_3.id,
+            'location_id': cls.stock_location.id,
+            'location_dest_id': cls.customer_location.id,
         })
 
-        self.batch = self.env['stock.picking.batch'].create({
+        cls.batch = cls.env['stock.picking.batch'].create({
             'name': 'Batch 1',
-            'company_id': self.env.company.id,
-            'picking_ids': [(4, self.picking_client_1.id), (4, self.picking_client_2.id)]
+            'company_id': cls.env.company.id,
+            'picking_ids': [(4, cls.picking_client_1.id), (4, cls.picking_client_2.id)]
         })
 
     def test_batch_scheduled_date(self):


### PR DESCRIPTION
In a lot of test class, we use `setUp` instead of
`setUpClass`. `setUp` is execute for each test method and `setUpClass`
will be execute only once by Class (and use savepoint + rollback).

Then change setUp into setUpClass reduce the time to make all tests
and avoid to repeat this error for the future.

https://github.com/odoo/enterprise/pull/21563