### PR TITLE
shipping connectors improvements vst

### DIFF
--- a/addons/delivery/__manifest__.py
+++ b/addons/delivery/__manifest__.py
@@ -29,6 +29,7 @@ invoices from picking, the system is able to add and compute the shipping line.
         'wizard/choose_delivery_package_views.xml',
         'wizard/choose_delivery_carrier_views.xml',
         'views/stock_package_type_views.xml',
+        'views/stock_picking_views.xml',
     ],
     'demo': ['data/delivery_demo.xml'],
     'installable': True,

--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -90,8 +90,6 @@ class StockPicking(models.Model):
     is_return_picking = fields.Boolean(compute='_compute_return_picking')
     return_label_ids = fields.One2many('ir.attachment', compute='_compute_return_label')
     destination_country_code = fields.Char(related='partner_id.country_id.code', string="Destination Country")
-    shipment_description = fields.Char(string='Shipment Description', compute='_compute_description', readonly=False)
-    shipment_declared_value = fields.Float(string='Declared Value', compute='_compute_declared_value', readonly=False)
 
     @api.depends('carrier_id', 'carrier_tracking_ref')
     def _compute_carrier_tracking_url(self):
@@ -112,14 +110,6 @@ class StockPicking(models.Model):
                 picking.return_label_ids = self.env['ir.attachment'].search([('res_model', '=', 'stock.picking'), ('res_id', '=', picking.id), ('name', 'like', '%s%%' % picking.carrier_id.get_return_label_prefix())])
             else:
                 picking.return_label_ids = False
-
-    def _compute_description(self):
-        for rec in self:
-            rec.shipment_description = rec.sale_id.order_line.product_id[0].categ_id.name if rec.sale_id else ""
-
-    def _compute_declared_value(self):
-        for rec in self:
-            rec.shipment_declared_value = rec.sale_id.amount_total if rec.sale_id else 0.0
 
     def get_multiple_carrier_tracking(self):
         self.ensure_one()

--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -90,6 +90,8 @@ class StockPicking(models.Model):
     is_return_picking = fields.Boolean(compute='_compute_return_picking')
     return_label_ids = fields.One2many('ir.attachment', compute='_compute_return_label')
     destination_country_code = fields.Char(related='partner_id.country_id.code', string="Destination Country")
+    shipment_description = fields.Char(string='Shipment Description', compute='_compute_description', readonly=False)
+    shipment_declared_value = fields.Float(string='Declared Value', compute='_compute_declared_value', readonly=False)
 
     @api.depends('carrier_id', 'carrier_tracking_ref')
     def _compute_carrier_tracking_url(self):
@@ -110,6 +112,14 @@ class StockPicking(models.Model):
                 picking.return_label_ids = self.env['ir.attachment'].search([('res_model', '=', 'stock.picking'), ('res_id', '=', picking.id), ('name', 'like', '%s%%' % picking.carrier_id.get_return_label_prefix())])
             else:
                 picking.return_label_ids = False
+
+    def _compute_description(self):
+        for rec in self:
+            rec.shipment_description = self.sale_id.order_line.product_id[0].categ_id.name if self.sale_id else ""
+
+    def _compute_declared_value(self):
+        for rec in self:
+            rec.shipment_declared_value = self.sale_id.amount_total if self.sale_id else 0.0
 
     def get_multiple_carrier_tracking(self):
         self.ensure_one()

--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -115,11 +115,11 @@ class StockPicking(models.Model):
 
     def _compute_description(self):
         for rec in self:
-            rec.shipment_description = self.sale_id.order_line.product_id[0].categ_id.name if self.sale_id else ""
+            rec.shipment_description = rec.sale_id.order_line.product_id[0].categ_id.name if rec.sale_id else ""
 
     def _compute_declared_value(self):
         for rec in self:
-            rec.shipment_declared_value = self.sale_id.amount_total if self.sale_id else 0.0
+            rec.shipment_declared_value = rec.sale_id.amount_total if rec.sale_id else 0.0
 
     def get_multiple_carrier_tracking(self):
         self.ensure_one()

--- a/addons/delivery/views/delivery_view.xml
+++ b/addons/delivery/views/delivery_view.xml
@@ -213,6 +213,9 @@
                     <group name='carrier_data' string="Shipping Information">
                         <field name="is_return_picking" invisible="1"/>
                         <field name="carrier_id" attrs="{'readonly': [('state', 'in', ('done', 'cancel'))]}" options="{'no_create': True, 'no_open': True}"/>
+                        <field name="shipment_description"/>
+                        <field name="declared_value"/>
+                        <field name="company_currency_id" invisible="1"/>
                         <field name="delivery_type" attrs="{'invisible':True}"/>
                         <label for="carrier_tracking_ref"/>
                         <div name="tracking">
@@ -267,6 +270,7 @@
                 <xpath expr="//field[@name='picking_partner_id']" position="after">
                     <field name="destination_country_code" optional="hide"/>
                     <field name="carrier_id" optional="hide"/>
+
                 </xpath>
             </field>
         </record>

--- a/addons/delivery/views/delivery_view.xml
+++ b/addons/delivery/views/delivery_view.xml
@@ -213,6 +213,8 @@
                     <group name='carrier_data' string="Shipping Information">
                         <field name="is_return_picking" invisible="1"/>
                         <field name="carrier_id" attrs="{'readonly': [('state', 'in', ('done', 'cancel'))]}" options="{'no_create': True, 'no_open': True}"/>
+                        <field name="shipment_declared_value"/>
+                        <field name="shipment_description"/>
                         <field name="delivery_type" attrs="{'invisible':True}"/>
                         <label for="carrier_tracking_ref"/>
                         <div name="tracking">

--- a/addons/delivery/views/delivery_view.xml
+++ b/addons/delivery/views/delivery_view.xml
@@ -213,8 +213,6 @@
                     <group name='carrier_data' string="Shipping Information">
                         <field name="is_return_picking" invisible="1"/>
                         <field name="carrier_id" attrs="{'readonly': [('state', 'in', ('done', 'cancel'))]}" options="{'no_create': True, 'no_open': True}"/>
-                        <field name="shipment_declared_value"/>
-                        <field name="shipment_description"/>
                         <field name="delivery_type" attrs="{'invisible':True}"/>
                         <label for="carrier_tracking_ref"/>
                         <div name="tracking">

--- a/addons/delivery/views/stock_picking_views.xml
+++ b/addons/delivery/views/stock_picking_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="view_picking_form_delivery">
+        <field name="name">stock.picking.delivery</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form"/>
+        <field name="arch" type="xml">
+        <xpath expr='//page[@name="operations"]/field[@name="move_ids_without_package"]/tree' position="inside">
+            <field name="sale_price" />
+        </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -389,6 +389,7 @@ class Picking(models.Model):
         ('available', 'Available'),
         ('expected', 'Expected'),
         ('late', 'Late')], compute='_compute_products_availability')
+    
     _sql_constraints = [
         ('name_uniq', 'unique(name, company_id)', 'Reference must be unique per company!'),
     ]

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -389,7 +389,7 @@ class Picking(models.Model):
         ('available', 'Available'),
         ('expected', 'Expected'),
         ('late', 'Late')], compute='_compute_products_availability')
-    
+
     _sql_constraints = [
         ('name_uniq', 'unique(name, company_id)', 'Reference must be unique per company!'),
     ]

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -389,9 +389,6 @@ class Picking(models.Model):
         ('available', 'Available'),
         ('expected', 'Expected'),
         ('late', 'Late')], compute='_compute_products_availability')
-    company_currency_id = fields.Many2one(string='Company Currency', readonly=True, related='company_id.currency_id')
-    declared_value = fields.Monetary(compute="_compute_declared_value", string="Declared Value", currency_field='company_currency_id')
-    shipment_description = fields.Char(string='Shipment Description', compute='_compute_shipment_description', readonly=False)
     _sql_constraints = [
         ('name_uniq', 'unique(name, company_id)', 'Reference must be unique per company!'),
     ]
@@ -606,18 +603,6 @@ class Picking(models.Model):
                 picking.show_validate = False
             else:
                 picking.show_validate = True
-
-    @api.depends('declared_value')
-    def _compute_declared_value(self):
-        for picking in self:
-            picking.declared_value = sum([move_line.sale_price for move_line in picking.move_line_ids])
-
-    @api.depends('shipment_description')
-    def _compute_shipment_description(self):
-        for picking in self:
-            if picking.move_lines:
-                picking.shipment_description = picking.move_lines[0].product_id.categ_id.name
-
 
     @api.model
     def _search_delay_alert_date(self, operator, value):

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -446,6 +446,9 @@
                                     <field name="user_id" domain="[('share', '=', False)]"/>
                                     <field name="group_id" groups="base.group_no_one"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" force_save="1"/>
+                                    <field name="shipment_description"/>
+                                    <field name="declared_value"/>
+                                    <field name="company_currency_id" invisible="1"/>
                                 </group>
                             </group>
                         </page>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -446,9 +446,6 @@
                                     <field name="user_id" domain="[('share', '=', False)]"/>
                                     <field name="group_id" groups="base.group_no_one"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" force_save="1"/>
-                                    <field name="shipment_description"/>
-                                    <field name="declared_value"/>
-                                    <field name="company_currency_id" invisible="1"/>
                                 </group>
                             </group>
                         </page>


### PR DESCRIPTION
In this commit:
========================
Added two new fields in stock picking related to shipping

`shipment_description`
`shipment_declared_value`

Before this commit:
========================
- The value of shipment description was static `MY DESCRIPTION` 
in delivery_dhl module which might be rejected by customs so we added field to set the
- Now description value default by taking the category name of the first product from the sale order line.
- Added field `sale_price` in stock move  and the  sum of this `sale_price` field will be calculated as the declared value of the shipment
- Convert `sale_price` in a stock.move.line to a store field

task-id: 2611210