### PR TITLE
[FIX] l10n_it_stock_ddt : fixed ddt report quantity

### DIFF
--- a/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
+++ b/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
@@ -107,20 +107,22 @@
                             <tbody>
                                 <t t-set="total_value" t-value="0"/>
                                 <t t-foreach="o.move_lines" t-as="move">
-                                    <tr>
-                                        <td>
-                                            <span t-field="move.product_id"/>
-                                        </td>
-                                        <td>
-                                            <span t-field="move.product_uom_qty"/>
-                                            <span t-field="move.product_uom" groups="uom.group_uom"/>
-                                        </td>
-                                        <td>
-                                            <t t-set="lst_price" t-value="move.product_id.lst_price * move.product_qty"/>
-                                            <span t-esc="lst_price"  t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
-                                            <t t-set="total_value" t-value="total_value + lst_price"/>
-                                        </td>
-                                    </tr>
+                                    <t t-if="move.quantity_done">
+                                        <tr>
+                                            <td>
+                                                <span t-field="move.product_id"/>
+                                            </td>
+                                            <td>
+                                                <span t-field="move.quantity_done"/>
+                                                <span t-field="move.product_uom" groups="uom.group_uom"/>
+                                            </td>
+                                            <td>
+                                                <t t-set="lst_price" t-value="move.product_id.lst_price * move.quantity_done"/>
+                                                <span t-esc="lst_price"  t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
+                                                <t t-set="total_value" t-value="total_value + lst_price"/>
+                                            </td>
+                                        </tr>
+                                    </t>
                                 </t>
                                 <tr>
                                     <td>


### PR DESCRIPTION
Currently, DDT use the product_uom_quantity of product for the ddt move which is inaccurate in case of no-backorder change in quantity

The fix correctly check if the done quantity is higher than 0 for the delivery and if it is, use it as the delivery quantity (else, no line is added)

opw-2663174


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
