### PR TITLE
[FIX] web_tour: fixed tooltip content font size in frontend

### DIFF
--- a/addons/web_tour/static/src/scss/tip.scss
+++ b/addons/web_tour/static/src/scss/tip.scss
@@ -129,7 +129,7 @@
 
         // Force style so that it does not depend on where the tooltip is attached
         line-height: $line-height-base;
-        font-size: $font-size-base;
+        font-size: $o-root-font-size;
         font-family: $font-family-sans-serif;
         font-weight: normal;
 


### PR DESCRIPTION
currently, the font size of the text in the tooltip is displayed bigger
in the frontend compared to the font size of the text in the backend.

so this commit fixes the issue by adding the static font size in the
tooltipcontent so that the text of the tooltip contains the same
font size in the frontend as well as in the backend

TaskID - 2661291

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
