### PR TITLE
[FIX] purchase: allow deleting a vendor from the product variant

### DIFF
--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -40,8 +40,8 @@
                     <attribute name="invisible">0</attribute>
                 </xpath>
                 <group name="purchase" position="before">
-                    <field name="seller_ids" context="{'default_product_tmpl_id':context.get('product_tmpl_id',active_id), 'product_template_invisible_variant': True, 'tree_view_ref':'purchase.product_supplierinfo_tree_view2'}" nolabel="1" attrs="{'invisible': [('product_variant_count','&gt;',1)]}"/>
-                    <field name="variant_seller_ids" context="{'default_product_tmpl_id': context.get('product_tmpl_id', active_id), 'tree_view_ref':'purchase.product_supplierinfo_tree_view2'}" nolabel="1" attrs="{'invisible': [('product_variant_count','&lt;=',1)]}"/>
+                    <field name="seller_ids" context="{'default_product_tmpl_id':context.get('product_tmpl_id',active_id), 'product_template_invisible_variant': True, 'tree_view_ref':'purchase.product_supplierinfo_tree_view2'}" nolabel="1" attrs="{'invisible': [('product_variant_count','&gt;',1)], 'readonly': [('product_variant_count','&gt;',1)]}"/>
+                    <field name="variant_seller_ids" context="{'default_product_tmpl_id': context.get('product_tmpl_id', active_id), 'tree_view_ref':'purchase.product_supplierinfo_tree_view2'}" nolabel="1" attrs="{'invisible': [('product_variant_count','&lt;=',1)], 'readonly': [('product_variant_count','&lt;=',1)]}"/>
                 </group>
                 <group name="bill" position="attributes">
                     <attribute name="groups">purchase.group_purchase_manager</attribute>


### PR DESCRIPTION
steps to reproduce the bug:
- Go to inventory > products > Create a new Product from ```product.template```
- Assign two vendors to the record
- Go to inventory > products > product variants > select the newly created product
- Remove any vendor and save

Problem:
An error indicating that the record ```product.supplierinfo``` does not exist or has been deleted will be triggered

In the ```product.product``` model, we have two One2Many fields ```seller_ids``` and ```variant_seller_ids```
which both point to ```product.supplierinfo```.
When we save, the write method will be called and will first delete the seller with seller_ids
and then try to update with variant_seller_ids but as both fields point to the same field,
the seller will already be deleted and an access error will be thrown

Solution:
As the two fields are never displayed at the same time in the view.
We can use the same invisibility condition to make them read only to prevent them from being both updated at the same time

opw-2661082

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
