### PR TITLE
[FIX] web: don't prevent DropdownItem click event if no href

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown_item.js
+++ b/addons/web/static/src/core/dropdown/dropdown_item.js
@@ -30,7 +30,9 @@ export class DropdownItem extends Component {
      * @param {MouseEvent} ev
      */
     onClick(ev) {
-        ev.preventDefault();
+        if (this.props.href){
+            ev.preventDefault();
+        }
 
         /** @type DropdownItemSelectedEventDetail */
         const detail = {

--- a/addons/web/static/tests/core/dropdown_tests.js
+++ b/addons/web/static/tests/core/dropdown_tests.js
@@ -68,22 +68,35 @@ QUnit.module("Components", ({ beforeEach }) => {
         assert.strictEqual(parent.el.outerHTML, '<a href="#" class="dropdown-item">coucou</a>');
     });
 
-    QUnit.test("DropdownItem: prevents click default when item clicked", async (assert) => {
-        assert.expect(2);
+    QUnit.test("DropdownItem: prevents click default with href", async (assert) => {
+        assert.expect(4);
         // A DropdownItem should preventDefault a click as it may take the shape
         // of an <a/> tag with an [href] attribute and e.g. could change the url when clicked.
         patchWithCleanup(DropdownItem.prototype, {
             onClick(ev) {
                 assert.ok(!ev.defaultPrevented);
                 this._super(...arguments);
-                assert.ok(ev.defaultPrevented);
+                const href = ev.target.getAttribute("href");
+                // defaultPrevented only if props.href is defined
+                assert.ok(href !== null ? ev.defaultPrevented : !ev.defaultPrevented);
             },
         });
         class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`<DropdownItem/>`;
+        Parent.template = owl.tags.xml`
+            <Dropdown>
+                <DropdownItem class="link" href="'#'"/>
+                <DropdownItem class="nolink" />
+            </Dropdown>`;
         env = await makeTestEnv();
         parent = await mount(Parent, { env, target });
-        await click(target, ".dropdown-item");
+        // The item containing the link class contains an href prop,
+        // which will turn it into <a href=> So it must be defaultPrevented
+        // The other one not contain any href props, it must not be defaultPrevented,
+        // so as not to prevent the background change flow for example
+        await click(parent.el, "button.dropdown-toggle");
+        await click(parent.el, ".link");
+        await click(parent.el, "button.dropdown-toggle");
+        await click(parent.el, ".nolink");
     });
 
     QUnit.test("can be styled", async (assert) => {


### PR DESCRIPTION
Before this commit
Each click event triggered inside a DropdownItem is default prevented

After this commit
Those click events will be default prevented only when the DropdownItem receives a props.href, which will turn it into an <a href/> element.
This corresponds to the initial intention: prevent the default click behavior of an <a href/> element and only keep the DropdownItem click behavior.

opw-2665795