### PR TITLE
[FIX] hr_holidays_attendance: fix deduct extra hours

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime.py
@@ -8,6 +8,7 @@ class HrAttendanceOvertime(models.Model):
     _name = "hr.attendance.overtime"
     _description = "Attendance Overtime"
     _rec_name = 'employee_id'
+    _order = 'date desc'
 
     def _default_employee(self):
         return self.env.user.employee_id

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -115,6 +115,7 @@ class HolidaysType(models.Model):
         """
         date_to = self._context.get('default_date_from') or fields.Date.today().strftime('%Y-1-1')
         date_from = self._context.get('default_date_to') or fields.Date.today().strftime('%Y-12-31')
+        employee_id = self._context.get('default_employee_id', self._context.get('employee_id')) or self.env.user.employee_id.id
 
         if not isinstance(value, bool):
             raise ValueError('Invalid value: %s' % (value))
@@ -128,11 +129,15 @@ class HolidaysType(models.Model):
         FROM
             hr_leave_allocation alloc
         WHERE
+            alloc.id is not null or (
+            alloc.employee_id = %s AND
+            alloc.active = True AND alloc.state = 'validate' AND
             alloc.date_to >= %s OR alloc.date_to IS NULL AND
             alloc.date_from <= %s 
+            )
         '''
 
-        self._cr.execute(query, (date_to, date_from))
+        self._cr.execute(query, (employee_id or None, date_to, date_from))
 
         return [('id', new_operator, [x['holiday_status_id'] for x in self._cr.dictfetchall()])]
 
@@ -141,10 +146,12 @@ class HolidaysType(models.Model):
     def _compute_valid(self):
         date_to = self._context.get('default_date_to', fields.Datetime.today())
         date_from = self._context.get('default_date_from', fields.Datetime.today())
+        employee_id = self._context.get('default_employee_id', self._context.get('employee_id', self.env.user.employee_id))
         for holiday_type in self:
             if holiday_type.requires_allocation:
                 allocation = self.env['hr.leave.allocation'].search([
                     ('holiday_status_id', '=', holiday_type.id),
+                    ('employee_id', '=', employee_id),
                     '|',
                     ('date_to', '>=', date_to),
                     '&',

--- a/addons/hr_holidays_attendance/models/hr_leave_allocation.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_allocation.py
@@ -4,6 +4,7 @@
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
 from odoo.tools import float_round
+from odoo.osv import expression
 
 
 class HolidaysAllocation(models.Model):
@@ -12,13 +13,11 @@ class HolidaysAllocation(models.Model):
     def default_get(self, fields):
         res = super().default_get(fields)
         if 'holiday_status_id' in fields and self.env.context.get('deduct_extra_hours'):
-            # Prevent loading manager allocated time off type
-            type_operator = '=' if self.env.context.get('deduct_extra_hours_allocation_type') else '!='
-            type_value = self.env.context.get('deduct_extra_hours_allocation_type', 'no')
-            leave_type = self.env['hr.leave.type'].search([
-                ('has_valid_allocation', '=', True),
-                ('overtime_deductible', '=', True),
-                ('requires_allocaiton', '=', 'yes')], limit=1)
+            domain = [('overtime_deductible', '=', True), ('requires_allocation', '=', 'yes')]
+            if self.env.context.get('deduct_extra_hours_employee_request', False):
+                # Prevent loading manager allocated time off type in self request contexts
+                domain = expression.AND([domain, [('employee_requests', '=', 'yes')]])
+            leave_type = self.env['hr.leave.type'].search(domain, limit=1)
             res['holiday_status_id'] = leave_type.id
         return res
 

--- a/addons/hr_holidays_attendance/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_leave_allocation_views.xml
@@ -31,8 +31,7 @@
                 <attribute name="invisible">1</attribute>
             </div>
             <xpath expr="//field[@name='holiday_status_id']" position="attributes">
-                <attribute name="domain">[('has_valid_allocation', '=', True), ('overtime_deductible', '=', True), ('requires_allocation', '=', 'yes'),
-                    ('employee_requests', '=', 'no')]</attribute>
+                <attribute name="domain">[('overtime_deductible', '=', True), ('requires_allocation', '=', 'yes'), ('employee_requests', '=', 'yes')]</attribute>
                 <attribute name="options">{'no_create': True, 'no_open': True}</attribute>
             </xpath>
             <xpath expr="//sheet" position="after">
@@ -51,7 +50,7 @@
         <field name="priority">70</field>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='holiday_status_id']" position="attributes">
-                <attribute name="domain">[('has_valid_allocation', '=', True), ('overtime_deductible', '=', True), ('requires_allocation', '=', 'yes')]</attribute>
+                <attribute name="domain">[('overtime_deductible', '=', True), ('requires_allocation', '=', 'yes')]</attribute>
             </xpath>
         </field>
     </record>

--- a/addons/hr_holidays_attendance/views/res_users_views.xml
+++ b/addons/hr_holidays_attendance/views/res_users_views.xml
@@ -11,7 +11,7 @@
                     name="%(hr_leave_allocation_overtime_action)d"
                     string="Deduct Extra Hours"
                     type="action"
-                    context="{'default_employee_id': employee_id, 'deduct_extra_hours': True, 'deduct_extra_hours_allocation_type': 'fixed_allocation'}"
+                    context="{'default_employee_id': employee_id, 'deduct_extra_hours': True, 'deduct_extra_hours_employee_request': True}"
                     attrs="{'invisible': [('request_overtime', '=', False)]}"/>
             </xpath>
         </field>


### PR DESCRIPTION
Since the Time Off B2B, the deduct extra hours didn't work anymore due
to an invalid domain.
This commit fixes the traceback but also the behaviour as the domain did
not make any sense anymore.

TaskId-2658077
