### PR TITLE
[FIX] sale_timesheet_margin: fix division by zero

### DIFF
--- a/addons/sale_timesheet_margin/models/sale_order_line.py
+++ b/addons/sale_timesheet_margin/models/sale_order_line.py
@@ -17,7 +17,7 @@ class SaleOrderLine(models.Model):
                 ['so_line', 'amount:sum', 'unit_amount:sum'],
                 ['so_line'])
             mapped_sol_timesheet_amount = {
-                amount['so_line'][0]: -amount['amount'] / amount['unit_amount']
+                amount['so_line'][0]: -amount['amount'] / amount['unit_amount'] if amount['unit_amount'] else 0.0
                 for amount in group_amount
             }
             for line in timesheet_sols:


### PR DESCRIPTION
~~If both amounts are zero the computed amount is zero.~~
~~If only the denomirator is zero, we let it fail.~~
If the denomirator is zero, we set the computed value to zero.

This issue was observed during upgrade request 41615, with following
traceback.
```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/15.0/odoo/service/server.py", line 1246, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/home/odoo/src/odoo/15.0/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/15.0/odoo/modules/loading.py", line 490, in load_modules
    migrations.migrate_module(package, 'end')
  File "/home/odoo/src/odoo/15.0/odoo/modules/migration.py", line 180, in migrate_module
    migrate(self.cr, installed_version)
  File "/tmp/tmp3r3s178t/migrations/sale_timesheet_margin/saas~14.5.1.0/end-migrate.py", line 14, in migrate
    util.recompute_fields(cr, "sale.order.line", ["purchase_price"], ids=ids)
  File "/tmp/tmp3r3s178t/migrations/util/orm.py", line 113, in recompute_fields
    records.recompute()
  File "/home/odoo/src/odoo/15.0/odoo/models.py", line 6096, in recompute
    process(field)
  File "/home/odoo/src/odoo/15.0/odoo/models.py", line 6080, in process
    field.recompute(recs)
  File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1243, in recompute
    self.compute_value(recs)
  File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1265, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/15.0/odoo/models.py", line 4249, in _compute_field_value
    getattr(self, field.compute)()
  File "/home/odoo/src/odoo/15.0/addons/sale_timesheet_margin/models/sale_order_line.py", line 21, in _compute_purchase_price
    for amount in group_amount
  File "/home/odoo/src/odoo/15.0/addons/sale_timesheet_margin/models/sale_order_line.py", line 21, in <dictcomp>
    for amount in group_amount
ZeroDivisionError: float division by zero
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
