### PR TITLE
[FIX] core: env creation broken because of missing cr.transaction

### DIFF
--- a/doc/cla/individual/Albin-John.md
+++ b/doc/cla/individual/Albin-John.md
@@ -1,0 +1,11 @@
+India, 2021-10-09
+￼
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+￼
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+￼
+Signed,
+￼
+Albin John albin_john@tutamail.com https://github.com/Albin-John

--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -62,7 +62,7 @@ def _initialize_db(id, db_name, demo, lang, user_password, login='admin', countr
 
         registry = odoo.modules.registry.Registry.new(db_name, demo, None, update_module=True)
 
-        with closing(db.cursor()) as cr:
+        with closing(registry.cursor()) as cr:
             env = odoo.api.Environment(cr, SUPERUSER_ID, {})
 
             if lang:


### PR DESCRIPTION
A cursor created by a Connection object is not expected to be used with
environments; use registry.cursor() instead.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
