### PR TITLE
[FIX] point_of_sale: allow invoicing user to access PoS invoice

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -27,7 +27,9 @@ class AccountMove(models.Model):
         if self.state == 'draft':
             return lot_values
 
-        for order in self.pos_order_ids:
+        # user may not have access to POS orders, but it's ok if they have
+        # access to the invoice
+        for order in self.sudo().pos_order_ids:
             for line in order.lines:
                 lots = line.pack_lot_ids or False
                 if lots:
@@ -44,8 +46,8 @@ class AccountMove(models.Model):
     def _get_reconciled_vals(self, partial, amount, counterpart_line):
         """Add pos_payment_name field in the reconciled vals to be able to show the payment method in the invoice."""
         result = super()._get_reconciled_vals(partial, amount, counterpart_line)
-        if counterpart_line.move_id.pos_payment_ids:
-            pos_payment = counterpart_line.move_id.pos_payment_ids
+        if counterpart_line.move_id.sudo().pos_payment_ids:
+            pos_payment = counterpart_line.move_id.sudo().pos_payment_ids
             result['pos_payment_name'] = pos_payment.payment_method_id.name
         return result
 

--- a/addons/pos_sale/views/point_of_sale_report.xml
+++ b/addons/pos_sale/views/point_of_sale_report.xml
@@ -2,11 +2,12 @@
 <odoo>
     <template id="report_invoice_document" inherit_id="account.report_invoice_document">
         <xpath expr="//td[@name='account_invoice_line_name']" position="inside">
-            <t t-if="o.pos_order_ids">
+            <t t-set="pos_orders" t-value="o.sudo().pos_order_ids"/>
+            <t t-if="pos_orders">
                 <div style="margin-left:15px; font-style: italic">
-                    <t t-set="down_payment_product" t-value="o.pos_order_ids[0].config_id.down_payment_product_id"/>
+                    <t t-set="down_payment_product" t-value="pos_orders[0].config_id.down_payment_product_id"/>
                     <t t-if="line.product_id == down_payment_product">
-                        <t t-set="sale_orders" t-value="o.pos_order_ids[0].lines.filtered(lambda l: l.product_id == down_payment_product and l.price_subtotal_incl == line.price_total).mapped('sale_order_origin_id')"/>
+                        <t t-set="sale_orders" t-value="pos_orders[0].lines.filtered(lambda l: l.product_id == down_payment_product and l.price_subtotal_incl == line.price_total).mapped('sale_order_origin_id')"/>
                         <t t-if="sale_orders">
                             <t t-set="sale_order" t-value="sale_orders[0]"/>
                             <t t-foreach="sale_order.order_line" t-as="sale_order_line">


### PR DESCRIPTION
If a user has access to account.move but not pos.order, it was not
possible to open the invoice or the report
