### PR TITLE
[FIX] project: last_update_id should not be copied

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -308,7 +308,7 @@ class Project(models.Model):
         tracking=True, index=True, copy=False, default=_default_stage_id, group_expand='_read_group_stage_ids')
 
     update_ids = fields.One2many('project.update', 'project_id')
-    last_update_id = fields.Many2one('project.update', string='Last Update')
+    last_update_id = fields.Many2one('project.update', string='Last Update', copy=False)
     last_update_status = fields.Selection(selection=[
         ('on_track', 'On Track'),
         ('at_risk', 'At Risk'),


### PR DESCRIPTION
Fields `last_update_id` should not be copied while copying Project.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
