### PR TITLE
[FIX] website_sale: stop changing location for product category

### DIFF
--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -53,6 +53,7 @@
             'website_sale/static/src/js/website_sale_validate.js',
             'website_sale/static/src/js/website_sale_recently_viewed.js',
             'website_sale/static/src/js/website_sale_tracking.js',
+            'website_sale/static/src/js/website_sale_category_link.js',
         ],
         'web._assets_primary_variables': [
             'website_sale/static/src/scss/primary_variables.scss',

--- a/addons/website_sale/static/src/js/website_sale_category_link.js
+++ b/addons/website_sale/static/src/js/website_sale_category_link.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import * as publicWidget from 'web.public.widget'
+
+publicWidget.registry.ProductCategoriesLinks = publicWidget.Widget.extend({
+    selector: '.products_categories',
+    events: {
+        'click [data-link-href]': '_openLink',
+    },
+
+    _openLink: function (ev) {
+        window.location.href = ev.currentTarget.getAttribute('data-link-href');
+    },
+});

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -405,7 +405,7 @@
     </template>
 
     <template id="categorie_link" name="Category Link">
-        <div t-attf-onclick="location.href='#{keep('/shop/category/' + slug(c), category=0)}';" class="custom-control custom-radio mb-1 d-inline-block">
+        <div t-att-data-link-href="keep('/shop/category/' + slug(c), category=0)" class="custom-control custom-radio mb-1 d-inline-block">
             <input type="radio" style="pointer-events:none;" class="custom-control-input" t-att-id="c.id" t-att-value="c.id" t-att-checked="'true' if c.id == category.id else None"/>
             <label class="custom-control-label font-weight-normal" t-att-for="c.id" t-field="c.name"/>
         </div>
@@ -428,7 +428,7 @@
                 <ul class="nav flex-column my-2">
                     <form>
                         <li class="nav-item">
-                            <div t-attf-onclick="location.href='#{keep('/shop', category=0)}';" class="custom-control custom-radio mb-1 d-inline-block">
+                            <div t-att-data-link-href="keep('/shop', category=0)" class="custom-control custom-radio mb-1 d-inline-block">
                                 <input type="radio" style="pointer-events:none;" class="custom-control-input o_not_editable" t-att-id="all_products" t-att-value="all_products" t-att-checked="'true' if not category else None"/>
                                 <label class="custom-control-label font-weight-normal" t-att-for="all_products">All Products</label>
                             </div>


### PR DESCRIPTION
In the product page, when the categories are activated
(through the customize menu item) and the page is in edit mode and when
the user click on one of the categories, the page was relocated.

We do not want that behavior in edit mode.

task-2666167

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
