### PR TITLE
[FIX] accounting: fix invoices preview total and untaxed amounts

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -198,7 +198,7 @@
                     <td class="text-right">
                         <span
                             t-att-class="oe_subtotal_footer_separator"
-                            t-esc="subtotal['amount']"
+                            t-esc="subtotal['formatted_amount']"
                         />
                     </td>
                 </tr>
@@ -211,7 +211,7 @@
             <tr class="border-black o_total">
                 <td><strong>Total</strong></td>
                 <td class="text-right">
-                    <span t-esc="tax_totals['amount_total']"/>
+                    <span t-esc="tax_totals['formatted_amount_total']"/>
                 </td>
             </tr>
         </template>


### PR DESCRIPTION
### Expected Behavior
The _total amount_ and _total taxes amount_ in invoice, purchase order and offer should be formated with the correct formating options (related to the client's location), and with the correct currency symbol, as it was the case in V14

### Observed behaviour
In V15, these amount are written as pure numerical values (eg : 1452.24 instead of $1.452,24). This is the case in every generated pdf, as well as in the user portal preview(s), but not in classical form view(s).

### Reproducibility
This bug can be reproduced following these steps:
1. Create a new invoice
2. Validate it
3. Preview it in the user portal of download the printable .pdf

This can also be done with a purchase order, following the same steps.

### Problem Root Cause
The problem comes from the fact we read the wrong fields, using `account.tax_totals.amount_total` and `account.tax_totals[subtotals].amount` instead of `account.tax_totals.formatted_amount_total` and `account.tax_totals[subtotals].formatted_amount`.

### Validation
Cf attached files :
- wrong_*.pdf : bugged version of invoice, order, ... printable PDF
- valid_*.pdf : corrected version of invoice, order, ... printable PDF

opw-2666924
opw-2666553
opw-2665130


[valid_bill.pdf](https://github.com/odoo/odoo/files/7346056/valid_bill.pdf)
[valid_invoice.pdf](https://github.com/odoo/odoo/files/7346057/valid_invoice.pdf)
[valid_order.pdf](https://github.com/odoo/odoo/files/7346058/valid_order.pdf)
[wrong_invoice.pdf](https://github.com/odoo/odoo/files/7346059/wrong_invoice.pdf)
[wrong_order.pdf](https://github.com/odoo/odoo/files/7346060/wrong_order.pdf)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
