### PR TITLE
[FIX] account: reposition tooltip indication

### DIFF
--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -19,7 +19,7 @@ tour.register('account_tour', {
         trigger: "button[name=action_save_onboarding_company_step]",
         extra_trigger: "a.o_onboarding_step_action[data-method=action_open_base_onboarding_company]",
         content: _t("Looks good. Let's continue."),
-        position: "left",
+        position: "bottom",
     }, {
         trigger: "a.o_onboarding_step_action[data-method=action_open_base_document_layout]",
         content: _t("Customize your layout."),
@@ -28,7 +28,7 @@ tour.register('account_tour', {
         trigger: "button[name=document_layout_save]",
         extra_trigger: "a.o_onboarding_step_action[data-method=action_open_base_document_layout]",
         content: _t("Once everything is as you want it, validate."),
-        position: "left",
+        position: "top",
     }, {
         trigger: "a.o_onboarding_step_action[data-method=action_open_account_onboarding_create_invoice]",
         content: _t("Now, we'll create your first invoice."),
@@ -86,7 +86,7 @@ tour.register('account_tour', {
         trigger: "button[name=send_and_print_action]",
         extra_trigger: "[name=move_type][raw-value=out_invoice]",
         content: _t("Let's send the invoice."),
-        position: "left"
+        position: "top"
     }
 ]);
 


### PR DESCRIPTION
Currently, hovering on the tooltip displays some content out of
the viewport. It happens because tooltip content div requires
270px width to display the text and the distance between the
tour indicator and viewport is less than 270px

so this commit fixes the issue by changing the position of the tooltip
indicator from left to the top so that the tooltip indicator displays
top of the element and hovering on it displays the full content

TaskID-2667140