### PR TITLE
[FIX] stock: remove upgrade_boolean from wave group

### DIFF
--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -35,7 +35,7 @@
                                         Process transfers in batch per worker
                                     </div>
                                     <div class="row mt-2" attrs="{'invisible': [('module_stock_picking_batch','=',False)]}">
-                                        <field name="group_stock_picking_wave" widget="upgrade_boolean" class="col-lg-1 ml16 mr0"/>
+                                        <field name="group_stock_picking_wave" class="col-lg-1 ml16 mr0"/>
                                         <div class="col pl-0">
                                             <label for="group_stock_picking_wave"/>
                                             <div class="text-muted">Process operations in wave transfers</div>


### PR DESCRIPTION
Process operations in wave transfers exists in community edition.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
