### PR TITLE
[IMP] purchase: Add purchase history for PO line

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -907,6 +907,7 @@ class PurchaseOrderLine(models.Model):
     partner_id = fields.Many2one('res.partner', related='order_id.partner_id', string='Partner', readonly=True, store=True)
     currency_id = fields.Many2one(related='order_id.currency_id', store=True, string='Currency', readonly=True)
     date_order = fields.Datetime(related='order_id.date_order', string='Order Date', readonly=True)
+    date_approve = fields.Datetime(related="order_id.date_approve", string='Confirmation Date', readonly=True)
     product_packaging_id = fields.Many2one('product.packaging', string='Packaging', domain="[('purchase', '=', True), ('product_id', '=', product_id)]", check_company=True)
     product_packaging_qty = fields.Float('Packaging Quantity')
 
@@ -1229,6 +1230,17 @@ class PurchaseOrderLine(models.Model):
                 line.product_uom_qty = line.product_uom._compute_quantity(line.product_qty, line.product_id.uom_id)
             else:
                 line.product_uom_qty = line.product_qty
+
+    def action_purchase_history(self):
+        self.ensure_one()
+        action = self.env["ir.actions.actions"]._for_xml_id("purchase.action_purchase_history")
+        action['domain'] = [('state', 'in', ['purchase', 'done']), ('product_id', '=', self.product_id.id)]
+        action['display_name'] = _("Purchase History for %s", self.product_id.display_name)
+        action['context'] = {
+            'search_default_partner_id': self.partner_id.id
+        }
+
+        return action
 
     def _suggest_quantity(self):
         '''

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -250,6 +250,7 @@
                                     <field name="product_packaging_qty" attrs="{'invisible': ['|', ('product_id', '=', False), ('product_packaging_id', '=', False)]}" groups="product.group_stock_packaging" optional="show"/>
                                     <field name="product_packaging_id" attrs="{'invisible': [('product_id', '=', False)]}" context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" groups="product.group_stock_packaging" optional="show"/>
                                     <field name="price_unit" attrs="{'readonly': [('qty_invoiced', '!=', 0)]}"/>
+                                    <button name="action_purchase_history" type="object" icon="fa-history" title="Purchase History" attrs="{'invisible': [('id', '=', False)]}"/>
                                     <field name="taxes_id" widget="many2many_tags" domain="[('type_tax_use','=','purchase'), ('company_id', '=', parent.company_id), ('country_id', '=', parent.tax_country_id)]" context="{'default_type_tax_use': 'purchase', 'search_view_ref': 'account.account_tax_view_search'}" options="{'no_create': True}" optional="show"/>
                                     <field name="price_subtotal" widget="monetary"/>
                                 </tree>
@@ -741,6 +742,32 @@
                 </search>
             </field>
         </record>
+
+    <record id="purchase_history_tree" model="ir.ui.view">
+        <field name="name">purchase.history.tree</field>
+        <field name="model">purchase.order.line</field>
+        <field name="arch" type="xml">
+            <tree create="false" default_order="order_id asc">
+                <field name="order_id" widget="many2one"/>
+                <field name="date_approve" widget="date"/>
+                <field name="partner_id"/>
+                <field name="product_uom_qty"/>
+                <field name="price_unit"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="action_purchase_history" model="ir.actions.act_window">
+        <field name="res_model">purchase.order.line</field>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="purchase.purchase_history_tree"/>
+        <field name="context">{}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No purchase order were made for this product yet!
+            </p>
+        </field>
+    </record>
 
     <record id="action_purchase_batch_bills" model="ir.actions.server">
         <field name="name">Create Vendor Bills</field>

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -31,8 +31,8 @@
             </xpath>
             <xpath expr="//page/field[@name='order_line']/tree/field[@name='product_qty']" position="after">
                 <field name="forecasted_issue" invisible="1"/>
-                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" attrs="{'invisible': ['|', ('forecasted_issue', '=', False), ('product_type', '!=', 'product')]}" class="text-danger"/>
-                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" attrs="{'invisible': ['|', ('forecasted_issue', '=', True), ('product_type', '!=', 'product')]}"/>
+                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" attrs="{'invisible': ['|', '|', ('id', '=', False), ('forecasted_issue', '=', False), ('product_type', '!=', 'product')]}" class="text-danger"/>
+                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" attrs="{'invisible': ['|', '|', ('id', '=', False), ('forecasted_issue', '=', True), ('product_type', '!=', 'product')]}"/>
             </xpath>
             <xpath expr="//div[@name='date_planned_div']" position="inside">
                 <button name="%(action_purchase_vendor_delay_report)d" class="oe_link" type="action" context="{'search_default_partner_id': partner_id}" attrs="{'invisible': ['|', ('state', 'in', ['purchase', 'done']), ('partner_id', '=', False)]}">


### PR DESCRIPTION
Sometimes it's difficult to track the price of a product, with the different discounts you can obtain.
Price of products might change often and it's very practical to track the price at the moment of the order to verify that it's in line with what you paid in the past.

Task-2658786

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
