### PR TITLE
[FIX] website_sale_wishlist

### DIFF
--- a/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
@@ -139,7 +139,7 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
         this._rpc({
             route: '/shop/wishlist/remove/' + wish,
         }).then(function () {
-            $(tr).hide();
+            $(tr).remove();
         });
 
         this.wishlistProductIDs = _.without(this.wishlistProductIDs, product);


### PR DESCRIPTION
- Fix mobile website wishlist cannot remove the favorite product

Description of the issue/feature this PR addresses:
- Mobile version of the website wishlist cannot remove the wishlist item

Current behavior before PR:
- After clicking the remove button inside the wishlist page, the wishlist item still appears.
- After checking the dev tools, found out the mobile version is using `display: grid !important;`, which override the `display: none;` from the jquery

Desired behavior after PR is merged:
- Remove the whole node instead, which makes the element not affecting by the important style. 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
