### PR TITLE
[IMP] web: command debug=assets

### DIFF
--- a/addons/web/static/src/core/debug/debug_providers.js
+++ b/addons/web/static/src/core/debug/debug_providers.js
@@ -11,6 +11,15 @@ commandProviderRegistry.add("debug", {
         const result = [];
         if (env.services.user.isAdmin) {
             if (env.debug) {
+                if (!env.debug.includes("assets")){
+                    result.push({
+                        action() {
+                            browser.location.search = "?debug=assets";
+                        },
+                        category: "debug",
+                        name: env._t("Activate debug mode (with assets)"),
+                    });
+                }
                 result.push({
                     action() {
                         const route = env.services.router.current;
@@ -27,7 +36,7 @@ commandProviderRegistry.add("debug", {
                             browser.location.search = "?debug=assets";
                         },
                         category: "debug",
-                        name: env._t("Activate debug mode"),
+                        name: env._t("Activate debug mode (with assets)"),
                     });
                 }
             }


### PR DESCRIPTION
This commit adds a command to activate the debug assets mode from
another debug mode.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
