### PR TITLE
[FIX] account: allow to edit some fields with Invoicing only

### DIFF
--- a/addons/account/views/product_view.xml
+++ b/addons/account/views/product_view.xml
@@ -55,8 +55,8 @@
                     <attribute name="invisible">0</attribute>
                 </xpath>
                 <page name="inventory" position="after">
-                    <page string="Accounting" name="invoicing" groups="account.group_account_readonly">
-                        <group name="properties">
+                    <page string="Accounting" name="invoicing" groups="account.group_account_readonly,account.group_account_invoice">
+                        <group name="properties" groups="account.group_account_readonly">
                             <group string="Receivables">
                                 <field name="property_account_income_id"
                                     groups="account.group_account_readonly"/>
@@ -66,7 +66,7 @@
                                     groups="account.group_account_readonly"/>
                             </group>
                         </group>
-                        <group name="accounting"/>
+                        <group name="accounting" groups="account.group_account_readonly,account.group_account_invoice"/>
                     </page>
                 </page>
                 <xpath expr="//div[@name='pricing']" position="after">


### PR DESCRIPTION
The only fields added in
`//page[@name='invoicing']//group[@name='accounting']`
are `unspsc_code_id`, `intrastat_id` and `email_template_id`, which
should all be available with only the rights for invoicing.

[opw-2665030](https://www.odoo.com/web#id=2665030&model=project.task)





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
