### PR TITLE
[FIX] point_of_sale: use correct rate date in test

### DIFF
--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from random import randint
+from datetime import datetime
 
 from odoo import fields
 from odoo.tests.common import TransactionCase, Form
@@ -216,6 +217,7 @@ class TestPoSCommon(TransactionCase):
         self.env['res.currency.rate'].create({
             'rate': 0.5,
             'currency_id': self.other_currency.id,
+            'name': datetime.today().date()
         })
         other_cash_journal = self.env['account.journal'].create({
             'name': 'Cash Other',


### PR DESCRIPTION
Since changes made in currency rate default value made in this PR
https://github.com/odoo/odoo/pull/76513 the date is stored based on user
timezone, and so doesn't work if the test runs around midnight with the
belgian timezone on the servers.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
