### PR TITLE
[FIX] crm: prevent ZeroDivisionError crash

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1453,8 +1453,8 @@ class Lead(models.Model):
                     total_won = team_won if field == 'stage_id' else field_result['won_total']
                     total_lost = team_lost if field == 'stage_id' else field_result['lost_total']
 
-                    s_lead_won *= value_result['won'] / total_won
-                    s_lead_lost *= value_result['lost'] / total_lost
+                    s_lead_won *= value_result['won'] / total_won if total_won > 0 else value_result['won']
+                    s_lead_lost *= value_result['lost'] / total_lost if total_lost > 0 else value_result['lost']
 
             # 3. Compute Probability to win
             lead_probabilities[lead_id] = round(100 * s_lead_won / (s_lead_won + s_lead_lost), 2)


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Prevent ZeroDivisionError

Current behavior before PR: Before this commit if there was no total_won or total_lost it would be '0'.
This 0 would then generate a ZeroDivisionError: float division by zero as it tries to divide by zero.
```
  File "/some-dev/server/addons/crm/models/crm_lead.py", line 404, in _compute_probabilities
    lead_probabilities = self._pls_get_naive_bayes_probabilities()
  File "/some-dev/server/addons/crm/models/crm_lead.py", line 1693, in _pls_get_naive_bayes_probabilities
    lead_probabilities[lead_id] = round(100 * s_lead_won / (s_lead_won + s_lead_lost), 2)
ZeroDivisionError: float division by zero
```

Desired behavior after PR is merged: By doing a check if the numbers are bigger than zero and if not continuing with the `value_results` we never get this.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
