### PR TITLE
[FIX] product: correct datetime format in warning

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -469,7 +469,7 @@ class PricelistItem(models.Model):
     def _check_date_range(self):
         for item in self:
             if item.date_start and item.date_end and item.date_start >= item.date_end:
-                raise ValidationError(_('%s : end date (%s) should be greater than start date (%s)', item.display_name, format_datetime(self.env, item.date_end), format_datetime(self.env, item.date_start)))
+                raise ValidationError(_('%s : end date (%s) should be greater than start date (%s)', item.display_name, format_datetime(self.env, item.date_end, dt_format=False), format_datetime(self.env, item.date_start, dt_format=False)))
         return True
 
     @api.constrains('price_min_margin', 'price_max_margin')


### PR DESCRIPTION
Before this commit, we were displaying datetime using
default format like `Jan 5, 2016, 10:20:31 PM` (`dt_format=medium`)

With this commit, we are passing `dt_format=False` so it will display
datetime according to format set in language

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
