### PR TITLE
[FIX] stock_account : Inventory valuations now show and take into account arc…

### DIFF
--- a/addons/stock_account/views/stock_account_views.xml
+++ b/addons/stock_account/views/stock_account_views.xml
@@ -89,7 +89,7 @@
             <field name="res_model">stock.valuation.layer</field>
             <field name="view_mode">tree,form</field>
             <field name="domain">[('product_id.type', '=', 'product')]</field>
-            <field name="context">{'search_default_group_by_product_id': 1}</field>
+            <field name="context">{'search_default_group_by_product_id': 1,'active_test':False}</field>
             <field name="target">current</field>
             <field name="search_view_id" ref="view_inventory_valuation_search"/>
         </record>


### PR DESCRIPTION
[FIX] stock : Inventory valuations now show and take into account archived products

In the inventory valuations report archived product are now visible and taken into account

The archived production should always show in inventory valuation even if the product is archived
their might still be some of this product in the inventory. And these product need to be taken into
account for inventory valuation.

Steps to reproduce:
Create a product and purchase one
Receive the product, now it appears in the inventory valuation report
Archive the product, it disappears from the inventory valuation report

opw-2587794

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
