### PR TITLE
[FIX] web: avoid bad positioning for BlockUI on mobile

### DIFF
--- a/addons/web/static/src/core/ui/block_ui.scss
+++ b/addons/web/static/src/core/ui/block_ui.scss
@@ -1,5 +1,5 @@
 .o_blockUI {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   z-index: 1100;


### PR DESCRIPTION
On mobile, since the commit [1], the BlockUI is not aligned with the
viewport due to its absolute position.

This commit restores the previous value ("fixed").

Steps to reproduce:
* Open Odoo
* Go to Apps
* Scroll a bit the page
* Install one App => BUG

Ref:
[1] odoo/odoo@0573acae2306bf5da2005852da9323ddc59e5431

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
