### PR TITLE
[FIX] account: allow accounting user to activate currency

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3290,7 +3290,7 @@ class AccountMove(models.Model):
         return action
 
     def action_activate_currency(self):
-        self.currency_id.filtered(lambda currency: not currency.active).write({'active': True})
+        self.sudo().currency_id.filtered(lambda currency: not currency.active).write({'active': True})
 
     @api.model
     def _move_dict_to_preview_vals(self, move_vals, currency_id=None):


### PR DESCRIPTION
Before this commit, Accounting user was not able to activate currency,
Admin/Accounting admin has write access to `res.currency` model.

With this commit, accounting use can activate currency

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
