### PR TITLE
[FIX] hr_contract: disable creation of contract history from kanban

### DIFF
--- a/addons/hr_contract/report/hr_contract_history_report_views.xml
+++ b/addons/hr_contract/report/hr_contract_history_report_views.xml
@@ -168,7 +168,7 @@
         <field name="name">hr.contract.history.view.kanban</field>
         <field name="model">hr.contract.history</field>
         <field name="arch" type="xml">
-            <kanban class="o_kanban_small_column" default_order="date_end" sample="1">
+            <kanban class="o_kanban_small_column" default_order="date_end" sample="1" create="false">
                 <field name="employee_id"/>
                 <field name="activity_state"/>
                 <field name="state"/>


### PR DESCRIPTION
New record should not be create from Kanban view for 
`hr.contract.history`.

Create is already disabled on list/form views.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
