### PR TITLE
[FIX] sale_stock : Avoid warehouse changing on confirmed SO

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -162,7 +162,8 @@ class SaleOrder(models.Model):
     @api.onchange('user_id')
     def onchange_user_id(self):
         super().onchange_user_id()
-        self.warehouse_id = self.user_id.with_company(self.company_id.id)._get_default_warehouse_id().id
+        if self.state in ['draft','sent']:
+            self.warehouse_id = self.user_id.with_company(self.company_id.id)._get_default_warehouse_id().id
 
     @api.onchange('partner_shipping_id')
     def _onchange_partner_shipping_id(self):


### PR DESCRIPTION
Warehouse should not be modified when the salesperson is modified
on a confirmed SO

Steps to reproduce :
Have multiple warehouses 1, 2 and 3
Create an SO for warehouse 2 or 3 and confirm it.
Edit the confirmed SO and change the salesperson, the warehouse is changed on the SO


opw-2614063

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
