### PR TITLE
[FIX] website: improve mega menus usability

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -25,6 +25,7 @@ const BaseAnimatedHeader = animations.Animation.extend({
         this.fixedHeader = false;
         this.scrolledPoint = 0;
         this.hasScrolled = false;
+        this.closeOpenedMenus = false;
     },
     /**
      * @override
@@ -167,6 +168,7 @@ const BaseAnimatedHeader = animations.Animation.extend({
             }
         } else {
             this.$el.removeClass('o_header_no_transition');
+            this.closeOpenedMenus = true;
         }
 
         // Indicates the page is scrolled, the logo size is changed.
@@ -177,9 +179,10 @@ const BaseAnimatedHeader = animations.Animation.extend({
             this.headerIsScrolled = headerIsScrolled;
         }
 
-        // Close opened menus
-        this.$dropdowns.removeClass('show');
-        this.$navbarCollapses.removeClass('show').attr('aria-expanded', false);
+        if (this.closeOpenedMenus) {
+            this.$dropdowns.removeClass('show');
+            this.$navbarCollapses.removeClass('show').attr('aria-expanded', false);
+        }
     },
     /**
      * Called when the window is resized

--- a/addons/website/static/src/js/editor/wysiwyg.js
+++ b/addons/website/static/src/js/editor/wysiwyg.js
@@ -55,6 +55,7 @@ Wysiwyg.include({
         var $dropdownMenuToggles = this.$('.o_mega_menu_toggle, #top_menu_container .dropdown-toggle');
         $dropdownMenuToggles.removeAttr('data-toggle').dropdown('dispose');
         $dropdownMenuToggles.on('click.wysiwyg_megamenu', ev => {
+            this.odooEditor.observerUnactive();
             var $toggle = $(ev.currentTarget);
 
             // Each time we toggle a dropdown, we will destroy the dropdown
@@ -67,7 +68,8 @@ Wysiwyg.include({
             // Then toggle the clicked one
             toggleDropdown($toggle)
                 .then(dispose)
-                .then(() => this._toggleMegaMenu($toggle[0]));
+                .then(() => this._toggleMegaMenu($toggle[0]))
+                .then(() => this.odooEditor.observerActive());
         });
 
         // Ensure :blank oe_structure elements are in fact empty as ':blank'

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -801,7 +801,7 @@ $-transition-duration: 200ms;
 }
 
 // Navbar
-.navbar .o_extra_menu_items.show > ul {
+.navbar .o_extra_menu_items.show > div {
     > li {
         + li {
             border-top: 1px solid gray('200');

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1201,6 +1201,7 @@ header {
         padding-right: $grid-gutter-width / 2;
     }
 }
+
 .o_mega_menu_container_size {
     $-header-template: o-website-value('header-template');
     @if not index(('sidebar', 'hamburger', 'magazine'), $-header-template) {
@@ -1218,6 +1219,26 @@ header {
         ));
     }
     @include make-container-max-widths($-mm-max-widths);
+}
+
+// The design of some of the new mega menu templates required a column with
+// an overlay that would overflow until the end of the container. For
+// technical reasons, this overlay has to be hardcoded here.
+%s_mega_menu_gray_area {
+    z-index: 1;
+
+    &:before {
+        content: '';
+        display: block;
+        width: 100vw;
+        height: 100%;
+        position: absolute;
+        left: 0;
+        top: 0;
+        z-index: -1;
+        pointer-events: none;
+        background: rgba(0, 0, 0, .05);
+    }
 }
 
 #wrapwrap.o_header_overlay {

--- a/addons/website/static/src/snippets/s_mega_menu_little_icons/000.scss
+++ b/addons/website/static/src/snippets/s_mega_menu_little_icons/000.scss
@@ -7,20 +7,6 @@
     }
 
     .s_mega_menu_gray_area:last-child {
-        // Allow to show the grey background used in the pseudo-element
-        z-index: 1;
-
-        &:before {
-            content: '';
-            display: block;
-            width: 100vw;
-            height: 100%;
-            position: absolute;
-            left: 0;
-            top: 0;
-            z-index: -1;
-            pointer-events: none;
-            background: rgba(0, 0, 0, .05);
-        }
+        @extend %s_mega_menu_gray_area;
     }
 }

--- a/addons/website/static/src/snippets/s_mega_menu_menus_logos/000.scss
+++ b/addons/website/static/src/snippets/s_mega_menu_menus_logos/000.scss
@@ -1,21 +1,7 @@
 
 .s_mega_menu_menus_logos:not([data-vcss]) {
     .s_mega_menu_gray_area:last-child {
-        // Allow to show the grey background used in the pseudo-element
-        z-index: 1;
-
-        &:before {
-            content: '';
-            display: block;
-            width: 100vw;
-            height: 100%;
-            position: absolute;
-            left: 0;
-            top: 0;
-            z-index: -1;
-            pointer-events: none;
-            background: rgba(0, 0, 0, .05);
-        }
+        @extend %s_mega_menu_gray_area;
     }
 
     .s_mega_menu_menus_logos_wrapper {

--- a/addons/website/static/src/snippets/s_mega_menu_odoo_menu/000.scss
+++ b/addons/website/static/src/snippets/s_mega_menu_odoo_menu/000.scss
@@ -2,7 +2,18 @@
 .s_mega_menu_odoo_menu:not([data-vcss]) {
     .s_mega_menu_odoo_menu_footer {
         // Apply color transparency to match with the preset used
-        border-color: rgba(0, 0, 0, .05) !important;
-        background: rgba(0, 0, 0, .05) !important;
+        border-color: rgba(0, 0, 0, .05);
+
+        .row > div:not(.o_cc) {
+            // TODO this should be replaced by proper structure and color
+            // classes
+            @extend %s_mega_menu_gray_area;
+
+            &::before {
+                @include o-position-absolute(0, 0, 0, 0);
+                width: auto;
+                height: auto;
+            }
+        }
     }
 }

--- a/addons/website/static/src/snippets/s_mega_menu_thumbnails/000.scss
+++ b/addons/website/static/src/snippets/s_mega_menu_thumbnails/000.scss
@@ -1,5 +1,13 @@
 .s_mega_menu_thumbnails:not([data-vcss]) {
-    .s_mega_menu_thumbnails_footer {
-        background: rgba(0, 0, 0, .05);
+    .s_mega_menu_thumbnails_footer:not(.o_cc) {
+        // TODO this should be replaced by proper structure and color
+        // classes
+        @extend %s_mega_menu_gray_area;
+
+        &::before {
+            @include o-position-absolute(0, 0, 0, 0);
+            width: auto;
+            height: auto;
+        }
     }
 }

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -4,6 +4,18 @@ odoo.define("website.tour.edit_megamenu", function (require) {
 const tour = require('web_tour.tour');
 const wTourUtils = require('website.tour_utils');
 
+const toggleMegaMenu = (stepOptions) => Object.assign({}, {
+    content: "Toggles the mega menu.",
+    trigger: '#top_menu .nav-item a.o_mega_menu_toggle',
+    run: function () {
+        // If the mega menu is displayed inside the extra menu items, it should
+        // already be displayed.
+        if (!this.$anchor[0].closest('.o_extra_menu_items')) {
+            this.$anchor.click();
+        }
+    },
+}, stepOptions);
+
 tour.register('edit_megamenu', {
     test: true,
     url: '/?enable_editor=1',
@@ -38,10 +50,32 @@ tour.register('edit_megamenu', {
         trigger: '.modal-dialog .btn-primary span:contains("Save")',
         run: 'click',
     },
-    wTourUtils.clickOnExtraMenuItem({extra_trigger: 'a[data-action=edit]'}),
+    // Edit a menu item
+    wTourUtils.clickOnEdit(),
+    wTourUtils.clickOnExtraMenuItem({extra_trigger: '#oe_snippets.o_loaded'}),
+    toggleMegaMenu({extra_trigger: '#top_menu .nav-item a.o_mega_menu_toggle:contains("Megaaaaa!")'}),
     {
-        content: "Menu should have a new megamenu item",
-        trigger: '#top_menu .nav-item a.o_mega_menu_toggle:contains("Megaaaaa!")',
+        content: "Clicks on the first title item.",
+        trigger: '.o_mega_menu h4',
+    },
+    {
+        content: "Press enter.",
+        trigger: '.o_mega_menu h4',
+        run: function (actions) {
+            this.$anchor[0].dispatchEvent(new window.InputEvent('input', {bubbles: true, inputType: 'insertParagraph'}));
+        },
+    },
+    {
+        content: "The menu should still be visible. Edit a menu item.",
+        trigger: '.o_mega_menu h4',
+        run: 'text New Menu Item',
+    },
+    ...wTourUtils.clickOnSave(),
+    wTourUtils.clickOnExtraMenuItem({extra_trigger: 'a[data-action=edit]'}),
+    toggleMegaMenu(),
+    {
+        content: "The menu item should have been renamed.",
+        trigger: '.o_mega_menu h4:contains("New Menu Item")',
         run: function () {}, // it's a check
     },
 ]);

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -462,8 +462,8 @@
     </div>
 
     <!-- Background -->
-    <t t-set="only_bg_color_selector" t-value="'section .row > div, .s_text_highlight'"/>
-    <t t-set="only_bg_color_exclude" t-value="'.s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .o_mega_menu .row > div, .s_image_gallery .row > div'"/>
+    <t t-set="only_bg_color_selector" t-value="'section .row > div, .s_text_highlight, .s_mega_menu_thumbnails_footer'"/>
+    <t t-set="only_bg_color_exclude" t-value="'.s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .s_image_gallery .row > div'"/>
 
     <t t-set="base_only_bg_image_selector" t-value="'.s_tabs .oe_structure > *, footer .oe_structure > *'"/>
     <t t-set="only_bg_image_selector" t-value="base_only_bg_image_selector"/>


### PR DESCRIPTION
This commit adds the possibility to modify some background colors of the
mega menus so that the templates are fully editable.

Some of these templates have a column with an extended background, using
the :before css pseudo element.
As this is not a DOM element, it cannot be changed from javascript.
It was decided that using shapes would not produce the same effect as
the designer intended, and that it would be too confusing for the user
to be provided with an option allowing to extend the background of a
column.
Therefore, these specific s_mega_menu_gray_area elements must have their
background hardcoded.

task-2668908


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
