### PR TITLE
[FIX] core: cr.transaction no longer depends on registry

### DIFF
--- a/odoo/api.py
+++ b/odoo/api.py
@@ -501,8 +501,12 @@ class Environment(Mapping):
         assert context is not None
         args = (cr, uid, context, su)
 
-        # if env already exists, return it
+        # determine transaction object
         transaction = cr.transaction
+        if transaction is None:
+            transaction = cr.transaction = Transaction(Registry(cr.dbname))
+
+        # if env already exists, return it
         for env in transaction.envs:
             if env.args == args:
                 return env

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -716,15 +716,10 @@ class Registry(Mapping):
         """ Return a new cursor for the database. The cursor itself may be used
             as a context manager to commit/rollback and close automatically.
         """
-        if self.test_cr is None:
-            cr = self._db.cursor()
-        else:
+        if self.test_cr is not None:
             # in test mode we use a proxy object that uses 'self.test_cr' underneath
-            cr = TestCursor(self.test_cr, self.test_lock)
-
-        # bind the cursor to a Transaction object, which manages environments
-        cr.transaction = odoo.api.Transaction(self)
-        return cr
+            return TestCursor(self.test_cr, self.test_lock)
+        return self._db.cursor()
 
 
 class DummyRLock(object):


### PR DESCRIPTION
The cursor features a "transaction" object to manage application-specific data in relation with cursor operations.  In its initial implementation, the transaction object was created by the registry.  This created a requirement: in order to be used in environments, a cursor had to be created by registry.cursor().

We now remove that unnecessary technical requirement by making environments create the transaction object on demand.

This proposal is a followup on https://github.com/odoo/odoo/pull/78125.