### PR TITLE
[FIX] l10n_lt: remove duplicate translation

### DIFF
--- a/addons/l10n_lt/i18n_extra/l10n_lt.pot
+++ b/addons/l10n_lt/i18n_extra/l10n_lt.pot
@@ -995,11 +995,6 @@ msgid "Liabilities under Short-Term Loan Agreements"
 msgstr ""
 
 #. module: l10n_lt
-#: model:account.account.template,name:l10n_lt.account_chart_template_lithuania_liquidity_transfer
-msgid "Liquidity Transfer"
-msgstr ""
-
-#. module: l10n_lt
 #: model:account.account.template,name:l10n_lt.account_account_template_4220
 msgid "Long-Term Liabilities under Loan Agreements"
 msgstr ""

--- a/addons/l10n_lt/i18n_extra/lt.po
+++ b/addons/l10n_lt/i18n_extra/lt.po
@@ -995,11 +995,6 @@ msgid "Liabilities under Short-Term Loan Agreements"
 msgstr "Įsipareigojimai pagal trumpalaikių paskolų sutartis"
 
 #. module: l10n_lt
-#: model:account.account.template,name:l10n_lt.account_chart_template_lithuania_liquidity_transfer
-msgid "Liquidity Transfer"
-msgstr "Likvidumo pervedimas"
-
-#. module: l10n_lt
 #: model:account.account.template,name:l10n_lt.account_account_template_4220
 msgid "Long-Term Liabilities under Loan Agreements"
 msgstr "Ilgalaikiai įsipareigojimai pagal paskolų sutartis"


### PR DESCRIPTION
Translation files contained multiple instances of the same reference.
This caused a traceback when loading the translations.

Fixes: #68552
