### PR TITLE
[IMP] product: involve product template in last update computation

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -168,6 +168,15 @@ class ProductProduct(models.Model):
             else:
                 record[variant_field] = record[template_field]
 
+    @api.depends("create_date", "write_date", "product_tmpl_id.create_date", "product_tmpl_id.write_date")
+    def _compute_concurrency_field(self):
+        # Intentionally not calling super() to involve all fields explicitly
+        for record in self:
+            record[self.CONCURRENCY_CHECK_FIELD] = max(filter(None, (
+                record.product_tmpl_id.write_date or record.product_tmpl_id.create_date,
+                record.write_date or record.create_date or fields.Datetime.now(),
+            )))
+
     def _compute_image_1920(self):
         """Get the image from the template if no image is set on the variant."""
         for record in self:

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -449,12 +449,6 @@ class ProductTemplate(models.Model):
                 'image_128',
                 'can_image_1024_be_zoomed',
             ])
-            # Touch all products that will fall back on the template field
-            # This is done because __last_update is used to compute the 'unique' SHA in image URLs
-            # for making sure that images are not retrieved from the browser cache after a change
-            # Performance discussion outcome:
-            # Actually touch all variants to avoid using filtered on the image_variant_1920 field
-            self.product_variant_ids.write({})
         return res
 
     @api.returns('self', lambda value: value.id)

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -625,10 +625,17 @@ class TestVariantsImages(common.TestProductCommon):
         """
         # Pretend setup happened in an older transaction by updating on the SQL layer and making sure it gets reloaded
         # Using _write() instead of write() because write() only allows updating log access fields at boot time
-        self.variants._write({
-            'write_date': self.cr.now() - timedelta(milliseconds=1),
+        before = self.cr.now() - timedelta(milliseconds=1)
+        self.template._write({
+            'create_date': before,
+            'write_date': before,
         })
-        self.variants.invalidate_cache(['write_date'], self.variants.ids)
+        self.variants._write({
+            'create_date': before,
+            'write_date': before,
+        })
+        self.template.invalidate_cache(['create_date', 'write_date'], self.template.ids)
+        self.variants.invalidate_cache(['create_date', 'write_date'], self.variants.ids)
 
         f = io.BytesIO()
         Image.new('RGB', (800, 500), '#000000').save(f, 'PNG')


### PR DESCRIPTION
Since [1] whenever the image of a `product.template` is updated, the
write date of all its related `product.product` is updated.  This was
done to force a change of the unique parameter on image fields, which is
based on the last update field.

After this commit the `product.product`'s last update is instead
computed by also taking the `product.template`'s last update into
account.  This avoids the need for updating the write date when the
image is changed, but on the other hand it also forces product images to
be reloaded whenever any other field of the `product.template` is
changed.

[1]: https://github.com/odoo/odoo/pull/71139

Related to https://github.com/odoo/odoo/pull/76309

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
