### PR TITLE
[IMP] 14.0 account_move: Separated move validation from move post method.

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2544,6 +2544,40 @@ class AccountMove(models.Model):
         )
         return self.action_post()
 
+    def _move_validation(self, move):
+        """Method that validates move.
+
+        :param move: Model<account.move> instance to validate.
+        :raises UserError: Validation failed.
+        """
+        if move.state == 'posted':
+            raise UserError(_('The entry %s (id %s) is already posted.') % (move.name, move.id))
+        if not move.line_ids.filtered(lambda line: not line.display_type):
+            raise UserError(_('You need to add a line before posting.'))
+        if move.auto_post and move.date > fields.Date.context_today(self):
+            date_msg = move.date.strftime(get_lang(self.env).date_format)
+            raise UserError(_("This move is configured to be auto-posted on %s", date_msg))
+
+        if not move.partner_id:
+            if move.is_sale_document():
+                raise UserError(_("The field 'Customer' is required, please complete it to validate the Customer Invoice."))
+            elif move.is_purchase_document():
+                raise UserError(_("The field 'Vendor' is required, please complete it to validate the Vendor Bill."))
+
+        if move.is_invoice(include_receipts=True) and float_compare(move.amount_total, 0.0, precision_rounding=move.currency_id.rounding) < 0:
+            raise UserError(_("You cannot validate an invoice with a negative total amount. You should create a credit note instead. Use the action menu to transform it into a credit note or refund."))
+
+        # Handle case when the invoice_date is not set. In that case, the invoice_date is set at today and then,
+        # lines are recomputed accordingly.
+        # /!\ 'check_move_validity' must be there since the dynamic lines will be recomputed outside the 'onchange'
+        # environment.
+        if not move.invoice_date:
+            if move.is_sale_document(include_receipts=True):
+                move.invoice_date = fields.Date.context_today(self)
+                move.with_context(check_move_validity=False)._onchange_invoice_date()
+            elif move.is_purchase_document(include_receipts=True):
+                raise UserError(_("The Bill/Refund date is required to validate this document."))
+
     def _post(self, soft=True):
         """Post/Validate the documents.
 
@@ -2572,33 +2606,7 @@ class AccountMove(models.Model):
         if not self.env.su and not self.env.user.has_group('account.group_account_invoice'):
             raise AccessError(_("You don't have the access rights to post an invoice."))
         for move in to_post:
-            if move.state == 'posted':
-                raise UserError(_('The entry %s (id %s) is already posted.') % (move.name, move.id))
-            if not move.line_ids.filtered(lambda line: not line.display_type):
-                raise UserError(_('You need to add a line before posting.'))
-            if move.auto_post and move.date > fields.Date.context_today(self):
-                date_msg = move.date.strftime(get_lang(self.env).date_format)
-                raise UserError(_("This move is configured to be auto-posted on %s", date_msg))
-
-            if not move.partner_id:
-                if move.is_sale_document():
-                    raise UserError(_("The field 'Customer' is required, please complete it to validate the Customer Invoice."))
-                elif move.is_purchase_document():
-                    raise UserError(_("The field 'Vendor' is required, please complete it to validate the Vendor Bill."))
-
-            if move.is_invoice(include_receipts=True) and float_compare(move.amount_total, 0.0, precision_rounding=move.currency_id.rounding) < 0:
-                raise UserError(_("You cannot validate an invoice with a negative total amount. You should create a credit note instead. Use the action menu to transform it into a credit note or refund."))
-
-            # Handle case when the invoice_date is not set. In that case, the invoice_date is set at today and then,
-            # lines are recomputed accordingly.
-            # /!\ 'check_move_validity' must be there since the dynamic lines will be recomputed outside the 'onchange'
-            # environment.
-            if not move.invoice_date:
-                if move.is_sale_document(include_receipts=True):
-                    move.invoice_date = fields.Date.context_today(self)
-                    move.with_context(check_move_validity=False)._onchange_invoice_date()
-                elif move.is_purchase_document(include_receipts=True):
-                    raise UserError(_("The Bill/Refund date is required to validate this document."))
+            self._move_validation(move)
 
             # When the accounting date is prior to the tax lock date, move it automatically to the next available date.
             # /!\ 'check_move_validity' must be there since the dynamic lines will be recomputed outside the 'onchange'

--- a/doc/cla/individual/albertopoljak.md
+++ b/doc/cla/individual/albertopoljak.md
@@ -1,0 +1,11 @@
+Croatia, 2021-10-13
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Alberto Poljak albertopoljak@gmail.com https://github.com/albertopoljak


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Currently there is no way to call these checks with custom method/addon without overwriting the
entire `_post` method (risky if anything other does the same) or if we don't duplicate that entire code that deals with it.

Specific usage example would be if you have a state before 'posted' (example 'marked for review' or similar). I want to call these checks with my previous button "Mark for review" and not only with button "Post". So as stated above my only option is to duplicate the whole validation code.

From pattern perspective this also moves specific functionality to its own method,  reducing the workload of mega function `_post`  making the code more readable and more easily adjustable to custom needs.



Current behavior before PR:
No easy way to call move validations from mega method `_post` without resorting to code duplication.

Desired behavior after PR is merged:
Can easily call (or add more) move validations.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
