### PR TITLE
[FIX] product: display pricelists that have no defined end date

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -608,7 +608,7 @@
                 <search string="Vendor">
                     <field name="name"/>
                     <field name="product_tmpl_id"/>
-                    <filter string="Active" name="active" domain="[('date_end', '&gt;=',  (context_today() - datetime.timedelta(days=1)).strftime('%%Y-%%m-%%d'))]"/>
+                    <filter string="Active" name="active" domain="['|', ('date_end', '=', False), ('date_end', '&gt;=',  (context_today() - datetime.timedelta(days=1)).strftime('%%Y-%%m-%%d'))]"/>
                     <filter string="Archived" name="archived" domain="[('date_end', '&lt;',  (context_today() - datetime.timedelta(days=1)).strftime('%%Y-%%m-%%d'))]"/>
                     <group expand="0" string="Group By">
                         <filter string="Product" name="groupby_product" domain="[]" context="{'group_by': 'product_tmpl_id'}"/>


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to purchase > Configuration > Vendor Pricelists
- Filters > select the “Active” filter

Problem:
Currently, the filter does not include records that do not have a specified `”date_end”`, even though they are considered active.

Opw-2659829




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
