### PR TITLE
[FIX] website: properly re-show the header when scrolling to the top

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -238,17 +238,24 @@ publicWidget.registry.StandardAffixedHeader = BaseAnimatedHeader.extend({
 
         const mainPosScrolled = (scroll > this.headerHeight + this.topGap);
         const reachPosScrolled = (scroll > this.scrolledPoint + this.topGap);
+        const fixedUpdate = (this.fixedHeader !== mainPosScrolled);
+        const showUpdate = (this.fixedHeaderShow !== reachPosScrolled);
 
-        // Switch between static/fixed position of the header
-        if (this.fixedHeader !== mainPosScrolled) {
-            this.$el.css('transform', mainPosScrolled ? 'translate(0, -100%)' : '');
+        if (fixedUpdate || showUpdate) {
+            this.$el.css('transform',
+                reachPosScrolled
+                ? `translate(0, -${this.topGap}px)`
+                : mainPosScrolled
+                ? 'translate(0, -100%)'
+                : '');
             void this.$el[0].offsetWidth; // Force a paint refresh
-            this._toggleFixedHeader(mainPosScrolled);
         }
-        // Show/hide header
-        if (this.fixedHeaderShow !== reachPosScrolled) {
-            this.$el.css('transform', reachPosScrolled ? `translate(0, -${this.topGap}px)` : 'translate(0, -100%)');
-            this.fixedHeaderShow = reachPosScrolled;
+
+        this.fixedHeaderShow = reachPosScrolled;
+
+        if (fixedUpdate) {
+            this._toggleFixedHeader(mainPosScrolled);
+        } else if (showUpdate) {
             this._adaptToHeaderChange();
         }
     },


### PR DESCRIPTION
Sometimes, when using the "standard affixed" header effect, when
scrolling to the top, the header was kept hidden and left a blank space.

This happened in fact systematically when scrolling to the top very
fast. Indeed, in that case, the code went through the header update
only once and was not able to go from state 3 (page scrolled header
visible) to state 1 (page not scrolled header visible) without going
through state 2 (page scrolled header invisible) and you thus ended
with a mix of state 1 and 2: page not scrolled and header invisible).