### PR TITLE
[FIX] web_editor: allow non editable to be unbreakable

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -891,7 +891,7 @@ export function isBold(node) {
 }
 
 export function isUnbreakable(node) {
-    if (!node || node.nodeType === Node.TEXT_NODE || !node.isContentEditable) {
+    if (!node || node.nodeType === Node.TEXT_NODE) {
         return false;
     }
     if (node.nodeType !== Node.ELEMENT_NODE) {


### PR DESCRIPTION
When starting the editor in a web page, if there is no content, the
oe_structure is not editable. Adding snippet at that moment will
trigger `idSet` on the node with isUnbreakable returning `false` for
the node that is unbreakable because of the check
`!node.isContentEditable` in `isUnbreakable`.

When setting the ouid for the first time with `idSet`, `getOuid` is
called with `optimize` to `true`. So all the ancestor of a node that
should be unbreakable will have the wrong ouid.

Performing any command to a node with a wrong ouid is suceptible to
wrongly be reverted.

By removing `!node.isContentEditable`, the node will have the proper
ouid in case an ancestor is not editable.

task-2633368

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
