### PR TITLE
[FIX] web_editor: poperly add youtube on website builder

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2700,23 +2700,28 @@ export class OdooEditor extends EventTarget {
                                     shouldPreValidate: () => false,
                                     callback: () => {
                                         execCommandAtStepIndex(stepIndexBeforeInsert, () => {
-                                            const video = document.createElement('iframe');
-                                            video.setAttribute('width', '560');
-                                            video.setAttribute('height', '315');
-                                            video.setAttribute(
-                                                'src',
-                                                `https://www.youtube.com/embed/${youtubeUrl[1]}`,
-                                            );
-                                            video.setAttribute('title', 'YouTube video player');
-                                            video.setAttribute('frameborder', '0');
-                                            video.setAttribute(
-                                                'allow',
-                                                'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture',
-                                            );
-                                            video.setAttribute('allowfullscreen', '1');
+                                            let videoElement;
+                                            if (this.options.getYoutubeVideoElement) {
+                                                videoElement = this.options.getYoutubeVideoElement(youtubeUrl[0]);
+                                            } else {
+                                                videoElement = document.createElement('iframe');
+                                                videoElement.setAttribute('width', '560');
+                                                videoElement.setAttribute('height', '315');
+                                                videoElement.setAttribute(
+                                                    'src',
+                                                    `https://www.youtube.com/embed/${youtubeUrl[1]}`,
+                                                );
+                                                videoElement.setAttribute('title', 'YouTube video player');
+                                                videoElement.setAttribute('frameborder', '0');
+                                                videoElement.setAttribute(
+                                                    'allow',
+                                                    'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture',
+                                                );
+                                                videoElement.setAttribute('allowfullscreen', '1');
+                                            }
                                             const sel = this.document.getSelection();
                                             if (sel.rangeCount) {
-                                                sel.getRangeAt(0).insertNode(video);
+                                                sel.getRangeAt(0).insertNode(videoElement);
                                                 sel.collapseToEnd();
                                             }
                                         });

--- a/addons/web_editor/static/lib/odoo-editor/src/powerbox/Powerbox.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/powerbox/Powerbox.js
@@ -261,6 +261,7 @@ export class Powerbox {
             );
             if (command) {
                 !command.isIntermediateStep &&
+                    (!command.shouldPreValidate || command.shouldPreValidate()) &&
                     this.options.preValidate &&
                     this.options.preValidate();
                 command.callback();

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -1281,16 +1281,25 @@ var VideoWidget = MediaWidget.extend({
             return Promise.resolve({bgVideoSrc: videoSrc});
         }
         if (this.$('.o_video_dialog_iframe').is('iframe') && videoSrc) {
-            this.$media = $(
-                '<div class="media_iframe_video" data-oe-expression="' + videoSrc + '">' +
-                    '<div class="css_editable_mode_display">&nbsp;</div>' +
-                    '<div class="media_iframe_video_size" contenteditable="false">&nbsp;</div>' +
-                    '<iframe src="' + videoSrc + '" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen"></iframe>' +
-                '</div>'
-            );
+            this.$media = this.getWrappedIframe(videoSrc);
             this.media = this.$media[0];
         }
         return Promise.resolve(this.media);
+    },
+
+    /**
+     * Get an iframe wrapped for the website builder.
+     *
+     * @param {string} src The video url.
+     */
+    getWrappedIframe: function (src) {
+        return $(
+            '<div class="media_iframe_video" data-oe-expression="' + src + '">' +
+                '<div class="css_editable_mode_display">&nbsp;</div>' +
+                '<div class="media_iframe_video_size" contenteditable="false">&nbsp;</div>' +
+                '<iframe src="' + src + '" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen"></iframe>' +
+            '</div>'
+        );
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -84,6 +84,12 @@ const Wysiwyg = Widget.extend({
             editorCollaborationOptions = this.setupCollaboration(options.collaborationChannel);
         }
 
+        const getYoutubeVideoElement =  (url) => {
+            const videoWidget = new weWidgets.VideoWidget(this, undefined, {});
+            const src = videoWidget._createVideoNode(url).$video.attr('src');
+            return videoWidget.getWrappedIframe(src)[0];
+        };
+
         this.odooEditor = new OdooEditor(this.$editable[0], Object.assign({
             _t: _t,
             toolbar: this.toolbar.$el[0],
@@ -94,6 +100,7 @@ const Wysiwyg = Widget.extend({
             controlHistoryFromDocument: this.options.controlHistoryFromDocument,
             getContentEditableAreas: this.options.getContentEditableAreas,
             defaultLinkAttributes: this.options.userGeneratedContent ? {rel: 'ugc' } : {},
+            getYoutubeVideoElement: getYoutubeVideoElement,
             getContextFromParentRect: options.getContextFromParentRect,
             getPowerboxElement: () => {
                 const selection = document.getSelection();


### PR DESCRIPTION
In the website builder, when pasting a youtube url,
we can transform it to an iframe in the editor through the
Powerbox.
Adding the iframe did not remove the text in the website builder.
Now it properly remove the text in note and the website builder.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
