### PR TITLE
[FIX] web_editor: allow iframe on website builder

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -678,7 +678,11 @@ export class OdooEditor extends EventTarget {
             } else if (record.type === 'attributes') {
                 const node = this.idFind(record.id);
                 if (node) {
-                    this._safeSetAttribute(node, record.attributeName, record.value);
+                    if (this._collabClientId) {
+                        this._safeSetAttribute(node, record.attributeName, record.value);
+                    } else {
+                        node.setAttribute(record.attributeName, record.value);
+                    }
                 }
             } else if (record.type === 'remove') {
                 const toremove = this.idFind(record.id);
@@ -687,13 +691,16 @@ export class OdooEditor extends EventTarget {
                 }
             } else if (record.type === 'add') {
                 let node = this.idFind(record.oid) || this.unserializeNode(record.node);
-                const fakeNode = document.createElement('fake-el');
-                fakeNode.appendChild(node);
-                DOMPurify.sanitize(fakeNode, { IN_PLACE: true });
-                node = fakeNode.childNodes[0];
-                if (!node) {
-                    continue;
+                if (this._collabClientId) {
+                    const fakeNode = document.createElement('fake-el');
+                    fakeNode.appendChild(node);
+                    DOMPurify.sanitize(fakeNode, { IN_PLACE: true });
+                    node = fakeNode.childNodes[0];
+                    if (!node) {
+                        continue;
+                    }
                 }
+
                 this.idSet(node, true);
 
                 if (record.append && this.idFind(record.append)) {
@@ -797,7 +804,11 @@ export class OdooEditor extends EventTarget {
                     const node = this.idFind(mutation.id);
                     if (node) {
                         if (mutation.oldValue) {
-                            this._safeSetAttribute(node, mutation.attributeName, mutation.oldValue);
+                            if (this._collabClientId) {
+                                this._safeSetAttribute(node, mutation.attributeName, mutation.oldValue);
+                            } else {
+                                node.setAttribute(mutation.attributeName, mutation.oldValue);
+                            }
                         } else {
                             node.removeAttribute(mutation.attributeName);
                         }


### PR DESCRIPTION
On website, if an iframe was in the page, the iframe was removed
when calling the redo command of the insertion of the iframe (and
also other cases).
 The reason is because of a sanitization process that is usefull only
 in a collaborative context.

 This commit disable the sanitization when the collaboration is not
 active.

task-2670597

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
