### PR TITLE
[FIX] base: fix avatar_mixin seed for hsl

### DIFF
--- a/odoo/addons/base/models/avatar_mixin.py
+++ b/odoo/addons/base/models/avatar_mixin.py
@@ -63,7 +63,7 @@ class AvatarMixin(models.AbstractModel):
 
     def _avatar_generate_svg(self):
         initial = html_escape(self[self._avatar_name_field][0].upper())
-        bgcolor = get_hsl_from_seed(self[self._avatar_name_field] + str(self.create_date.timestamp()))
+        bgcolor = get_hsl_from_seed(self[self._avatar_name_field] + str(self.create_date.timestamp() if self.create_date else ""))
         return b64encode((
             "<?xml version='1.0' encoding='UTF-8' ?>"
             "<svg height='180' width='180' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'>"


### PR DESCRIPTION
Some records have NULL create_date. In that case we get a traceback like
below.
```
 Traceback (most recent call last):
   ...
   File "/home/odoo/src/odoo/15.0/addons/mail/models/mail_thread.py", line 410, in _compute_field_value
    return super()._compute_field_value(field)
   File "/home/odoo/src/odoo/15.0/odoo/models.py", line 4249, in _compute_field_value
    getattr(self, field.compute)()
   File "/home/odoo/src/odoo/15.0/odoo/addons/base/models/res_partner.py", line 259, in _compute_avatar_128
    super()._compute_avatar_128()
   File "/home/odoo/src/odoo/15.0/odoo/addons/base/models/avatar_mixin.py", line 62, in _compute_avatar_128
    self._compute_avatar('avatar_128', 'image_128')
   File "/home/odoo/src/odoo/15.0/odoo/addons/base/models/res_partner.py", line 263, in _compute_avatar
    super(Partner, partners_with_internal_user)._compute_avatar(avatar_field, image_field)
   File "/home/odoo/src/odoo/15.0/odoo/addons/base/models/avatar_mixin.py", line 39, in _compute_avatar
    avatar = record._avatar_generate_svg()
   File "/home/odoo/src/odoo/15.0/odoo/addons/base/models/avatar_mixin.py", line 66, in _avatar_generate_svg
    bgcolor = get_hsl_from_seed(self[self._avatar_name_field] + str(self.create_date.timestamp()))
 AttributeError: 'bool' object has no attribute 'timestamp'
```
Observed during upgrade request 40906

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
