### PR TITLE
[REF] hr*: misc cleanup

### DIFF
--- a/addons/hr/__manifest__.py
+++ b/addons/hr/__manifest__.py
@@ -67,9 +67,6 @@
             'hr/static/tests/m2x_avatar_employee_tests.js',
             'hr/static/tests/standalone_m2o_avatar_employee_tests.js',
         ],
-        'web.assets_qweb': [
-            'hr/static/src/xml/hr_templates.xml',
-        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/hr/static/src/xml/hr_templates.xml
+++ b/addons/hr/static/src/xml/hr_templates.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<template xml:space="preserve">
-    <!-- TODO remove in master -->
-</template>

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -73,8 +73,6 @@ class HrExpense(models.Model):
     tax_ids = fields.Many2many('account.tax', 'expense_tax', 'expense_id', 'tax_id',
         compute='_compute_from_product_id_company_id', store=True, readonly=False,
         domain="[('company_id', '=', company_id), ('type_tax_use', '=', 'purchase')]", string='Taxes')
-    # TODO SGV can be removed
-    untaxed_amount = fields.Float("Subtotal", store=True, compute='_compute_amount', digits='Account')
     amount_residual = fields.Monetary(string='Amount Due', compute='_compute_amount_residual')
     total_amount = fields.Monetary("Amount paid", compute='_compute_amount', store=True, currency_field='currency_id', tracking=True, readonly=False)
     company_currency_id = fields.Many2one('res.currency', string="Report Company Currency", related='company_id.currency_id', readonly=True)
@@ -152,7 +150,6 @@ class HrExpense(models.Model):
     @api.depends('quantity', 'unit_amount', 'tax_ids', 'currency_id')
     def _compute_amount(self):
         for expense in self:
-            expense.untaxed_amount = expense.unit_amount * expense.quantity
             taxes = expense.tax_ids.compute_all(expense.unit_amount, expense.currency_id, expense.quantity, expense.product_id, expense.employee_id.user_id.partner_id)
             expense.total_amount = taxes.get('total_included')
 

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -68,10 +68,9 @@ class HolidaysType(models.Model):
     virtual_leaves_taken = fields.Float(
         compute='_compute_leaves', string='Virtual Time Off Already Taken',
         help='Sum of validated and non validated time off requests.')
-    # KBA TODO in master: rename, change to int
     closest_allocation_to_expire = fields.Many2one('hr.leave.allocation', 'Allocation', compute='_compute_leaves')
-    group_days_allocation = fields.Float(
-        compute='_compute_group_days_allocation', string='Days Allocated')
+    allocation_count = fields.Integer(
+        compute='_compute_allocation_count', string='Allocations')
     group_days_leave = fields.Float(
         compute='_compute_group_days_leave', string='Group Time Off')
     company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company)
@@ -339,7 +338,7 @@ class HolidaysType(models.Model):
             holiday_status.virtual_leaves_taken = result.get('virtual_leaves_taken', 0)
             holiday_status.closest_allocation_to_expire = result.get('closest_allocation_to_expire', 0)
 
-    def _compute_group_days_allocation(self):
+    def _compute_allocation_count(self):
         date_from = fields.Datetime.to_string(datetime.datetime.now().replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0))
         domain = [
             ('holiday_status_id', 'in', self.ids),
@@ -354,7 +353,7 @@ class HolidaysType(models.Model):
         )
         grouped_dict = dict((data['holiday_status_id'][0], data['holiday_status_id_count']) for data in grouped_res)
         for allocation in self:
-            allocation.group_days_allocation = grouped_dict.get(allocation.id, 0)
+            allocation.allocation_count = grouped_dict.get(allocation.id, 0)
 
     def _compute_group_days_leave(self):
         grouped_res = self.env['hr.leave'].read_group(

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -23,7 +23,7 @@
                     <div class="oe_button_box" name="button_box">
                         <button class="oe_stat_button" type="object" name="action_see_days_allocated" icon="fa-calendar" attrs="{'invisible': ['|', ('requires_allocation', '=', 'no'), ('id', '=', False)]}">
                             <div class="o_stat_info">
-                                <field name="group_days_allocation"/>
+                                <field name="allocation_count"/>
                                 <span class="o_stat_text">Allocations</span>
                             </div>
                         </button>

--- a/addons/hr_work_entry_holidays/models/hr_contract.py
+++ b/addons/hr_work_entry_holidays/models/hr_contract.py
@@ -29,10 +29,6 @@ class HrContract(models.Model):
         else:
             return leave.work_entry_type_id
 
-    # YTI TODO: Master remove the method (deprecated)
-    def _get_more_vals_leave(self, leave):
-        return [('leave_id', leave.holiday_id and leave.holiday_id.id)]
-
     def _get_more_vals_leave_interval(self, interval, leaves):
         result = super()._get_more_vals_leave_interval(interval, leaves)
         for leave in leaves:


### PR DESCRIPTION
*: hr_expense, hr_holidays, hr_work_entry_holidays

- Remove unused template;
- Remove unused fields (hr_expense);
- Rename group_days_allocation to convey proper meaning;
- Remove deprecated method.

TaskID: 2665866

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
