### PR TITLE
[FIX] web_editor: improve email conversion for mail clients

### DIFF
--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -125,7 +125,7 @@ class Digest(models.Model):
             digest.next_run_date = digest._get_next_run_date()
 
     def _action_send_to_user(self, user, tips_count=1, consum_tips=True):
-        rendered_body = self.env['mail.render.mixin']._render_template(
+        rendered_body = self.env['mail.render.mixin'].with_context(preserve_comments=True)._render_template(
             'digest.digest_mail_main',
             'digest.digest',
             self.ids,

--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -276,8 +276,11 @@ class MailRenderMixin(models.AbstractModel):
         for record in self.env[model].browse(res_ids):
             variables['object'] = record
             try:
-                render_result = self.env['ir.qweb']._render(html.fragment_fromstring(
-                    template_src, create_parent='div'), variables, raise_on_code=is_restricted)
+                render_result = self.env['ir.qweb']._render(
+                    html.fragment_fromstring(template_src, create_parent='div'),
+                    variables,
+                    raise_on_code=is_restricted,
+                )
                 # remove the rendered tag <div> that was added in order to wrap potentially multiples nodes into one.
                 render_result = render_result[5:-6]
             except QWebCodeFound:

--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -162,7 +162,14 @@ class MailRenderMixin(models.AbstractModel):
         _sub_relative2absolute.base_url = base_url
         html = re.sub(r"""(<img(?=\s)[^>]*\ssrc=")(/[^/][^"]+)""", _sub_relative2absolute, html)
         html = re.sub(r"""(<a(?=\s)[^>]*\shref=")(/[^/][^"]+)""", _sub_relative2absolute, html)
-        html = re.sub(r"""(<[^>]+\bstyle="[^"]+\burl\('?)(/[^/'][^'")]+)""", _sub_relative2absolute, html)
+        html = re.sub(re.compile(
+            r"""( # Group 1: element up to url in style
+                <[^>]+\bstyle=" # Element with a style attribute
+                [^"]+\burl\( # Style attribute contains "url(" style
+                (?:&\#34;|')?) # url style may start with (escaped) quote: capture it
+            ( # Group 2: url itself
+                /(?:[^'")]|(?!&\#34;))+ # stop at the first closing quote
+        )""", re.VERBOSE), _sub_relative2absolute, html)
 
         return wrapper(html)
 

--- a/addons/mail/tests/__init__.py
+++ b/addons/mail/tests/__init__.py
@@ -4,6 +4,7 @@
 from . import test_mail_channel
 from . import test_mail_channel_as_guest
 from . import test_mail_channel_partner
+from . import test_mail_composer
 from . import test_mail_full_composer
 from . import test_mail_render
 from . import test_mail_template

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import users
+from odoo.addons.mail.tests.common import MailCommon
+
+
+class TestMailComposer(MailCommon):
+    @classmethod
+    def setUpClass(cls):
+        super(TestMailComposer, cls).setUpClass()
+        cls.env['ir.config_parameter'].set_param('mail.restrict.template.rendering', True)
+        cls.user_employee.groups_id -= cls.env.ref('mail.group_mail_template_editor')
+        cls.test_record = cls.env['res.partner'].with_context(cls._test_context).create({
+            'name': 'Test',
+        })
+        cls.body_html = """<div>
+    <h1>Hello sir!</h1>
+    <p>Here! <a href="https://www.example.com">
+        <!--[if mso]>
+            <i style="letter-spacing: 25px; mso-font-width: -100%; mso-text-raise: 30pt;">&nbsp;</i>
+        <![endif]-->
+        A link for you!
+        <!--[if mso]>
+            <i style="letter-spacing: 25px; mso-font-width: -100%;">&nbsp;</i>
+        <![endif]-->
+    </a> Make good use of it.</p>
+</div>"""
+
+        cls.mail_template = cls.env['mail.template'].create({
+            'name': 'Test template with mso conditionals',
+            'subject': 'MSO FTW',
+            'body_html': cls.body_html,
+            'lang': '{{ object.lang }}',
+            'auto_delete': True,
+            'model_id': cls.env.ref('base.model_res_partner').id,
+        })
+
+    @users('employee')
+    def test_mail_mass_mode_template_with_mso(self):
+        mail_compose_message = self.env['mail.compose.message'].create({
+            'composition_mode': 'mass_mail',
+            'model': 'res.partner',
+            'template_id': self.mail_template.id,
+            'subject': 'MSO FTW',
+        })
+
+        values = mail_compose_message.get_mail_values(self.partner_employee.ids)
+
+        self.assertIn("""<div>
+    <h1>Hello sir!</h1>
+    <p>Here! <a href="https://www.example.com">
+        A link for you!
+    </a> Make good use of it.</p>
+</div>""",
+            values[self.partner_employee.id]['body_html'],
+            'We must remove comments')
+
+    @users('employee')
+    def test_mail_mass_mode_compose_with_mso(self):
+        composer = self.env['mail.compose.message'].with_context({
+            'default_model': self.test_record._name,
+            'default_composition_mode': 'mass_mail',
+            'active_ids': [self.test_record.id],
+            'active_model': self.test_record._name,
+            'active_id': self.test_record.id
+        }).create({
+            'body': self.body_html,
+            'partner_ids': [(4, self.partner_employee.id)],
+            'composition_mode': 'mass_mail',
+        })
+        with self.mock_mail_gateway(mail_unlink_sent=True):
+            composer._action_send_mail()
+
+        values = composer.get_mail_values(self.partner_employee.ids)
+
+        self.assertIn("""<div>
+    <h1>Hello sir!</h1>
+    <p>Here! <a href="https://www.example.com">
+        A link for you!
+    </a> Make good use of it.</p>
+</div>""",
+            values[self.partner_employee.id]['body_html'],
+            'We must remove comments')

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -47,14 +47,9 @@ class TestMailComposer(MailCommon):
 
         values = mail_compose_message.get_mail_values(self.partner_employee.ids)
 
-        self.assertIn("""<div>
-    <h1>Hello sir!</h1>
-    <p>Here! <a href="https://www.example.com">
-        A link for you!
-    </a> Make good use of it.</p>
-</div>""",
+        self.assertIn(self.body_html,
             values[self.partner_employee.id]['body_html'],
-            'We must remove comments')
+            'We must preserve (mso) comments in email html')
 
     @users('employee')
     def test_mail_mass_mode_compose_with_mso(self):
@@ -74,11 +69,6 @@ class TestMailComposer(MailCommon):
 
         values = composer.get_mail_values(self.partner_employee.ids)
 
-        self.assertIn("""<div>
-    <h1>Hello sir!</h1>
-    <p>Here! <a href="https://www.example.com">
-        A link for you!
-    </a> Make good use of it.</p>
-</div>""",
+        self.assertIn(self.body_html,
             values[self.partner_employee.id]['body_html'],
-            'We must remove comments')
+            'We must preserve (mso) comments in email html')

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -221,7 +221,7 @@ class TestMailRender(common.MailCommon):
         rendered_local_links = [
             '<div style="background-image:url(%s/web/path?a=a&b=b);"/>' % base_url,
             '<div style="background-image:url(\'%s/web/path?a=a&b=b\');"/>' % base_url,
-            '<div style="background-image:url(&#34;/web/path?a=a&b=b&#34;);"/>'
+            '<div style="background-image:url(&#34;%s/web/path?a=a&b=b&#34;);"/>' % base_url
         ]
         for source, expected in zip(local_links_template_bits, rendered_local_links):
             rendered = self.env['mail.render.mixin']._replace_local_links(source)

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -211,6 +211,23 @@ class TestMailRender(common.MailCommon):
             self.assertEqual(rendered, expected)
 
     @users('employee')
+    def test_render_template_local_links(self):
+        local_links_template_bits = [
+            '<div style="background-image:url(/web/path?a=a&b=b);"/>',
+            '<div style="background-image:url(\'/web/path?a=a&b=b\');"/>',
+            '<div style="background-image:url(&#34;/web/path?a=a&b=b&#34;);"/>',
+        ]
+        base_url = self.env['mail.render.mixin'].get_base_url()
+        rendered_local_links = [
+            '<div style="background-image:url(%s/web/path?a=a&b=b);"/>' % base_url,
+            '<div style="background-image:url(\'%s/web/path?a=a&b=b\');"/>' % base_url,
+            '<div style="background-image:url(&#34;/web/path?a=a&b=b&#34;);"/>'
+        ]
+        for source, expected in zip(local_links_template_bits, rendered_local_links):
+            rendered = self.env['mail.render.mixin']._replace_local_links(source)
+            self.assertEqual(rendered, expected)
+
+    @users('employee')
     def test_render_template_qweb(self):
         partner = self.env['res.partner'].browse(self.render_object.ids)
         for source, expected in zip(self.base_qweb_bits, self.base_rendered):

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -592,7 +592,8 @@ class MailComposer(models.TransientModel):
             res_ids = [res_ids]
 
         subjects = self._render_field('subject', res_ids, options={"render_safe": True})
-        bodies = self._render_field('body', res_ids, post_process=True)
+        # We want to preserve comments in emails so as to keep mso conditionals
+        bodies = self.with_context(preserve_comments=self.composition_mode == 'mass_mail')._render_field('body', res_ids, post_process=True)
         emails_from = self._render_field('email_from', res_ids)
         replies_to = self._render_field('reply_to', res_ids)
         default_recipients = {}

--- a/addons/mass_mailing/data/mass_mailing_demo.xml
+++ b/addons/mass_mailing/data/mass_mailing_demo.xml
@@ -87,7 +87,7 @@
             <field name="reply_to">Info &lt;info@yourcompany.example.com&gt;</field>
             <field name="body_html" type="html">
 <div class="o_layout o_default_theme oe_unremovable oe_unmovable" data-name="Mailing">
-    <div class="container o_mail_wrapperoe_unremovable oe_unmovable" style="border-collapse:collapse;">
+    <div class="container o_mail_wrapper oe_unremovable oe_unmovable" style="border-collapse:collapse;">
         <div class="row">
             <div class="col o_mail_no_options o_mail_wrapper_td oe_structure" style="text-align:left;width:100%;">
                 <div class="o_mail_block_header_logo" data-snippet="s_mail_block_header_logo">

--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -78,7 +78,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
                 $editable.find('img').attr(attribute, function () {
                     return $(this)[attribute]();
                 }).css(attribute, function () {
-                    return $(this).get(0).style[attribute] || attribute === 'width' ? $(this)[attribute]() + 'px' : 'auto';
+                    return $(this).get(0).style[attribute] || attribute === 'width' ? $(this)[attribute]() + 'px' : '';
                 });
             });
 

--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -41,7 +41,6 @@ Odoo Web Editor widget.
             'web_editor/static/lib/odoo-editor/src/utils/constants.js',
             'web_editor/static/lib/odoo-editor/src/utils/sanitize.js',
             'web_editor/static/lib/odoo-editor/src/utils/serialize.js',
-            'web_editor/static/lib/odoo-editor/src/utils/utils.js',
             'web_editor/static/lib/odoo-editor/src/utils/DOMPurify.js',
             'web_editor/static/lib/odoo-editor/src/tablepicker/TablePicker.js',
             'web_editor/static/lib/odoo-editor/src/powerbox/patienceDiff.js',
@@ -88,6 +87,7 @@ Odoo Web Editor widget.
         'web.assets_common': [
             'web_editor/static/lib/vkbeautify/**/*',
             'web_editor/static/src/js/common/**/*',
+            'web_editor/static/lib/odoo-editor/src/utils/utils.js',
         ],
         'web.assets_backend': [
             'web_editor/static/src/scss/web_editor.common.scss',

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -411,8 +411,6 @@ function bootstrapToTable($editable) {
     for (const masonryRow of $editable.find('.o_masonry_grid_container > .o_fake_table > .row.h-100')) {
         masonryRow.style.removeProperty('height');
         masonryRow.parentElement.style.setProperty('height', '100%');
-        // Children will only take 100% height if the parent has a height property.
-        masonryRow.parentElement.parentElement.style.setProperty('height', 0);
     }
 
     // Now convert all containers with rows to tables.
@@ -671,6 +669,10 @@ function formatTables($editable) {
             columnIndex += 1;
         }
         $table.css('padding', '');
+    }
+    // Ensure a tbody in every table and cancel its default style.
+    for (const table of $editable.find('table:not(:has(tbody))')) {
+        $(table).contents().wrap('<tbody style="vertical-align: top"/>');
     }
     // Children will only take 100% height if the parent has a height property.
     for (const node of $editable.find('*').filter((i, n) => (

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -424,6 +424,9 @@ function bootstrapToTable($editable) {
             $table.append(child);
         }
         $table.removeClass('container container-fluid o_fake_table');
+        if (!$table[0].className) {
+            $table.removeAttr('class');
+        }
         $container.before($table);
         $container.remove();
 
@@ -440,6 +443,9 @@ function bootstrapToTable($editable) {
                 $row.attr(attr.name, attr.value);
             }
             $row.removeClass('row');
+            if (!$row[0].className) {
+                $row.removeAttr('class');
+            }
             for (const child of [...bootstrapRow.childNodes]) {
                 $row.append(child);
             }
@@ -515,6 +521,9 @@ function bootstrapToTable($editable) {
                     }
                     const colMatch = bootstrapColumn.className.match(reColMatch);
                     $currentCol.removeClass(colMatch[0]);
+                    if (!$currentCol[0].className) {
+                        $currentCol.removeAttr('class');
+                    }
                     for (const child of [...bootstrapColumn.childNodes]) {
                         $currentCol.append(child);
                     }

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -478,13 +478,13 @@ function bootstrapToTable($editable) {
                 if (gridIndex + columnSize < 12) {
                     $currentCol = grid[gridIndex];
                     _applyColspanToGridElement($currentCol, columnSize);
-                    gridIndex += columnSize;
                     if (columnIndex === $bootstrapColumns.length - 1) {
                         // We handled all the columns but there is still space
                         // in the row. Insert the columns and fill the row.
                         grid[gridIndex].attr('colspan', 12 - gridIndex);
                         $currentRow.append(...grid.filter(td => td.attr('colspan')));
                     }
+                    gridIndex += columnSize;
                 } else if (gridIndex + columnSize === 12) {
                     // Finish the row.
                     $currentCol = grid[gridIndex];

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -1,23 +1,10 @@
-odoo.define('web_editor.convertInline', function (require) {
+/** @odoo-module alias=web_editor.convertInline */
 'use strict';
 
-var FieldHtml = require('web_editor.field.html');
+import FieldHtml from 'web_editor.field.html';
+import { rgbToHex } from '../../../lib/odoo-editor/src/utils/utils';
 
 const SELECTORS_IGNORE = /(^\*$|:hover|:before|:after|:active|:link|::|'|\([^(),]+[,(])/;
-
-// Note: duplicated from odoo-editor utils.
-// DOES NOT SUPPORT RGBA (Outlook doesn't support transparency)
-function rgbToHex(rgb = '') {
-    return (
-        '#' +
-        (rgb.match(/\d{1,3}/g) || [])
-            .map(x => {
-                x = parseInt(x).toString(16);
-                return x.length === 1 ? '0' + x : x;
-            })
-            .join('')
-    );
-}
 
 /**
  * Returns the css rules which applies on an element, tweaked so that they are
@@ -839,7 +826,7 @@ FieldHtml.include({
     },
 });
 
-return {
+export default {
     fontToImg: fontToImg,
     bootstrapToTable: bootstrapToTable,
     cardToTable: cardToTable,
@@ -851,4 +838,3 @@ return {
     normalizeRem: normalizeRem,
     attachmentThumbnailToLinkImg: attachmentThumbnailToLinkImg,
 };
-});

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -2,7 +2,7 @@
 'use strict';
 
 import FieldHtml from 'web_editor.field.html';
-import { rgbToHex } from '../../../lib/odoo-editor/src/utils/utils';
+import { isBlock, rgbToHex } from '../../../lib/odoo-editor/src/utils/utils';
 
 const SELECTORS_IGNORE = /(^\*$|:hover|:before|:after|:active|:link|::|'|\([^(),]+[,(])/;
 
@@ -426,6 +426,9 @@ function bootstrapToTable($editable) {
 
 
         // ROWS
+        // First give all siblings of rows a separate row/col parent combo.
+        $table.children().filter((i, child) => isBlock(child) && !$(child).hasClass('row')).wrap('<div class="row"><div class="col-12"/></div>');
+
         const $bootstrapRows = $table.children().filter('.row');
         for (const bootstrapRow of $bootstrapRows) {
             const $bootstrapRow = $(bootstrapRow);

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -649,20 +649,31 @@ function formatTables($editable) {
         const tablePaddingRight = +$table.css('padding-right').match(rePadding)[1];
         const tablePaddingBottom = +$table.css('padding-bottom').match(rePadding)[1];
         const tablePaddingLeft = +$table.css('padding-left').match(rePadding)[1];
-        for (const column of $table.find('td').filter((i, td) => $(td).closest('table').is($table))) {
+        const $columns = $table.find('td').filter((i, td) => $(td).closest('table').is($table));
+        let columnIndex = 0;
+        for (const column of $columns) {
             const $column = $(column);
             if ($column.css('padding')) {
-                const columnPaddingTop = +$column.css('padding-top').match(rePadding)[1];
                 const columnPaddingRight = +$column.css('padding-right').match(rePadding)[1];
-                const columnPaddingBottom = +$column.css('padding-bottom').match(rePadding)[1];
                 const columnPaddingLeft = +$column.css('padding-left').match(rePadding)[1];
                 $column.css({
-                    'padding-top': columnPaddingTop + tablePaddingTop,
                     'padding-right': columnPaddingRight + tablePaddingRight,
-                    'padding-bottom': columnPaddingBottom + tablePaddingBottom,
                     'padding-left': columnPaddingLeft + tablePaddingLeft,
                 });
+                if (!columnIndex) {
+                    const columnPaddingTop = +$column.css('padding-top').match(rePadding)[1];
+                    $column.css({
+                        'padding-top': columnPaddingTop + tablePaddingTop,
+                    });
+                }
+                if (columnIndex === $columns.length - 1) {
+                    const columnPaddingBottom = +$column.css('padding-bottom').match(rePadding)[1];
+                    $column.css({
+                        'padding-bottom': columnPaddingBottom + tablePaddingBottom,
+                    });
+                }
             }
+            columnIndex += 1;
         }
         $table.css('padding', '');
     }

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -407,8 +407,13 @@ function bootstrapToTable($editable) {
     // height contents, which is only possible if the table itself has a set
     // height. We also need to restyle it because of the change in structure.
     $editable.find('.o_masonry_grid_container').css('padding', 0)
-        .find('> .o_fake_table').css('height', function() { return $(this).height() })
-        .find('.row').css('height', '');
+    .find('> .o_fake_table').css('height', function() { return $(this).height() });
+    for (const masonryRow of $editable.find('.o_masonry_grid_container > .o_fake_table > .row.h-100')) {
+        masonryRow.style.removeProperty('height');
+        masonryRow.parentElement.style.setProperty('height', '100%');
+        // Children will only take 100% height if the parent has a height property.
+        masonryRow.parentElement.parentElement.style.setProperty('height', 0);
+    }
 
     // Now convert all containers with rows to tables.
     for (const container of $editable.find('.container:has(.row), .container-fluid:has(.row), .o_fake_table:has(.row)')) {
@@ -666,6 +671,14 @@ function formatTables($editable) {
             columnIndex += 1;
         }
         $table.css('padding', '');
+    }
+    // Children will only take 100% height if the parent has a height property.
+    for (const node of $editable.find('*').filter((i, n) => (
+        n.style && n.style.getPropertyValue('height') === '100%' && (
+            !n.parentElement.style.getPropertyValue('height') ||
+            n.parentElement.style.getPropertyValue('height').includes('%'))
+    ))) {
+        node.parentElement.style.setProperty('height', '0');
     }
 }
 

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -701,6 +701,11 @@ function classToStyle($editable) {
         if ($target.get(0).style.width) {
             $target.attr('width', $target.css('width')); // Widths need to be applied as attributes as well.
         }
+
+        // Media list images should not have an inline height
+        if (node.nodeName === 'IMG' && $target.hasClass('s_media_list_img')) {
+            $target.css('height', '');
+        }
         // Apple Mail
         if (node.nodeName === 'TD' && !node.childNodes.length) {
             $(node).html('&nbsp;');
@@ -818,7 +823,7 @@ FieldHtml.include({
             $editable.find('img').attr(attribute, function(){
                 return $(this)[attribute]();
             }).css(attribute, function(){
-                return $(this).get(0).style[attribute] || $(this)[attribute]() || 'auto';
+                return $(this).get(0).style[attribute] || attribute === 'width' ? $(this)[attribute]() + 'px' : '';
             });
         });
         $odooEditor.addClass('odoo-editor');

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -385,7 +385,11 @@ function _createTable(attributes = []) {
         delete layoutStyles['line-height'];
         $table.css(layoutStyles);
     } else {
-        $table.css(tableStyles);
+        for (const styleName in tableStyles) {
+            if (!('style' in attributes && attributes.style.value.includes(styleName + ':'))) {
+                $table.css(styleName, tableStyles[styleName]);
+            }
+        }
     }
     return $table;
 }

--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -939,7 +939,10 @@ class QWeb(object):
         body = []
         if el.getchildren():
             for item in el:
-                if not isinstance(item, etree._Comment):
+                if isinstance(item, etree._Comment):
+                    if self.env.context.get('preserve_comments'):
+                        self._appendText("<!--%s-->" % item.text, options)
+                else:
                     body.extend(self._compile_node(item, options, indent))
                 # comments can also contains tail text
                 if item.tail is not None:


### PR DESCRIPTION
This PR brings multiple fixes and improvements to the email conversion mechanism for email client compatibility (`convert_inline`).

When converting a div to a table, we apply some styles to undo the table's default styles. This makes sure these styles don't override any inline styles the div might have been holding.

When converting bootstrap grids into tables, we have to move the containers' paddings into the cells, otherwise they would not render properly in all mail clients. Before this fix, verical padding was moved to each cell, which is wrong: it should be applied to the first (top) and last cell (bottom) only, which it now is.

Some code from odoo-editor utils is needed in convertInline. In order to avoid duplication, we need to import that code. To that effect, we can't have the utils being lazy loaded into mass mailing's iframe while convertInline is loaded the usual way.
This loads the lightweight utils together with convertInline and turns convertInline into an odoo-module, which makes it easier to simply import the utils and delete duplicated code.

The following structure is not always properly rendered in mail clients:

```html
<table>
    <tbody>
        <tr>
            <td>
                <h1>Text</h1>
                <p>Text</p>
            </td>
        </tr>
    </tbody>
</table>
```

where the h1 and p can be any block-level element.

This prevents that from happening by wrapping each block in a separate row/column combo like so:

```html
<table>
    <tbody>
        <tr>
            <td>
                <h1>Text</h1>
            </td>
        <tr>
            <td>
                <p>Text</p>
            </td>
        </tr>
    </tbody>
</table>
```

When converting a mailing for mail client compatibility, we guarantee a height for each image. When none can be found, or in the special case of media_list, that height should however not be forced so the client can make it take the full height of the cell automatically. This is accomplished by this PR.

On converting emails for mail client compatibility, masonry showed a few sizing issues, which are fixed with this PR.

This adds a test for the _replace_local_links function of mail render mixin, in the case of urls in style attributes.

`_replace_local_links` ensures urls are given as absolute rather relative paths, for link `href`, img `src` and within styles. This failed when the style contained escaped single quotes (eg: `background-image: url(&#34;/my_url/path&#34;);`). This PR adapts the failing regex appropriately.

This ensures that every `table` element has its contents wrapped in a `tbody` element, and that that element has its default vertical alignment replaced with "top" to mimick the grid it's converted from.

This adds a test sending a mail with comments (MSO conditionals) in mass_mail mode.

For email design in the context of Microsoft Outlook, we want to keep some magic Microsoft comments (Outlook conditional comment), which - until this PR - were skipped by QWeb. These allow us to change the rendering exclusively for Outlook so as to overcome some of its limitations. This PR introduces a qweb rendering option (`preserve_comments`) for when - like in mass mailing and digest - we want to keep comments.

mass_mailing_demo has a missing space separating two classes in its mass_mail_1 template. This restores it.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
