### PR TITLE
[IMP] point_of_sale: Authorizes the uses of POS in HTTPS with direct …

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -574,7 +574,8 @@ class PosConfig(models.Model):
          }
 
     def _force_http(self):
-        if self.other_devices:
+        enforce_https = self.env['ir.config_parameter'].sudo().get_param('point_of_sale.enforce_https')
+        if not enforce_https and self.other_devices:
             return True
         return False
 

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -32,7 +32,8 @@ class PosConfig(models.Model):
             self.set_tip_after_payment = False
 
     def _force_http(self):
-        if self.printer_ids.filtered(lambda pt: pt.printer_type == 'epson_epos'):
+        enforce_https = self.env['ir.config_parameter'].sudo().get_param('point_of_sale.enforce_https')
+        if not enforce_https and self.printer_ids.filtered(lambda pt: pt.printer_type == 'epson_epos'):
             return True
         return super(PosConfig, self)._force_http()
 

--- a/addons/pos_six/models/pos_config.py
+++ b/addons/pos_six/models/pos_config.py
@@ -8,6 +8,7 @@ class PosConfig(models.Model):
     _inherit = 'pos.config'
 
     def _force_http(self):
-        if self.payment_method_ids.filtered(lambda pm: pm.use_payment_terminal == 'six'):
+        enforce_https = self.env['ir.config_parameter'].sudo().get_param('point_of_sale.enforce_https')
+        if not enforce_https and self.payment_method_ids.filtered(lambda pm: pm.use_payment_terminal == 'six'):
             return True
         return super(PosConfig, self)._force_http()


### PR DESCRIPTION
…devices

To avoid the use of certificates when using direct devices
POS was redirected in HTTP

With new Chrome or Edge security measures this is no longer possible.

We add here the possibility to choose to redirect
the POS in https by adding a specific key in the parameters

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
