### PR TITLE
[IMP] l10n_ae_pos: Allows the use of two languages on the pos receipt

### DIFF
--- a/addons/l10n_gcc_pos/__manifest__.py
+++ b/addons/l10n_gcc_pos/__manifest__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Gulf Cooperation Council - Point of Sale',
+    'author': 'Odoo S.A',
+    'category': 'Accounting/Localizations/Point of Sale',
+    'description': """
+GCC POS Localization
+=======================================================
+    """,
+    'license': 'LGPL-3',
+    'depends': ['point_of_sale', 'l10n_gcc_invoice'],
+    'data': [
+    ],
+    'assets': {
+        'web.assets_qweb': [
+            'l10n_gcc_pos/static/src/xml/OrderReceipt.xml',
+        ],
+        'point_of_sale.assets': [
+            'l10n_gcc_pos/static/src/js/OrderReceipt.js',
+            'l10n_gcc_pos/static/src/css/OrderReceipt.css',
+        ]
+    },
+    'auto_install': True,
+}

--- a/addons/l10n_gcc_pos/static/src/css/OrderReceipt.css
+++ b/addons/l10n_gcc_pos/static/src/css/OrderReceipt.css
@@ -1,0 +1,3 @@
+.pos-receipt-amount-arabic {
+    padding-left: 0em !important;
+}

--- a/addons/l10n_gcc_pos/static/src/js/OrderReceipt.js
+++ b/addons/l10n_gcc_pos/static/src/js/OrderReceipt.js
@@ -1,0 +1,19 @@
+odoo.define('l10n_gcc_pos.OrderReceipt', function (require) {
+    'use strict';
+
+    const OrderReceipt = require('point_of_sale.OrderReceipt')
+    const Registries = require('point_of_sale.Registries');
+
+    const OrderReceiptGCC = OrderReceipt =>
+        class extends OrderReceipt {
+
+            get receiptEnv() {
+                let receipt_render_env = super.receiptEnv;
+                let receipt = receipt_render_env.receipt;
+                receipt.is_gcc_country = ['SA', 'AE', 'BH', 'OM', 'QA', 'KW'].includes(receipt_render_env.order.pos.company.country.code);
+                return receipt_render_env;
+            }
+        }
+    Registries.Component.extend(OrderReceipt, OrderReceiptGCC)
+    return OrderReceiptGCC
+});

--- a/addons/l10n_gcc_pos/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_gcc_pos/static/src/xml/OrderReceipt.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="1">
+
+        <xpath expr="//div[hasclass('pos-receipt-contact')]" position="after">
+            <t t-if="receipt.is_gcc_country">
+                <br/>
+                <br/>
+                <div class="pos-receipt-header">
+                    <span id="title_english" t-translation="off">Tax Invoice</span>
+                </div>
+                <div class="pos-receipt-header">
+                    <span id="title_arabic" t-translation="off">الفاتورة الضريبية</span>
+                </div>
+            </t>
+        </xpath>
+
+        <xpath expr="//t[@t-esc='receipt.cashier']/.." position="attributes">
+            <attribute name="t-if">!receipt.is_gcc_country</attribute>
+        </xpath>
+        <xpath expr="//t[@t-esc='receipt.cashier']/.." position="after">
+            <div t-if="receipt.is_gcc_country" t-translation="off">
+                <div>Served by/خدم بواسطة <t t-esc="receipt.cashier"/></div>
+            </div>
+        </xpath>
+
+        <xpath expr="//span[@t-esc='env.pos.format_currency(receipt.subtotal)']/.." position="attributes">
+            <attribute name="t-if">!receipt.is_gcc_country</attribute>
+        </xpath>
+        <xpath expr="//span[@t-esc='env.pos.format_currency(receipt.subtotal)']/.." position="after">
+            <div t-if="receipt.is_gcc_country" t-translation="off">
+                Subtotal/الإجمالي الفرعي
+                <span t-esc="env.pos.format_currency(receipt.subtotal)" class="pos-receipt-right-align"/>
+            </div>
+        </xpath>
+
+        <xpath expr="//span[@t-esc='env.pos.format_currency(receipt.total_with_tax)']/.." position="attributes">
+            <attribute name="t-if">!receipt.is_gcc_country</attribute>
+        </xpath>
+        <xpath expr="//span[@t-esc='env.pos.format_currency(receipt.total_with_tax)']/.." position="after">
+            <div t-if="receipt.is_gcc_country" class="pos-receipt-amount pos-receipt-amount-arabic" t-translation="off">
+                TOTAL/الإجمالي
+                <span t-esc="env.pos.format_currency(receipt.total_with_tax)" class="pos-receipt-right-align"/>
+            </div>
+        </xpath>
+
+        <xpath expr="//span[@t-esc='env.pos.format_currency(receipt.rounding_applied)']/.." position="attributes">
+            <attribute name="t-if">!receipt.is_gcc_country</attribute>
+        </xpath>
+        <xpath expr="//span[@t-esc='env.pos.format_currency(receipt.rounding_applied)']/.." position="after">
+            <div t-if="receipt.is_gcc_country" class="pos-receipt-amount pos-receipt-amount-arabic" t-translation="off">
+                Rounding/التقريب
+                <span t-esc="env.pos.format_currency(receipt.rounding_applied)" class="pos-receipt-right-align"/>
+            </div>
+        </xpath>
+
+        <xpath expr="//span[@t-esc='env.pos.format_currency(receipt.total_rounded)']/.." position="attributes">
+            <attribute name="t-if">!receipt.is_gcc_country</attribute>
+        </xpath>
+        <xpath expr="//span[@t-esc='env.pos.format_currency(receipt.total_rounded)']/.." position="after">
+            <div t-if="receipt.is_gcc_country" class="pos-receipt-amount pos-receipt-amount-arabic" t-translation="off">
+                To Pay/للسداد
+                <span t-esc="env.pos.format_currency(receipt.total_rounded)" class="pos-receipt-right-align"/>
+            </div>
+        </xpath>
+
+        <xpath expr="//span[@t-esc='env.pos.format_currency(receipt.change)']/.." position="attributes">
+            <attribute name="t-if">!receipt.is_gcc_country</attribute>
+        </xpath>
+        <xpath expr="//span[@t-esc='env.pos.format_currency(receipt.change)']/.." position="after">
+            <div t-if="receipt.is_gcc_country" class="pos-receipt-amount receipt-change pos-receipt-amount-arabic" t-translation="off">
+                CHANGE/الباقي
+                <span t-esc="env.pos.format_currency(receipt.change)" class="pos-receipt-right-align"/>
+            </div>
+        </xpath>
+
+        <xpath expr="//span[@t-esc='env.pos.format_currency(receipt.total_discount)']/.." position="attributes">
+            <attribute name="t-if">!receipt.is_gcc_country</attribute>
+        </xpath>
+        <xpath expr="//span[@t-esc='env.pos.format_currency(receipt.total_discount)']/.." position="after">
+            <div t-if="receipt.is_gcc_country" t-translation="off">
+                Discounts/الخصومات
+                <span t-esc="env.pos.format_currency(receipt.total_discount)" class="pos-receipt-right-align"/>
+            </div>
+        </xpath>
+
+        <xpath expr="//span[@t-esc='env.pos.format_currency(receipt.total_tax)']/.." position="attributes">
+            <attribute name="t-if">!receipt.is_gcc_country</attribute>
+        </xpath>
+        <xpath expr="//span[@t-esc='env.pos.format_currency(receipt.total_tax)']/.." position="after">
+            <div t-if="receipt.is_gcc_country" t-translation="off">
+                Total Taxes/إجمالي الضرائب
+                <span t-esc="env.pos.format_currency(receipt.total_tax)" class="pos-receipt-right-align"/>
+            </div>
+        </xpath>
+    </t>
+
+    <t t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension" owl="1">
+        <xpath expr="//t[@t-if='isSimple(line)']/div/span[hasclass('price_display')]" position="attributes">
+            <attribute name="t-if">!receipt.is_gcc_country</attribute>
+        </xpath>
+        <xpath expr="//t[@t-if='isSimple(line)']/div/span[hasclass('price_display')]" position="after">
+            <div class="responsive-price" t-if="receipt.is_gcc_country">
+                <div class="pos-receipt-left-padding" style="display: inline-flex;">
+                    <div t-translation="off">Taxes/الضرائب</div>:<span t-esc="env.pos.format_currency_no_symbol(line.tax)" style="margin-left: 5px"/>
+                </div>
+                <span t-esc="env.pos.format_currency_no_symbol(line.price_display)" class="price_display pos-receipt-right-align"/>
+            </div>
+        </xpath>
+
+        <xpath expr="//t[@t-esc='line.unit_name']/.." position="attributes">
+            <attribute name="t-if">!receipt.is_gcc_country</attribute>
+        </xpath>
+        <xpath expr="//t[@t-esc='line.unit_name']/.." position="after">
+            <t t-if="receipt.is_gcc_country">
+                <div class="pos-receipt-left-padding">
+                    <t t-esc="Math.round(line.quantity * Math.pow(10, env.pos.dp['Product Unit of Measure'])) / Math.pow(10, env.pos.dp['Product Unit of Measure'])"/>
+                    <t t-if="!line.is_in_unit" t-esc="line.unit_name" />
+                    x
+                    <t t-esc="env.pos.format_currency_no_symbol(line.price_display_one)" />
+                </div>
+                <div class="responsive-price">
+                    <div class="pos-receipt-left-padding" style="display: inline-flex;">
+                        <div t-translation="off">Taxes/الضرائب</div>:<span t-esc="env.pos.format_currency_no_symbol(line.tax)" style="margin-left: 5px"/>
+                    </div>
+                    <span t-esc="env.pos.format_currency_no_symbol(line.price_display)" class="price_display pos-receipt-right-align"/>
+                </div>
+            </t>
+        </xpath>
+
+        <xpath expr="//t[@t-esc='line.discount']/.." position="attributes">
+            <attribute name="t-if">!receipt.is_gcc_country</attribute>
+        </xpath>
+        <xpath expr="//t[@t-esc='line.discount']/.." position="after">
+            <div class="pos-receipt-left-padding" style="display: inline-flex;" t-if="receipt.is_gcc_country" t-translation="off">
+                <div>Discount/الخصم</div>: <t t-esc="line.discount" />%
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/l10n_sa_pos/__init__.py
+++ b/addons/l10n_sa_pos/__init__.py
@@ -1,0 +1,4 @@
+# -*- encoding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/l10n_sa_pos/__manifest__.py
+++ b/addons/l10n_sa_pos/__manifest__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'K.S.A. - Point of Sale',
+    'author': 'Odoo S.A',
+    'category': 'Accounting/Localizations/Point of Sale',
+    'description': """
+K.S.A. POS Localization
+=======================================================
+    """,
+    'license': 'LGPL-3',
+    'depends': ['l10n_gcc_pos', 'l10n_sa_invoice'],
+    'data': [
+    ],
+    'assets': {
+        'web.assets_qweb': [
+            'l10n_sa_pos/static/src/xml/OrderReceipt.xml',
+        ],
+        'point_of_sale.assets': [
+            'web/static/lib/zxing-library/zxing-library.js',
+            'l10n_sa_pos/static/src/js/OrderReceipt.js',
+        ]
+    },
+    'auto_install': True,
+}

--- a/addons/l10n_sa_pos/models/__init__.py
+++ b/addons/l10n_sa_pos/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- encoding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import pos_order

--- a/addons/l10n_sa_pos/models/pos_order.py
+++ b/addons/l10n_sa_pos/models/pos_order.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import base64
+
+from odoo import fields, api, models
+
+
+class POSOrder(models.Model):
+    _inherit = 'pos.order'
+
+    def _prepare_invoice_vals(self):
+        vals = super()._prepare_invoice_vals()
+        if self.company_id.country_id.code == 'SA':
+            vals.update({'l10n_sa_confirmation_datetime': self.date_order})
+        return vals

--- a/addons/l10n_sa_pos/static/src/js/OrderReceipt.js
+++ b/addons/l10n_sa_pos/static/src/js/OrderReceipt.js
@@ -1,0 +1,56 @@
+odoo.define('l10n_sa_pos.OrderReceipt', function (require) {
+    'use strict';
+
+    const OrderReceipt = require('point_of_sale.OrderReceipt')
+    const Registries = require('point_of_sale.Registries');
+
+    const OrderReceiptQRCodeSA = OrderReceipt =>
+        class extends OrderReceipt {
+            mounted() {
+                super.mounted(...arguments);
+                if (this._receiptEnv.order.pos.company.country.code === 'SA') {
+                    const codeWriter = new window.ZXing.BrowserQRCodeSvgWriter()
+                    codeWriter.writeToDom('#qrcode', this._receiptEnv.receipt.qr_code, 150, 150);
+                }
+            }
+
+            get receiptEnv() {
+                if (this._receiptEnv.order.pos.company.country.code === 'SA') {
+                    let receipt_render_env = super.receiptEnv;
+                    let receipt = receipt_render_env.receipt;
+                    receipt.qr_code = this.compute_sa_qr_code(receipt.company.name, receipt.company.vat, receipt.date.isostring, receipt.total_with_tax, receipt.total_tax);
+                    return receipt_render_env;
+                }
+                return super.receiptEnv;
+            }
+
+            compute_sa_qr_code(name, vat, date_isostring, amount_total, amount_tax) {
+                /* Generate the qr code for Saudi e-invoicing. Specs are available at the following link at page 23
+                https://zatca.gov.sa/ar/E-Invoicing/SystemsDevelopers/Documents/20210528_ZATCA_Electronic_Invoice_Security_Features_Implementation_Standards_vShared.pdf
+                */
+                const seller_name_enc = this._compute_qr_code_field(1, name);
+                const company_vat_enc = this._compute_qr_code_field(2, vat);
+                const timestamp_enc = this._compute_qr_code_field(3, date_isostring);
+                const invoice_total_enc = this._compute_qr_code_field(4, amount_total.toString());
+                const total_vat_enc = this._compute_qr_code_field(5, amount_tax.toString());
+
+                const str_to_encode = seller_name_enc.concat(company_vat_enc, timestamp_enc, invoice_total_enc, total_vat_enc);
+
+                let binary = '';
+                for (let i = 0; i < str_to_encode.length; i++) {
+                    binary += String.fromCharCode(str_to_encode[i]);
+                }
+                return btoa(binary);
+            }
+
+            _compute_qr_code_field(tag, field) {
+                const textEncoder = new TextEncoder();
+                const name_byte_array = Array.from(textEncoder.encode(field));
+                const name_tag_encoding = [tag];
+                const name_length_encoding = [name_byte_array.length];
+                return name_tag_encoding.concat(name_length_encoding, name_byte_array);
+            }
+        }
+    Registries.Component.extend(OrderReceipt, OrderReceiptQRCodeSA)
+    return OrderReceiptQRCodeSA
+});

--- a/addons/l10n_sa_pos/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_sa_pos/static/src/xml/OrderReceipt.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="1">
+        <xpath expr="//img[hasclass('pos-receipt-logo')]" position="after">
+            <t if="receipt.is_gcc_country">
+                <div t-if="receipt.qr_code" id="qrcode" class="pos-receipt-logo"/>
+                <br/>
+            </t>
+        </xpath>
+
+        <xpath expr="//span[@id='title_english']" position="replace">
+            <span id="title_english">Simplified Tax Invoice</span>
+        </xpath>
+
+        <xpath expr="//span[@id='title_arabic']" position="replace">
+            <span id="title_arabic">فاتورة ضريبية مبسطة</span>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
Receipts in arabic and english are mantatory by law in most arab countries. This module allows the use of two languages on the pos receipt with dynamic translations. This module will be reused in another PR for KSA where a mandatory qr code will need to appear.

This module has been made as generic as possible to allow its use in other countries needed two languages on their receipts. For this reason, I am not sure if the module should be a l10n or a normal one (pos_dual_lang_receipt?)






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
