### PR TITLE
[FIX] mrp : Remove operations from production template when the modul…

### DIFF
--- a/addons/mrp/report/mrp_production_templates.xml
+++ b/addons/mrp/report/mrp_production_templates.xml
@@ -43,7 +43,7 @@
                         </div>
                     </div>
 
-                    <div t-if="o.workorder_ids">
+                    <div t-if="o.workorder_ids" groups="mrp.group_mrp_routings">
                         <h3>
                             <span t-if="o.state == 'done'">Operations Done</span>
                             <span t-else="">Operations Planned</span>


### PR DESCRIPTION
…e is disabled

Current Behaviour :
1. Enable Work Orders
2. Add an operation to a BOM
3. Disable Work Orders
4. Create a manufacturing order for this product and finish the manufacturing.
5. Print the production order

What is the current behavior that you observe?
The production order has the operations in it even though the work order option has been disabled. This is because disabling the work order option just hides the operations and does not remove it from the BOM.

What would be your expected behavior in this case?
The printed production should not show the operation.

opw-2660545

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
