### PR TITLE
[IMP] l10n_ar: total amount in letters for MiPyMEs

### DIFF
--- a/addons/l10n_ar/__manifest__.py
+++ b/addons/l10n_ar/__manifest__.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Argentinian Accounting',
-    'version': "3.4",
+    'version': "3.5",
     'description': """
 Functional
 ----------

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -241,6 +241,14 @@
             </div>
         </xpath>
 
+        <!-- Show total amount in letters for MiPyMEs document types according to the law
+         http://biblioteca.afip.gob.ar/dcp/LEY_C_027440_2018_05_09 article 5.f -->
+        <xpath expr="//div[@id='total']/div/table" position="after">
+            <t t-if="o.l10n_latam_document_type_id.code in ['201', '202', '203', '206', '207', '208', '211', '212', '213']">
+                <strong>Son: </strong><span t-esc="o.currency_id.with_context(lang='es_AR').amount_to_text(o.amount_total)"/>
+            </t>
+        </xpath>
+
         <!-- RG 5003: Add legend for 'A' documents that have a Monotribuista receptor -->
         <p name="comment" position="after">
             <p t-if="o.partner_id.l10n_ar_afip_responsibility_type_id.code in ['6', '13'] and o.l10n_latam_document_type_id.l10n_ar_letter == 'A'" >
@@ -418,6 +426,14 @@
                 </t>
 
             </div>
+        </xpath>
+
+        <!-- Show total amount in letters for MiPyMEs document types according to the law
+         http://biblioteca.afip.gob.ar/dcp/LEY_C_027440_2018_05_09 article 5.f -->
+        <xpath expr="//div[@id='total']/div/table" position="after">
+            <t t-if="o.l10n_latam_document_type_id.code in ['201', '202', '203', '206', '207', '208', '211', '212', '213']">
+                <strong>Son: </strong><span t-esc="o.currency_id.with_context(lang='es_AR').amount_to_text(o.amount_total)"/>
+            </t>
         </xpath>
 
         <!-- RG 5003: Add legend for 'A' documents that have a Monotribuista receptor -->


### PR DESCRIPTION
> l10n_ar task: 647

**Description of the issue/feature this PR addresses:**

According to the Argentinean law N° 27440, it is required for MiPyMEs
document types to show in the report the total amount in letters.

Do not FW-port.
PR for 14+: https://github.com/odoo/odoo/pull/79228

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
