### PR TITLE
[FIX] account: set date of reversing exchange diff moves to reversed moves date

### DIFF
--- a/addons/account/models/account_full_reconcile.py
+++ b/addons/account/models/account_full_reconcile.py
@@ -27,9 +27,8 @@ class AccountFullReconcile(models.Model):
         res = super().unlink()
 
         # Reverse all exchange moves at once.
-        today = fields.Date.context_today(self)
         default_values_list = [{
-            'date': today,
+            'date': move.date,
             'ref': _('Reversal of: %s') % move.name,
         } for move in moves_to_reverse]
         moves_to_reverse._reverse_moves(default_values_list, cancel=True)


### PR DESCRIPTION
When reconciling, exchange difference entries are created with date set at move date. But when unreconciling, reversed exchange difference entries are created with date = “today”. Meaning that if old moves are reconciled/unreconciled multiple times, new exchange entries are created within move fiscal period, but reversed exchange are created in current fiscal period. Creating aberrant results in P&L and Balance Sheet for move period.

Task: 2666942