### PR TITLE
Fix LINUX  requirements.txt error failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,11 @@ freezegun==0.3.11; python_version < '3.8'
 freezegun==0.3.15; python_version >= '3.8'
 gevent==1.1.2 ; sys_platform != 'win32' and python_version < '3.7'
 gevent==1.5.0 ; python_version == '3.7'
-gevent==20.9.0 ; python_version >= '3.8'
+gevent==21.8.0 ; python_version >= '3.8'
 gevent==1.4.0 ; sys_platform == 'win32' and python_version < '3.7'
 greenlet==0.4.10 ; python_version < '3.7'
 greenlet==0.4.15 ; python_version == '3.7'
-greenlet==0.4.17 ; python_version > '3.7'
+greenlet==1.1.2 ; python_version > '3.7'
 html2text==2018.1.9
 idna==2.6
 Jinja2==2.10.1; python_version < '3.8'


### PR DESCRIPTION
Fix LINUX source installation pip3 install -r requirements.txt error failure 。
修复LINUX 源码安装pip3 install -r requirements.txt 错误失败。

Description of the issue/feature this PR addresses:https://github.com/odoo/odoo/issues/78020


Desired behavior after PR is merged:

[LOG.txt](https://github.com/odoo/odoo/files/7316002/LOG.txt)
![截图_选择区域_20211010003201](https://user-images.githubusercontent.com/28694676/136666856-94465502-7925-4bd7-83c5-3bf45eeff3a4.png)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
