### PR TITLE
[FIX] account: unposted move not proposed for reconciliation

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -516,7 +516,7 @@ class AccountReconcileModel(models.Model):
             LEFT JOIN res_company company           ON company.id = st_line.company_id
             LEFT JOIN partners_table line_partner   ON line_partner.line_id = st_line.id
             , account_move_line aml
-            LEFT JOIN account_move move             ON move.id = aml.move_id AND move.state = 'posted'
+            LEFT JOIN account_move move             ON move.id = aml.move_id
             LEFT JOIN account_account account       ON account.id = aml.account_id
             WHERE st_line.id IN %s
                 AND aml.company_id = st_line.company_id


### PR DESCRIPTION
1. Have Bank journal with 'Post At' is set to 'Bank Reconciliation'
2. Create and validate a bill with reference and register a payment.
3. For said payment create a bank statement line.
4. Be sure to have other posted account.move.line's with a similar
reference so they could be considered for this payment (if that's not
the case reconcile will work but only because it will fall back to
checking any move lines for the partner with matching amount regardless
of the reference).
5. Try to reconcile.

The proper move line of the payment will not be selected. This occure
because it's not correctly detected the communication flag of the draft
move, thus not giving the correct priority.

opw-2657393

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
