### PR TITLE
[FIX] web_editor: use color css name fix reset color

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -53,7 +53,7 @@ const LinkTools = Link.extend({
         if (!this.el) {
             return this._super(...arguments);
         }
-        $('.oe_edited_link').removeClass('oe_edited_link');
+        this.$link.removeClass('oe_edited_link');
         const $contents = this.$link.contents();
         if (!this.$link.attr('href') && !this.colorCombinationClass) {
             $contents.unwrap();


### PR DESCRIPTION
`_updateEditorUI` was reseting color to old or non css color value
due to a race condition in the editor selection.

task-2654666


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
