### PR TITLE
[FIX] website_crm: fix random website_crm_pre_tour bug

### DIFF
--- a/addons/website_crm/static/tests/tours/website_crm.js
+++ b/addons/website_crm/static/tests/tours/website_crm.js
@@ -8,10 +8,12 @@ odoo.define('website_crm.tour', function(require) {
         url: '/contactus?enable_editor=1',
     }, [{
         content: "Select contact form",
-        trigger: "section.s_website_form",
+        trigger: "#wrap.o_editable section.s_website_form",
+        extra_trigger: "body.editor_enable",
     }, {
         content: "Open action select",
         trigger: "we-select:has(we-button:contains('Create an Opportunity')) we-toggler",
+        extra_trigger: "#oe_snippets .o_we_customize_snippet_btn.active",
     }, {
         content: "Select 'Create an Opportunity' as form action",
         trigger: "we-select we-button:contains('Create an Opportunity')",


### PR DESCRIPTION
PURPOSE

The purpose of this commit is to fix the random bug of 
'TestWebsiteCrm.test_catch_logged_partner_info_tour' on runbot.

SPECIFICATIONS

Currently, The 'TestWebsiteCrm.test_catch_logged_partner_info_tour' is
randomly failing on runbot. The tour is trigger on the contact us page.
This tour is linked with selectors. So, This updates the selectors and
adds the extra triggers.

This is the goal of this commit.

LINKS

PR #78512
Task-2649723

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
