### PR TITLE
[FIX] link_tracker: add a system parameter to disabled the tracking

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -82,8 +82,21 @@ class LinkTracker(models.Model):
 
     @api.depends('url')
     def _compute_redirected_url(self):
+        """Compute the URL to which we will redirect the user.
+
+        By default, add UTM values as GET parameters. But if the system parameter
+        `link_tracker.no_external_tracking` is set, we add the UTM values in the URL
+        *only* for URLs that redirect to the local website (base URL).
+        """
+        no_external_tracking = self.env['ir.config_parameter'].sudo().get_param('link_tracker.no_external_tracking')
+
         for tracker in self:
+            base_domain = urls.url_parse(tracker.get_base_url()).netloc
             parsed = urls.url_parse(tracker.url)
+            if no_external_tracking and parsed.netloc and parsed.netloc != base_domain:
+                tracker.redirected_url = parsed.to_url()
+                continue
+
             utms = {}
             for key, field_name, cook in self.env['utm.mixin'].tracking_fields():
                 field = self._fields[field_name]

--- a/addons/link_tracker/tests/__init__.py
+++ b/addons/link_tracker/tests/__init__.py
@@ -2,5 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import common
+from . import test_link_tracker
 from . import test_mail_render_mixin
 from . import test_link_tracker

--- a/addons/link_tracker/tests/test_link_tracker.py
+++ b/addons/link_tracker/tests/test_link_tracker.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from .common import MockLinkTracker
 from odoo.tests import common
 from odoo.exceptions import UserError
 
 
-class TestLinkTracker(common.TransactionCase):
+class TestLinkTracker(common.TransactionCase, MockLinkTracker):
     def test_create(self):
         link_trackers = self.env['link.tracker'].create([
             {
@@ -88,3 +89,62 @@ class TestLinkTracker(common.TransactionCase):
 
         with self.assertRaises(UserError):
             (link_1 | link_2).write({'medium_id': False})
+
+    def test_no_external_tracking(self):
+        self.env['ir.config_parameter'].set_param('link_tracker.no_external_tracking', '1')
+
+        campaign = self.env['utm.campaign'].create({'name': 'campaign'})
+        source = self.env['utm.source'].create({'name': 'source'})
+        medium = self.env['utm.medium'].create({'name': 'medium'})
+
+        expected_utm_params = {
+            'utm_campaign': campaign.name,
+            'utm_source': source.name,
+            'utm_medium': medium.name,
+        }
+
+        # URL to an external website -> UTM parameters should no be added
+        # because the system parameter "no_external_tracking" is set
+        link = self.env['link.tracker'].create({
+            'url': 'http://external.com/test?a=example.com',
+            'campaign_id': campaign.id,
+            'source_id': source.id,
+            'medium_id': medium.id,
+            'title': 'Title',
+        })
+        self.assertLinkParams(
+            'http://external.com/test',
+            link,
+            {'a': 'example.com'}
+        )
+
+        # URL to the local website -> UTM parameters should be added since we know we handle them
+        # even though the parameter "no_external_tracking" is enabled
+        link.url = 'https://test.odoo.com/test?a=example.com'
+        self.assertLinkParams(
+            'https://test.odoo.com/test',
+            link,
+            {**expected_utm_params, 'a': 'example.com'}
+        )
+
+        # Relative URL to the local website -> UTM parameters should be added since we know we handle them
+        # even though the parameter "no_external_tracking" is enabled
+        link.url = '/test?a=example.com'
+
+        self.assertLinkParams(
+            '/test',
+            link,
+            {**expected_utm_params, 'a': 'example.com'}
+        )
+
+        # Deactivate the system parameter
+        self.env['ir.config_parameter'].set_param('link_tracker.no_external_tracking', False)
+
+        # URL to an external website -> UTM parameters should be added since
+        # the system  parameter "link_tracker.no_external_tracking" is disabled
+        link.url = 'http://external.com/test?a=example.com'
+        self.assertLinkParams(
+            'http://external.com/test',
+            link,
+            {**expected_utm_params, 'a': 'example.com'}
+        )


### PR DESCRIPTION
Bug
===
If you send a URL (which will be transformed into a link tracker) to
an external website (e.g. in mass mailing, social, ...), the UTM values
will be added in the GET parameters of the URL.

The external website might crash if those parameters are not supported
by it.

We want to add a system parameter `link_tracker.no_external_tracking`
to be able to not add those UTM values in the redirected URL.

This is done only for external website, because it will never be an
issue if the URL redirect to Odoo.

Task-2657413

X-original-commit: 0b3538e50b4a5c3d9b699d5b2349cb5188d88c88
