### PR TITLE
[FIX] web_editor: fix active class disappearing on tabs snippet

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -55,6 +55,7 @@ const Wysiwyg = Widget.extend({
         this.colorpickers = {};
         this._onDocumentMousedown = this._onDocumentMousedown.bind(this);
         this._onBlur = this._onBlur.bind(this);
+        this.customizableLinksSelector = 'a:not([data-toggle="tab"]):not([data-toggle="collapse"])';
     },
     /**
      *
@@ -185,7 +186,7 @@ const Wysiwyg = Widget.extend({
 
             self.openMediaDialog(params);
         });
-        this.$editable.on('dblclick', 'a', function (ev) {
+        this.$editable.on('dblclick', this.customizableLinksSelector, function (ev) {
             if (!this.getAttribute('data-oe-model') && self.toolbar.$el.is(':visible')) {
                 self.showTooltip = false;
                 self.toggleLinkTools({
@@ -827,6 +828,10 @@ const Wysiwyg = Widget.extend({
      * @param {boolean} [options.noFocusUrl=false] Disable the automatic focusing of the URL field.
      */
     toggleLinkTools(options = {}) {
+        const linkEl = getInSelection(this.odooEditor.document, 'a');
+        if (linkEl && !linkEl.matches(this.customizableLinksSelector)) {
+            return;
+        }
         if (this.snippetsMenu && !options.forceDialog) {
             if (this.linkTools) {
                 this.linkTools.destroy();
@@ -1344,7 +1349,7 @@ const Wysiwyg = Widget.extend({
             this._updateMediaJustifyButton();
             this._updateFaResizeButtons();
         }
-        const link = getInSelection(this.odooEditor.document, 'a');
+        const link = getInSelection(this.odooEditor.document, this.customizableLinksSelector);
         if (isInMedia || link) {
             // Handle the media/link's tooltip.
             this.showTooltip = true;

--- a/addons/website/static/src/js/editor/wysiwyg.js
+++ b/addons/website/static/src/js/editor/wysiwyg.js
@@ -59,7 +59,7 @@ Wysiwyg.include({
                 ev.preventDefault();
             }
 
-            if ($target.is('a') && !$target.attr('data-oe-model') && !$target.find('> [data-oe-model]').length && $target.closest('#wrapwrap').length) {
+            if ($target.is(this.customizableLinksSelector) && !$target.attr('data-oe-model') && !$target.find('> [data-oe-model]').length && $target.closest('#wrapwrap').length) {
                 if (!$target.data('popover-widget-initialized')) {
                     // TODO this code is ugly maybe the mutex should be in the
                     // editor root widget / the popover should not depend on

--- a/addons/website/views/snippets/s_tabs.xml
+++ b/addons/website/views/snippets/s_tabs.xml
@@ -5,7 +5,7 @@
     <section class="s_tabs pt48 pb48" data-vcss="001">
         <div class="container">
             <div class="s_tabs_main">
-                <div class="s_tabs_nav mb-3 o_no_link_popover">
+                <div class="s_tabs_nav mb-3">
                     <ul class="nav nav-pills" role="tablist">
                         <li class="nav-item">
                             <a class="nav-link active" id="nav_tabs_link_1" data-toggle="tab" href="#nav_tabs_content_1" role="tab" aria-controls="nav_tabs_content_1" aria-selected="true">Home</a>


### PR DESCRIPTION
Before this commit, the active class of the tabs snippet buttons
disappeared when leaving the edition of the buttons.

task-2656662

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
