### PR TITLE
[FIX] core: lower_logging record.args not str

### DIFF
--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -836,7 +836,7 @@ class lower_logging(logging.Handler):
             record.levelname = f'_{record.levelname}'
             record.levelno = self.max_level
             self.had_error_log = True
-            record.args = tuple(arg.replace('Traceback (most recent call last):', '_Traceback_ (most recent call last):') for arg in record.args)
+            record.args = tuple(arg.replace('Traceback (most recent call last):', '_Traceback_ (most recent call last):') if type(arg) is str else arg for arg in record.args)  # pylint: disable=unidiomatic-typecheck
 
         for handler in self.old_handlers:
             if handler.level <= record.levelno:


### PR DESCRIPTION
As per the logging documentation, it is fine to send arguments that are
not string. Logging takes care of stringifying and injecting the
arguments in the message template.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
