### PR TITLE
[FIX] (website_)event_booth_sale: fix e-commerce displayed price

### DIFF
--- a/addons/event_booth_sale/models/event_type_booth.py
+++ b/addons/event_booth_sale/models/event_type_booth.py
@@ -9,6 +9,7 @@ class EventTypeBooth(models.Model):
 
     product_id = fields.Many2one(related='booth_category_id.product_id')
     price = fields.Float(related='booth_category_id.price')
+    price_reduce = fields.Float(related='booth_category_id.price_reduce')
     currency_id = fields.Many2one(related='booth_category_id.currency_id')
 
     @api.model

--- a/addons/event_booth_sale/models/sale_order_line.py
+++ b/addons/event_booth_sale/models/sale_order_line.py
@@ -92,11 +92,6 @@ class SaleOrderLine(models.Model):
 
     def _get_display_price(self):
         if self.event_booth_pending_ids and self.event_id:
-            company = self.event_id.company_id or self.env.company
-            currency = company.currency_id
-            total_price = sum([booth.price for booth in self.event_booth_pending_ids])
-            return currency._convert(
-                total_price, self.order_id.currency_id,
-                self.order_id.company_id or self.env.company.id,
-                self.order_id.date_order or fields.Date.today())
+            return sum(booth.price_reduce for booth in
+                       self.event_booth_pending_ids.with_context(pricelist=self.order_id.pricelist_id.id))
         return super()._get_display_price()

--- a/addons/event_booth_sale/tests/__init__.py
+++ b/addons/event_booth_sale/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_event_internals
+from . import test_event_booth_sale

--- a/addons/event_booth_sale/tests/common.py
+++ b/addons/event_booth_sale/tests/common.py
@@ -2,9 +2,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.event_booth.tests.common import TestEventBoothCommon
+from odoo.addons.sales_team.tests.common import TestSalesCommon
 
 
-class TestEventBoothSaleCommon(TestEventBoothCommon):
+class TestEventBoothSaleCommon(TestEventBoothCommon, TestSalesCommon):
 
     @classmethod
     def setUpClass(cls):

--- a/addons/event_booth_sale/tests/test_event_booth_sale.py
+++ b/addons/event_booth_sale/tests/test_event_booth_sale.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime, timedelta
+
+from odoo import fields
+from odoo import Command
+from odoo.addons.event_booth_sale.tests.common import TestEventBoothSaleCommon
+from odoo.tests.common import users
+
+
+class TestEventBoothSale(TestEventBoothSaleCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestEventBoothSale, cls).setUpClass()
+
+        cls.event_0 = cls.env['event.event'].create({
+            'name': 'TestEvent',
+            'auto_confirm': True,
+            'date_begin': fields.Datetime.to_string(datetime.today() + timedelta(days=1)),
+            'date_end': fields.Datetime.to_string(datetime.today() + timedelta(days=15)),
+            'date_tz': 'Europe/Brussels',
+        })
+
+        cls.booth_1 = cls.env['event.booth'].create({
+            'name': 'Test Booth 1',
+            'booth_category_id': cls.event_booth_category_1.id,
+            'event_id': cls.event_0.id,
+        })
+
+        cls.booth_2 = cls.env['event.booth'].create({
+            'name': 'Test Booth 2',
+            'booth_category_id': cls.event_booth_category_1.id,
+            'event_id': cls.event_0.id,
+        })
+
+    @users('user_sales_salesman')
+    def test_event_booth_sale(self):
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.event_customer.id,
+        })
+
+        sale_order.write({
+            'order_line': [
+                Command.create({
+                    'product_id': self.event_booth_product.id,
+                    'event_id': self.event_0.id,
+                    'event_booth_category_id': self.event_booth_category_1.id,
+                    'event_booth_pending_ids': (self.booth_1 + self.booth_2).ids
+                })
+            ]
+        })
+
+        self.assertEqual(self.event_booth_product.list_price, self.booth_1.price,
+                         "Booth price should be equal from product price.")
+        self.assertEqual(sale_order.amount_untaxed, self.booth_1.price + self.booth_2.price,
+                         "Amount should be the sum of the booths prices.")
+
+        self.event_booth_category_1.write({'price': 100.0})
+        sale_order.update_prices()
+
+        self.assertNotEqual(self.event_booth_product.list_price, self.booth_1.price,
+                            "Booth price should be different from product price.")
+        self.assertEqual(sale_order.amount_untaxed, self.booth_1.price + self.booth_2.price,
+                         "Amount should be the sum of the booths prices.")

--- a/addons/website_event_booth_sale/models/sale_order.py
+++ b/addons/website_event_booth_sale/models/sale_order.py
@@ -29,20 +29,26 @@ class SaleOrder(models.Model):
             order_line = self.env['sale.order.line'].sudo().search([
                 ('id', 'in', self.order_line.ids),
                 ('event_booth_pending_ids', 'in', event_booth_pending_ids)])
-            booths = self.env['event.booth'].browse(event_booth_pending_ids)
-            new_registration_ids = [Command.create({
-                                        'event_booth_id': booth.id,
-                                        **kwargs.get('registration_values'),
-                                    }) for booth in booths]
-            if order_line:
-                event_booth_registration_ids = [Command.delete(reg.id)
-                                                for reg in order_line.event_booth_registration_ids] + new_registration_ids
-            else:
-                event_booth_registration_ids = new_registration_ids
+            booths = self.env['event.booth'].browse(event_booth_pending_ids).with_context(pricelist=self.pricelist_id.id)
+            if order_line.event_booth_pending_ids.ids != event_booth_pending_ids:
+                new_registration_ids = [Command.create({
+                                            'event_booth_id': booth.id,
+                                            **kwargs.get('registration_values'),
+                                        }) for booth in booths]
+                if order_line:
+                    event_booth_registration_ids = [Command.delete(reg.id)
+                                                    for reg in order_line.event_booth_registration_ids] + new_registration_ids
+                else:
+                    event_booth_registration_ids = new_registration_ids
+                values.update(event_booth_registration_ids=event_booth_registration_ids)
 
+            if self.pricelist_id.discount_policy == 'without_discount':
+                price_unit = sum(booth.price for booth in booths)
+            else:
+                price_unit = sum(booth.price_reduce for booth in booths)
             values.update(
                 event_id=booths.event_id.id,
-                event_booth_registration_ids=event_booth_registration_ids,
+                price_unit=price_unit,
                 name=booths._get_booth_multiline_description,
             )
 
@@ -50,6 +56,11 @@ class SaleOrder(models.Model):
 
     def _cart_update(self, product_id=None, line_id=None, add_qty=0, set_qty=0, **kwargs):
         values = {}
+        if line_id:
+            line = self.env['sale.order.line'].browse(line_id)
+            booths = line.event_booth_pending_ids
+            if booths:
+                kwargs.update({'event_booth_pending_ids': booths.ids})
         product = self.env['product.product'].browse(product_id)
         if product.detailed_type == 'event_booth' and set_qty > 1:
             set_qty = 1


### PR DESCRIPTION
PURPOSE

Since this change (https://github.com/odoo/odoo/pull/75843), the displayed price
on the e-commerce was the product price and not the sum of the prices of all the
selected booths. Pricelist weren't taken into account either.
This commit fix these issues.

LINKS

Task-2657480

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
