### PR TITLE
[FIX] point_of_sale: Hold library firmware-brcm80211 for IoT build

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
@@ -20,6 +20,8 @@ echo "export LC_ALL=en_US.UTF-8" >> ~/.bashrc
 locale-gen
 source ~/.bashrc
 
+# upgrade firmware-brcm80211 broke access point on rpi4
+apt-mark hold firmware-brcm80211
 apt-get update && apt-get -y upgrade
 # Do not be too fast to upgrade to more recent firmware and kernel than 4.38
 # Firmware 4.44 seems to prevent the LED mechanism from working


### PR DESCRIPTION
The new version of firmware-brcm80211 20190114-2+rpt3 are unstable
when we use it with the IoT.

So we need to keep the original version of the last official version
of raspberry-pi OS 20190114-1+rpt11

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
