### PR TITLE
[IMP] requirements: adapt to debian bullseye

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,6 @@ Depends:
  python3-jinja2,
  python3-libsass,
  python3-lxml,
- python3-mako,
  python3-num2words,
  python3-ofxparse,
  python3-passlib,

--- a/odoo/__init__.py
+++ b/odoo/__init__.py
@@ -16,7 +16,7 @@ __path__ = [
 ]
 
 import sys
-assert sys.version_info > (3, 6), "Outdated python version detected, Odoo requires Python >= 3.6 to run."
+assert sys.version_info > (3, 7), "Outdated python version detected, Odoo requires Python >= 3.7 to run."
 
 #----------------------------------------------------------
 # Running mode flags (gevent, prefork)

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,22 +29,22 @@ psutil==5.6.6
 psycopg2==2.7.7; sys_platform != 'win32' and python_version < '3.8'
 psycopg2==2.8.6; sys_platform == 'win32' or python_version >= '3.8'
 pydot==1.4.1
-python-ldap==3.2.0; sys_platform != 'win32'
+pyopenssl==19.0.0
 PyPDF2==1.26.0
+pypiwin32 ; sys_platform == 'win32'
 pyserial==3.4
 python-dateutil==2.7.3
+python-ldap==3.2.0; sys_platform != 'win32'
+python-stdnum==1.13
 pytz==2019.3
 pyusb==1.0.2
 qrcode==6.1
 reportlab==3.5.59 # version < 3.5.54 are not compatible with Pillow 8.1.2 and 3.5.59 is bullseye
 requests==2.22.0
-zeep==3.4.0
-python-stdnum==1.13
 vobject==0.9.6.1
 Werkzeug==0.16.1
-XlsxWriter==1.1.2
-xlwt==1.3.*
 xlrd==1.1.0; python_version < '3.8'
 xlrd==1.2.0; python_version >= '3.8'
-pypiwin32 ; sys_platform == 'win32'
-pyopenssl==19.0.0
+XlsxWriter==1.1.2
+xlwt==1.3.*
+zeep==3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ libsass==0.18.0
 lxml==4.3.2 ; sys_platform != 'win32' and python_version == '3.7'
 lxml==4.6.1 ; sys_platform != 'win32' and python_version > '3.7'
 lxml ; sys_platform == 'win32'
-Mako==1.1.0
 MarkupSafe==1.1.0
 num2words==0.5.6
 ofxparse==0.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,52 +1,45 @@
 Babel==2.6.0
 chardet==3.0.4
-decorator==4.3.0
-docutils==0.14
+decorator==4.4.2
+docutils==0.16
 ebaysdk==2.1.5
 freezegun==0.3.11; python_version < '3.8'
 freezegun==0.3.15; python_version >= '3.8'
-gevent==1.1.2 ; sys_platform != 'win32' and python_version < '3.7'
 gevent==1.5.0 ; python_version == '3.7'
 gevent==20.9.0 ; python_version >= '3.8'
-gevent==1.4.0 ; sys_platform == 'win32' and python_version < '3.7'
-greenlet==0.4.10 ; python_version < '3.7'
 greenlet==0.4.15 ; python_version == '3.7'
 greenlet==0.4.17 ; python_version > '3.7'
-html2text==2018.1.9
-idna==2.6
+html2text==2020.1.16
+idna==2.8
 Jinja2==2.10.1; python_version < '3.8'
 # bullseye version, focal patched 2.10
 Jinja2==2.11.2; python_version >= '3.8'
-libsass==0.17.0
-lxml==3.7.1 ; sys_platform != 'win32' and python_version < '3.7'
+libsass==0.18.0
 lxml==4.3.2 ; sys_platform != 'win32' and python_version == '3.7'
 lxml==4.6.1 ; sys_platform != 'win32' and python_version > '3.7'
 lxml ; sys_platform == 'win32'
-Mako==1.0.7
+Mako==1.1.0
 MarkupSafe==1.1.0
 num2words==0.5.6
 ofxparse==0.19
-passlib==1.7.1
-Pillow==5.4.1 ; python_version <= '3.7' and sys_platform != 'win32'
-Pillow==6.1.0 ; python_version <= '3.7' and sys_platform == 'win32'
-Pillow==8.1.1 ; python_version > '3.7'
+passlib==1.7.2
+Pillow==8.1.2  # could be 7.0.0 (Focal) when backported security patches are present
 polib==1.1.0
 psutil==5.6.6
 psycopg2==2.7.7; sys_platform != 'win32' and python_version < '3.8'
-psycopg2==2.8.5; sys_platform == 'win32' or python_version >= '3.8'
+psycopg2==2.8.6; sys_platform == 'win32' or python_version >= '3.8'
 pydot==1.4.1
-python-ldap==3.1.0; sys_platform != 'win32'
+python-ldap==3.2.0; sys_platform != 'win32'
 PyPDF2==1.26.0
 pyserial==3.4
 python-dateutil==2.7.3
-pytz==2019.1
+pytz==2019.3
 pyusb==1.0.2
 qrcode==6.1
-reportlab==3.5.13; python_version < '3.8'
-reportlab==3.5.55; python_version >= '3.8'
-requests==2.21.0
-zeep==3.2.0
-python-stdnum==1.8
+reportlab==3.5.59 # version < 3.5.54 are not compatible with Pillow 8.1.2 and 3.5.59 is bullseye
+requests==2.22.0
+zeep==3.4.0
+python-stdnum==1.13
 vobject==0.9.6.1
 Werkzeug==0.16.1
 XlsxWriter==1.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ requires =
   python3-idna
   python3-jinja2
   python3-lxml
-  python3-mako
   python3-markupsafe
   python3-mock
   python3-num2words

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'xlsxwriter',
         'xlwt',
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     extras_require={
         'ldap': ['python-ldap'],
         'SSL': ['pyopenssl'],

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         'Jinja2',
         'lxml',  # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/
         'libsass',
-        'mako',
         'mock',
         'ofxparse',
         'passlib',

--- a/setup/package.dfdebian
+++ b/setup/package.dfdebian
@@ -33,7 +33,6 @@ RUN apt-get update -qq &&  \
         python3-jinja2 \
         python3-libsass \
         python3-lxml \
-        python3-mako \
         python3-ofxparse \
         python3-passlib \
         python3-polib \

--- a/setup/package.dffedora
+++ b/setup/package.dffedora
@@ -25,7 +25,6 @@ RUN dnf update -d 0 -e 0 -y && \
         python3-idna \
         python3-jinja2 \
         python3-lxml \
-        python3-mako \
         python3-markupsafe \
         python3-mock \
         python3-num2words \


### PR DESCRIPTION
With the release of Debian Bullseye and as the Odoo policy is to stick
as close as possible to python3-* Debian packages versions, the time as
come to adapt the requirements.