### PR TITLE
Failed to fix LINUX Python>3.9.7 requirements.txt error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,11 @@ freezegun==0.3.11; python_version < '3.8'
 freezegun==0.3.15; python_version >= '3.8'
 gevent==1.1.2 ; sys_platform != 'win32' and python_version < '3.7'
 gevent==1.5.0 ; python_version == '3.7'
-gevent==20.9.0 ; python_version >= '3.8'
+gevent==21.8.0 ; python_version >= '3.8'
 gevent==1.4.0 ; sys_platform == 'win32' and python_version < '3.7'
 greenlet==0.4.10 ; python_version < '3.7'
 greenlet==0.4.15 ; python_version == '3.7'
-greenlet==0.4.17 ; python_version > '3.7'
+greenlet==1.1.2 ; python_version > '3.7'
 html2text==2018.1.9
 idna==2.6
 Jinja2==2.10.1; python_version < '3.8'


### PR DESCRIPTION
Failed to fix LINUX Python>3.9.7 requirements.txt error
修复 LINUX  Python>3.9.7 requirements.txt 错误失败

Description of the issue/feature this PR addresses:https://github.com/odoo/odoo/issues/78020



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
