### PR TITLE
[FIX] web_editor: fix italic and underline in FF

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -902,6 +902,26 @@ export function isBold(node) {
     const fontWeight = +getComputedStyle(closestElement(node)).fontWeight;
     return fontWeight > 500 || fontWeight > +getComputedStyle(closestBlock(node)).fontWeight;
 }
+/**
+ * Return true if the given node font style equal italic
+ *
+ * @param {Node} node
+ * @returns {boolean}
+ */
+export function isItalic(node) {
+    const fontStyle = getComputedStyle(closestElement(node)).fontStyle;
+    return fontStyle === 'italic';
+}
+/**
+ * Return true if the given node text-decoration style equal underline
+ *
+ * @param {Node} node
+ * @returns {boolean}
+ */
+export function isUnderline(node) {
+    const textDecoration = getComputedStyle(closestElement(node)).textDecorationLine;
+    return textDecoration === 'underline';
+}
 
 export function isUnbreakable(node) {
     if (!node || node.nodeType === Node.TEXT_NODE) {

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -155,9 +155,8 @@ tour.register('rte_translator', {
 }, {
     content: "save new change",
     trigger: 'button[data-action=save]',
-    extra_trigger: '#wrap.o_dirty p u',
-
-    }, {
+    extra_trigger: '#wrap.o_dirty p span[style="text-decoration: underline;"]',
+}, {
     content : "click language dropdown",
     trigger : '.js_language_selector .dropdown-toggle',
     extra_trigger: 'body:not(.o_wait_reload):not(:has(.note-editor)) a[data-action="edit"]',

--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -5,6 +5,7 @@ import itertools
 import json
 import logging
 import operator
+import lxml.html
 from collections import defaultdict
 from difflib import get_close_matches
 
@@ -425,9 +426,15 @@ class IrTranslation(models.Model):
                 else:
                     translations_to_match.append(translation)
 
+            terms_text_content = {}
+            if translations_to_match:
+                for term in terms:
+                    terms_text_content[lxml.html.fromstring(term).text_content()] = term
+
             for translation in translations_to_match:
-                matches = get_close_matches(translation.src, terms, 1, 0.9)
-                src = matches[0] if matches else None
+                src_text_content = lxml.html.fromstring(translation.src).text_content()
+                matches = get_close_matches(src_text_content, terms_text_content, 1, 0.9)
+                src = terms_text_content[matches[0]] if matches else None
                 if not src:
                     outdated += translation
                 elif (src, translation.lang) in done:

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -737,7 +737,7 @@ class TestXMLTranslation(TransactionCase):
         self.assertEqual(len(translations), 2)
 
         # modifying the arch should sync existing translations without errors
-        new_arch = archf % ('Subtotal', 'Subtotal:<br/>')
+        new_arch = archf % ('Subtotal', 'Subtotal : <br/>')
         view.write({"arch_db": new_arch})
 
         translations = self.env['ir.translation'].search([
@@ -746,7 +746,7 @@ class TestXMLTranslation(TransactionCase):
             ('res_id', '=', view.id),
         ])
         # 'Subtotal' being src==value, it will be discared
-        # 'Subtotal:' will be discarded as it match 'Subtotal' instead of 'Subtotal:<br/>'
+        # 'Subtotal:' will be discarded as it match 'Subtotal' instead of 'Subtotal : <br/>'
         self.assertEqual(len(translations), 0)
 
     def test_cache_consistency(self):

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -2481,7 +2481,7 @@ class TestViewTranslations(common.TransactionCase):
         self.assertEqual(len(translations), 2)
 
         # modifying the arch should sync existing translations without errors
-        new_arch = archf % ('Subtotal', 'Subtotal:<br/>')
+        new_arch = archf % ('Subtotal', 'Subtotal : <br/>')
         view.write({"arch": new_arch})
         self.assertEqual(view.arch, new_arch)
 
@@ -2491,7 +2491,7 @@ class TestViewTranslations(common.TransactionCase):
             ('res_id', '=', view.id),
         ])
         # 'Subtotal' being src==value, it will be discared
-        # 'Subtotal:' will be discarded as it match 'Subtotal' instead of 'Subtotal:<br/>'
+        # 'Subtotal:' will be discarded as it match 'Subtotal' instead of 'Subtotal : <br/>'
         self.assertEqual(len(translations), 0)
 
     def test_cache_consistency(self):


### PR DESCRIPTION
When selecting the text content of a link
the underline and italic commands were not working in Firefox.

We re-implement the Browser command to fix this.

task-2667950

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
