### PR TITLE
[FIX] mrp: Unbuild order using wrong bom

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -87,6 +87,7 @@ class MrpUnbuild(models.Model):
             self.product_id = self.mo_id.product_id.id
             self.product_qty = self.mo_id.product_qty
             self.product_uom_id = self.mo_id.product_uom_id
+            self.bom_id = self.mo_id.bom_id
 
     @api.onchange('product_id')
     def _onchange_product_id(self):


### PR DESCRIPTION
Current behaviour:
Unbuilding order use the last BOM created for the product

Expected behaviour:
Unbuilding order should use the BOM that has been used for the MO

Steps to reproduce:
Create a product with a BOM
Create a MO and mark it as done
Create another BOM for the same product
Create unbuild order for the MO
The wrong BOM is selected by default

opw-2636632

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
