### PR TITLE
[FIX] event_sale: Fix kanban card layout with free tickets

### DIFF
--- a/addons/event_sale/i18n/event_sale.pot
+++ b/addons/event_sale/i18n/event_sale.pot
@@ -200,7 +200,7 @@ msgstr ""
 
 #. module: event_sale
 #: model:ir.model.fields.selection,name:event_sale.selection__event_registration__payment_status__free
-msgid "Free Admission"
+msgid "Free"
 msgstr ""
 
 #. module: event_sale

--- a/addons/event_sale/models/event_registration.py
+++ b/addons/event_sale/models/event_registration.py
@@ -15,7 +15,7 @@ class EventRegistration(models.Model):
     payment_status = fields.Selection(string="Payment Status", selection=[
             ('to_pay', 'Not Paid'),
             ('paid', 'Paid'),
-            ('free', 'Free Admission'),
+            ('free', 'Free'),
         ], compute="_compute_payment_status", compute_sudo=True)
     utm_campaign_id = fields.Many2one(compute='_compute_utm_campaign_id', readonly=False, store=True)
     utm_source_id = fields.Many2one(compute='_compute_utm_source_id', readonly=False, store=True)


### PR DESCRIPTION
The larger payment status `Free Admission` replacing `Free` in #61668 made it
require two lines in the attendee kanban card, making it taller, and with
additional and unnecessary whitespace.

Task-2586017