### PR TITLE
[FIX] website_crm_partner_assign: removes traceback while opening opp…

### DIFF
--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -164,7 +164,7 @@ class WebsiteAccount(CustomerPortal):
                 'opportunity': opp,
                 'user_activity': opp.sudo().activity_ids.filtered(lambda activity: activity.user_id == request.env.user)[:1],
                 'stages': request.env['crm.stage'].search([('is_won', '!=', True)], order='sequence desc, name desc, id desc'),
-                'activity_types': request.env['mail.activity.type'].sudo().search(['|', ('res_model_id.model', '=', opp._name), ('res_model_id', '=', False)]),
+                'activity_types': request.env['mail.activity.type'].sudo().search(['|', ('res_model', '=', opp._name), ('res_model', '=', False)]),
                 'states': request.env['res.country.state'].sudo().search([]),
                 'countries': request.env['res.country'].sudo().search([]),
             })


### PR DESCRIPTION
PURPOSE

Traceback occurs while opening opportunity from front-end, it
should not happen.

SPECIFICATIONS

The goal of this commit is to fix the traceback while opening 
opportunity, for solving this issue we need to use the proper
fields while rendering the template instead of using invalid field.

LINKS
PR #78280
Task 2443894
