### PR TITLE
[FIX] web_editor: traceback when tab in table layout

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -220,6 +220,7 @@ export class OdooEditor extends EventTarget {
         editable.oid = 'root';
         this._idToNodeMap.set(1, editable);
         this.editable = this.options.toSanitize ? sanitize(editable) : editable;
+        this.editable.classList.add("odoo-editor-editable");
 
         // Set contenteditable before clone as FF updates the content at this point.
         this._activateContenteditable();
@@ -2182,7 +2183,7 @@ export class OdooEditor extends EventTarget {
         } else if (ev.key === 'Tab') {
             // Tab
             const sel = this.document.getSelection();
-            const closestTag = (closestElement(sel.anchorNode, 'li, table') || {}).tagName;
+            const closestTag = (closestElement(sel.anchorNode, 'li, table', true) || {}).tagName;
 
             if (closestTag === 'LI') {
                 this._applyCommand('indentList', ev.shiftKey ? 'outdent' : 'indent');

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -285,10 +285,15 @@ export function findNode(domPath, findCallback = () => true, stopCallback = () =
  *
  * @param {Node} node
  * @param {string} [selector=undefined]
+ * @param {boolean} [restrictToEditable=false]
  * @returns {HTMLElement}
  */
-export function closestElement(node, selector) {
+export function closestElement(node, selector, restrictToEditable=false) {
     const element = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+    if (restrictToEditable && selector && element) {
+        const elementFound = element.closest(selector);
+        return elementFound && elementFound.querySelector('.odoo-editor-editable') ? null : elementFound;
+    }
     return selector && element ? element.closest(selector) : element || node;
 }
 


### PR DESCRIPTION
When the editor was inside a table in the odoo view HTML,
The KeyDown detected that the selection was inside a table
and was trying to add a row bellow the table outside the editor.

task-2601451


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
