### PR TITLE
[FIX] event_sale: fix kanban card layout for free tickets

### DIFF
--- a/addons/event_sale/models/event_registration.py
+++ b/addons/event_sale/models/event_registration.py
@@ -15,7 +15,7 @@ class EventRegistration(models.Model):
     payment_status = fields.Selection(string="Payment Status", selection=[
             ('to_pay', 'Not Paid'),
             ('paid', 'Paid'),
-            ('free', 'Free Admission'),
+            ('free', 'Free'),
         ], compute="_compute_payment_status", compute_sudo=True)
     utm_campaign_id = fields.Many2one(compute='_compute_utm_campaign_id', readonly=False, store=True)
     utm_source_id = fields.Many2one(compute='_compute_utm_source_id', readonly=False, store=True)


### PR DESCRIPTION
The larger payment status `"Free Admission"` replacing `"Free"` in #61668
made it require two lines on the attendee kanban card. The card was hence
taller and with additional and unnecessary whitespace.

To provide a fix promptly, the approach of renaming back the payment status
to `"Free"` was chosen.

Task-2586017