### PR TITLE
[FIX] web: action context pollution from session storage

### DIFF
--- a/addons/crm/static/src/js/forecast/forecast_search_model.js
+++ b/addons/crm/static/src/js/forecast/forecast_search_model.js
@@ -38,7 +38,7 @@ export class ForecastSearchModel extends SearchModel {
         for (const queryElem of this.query) {
             const searchItem = this.searchItems[queryElem.searchItemId];
             if (searchItem.type === "filter") {
-                const context = makeContext(searchItem.context || {});
+                const context = makeContext([searchItem.context || {}]);
                 if (context.forecast_filter) {
                     forecastFilter = true;
                     break;

--- a/addons/web/static/src/core/context.js
+++ b/addons/web/static/src/core/context.js
@@ -8,17 +8,21 @@ import { evaluateExpr } from "./py_js/py";
  */
 
 /**
- * Create an evaluated context from an arbitrary list of context representations
+ * Create an evaluated context from an arbitrary list of context representations.
+ * The evaluated context in construction is used along the way to evaluate further parts.
  *
- * @param  {...ContextDescription} contexts
+ * @param {ContextDescription[]} contexts
+ * @param {Context} [initialEvaluationContext] optional evaluation context to start from.
  * @returns {Context}
  */
-export function makeContext(...contexts) {
-    let context = {};
+export function makeContext(contexts, initialEvaluationContext) {
+    const evaluationContext = Object.assign({}, initialEvaluationContext);
+    const context = {};
     for (let ctx of contexts) {
         if (ctx !== "") {
-            const subCtx = typeof ctx === "string" ? evaluateExpr(ctx, context) : ctx;
-            Object.assign(context, subCtx);
+            ctx = typeof ctx === "string" ? evaluateExpr(ctx, evaluationContext) : ctx;
+            Object.assign(context, ctx);
+            Object.assign(evaluationContext, context); // is this behavior really wanted ?
         }
     }
     return context;

--- a/addons/web/static/src/legacy/backend_utils.js
+++ b/addons/web/static/src/legacy/backend_utils.js
@@ -169,7 +169,7 @@ export function searchModelStateToLegacy(state) {
             case "filter":
                 let context = item.context;
                 try {
-                    context = makeContext(context);
+                    context = makeContext([context]);
                 } catch (e) {}
                 filter.context = context;
         }

--- a/addons/web/static/src/search/search_arch_parser.js
+++ b/addons/web/static/src/search/search_arch_parser.js
@@ -19,7 +19,7 @@ const DEFAULT_VIEWS_WITH_SEARCH_PANEL = ["kanban", "list"];
  */
 const getContextGroubBy = (context) => {
     try {
-        return makeContext(context).group_by.split(":");
+        return makeContext([context]).group_by.split(":");
     } catch (err) {
         return [];
     }

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1336,7 +1336,7 @@ export class SearchModel extends EventBus {
         }
         let context;
         try {
-            context = makeContext(...contexts); // what we want?
+            context = makeContext(contexts);
             return context;
         } catch (error) {
             throw new Error(
@@ -1732,7 +1732,7 @@ export class SearchModel extends EventBus {
         const { description, isDefault, isShared } = params;
         const fns = this.env.__getContext__.callbacks;
         const localContext = Object.assign({}, ...fns.map((fn) => fn()));
-        const context = makeContext(this._getContext(), localContext);
+        const context = makeContext([this._getContext(), localContext]);
         const userContext = this.userService.context;
         for (const key in context) {
             if (key in userContext || /^search(panel)?_default_/.test(key)) {
@@ -1836,7 +1836,7 @@ export class SearchModel extends EventBus {
             case "favorite":
             case "filter": {
                 //Return a deep copy of the filter/favorite to avoid the view to modify the context
-                return makeContext(searchItem.context && deepCopy(searchItem.context));
+                return makeContext([searchItem.context && deepCopy(searchItem.context)]);
             }
             default: {
                 return null;

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -183,11 +183,13 @@ function makeActionManager(env) {
      * with a unique jsId.
      */
     function _preprocessAction(action, context = {}) {
-        action.context = makeContext(env.services.user.context, context, action.context);
+        action.context = makeContext([context, action.context], env.services.user.context);
         if (action.domain) {
             const domain = action.domain || [];
             action.domain =
-                typeof domain === "string" ? evaluateExpr(domain, action.context) : domain;
+                typeof domain === "string"
+                    ? evaluateExpr(domain, Object.assign(env.services.user.context, action.context))
+                    : domain;
         }
         action = { ...action }; // manipulate a copy to keep cached action unmodified
         action._originalAction = JSON.stringify(action);
@@ -1111,7 +1113,7 @@ function makeActionManager(env) {
     async function doActionButton(params) {
         // determine the action to execute according to the params
         let action;
-        const context = makeContext(params.context, params.buttonContext);
+        const context = makeContext([params.context, params.buttonContext]);
         if (params.special) {
             action = { type: "ir.actions.act_window_close", infos: { special: true } };
         } else if (params.type === "object") {
@@ -1162,7 +1164,7 @@ function makeActionManager(env) {
             activeCtx.active_id = params.resId;
             activeCtx.active_ids = [params.resId];
         }
-        action.context = makeContext(currentCtx, params.buttonContext, activeCtx, action.context);
+        action.context = makeContext([currentCtx, params.buttonContext, activeCtx, action.context]);
         // in case an effect is returned from python and there is already an effect
         // attribute on the button, the priority is given to the button attribute
         const effect = params.effect ? evaluateExpr(params.effect) : action.effect;

--- a/addons/web/static/tests/core/context_tests.js
+++ b/addons/web/static/tests/core/context_tests.js
@@ -6,25 +6,40 @@ QUnit.module("utils", {}, () => {
     QUnit.module("makeContext");
 
     QUnit.test("return empty context", (assert) => {
-        assert.deepEqual(makeContext(), {});
+        assert.deepEqual(makeContext([]), {});
     });
 
     QUnit.test("duplicate a context", (assert) => {
         const ctx1 = { a: 1 };
-        const ctx2 = makeContext(ctx1);
+        const ctx2 = makeContext([ctx1]);
         assert.notStrictEqual(ctx1, ctx2);
         assert.deepEqual(ctx1, ctx2);
     });
 
     QUnit.test("can accept undefined or empty string", (assert) => {
-        assert.deepEqual(makeContext(undefined), {});
-        assert.deepEqual(makeContext({ a: 1 }, undefined, { b: 2 }), { a: 1, b: 2 });
-        assert.deepEqual(makeContext(""), {});
-        assert.deepEqual(makeContext({ a: 1 }, "", { b: 2 }), { a: 1, b: 2 });
+        assert.deepEqual(makeContext([undefined]), {});
+        assert.deepEqual(makeContext([{ a: 1 }, undefined, { b: 2 }]), { a: 1, b: 2 });
+        assert.deepEqual(makeContext([""]), {});
+        assert.deepEqual(makeContext([{ a: 1 }, "", { b: 2 }]), { a: 1, b: 2 });
     });
 
     QUnit.test("evaluate strings", (assert) => {
-        assert.deepEqual(makeContext("{'a': 33}"), { a: 33 });
-        assert.deepEqual(makeContext({ a: 1 }, "{'b': a + 1}"), { a: 1, b: 2 });
+        assert.deepEqual(makeContext(["{'a': 33}"]), { a: 33 });
+    });
+
+    QUnit.test("evaluated context is used as evaluation context along the way", (assert) => {
+        assert.deepEqual(makeContext([{ a: 1 }, "{'a': a + 1}"]), { a: 2 });
+        assert.deepEqual(makeContext([{ a: 1 }, "{'b': a + 1}"]), { a: 1, b: 2 });
+        assert.deepEqual(makeContext([{ a: 1 }, "{'b': a + 1}", "{'c': b + 1}"]), {
+            a: 1,
+            b: 2,
+            c: 3,
+        });
+        assert.deepEqual(makeContext([{ a: 1 }, "{'b': a + 1}", "{'a': b + 1}"]), { a: 3, b: 2 });
+    });
+
+    QUnit.test("initial evaluation context", (assert) => {
+        assert.deepEqual(makeContext(["{'a': a + 1}"], { a: 1 }), { a: 2 });
+        assert.deepEqual(makeContext(["{'b': a + 1}"], { a: 1 }), { b: 2 });
     });
 });

--- a/addons/web/static/tests/webclient/actions/misc_tests.js
+++ b/addons/web/static/tests/webclient/actions/misc_tests.js
@@ -187,12 +187,7 @@ QUnit.module("ActionManager", (hooks) => {
 
         let action = await loadAction(3, actionParams);
         assert.verifySteps(["server loaded"]);
-        const baseContext = {
-            lang: "en",
-            tz: "taht",
-            uid: 7,
-        };
-        assert.deepEqual(action.context, { ...baseContext, ...actionParams });
+        assert.deepEqual(action.context, actionParams);
 
         // Modify the action in place
         action.context.additionalContext.some.deep.nested = "Nesta";
@@ -201,7 +196,7 @@ QUnit.module("ActionManager", (hooks) => {
         actionParams.additionalContext.some.deep.nested = "Marley";
         action = await loadAction(3, actionParams);
         assert.verifySteps([], "loaded from cache");
-        assert.deepEqual(action.context, { ...baseContext, ...actionParams });
+        assert.deepEqual(action.context, actionParams);
     });
 
     QUnit.test("no widget memory leaks when doing some action stuff", async function (assert) {

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -1594,11 +1594,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.expect(1);
         const expectedAction = {
             ...serverData.actions[3],
-            context: {
-                lang: "en",
-                uid: 7,
-                tz: "taht",
-            },
+            context: {},
         };
         patchWithCleanup(browser, {
             sessionStorage: Object.assign(Object.create(sessionStorage), {


### PR DESCRIPTION
Before this commit
An action retrieved from the session storage may not take into account
changes in the user context because the user context is duplicated in
the action context. When the user context changes i.e. through the
switch company menu (allowed_company_ids) and the browser reloads,
the action service will make the action context concatening the new user
context with the context of the action stored in the session storage,
which has still values from the previous user context.

After this commit
The makeContext function can now take an initial evaluation context.
This is then used in the action service in order to make use of the user
context when the action context is generated but without appending
it into the action one.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
