### PR TITLE
[FIX] l10n_sa: install taxes and fiscal positions properly on demo company

### DIFF
--- a/addons/l10n_sa/__manifest__.py
+++ b/addons/l10n_sa/__manifest__.py
@@ -20,10 +20,10 @@ In future this module will include some payroll rules for ME .
         'data/account.account.template.csv',
         'data/account_tax_group.xml',
         'data/l10n_sa_chart_data.xml',
-        'data/account_chart_template_configure_data.xml',
         'data/account_tax_report_data.xml',
         'data/account_tax_template_data.xml',
         'data/account_fiscal_position_template_data.xml',
+        'data/account_chart_template_configure_data.xml',
     ],
     'demo': [
         'demo/demo_company.xml',


### PR DESCRIPTION
When installing the module, the current company didn't receive taxes and fiscal positions, even though the accounts were properly created.
