### PR TITLE
[I18N] google_calendar: fix call to _set_auth_tokens method

### DIFF
--- a/addons/google_calendar/wizard/reset_account.py
+++ b/addons/google_calendar/wizard/reset_account.py
@@ -45,7 +45,7 @@ class ResetGoogleAccount(models.TransientModel):
                 'need_sync': True,
             })
 
-        self.user_id._set_auth_tokens(False, False, 0)
+        self._set_auth_tokens(False, False, 0)
         self.user_id.write({
             'google_calendar_sync_token': False,
             'google_calendar_cal_id': False,

--- a/addons/google_calendar/wizard/reset_account.py
+++ b/addons/google_calendar/wizard/reset_account.py
@@ -45,7 +45,7 @@ class ResetGoogleAccount(models.TransientModel):
                 'need_sync': True,
             })
 
-        self._set_auth_tokens(False, False, 0)
+        self.env['google.calendar.credentials']._set_auth_tokens(False, False, 0)
         self.user_id.write({
             'google_calendar_sync_token': False,
             'google_calendar_cal_id': False,

--- a/addons/google_calendar/wizard/reset_account.py
+++ b/addons/google_calendar/wizard/reset_account.py
@@ -45,7 +45,7 @@ class ResetGoogleAccount(models.TransientModel):
                 'need_sync': True,
             })
 
-        self.user_id.google_cal_account_id._set_auth_tokens(False, False, 0)
+        self.user_id.sudo().google_cal_account_id._set_auth_tokens(False, False, 0)
         self.user_id.write({
             'google_calendar_sync_token': False,
             'google_calendar_cal_id': False,

--- a/addons/google_calendar/wizard/reset_account.py
+++ b/addons/google_calendar/wizard/reset_account.py
@@ -45,7 +45,7 @@ class ResetGoogleAccount(models.TransientModel):
                 'need_sync': True,
             })
 
-        self.env['google.calendar.credentials']._set_auth_tokens(False, False, 0)
+        self.user_id.google_cal_account_id._set_auth_tokens(False, False, 0)
         self.user_id.write({
             'google_calendar_sync_token': False,
             'google_calendar_cal_id': False,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Error during reset google calendar token in the user google calendar tab

Current behavior before PR:
Go to user, and calendar tab
Reset your token
you will get an exception traceback msg, saying that in user object there is no _set_auth_tokens method

Desired behavior after PR is merged:
Making the same action you will have your tokens cleaned up.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
