### PR TITLE
[FIX] website_mail_channel: Replace relative links with absolute ones before notifying partners

### DIFF
--- a/addons/website_mail_channel/models/mail_mail.py
+++ b/addons/website_mail_channel/models/mail_mail.py
@@ -30,6 +30,7 @@ class MailMail(models.Model):
                         %(unsub)s: %(unsub_url)s
                     """ % vals
             body = tools.append_content_to_html(self.body, footer, container_tag='div')
+            body = self.env['mail.thread']._replace_local_links(body)
             return body
         else:
             return super(MailMail, self)._send_prepare_body()


### PR DESCRIPTION
The `body` field from `mail.message` is used instead of `body_html` or the super() value, but this field has not been pre-processed with `_replace_local_links`. So we are doing it there to allow partners seeing our `<img src=...>` and clicking on `<a href=...>`.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
