### PR TITLE
[FIX] mrp_subcontracting: validate a partial picking

### DIFF
--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -135,6 +135,8 @@ class MrpProduction(models.Model):
                 return False
             if not all(line.lot_id for line in mo.move_raw_ids.filtered(lambda sm: sm.has_tracking != 'none').move_line_ids):
                 return False
+            if mo.product_id.tracking != 'none' and not mo.lot_producing_id:
+                return False
             return True
 
         return self.filtered(filter_in)


### PR DESCRIPTION
When validating a receipt, if the product is subcontracted and if the
picking is not fully done, it will be impossible to create a backorder

To reproduce the issue:
1. Create two products P_compo, P_finished
    - Both storable
    - Both tracked by lot
    - P_compo must have the route "Resupply Subcontractor on Order"
2. Update P_compo's quantity: 4
3. Create a BoM:
    - Product: P_finished
    - BoM type: Subcontracting
    - Subcontractors: a partner P
    - Components: 1 x P_compo
4. In Inventory, create a planned transfer T:
    - Operation Type: Receipt
    - Receive From: P
    - Operations: 4 x P_finished
5. Mark as Todo
6. Inventory > Delivery Orders, find the delivery of P_compo for P and
process it
7. Back to T, Record Components:
    - Quantity: 3/4
    - Set a Lot for P_finished
8. Validate T, Create Backorder

Error: a User Error is raised "You need to supply a Lot/Serial Number
for product: - P_finished"

Since P_finished is subcontracted, a related MO has been generated. On
step 7, when recording the used components, since all P_finished have
not been produced, a second MO is created for the last P_finished.
However, when validating T, both MOs are selected and validated. This is
an error since the user has not yet recorded the used components for the
last MO. The latter should not be validated.

OPW-2582538