### PR TITLE
[WIP][FIX] website,_mail,_mass_mailing,_payment: fix link edition

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -425,6 +425,9 @@ var SnippetEditor = Widget.extend({
         if (this.$target.parent('.row').length) {
             return _t("Column");
         }
+        if (this.$target.is('.btn')) {
+            return _t("Button");
+        }
         return _t("Block");
     },
     /**

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2396,6 +2396,11 @@ var SnippetsMenu = Widget.extend({
             customTabPaneEl.removeAttribute('id');
         }
 
+        // TODO: remove this (?) or find a way to catch the unremovable parts of
+        // snippets using the new _getUnremovableElements method.
+        // Force oe_unremovable on non-removable parts of snippets
+        // $html.find(this.options.unremovableElementsSelector).addClass('oe_unremovable');
+
         // Add the computed template and make elements draggable
         this.$el.html($html);
         this.$el.append(this.customizePanel);

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -114,7 +114,7 @@ const Link = Widget.extend({
             .replace(allBtnClassSuffixes, ' ')
             .replace(allBtnShapes, ' ');
         // 'o_submit' class will force anchor to be handled as a button in linkdialog.
-        if (/(?:s_website_form_send|o_submit)/.test(this.data.className)) {
+        if (/(?:s_website_form_send|s_donation_donate_btn|o_submit)/.test(this.data.className)) {
             this.isButton = true;
         }
     },

--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -364,7 +364,8 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         return [];
     },
     _getUnremovableElements () {
-        return this._targetForEdition()[0].querySelectorAll("#top_menu a:not(.oe_unremovable)");
+        return this._targetForEdition()[0].querySelectorAll("#top_menu a:not(.oe_unremovable)" +
+            ', .s_website_form_send, .s_donation_donate_btn, .o_submit, ul[role="tablist"] > li, a[role="tab"][data-toggle="collapse"]');
     },
     /**
      * Call preventDefault of an event.


### PR DESCRIPTION
Before this commit the user could remove the submit button of forms
and edit the url of other buttons and links that were used as a
ui elements for widgets rather than real links. The edition of buttons
introduced in [1] was also broken.

This commit fixes the deletion of the submit button and edition of the
url. It also re-introduces the edition of button styles.

[1] : fc83af4b0b209ffc0ae3d117fd9865b68aa2f118

task-2669592