### PR TITLE
[FIX] web_editor: Focus on composer if no anchor selected

### DIFF
--- a/addons/web_editor/static/lib/summernote/src/js/module/Editor.js
+++ b/addons/web_editor/static/lib/summernote/src/js/module/Editor.js
@@ -696,8 +696,10 @@ define([
       // ODOO MODIFICATION START
       if (currentSelection && document.getSelection) {
         selection = document.getSelection();
-        selection.removeAllRanges();
-        selection.addRange(currentSelection);
+        if (!selection || selection.rangeCount === 0) {
+          selection.removeAllRanges();
+          selection.addRange(currentSelection);
+        }
       }
       // ODOO MODIFICATION END
 


### PR DESCRIPTION
Steps to reproduce:

  - Go to any chatter
  - Click on "Send message"
  - Open the Full Composer
  - Click directly on the "Link" button of the composer
  - Add label and url then save

Issue:

  Link not added to composer.

Solution:

  When getting link info, focus on the closest element of the composer.

Related fixes:
https://github.com/odoo/odoo/commit/da14e4449e5e318eb72e1b9f268fb797adb0c6a6
https://github.com/odoo/odoo/commit/d2f3c9e7975188753fa17c06db3fc5c73c773944

opw-2544149