### PR TITLE
[FIX] web_editor: Properly remove link tools frame

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -53,7 +53,7 @@ const LinkTools = Link.extend({
         if (!this.el) {
             return this._super(...arguments);
         }
-        $('.oe_edited_link').removeClass('oe_edited_link');
+        this.$link.removeClass('oe_edited_link');
         const $contents = this.$link.contents();
         if (!this.$link.attr('href') && !this.colorCombinationClass) {
             $contents.unwrap();


### PR DESCRIPTION
In mass mailing the link tools borders were not removed properly
because the element couldn't be found inside the Iframe with a $() selector.
Changed to use the `this.$link` of the `link_tool` class.

task-2634073


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
