### PR TITLE
[FIX] web_editor: activate the redo button when needed

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -637,7 +637,7 @@ export class OdooEditor extends EventTarget {
     }
 
     // One step completed: apply to vDOM, setup next history step
-    historyStep(skipRollback = false) {
+    historyStep(skipRollback = false, { stepId } = {}) {
         if (!this._historyStepsActive) {
             return;
         }
@@ -654,7 +654,7 @@ export class OdooEditor extends EventTarget {
             return false;
         }
 
-        currentStep.id = this._generateId();
+        currentStep.id = stepId || this._generateId();
         const previousStep = peek(this._historySteps);
         currentStep.clientId = this._collabClientId;
         currentStep.previousStepId = previousStep.id;
@@ -752,10 +752,10 @@ export class OdooEditor extends EventTarget {
             // Consider the position consumed.
             this._historyStepsStates.set(this._historySteps[pos].id, 'consumed');
             this.historyRevert(this._historySteps[pos]);
-            this.historyStep(true);
             // Consider the last position of the history as an undo.
-            const undoStep = this._historySteps[this._historySteps.length - 1];
-            this._historyStepsStates.set(undoStep.id, 'undo');
+            const stepId = this._generateId();
+            this._historyStepsStates.set(stepId, 'undo');
+            this.historyStep(true, { stepId });
             this.dispatchEvent(new Event('historyUndo'));
         }
     }
@@ -770,9 +770,9 @@ export class OdooEditor extends EventTarget {
             this._historyStepsStates.set(this._historySteps[pos].id, 'consumed');
             this.historyRevert(this._historySteps[pos]);
             this.historySetSelection(this._historySteps[pos]);
-            this.historyStep(true);
-            const lastStep = this._historySteps[this._historySteps.length - 1];
-            this._historyStepsStates.set(lastStep.id, 'redo');
+            const stepId = this._generateId();
+            this._historyStepsStates.set(stepId, 'redo');
+            this.historyStep(true, { stepId });
             this.dispatchEvent(new Event('historyRedo'));
         }
     }

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -162,6 +162,7 @@ export class OdooEditor extends EventTarget {
                     }
                 },
                 isHintBlacklisted: () => false,
+                filterMutationRecords: (records) => records,
                 _t: string => string,
             },
             options,
@@ -422,9 +423,9 @@ export class OdooEditor extends EventTarget {
         this._observerUnactiveLabels.add(label);
         if (this.observer) {
             clearTimeout(this.observerTimeout);
-            this.observer.disconnect();
             this.observerFlush();
             this.dispatchEvent(new Event('observerUnactive'));
+            this.observer.disconnect();
         }
     }
     observerFlush() {
@@ -572,7 +573,7 @@ export class OdooEditor extends EventTarget {
             }
             filteredRecords.push(record);
         }
-        return filteredRecords;
+        return this.options.filterMutationRecords(filteredRecords);
     }
 
     // History
@@ -1505,6 +1506,7 @@ export class OdooEditor extends EventTarget {
         }
     }
     _activateContenteditable() {
+        this.observerUnactive('_activateContenteditable');
         this.editable.setAttribute('contenteditable', this.options.isRootEditable);
 
         for (const node of this.options.getContentEditableAreas()) {
@@ -1512,8 +1514,10 @@ export class OdooEditor extends EventTarget {
                 node.setAttribute('contenteditable', true);
             }
         }
+        this.observerActive('_activateContenteditable');
     }
     _stopContenteditable() {
+        this.observerUnactive('_stopContenteditable');
         if (this.options.isRootEditable) {
             this.editable.setAttribute('contenteditable', !this.options.isRootEditable);
         }
@@ -1522,6 +1526,7 @@ export class OdooEditor extends EventTarget {
                 node.setAttribute('contenteditable', false);
             }
         }
+        this.observerActive('_stopContenteditable');
     }
 
     // HISTORY

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -115,6 +115,11 @@ const Wysiwyg = Widget.extend({
                 return node.hasAttribute &&
                     (node.hasAttribute('data-target') || node.hasAttribute('data-oe-model'));
             },
+            filterMutationRecords: (records) => {
+                return records.filter((record) => {
+                    return !(record.target.classList && record.target.classList.contains('o_header_standard'))
+                })
+            },
             noScrollSelector: 'body, .note-editable, .o_content, #wrapwrap',
             commands: commands,
             plugins: options.editorPlugins,


### PR DESCRIPTION
Because the `_historyStepsStates` was not fully set at the time of
calling `historyStep` in `historyUndo` or `historyRedo`, the listener
for the event "historyStep" was triggered to early and `historyCanRedo` at
that time could not possibly be accurate.

This commit call `historyStep` after setting all ids in
`_historyStepsStates`.

task-2667885




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
