### PR TITLE
[IMP] crm_iap_lead_website: fix usages of 'lead_ids' field

### DIFF
--- a/addons/crm_iap_lead_website/models/ir.py
+++ b/addons/crm_iap_lead_website/models/ir.py
@@ -17,7 +17,7 @@ class IrHttp(models.AbstractModel):
             visitor_sudo = request.env['website.visitor']._get_visitor_from_request()
             # We are avoiding to create a reveal_view if a lead is already
             # created from another module, e.g. website_form
-            if not (visitor_sudo and visitor_sudo.lead_ids):
+            if not visitor_sudo or 'lead_ids' not in visitor_sudo or not visitor_sudo.lead_ids:
                 country_code = 'geoip' in request.session and request.session['geoip'].get('country_code')
                 state_code = 'geoip' in request.session and request.session['geoip'].get('region')
                 if country_code:


### PR DESCRIPTION
PURPOSE

The purpose of this commit is to minimize the AttributeError: 'website.visitor'
object has no attribute 'lead_ids'.

SPECIFICATIONS

While installing 'crm_iap_lead_website' module, 'website_crm' module will
auto-install. But while uninstalling only the 'website_crm' module, it removes
the 'lead_ids' field and when a public user is visiting the website home/contactus page,
the error is coming.

This checks the 'lead_ids' field attribute in the 'website.crm' object
using hasattr. Because there is no relational field/relation exists
after uninstalling the module.

This is the goal of this commit.

LINKS

PR #78355
TaskID-2655439


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
