### PR TITLE
[FIX] stock : Product Search in stock picking consistent with general…

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -412,7 +412,7 @@
                     <field name="name" string="Transfer" filter_domain="['|', ('name', 'ilike', self), ('origin', 'ilike', self)]"/>
                     <field name="partner_id" filter_domain="[('partner_id', 'child_of', self)]"/>
                     <field name="origin"/>
-                    <field name="product_id"/>
+                    <field name="product_id" filter_domain="['|', '|', ('product_id.default_code', 'ilike', self), ('product_id.name', 'ilike', self), ('product_id.barcode', 'ilike', self)]"/>
                     <field name="picking_type_id"/>
                     <filter name="my_transfers" string="My Transfers" domain="[('user_id', '=', uid)]"/>
                     <separator/>


### PR DESCRIPTION
… product search

Current situation in stock picking :
Variant 1 : 'SoMething'
Variant 2 : 'SomethingElse'
Searching for 'SoMething' -> one result
Searching for 'Something' -> two results

Situation in generic product search :
Variant 1 : 'SoMething'
Variant 2 : 'SomethingElse'
Searching for 'SoMething' -> two results
Searching for 'Something' -> two results

The fix make the product search in stock picking more consistent with the rest of Odoo.

opw-2646214

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
