### PR TITLE
[FIX] web: do not write before saving when clicking on a radio

### DIFF
--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -3429,6 +3429,34 @@ var FieldRadio = FieldSelection.extend({
 
     /**
      * @private
+     * @param {MouseEvent} ev
+     * @returns {Object}
+     */
+    _getQuickEditExtraInfo: function (ev) {
+        // can be either the input or the label
+        const $target = ev.target.nodeName === 'INPUT'
+            ? $(ev.target)
+            : $(ev.target).siblings('input');
+
+        const index = $target.data('index');
+        const value = this.values[index];
+        return {value};
+    },
+
+    /**
+     * @private
+     * @override
+     * @params {Object} extraInfo
+     */
+    _quickEdit: function (extraInfo) {
+        if (extraInfo.value) {
+            this._saveValue(extraInfo.value);
+        }
+        return this._super.apply(this, arguments);
+    },
+
+    /**
+     * @private
      * @override
      */
     _render: function () {
@@ -3477,6 +3505,19 @@ var FieldRadio = FieldSelection.extend({
         }
     },
 
+    /**
+     * @private
+     * @param {Array} new value, [value] for a selection field,
+     *                           [id, display_name] for a Many2One
+     */
+    _saveValue: function (value) {
+        if (this.field.type === 'many2one') {
+            this._setValue({id: value[0], display_name: value[1]});
+        } else {
+            this._setValue(value[0]);
+        }
+    },
+
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
@@ -3486,12 +3527,12 @@ var FieldRadio = FieldSelection.extend({
      * @param {MouseEvent} event
      */
     _onInputClick: function (event) {
-        var index = $(event.target).data('index');
-        var value = this.values[index];
-        if (this.field.type === 'many2one') {
-            this._setValue({id: value[0], display_name: value[1]});
+        if (this.mode === 'readonly') {
+            this._onClick(...arguments);
         } else {
-            this._setValue(value[0]);
+            const index = $(event.currentTarget).data('index');
+            const value = this.values[index];
+            this._saveValue(value);
         }
     },
 });

--- a/addons/web/static/tests/legacy/views/form_tests.js
+++ b/addons/web/static/tests/legacy/views/form_tests.js
@@ -11195,6 +11195,43 @@ QUnit.module('Views', {
         form.destroy();
     });
 
+    QUnit.test('Quick Edition: Selection radio click on value', async function (assert) {
+        assert.expect(5);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <form>
+                    <group>
+                        <field name="state" widget="radio"/>
+                    </group>
+                </form>`,
+            res_id: 1,
+            mockRPC: function (route, args) {
+                if (args.model === 'partner' && args.method === 'write') {
+                    assert.step('Write');
+                }
+                return this._super(route, args);
+            },
+        });
+
+        assert.containsOnce(form, '.o_form_view.o_form_readonly');
+        assert.containsOnce(form, 'input[type="radio"]:eq(0):checked');
+
+        // click on the last value
+        await testUtils.dom.click(form.$('.o_radio_item .o_form_label:contains(EF)'));
+
+        // should be switched in edit mode
+        assert.containsOnce(form, '.o_form_view.o_form_editable');
+        assert.containsOnce(form, 'input[type="radio"]:eq(2):checked');
+
+        assert.verifySteps([], "No write RPC done");
+
+        form.destroy();
+    });
+
     QUnit.test('Quick Edition: non-editable form', async function (assert) {
         assert.expect(3);
 


### PR DESCRIPTION
Bug
===
If we open a view in readonly mode, click on a radio widget and if a
constraint exists on this field, an error message is raised.
(e.g. the enroll field in "website_slides_sale").

Technical
=========
This is because in the "Basic controller", in the "_onFieldChanged",
we force "force_save" if the view is in readonly mode. This is wanted
for widgets that can change the value even in readonly mode
(e.g. Priority), but clicking on a Radio widget switch the mode to edit,
so this is not needed.

To fix that, we call `setValue` after switching to the edit mode. So
the `setValue` is skipped in `_onInputClick` if we are in readonly mode,
and the `setValue` is done in `_quickEdit` instead.

Task-2668763