### PR TITLE
Using https in oauth redirect_uri

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -57,7 +57,7 @@ class OAuthLogin(Home):
         except Exception:
             providers = []
         for provider in providers:
-            return_url = request.httprequest.url_root + 'auth_oauth/signin'
+            return_url = request.env['ir.config_parameter'].sudo().get_param('web.base.url') + '/auth_oauth/signin'
             state = self.get_state(provider)
             params = dict(
                 response_type='token',

--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -18,6 +18,7 @@ from odoo import registry as registry_get
 from odoo.addons.auth_signup.controllers.main import AuthSignupHome as Home
 from odoo.addons.web.controllers.main import db_monodb, ensure_db, set_cookie_and_redirect, login_and_redirect
 
+from urllib.parse import urljoin
 
 _logger = logging.getLogger(__name__)
 
@@ -57,7 +58,8 @@ class OAuthLogin(Home):
         except Exception:
             providers = []
         for provider in providers:
-            return_url = request.env['ir.config_parameter'].sudo().get_param('web.base.url') + '/auth_oauth/signin'
+            base_url = request.env['ir.config_parameter'].sudo().get_param('web.base.url', request.httprequest.url_root)
+            return_url = urljoin(base_url, 'auth_oauth/signin')
             state = self.get_state(provider)
             params = dict(
                 response_type='token',

--- a/doc/cla/individual/jcardus.md
+++ b/doc/cla/individual/jcardus.md
@@ -1,0 +1,11 @@
+Portugal, 2021-10-4
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Joaquim Cardeira asklocation.net@gmail.com https://github.com/jcardus


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
For the redirect_uri, Amazon Cognito requires HTTPS over HTTP except for http://localhost for testing purposes only.

https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html

I didn't manage go get https on the redirect_uri when behind a load balancer. I also tried with proxy_mode. This way at least we can configure it manually

Current behavior before PR:
oauth with AWS Cognito doesn't work

Desired behavior after PR is merged:
oauth with AWS Cognito works






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
