### PR TITLE
[FIX] mail: ensure that rtc call avatars are circular

### DIFF
--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.scss
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.scss
@@ -18,6 +18,8 @@
 .o_RtcCallParticipantCard_avatarImage {
     max-height: 100px;
     max-width: 100px;
+    aspect-ratio: 1;
+    object-fit: cover;
     border: 5px solid gray('700');
 
     &.o-isTalking {


### PR DESCRIPTION
Before this commit, the avatars of call participants could have a
non-circular shape on some browsers, this commit fixes this issue.

