### PR TITLE
[FIX] project,hr_timesheet: fix hr timesheet graph extension

### DIFF
--- a/addons/hr_timesheet/static/src/js/timesheet_graph_view.js
+++ b/addons/hr_timesheet/static/src/js/timesheet_graph_view.js
@@ -1,12 +1,12 @@
 /** @odoo-module **/
 
-import { GraphView } from "@web/views/graph/graph_view";
+import { ProjectGraphView } from "@project/js/project_graph_view";
 import { hrTimesheetGraphModel } from "./timesheet_graph_model";
 import { registry } from "@web/core/registry";
 
 const viewRegistry = registry.category("views");
 
-export class hrTimesheetGraphView extends GraphView {}
+export class hrTimesheetGraphView extends ProjectGraphView {}
 hrTimesheetGraphView.Model = hrTimesheetGraphModel;
 
 viewRegistry.add("hr_timesheet_graphview", hrTimesheetGraphView);

--- a/addons/project/static/src/js/project_graph_view.js
+++ b/addons/project/static/src/js/project_graph_view.js
@@ -6,7 +6,7 @@ import { GraphView } from "@web/views/graph/graph_view";
 
 const viewRegistry = registry.category("views");
 
-class ProjectGraphView extends GraphView {}
+export class ProjectGraphView extends GraphView {}
 ProjectGraphView.ControlPanel = ProjectControlPanel;
 
 viewRegistry.add("project_graph", ProjectGraphView);

--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -2,6 +2,29 @@
 
 import tour from 'web_tour.tour';
 
+function openProjectUpdateAndReturnToTasks(view, viewClass) {
+    return [{
+            trigger: '.o_project_updates_breadcrumb',
+            content: 'Open Project Update from view : ' + view,
+            extra_trigger: "." + viewClass,
+        }, {
+            trigger: ".o-kanban-button-new",
+            content: "Create a new update from project task view : " + view,
+            extra_trigger: '.o_pupdate_kanban',
+        }, {
+            trigger: "button.o_form_button_cancel",
+            content: "Discard project update from project task view : " + view,
+        }, {
+            trigger: ".o_switch_view.o_list",
+            content: "Go to list of project update from view " + view,
+        }, {
+            trigger: '.o_back_button',
+            content: 'Go back to the task view : ' + view,
+            extra_trigger: '.o_list_view',
+        },
+    ];
+}
+
 tour.register('project_update_tour', {
     test: true,
     url: '/web',
@@ -72,7 +95,7 @@ tour.register('project_update_tour', {
     trigger: ".o_kanban_record .oe_kanban_content",
     extra_trigger: '.o_kanban_project_tasks',
     run: "drag_and_drop .o_kanban_group:eq(1) ",
-}, {    
+}, {
     trigger: ".o_project_updates_breadcrumb",
     content: 'Open Updates'
 }, {
@@ -97,9 +120,6 @@ tour.register('project_update_tour', {
 }, {
     trigger: ".modal-footer button"
 }, {
-    trigger: '.o_back_button',
-    content: 'Go back to edit to the list view',
-
     trigger: ".o_open_milestone:eq(1) .o_milestone_detail span:eq(0)",
     extra_trigger: ".o_add_milestone a",
     run: function () {
@@ -135,4 +155,31 @@ tour.register('project_update_tour', {
 }, {
     trigger: ".o_field_widget[name=description] div[name='milestone'] ul li span:contains('(due 12/12/2100)')",
     run: function () {},
-}]);
+}, {
+    trigger: '.o_back_button',
+    content: 'Go back to the kanban view the project',
+}, {
+    trigger: '.o_switch_view.o_list',
+    content: 'Open List View of Project Updates',
+}, {
+    trigger: '.o_back_button',
+    content: 'Go back to the kanban view the project',
+    extra_trigger: '.o_list_view',
+}, {
+    trigger: '.o_switch_view.o_graph',
+    content: 'Open Graph View of Tasks',
+}, ...openProjectUpdateAndReturnToTasks("Graph", "o_graph_view"), {
+    trigger: '.o_switch_view.o_list',
+    content: 'Open List View of Tasks',
+    extra_trigger: '.o_graph_view',
+}, ...openProjectUpdateAndReturnToTasks("List", "o_list_view"), {
+    trigger: '.o_switch_view.o_pivot',
+    content: 'Open Pivot View of Tasks',
+}, ...openProjectUpdateAndReturnToTasks("Pivot", "o_pivot_view"), {
+    trigger: '.o_switch_view.o_calendar',
+    content: 'Open Calendar View of Tasks',
+}, ...openProjectUpdateAndReturnToTasks("Calendar", "o_calendar_view"), {
+    trigger: '.o_switch_view.o_activity',
+    content: 'Open Activity View of Tasks',
+}, ...openProjectUpdateAndReturnToTasks("Activity", "o_activity_view"),
+]);


### PR DESCRIPTION
This commit fixes the broken inheritence between project and
hr_timesheet modules regarding the GraphView.

Hr Timesheet module extends GraphView rather than ProjectGraphView which
makes the view unaware it should use the ProjectControlPanel.

This commit adds project tour steps to ensure every view contains the
project update breadcrumb.

task-2642872

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
