### PR TITLE
[FIX] web: control_panel view switcher wrap

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.scss
+++ b/addons/web/static/src/search/control_panel/control_panel.scss
@@ -69,6 +69,9 @@
 
     .o_cp_bottom_right {
         display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        column-gap: $o-horizontal-padding;
 
         > .o_cp_pager {
             margin: auto 0 auto auto;
@@ -87,12 +90,6 @@
         }
 
         > .o_cp_switch_buttons {
-            > .btn:first-child {
-                margin-left: $o-horizontal-padding;
-                @include media-breakpoint-down(sm) {
-                    margin-left: 0;
-                }
-            }
             .dropdown-menu {
                 right: 0;
             }


### PR DESCRIPTION
Before this commit, when the view switcher contained too many elements
(e.g.: CRM), in desktop mode but with a relatively small screen size
(i.e.: width ~< 1300px), the buttons of the view switcher went outside of the screen.

After this commit, the whole view switcher block is rejected on a new line.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
