### PR TITLE
[FIX] web_editor: better field html sizing

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -113,7 +113,7 @@
                         </group>
                         </page>
                     </notebook>
-                    <field name="note" placeholder="Legal Notes..."/>
+                    <field name="note" options="{'odooFieldStyle': false}" placeholder="Legal Notes..."/>
                     </sheet>
                 </form>
             </field>

--- a/addons/account/wizard/account_invoice_send_views.xml
+++ b/addons/account/wizard/account_invoice_send_views.xml
@@ -48,7 +48,7 @@
                                 </div>
                                 <field name="subject" placeholder="Subject..." attrs="{'required': [('is_email', '=', True), ('composition_mode', '=', 'comment')]}"/>
                             </group>
-                            <field name="body" style="border:none;" options="{'style-inline': true}"/>
+                            <field name="body" style="border:none;" options="{'style-inline': true, 'odooFieldStyle': false}" />
                         </div>
                         <group>
                             <group attrs="{'invisible': [('composition_mode', '=', 'mass_mail')]}">

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -163,7 +163,7 @@
                                 </group>
                             </group>
                             <label for="description"/>
-                            <field name="description"/>
+                            <field name="description" options="{'odooFieldStyle': false}"/>
                         </page>
                         <page name="page_options" string="Options">
                             <group>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -254,7 +254,7 @@
 
                         <notebook>
                             <page string="Internal Notes" name="internal_notes">
-                                <field name="description" placeholder="Add a description..."/>
+                                <field name="description" options="{'odooFieldStyle': false}" placeholder="Add a description..."/>
                             </page>
                             <page name="extra" string="Extra Info" attrs="{'invisible': [('type', '=', 'opportunity')]}">
                                 <group>

--- a/addons/event_booth/views/event_booth_category_views.xml
+++ b/addons/event_booth/views/event_booth_category_views.xml
@@ -18,7 +18,7 @@
                     </group>
                     <notebook>
                         <page string="Description" name="description">
-                            <field name="description"/>
+                            <field name="description" options="{'odooFieldStyle': false}"/>
                         </page>
                     </notebook>
                 </sheet>

--- a/addons/gamification/views/gamification_karma_rank_views.xml
+++ b/addons/gamification/views/gamification_karma_rank_views.xml
@@ -78,10 +78,10 @@
                         </group>
                         <notebook>
                             <page string="Description" name="description">
-                                <field name="description" placeholder="e.g. A Master Chief knows quite everything on the forum! You cannot beat him!"/>
+                                <field name="description" placeholder="e.g. A Master Chief knows quite everything on the forum! You cannot beat him!" options="{'odooFieldStyle': false}"/>
                             </page>
                             <page string="Motivational" name="motivational">
-                                <field name="description_motivational" placeholder="e.g. Reach this rank to gain a free mug !"/>
+                                <field name="description_motivational" placeholder="e.g. Reach this rank to gain a free mug !" options="{'odooFieldStyle': false}"/>
                             </page>
                         </notebook>
                     </sheet>

--- a/addons/hr/views/hr_plan_views.xml
+++ b/addons/hr/views/hr_plan_views.xml
@@ -76,7 +76,7 @@
                             <field name="summary"/>
                             <field name="responsible"/>
                             <field name="responsible_id" attrs="{'invisible': [('responsible', '!=', 'other')]}"/>
-                            <field name="note"/>
+                            <field name="note" options="{'odooFieldStyle': false}"/>
                         </group>
                     </sheet>
                 </form>

--- a/addons/hr_recruitment/views/hr_recruitment_views.xml
+++ b/addons/hr_recruitment/views/hr_recruitment_views.xml
@@ -156,7 +156,7 @@
                 </group>
                 <notebook>
                     <page string="Application Summary">
-                        <field name="description" placeholder="Motivations..."/>
+                        <field name="description" placeholder="Motivations..." options="{'odooFieldStyle': false}"/>
                     </page>
                 </notebook>
             </sheet>

--- a/addons/lunch/views/lunch_orders_views.xml
+++ b/addons/lunch/views/lunch_orders_views.xml
@@ -242,7 +242,7 @@
                             <label for="note" class="font-weight-bold" />
                         </div>
                         <div class="col-10">
-                            <field name="note" nolabel="1" placeholder="Information, allergens, ..." />
+                            <field name="note" options="{'odooFieldStyle': false}" nolabel="1" placeholder="Information, allergens, ..." />
                         </div>
                     </div>
                 </div>

--- a/addons/lunch/views/lunch_product_views.xml
+++ b/addons/lunch/views/lunch_product_views.xml
@@ -89,7 +89,7 @@
                             <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                         <label for="description"/>
-                        <field name='description'/>
+                        <field name="description" options="{'odooFieldStyle': false}"/>
                     </group>
                 </sheet>
             </form>

--- a/addons/mail/views/ir_actions_server_views.xml
+++ b/addons/mail/views/ir_actions_server_views.xml
@@ -35,7 +35,7 @@
                                 }"/>
                             </group>
                         </group>
-                        <field name="activity_note" placeholder="Log a note..."/>
+                        <field name="activity_note" options="{'minHeight': 40}" placeholder="Log a note..."/>
                     </page>
                 </xpath>
                 <xpath expr="//field[@name='link_field_id']" position="after">

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -126,7 +126,7 @@
                             <field name="user_id"/>
                         </group>
                     </group>
-                    <field name="note" placeholder="Log a note..."/>
+                    <field name="note" options="{'odooFieldStyle': false}" placeholder="Log a note..."/>
                     <footer>
                         <field name="id" invisible="1"/>
                         <button id="mail_activity_schedule" string="Schedule" name="action_close_dialog" type="object" class="btn-primary"

--- a/addons/mail/views/mail_message_views.xml
+++ b/addons/mail/views/mail_message_views.xml
@@ -49,7 +49,7 @@
                         </group>
                         <notebook>
                             <page string="Body" name="body">
-                                <field name="body" options="{'style-inline': true}"/>
+                                <field name="body" options="{'style-inline': true, 'odooFieldStyle': false}"/>
                             </page>
                             <page string="Gateway" name="gateway">
                                 <group>

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -46,7 +46,7 @@
                                 <div class="oe_title">
                                     <h2 style="display: inline-block;"><field name="subject" placeholder="Subject (placeholders may be used here)"/></h2>
                                 </div>
-                                <field name="body_html" widget="html" options="{'style-inline': true, 'codeview': true }"/>
+                                <field name="body_html" widget="html" class="oe-bordered-editor" options="{'odooFieldStyle': false, 'style-inline': true, 'codeview': true }"/>
                                 <field name="attachment_ids" widget="many2many_binary"/>
                             </page>
                             <page string="Email Configuration" name="email_configuration">

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -69,7 +69,7 @@
                                     'required':[('reply_to_mode', '!=', 'update'), ('composition_mode', '=', 'mass_mail')]}"/>
                     </group>
                     <field name="can_edit_body" invisible="1"/>
-                    <field name="body" options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
+                    <field name="body" placeholder="Write a message..." options="{'style-inline': true, 'odooFieldStyle': false}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
                     <group col="4">
                         <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1" colspan="2"/>
                         <field name="template_id" options="{'no_create': True}"

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -365,7 +365,7 @@
                     </group>
                     <notebook>
                         <page string="Description" name="description">
-                            <field name="note"/>
+                            <field name="note" options="{'odooFieldStyle': false}"/>
                         </page>
                         <page string="Product Information" name="product_information">
                             <group>

--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -307,6 +307,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
     _getWysiwygOptions: function () {
         const options = this._super.apply(this, arguments);
         options.resizable = false;
+        options.odooFieldStyle = false;
         options.defaultDataForLinkTools = { isNewWindow: true };
         if (!this._wysiwygSnippetsActive) {
             delete options.snippets;

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -105,7 +105,7 @@
                                     <field name="worksheet_type" widget="radio"/>
                                     <field name="worksheet" help="Upload your PDF file." widget="pdf_viewer" attrs="{'invisible':  [('worksheet_type', '!=', 'pdf')], 'required':  [('worksheet_type', '=', 'pdf')]}"/>
                                     <field name="worksheet_google_slide" placeholder="Google Slide Link" widget="embed_viewer" attrs="{'invisible':  [('worksheet_type', '!=', 'google_slide')], 'required': [('worksheet_type', '=', 'google_slide')]}"/>
-                                    <field name="note" attrs="{'invisible':  [('worksheet_type', '!=', 'text')]}"/>
+                                    <field name="note" options="{'odooFieldStyle': false}" attrs="{'invisible':  [('worksheet_type', '!=', 'text')]}"/>
                                 </group>
                             </page>
                         </notebook>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -219,7 +219,7 @@
                     <field name="worksheet_type" invisible="1"/>
                     <field name="worksheet" widget="pdf_viewer" attrs="{'invisible': [('worksheet_type', '!=', 'pdf')]}"/>
                     <field name="worksheet_google_slide" widget="embed_viewer" attrs="{'invisible': [('worksheet_type', '!=', 'google_slide')]}"/>
-                    <field name="operation_note" attrs="{'invisible': [('worksheet_type', '!=', 'text')]}"/>
+                    <field name="operation_note" options="{'odooFieldStyle': false}" attrs="{'invisible': [('worksheet_type', '!=', 'text')]}"/>
                 </page>
                 </notebook>
             </sheet>

--- a/addons/project/static/src/js/project_form.js
+++ b/addons/project/static/src/js/project_form.js
@@ -17,8 +17,7 @@ const ProjectFormController = FormController.extend({
     _onDomUpdated() {
         const $editable = this.$el.find('.note-editable');
         if ($editable.length) {
-            const resizerHeight = this.$el.find('.o_wysiwyg_resizer').outerHeight();
-            const newHeight = window.innerHeight - $editable.offset().top - resizerHeight - 1;
+            const newHeight = window.innerHeight - $editable.offset().top - 42;
             $editable.outerHeight(newHeight);
         }
     },

--- a/addons/project/static/src/js/widgets/html_with_action_widget.js
+++ b/addons/project/static/src/js/widgets/html_with_action_widget.js
@@ -15,8 +15,7 @@ export const FieldHtmlWithAction = FieldHtml.extend({
             bus.on("DOM_updated", this, () => {
                 const $editable = this.$el.find('.note-editable');
                 if ($editable.length) {
-                    const resizerHeight = this.$el.find('.o_wysiwyg_resizer').outerHeight();
-                    const newHeight = window.innerHeight - $editable.offset().top - resizerHeight - 1;
+                    const newHeight = window.innerHeight - $editable.offset().top - 30;
                     $editable.outerHeight(newHeight);
                 }
             });

--- a/addons/project/static/src/scss/project_form.scss
+++ b/addons/project/static/src/scss/project_form.scss
@@ -5,7 +5,7 @@
 .o_form_project_project, .o_form_project_tasks {
     .note-editable {
         border: 0;
-        padding: $o-horizontal-padding $o-horizontal-padding;
+        padding: 0;
     }
 }
 

--- a/addons/project/views/project_sharing_views.xml
+++ b/addons/project/views/project_sharing_views.xml
@@ -194,7 +194,7 @@
                     </group>
                     <notebook>
                         <page name="description_page" string="Description">
-                            <field name="description" type="html" options="{'collaborative': true}"/>
+                            <field name="description" type="html" options="{'collaborative': true, 'odooFieldStyle': false}"/>
                         </page>
                         <page name="sub_tasks_page" string="Sub-tasks" attrs="{'invisible': [('allow_subtasks', '=', False)]}">
                             <field name="child_ids" context="{'default_project_id': project_id if not parent_id or not display_project_id else display_project_id, 'default_user_ids': [(6, 0, [uid])], 'default_parent_id': id, 'default_partner_id': partner_id, 'form_view_ref' : 'project.project_sharing_project_task_view_form'}">

--- a/addons/project/views/project_update_views.xml
+++ b/addons/project/views/project_update_views.xml
@@ -37,7 +37,7 @@
                     <separator/>
                     <notebook>
                         <page string="Description" name="description">
-                            <field name="description" widget="html_with_action" nolabel="1" class="o_project_update_description"/>
+                            <field name="description" widget="html_with_action" options="{'odooFieldStyle': false, 'height': 450}" nolabel="1" class="o_project_update_description"/>
                         </page>
                     </notebook>
                 </sheet>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -860,7 +860,7 @@
                     </group>
                     <notebook>
                         <page name="description_page" string="Description">
-                            <field name="description" type="html" options="{'collaborative': true}"/>
+                            <field name="description" type="html" options="{'collaborative': true, 'odooFieldStyle': false, 'height': 450}"/>
                         </page>
                         <page name="sub_tasks_page" string="Sub-tasks" attrs="{'invisible': [('allow_subtasks', '=', False)]}">
                             <field name="child_ids" context="{'default_project_id': project_id if not parent_id or not display_project_id else display_project_id, 'default_user_ids': user_ids, 'default_parent_id': id, 'default_partner_id': partner_id}">

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -208,10 +208,10 @@
                         </group>
                     </page>
                     <page string="Repair Notes">
-                        <field name="internal_notes" placeholder="Add internal notes."/>
+                        <field name="internal_notes" placeholder="Add internal notes."  options="{'odooFieldStyle': false}"/>
                     </page>
                     <page string="Quotation Notes">
-                        <field name="quotation_notes" placeholder="Add quotation notes."/>
+                        <field name="quotation_notes" placeholder="Add quotation notes." options="{'odooFieldStyle': false}"/>
                     </page>
                 </notebook>
                 </sheet>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -451,7 +451,7 @@
                             </group>
                         </page>
                         <page string="Note" name="note">
-                            <field name="note" string="Note" placeholder="Add an internal note that will be printed on the Picking Operations sheet"/>
+                            <field name="note" string="Note" options="{'odooFieldStyle': false, 'height': 400}" placeholder="Add an internal note that will be printed on the Picking Operations sheet"/>
                         </page>
                     </notebook>
                 </sheet>

--- a/addons/stock/views/stock_production_lot_views.xml
+++ b/addons/stock/views/stock_production_lot_views.xml
@@ -44,7 +44,7 @@
                 </group>
                 <notebook attrs="{'invisible': [('display_complete', '=', False)]}">
                     <page string="Description" name="description">
-                        <field name="note"/>
+                        <field name="note" options="{'odooFieldStyle': false}"/>
                     </page>
                 </notebook>
                 </sheet>

--- a/addons/survey/views/gamification_badge_views.xml
+++ b/addons/survey/views/gamification_badge_views.xml
@@ -16,7 +16,7 @@
                         </h1>
                     </div>
                     <group>
-                        <field name="description" nolabel="1" placeholder="e.g. No one can solve challenges like you do"/>
+                        <field name="description" nolabel="1" options="{'odooFieldStyle': false}" placeholder="e.g. No one can solve challenges like you do"/>
                     </group>
                     <group string="Rewards for challenges">
                         <field name="level"/>

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -164,7 +164,7 @@
                             </group>
                         </page>
                         <page string="Description" name="survey_description">
-                            <field name="description" widget="html"/>
+                            <field name="description" widget="html" options="{'odooFieldStyle': false}"/>
                         </page>
                         <page string="Options" name="options" attrs="{'invisible': [('is_page', '=', True)]}">
                             <group string="Constraints">

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -81,7 +81,7 @@
                             </field>
                         </page>
                         <page string="Description" name="description">
-                            <field name="description" nolabel="1"></field>
+                            <field name="description" nolabel="1" options="{'odooFieldStyle': false}"/>
                         </page>
                         <page string="End Message" name="description_done">
                             <field name="description_done" nolabel="1"></field>

--- a/addons/survey/wizard/survey_invite_views.xml
+++ b/addons/survey/wizard/survey_invite_views.xml
@@ -45,7 +45,7 @@
                             <field name="subject" placeholder="Subject..."/>
                         </group>
                         <field name="can_edit_body" invisible="1"/>
-                        <field name="body" options="{'style-inline': true, 'height': 380}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
+                        <field name="body" options="{'odooFieldStyle': false, 'style-inline': true, 'height': 380}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
                         <group>
                             <group>
                                 <field name="attachment_ids" widget="many2many_binary"/>

--- a/addons/web/static/src/legacy/scss/form_view.scss
+++ b/addons/web/static/src/legacy/scss/form_view.scss
@@ -696,14 +696,18 @@ $o-form-label-margin-right: 0px;
 
     // Translate icon
     span.o_field_translate {
-            padding: 0 $o-form-spacing-unit 0 0 !important;
-            vertical-align: top;
-            position: relative;
-            margin-left: -35px;
-            width: 35px !important; // important is usefull for textarea
-            display: inline-block;
-            text-align: right;
-            border: none;  // usefull for textarea
+        padding: 0 $o-form-spacing-unit 0 0 !important;
+        vertical-align: top;
+        position: relative;
+        margin-left: -35px;
+        width: 35px !important; // important is usefull for textarea
+        display: inline-block;
+        text-align: right;
+        border: none;  // usefull for textarea
+        background-color: rgba($o-view-background-color, 0.8); // usefull in code view
+        &:hover {
+            background-color: $o-view-background-color
+        }
     }
     input, textarea {
         &.o_field_translate {

--- a/addons/web/static/src/legacy/scss/form_view.scss
+++ b/addons/web/static/src/legacy/scss/form_view.scss
@@ -654,6 +654,16 @@ $o-form-label-margin-right: 0px;
 
         .tab-content > .tab-pane {
             padding: $o-horizontal-padding 0;
+            .note-editable {
+                border-width: 0;
+                padding: 0;
+                &.oe-odoo-field-style {
+                	border-bottom-width: 1px;
+                }
+            }
+            .oe-bordered-editor>.note-editable {
+                border-width: 1px;
+            }
         }
     }
 
@@ -672,7 +682,7 @@ $o-form-label-margin-right: 0px;
     }
     .o_field_widget, .btn {
         .o_field_widget {
-            margin-bottom: 0px;
+            margin-bottom: 0;
         }
     }
     .o_td_label .o_form_label:not(.o_status), .o_checkbox_optional_field > .o_form_label {

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2281,7 +2281,7 @@ export class OdooEditor extends EventTarget {
 
     clean() {
         this.observerUnactive();
-        for (const hint of this.document.querySelectorAll('.oe-hint')) {
+        for (const hint of this.editable.querySelectorAll('.oe-hint')) {
             hint.classList.remove('oe-hint', 'oe-command-temporary-hint');
             hint.removeAttribute('placeholder');
         }

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -530,7 +530,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
         $button.css({
             'font-size': '15px',
             position: 'absolute',
-            right: odoo.debug && this.nodeOptions.codeview ? '40px' : '5px',
+            right: odoo.debug && this.nodeOptions.codeview ? '56px' : '16px',
             top: '5px',
         });
         this.$el.append($button);

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -204,10 +204,12 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
                 noVideos: 'noVideos' in this.nodeOptions ? this.nodeOptions.noVideos : true,
             },
             linkForceNewWindow: true,
-
+            odooFieldStyle: 'odooFieldStyle' in this.nodeOptions ? this.nodeOptions.odooFieldStyle : true,
+            resizable: 'resizable' in this.nodeOptions ? this.nodeOptions.resizable : false,
+            height: this.nodeOptions.height,
+            minHeight: this.nodeOptions.minHeight,
+            maxHeight: this.nodeOptions.maxHeight,
             tabsize: 0,
-            height: this.nodeOptions.height || 110,
-            resizable: 'resizable' in this.nodeOptions ? this.nodeOptions.resizable : true,
             editorPlugins: [QWebPlugin],
         });
     },

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -551,6 +551,17 @@ const Wysiwyg = Widget.extend({
         this.$editable = this.options.editable || $('<div class="note-editable">');
         this.$root = this.$editable;
 
+        if (this.options.odooFieldStyle) {
+            this.$editable.addClass("oe-odoo-field-style");
+            this.$editable.css("min-height", this.options.minHeight || 10);
+        } else if (this.options.height) {
+            this.$editable.height(this.options.height);
+        } else {
+            this.$editable.css("min-height", this.options.minHeight || 100);
+        }
+        if (this.options.maxHeight && this.options.maxHeight > 10) {
+            this.$editable.css("max-height", this.options.maxHeight || 450);
+        }
         if (this.options.resizable && !device.isMobile) {
             const $wrapper = $('<div class="o_wysiwyg_wrapper odoo-editor">');
             this.$root = $wrapper;

--- a/addons/web_editor/static/src/scss/web_editor.backend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.backend.scss
@@ -3,10 +3,10 @@
     word-wrap: break-word;
     overflow: hidden;
 
-    .odoo-editor #codeview-btn-group {
+    #codeview-btn-group {
         position: absolute;
         top: 0;
-        right: 0;
+        right: 16px;
     }
 
     .note-editable {

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -709,6 +709,16 @@ img::selection {
     color: black;
     height: 100%;
     padding: 5px 10px;
+    &.oe-text-field-style {
+        border-top:0;
+        border-right:0;
+        border-left:0;
+        padding: 3px 0 5px;
+    }
+}
+.oe_bordered_editor .note-editable.oe-text-field-style {
+    border: $o-we-border-width solid $o-we-fg-light;
+    padding: 5px 10px;
 }
 
 .o_we_no_pointer_events {

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -201,7 +201,7 @@
                             </group>
                         </page>
                         <page string="Description" name="description">
-                            <field name="description"/>
+                            <field name="description" options="{'odooFieldStyle': false}"/>
                         </page>
                         <page string="Interactivity" name="interactivity">
                             <group>

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -86,7 +86,7 @@
                                 </group>
                             </page>
                             <page name="description" string="Description">
-                                <field name="description" placeholder="e.g. In this video, we'll give you the keys on how Odoo can help you to grow your business. At the end, we'll propose you a quiz to test your knowledge."/>
+                                <field name="description" options="{'odooFieldStyle': false}" placeholder="e.g. In this video, we'll give you the keys on how Odoo can help you to grow your business. At the end, we'll propose you a quiz to test your knowledge."/>
                             </page>
                             <page string="Additional Resources" name="external_links" >
                                 <group string="External Links">

--- a/addons/website_slides/wizard/slide_channel_invite_views.xml
+++ b/addons/website_slides/wizard/slide_channel_invite_views.xml
@@ -20,7 +20,7 @@
                             <field name="subject" placeholder="Subject..."/>
                         </group>
                         <field name="can_edit_body" invisible="1"/>
-                        <field name="body" options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
+                        <field name="body" options="{'style-inline': true, 'odooFieldStyle': false}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
                         <group>
                             <group>
                                 <field name="attachment_ids" widget="many2many_binary"/>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -321,7 +321,7 @@
                                             </group>
                                         </group>
                                         <group>
-                                            <field name="comment" placeholder="Internal notes..."/>
+                                            <field name="comment" options="{'odooFieldStyle': false}" placeholder="Internal notes..."/>
                                         </group>
                                         <field name="lang" invisible="True"/>
                                         <field name="user_id" invisible="True"/>
@@ -344,7 +344,7 @@
                             </group>
                         </page>
                         <page name='internal_notes' string="Internal Notes">
-                            <field name="comment" options="{'height': 70}" placeholder="Internal note..."/>
+                            <field name="comment" options="{'odooFieldStyle': false}" placeholder="Internal note..."/>
                         </page>
                     </notebook>
                 </sheet>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -119,7 +119,7 @@
                                 </tree>
                             </field>
                         </page><page string="Notes" name="notes">
-                            <field name="comment"/>
+                            <field name="comment" options="{'odooFieldStyle': false}"/>
                         </page>
                     </notebook>
                   </sheet>


### PR DESCRIPTION
Allow wysiwyg field html to blend better in odoo view,
Remove the default resizer by a auto size field html.

task-2637488


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
