### PR TITLE
[FIX] mail: use computed search field

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1063,7 +1063,7 @@ class Message(models.Model):
                 ('res_id', 'in', moderated_channel_ids),
                 '|',
                 ('author_id', '=', self.env.user.partner_id.id),
-                ('moderation_status', '=', 'pending_moderation'),
+                ('need_moderation', '=', True),
             ]
             messages |= self.search(moderated_messages_dom, limit=limit)
             # Truncate the results to `limit`


### PR DESCRIPTION
The compute does a more than searching on the moderation_status
Before this commit, one could see the messages pending moderation from
other people.
Introduced at c2918c139b8f1026b5
