### PR TITLE
[FIX] web: use full width for the onboarding banner

### DIFF
--- a/addons/web/static/src/views/onboarding_banner.js
+++ b/addons/web/static/src/views/onboarding_banner.js
@@ -48,5 +48,5 @@ export class OnboardingBanner extends owl.Component {
     }
 }
 
-OnboardingBanner.template = owl.tags.xml`<div t-raw="bannerHTML" />`;
+OnboardingBanner.template = owl.tags.xml`<div class="w-100" t-raw="bannerHTML" />`;
 OnboardingBanner.props = {};


### PR DESCRIPTION

![Screenshot from 2021-10-11 14-36-41](https://user-images.githubusercontent.com/49784121/136790966-24b7a2e2-b229-4fcd-b981-7d45be39fff5.png)
The owl OnboardingBanner component should be full width.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
