### PR TITLE
[FIX] website_slides: fix slide embed code page selector

### DIFF
--- a/addons/website_slides/static/src/js/slides.js
+++ b/addons/website_slides/static/src/js/slides.js
@@ -81,18 +81,18 @@ var SlideSocialEmbed = publicWidget.Widget.extend({
      * @param {Object} ev
      */
     _onChangePage: function (ev) {
-        ev.preventDefault();
-        var input = this.$('input');
+        var input = $(ev.currentTarget);
         var page = parseInt(input.val());
-        if (this.max_page && !(page > 0 && page <= this.max_page)) {
+        if (this.max_page && page > this.max_page || page < 1) {
             page = 1;
         }
+        input.val(page);
         this._updateEmbeddedCode(page);
     },
 });
 
 publicWidget.registry.websiteSlidesEmbed = publicWidget.Widget.extend({
-    selector: '#wrapwrap',
+    selector: '.oe_slide_js_embed_code_widget',
 
     /**
      * @override
@@ -100,8 +100,25 @@ publicWidget.registry.websiteSlidesEmbed = publicWidget.Widget.extend({
      */
     start: function (parent) {
         var defs = [this._super.apply(this, arguments)];
-        $('iframe.o_wslides_iframe_viewer').on('ready', this._onIframeViewerReady.bind(this));
+        this._timeout = setTimeout(this._checkIframeLoaded.bind(this), 100);
         return Promise.all(defs);
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @private
+     */
+    _checkIframeLoaded: function () {
+        var $iframe = $('iframe.o_wslides_iframe_viewer');
+        var iframeDoc = $iframe[0].contentDocument || $iframe[0].contentWindow.document;
+        
+        if (iframeDoc.readyState  == 'complete') {
+            clearTimeout(this._timeout);
+            this._onIframeViewerReady($iframe);
+        }
     },
 
     //--------------------------------------------------------------------------
@@ -110,13 +127,10 @@ publicWidget.registry.websiteSlidesEmbed = publicWidget.Widget.extend({
 
     /**
      * @private
-     * @param {Event} ev
+     * @param {Object} $iframe
      */
-    _onIframeViewerReady: function (ev) {
-        // TODO : make it work. For now, once the iframe is loaded, the value of #page_count is
-        // still now set (the pdf is still loading)
-        var $iframe = $(ev.currentTarget);
-        var maxPage = $iframe.contents().find('#page_count').val();
+    _onIframeViewerReady: function ($iframe) {
+        var maxPage = parseInt($iframe.contents().find('#page_count').text());
         new SlideSocialEmbed(this, maxPage).attachTo($('.oe_slide_js_embed_code_widget'));
     },
 });


### PR DESCRIPTION
The page selector, which updates the slide's embed code with the selected
page was not working because it was waiting on an iframe 'load' event that
never/randomly fired.

After some research, it seems that the best way to check if an iframe has
been loaded is with a timeout that checks the iframe document's readyState
property directly at regular intervals.

This commit updates the JS code accordingly.

Description of the issue/feature this PR addresses:
There is no validation of a website slide's embed code page selector and the embed code is not updated according to the page input, basically making that input useless.

Current behavior before PR:
Slide embed code page selector not working
![image](https://user-images.githubusercontent.com/84017456/137338430-668d2242-6921-4ec5-8072-f5cbe1ddcbcc.png)

Desired behavior after PR is merged:
Validate the embed code page selector input to not allow numbers above the max page and below 1, and update the embed code with the selected page. 

Impacted versions:
13, 14, 15, master

Patch tested in Chrome and Firefox, on each of the impacted versions.
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
