### PR TITLE
[IMP] rating: Log incomplete ratings

### DIFF
--- a/addons/rating/__manifest__.py
+++ b/addons/rating/__manifest__.py
@@ -10,6 +10,7 @@ This module allows a customer to give rating.
         'mail',
     ],
     'data': [
+        'data/ir_cron_data.xml',
         'views/rating_rating_views.xml',
         'views/rating_template.xml',
         'views/mail_message_views.xml',

--- a/addons/rating/controllers/main.py
+++ b/addons/rating/controllers/main.py
@@ -43,7 +43,7 @@ class Rating(http.Controller):
             3: _("Okay"),
             1: _("Dissatisfied")
         }
-        rating.write({'rating': rate, 'consumed': True})
+        rating.write({'rating': rate})
         lang = rating.partner_id.lang or get_lang(request.env).code
         return request.env['ir.ui.view'].with_context(lang=lang)._render_template('rating.rating_external_page_submit', {
             'rating': rating, 'token': token,

--- a/addons/rating/data/ir_cron_data.xml
+++ b/addons/rating/data/ir_cron_data.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<odoo>
+    <data noupdate="1">
+        <record id="ir_cron_apply_rating" model="ir.cron">
+            <field name="name">Apply ratings with no feedback</field>
+            <field name="model_id" ref="model_rating_rating"/>
+            <field name="state">code</field>
+            <field name="code">model._cron_apply_ratings()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">hours</field>
+            <field name="numbercall">-1</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/rating/models/rating_mixin.py
+++ b/addons/rating/models/rating_mixin.py
@@ -196,8 +196,7 @@ class RatingMixin(models.AbstractModel):
             )
 
     def rating_apply(self, rate, token=None, feedback=None, subtype_xmlid=None):
-        """ Apply a rating given a token. If the current model inherits from
-        mail.thread mixin, a message is posted on its chatter. User going through
+        """ Apply a rating given a token. User going through
         this method should have at least employee rights because of rating
         manipulation (either employee, either sudo-ed in public controllers after
         security check granting access).
@@ -216,20 +215,28 @@ class RatingMixin(models.AbstractModel):
             rating = self.env['rating.rating'].search([('res_model', '=', self._name), ('res_id', '=', self.ids[0])], limit=1)
         if rating:
             rating.write({'rating': rate, 'feedback': feedback, 'consumed': True})
-            if hasattr(self, 'message_post'):
-                feedback = tools.plaintext2html(feedback or '')
-                self.message_post(
-                    body="<img src='/rating/static/src/img/rating_%s.png' alt=':%s/10' style='width:18px;height:18px;float:left;margin-right: 5px;'/>%s"
-                    % (rate, rate, feedback),
-                    subtype_xmlid=subtype_xmlid or "mail.mt_comment",
-                    author_id=rating.partner_id and rating.partner_id.id or None  # None will set the default author in mail_thread.py
-                )
-            if hasattr(self, 'stage_id') and self.stage_id and hasattr(self.stage_id, 'auto_validation_kanban_state') and self.stage_id.auto_validation_kanban_state:
-                if rating.rating > 2:
-                    self.write({'kanban_state': 'done'})
-                else:
-                    self.write({'kanban_state': 'blocked'})
+            self._log_rating(rating, subtype_xmlid)
         return rating
+
+    def _log_rating(self, rating, subtype_xmlid=None):
+        """ Attempt to log a rating in the chatter and change the kanban state of the related task.
+
+        :param rating.rating rating : the rating
+        :param string subtype_xmlid : xml id of a valid mail.message.subtype
+        """
+        if hasattr(self, 'message_post'):
+            feedback = tools.plaintext2html(rating.feedback or '')
+            self.message_post(
+                body="<img src='/rating/static/src/img/rating_%s.png' alt=':%s/5' style='width:18px;height:18px;float:left;margin-right: 5px;'/>%s"
+                % (int(rating.rating), int(rating.rating), feedback),
+                subtype_xmlid=subtype_xmlid or "mail.mt_comment",
+                author_id=rating.partner_id and rating.partner_id.id or None  # None will set the default author in mail_thread.py
+            )
+        if hasattr(self, 'stage_id') and self.stage_id and hasattr(self.stage_id, 'auto_validation_kanban_state') and self.stage_id.auto_validation_kanban_state:
+            if rating.rating > 2:
+                self.write({'kanban_state': 'done'})
+            else:
+                self.write({'kanban_state': 'blocked'})
 
     def _rating_get_repartition(self, add_stats=False, domain=None):
         """ get the repatition of rating grade for the given res_ids.


### PR DESCRIPTION
Previously, when a customer submitted a rating by clicking on a link, but closed the page without sending the feedack form, the rating would be created, but wouldn't be logged in the chatter of the related task, and the kanban state of the task wouldn't change.

This PR introduces a new hourly cron job, whose role is to identify such ratings, and log them in the chatter and change the kanban state of the task.

Task-2207626