### PR TITLE
[FIX] web_editor: span gradient across text style changes

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -555,8 +555,14 @@ export const editorCommands = {
                 } else {
                     font = [];
                 }
-            } else if (node.nodeType === Node.TEXT_NODE && isVisibleStr(node)) {
-                // Node is a visible text node: wrap it in a <font>.
+            } else if ((node.nodeType === Node.TEXT_NODE && isVisibleStr(node))
+                    || (node.nodeType === Node.ELEMENT_NODE &&
+                        ['inline', 'inline-block'].includes(getComputedStyle(node).display) &&
+                        isVisibleStr(node.textContent) &&
+                        !node.classList.contains('btn') &&
+                        !node.querySelector('font'))) {
+                // Node is a visible text or inline node without font nor a button:
+                // wrap it in a <font>.
                 const previous = node.previousSibling;
                 const classRegex = mode === 'color' ? BG_CLASSES_REGEX : TEXT_CLASSES_REGEX;
                 if (

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -3835,5 +3835,21 @@ X[]
                 });
             });
         });
+        it('should apply a color to a slice of text containing a span', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>a[b<span>c</span>d]e</p>',
+                stepFunction: editor => editor.execCommand('applyColor', 'rgb(255, 0, 0)', 'color'),
+                contentAfter: '<p>a<font style="color: rgb(255, 0, 0);">[b<span>c</span>d]</font>e</p>',
+            });
+        });
+        it('should distribute color to texts and to button separately', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>a[b<a class="btn">c</a>d]e</p>',
+                stepFunction: editor => editor.execCommand('applyColor', 'rgb(255, 0, 0)', 'color'),
+                contentAfter: '<p>a<font style="color: rgb(255, 0, 0);">[b</font>' +
+                    '<a class="btn"><font style="color: rgb(255, 0, 0);">c</font></a>' +
+                    '<font style="color: rgb(255, 0, 0);">d]</font>e</p>',
+            });
+        });
     });
 });

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -911,10 +911,11 @@ section, .oe_img_bg, [data-oe-shape-data] {
     -webkit-text-fill-color: transparent;
 
     // FIXME (or wait for a fix in Chrome): the code below is needed to make
-    // animated text work with gradient background on Chrome. But the side
-    // effect is that text node wrapping by a span (e.g. bold, italic) no longer
-    // have the "gradient crossing all the text" on it but its own gradient.
-    * {
+    // animated text work with gradient background on Chrome. It is not based
+    // on ".text-gradient *" only to avoid a side effect that makes text nodes
+    // wrapped in a span (e.g. bold, italic) no longer have the "gradient
+    // crossing the whole text" on them but their own gradient.
+    .o_animated_text, .o_animated_text *, &.o_animated_text * {
         background-image: inherit;
         -webkit-background-clip: inherit;
         -webkit-text-fill-color: inherit;


### PR DESCRIPTION
Since [1] the gradient text image was reset within each font or span
block (e.g. for applying bold style).
The change was done because Chrome does not inherit the involved styles
when a transform is used, which is the case in animated texts.

After this commit the inherit style is only applied on animated texts.
This lets the gradient span across style changes.
This PR also makes the color changes apply across inline elements as if they were a single text.

[1]: https://github.com/odoo/odoo/commit/187acb938f70a2130d25fa76079221339c742f1e

task-2666200
