### PR TITLE
[IMP] hr_holidays: clean leave responsibles on user creation

### DIFF
--- a/addons/hr_holidays/models/res_users.py
+++ b/addons/hr_holidays/models/res_users.py
@@ -69,3 +69,9 @@ class User(models.Model):
         responsibles_to_remove_ids = set(self.ids) - {x['leave_manager_id'][0] for x in res}
         approver_group.sudo().write({
             'users': [(3, manager_id) for manager_id in responsibles_to_remove_ids]})
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        users = super().create(vals_list)
+        users._clean_leave_responsible_users()
+        return users


### PR DESCRIPTION
New users automatically received the Leave Responsible role even though
they were not managing any employees.

TaskID: 2635715

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
