### PR TITLE
[IMP] website_crm_iap_reveal: add website_crm dependency

### DIFF
--- a/addons/website_crm_iap_reveal/__manifest__.py
+++ b/addons/website_crm_iap_reveal/__manifest__.py
@@ -10,7 +10,7 @@
         'iap_crm',
         'iap_mail',
         'crm_iap_mine',
-        'website'
+        'website_crm',
     ],
     'data': [
         'data/ir_cron_data.xml',


### PR DESCRIPTION
PURPOSE

The purpose of this commit is to minimize the AttributeError: 'website.visitor'
object has no attribute 'lead_ids'.

SPECIFICATIONS

While installing 'website_crm_iap_reveal' module, 'website_crm' module will
auto-install. But while uninstalling only the 'website_crm' module, it removes
the 'lead_ids' field and when a public user is visiting the website home/contactus page,
the error is coming.

This adds the dependency of 'website_crm' module.

This is the goal of this commit.

LINKS

PR #78354
Task-2655439


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
