### PR TITLE
[FIX] sale_timesheet: fix multiple issues in project profitability

### DIFF
--- a/addons/sale_timesheet/models/project_overview.py
+++ b/addons/sale_timesheet/models/project_overview.py
@@ -84,7 +84,8 @@ class Project(models.Model):
             'timesheet_cost': 'cost',
             'expense_cost': 'expense_cost',
             'expense_amount_untaxed_invoiced':  'expense_amount_untaxed_invoiced',
-            }
+            'expense_amount_untaxed_to_invoice': 'expense_amount_untaxed_to_invoice',
+        }
         profit = dict.fromkeys(list(field_map.values()) + ['total'], 0.0)
         profitability_raw_data = self.env['project.profitability.report'].read_group([('project_id', 'in', self.ids)], ['project_id'] + list(field_map), ['project_id'])   
         for data in profitability_raw_data:

--- a/addons/sale_timesheet/tests/test_reporting.py
+++ b/addons/sale_timesheet/tests/test_reporting.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.osv import expression
 from odoo.tools import float_is_zero, float_compare
 from odoo.addons.sale_timesheet.tests.common import TestCommonSaleTimesheetNoChart
 
@@ -404,3 +405,183 @@ class TestReporting(TestCommonSaleTimesheetNoChart):
         self.assertTrue(float_is_zero(project_global_stat['expense_amount_untaxed_to_invoice'], precision_rounding=rounding), "The expense cost to reinvoice of the global project should be 0.0")
         self.assertTrue(float_is_zero(project_global_stat['expense_amount_untaxed_invoiced'], precision_rounding=rounding), "The expense invoiced amount of the project from SO1 should be 0.0")
         self.assertEqual(float_compare(project_global_stat['expense_cost'], expense2.amount, precision_rounding=rounding), 0, "The expense cost of the global project should be 0.0")
+
+    def test_reversed_downpayment(self):
+        # this test suppose everything is in the same currency as the current one
+        currency = self.env.company.currency_id
+        rounding = currency.rounding
+
+        self.sale_order_2.action_confirm()
+        context = {
+            'active_model': 'sale.order',
+            'active_ids': self.sale_order_2.ids,
+            'active_id': self.sale_order_2.id,
+            'default_journal_id': self.env['account.journal'].search([
+                ('company_id', '=', self.env.company.id),
+                ('type', '=', 'sale')
+            ], limit=1).id,
+            'open_invoices': True,
+        }
+        # Let's do an invoice for a deposit of 100
+        downpayment = self.env['sale.advance.payment.inv'].with_context(context).create({
+            'advance_payment_method': 'percentage',
+            'amount': 10,
+        })
+        action_invoice = downpayment.create_invoices()
+        invoice_id = action_invoice['res_id']
+        invoice_downpayment = self.env['account.move'].browse(invoice_id)
+        invoice_downpayment.action_post()
+        posted_invoice_res_ids = [invoice_id]
+        downpayment2 = self.env['sale.advance.payment.inv'].with_context(context).create({
+            'advance_payment_method': 'percentage',
+            'amount': 25,
+        })
+        action_invoice = downpayment2.create_invoices()
+        invoice_downpayment2 = self.env['account.move'].search(expression.AND([action_invoice['domain'], [('id', 'not in', posted_invoice_res_ids)]]))
+        invoice_downpayment2.action_post()
+        posted_invoice_res_ids += invoice_downpayment2.ids
+        milestone_to_invoice = self.so_line_order_project.price_unit * self.so_line_order_project.qty_to_invoice
+        timesheets_to_invoice = self.so_line_order_task.price_unit * self.so_line_order_task.qty_to_invoice
+        total_product_price = milestone_to_invoice + timesheets_to_invoice
+        credit_note_wizard = self.env['account.move.reversal'].with_context({
+            'active_ids': invoice_downpayment2.ids,
+            'active_id': invoice_downpayment2.id,
+            'active_model': 'account.move'
+        }).create({
+            'refund_method': 'refund',
+            'reason': 'reason test create',
+        })
+        action_moves = credit_note_wizard.reverse_moves()
+        credit_id = action_moves['res_id']
+        invoice_credit = self.env['account.move'].browse(credit_id)
+        invoice_credit.action_post()
+        posted_invoice_res_ids += invoice_credit.ids
+        project_so_2 = self.so_line_order_project.project_id
+        task_so_2 = self.so_line_order_project.task_id
+        task_in_global_2 = self.so_line_order_task.task_id
+
+        self.env['project.profitability.report'].flush()
+        project_so_2_stat = self.env['project.profitability.report'].read_group([('project_id', 'in', project_so_2.ids)], ['project_id', 'amount_untaxed_to_invoice', 'amount_untaxed_invoiced', 'timesheet_unit_amount', 'timesheet_cost', 'expense_cost', 'expense_amount_untaxed_to_invoice', 'expense_amount_untaxed_invoiced'], ['project_id'])[0]
+        self.assertEqual(float_compare(project_so_2_stat['amount_untaxed_invoiced'], 0.1 * total_product_price, precision_rounding=rounding), 0,
+                         "The invoiced amount is the amount of downpayments not reversed")
+        self.assertEqual(float_compare(project_so_2_stat['amount_untaxed_to_invoice'], milestone_to_invoice - 0.1 * total_product_price, precision_rounding=rounding), 0,
+                         "The amount to invoice is the milestone product minus the downpayment not reversed")
+        self.assertTrue(float_is_zero(project_so_2_stat['timesheet_unit_amount'], precision_rounding=rounding),
+                        "The timesheet unit amount of the project from SO2 is 0")
+        self.assertTrue(float_is_zero(project_so_2_stat['timesheet_cost'], precision_rounding=rounding),
+                        "The timesheet cost of the project from SO2 is 0")
+        self.assertTrue(float_is_zero(project_so_2_stat['expense_amount_untaxed_to_invoice'], precision_rounding=rounding),
+                        "The expense cost to reinvoice of the project from SO2 should be 0.0")
+        self.assertTrue(float_is_zero(project_so_2_stat['expense_amount_untaxed_invoiced'], precision_rounding=rounding),
+                        "The expense invoiced amount of the project from SO2 should be 0.0")
+        self.assertTrue(float_is_zero(project_so_2_stat['expense_cost'], precision_rounding=rounding),
+                        "The expense cost of the project from SO2 should be 0.0")
+
+        # logged some timesheets: on project only, then on tasks with different employees
+        timesheet2 = self._log_timesheet_user(project_so_2, 2)
+        timesheet4 = self._log_timesheet_user(project_so_2, 3, task_so_2)
+
+        timesheet6 = self._log_timesheet_manager(project_so_2, 2, task_so_2)
+        timesheet8 = self._log_timesheet_manager(self.project_global, 3, task_in_global_2)
+
+        # simulate the auto creation of the SO line for expense, like we confirm a vendor bill.
+        so_line_expense = self.env['sale.order.line'].create({
+            'name': self.product_expense.name,
+            'product_id': self.product_expense.id,
+            'product_uom_qty': 0.0,
+            'product_uom': self.product_expense.uom_id.id,
+            'price_unit': self.product_expense.list_price,  # reinvoice at sales price
+            'order_id': self.sale_order_2.id,
+            'is_expense': True,
+        })
+
+        expense1 = self.env['account.analytic.line'].create({
+            'name': 'expense on project_so_2',
+            'account_id': project_so_2.analytic_account_id.id,
+            'so_line': so_line_expense.id,
+            'employee_id': self.employee_user.id,
+            'unit_amount': 4,
+            'amount': 4 * self.product_expense.list_price * -1,
+            'product_id': self.product_expense.id,
+            'product_uom_id': self.product_expense.uom_id.id,
+        })
+
+        self.env['project.profitability.report'].flush()
+
+        project_so_2_stat = self.env['project.profitability.report'].read_group([('project_id', 'in', project_so_2.ids)], ['project_id', 'amount_untaxed_to_invoice', 'amount_untaxed_invoiced', 'timesheet_unit_amount', 'timesheet_cost', 'expense_cost', 'expense_amount_untaxed_to_invoice', 'expense_amount_untaxed_invoiced'], ['project_id'])[0]
+        project_so_2_timesheet_cost = timesheet2.amount + timesheet4.amount + timesheet6.amount
+        project_so_2_timesheet_sold_unit = timesheet2.unit_amount + timesheet4.unit_amount + timesheet6.unit_amount
+        self.assertEqual(float_compare(project_so_2_stat['amount_untaxed_invoiced'], 0.1 * total_product_price, precision_rounding=rounding), 0,
+                         "The invoiced amount of the project from SO2 should only include downpayment not reversed")
+        self.assertEqual(float_compare(project_so_2_stat['amount_untaxed_to_invoice'], milestone_to_invoice - 0.1 * total_product_price, precision_rounding=rounding), 0,
+                         "The amount to invoice of the project from SO2 should include the milestone to invoice minus the downpayment")
+        self.assertEqual(float_compare(project_so_2_stat['timesheet_unit_amount'], project_so_2_timesheet_sold_unit, precision_rounding=rounding), 0,
+                         "The timesheet unit amount of the project from SO2 should include all timesheet in project")
+        self.assertEqual(float_compare(project_so_2_stat['timesheet_cost'], project_so_2_timesheet_cost, precision_rounding=rounding), 0,
+                         "The timesheet cost of the project from SO2 should include all timesheet")
+        self.assertEqual(float_compare(project_so_2_stat['expense_amount_untaxed_to_invoice'], -expense1.amount, precision_rounding=rounding), 0,
+                         "The expense cost to reinvoice of the project from SO2 should be the expense amount")
+        self.assertTrue(float_is_zero(project_so_2_stat['expense_amount_untaxed_invoiced'], precision_rounding=rounding),
+                        "The expense invoiced amount of the project from SO2 should be 0.0")
+        self.assertEqual(float_compare(project_so_2_stat['expense_cost'], expense1.amount, precision_rounding=rounding), 0,
+                         "The expense cost of the project from SO1 should be expense amount")
+
+        # invoice the Sales Order SO2
+        context = {
+            "active_model": 'sale.order',
+            "active_ids": self.sale_order_2.ids,
+            "active_id": self.sale_order_2.id,
+            'open_invoices': True,
+        }
+        payment = self.env['sale.advance.payment.inv'].with_context(mail_notrack=True).create({
+            'advance_payment_method': 'delivered',
+        })
+        action_invoice = payment.with_context(context).create_invoices()
+        invoice_payment = self.env['account.move'].search(expression.AND([action_invoice['domain'], [('id', 'not in', posted_invoice_res_ids)]]))
+        invoice_payment.action_post()
+        self.env['project.profitability.report'].flush()
+
+        project_so_2_stat = self.env['project.profitability.report'].read_group([('project_id', 'in', project_so_2.ids)], ['project_id', 'amount_untaxed_to_invoice', 'amount_untaxed_invoiced', 'timesheet_unit_amount', 'timesheet_cost', 'expense_cost', 'expense_amount_untaxed_to_invoice', 'expense_amount_untaxed_invoiced'], ['project_id'])[0]
+        self.assertEqual(float_compare(project_so_2_stat['amount_untaxed_invoiced'], milestone_to_invoice, precision_rounding=rounding), 0,
+                         "The invoiced amount of the project from SO2 should only include timesheet linked to task")
+        self.assertTrue(float_is_zero(project_so_2_stat['amount_untaxed_to_invoice'], precision_rounding=rounding),
+                        "The amount to invoice of the project from SO2 should be 0.0")
+        self.assertEqual(float_compare(project_so_2_stat['timesheet_unit_amount'], project_so_2_timesheet_sold_unit, precision_rounding=rounding), 0,
+                         "The timesheet unit amount of the project from SO2 should include all timesheet in project")
+        self.assertEqual(float_compare(project_so_2_stat['timesheet_cost'], project_so_2_timesheet_cost, precision_rounding=rounding), 0,
+                         "The timesheet cost of the project from SO2 should include all timesheet")
+        self.assertTrue(float_is_zero(project_so_2_stat['expense_amount_untaxed_to_invoice'], precision_rounding=rounding),
+                        "The expense to invoice amount of the project from SO2 should be 0.0")
+        self.assertEqual(float_compare(project_so_2_stat['expense_amount_untaxed_invoiced'], -1 * expense1.amount, precision_rounding=rounding), 0,
+                         "The expense cost reinvoiced of the project from SO2 should be the expense amount")
+        self.assertEqual(float_compare(project_so_2_stat['expense_cost'], expense1.amount, precision_rounding=rounding), 0,
+                         "The expense cost of the project from SO2 should be the expense amount")
+
+        credit_note_wizard = self.env['account.move.reversal'].with_context({
+            'active_ids': invoice_payment.ids,
+            'active_id': invoice_payment.id,
+            'active_model': 'account.move'
+        }).create({
+            'refund_method': 'refund',
+            'reason': 'reason test create',
+        })
+        action_moves = credit_note_wizard.reverse_moves()
+        credit_id = action_moves['res_id']
+        invoice_credit = self.env['account.move'].browse(credit_id)
+        invoice_credit.action_post()
+
+        project_so_2_stat = self.env['project.profitability.report'].read_group([('project_id', 'in', project_so_2.ids)], ['project_id', 'amount_untaxed_to_invoice', 'amount_untaxed_invoiced', 'timesheet_unit_amount', 'timesheet_cost', 'expense_cost', 'expense_amount_untaxed_to_invoice', 'expense_amount_untaxed_invoiced'], ['project_id'])[0]
+        self.assertEqual(float_compare(project_so_2_stat['amount_untaxed_invoiced'], 0.1 * total_product_price, precision_rounding=rounding), 0,
+                         "The invoiced amount of the project from SO2 should only include downpayment not reversed")
+        self.assertEqual(float_compare(project_so_2_stat['amount_untaxed_to_invoice'], milestone_to_invoice - 0.1 * total_product_price, precision_rounding=rounding), 0,
+                         "The amount to invoice of the project from SO2 should include the milestone to invoice minus the downpayment")
+        self.assertEqual(float_compare(project_so_2_stat['timesheet_unit_amount'], project_so_2_timesheet_sold_unit, precision_rounding=rounding), 0,
+                         "The timesheet unit amount of the project from SO2 should include all timesheet in project")
+        self.assertEqual(float_compare(project_so_2_stat['timesheet_cost'], project_so_2_timesheet_cost, precision_rounding=rounding), 0,
+                         "The timesheet cost of the project from SO2 should include all timesheet")
+        self.assertEqual(float_compare(project_so_2_stat['expense_amount_untaxed_to_invoice'], -expense1.amount, precision_rounding=rounding), 0,
+                         "The expense cost to reinvoice of the project from SO2 should be the expense amount")
+        self.assertTrue(float_is_zero(project_so_2_stat['expense_amount_untaxed_invoiced'], precision_rounding=rounding),
+                        "The expense invoiced amount of the project from SO2 should be 0.0")
+        self.assertEqual(float_compare(project_so_2_stat['expense_cost'], expense1.amount, precision_rounding=rounding), 0,
+                         "The expense cost of the project from SO1 should be expense amount")

--- a/addons/sale_timesheet/views/hr_timesheet_templates.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_templates.xml
@@ -172,6 +172,12 @@
                                                     </td>
                                                     <td>Re-invoiced costs</td>
                                                 </tr>
+                                                <tr t-if="display_cost &amp; (dashboard['profit']['expense_amount_untaxed_to_invoice'] != 0)">
+                                                    <td class="o_timesheet_plan_dashboard_cell">
+                                                        <t t-esc="dashboard['profit']['expense_amount_untaxed_to_invoice']" t-options='{"widget": "monetary", "display_currency": currency}'/>
+                                                    </td>
+                                                    <td>To re-invoice costs</td>
+                                                </tr>
                                                 <tr>
                                                     <td class="o_timesheet_plan_dashboard_total">
                                                         <b>


### PR DESCRIPTION
This commit fixes issues with downpayment and credit notes in project
profitability report.

Steps to reproduce opw-2596224:
- Go to sale
- Make a RFQ for a service product with service_policy set at
delivered_timesheet (Timesheets on tasks), set quantity as 10
- Confirm order and create two invoices for 15%, confirm the two
invoices
- Create a credit note for one of the invoice and confirm it
- Go back to the Sale Order and click on Project Overview
=> Inconsistencies (Downpayment reported twice)
- Add an expense
=> Inconsistencies in expense amount untaxed invoiced

This issue is fixed by :
- Excluding downpayments which are linked to a reversed invoice line
- Use expense amount to invoice and expense amount invoiced separetely
in the project overview.
- Do not report not invoiced SOLs in the expense amount invoiced.
- Exclude negative amounts in analytic account which are linked to
credit notes.

opw-2596224

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
