### PR TITLE
[FIX] web_editor: link widget should respect native bootstrap class

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -95,7 +95,7 @@ const Link = Widget.extend({
         }
 
         const allBtnColorPrefixes = /(^|\s+)(bg|text|border)(-[a-z0-9_-]*)?/gi;
-        const allBtnClassSuffixes = /(^|\s+)btn(-[a-z0-9_-]*)?/gi;
+        const allBtnClassSuffixes = /(^|\s+)btn(?!-block)(-[a-z0-9_-]*)?/gi;
         const allBtnShapes = /\s*(rounded-circle|flat)\s*/gi;
         this.data.className = this.data.iniClassName
             .replace(allBtnColorPrefixes, ' ')


### PR DESCRIPTION
Before this commit, When you try to edit the link then the link widget is
removing 'btn-block' class from the class list of the link node.

After this commit, the link widget will allow using 'btn-block' class.