### PR TITLE
[FIX] sale: conflicting context content

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -186,7 +186,7 @@ class AccountMoveLine(models.Model):
 
         if self.product_id.expense_policy == 'sales_price':
             product = self.product_id.with_context(
-                partner=order.partner_id.id,
+                partner=order.partner_id,
                 date_order=order.date_order,
                 pricelist=order.pricelist_id.id,
                 uom=self.product_uom_id.id,


### PR DESCRIPTION
Most uses (correct ones) of the `partner` context key content expect a `res.partner` recordset as `partner` context value.
This value is extracted during the pricelist price computation (but not used anyway...).

But in one case, fixed by the current commit, a `res.partner` id is placed in the context, as `partner` value.  In some cases, this may trigger "Comparing Apple and Oranges" errors, since `with_context` calls returns a new or existing environment, verifying whether an environment with the same values (user, context, ...) exists.
During this comparison, the new context, with an id (int) as `partner` value, is compared with existing contexts, potentially including some with a recordset on the same key.  Such a comparison fails on the lowest `__eq__` level, raising "Comparing apples with oranges" error.

This commit fixes this case, by making sure the value put in the `partner` context value is always a recordset, and not an id.

Note: In the future, this context key should be dropped because it's still a bad practice to put recordsets in the context.
