### PR TITLE
[FIX] hr_holidays: fix allocation duration changes

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -206,10 +206,7 @@ class HolidaysAllocation(models.Model):
     @api.depends('number_of_days', 'employee_id')
     def _compute_number_of_hours_display(self):
         for allocation in self:
-            if allocation.parent_id and allocation.parent_id.type_request_unit == "hour":
-                allocation.number_of_hours_display = allocation.number_of_days * HOURS_PER_DAY
-            else:
-                allocation.number_of_hours_display = allocation.number_of_days * (allocation.employee_id.sudo().resource_id.calendar_id.hours_per_day or HOURS_PER_DAY)
+            allocation.number_of_hours_display = allocation.number_of_days * HOURS_PER_DAY
 
     @api.multi
     @api.depends('number_of_hours_display', 'number_of_days_display')
@@ -249,7 +246,7 @@ class HolidaysAllocation(models.Model):
     @api.onchange('number_of_hours_display')
     def _onchange_number_of_hours_display(self):
         for allocation in self:
-            allocation.number_of_days = allocation.number_of_hours_display / (allocation.employee_id.resource_calendar_id.hours_per_day or HOURS_PER_DAY)
+            allocation.number_of_days = allocation.number_of_hours_display / HOURS_PER_DAY
 
     @api.multi
     @api.onchange('number_of_days_display')


### PR DESCRIPTION
Fixes the allocation duration changing upon modifying the employee's
resource calendar.
Since the number of hours is computes from the number of days divided by
the number of hours per day, changing the employee's schedule results in
the number of hours changing on the allocation aswell.

TaskId-2664699