### PR TITLE
try to fix issue #38905

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2414,6 +2414,10 @@ class Selection(Field):
         raise ValueError("Wrong value for %s: %r" % (self, value))
 
     def convert_to_export(self, value, record):
+        if not record._context.get('import_compat', False):
+            for item in self._description_selection(record.env):
+                if item[0] == value:
+                    return item[1]
         if not isinstance(self.selection, list):
             # FIXME: this reproduces an existing buggy behavior!
             return value if value else ''


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
#38905, not show correct selection value when export even on non-import mode
Current behavior before PR:
#38905, not show correct selection value when export even on non-import mode
Desired behavior after PR is merged:
correct value in export excel file



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
