### PR TITLE
Fix breaking onchange inheritance

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -19,16 +19,20 @@ class AccountRegisterPayments(models.TransientModel):
 
     @api.onchange('journal_id')
     def _onchange_journal_id(self):
+        res = {}
         if hasattr(super(AccountRegisterPayments, self), '_onchange_journal_id'):
-            super(AccountRegisterPayments, self)._onchange_journal_id()
+            res = super(AccountRegisterPayments, self)._onchange_journal_id()
         if self.journal_id.check_manual_sequencing:
             self.check_number = self.journal_id.check_sequence_id.number_next_actual
+        return res
 
     @api.onchange('amount')
     def _onchange_amount(self):
+        res = {}
         if hasattr(super(AccountRegisterPayments, self), '_onchange_amount'):
-            super(AccountRegisterPayments, self)._onchange_amount()
+            res = super(AccountRegisterPayments, self)._onchange_amount()
         self.check_amount_in_words = self.currency_id.amount_to_text(self.amount) if self.currency_id else False
+        return res
 
     def _prepare_payment_vals(self, invoices):
         res = super(AccountRegisterPayments, self)._prepare_payment_vals(invoices)


### PR DESCRIPTION
_onchange_journal_id and _onchange_amount methods in account.regiter.payment base class returns both domain informations to ui.
Don't break inheritance behavior here and returns the data returned by super.

Description of the issue/feature this PR addresses:
domain not passed to ui

Current behavior before PR:
proposed journals are wrongly filtered

Desired behavior after PR is merged:
Filter journals on type "general" when amount = 0.0



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
