### PR TITLE
[FIX] hr_holidays: Wrong domain for my department leaves

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -649,7 +649,7 @@
             'search_default_my_team_leaves':1,
             'search_default_approve':1}
         </field>
-        <field name="domain">['|', '|', '&amp;', ('employee_id.leave_manager_id', '=', uid), ('holiday_status_id.validation_type', '=', 'manager'), '&amp;', ('holiday_status_id.responsible_id', '=', uid), ('holiday_status_id.validation_type', '=', 'hr'), '&amp;', '|', ('holiday_status_id.responsible_id', '=', uid), ('holiday_status_id.responsible_id', '=', uid), ('holiday_status_id.validation_type', '=', 'both')]</field>
+        <field name="domain">['|', '|', '&amp;', ('employee_id.leave_manager_id', '=', uid), ('holiday_status_id.validation_type', '=', 'manager'), '&amp;', ('holiday_status_id.responsible_id', '=', uid), ('holiday_status_id.validation_type', '=', 'hr'), '&amp;', '|', ('holiday_status_id.responsible_id', '=', uid), ('employee_id.leave_manager_id', '=', uid), ('holiday_status_id.validation_type', '=', 'both')]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a new time off request


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The domain has not been correctly been formed

Current behavior before PR:

Leave manager cannot access his department leaves

Desired behavior after PR is merged:

Access the desired leaves

Applies to 13 and 14, but not to 15.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
