### PR TITLE
[IMP] mail,  fleet, hr_recruitment : integrate fleet and documents

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -336,6 +336,15 @@ class FleetVehicle(models.Model):
             vehicle.driver_id = vehicle.future_driver_id
             vehicle.future_driver_id = False
 
+    def action_get_attachment_view(self):
+        action = self.env['ir.actions.act_window']._for_xml_id('base.action_attachment')
+        action.update({
+            'name': _('Documents'),
+            'domain': [('res_id', '=', self.id), ('res_model', '=', 'fleet.vehicle')],
+            'context': dict(self._context, default_res_id=self.id, default_res_model=self._name)
+        })
+        return action
+
     def toggle_active(self):
         self.env['fleet.vehicle.log.contract'].with_context(active_test=False).search([('vehicle_id', 'in', self.ids)]).toggle_active()
         self.env['fleet.vehicle.log.services'].with_context(active_test=False).search([('vehicle_id', 'in', self.ids)]).toggle_active()

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -49,6 +49,9 @@
                             attrs="{'invisible': [('vehicle_type', '!=', 'car')]}">
                             <field name="odometer_count" widget="statinfo" string="Odometer"/>
                         </button>
+                        <button name="action_get_attachment_view" class="oe_stat_button" icon="fa-file-text" type="object">
+                            <field name="message_attachment_count" widget="statinfo" string="Documents"/>
+                        </button>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="image_128" widget='image' class="oe_avatar"/>

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1097,13 +1097,13 @@ class HrExpenseSheet(models.Model):
     # Mail Thread
     # --------------------------------------------
 
-    def _get_mail_thread_data_attachments(self):
+    def _get_mail_thread_data_attachments(self, data):
         """
         In order to see in the sheet attachment preview the corresponding
         expenses' attachments, the latter attachments are added to the fetched data for the sheet record.
         """
         self.ensure_one()
-        res = super()._get_mail_thread_data_attachments()
+        res = super()._get_mail_thread_data_attachments(data)
         expense_ids = self.expense_line_ids
         expense_attachments = self.env['ir.attachment'].search([('res_id', 'in', expense_ids.ids), ('res_model', '=', 'hr.expense')], order='id desc')
         return res | expense_attachments

--- a/addons/hr_recruitment/views/hr_recruitment_views.xml
+++ b/addons/hr_recruitment/views/hr_recruitment_views.xml
@@ -545,7 +545,7 @@
                     icon="fa-file-text-o"
                     name="action_open_attachments"
                     type="object">
-                    <field name="documents_count" widget="statinfo" string="Documents"/>
+                    <field name="attachment_count" widget="statinfo" string="Documents"/>
                 </button>
                 <button class="oe_stat_button" type="action"
                     name="%(action_hr_job_sources)d" icon="fa-bar-chart-o"

--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -432,7 +432,7 @@ class DiscussController(http.Controller):
     @http.route('/mail/thread/data', methods=['POST'], type='json', auth='user')
     def mail_thread_data(self, thread_model, thread_id, request_list, **kwargs):
         thread = request.env[thread_model].with_context(active_test=False).search([('id', '=', thread_id)])
-        return thread._get_mail_thread_data(request_list)
+        return thread._get_mail_thread_data(request_list, kwargs)
 
     @http.route('/mail/thread/messages', methods=['POST'], type='json', auth='user')
     def mail_thread_messages(self, thread_model, thread_id, max_id=None, min_id=None, limit=30, **kwargs):

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3133,11 +3133,11 @@ class MailThread(models.AbstractModel):
             return self.company_id
         return False
 
-    def _get_mail_thread_data_attachments(self):
+    def _get_mail_thread_data_attachments(self, data):
         self.ensure_one()
         return self.env['ir.attachment'].search([('res_id', '=', self.id), ('res_model', '=', self._name)], order='id desc')
 
-    def _get_mail_thread_data(self, request_list):
+    def _get_mail_thread_data(self, request_list, data):
         self.ensure_one()
         res = {'hasWriteAccess': False}
         try:
@@ -3149,7 +3149,7 @@ class MailThread(models.AbstractModel):
         if 'activities' in request_list:
             res['activities'] = self.activity_ids.activity_format()
         if 'attachments' in request_list:
-            res['attachments'] = self._get_mail_thread_data_attachments()._attachment_format(commands=True)
+            res['attachments'] = self._get_mail_thread_data_attachments(data)._attachment_format(commands=True)
         if 'followers' in request_list:
             res['followers'] = [{
                 'id': follower.id,

--- a/addons/mail/static/src/components/attachment_box/attachment_box.xml
+++ b/addons/mail/static/src/components/attachment_box/attachment_box.xml
@@ -18,7 +18,7 @@
                             record="attachmentBoxView.attachmentList"
                         />
                     </t>
-                    <button class="o_AttachmentBox_buttonAdd btn btn-link" type="button" t-on-click="attachmentBoxView.onClickAddAttachment">
+                    <button class="o_AttachmentBox_buttonAdd btn btn-link" type="button" t-on-click="attachmentBoxView.onClickAddAttachment" t-if="attachmentBoxView.chatter.hasAttachmentUpload">
                         <i class="fa fa-plus-square"/>
                         Attach files
                     </button>

--- a/addons/mail/static/src/components/chatter_container/chatter_container.js
+++ b/addons/mail/static/src/components/chatter_container/chatter_container.js
@@ -121,6 +121,10 @@ Object.assign(ChatterContainer, {
             type: Boolean,
             optional: true,
         },
+        hasAttachmentUpload: {
+            type: Boolean,
+            optional: true,
+        },
         isAttachmentBoxVisibleInitially: {
             type: Boolean,
             optional: true,

--- a/addons/mail/static/src/js/basic_view.js
+++ b/addons/mail/static/src/js/basic_view.js
@@ -22,6 +22,10 @@ BasicView.include({
                 this._getFieldOption('message_ids', 'open_attachments', false) ||
                 this._getFieldOption('message_follower_ids', 'open_attachments', false)
             ),
+            hasAttachmentUpload: (
+                this._getFieldOption('message_ids', 'has_attachment_upload', true) ||
+                this._getFieldOption('message_follower_ids', 'has_attachment_upload', true)
+            ),
         };
         const fieldsInfo = this.fieldsInfo[this.viewType];
         this.rendererParams.chatterFields = this.chatterFields;

--- a/addons/mail/static/src/models/chatter.js
+++ b/addons/mail/static/src/models/chatter.js
@@ -41,7 +41,7 @@ registerModel({
          * @param {MouseEvent} ev
          */
         onClickButtonAttachments(ev) {
-            if (this.thread && this.thread.allAttachments.length === 0) {
+            if (this.thread && this.thread.allAttachments.length === 0 && this.hasAttachmentUpload) {
                 this.fileUploader.openBrowserFileUploader();
             } else {
                 this.update({ attachmentBoxView: this.attachmentBoxView ? clear() : insertAndReplace() });
@@ -164,7 +164,7 @@ registerModel({
          * @returns {FieldCommand}
          */
         _computeDropZoneView() {
-            if (this.useDragVisibleDropZone.isVisible) {
+            if (this.useDragVisibleDropZone.isVisible && this.hasAttachmentUpload) {
                 return insertAndReplace();
             }
             return clear();
@@ -422,6 +422,9 @@ registerModel({
         }),
         isShowingAttachmentsLoading: attr({
             default: false,
+        }),
+        hasAttachmentUpload: attr({
+            default: true,
         }),
         scrollPanelRef: attr(),
         /**

--- a/addons/mail/static/src/models/chatter.js
+++ b/addons/mail/static/src/models/chatter.js
@@ -239,6 +239,20 @@ registerModel({
         },
         /**
          * @private
+         * @returns {Object}
+         */
+        _setThreadValue() {
+            return {
+                // If the thread was considered to have the activity
+                // mixin once, it will have it forever.
+                hasActivities: this.hasActivities ? true : undefined,
+                id: this.threadId,
+                model: this.threadModel,
+            }
+        },
+
+        /**
+         * @private
          */
         _onThreadIdOrThreadModelChanged() {
             if (this.threadId) {
@@ -247,13 +261,9 @@ registerModel({
                 }
                 this.update({
                     attachmentBoxView: this.isAttachmentBoxVisibleInitially ? insertAndReplace() : clear(),
-                    thread: insert({
-                        // If the thread was considered to have the activity
-                        // mixin once, it will have it forever.
-                        hasActivities: this.hasActivities ? true : undefined,
-                        id: this.threadId,
-                        model: this.threadModel,
-                    }),
+                    thread: insert(
+                        this._setThreadValue()
+                    ),
                 });
             } else if (!this.thread || !this.thread.isTemporary) {
                 const currentPartner = this.messaging.currentPartner;

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -502,6 +502,18 @@ registerModel({
             });
         },
         /**
+         * Requests the given Attachments data.
+         *
+         * @param {string[]} requestList
+         */
+        _getThreadParam(requestSet) {
+            return {
+                request_list: [...requestSet],
+                thread_id: this.id,
+                thread_model: this.model,
+            }
+        },
+        /**
          * Requests the given `requestList` data from the server.
          *
          * @param {string[]} requestList
@@ -528,11 +540,7 @@ registerModel({
                 suggestedRecipients: suggestedRecipientsData,
             } = await this.messaging.rpc({
                 route: '/mail/thread/data',
-                params: {
-                    request_list: [...requestSet],
-                    thread_id: this.id,
-                    thread_model: this.model,
-                },
+                params: this._getThreadParam(requestSet),
             }, { shadow: true });
             if (!this.exists()) {
                 return;

--- a/addons/mail/static/src/widgets/form_renderer/form_renderer.js
+++ b/addons/mail/static/src/widgets/form_renderer/form_renderer.js
@@ -4,6 +4,7 @@ import { ChatterContainer } from '@mail/components/chatter_container/chatter_con
 
 import FormRenderer from 'web.FormRenderer';
 import { ComponentWrapper } from 'web.OwlCompatibility';
+import Domain from 'web.Domain';
 
 const { Component } = owl;
 
@@ -92,6 +93,7 @@ FormRenderer.include({
      * @returns {Object}
      */
     _makeChatterContainerProps() {
+        const hasAttachmentUpload = new Domain(this.chatterFields.hasAttachmentUpload).compute(this.state.evalContext);
         return {
             hasActivities: this.chatterFields.hasActivityIds,
             hasFollowers: this.chatterFields.hasMessageFollowerIds,
@@ -100,6 +102,7 @@ FormRenderer.include({
             isAttachmentBoxVisibleInitially: this.chatterFields.isAttachmentBoxVisibleInitially,
             threadId: this.state.res_id,
             threadModel: this.state.model,
+            hasAttachmentUpload: hasAttachmentUpload,
         };
     },
     /**

--- a/addons/mail/static/tests/qunit_suite_tests/components/chatter_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/chatter_tests.js
@@ -528,6 +528,34 @@ QUnit.test('do not post message with "Enter" keyboard shortcut', async function 
     );
 });
 
+QUnit.test('cannot be uploaded attachment in chatter with option hasAttachmentUpload false' , async function (assert) {
+    assert.expect(1);
+
+    const pyEnv = await startServer();
+    const resPartnerId1 = pyEnv['res.partner'].create();
+    pyEnv['ir.attachment'].create([
+        {
+            mimetype: 'text/plain',
+            name: 'Blah.txt',
+            res_id: resPartnerId1,
+            res_model: 'res.partner',
+        },
+    ]);
+    const { click, createChatterContainerComponent } = await start({});
+    await createChatterContainerComponent({
+        threadId: resPartnerId1,
+        threadModel: 'res.partner',
+        hasAttachmentUpload: false,
+    });
+    await click(`.o_ChatterTopbar_buttonAttachments`);
+    assert.strictEqual(
+        document.querySelectorAll(`.o_AttachmentBox_buttonAdd`).length,
+        0,
+        "should not have an attach files button in the chatter"
+    );
+});
+
+
 });
 });
 });


### PR DESCRIPTION
- improve the document flow for fleet vehicle.

  Purpose of the task is to add stat button on vehicle form view
  for attachment and on click of that button open the attachment
  kanban view. from this button user can create an attachment.
  
  Also some code refactor for hr_recruitment. removed unused field
  document_ids and rename the count field as attachment_count instead
  of document_count(due to conflict with name in document.mixin).

-  filter attachment and disable upload in chatter

    Currently, we can not filter attachment in chatter and we can not
    disable the 'add an attachment' button in chatter.
    Purpose of the task is to disable the upload button and filter the
    chatter attachments so user can upload the document using stat button
    of document app.
    
    So in this commit, Added the options 'disable_upload' and
    'attachment_domain' in chatter field so user can filter attachment
    and disable the upload from bottom chatter of the form view.
    For ex - 
               options="{'disable_upload': [('documents_fleet_settings', '=', True)],
                                    'attachment_domain': [('documents_ids', '=', False)]}"
  
closes odoo/odoo#78592
task-2144780


