### PR TITLE
[MERGE][IMP] portal: allow portal users to deactivate their accounts

### DIFF
--- a/addons/auth_password_policy/static/src/css/password_field.css
+++ b/addons/auth_password_policy/static/src/css/password_field.css
@@ -14,3 +14,7 @@ meter.o_password_meter {
     /* also input has a 5px bottom margin... */
     bottom: calc(50% - 7px + 5px)
 }
+
+input + meter.o_password_meter[length="0"] {
+    display: none;
+}

--- a/addons/auth_password_policy/static/src/js/password_gauge.js
+++ b/addons/auth_password_policy/static/src/js/password_gauge.js
@@ -111,6 +111,7 @@ var PasswordPolicyMeter = Widget.extend({
         low: 0.5,
         high: 0.99,
         max: 1,
+        length: 0,
         value: 0,
         optimum: 1,
     },
@@ -133,6 +134,7 @@ var PasswordPolicyMeter = Widget.extend({
      * @param {String} password
      */
     update: function (password) {
+        this.el.setAttribute('length', password.length);
         this.el.value = policy.computeScore(password, this._required, this._recommended);
     }
 });

--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -84,7 +84,7 @@ class AuthSignupHome(Home):
                         "Password reset attempt for <%s> by user <%s> from %s",
                         login, request.env.user.login, request.httprequest.remote_addr)
                     request.env['res.users'].sudo().reset_password(login)
-                    qcontext['message'] = _("An email has been sent with credentials to reset your password")
+                    qcontext['message'] = _("Password reset instructions sent to your email")
             except UserError as e:
                 qcontext['error'] = e.args[0]
             except SignupError:

--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -156,7 +156,7 @@ class ResUsers(models.Model):
         if not users:
             users = self.search([('email', '=', login)])
         if len(users) != 1:
-            raise Exception(_('Reset password: invalid username or email'))
+            raise Exception(_('No account found for this login'))
         return users.action_reset_password()
 
     def action_reset_password(self):

--- a/addons/auth_signup/views/auth_signup_login_templates.xml
+++ b/addons/auth_signup/views/auth_signup_login_templates.xml
@@ -65,7 +65,7 @@
                     <p class="alert alert-success" t-if="message" role="status">
                         <t t-esc="message"/>
                     </p>
-                    <a href="/web/login" class="btn btn-link btn-sm float-right" role="button">Back to Login</a>
+                    <a href="/web/login" class="btn btn-link btn-sm float-left" role="button">Back to Login</a>
                 </div>
 
                 <form class="oe_reset_password_form" role="form" method="post" t-if="not message">
@@ -91,7 +91,7 @@
                     <input type="hidden" name="redirect" t-att-value="redirect"/>
                     <input type="hidden" name="token" t-att-value="token"/>
                     <div class="clearfix oe_login_buttons">
-                        <button type="submit" class="btn btn-primary btn-block">Confirm</button>
+                        <button type="submit" class="btn btn-primary btn-block">Reset Password</button>
                         <div class="d-flex justify-content-between align-items-center small mt-2">
                             <a t-if="not token" t-attf-href="/web/login?{{ keep_query() }}">Back to Login</a>
                             <a t-if="invalid_token" href="/web/login">Back to Login</a>

--- a/addons/auth_totp_portal/views/templates.xml
+++ b/addons/auth_totp_portal/views/templates.xml
@@ -1,6 +1,6 @@
 <odoo>
     <template id="totp_portal_hook" name="TOTP Portal hook" inherit_id="portal.portal_my_security">
-        <xpath expr="//div[hasclass('o_portal_security_body')]">
+        <xpath expr="//section[@name='portal_change_password']" position="after">
             <!--
                 portal users don't have access to non-qweb views anymore, so
                 embed the target view as a *data island* of sorts, a JSON embed

--- a/addons/auth_totp_portal/views/templates.xml
+++ b/addons/auth_totp_portal/views/templates.xml
@@ -11,7 +11,12 @@
                 <t t-esc="env.ref('auth_totp.view_totp_wizard').sudo().get_combined_arch()"/>
             </div>
             <section>
-                <h3>Two-factor authentication</h3>
+                <h3>
+                    Two-factor authentication
+                    <a href="https://www.odoo.com/documentation/master/applications/general/auth/2fa.html" target="_blank">
+                        <i title="Documentation" class="fa fa-fw o_button_icon fa-info-circle"></i>
+                    </a>
+                </h3>
                 <t t-if="not user_id.totp_enabled">
                     <div class="alert alert-secondary" role="status">
                         <i class="fa fa-warning"/>

--- a/addons/phone_validation/models/__init__.py
+++ b/addons/phone_validation/models/__init__.py
@@ -4,3 +4,4 @@
 from . import phone_blacklist
 from . import mail_thread_phone
 from . import res_partner
+from . import res_users

--- a/addons/phone_validation/models/res_users.py
+++ b/addons/phone_validation/models/res_users.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, models
+from odoo.addons.phone_validation.tools import phone_validation
+
+
+class Users(models.Model):
+    _inherit = 'res.users'
+
+    def _deactivate_portal_user(self, **post):
+        """Blacklist the phone of the user after deleting it."""
+        numbers_to_blacklist = {}  # numbers to blacklist and the related user
+        if post.get('request_blacklist'):
+            for user in self:
+                sanitized = phone_validation.phone_sanitize_numbers_w_record([user.phone, user.mobile], user)
+                user_phone = sanitized[user.phone]['sanitized']
+                user_mobile = sanitized[user.mobile]['sanitized']
+                if user_phone:
+                    numbers_to_blacklist[user_phone] = user
+                if user_mobile:
+                    numbers_to_blacklist[user_mobile] = user
+
+        super(Users, self)._deactivate_portal_user(**post)
+
+        if numbers_to_blacklist:
+            current_user = self.env.user
+            blacklists = self.env['phone.blacklist']._add(
+                list(numbers_to_blacklist.keys()))
+            for blacklist in blacklists:
+                user = numbers_to_blacklist[blacklist.number]
+                blacklist._message_log(
+                    body=_('Blocked by deletion of portal account %(portal_user_name)s by %(user_name)s (#%(user_id)s)',
+                           user_name=current_user.name, user_id=current_user.id,
+                           portal_user_name=user.name),
+                )

--- a/addons/portal/static/src/js/portal.js
+++ b/addons/portal/static/src/js/portal.js
@@ -237,6 +237,30 @@ publicWidget.registry.RemoveAPIKeyButton = publicWidget.Widget.extend({
     }
 });
 
+publicWidget.registry.portalSecurity = publicWidget.Widget.extend({
+    selector: '.o_portal_security_body',
+
+    /**
+     * @override
+     */
+    init: function () {
+        // Show the "deactivate your account" modal if needed
+        $('.modal.show#portal_deactivate_account_modal').removeClass('d-block').modal('show');
+
+        // Remove the error messages when we close the modal,
+        // so when we re-open it again we get a fresh new form
+        $('.modal#portal_deactivate_account_modal').on('hide.bs.modal', (event) => {
+            const $target = $(event.currentTarget);
+            $target.find('.alert').remove();
+            $target.find('.invalid-feedback').remove();
+            $target.find('.is-invalid').removeClass('is-invalid');
+        });
+
+        return this._super(...arguments);
+    },
+
+});
+
 /**
  * Wraps an RPC call in a check for the result being an identity check action
  * descriptor. If no such result is found, just returns the wrapped promise's

--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -540,6 +540,11 @@ form label {
             @extend .text-nowrap;
         }
     }
+    section[name="portal_deactivate_account"] {
+        label {
+            white-space: normal!important;
+        }
+    }
 }
 
 // Copyright

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -479,7 +479,7 @@
             <div class="alert alert-danger" role="alert" t-if="get_error(errors)">
                 <t t-esc="errors"/>
             </div>
-            <section>
+            <section name="portal_change_password">
                 <h3>Change Password</h3>
                 <t t-set="path">password</t>
                 <div class="alert alert-success" role="alert" t-if="success and success.get('password')">
@@ -554,6 +554,73 @@
                 </div>
                 <div>
                     <button type="submit" class="btn btn-secondary o_portal_new_api_key">New API Key</button>
+                </div>
+            </section>
+            <section name="portal_deactivate_account" groups="base.group_portal">
+                <h3>Delete Account</h3>
+                <t t-set="deactivate_error" t-value="get_error(errors, 'deactivate')"/>
+                <button class="btn btn-secondary" data-toggle="modal"
+                    data-target="#portal_deactivate_account_modal">
+                    Delete Account
+                </button>
+                <div t-attf-class="modal #{'show d-block' if open_deactivate_modal else ''}"
+                    id="portal_deactivate_account_modal" tabindex="-1" role="dialog">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header bg-danger">
+                                <h5 class="modal-title">Are you sure you want to do this?</h5>
+                                <button type="button" class="close" data-dismiss="modal">
+                                    ×
+                                </button>
+                            </div>
+                            <form action="/my/deactivate_account" method="post" class="modal-body"
+                                id="portal_deactivate_account_form">
+                                <div>
+                                    <div class="alert alert-danger"
+                                        t-esc="get_error(errors, 'deactivate.other')"/>
+                                    <p class="text-muted">
+                                        Disable your account, preventing any further login.<br/>
+                                        <b>
+                                            <i class="fa fa-exclamation-triangle text-danger"></i>
+                                            This action cannot be undone.
+                                        </b>
+                                    </p>
+                                    <hr/>
+                                    <p>1. Enter your password to confirm you own this account</p>
+                                    <input name="password" type="password" required="1"
+                                        t-attf-class="form-control #{'is-invalid' if deactivate_error == 'password' else ''}"
+                                        placeholder="Password"/>
+                                    <div t-if="deactivate_error == 'password'" class="invalid-feedback">
+                                        Wrong password.
+                                    </div>
+                                    <hr/>
+                                    <p>
+                                        2. Confirm you want to delete your account by
+                                        copying down your login (<t t-esc="env.user.login"/>).
+                                    </p>
+                                    <input name="validation" type="text" required="1"
+                                        t-attf-class="form-control #{'is-invalid' if deactivate_error == 'validation' else ''}"/>
+                                    <div t-if="deactivate_error == 'validation'" class="invalid-feedback">
+                                        You should enter "<t t-esc="env.user.login"/>" to validate your action.
+                                    </div>
+                                    <div class="d-flex flex-row align-items-center">
+                                        <input type="checkbox" name="request_blacklist" id="request_blacklist" checked="1"/>
+                                        <label for="request_blacklist" class="ml-2 mw-100 font-weight-normal mt-3">
+                                            Put my email and phone in a block list to make sure I'm never contacted again
+                                        </label>
+                                    </div>
+                                </div>
+                                <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                            </form>
+                            <div class="modal-footer justify-content-start">
+                                <input type="submit" class="btn btn-danger" form="portal_deactivate_account_form"
+                                    value="Delete Account"/>
+                                <button type="button" class="btn" data-dismiss="modal">
+                                    Cancel
+                                </button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </section>
         </div></t>

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -518,7 +518,7 @@
                             <t t-esc="get_error(errors, 'password.new2')"/>
                         </div>
                     </div>
-                    <button type="submit" class="btn btn-danger">Change Password</button>
+                    <button type="submit" class="btn btn-secondary">Change Password</button>
                 </form>
             </section>
             <section t-if="debug and allow_api_keys">
@@ -553,7 +553,7 @@
                     </table>
                 </div>
                 <div>
-                    <button type="submit" class="btn btn-primary o_portal_new_api_key">New API Key</button>
+                    <button type="submit" class="btn btn-secondary o_portal_new_api_key">New API Key</button>
                 </div>
             </section>
         </div></t>

--- a/addons/test_mail_full/tests/__init__.py
+++ b/addons/test_mail_full/tests/__init__.py
@@ -8,6 +8,7 @@ from . import test_mass_mailing
 from . import test_mass_mailing_statistics
 from . import test_mass_sms
 from . import test_rating
+from . import test_res_users
 from . import test_sms_composer
 from . import test_sms_management
 from . import test_sms_performance

--- a/addons/test_mail_full/tests/test_res_users.py
+++ b/addons/test_mail_full/tests/test_res_users.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
+
+
+class TestResUsers(MailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestResUsers, cls).setUpClass()
+        cls.portal_user = mail_new_test_user(
+            cls.env,
+            login='portal_user',
+            mobile='+32 494 12 34 56',
+            phone='+32 494 12 34 89',
+            password='password',
+            name='Portal User',
+            email='portal@test.example.com',
+            groups='base.group_portal',
+        )
+
+        cls.portal_user_2 = mail_new_test_user(
+            cls.env,
+            login='portal_user_2',
+            mobile='+32 494 12 34 22',
+            phone='invalid phone',
+            password='password',
+            name='Portal User 2',
+            email='portal_2@test.example.com',
+            groups='base.group_portal',
+        )
+
+        # Remove existing blacklisted email / phone (they will be sanitized, so we avoid to sanitize them here)
+        cls.env['mail.blacklist'].search([]).unlink()
+        cls.env['phone.blacklist'].search([]).unlink()
+
+    def test_deactivate_portal_users_blacklist(self):
+        """Test that the email and the phone are blacklisted
+        when a portal user deactivate his own account.
+        """
+        (self.portal_user | self.portal_user_2)._deactivate_portal_user(request_blacklist=True)
+
+        self.assertFalse(self.portal_user.active, 'Should have archived the user')
+        self.assertFalse(self.portal_user.partner_id.active, 'Should have archived the partner')
+        self.assertFalse(self.portal_user_2.active, 'Should have archived the user')
+        self.assertFalse(self.portal_user_2.partner_id.active, 'Should have archived the partner')
+
+        blacklist = self.env['mail.blacklist'].search([
+            ('email', 'in', ('portal@test.example.com', 'portal_2@test.example.com')),
+        ])
+        self.assertEqual(len(blacklist), 2, 'Should have blacklisted the users email')
+
+        blacklists = self.env['phone.blacklist'].search([
+            ('number', 'in', ('+32494123489', '+32494123456', '+32494123422')),
+        ])
+        self.assertEqual(len(blacklists), 3, 'Should have blacklisted the user phone and mobile')
+
+        blacklist = self.env['phone.blacklist'].search([('number', '=', 'invalid phone')])
+        self.assertFalse(blacklist, 'Should have skipped invalid phone')
+
+    def test_deactivate_portal_users_no_blacklist(self):
+        """Test the case when the user do not want to blacklist his email / phone."""
+        (self.portal_user | self.portal_user_2)._deactivate_portal_user(request_blacklist=False)
+
+        self.assertFalse(self.portal_user.active, 'Should have archived the user')
+        self.assertFalse(self.portal_user.partner_id.active, 'Should have archived the partner')
+        self.assertFalse(self.portal_user_2.active, 'Should have archived the user')
+        self.assertFalse(self.portal_user_2.partner_id.active, 'Should have archived the partner')
+
+        blacklists = self.env['mail.blacklist'].search([])
+        self.assertFalse(blacklists, 'Should not have blacklisted the users email')
+
+        blacklists = self.env['phone.blacklist'].search([])
+        self.assertFalse(blacklists, 'Should not have blacklisted the user phone and mobile')

--- a/odoo/addons/base/models/__init__.py
+++ b/odoo/addons/base/models/__init__.py
@@ -44,5 +44,6 @@ from . import res_config
 from . import res_currency
 from . import res_company
 from . import res_users
+from . import res_users_deletion
 
 from . import decimal_precision

--- a/odoo/addons/base/models/res_users_deletion.py
+++ b/odoo/addons/base/models/res_users_deletion.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+
+
+from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class ResUsersDeletion(models.Model):
+    """User deletion requests.
+
+    Those requests are logged in a different model to keep a trace of this action and the
+    deletion is done in a CRON. Indeed, removing a user can be a heavy operation on
+    large database (because of create_uid, write_uid on each model, which are not always
+    indexed). This model just remove the users added in the deletion queue, remaining code
+    must deal with other consideration (archiving, blacklist email...).
+    """
+
+    _name = 'res.users.deletion'
+    _description = 'Users Deletion Request'
+    _rec_name = 'user_id'
+
+    # Integer field because the related user might be deleted from the database
+    user_id = fields.Many2one('res.users', string='User', ondelete='set null')
+    user_id_int = fields.Integer('User Id', compute='_compute_user_id_int', store=True)
+    state = fields.Selection([('todo', 'To Do'), ('done', 'Done'), ('fail', 'Failed')],
+                             string='State', required=True, default='todo')
+
+    @api.depends('user_id')
+    def _compute_user_id_int(self):
+        for user_deletion in self:
+            if user_deletion.user_id:
+                user_deletion.user_id_int = user_deletion.user_id.id
+
+    @api.autovacuum
+    def _gc_portal_users(self):
+        """Remove the portal users that asked to deactivate their account.
+
+        (see <res.users>::_deactivate_portal_user)
+
+        Removing a user can be an heavy operation on large database (because of
+        create_uid, write_uid on each models, which are not always indexed). Because of
+        that, this operation is done in a CRON.
+        """
+        delete_requests = self.search([('state', '=', 'todo')])
+
+        # filter the requests related to a deleted user
+        done_requests = delete_requests.filtered(lambda request: not request.user_id)
+        done_requests.state = 'done'
+
+        for delete_request in (delete_requests - done_requests):
+            user = delete_request.user_id
+            user_name = user.name
+            try:
+                with self.env.cr.savepoint():
+                    partner = user.partner_id
+                    user.unlink()
+                    partner.unlink()
+                    _logger.info('User #%i %r, deleted. Original request from %r.',
+                                 user.id, user_name, delete_request.create_uid.name)
+                    delete_request.state = 'done'
+            except Exception:
+                delete_request.state = 'fail'

--- a/odoo/addons/base/security/ir.model.access.csv
+++ b/odoo/addons/base/security/ir.model.access.csv
@@ -70,6 +70,8 @@
 "access_res_partner_title_group_partner_manager","res_partner_title group_user","model_res_partner_title",,1,0,0,0
 "access_res_users_all","res_users all","model_res_users",,1,0,0,0
 "access_res_users_group_erp_manager","res_users group_erp_manager","model_res_users","group_erp_manager",1,1,1,1
+"access_res_users_deletion_all","res_users_deletion all","model_res_users_deletion",,0,0,0,0
+"access_res_users_deletion_group_erp_manager","res_users_deletion group_erp_manager","model_res_users_deletion","group_erp_manager",1,1,1,1
 "access_res_users_log_all","res_users_log_all","model_res_users_log",,1,0,1,0
 "access_res_users_identitycheck_employee","id check employees","model_res_users_identitycheck","group_user",1,1,1,0
 "access_res_users_identitycheck_portal","id check portal","model_res_users_identitycheck","group_portal",1,1,1,0


### PR DESCRIPTION
Purpose
=======
Allow portal users to deactivate their accounts from the portal view.

After the deactivation, they are redirected to the login page, so
they can verify that they can not longer login with their credentials.

We first archived the record and remove sensitive information (password,
login, so he can not log in again with the same credentials).

After the deactivation, we blacklist the email and the phone of the
user, so we are sure that we never send him again email / SMS.

Then, we create a <res.users.deletion> to delete the user and the 
partner in a CRON because this operation can be heavy (write_uid,
create_uid field on all models).

Task-2629544