### PR TITLE
[IMP] l10n_pe: moved ICBPER tax group in community module

### DIFF
--- a/addons/l10n_pe/data/account_tax_group_data.xml
+++ b/addons/l10n_pe/data/account_tax_group_data.xml
@@ -45,5 +45,10 @@
             <field name="sequence">100</field>
             <field name="country_id" ref="base.pe"/>
         </record>
+        <record id="tax_group_icbper" model="account.tax.group">
+            <field name="name">ICBPER</field>
+            <field name="sequence">0</field>
+            <field name="country_id" ref="base.pe"/>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
The ICBPER tax group was defined only in l10n_pe_edi, while all other tax groups are defined in l10n_pe.
The old record XMLID is being renamed to l10n_pe, nothing else should change.
If l10n_pe is upgraded too, the l10n_pe.tax_group.icbper will be automatically added and we need to remove it before renaming.

Communiy PR: https://github.com/odoo/odoo/pull/78187
Enterprise PR: https://github.com/odoo/enterprise/pull/21596
Upgrade PR: https://github.com/odoo/upgrade/pull/2914