### PR TITLE
[FIX] event: allow internal users to read registrations

### DIFF
--- a/addons/event/i18n/event.pot
+++ b/addons/event/i18n/event.pot
@@ -1712,6 +1712,12 @@ msgid "Only event users or managers are allowed to create or update registration
 msgstr "Only event users or managers are allowed to create or update registrations."
 
 #. module: event
+#: code:addons/event/models/event.py:441
+#, python-format
+msgid "Only internal users are allowed to read registrations."
+msgstr "Only internal users are allowed to read registrations."
+
+#. module: event
 #: model_terms:event.event,description:event.event_0
 msgid ""
 "OpenElec Applications reserves the right to cancel, re-name or re-locate the"

--- a/addons/event/models/event.py
+++ b/addons/event/models/event.py
@@ -436,7 +436,11 @@ class EventRegistration(models.Model):
 
     @api.model
     def check_access_rights(self, operation, raise_exception=True):
-        if not self.env.is_admin() and not self.user_has_groups('event.group_event_user'):
+        if operation == 'read' and not self.env.is_admin() and not self.user_has_groups('base.group_user'):
+            if raise_exception:
+                raise AccessError(_('Only internal users are allowed to read registrations.'))
+            return False
+        elif operation != 'read' and not self.env.is_admin() and not self.user_has_groups('event.group_event_user'):
             if raise_exception:
                 raise AccessError(_('Only event users or managers are allowed to create or update registrations.'))
             return False


### PR DESCRIPTION
Bug
===
Since 85053a8b667429d1510429cf5bd6ff665206a21d we limited the access
of the registration to the event users. But now we want to limit the
access to the internal users.

So only the portal users and the public users will be concerned by this
restriction.

Task-2666823