### PR TITLE
[FIX] account: carryover lines: improve view

### DIFF
--- a/addons/account/models/account_tax_carryover_line.py
+++ b/addons/account/models/account_tax_carryover_line.py
@@ -9,11 +9,10 @@ class AccountTaxCarryoverLine(models.Model):
 
     name = fields.Char(required=True)
     amount = fields.Float(required=True, default=0.0)
-    date = fields.Date(required=True, default=fields.Date.context_today, readonly=True)
+    date = fields.Date(required=True, default=fields.Date.context_today)
     tax_report_line_id = fields.Many2one(
         comodel_name='account.tax.report.line',
         string="Tax report line",
-        domain="[('report_id', '=', tax_report_id)]",
     )
     tax_report_id = fields.Many2one(related='tax_report_line_id.report_id')
     tax_report_country_id = fields.Many2one(related='tax_report_id.country_id')

--- a/addons/account/views/account_tax_report_views.xml
+++ b/addons/account/views/account_tax_report_views.xml
@@ -75,7 +75,6 @@
                             <group>
                                 <field name="tax_report_id" invisible="1"/>
                                 <field name="name"/>
-                                <field name="tax_report_line_id"/>
                                 <field name="tax_report_country_id"/>
                                 <field name="foreign_vat_fiscal_position_id"/>
                             </group>


### PR DESCRIPTION
- allow editing the date of a carryover line manually

- don't display the tax report line the carryover line is linked to anymore, as the user goes through this line to open the carryover line anyway, and it shouldn't be editable.

- also remove a domain that made no sense on carryover lines: pointing to a related field depending on the field defining the domain

Manual forward-port of https://github.com/odoo/odoo/pull/77718
