### PR TITLE
[IMP] account, base_vat: verify VAT numbers and apply Fiscal Positions for companies in a VAT Unit

### DIFF
--- a/addons/account/models/__init__.py
+++ b/addons/account/models/__init__.py
@@ -9,6 +9,7 @@ from . import account_journal
 from . import account_tax
 from . import account_tax_carryover_line
 from . import account_tax_report
+from . import account_tax_unit
 from . import account_reconcile_model
 from . import account_payment_term
 from . import account_move

--- a/addons/account/models/account_tax_unit.py
+++ b/addons/account/models/account_tax_unit.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models, fields, _
+from odoo.exceptions import ValidationError
+
+
+class AccountTaxUnit(models.Model):
+    _name = "account.tax.unit"
+    _description = "Tax Unit"
+
+    name = fields.Char(string="Name", required=True)
+    country_id = fields.Many2one(string="Country", comodel_name='res.country', required=True, help="The country in which this tax unit is used to group your companies' tax reports declaration.")
+    vat = fields.Char(string="Tax ID", required=True, help="The identifier to be used when submitting a report for this unit.")
+    company_ids = fields.Many2many(string="Companies", comodel_name='res.company', required=True, help="Members of this unit")
+    main_company_id = fields.Many2one(string="Main Company", comodel_name='res.company', required=True, help="Main company of this unit; the one actually reporting and paying the taxes.")
+
+    @api.constrains('country_id', 'company_ids')
+    def _validate_companies_country(self):
+        for record in self:
+            currencies = set()
+            for company in record.company_ids:
+                currencies.add(company.currency_id)
+
+                if any(unit != record and unit.country_id == record.country_id for unit in company.account_tax_unit_ids):
+                    raise ValidationError(_("Company %s already belongs to a tax unit in %s. A company can at most be part of one tax unit per country.", company.name, record.country_id.name))
+
+            if len(currencies) > 1:
+                raise ValidationError(_("A tax unit can only be created between companies sharing the same main currency."))
+
+    @api.constrains('company_ids', 'main_company_id')
+    def _validate_main_company(self):
+        for record in self:
+            if record.main_company_id not in record.company_ids:
+                raise ValidationError(_("The main company of a tax unit has to be part of it."))
+
+    @api.onchange('company_ids')
+    def _onchange_company_ids(self):
+        for record in self:
+            if not record.main_company_id and record.company_ids:
+                record.main_company_id = record.company_ids[0]

--- a/addons/account/security/ir.model.access.csv
+++ b/addons/account/security/ir.model.access.csv
@@ -150,3 +150,6 @@ access_account_tour_upload_bill,account.tour.upload.bill,model_account_tour_uplo
 access_account_tour_upload_bill_email_confirm,account.tour.upload.bill.email.confirm,model_account_tour_upload_bill_email_confirm,account.group_account_manager,1,1,1,0
 
 access_account_accrued_orders_wizard,account.account.accrued.orders.wizard,account.model_account_accrued_orders_wizard,group_account_user,1,1,1,0
+
+access_account_tax_unit_readonly,access_account_tax_unit_readonly,model_account_tax_unit,account.group_account_readonly,1,0,0,0
+access_account_tax_unit_manager,access_account_tax_unit_manager,model_account_tax_unit,account.group_account_manager,1,1,1,1

--- a/addons/base_vat/models/__init__.py
+++ b/addons/base_vat/models/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_fiscal_position
+from . import account_tax_unit
 from . import res_config_settings
 from . import res_company
 from . import res_partner

--- a/addons/base_vat/models/account_tax_unit.py
+++ b/addons/base_vat/models/account_tax_unit.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, models, _
+from odoo.exceptions import ValidationError
+
+
+class AccountTaxUnit(models.Model):
+    _inherit = 'account.tax.unit'
+
+    @api.constrains('country_id', 'vat')
+    def _validate_vat(self):
+        for record in self:
+            if not record.vat:
+                continue
+
+            checked_country_code = self.env['res.partner']._run_vat_test(record.vat, record.country_id)
+
+            if checked_country_code and checked_country_code != record.country_id.code.lower():
+                raise ValidationError(_("The country detected for this VAT number does not match the one set on this Tax unit."))
+
+            if not checked_country_code:
+                error_label = _("tax unit [%s]", record.name)
+                error_message = self.env['res.partner']._build_vat_error_message(record.country_id.code.lower(), record.vat, error_label)
+                raise ValidationError(error_message)


### PR DESCRIPTION
[FIX] account: enable VIES/vat checks on tax units
Since the VIES check is in base_vat, account.tax.unit is moved from account_reports

[IMP] base_vat: validate VAT numbers on tax units
VAT Numbers specified on VAT units are now verified using the features of base VAT (VIES or simple checks)

[IMP] account: create fiscal positions for companies in a tax unit
Companies in the same VAT unit shouldn't charge VAT to other companies in the same unit. This commit creates new fiscal positions for each company in a VAT unit, and applies it to each partner of the other companies.

Task-2584180