### PR TITLE
[WIP] Split QWeb translations

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -7,6 +7,7 @@ import logging
 
 from odoo import _, api, fields, models, tools, Command
 from odoo.exceptions import UserError
+from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
 
@@ -47,7 +48,7 @@ class MailTemplate(models.Model):
     email_cc = fields.Char('Cc', help="Carbon copy recipients (placeholders may be used here)")
     reply_to = fields.Char('Reply To', help="Email address to which replies will be redirected when sending emails in mass; only used when the reply is not logged in the original discussion thread.")
     # content
-    body_html = fields.Html('Body', render_engine='qweb', translate=True, sanitize=False)
+    body_html = fields.Html('Body', render_engine='qweb', translate=html_translate, sanitize=False)
     attachment_ids = fields.Many2many('ir.attachment', 'email_template_attachment_rel', 'email_template_id',
                                       'attachment_id', 'Attachments',
                                       help="You may attach files to this template, to be added to all "

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -121,12 +121,12 @@ class TestMailRender(common.MailCommon):
             'value': cls.base_qweb_bits_fr[0],
         })
         cls.env['ir.translation'].create({
-            'type': 'model',
+            'type': 'model_terms',
             'name': 'mail.template,body_html',
             'lang': 'fr_FR',
             'res_id': cls.test_template.id,
-            'src': cls.test_template.body_html,
-            'value': cls.base_qweb_bits_fr[1],
+            'src': "Hello",
+            'value': "Bonjour",
         })
         cls.env['ir.model.data'].create({
             'name': 'test_template_xmlid',

--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -104,15 +104,8 @@ class TestMailTemplate(TestMailCommon, TestRecipients):
             'model': 'ir.ui.view',
             'res_id': view.id
         })
-        cls.env['ir.translation'].create({
-            'type': 'model_terms',
-            'name': 'ir.ui.view,arch_db',
-            'module': 'test_mail',
-            'lang': 'es_ES',
-            'res_id': view.id,
-            'src': 'English Layout',
-            'value': 'Spanish Layout',
-            'state': 'translated',
+        view.with_context(lang='es_ES').write({
+            'arch_db': '<body><t t-out="message.body"/> Spanish Layout <t t-esc="model_description"/></body>'
         })
 
         # admin should receive emails

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -141,7 +141,7 @@ TRANSLATED_ELEMENTS = {
     'abbr', 'b', 'bdi', 'bdo', 'br', 'cite', 'code', 'data', 'del', 'dfn', 'em',
     'font', 'i', 'ins', 'kbd', 'keygen', 'mark', 'math', 'meter', 'output',
     'progress', 'q', 'ruby', 's', 'samp', 'small', 'span', 'strong', 'sub',
-    'sup', 'time', 'u', 'var', 'wbr', 'text',
+    'sup', 't', 'text', 'time', 'u', 'var', 'wbr',
 }
 
 # Which attributes must be translated. This is a dict, where the value indicates
@@ -188,7 +188,7 @@ def translate_xml_node(node, callback, parse, serialize):
         """ Return whether the given node can be translated as a whole. """
         return (
             node.tag in TRANSLATED_ELEMENTS
-            and not any(key.startswith("t-") for key in node.attrib)
+            and all(not key.startswith("t-") or key == "t-out" for key in node.attrib)
             and all(translatable(child) for child in node)
         )
 


### PR DESCRIPTION
Split email template translations and consider `t-out` as inline text
Before this PR, the following was split into two translations
```xml
<p>Your invoice <t t-out="object.name"/> has been validated</p>
```
which was difficult to translate (not always split in meaningful parts).

TODO: adapt the website editor for translations