### PR TITLE
[FIX] fix order issue in graph view

### DIFF
--- a/addons/web/static/src/views/graph/graph_arch_parser.js
+++ b/addons/web/static/src/views/graph/graph_arch_parser.js
@@ -26,7 +26,8 @@ export class GraphArchParser extends XMLParser {
                     if (mode && MODES.includes(mode)) {
                         archInfo.mode = mode;
                     }
-                    const order = node.getAttribute("order");
+                    let order = node.getAttribute("order");
+                    order = order && order.toUpperCase();
                     if (order && ORDERS.includes(order)) {
                         archInfo.order = order;
                     }

--- a/addons/web/static/tests/views/graph_view_tests.js
+++ b/addons/web/static/tests/views/graph_view_tests.js
@@ -3018,6 +3018,48 @@ QUnit.module("Views", (hooks) => {
         checkDatasets(assert, graph, "data", { data: [4, 3, 1] });
     });
 
+    QUnit.test("graph view sort by measure in lower case(desc)", async function (assert) {
+        assert.expect(2);
+
+        serverData.models.product.records.push({ id: 38, display_name: "zphone" });
+        serverData.models.foo.records[1].product_id = 38;
+
+        const graph = await makeView({
+            serverData,
+            type: "graph",
+            resModel: "foo",
+            arch: `
+                <graph order="desc">
+                    <field name="product_id"/>
+                </graph>
+            `,
+        });
+
+        checkLegend(assert, graph, "Count", "measure should be by count");
+        checkDatasets(assert, graph, "data", { data: [4, 3, 1] });
+    });
+
+    QUnit.test("graph view sort by measure in lower case(asc)", async function (assert) {
+        assert.expect(2);
+
+        serverData.models.product.records.push({ id: 38, display_name: "zphone" });
+        serverData.models.foo.records[1].product_id = 38;
+
+        const graph = await makeView({
+            serverData,
+            type: "graph",
+            resModel: "foo",
+            arch: `
+                <graph order="asc">
+                    <field name="product_id"/>
+                </graph>
+            `,
+        });
+
+        checkLegend(assert, graph, "Count", "measure should be by count");
+        checkDatasets(assert, graph, "data", { data: [1, 3, 4] });
+    });
+
     QUnit.test("graph view sort by measure for grouped data", async function (assert) {
         assert.expect(8);
 


### PR DESCRIPTION
purpose of this task to fix order issue in graph view, changes in order property
in studio  does not reflect in view.
value passed from studio is in lower case and in order to sort parser aspect
value in upper case, so add lower case 'desc' & 'asc' in order list

task: 2660731

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
