### PR TITLE
[FIX] purchase: fix MemoryError when there are lots of line_ids

### DIFF
--- a/addons/purchase/models/analytic_account.py
+++ b/addons/purchase/models/analytic_account.py
@@ -12,11 +12,15 @@ class AccountAnalyticAccount(models.Model):
     @api.depends('line_ids')
     def _compute_purchase_order_count(self):
         for account in self:
-            account.purchase_order_count = len(account.line_ids.move_id.purchase_order_id)
+            account.purchase_order_count = self.env['purchase.order'].search_count([
+                ('order_line.invoice_lines.analytic_line_ids.account_id', '=', account.id)
+            ])
 
     def action_view_purchase_orders(self):
         self.ensure_one()
-        purchase_orders = self.line_ids.move_id.purchase_order_id
+        purchase_orders = self.env['purchase.order'].search([
+            ('order_line.invoice_lines.analytic_line_ids.account_id', '=', self.id)
+        ])
         result = {
             "type": "ir.actions.act_window",
             "res_model": "purchase.order",


### PR DESCRIPTION
It seems that this long dereference causes a MemoryError for accounts
with many associated line_ids
```
select count(*) from account_analytic_account a join account_analytic_line l on l.account_id = a.id join account_move_line ml on ml.id = l.move_id where a.id=7
+---------+
| count   |
|---------|
| 131672  |
+---------+
```
The solution we propose is to use search_read inverting the order of
dereferences.

```
 Traceback (most recent call last):
   File "/tmp/tmpfhzemskj/migrations/base/tests/test_mock_crawl.py", line 182, in crawl_menu
    self.mock_action(action_vals)
   File "/tmp/tmpfhzemskj/migrations/base/tests/test_mock_crawl.py", line 293, in mock_action
    mock_method(model, view, fields_list, domain, group_by)
   File "/tmp/tmpfhzemskj/migrations/base/tests/test_mock_crawl.py", line 319, in mock_view_form
    [data] = record.read(fields_list)
   File "/home/odoo/src/odoo/15.0/odoo/models.py", line 3227, in read
    return self._read_format(fnames=fields, load=load)
   File "/home/odoo/src/odoo/15.0/odoo/models.py", line 3247, in _read_format
    vals[name] = convert(record[name], record, use_name_get)
   File "/home/odoo/src/odoo/15.0/odoo/models.py", line 5867, in __getitem__
    return self._fields[key].__get__(self, type(self))
   File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1106, in __get__
    self.compute_value(recs)
   File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1265, in compute_value
    records._compute_field_value(self)
   File "/home/odoo/src/odoo/15.0/addons/mail/models/mail_thread.py", line 410, in _compute_field_value
    return super()._compute_field_value(field)
   File "/home/odoo/src/odoo/15.0/odoo/models.py", line 4249, in _compute_field_value
    getattr(self, field.compute)()
   File "/home/odoo/src/odoo/15.0/addons/purchase/models/analytic_account.py", line 15, in _compute_purchase_order_count
    account.purchase_order_count = len(account.line_ids.move_id.purchase_order_id)
   File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 2605, in __get__
    return self.mapped(records)
   File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1176, in mapped
    self.__get__(first(remaining), type(remaining))
   File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 2603, in __get__
    return super().__get__(records, owner)
   File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1106, in __get__
    self.compute_value(recs)
   File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1265, in compute_value
    records._compute_field_value(self)
   File "/home/odoo/src/odoo/15.0/odoo/models.py", line 4251, in _compute_field_value
    field.compute(self)
   File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 615, in _compute_related
    values = [first(value[name]) for value in values]
   File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 615, in <listcomp>
    values = [first(value[name]) for value in values]
   File "/home/odoo/src/odoo/15.0/odoo/models.py", line 5867, in __getitem__
    return self._fields[key].__get__(self, type(self))
   File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 2603, in __get__
    return super().__get__(records, owner)
   File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1083, in __get__
    recs._fetch_field(self)
   File "/home/odoo/src/odoo/15.0/odoo/models.py", line 3276, in _fetch_field
    self._read(fnames)
   File "/home/odoo/src/odoo/15.0/odoo/models.py", line 3364, in _read
    self.env.cache.update(fetched, field, values)
   File "/home/odoo/src/odoo/15.0/odoo/api.py", line 893, in update
    field_cache.update(zip(records._ids, values))
 MemoryError
```

Observed during the upgrade of 41031

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
