### PR TITLE
[IMP] stock: Inventory Adjustments improvements

### DIFF
--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -135,6 +135,7 @@
         ],
         'web.assets_qweb': [
             'stock/static/src/xml/inventory_report.xml',
+            'stock/static/src/xml/inventory_adjustments.xml',
             'stock/static/src/xml/inventory_lines.xml',
             'stock/static/src/xml/popover_widget.xml',
             'stock/static/src/xml/forecast_widget.xml',

--- a/addons/stock/static/src/xml/inventory_adjustments.xml
+++ b/addons/stock/static/src/xml/inventory_adjustments.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates id="template" xml:space="preserve">
+
+<t t-extend="ListView.buttons" t-name="StockInventoryAdjustments.Buttons">
+    <t t-jquery="button.o_list_button_add" t-operation="after">
+        <button class="btn btn-secondary o_button_apply_all" type="button">
+            Apply All
+        </button>
+    </t>
+</t>
+
+</templates>

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -40,7 +40,7 @@
                             <field name="scrap_location" attrs="{'invisible': [('usage', 'not in', ('inventory', 'internal'))]}"/>
                             <field name="return_location"/>
                         </group>
-                        <group string="Cyclic Inventory" attrs="{'invisible': ['|', ('usage', 'not in', ('internal', 'transit')), ('company_id', '=', False)]}">
+                        <group string="Cyclic Counting" attrs="{'invisible': ['|', ('usage', 'not in', ('internal', 'transit')), ('company_id', '=', False)]}">
                             <field name="cyclic_inventory_frequency"/>
                             <field name="last_inventory_date"/>
                             <field name="next_inventory_date" attrs="{'invisible': [('active', '=', False)]}"/>

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -9,6 +9,7 @@
             <search string="Quants">
                 <field name="product_id"/>
                 <field name="location_id"/>
+                <field name="storage_category_id" groups="stock.group_stock_storage_categories" />
                 <field name="user_id"/>
                 <field name="inventory_date"/>
                 <field name="product_categ_id"/>
@@ -22,6 +23,7 @@
                     <filter name="on_hand" string="On Hand" domain="[('on_hand', '=', True)]"/>
                     <filter name="to_count" string="To Count" domain="[('inventory_date', '&lt;=', context_today().strftime('%Y-%m-%d'))]"/>
                     <filter name="to_apply" string="To Apply" domain="[('inventory_quantity_set', '=', True)]"/>
+                    <filter name="priority_products" string="Starred Products" domain="[('priority', '=', 1)]"/>
                     <separator/>
                     <filter name="negative" string="Negative Stock" domain="[('quantity', '&lt;', 0.0)]"/>
                     <filter name="reserved" string="Reservations" domain="[('reserved_quantity', '&gt;', 0.0)]"/>
@@ -33,6 +35,7 @@
                 <group expand='0' string='Group by...'>
                     <filter string='Product' name="productgroup" context="{'group_by': 'product_id'}"/>
                     <filter string='Location' name="locationgroup" domain="[]" context="{'group_by': 'location_id'}"/>
+                    <filter string='Storage Category' name="storagecategorygroup" domain="[]" context="{'group_by': 'storage_category_id'}"/>
                     <filter string='Owner' name="owner" context="{'group_by': 'owner_id'}" groups="stock.group_tracking_owner"/>
                     <filter string='Lot/Serial Number' name="Lot_Serial_number" context="{'group_by': 'lot_id'}" groups="stock.group_production_lot"/>
                     <filter string='Package' name="package" domain="[]" context="{'group_by': 'package_id'}" groups="stock.group_tracking_lot"/>
@@ -298,6 +301,20 @@
         </field>
     </record>
 
+    <record id="duplicated_sn_warning" model="ir.ui.view">
+        <field name="name">stock.quant.duplicated.sn.warning</field>
+        <field name="priority">1000</field>
+        <field name="model">stock.quant</field>
+        <field name="arch" type="xml">
+            <form string="Duplicated SN Warning">
+                This SN is already in another location.
+                <footer>
+                    <button string="Close" class="btn btn-primary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
     <!-- Inventory Adjustments view -->
     <record model="ir.ui.view" id="view_stock_quant_tree_inventory_editable">
         <field name="name">stock.quant.inventory.tree.editable</field>
@@ -312,19 +329,27 @@
                 </header>
                 <field name="id" invisible="1"/>
                 <field name="is_outdated" invisible="1"/>
+                <field name="sn_duplicated" invisible="1"/>
                 <field name="tracking" invisible="1"/>
                 <field name="inventory_quantity_set" invisible="1"/>
                 <field name="location_id" domain="[('usage', 'in', ['internal', 'transit'])]" attrs="{'readonly': [('id', '!=', False)]}" invisible="context.get('hide_location', False)" options="{'no_create': True}"/>
+                <field name="storage_category_id" groups="stock.group_stock_storage_categories" invisible="context.get('hide_location', False)" options="{'no_create': True}" optional="hidden"/>
+                <field name="cyclic_inventory_frequency" invisible="context.get('hide_location', False)" options="{'no_create': True}" optional="hidden"/>
+                <field name="priority" widget="priority" nolabel="1" optional="hidden"/>
                 <field name="product_id" attrs="{'readonly': [('id', '!=', False)]}" readonly="context.get('single_product', False)" force_save="1" options="{'no_create': True}"/>
                 <field name="product_categ_id" optional="hide"/>
+                <button name="action_warning_duplicated_sn" type="object" attrs="{'invisible': [('sn_duplicated', '=', False)]}" title="This lot/serial number is already in another location" class="btn btn-secondary text-warning pull-right" icon="fa-warning"/>
                 <field name="lot_id" groups="stock.group_production_lot"
-                    attrs="{'readonly': ['|', ('id', '!=', False), ('tracking', 'not in', ['serial', 'lot'])]}"
+                    attrs="{'readonly': ['|', ('tracking', 'not in', ['serial', 'lot']), '&amp;', ('id', '!=', False), '|', ('lot_id', '!=', False), ('quantity', '!=', 0)]}"
                     invisible="context.get('hide_lot', False)"
-                    context="{'default_product_id': product_id, 'default_company_id': company_id}"/>
+                    context="{'default_product_id': product_id, 'default_company_id': company_id}"
+                    decoration-warning="sn_duplicated"
+                    force_save="1"/>
                 <field name="package_id" groups="stock.group_tracking_lot" attrs="{'readonly': [('id', '!=', False)]}"/>
                 <field name="owner_id" groups="stock.group_tracking_owner" attrs="{'readonly': [('id', '!=', False)]}" options="{'no_create': True}"/>
+                <field name="last_count_date" optional='hidden' readonly='1'/>
                 <field name="available_quantity" string="Available Quantity" decoration-danger="available_quantity &lt; 0" optional="hidden"/>
-                <field name="quantity" optional="show" string="On Hand Quantity"/>
+                <field name="quantity" optional="show" decoration-warning="quantity &lt; 0" string="On Hand Quantity"/>
                 <field name="product_uom_id" groups="uom.group_uom" string="UoM"/>
                 <field name="inventory_quantity" widget="counted_quantity_widget"/>
                 <field name="inventory_diff_quantity" string="Difference"  attrs="{'invisible': [('inventory_quantity_set', '=', False)]}" decoration-muted="inventory_diff_quantity == 0" decoration-danger="inventory_diff_quantity &lt; 0" decoration-success="inventory_diff_quantity &gt; 0" decoration-bf="inventory_diff_quantity != 0"/>

--- a/addons/stock/wizard/stock_inventory_adjustment_name.py
+++ b/addons/stock/wizard/stock_inventory_adjustment_name.py
@@ -23,5 +23,5 @@ class StockInventoryAdjustmentName(models.TransientModel):
     show_info = fields.Boolean('Show warning')
 
     def action_apply(self):
-        return self.quant_ids.with_context(
-            inventory_name=self.inventory_adjustment_name).action_apply_inventory()
+        quants = self.quant_ids.filtered('inventory_quantity_set')
+        quants.with_context(inventory_name=self.inventory_adjustment_name).action_apply_inventory()

--- a/addons/stock/wizard/stock_track_confirmation_views.xml
+++ b/addons/stock/wizard/stock_track_confirmation_views.xml
@@ -7,7 +7,10 @@
             <form string="Lots or serial numbers were not provided for tracked products">
                 <field name="product_ids" invisible="1"/>
                 <field name="quant_ids" invisible="1"/>
-                <p>Some products of the inventory adjustment are tracked. Are you sure you don't want to specify a serial or lot number for them?</p>
+                <p>
+                    Those products you added are tracked but lots/serials were not defined. Once applied those can't be changed.<br/>
+                    Apply anyway?
+                </p>
                 <strong>Tracked product(s):</strong>
                 <field name="tracking_line_ids" readonly="1">
                     <tree>
@@ -16,7 +19,7 @@
                     </tree>
                 </field>
                 <footer>
-                    <button name="action_confirm" string="Confirm" type="object" class="btn-primary" data-hotkey="q"/>
+                    <button name="action_confirm" string="Apply" type="object" class="btn-primary" data-hotkey="q"/>
                     <button string="Discard" special="cancel" data-hotkey="z" class="btn-secondary"/>
                 </footer>
             </form>


### PR DESCRIPTION
Improvements of the Inventory Adjustements page, among which:
 - Add a new 'Apply All' button (without the need to select a record)
 - Show the date at which the last count was done
 - Add warning icon next to duplicated SN

Task-id: 2648295

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
