### PR TITLE
[FIX] base: support tail text after a comment

### DIFF
--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -1066,6 +1066,7 @@ class QWeb(object):
             for item in el:
                 # ignore comments & processing instructions
                 if isinstance(item, etree._Comment):
+                    body.extend(self._compile_tail(item))
                     continue
                 body.extend(self._compile_node(item, options))
                 body.extend(self._compile_tail(item))

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -724,6 +724,31 @@ class TestPageSplit(TransactionCase):
             E.div(E.table(E.tr(), E.tr(), E.tr()))
         )
 
+
+class TestQWebMisc(TransactionCase):
+    def test_render_comment_tail(self):
+        """ Test the rendering of a tail text, near a comment.
+        """
+
+        view1 = self.env['ir.ui.view'].create({
+            'name': "dummy",
+            'type': "qweb",
+            'arch': """
+            <t>
+                <!-- it is a comment -->
+                <!-- it is another comment -->
+                Text 1
+                <!-- it is still another comment -->
+                Text 2
+                <t>ok</t>
+            </t>
+            """
+        })
+        emptyline = b'\n                '
+        expected = emptyline * 3 + b'Text 1' + emptyline * 2 + b'Text 2' + emptyline + b'ok\n            '
+        self.assertEqual(view1._render(), expected)
+
+
 def load_tests(loader, suite, _):
     # can't override TestQWeb.__dir__ because dir() called on *class* not
     # instance


### PR DESCRIPTION
This commit fixes the case where you have some text after a comment.
Until know, we miss it. Now we render the tail part.

```
<t>
        <!-- HIDE Text 1 -->
        Text 1
        <p>SHOW Text 2</p>
</t>
```

After the fix, Text 1 is correctly rendered

This commit fixes #76628