### PR TITLE
[FIX] delivery : removed service from rule-based delivery quantity

### DIFF
--- a/addons/delivery/models/delivery_grid.py
+++ b/addons/delivery/models/delivery_grid.py
@@ -82,6 +82,8 @@ class ProviderGrid(models.Model):
                 total_delivery += line.price_total
             if not line.product_id or line.is_delivery:
                 continue
+            if line.product_id.type == "service":
+                continue
             qty = line.product_uom._compute_quantity(line.product_uom_qty, line.product_id.uom_id)
             weight += (line.product_id.weight or 0.0) * qty
             volume += (line.product_id.volume or 0.0) * qty


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Removed service from rule-based delivery quantity.

Current behavior before PR:

Product of type service are accounted for when computing the quantity, weight and volume metrics used in the price computation of rule based delivery.

Desired behavior after PR is merged:
Service-type products should be excluded from such computations.

opw-2647067

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
