### PR TITLE
[FIX] website: restore icons for snippet "Big Icons Subtitles"

### DIFF
--- a/addons/website/views/snippets/s_mega_menu_big_icons_subtitles.xml
+++ b/addons/website/views/snippets/s_mega_menu_big_icons_subtitles.xml
@@ -71,7 +71,7 @@
 <template id="s_mega_menu_big_icons_subtitles_item">
     <a href="#" class="nav-link o_default_snippet_text px-2 my-2 rounded text-wrap" data-name="Menu Item">
         <div class="media align-items-center">
-            <i t-attf-class="fa rounded rounded-circle mr-3 #{_icon_class}"/>
+            <i t-attf-class="fa rounded rounded-circle mr-3 #{_icon_classes}"/>
             <div class="media-body">
                 <h4 class="mt-0 mb-0" t-esc="_title"/>
                 <span><font style="font-size: 14px;" t-esc="_text"/></span>


### PR DESCRIPTION
"Big Icons Subtitles" snippet is not displaying any icons
![image](https://user-images.githubusercontent.com/22187704/137579927-29b6d346-b4b6-46bd-8b75-7f7f1cd6a26f.png)
