### PR TITLE
[FIX] crm: exception raised creating contact

### DIFF
--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -60,8 +60,9 @@ class Partner(models.Model):
             p.meeting_count = len(result.get(p.id, []))
 
     def _compute_meeting(self):
-        if self.ids:
-            all_partners = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
+        all_partners = self.with_context(active_test=False).search(
+            [('id', 'child_of', self.ids)])
+        if all_partners:
             self.env.cr.execute("""
                 SELECT res_partner_id, calendar_event_id, count(1)
                   FROM calendar_event_res_partner_rel
@@ -101,7 +102,7 @@ class Partner(models.Model):
             'default_partner_ids': partner_ids,
             'default_attendee_ids': [(0, 0, {'partner_id': pid}) for pid in partner_ids],
         }
-        action['domain'] = ['|', ('id', 'in', self._compute_meeting()[self.id]), ('partner_ids', 'in', self.ids)]
+        action['domain'] = ['|', ('id', 'in', self._compute_meeting().get(self.id, [])), ('partner_ids', 'in', self.ids)]
         return action
 
     def action_view_opportunity(self):

--- a/doc/cla/individual/fredzamoabg.md
+++ b/doc/cla/individual/fredzamoabg.md
@@ -1,0 +1,11 @@
+Italy, 2021-10-14
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Alfredo Zamora alfredo.zamora@agilebg.com https://github.com/fredzamoabg


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Create partner causes exception in CRM module in `_compute_meeting` method.

```
psycopg2.ProgrammingError: ERRORE:  errore di sintassi a o presso ")"

LINE 4:                  WHERE res_partner_id IN ()
```

The problem is verified if user has a domain search for res.partner based specific field (ie. **('user_id', '=', self.env.uid)**)


Current behavior before PR:
Due to specific domain search associated to user, this call here https://github.com/odoo/odoo/blob/a416b0f2096dbb62cbc991111e01428e9e77b21f/addons/crm/models/res_partner.py#L64 returns no records causing the exception in next SQL execution.

workarround: set the fields used in domain search during partner creation

Desired behavior after PR is merged:
check is done on records found in `_compute_meeting` avoiding exception.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
