### PR TITLE
[FIX] l10n_sa: remove duplicate xmlid in translations

### DIFF
--- a/addons/l10n_sa/i18n_extra/ar.po
+++ b/addons/l10n_sa/i18n_extra/ar.po
@@ -374,11 +374,6 @@ msgid "Deferred income"
 msgstr "الإيرادات مؤجلة"
 
 #. module: l10n_sa
-#: model:account.account.template,name:l10n_sa.sa_account_201019
-msgid "Accrued Dubai Customs"
-msgstr "جمارك دبي مستحقة"
-
-#. module: l10n_sa
 #: model:account.account.template,name:l10n_sa.sa_account_202001
 msgid "End of Service Provision"
 msgstr "مخصص نهاية الخدمة"

--- a/addons/l10n_sa/i18n_extra/l10n_sa.pot
+++ b/addons/l10n_sa/i18n_extra/l10n_sa.pot
@@ -374,11 +374,6 @@ msgid "Deferred income"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.account.template,name:l10n_sa.sa_account_201019
-msgid "Accrued Dubai Customs"
-msgstr ""
-
-#. module: l10n_sa
 #: model:account.account.template,name:l10n_sa.sa_account_202001
 msgid "End of Service Provision"
 msgstr ""


### PR DESCRIPTION
Module was not installable in some circumstances
    
To reproduce:
    - Make Arabic and Arabic (Syria) languages active
    - Try installing l10n_sa
    ==> crash: "psycopg2.errors.CardinalityViolation: ON CONFLICT DO UPDATE command cannot affect row a second time"
    
This was due to duplicate xmlid in the translation file.