### PR TITLE
[FIX] website_sale: Display pricelist price if no price_unit 

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -126,6 +126,10 @@ class SaleOrder(models.Model):
                     # but we still want to use the price defined on the pricelist
                     discount = 0
                     pu = price
+            else:
+                # In case the price_unit equal 0 and therefore not able to calculate the discount,
+                # we fallback on the price defined on the pricelist.
+                pu = price
         else:
             pu = product.price
             if order.pricelist_id and order.partner_id:

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -110,6 +110,11 @@ class SaleOrder(models.Model):
             # 'sale.order.line'.
             price, rule_id = order.pricelist_id.with_context(product_context).get_product_price_rule(product, qty or 1.0, order.partner_id)
             pu, currency = request.env['sale.order.line'].with_context(product_context)._get_real_price_currency(product, rule_id, qty, product.uom_id, order.pricelist_id.id)
+            if order.pricelist_id and order.partner_id:
+                order_line = order._cart_find_product_line(product.id)
+                if order_line:
+                    price = self.env['account.tax']._fix_tax_included_price_company(price, product.taxes_id, order_line[0].tax_id, self.company_id)
+                    pu = self.env['account.tax']._fix_tax_included_price_company(pu, product.taxes_id, order_line[0].tax_id, self.company_id)
             if pu != 0:
                 if order.pricelist_id.currency_id != currency:
                     # we need new_list_price in the same currency as price, which is in the SO's pricelist's currency
@@ -261,12 +266,6 @@ class SaleOrder(models.Model):
                 })
             product_with_context = self.env['product.product'].with_context(product_context)
             product = product_with_context.browse(product_id)
-            values['price_unit'] = self.env['account.tax']._fix_tax_included_price_company(
-                order_line._get_display_price(product),
-                order_line.product_id.taxes_id,
-                order_line.tax_id,
-                self.company_id
-            )
 
             order_line.write(values)
 

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -200,6 +200,44 @@ class TestWebsitePriceList(TransactionCase):
         self.assertEqual(sol.price_reduce, 27.75, 'Both reductions should be applied')
         self.assertEqual(sol.price_total, 13875)
 
+    def test_pricelist_with_no_list_price(self):
+        product = self.env['product.product'].create({
+            'name': 'Super Product',
+            'list_price': 0,
+            'taxes_id': False,
+        })
+        current_website = self.env['website'].get_current_website()
+        website_pricelist = current_website.get_current_pricelist()
+        website_pricelist.write({
+            'discount_policy': 'without_discount',
+            'item_ids': [(5, 0, 0), (0, 0, {
+                'applied_on': '1_product',
+                'product_tmpl_id': product.product_tmpl_id.id,
+                'min_quantity': 0,
+                'compute_price': 'fixed',
+                'fixed_price': 10,
+            })]
+        })
+        so = self.env['sale.order'].create({
+            'partner_id': self.env.user.partner_id.id,
+            'order_line': [(0, 0, {
+                'name': product.name,
+                'product_id': product.id,
+                'product_uom_qty': 5,
+                'product_uom': product.uom_id.id,
+                'price_unit': product.list_price,
+                'tax_id': False,
+            })]
+        })
+        sol = so.order_line
+        self.assertEqual(sol.price_total, 0)
+        so.pricelist_id = website_pricelist
+        with MockRequest(self.env, website=current_website, sale_order_id=so.id):
+            so._cart_update(product_id=product.id, line_id=sol.id, set_qty=5)
+        self.assertEqual(sol.price_unit, 10.0, 'Pricelist price should be applied')
+        self.assertEqual(sol.price_reduce, 10.0, 'Pricelist price should be applied')
+        self.assertEqual(sol.price_total, 50.0)
+
 
 def simulate_frontend_context(self, website_id=1):
     # Mock this method will be enough to simulate frontend context in most methods

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -4,6 +4,8 @@ try:
     from unittest.mock import patch
 except ImportError:
     from mock import patch
+
+from odoo.addons.website.tools import MockRequest
 from odoo.tests import tagged
 from odoo.tests.common import HttpCase, TransactionCase
 from odoo.tools import DotDict
@@ -147,6 +149,56 @@ class TestWebsitePriceList(TransactionCase):
             pls = self.get_pl(show, current_pl, country)
             self.assertEquals(len(set(pls.mapped('name')) & set(result)), len(pls), 'Test failed for %s (%s %s vs %s %s)'
                               % (country, len(pls), pls.mapped('name'), len(result), result))
+
+    def test_pricelist_combination(self):
+        product = self.env['product.product'].create({
+            'name': 'Super Product',
+            'list_price': 100,
+            'taxes_id': False,
+        })
+        current_website = self.env['website'].get_current_website()
+        website_pricelist = current_website.get_current_pricelist()
+        website_pricelist.write({
+            'discount_policy': 'with_discount',
+            'item_ids': [(5, 0, 0), (0, 0, {
+                'applied_on': '1_product',
+                'product_tmpl_id': product.product_tmpl_id.id,
+                'min_quantity': 500,
+                'compute_price': 'percentage',
+                'percent_price': 63,
+            })]
+        })
+        promo_pricelist = self.env['product.pricelist'].create({
+            'name': 'Super Pricelist',
+            'discount_policy': 'without_discount',
+            'item_ids': [(0, 0, {
+                'applied_on': '1_product',
+                'product_tmpl_id': product.product_tmpl_id.id,
+                'base': 'pricelist',
+                'base_pricelist_id': website_pricelist.id,
+                'compute_price': 'formula',
+                'price_discount': 25
+            })]
+        })
+        so = self.env['sale.order'].create({
+            'partner_id': self.env.user.partner_id.id,
+            'order_line': [(0, 0, {
+                'name': product.name,
+                'product_id': product.id,
+                'product_uom_qty': 1,
+                'product_uom': product.uom_id.id,
+                'price_unit': product.list_price,
+                'tax_id': False,
+            })]
+        })
+        sol = so.order_line
+        self.assertEqual(sol.price_total, 100.0)
+        so.pricelist_id = promo_pricelist
+        with MockRequest(self.env, website=current_website, sale_order_id=so.id):
+            so._cart_update(product_id=product.id, line_id=sol.id, set_qty=500)
+        self.assertEqual(sol.price_unit, 37.0, 'Both reductions should be applied')
+        self.assertEqual(sol.price_reduce, 27.75, 'Both reductions should be applied')
+        self.assertEqual(sol.price_total, 13875)
 
 
 def simulate_frontend_context(self, website_id=1):


### PR DESCRIPTION
Steps to reproduce:

  - Install website_sale module
  - Enable discount and advanced pricelist in settings
  - Create product with sale price 0$ and set a website in
    eCommerce + publish the product
  - Create pricelist PPP with Discount Policy as
    "Show public price & discount to the customer" and selectable in the website
  - Go to the product and set an extra price of 10$ for the new pricelist
  - Go to the product in the eshop and select the pricelist PPP
  - Add the product to the shop cart

Issue:

  The price displayed is 0$ instead of 10$.

Cause:

  Since price_unit equal 0$, not possible to calculate the discount and
  therefore using the 0$ value.

Solution:

  Use price of pricelist in case 'discount_policy' is 'without_discount'
  and price_unit equal 0$.

opw-2652192