### PR TITLE
[FIX] core: remove field unlink check

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2288,7 +2288,7 @@ class IrModelData(models.Model):
                 module = xmlid.split('.', 1)[0]
                 record = record.with_context(module=module)
                 if record._name == 'ir.model.fields' and not module.startswith('test_'):
-                    _logger.warning(
+                    _logger.runbot(
                         "Deleting field %s.%s (hint: fields should be"
                         " explicitly removed by an upgrade script)",
                         record.model, record.name,


### PR DESCRIPTION
This warning was introduced before the upgrade scripts ir.model.fields
unlink overrides and is now irrelevant in odoo upgrade process.

This checks breaks the exception mechanism used to add computed
fields in stable.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
