### PR TITLE
[FIX] sale_mrp: filter variant BOMs for anglo_saxon price_unit

### DIFF
--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -11,7 +11,9 @@ class AccountMoveLine(models.Model):
 
         so_line = self.sale_line_ids and self.sale_line_ids[-1] or False
         if so_line:
-            bom = so_line.product_id.product_tmpl_id.bom_ids.filtered(lambda b: not b.company_id or b.company_id == so_line.company_id)[:1]
+            bom = (so_line.product_id.variant_bom_ids or so_line.product_id.product_tmpl_id.bom_ids).filtered(
+                lambda b: not b.company_id or b.company_id == so_line.company_id
+            )[:1]
             if bom and bom.type == 'phantom':
                 qty_to_invoice = self.product_uom_id._compute_quantity(self.quantity, self.product_id.uom_id)
                 qty_invoiced = sum([x.product_uom_id._compute_quantity(x.quantity, x.product_id.uom_id) for x in so_line.invoice_lines if x.move_id.state == 'posted'])


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When invoicing a product with variants and a kit BOM for each of those variants, the Cost Of Good Sold had the wrong amount.
As you can see on the screenshot, the COGS in the invoice for the product Tic-Tac (orange) has a price of 7, it should be 9 as shown in the BoM Structure & Cost of Tic-Tac (orange), instead it's using the value of the Tic-Tac (coca)

![image](https://user-images.githubusercontent.com/29302288/137452648-f6f71721-0108-4681-94ed-204e436c0d6e.png)

Current behavior before PR:
The function _stock_account_get_anglo_saxon_price_unit() on the sale_mrp module was selecting the product bom from the product_template of our product. However variants share the same product template, resulting in all variant boms to be selected, and the first one in the list being arbitrarily selected; most of the time the wrong one.
The price_unit was then computed using the incorrect bom.

Desired behavior after PR is merged:
We use the variant_bom_ids of the product when available, if not we fall back to the bom_ids of the product template.


Related support ticket: https://www.odoo.com/web#id=2662863&action=3531&model=project.task&view_type=form&cids=1&menu_id=4720


