### PR TITLE
[FIX] website: fix save animated snippet

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2859,6 +2859,12 @@ options.registry.WebsiteAnimate = options.Class.extend({
     /**
      * @override
      */
+    async onBuilt() {
+        this.$target[0].classList.toggle('o_animate_preview', this.$target[0].classList.contains('o_animate'));
+    },
+    /**
+     * @override
+     */
     onFocus() {
         if (this.isAnimatedText) {
             // For animated text, the animation options must be in the editor


### PR DESCRIPTION
Before this commit, when dropping custom snippet (or saved snippet)
containing an animation in the page, the animated element of the
snippet remained hidden.

task-2664876

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
