### PR TITLE
[FIX] base: missing Saudi Arabia in the gcc country group

### DIFF
--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -1625,7 +1625,7 @@
 
         <record id="gulf_cooperation_council" model="res.country.group">
             <field name="name">Gulf Cooperation Council (GCC)</field>
-            <field name="country_ids" eval="[(6,0, [ref('base.ae'), ref('base.bh'), ref('base.om'), ref('base.qa'), ref('base.kw')])]"/>
+            <field name="country_ids" eval="[(6,0, [ref('base.sa'), ref('base.ae'), ref('base.bh'), ref('base.om'), ref('base.qa'), ref('base.kw')])]"/>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
The Gulf Cooperation Council country group is missing the kingdom of Saudi Arabia

Members are : Bahrain, Kuwait, Oman, Qatar, Saudi Arabia and United Arab Emirates

https://en.wikipedia.org/wiki/Gulf_Cooperation_Council


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
