### PR TITLE
[ADD] l10n_ar: refunds with liquido docs

### DIFF
--- a/addons/l10n_ar/models/account_journal.py
+++ b/addons/l10n_ar/models/account_journal.py
@@ -81,7 +81,6 @@ class AccountJournal(models.Model):
         receipt_m_code = ['54']
         receipt_codes = ['4', '9', '15']
         expo_codes = ['19', '20', '21']
-        liq_product_codes = ['60', '61']
         if self.type != 'sale':
             return []
         elif self.l10n_ar_afip_pos_system == 'II_IM':
@@ -89,7 +88,7 @@ class AccountJournal(models.Model):
             return usual_codes + receipt_codes + expo_codes + invoice_m_code + receipt_m_code
         elif self.l10n_ar_afip_pos_system in ['RAW_MAW', 'RLI_RLM']:
             # electronic/online invoice
-            return usual_codes + receipt_codes + invoice_m_code + receipt_m_code + mipyme_codes + liq_product_codes
+            return usual_codes + receipt_codes + invoice_m_code + receipt_m_code + mipyme_codes
         elif self.l10n_ar_afip_pos_system in ['CPERCEL', 'CPEWS']:
             # invoice with detail
             return usual_codes + invoice_m_code


### PR DESCRIPTION
Two modifications related to document types of type "liquidación"
1. Do not allow to use liquido producto on Sales POS, they are mean to be used in purchases
2. Previously only document 99 was able to be used on invoices and refunds, now we add more documents ('186', '188', '189') and we also fix export to VAT book (if a document for invoices is used for refunds it should be exported with negative amounts)


This PR goes together with https://github.com/odoo/enterprise/pull/21662



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
