### PR TITLE
[FIX] web: Avoid competition in change and hide events from datepicker

### DIFF
--- a/addons/web/static/src/js/components/datepicker.js
+++ b/addons/web/static/src/js/components/datepicker.js
@@ -81,7 +81,9 @@ odoo.define('web.DatePickerOwl', function (require) {
          * @param {...any} args anything that will be passed to the datetimepicker function.
          */
         _datetimepicker(...args) {
+            this.ignoreBootstrapEvents = true;
             $(this.el).datetimepicker(...args);
+            this.ignoreBootstrapEvents = false;
         }
 
         /**
@@ -120,6 +122,9 @@ odoo.define('web.DatePickerOwl', function (require) {
          * @private
          */
         _onDateTimePickerHide() {
+            if (this.ignoreBootstrapEvents) {
+                return;
+            }
             const date = this._parseInput(this.inputRef.el.value);
             this.state.warning = date.format('YYYY-MM-DD') > moment().format('YYYY-MM-DD');
             this.trigger('datetime-changed', { date });
@@ -132,6 +137,9 @@ odoo.define('web.DatePickerOwl', function (require) {
          * @private
          */
         _onDateTimePickerShow() {
+            if (this.ignoreBootstrapEvents) {
+                return;
+            }
             this.inputRef.el.select();
         }
 


### PR DESCRIPTION
If we set a date manually via the input while the datepicker widget is displayed and we click outside the widget while remaining in the dropdown custom filter, a traceback appears.
Because two triggers on datetime-changed are done almost at the same time change.input hide.widget

Now we ignore lib events for `_datetimepicker()`

OPW-2591874
