### PR TITLE
[FIX] mail: chatter in chat window should log notes

### DIFF
--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -1216,7 +1216,7 @@ function factory(dependencies) {
          * If true composer will log a note, else a comment will be posted.
          */
         isLog: attr({
-            default: false,
+            default: true,
         }),
         /**
          * Determines whether a post_message request is currently pending.


### PR DESCRIPTION
### Expected Behaviour

When a user reply to a mention (on an invoice, a client profile, ...) in a log_note, and this user answers directly in the chatbox, the answer should be considered as an internal discussion, and so be posted as a log_note.

### Observed behaviour

Since V12, when a user reply in the chatbox, the reply is automatically set as a "send-message" reply, which is a issue as the user sends an email to all followers of the discussion while he probably thinks his answer will be visible only by the internal users.

### Reproducibility

This bug can be reproduced following these steps:
1. Declare at least 2 users (A and B) and make sure user A handles notifications in Odoo
2. Log as user B, go anywhere in Odoo and mention the user A in a log_note
3. Log as user A, open the mention notification and reply in the chatbox
4. The answer will be noted as a send-message answer, sending then e-mails to all followers ...

### Problem Root Cause

As long as the V12 isn't supported anymore, we didn't investigate this version. In V13, the issue comes from the fact the chatbox didn't use the same composer class as the discussion module, and then it's not possible to send a log note from the chatbox. In V14, as the discussion module has been totally refactored, the "error" comes from the arbitrary choice to set "false" as the default value of "isLog" on a general message, which implies that the answer from the chatbox is considered as a "send-message" and not as a "log-note".

### Validation
- Wrong behaviour : https://drive.google.com/file/d/1Nx6v27vcxsCkJuifqD9-0T-Xmqc-Khhh/view (from JQU)
- Correct behaviour : cf following screenshot, where we can see that an answer to a mention is now correclty set as log_note (by the bg color in the answer). This has also been validated to make sure a classical chat discussion wasn't impacted, as seen in the screenshot.

![message_to_log](https://user-images.githubusercontent.com/91665701/137698546-fbc6f803-c4fa-448c-a662-e831d7d7b974.png)


### Related tickets

opw-2602712
opw-2659484


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
