### PR TITLE
Master fix zero quantity transfer lines ready vst

### DIFF
--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -276,7 +276,7 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         production.action_assign()
         self.assertFalse(production.move_raw_ids.move_orig_ids)
         self.assertEqual(production.state, 'confirmed')
-        self.assertEqual(production.reservation_state, 'assigned')
+        self.assertEqual(production.reservation_state, 'confirmed')
 
     def test_manufacturing_3_steps_flexible(self):
         """ Test MO/picking before manufacturing/picking after manufacturing

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -898,6 +898,8 @@ class StockMove(models.Model):
             'partially_available': 2,
             'confirmed': 1,
         }
+        if all(move.product_uom_qty == 0 for move in self):
+            return 'confirmed'
         moves_todo = self\
             .filtered(lambda move: move.state not in ['cancel', 'done'] and not (move.state == 'assigned' and not move.product_uom_qty))\
             .sorted(key=lambda move: (sort_map.get(move.state, 0), move.product_uom_qty))

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -898,7 +898,7 @@ class StockMove(models.Model):
             'partially_available': 2,
             'confirmed': 1,
         }
-        if all(move.product_uom_qty == 0 and not move.state == 'assigned' for move in self):
+        if all(move.product_uom_qty == 0 for move in self):
             return 'confirmed'
         moves_todo = self\
             .filtered(lambda move: move.state not in ['cancel', 'done'] and not (move.state == 'assigned' and not move.product_uom_qty))\

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -898,7 +898,7 @@ class StockMove(models.Model):
             'partially_available': 2,
             'confirmed': 1,
         }
-        if all(move.product_uom_qty == 0 for move in self):
+        if all(move.product_uom_qty == 0 and not move.state == 'assigned' for move in self):
             return 'confirmed'
         moves_todo = self\
             .filtered(lambda move: move.state not in ['cancel', 'done'] and not (move.state == 'assigned' and not move.product_uom_qty))\


### PR DESCRIPTION
In this commit:
=============================
Improved the workflow for the product reservation for transfer
Now if any line from the transfer contains the product demand > 0
then only it will go for the reservation process

Before this commit:
============================
When we have a transfer which has line containing 0 demand at that
time it was always goes into the ready state

task-id: 2663993