### PR TITLE
[FIX] website: use base-1 as default palette for configurator

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -357,13 +357,15 @@ class Website(models.Model):
     @api.model
     def configurator_apply(self, **kwargs):
         def set_colors(selected_palette):
+            url = '/website/static/src/scss/options/user_values.scss'
+            selected_palette_name = selected_palette if isinstance(selected_palette, str) else 'base-1'
+            values = {'color-palettes-name': "'%s'" % selected_palette_name}
+            self.env['web_editor.assets'].make_scss_customization(url, values)
+
             if isinstance(selected_palette, list):
                 url = '/website/static/src/scss/options/colors/user_color_palette.scss'
                 values = {f'o-color-{i}': color for i, color in enumerate(selected_palette, 1)}
-            else:
-                url = '/website/static/src/scss/options/user_values.scss'
-                values = {'color-palettes-name': "'%s'" % selected_palette}
-            self.env['web_editor.assets'].make_scss_customization(url, values)
+                self.env['web_editor.assets'].make_scss_customization(url, values)
 
         def set_features(selected_features):
             features = self.env['website.configurator.feature'].browse(selected_features)


### PR DESCRIPTION
When using the configurator the user can upload its logo to
generate a color palette. In this case we select the base-1
palette as default palette instead of the theme's default palette.
Doing so avoids the potential customizations the theme palette
may introduces.

task-2665885

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
