### PR TITLE
[IMP] web: add touch events helper for tests

### DIFF
--- a/addons/web/static/src/core/utils/numbers.js
+++ b/addons/web/static/src/core/utils/numbers.js
@@ -20,3 +20,15 @@ export function computeVariation(value, comparisonValue) {
     }
     return (value - comparisonValue) / Math.abs(comparisonValue);
 }
+
+/**
+ * Returns value clamped to the inclusive range of min and max.
+ * 
+ * @param {Number} num
+ * @param {Number} min
+ * @param {Number} max 
+ * @returns {Number}
+ */
+export function clamp(num, min, max) {
+    return Math.max(Math.min(num, max), min);
+}


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR adds some touch events helper in tests/helpers/utils of web. It is used for the tests of the ActionSwiper component of web_mobile.
It is linked to the tasks with IDs 2391177 and 2361187.
Current behavior before PR:
It is difficult to generate touch actions in tests
Desired behavior after PR is merged:
You can used those new events in your tests to generate touch interaction at precise coordinates.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
