### PR TITLE
[FIX] auth_signup: bulk signup_url generation

### DIFF
--- a/addons/auth_signup/models/res_partner.py
+++ b/addons/auth_signup/models/res_partner.py
@@ -91,10 +91,10 @@ class ResPartner(models.Model):
                 if fragment:
                     query['redirect'] = base + werkzeug.urls.url_encode(fragment)
 
-            url = "/web/%s?%s" % (route, werkzeug.urls.url_encode(query))
+            signup_url = "/web/%s?%s" % (route, werkzeug.urls.url_encode(query))
             if not self.env.context.get('relative_url'):
-                url = werkzeug.urls.url_join(base_url, url)
-            res[partner.id] = url
+                signup_url = werkzeug.urls.url_join(base_url, signup_url)
+            res[partner.id] = signup_url
 
         return res
 


### PR DESCRIPTION
When calling `_get_signup_url_for_action` on more than one partner,
because the `url` input parameter was re-used for the actual signup
URL before assigning to the partners map (in
559bdc976e72475a21f6f8d8380e0e4bb3942aae), from the second iteration
onwards the signup URL will almost certainly get misgenerated to
redirect to the previous signup URL (accumulating).

As `signup_url` is not normally accessed in bulk this should not
usually be an issue.

Reported by Andreas Brückl
