### PR TITLE
[FIX] website: fix menu items width calculation

### DIFF
--- a/addons/web/static/src/legacy/js/core/menu.js
+++ b/addons/web/static/src/legacy/js/core/menu.js
@@ -28,7 +28,8 @@ export async function initAutoMoreMenu(el, options) {
     }, options || {});
 
     const isUserNavbar = el.parentElement.classList.contains('o_main_navbar');
-    const dropdownSubMenuClasses = ['show', 'border', 'position-static'];
+    const dropdownSubMenuClasses = ['show', 'border-0', 'position-static'];
+    const dropdownToggleClasses = ['h-auto', 'py-2', 'text-secondary'];
     var autoMarginLeftRegex = /\bm[lx]?(?:-(?:sm|md|lg|xl))?-auto\b/;
     var autoMarginRightRegex = /\bm[rx]?(?:-(?:sm|md|lg|xl))?-auto\b/;
     var extraItemsToggle = null;
@@ -63,8 +64,12 @@ export async function initAutoMoreMenu(el, options) {
             } else {
                 item.classList.remove('dropdown-item');
                 const dropdownSubMenu = item.querySelector('.dropdown-menu');
+                const dropdownSubMenuButton = item.querySelector('.dropdown-toggle');
                 if (dropdownSubMenu) {
                     dropdownSubMenu.classList.remove(...dropdownSubMenuClasses);
+                }
+                if (dropdownSubMenuButton) {
+                    dropdownSubMenuButton.classList.remove(...dropdownToggleClasses);
                 }
             }
             el.insertBefore(item, extraItemsToggle);
@@ -127,9 +132,13 @@ export async function initAutoMoreMenu(el, options) {
                 navLink.classList.toggle('active', el.classList.contains('active'));
             } else {
                 const dropdownSubMenu = el.querySelector('.dropdown-menu');
-                el.classList.add('dropdown-item');
+                const dropdownSubMenuButton = el.querySelector('.dropdown-toggle');
+                el.classList.add('dropdown-item', 'p-0');
                 if (dropdownSubMenu) {
                     dropdownSubMenu.classList.add(...dropdownSubMenuClasses);
+                }
+                if (dropdownSubMenuButton) {
+                    dropdownSubMenuButton.classList.add(...dropdownToggleClasses);
                 }
             }
             dropdownMenu.appendChild(el);
@@ -152,8 +161,8 @@ export async function initAutoMoreMenu(el, options) {
     }
 
     function _addExtraItemsButton(target) {
-        let dropdownMenu = document.createElement('ul');
-        extraItemsToggle = document.createElement('li');
+        let dropdownMenu = document.createElement('div');
+        extraItemsToggle = dropdownMenu.cloneNode();
         const extraItemsToggleIcon = document.createElement('i');
         const extraItemsToggleLink = document.createElement('a');
 

--- a/addons/web/static/src/legacy/js/core/menu.js
+++ b/addons/web/static/src/legacy/js/core/menu.js
@@ -34,6 +34,15 @@ export async function initAutoMoreMenu(el, options) {
     var autoMarginRightRegex = /\bm[rx]?(?:-(?:sm|md|lg|xl))?-auto\b/;
     var extraItemsToggle = null;
     let debounce;
+    const afterFontsloading = new Promise((resolve) => {
+        if (document.fonts) {
+            document.fonts.ready.then(resolve);
+        } else {
+            // IE: don't wait more than max .15s.
+            setTimeout(resolve, 150);
+        }
+    });
+    afterFontsloading.then(_adapt);
 
     if (options.images.length) {
         await _afterImagesLoading(options.images);
@@ -45,7 +54,6 @@ export async function initAutoMoreMenu(el, options) {
         debounce = setTimeout(_adapt, 250);
     };
     window.addEventListener('resize', debouncedAdapt);
-    _adapt();
 
     el.addEventListener('dom:autoMoreMenu:adapt', _adapt);
     el.addEventListener('dom:autoMoreMenu:destroy', destroy, {once: true});

--- a/addons/website/static/src/js/menu/navbar.js
+++ b/addons/website/static/src/js/menu/navbar.js
@@ -40,13 +40,13 @@ var WebsiteNavbar = publicWidget.RootWidget.extend({
      */
     start: function () {
         var self = this;
-        initAutoMoreMenu(this.el.querySelector('ul.o_menu_sections'), {
+        initAutoMoreMenu(this.el.querySelector('.o_menu_sections'), {
             maxWidth: function () {
                 // The navbar contains different elements in community and
                 // enterprise, so we check for both of them here only
                 return self.$el.width()
                     - (self.$('.o_menu_systray').outerWidth(true) || 0)
-                    - (self.$('ul#oe_applications').outerWidth(true) || 0)
+                    - (self.$('#oe_applications').outerWidth(true) || 0)
                     - (self.$('.o_menu_toggle').outerWidth(true) || 0)
                     - (self.$('.o_menu_brand').outerWidth(true) || 0);
             },


### PR DESCRIPTION
ISSUE:

The width of menu items is computed (in 'initAutoMoreMenu')
to check for overflow and fold extra items in a "+" dropdown.

[1] When the page is not in cache yet, the width is computed
while font is not loaded yet and the value obtained is not
the same when font is already available [2] (e.g. if we go
to another page).

This explains why we get an additional folded item comparing
[1] and [2].

The goal of this PR is to fix this behaviour by waiting
for font loading before the update.

task-2618929
