### PR TITLE
[IMP] mail: avoid email loops when Odoo reply automatically

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -123,6 +123,7 @@ class Applicant(models.Model):
     _order = "priority desc, id desc"
     _inherit = ['mail.thread.cc', 'mail.activity.mixin', 'utm.mixin']
     _mailing_enabled = True
+    _primary_email = 'email_from'
 
     name = fields.Char("Subject / Application", required=True, help="Email subject for applications sent via email", index='trigram')
     active = fields.Boolean("Active", default=True, help="If the active field is set to false, it will allow you to hide the case without removing it.")

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -32,6 +32,7 @@
         'data/mail_message_subtype_data.xml',
         'data/mail_templates_chatter.xml',
         'data/mail_templates_email_layouts.xml',
+        'data/mail_templates_mailgateway.xml',
         'data/mail_channel_data.xml',
         'data/mail_activity_data.xml',
         'data/ir_cron_data.xml',

--- a/addons/mail/data/mail_templates_chatter.xml
+++ b/addons/mail/data/mail_templates_chatter.xml
@@ -59,25 +59,5 @@
                 </t>
             </p>
         </template>
-
-        <!-- Mail gateway templates -->
-        <template id="mail_bounce_catchall">
-<div>
-    <p>Hello <t t-esc="message['email_from']"/>,</p>
-    <p>The email sent to <t t-esc="message['to']"/> cannot be processed. This address
-    is used to collect replies and should not be used to directly contact <t t-esc="res_company.name"/>.</p>
-    <p>Please contact us instead using <a t-att-href="'mailto:%s' % res_company.email"><t t-esc="res_company.email"/></a></p>
-    <p>Regards,</p>
-    <p>The <t t-esc="res_company.name"/> team.</p>
-</div>
-<blockquote><t t-esc="message['body']"/></blockquote>
-        </template>
-
-        <!-- Mail bounce alias mail template -->
-        <template id="mail_bounce_alias_security">
-<div><t t-out="body"/></div>
-<blockquote><t t-out="message['body']"/></blockquote>
-        </template>
-
     </data>
 </odoo>

--- a/addons/mail/data/mail_templates_mailgateway.xml
+++ b/addons/mail/data/mail_templates_mailgateway.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="message_notification_limit_email">
+            <p>Dear Sender,</p>
+            <p>
+                The message below could not be accepted by the address <t t-esc="email"/> because you have
+                contacted it too many times in the last few minutes.
+                <br/>
+                Please try again later.
+            </p>
+            <p>Kind Regards</p>
+        </template>
+
+        <template id="mail_bounce_catchall">
+<div>
+    <p>Hello <t t-esc="message['email_from']"/>,</p>
+    <p>The email sent to <t t-esc="message['to']"/> cannot be processed. This address
+    is used to collect replies and should not be used to directly contact <t t-esc="res_company.name"/>.</p>
+    <p>Please contact us instead using <a t-att-href="'mailto:%s' % res_company.email"><t t-esc="res_company.email"/></a></p>
+    <p>Regards,</p>
+    <p>The <t t-esc="res_company.name"/> team.</p>
+</div>
+<blockquote><t t-esc="message['body']"/></blockquote>
+        </template>
+
+        <!-- Mail bounce alias mail template -->
+        <template id="mail_bounce_alias_security">
+<div><t t-out="body"/></div>
+<blockquote><t t-out="message['body']"/></blockquote>
+        </template>
+    </data>
+</odoo>

--- a/addons/mail/models/mail_thread_blacklist.py
+++ b/addons/mail/models/mail_thread_blacklist.py
@@ -124,3 +124,11 @@ class MailBlackListMixin(models.AbstractModel):
             }
         else:
             raise AccessError(_("You do not have the access right to unblacklist emails. Please contact your administrator."))
+
+    @api.model
+    def _routing_detect_loop_from_records_domain(self, email_from_normalized):
+        """Return the domain to be used to detect duplicated records created by alias.
+
+        :param email_from_normalized: FROM of the incoming email, normalized
+        """
+        return [('email_normalized', '=', email_from_normalized)]

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -114,11 +114,13 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
     def format(self, template, to='groups@example.com, other@gmail.com', subject='Frogs',
                email_from='Sylvie Lelitre <test.sylvie.lelitre@agrolait.com>', return_path='', cc='',
                extra='', msg_id='<1198923581.41972151344608186760.JavaMail@agrolait.com>',
-               **kwargs):
+               references='', **kwargs):
+        if not return_path:
+            return_path = '<whatever-2a840@postmaster.twitter.com>'
         return template.format(
             subject=subject, to=to, cc=cc,
             email_from=email_from, return_path=return_path,
-            extra=extra, msg_id=msg_id,
+            extra=extra, msg_id=msg_id, references=references,
             **kwargs)
 
     def format_and_process(self, template, email_from, to, subject='Frogs', cc='',

--- a/addons/mail_group/models/mail_group_message.py
+++ b/addons/mail_group/models/mail_group_message.py
@@ -21,6 +21,7 @@ class MailGroupMessage(models.Model):
     _description = 'Mailing List Message'
     _rec_name = 'subject'
     _order = 'create_date DESC'
+    _primary_email = 'email_from'
 
     # <mail.message> fields, can not be done with inherits because it will impact
     # the performance of the <mail.message> model (different cache, so the ORM will need

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -941,6 +941,7 @@ class Task(models.Model):
     _inherit = ['portal.mixin', 'mail.thread.cc', 'mail.activity.mixin', 'rating.mixin']
     _mail_post_access = 'read'
     _order = "priority desc, sequence, id desc"
+    _primary_email = 'email_from'
     _check_company_auto = True
 
     @api.model
@@ -2142,7 +2143,6 @@ class Task(models.Model):
             custom_values = {}
         defaults = {
             'name': msg.get('subject') or _("No Subject"),
-            'email_from': msg.get('from'),
             'planned_hours': 0.0,
             'partner_id': msg.get('author_id'),
             'description': msg.get('body'),

--- a/addons/test_mail/data/test_mail_data.py
+++ b/addons/test_mail/data/test_mail_data.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-MAIL_TEMPLATE = """Return-Path: <whatever-2a840@postmaster.twitter.com>
+MAIL_TEMPLATE = """Return-Path: {return_path}
 To: {to}
 cc: {cc}
 Received: by mail1.openerp.com (Postfix, from userid 10002)

--- a/addons/test_mass_mailing/models/mailing_models.py
+++ b/addons/test_mass_mailing/models/mailing_models.py
@@ -10,6 +10,7 @@ class MailingSimple(models.Model):
     _description = 'Simple Mailing'
     _name = 'mailing.test.simple'
     _inherit = ['mail.thread']
+    _primary_email = 'email_from'
 
     name = fields.Char()
     email_from = fields.Char()


### PR DESCRIPTION
Purpose
=======
In this commit, we will fix the loops that occur when you send an email
to an alias (to create a ticket e.g.). In that case Odoo can reply
"Your ticket has been created" and then the auto-replier of the user
can reply to this email and the loop occurs.

Specifications
==============
To solve this issues, we add 2 system parameters
- <mail.gateway.loop.minutes>, 120 minutes by default
- <mail.gateway.loop.threshold>, 20 by default

When an email is sent to an alias, we look on the last records created
<mail.gateway.loop.minutes> minutes ago. If we overcome the limit
<mail.gateway.loop.threshold> the email is ignored.

Alias creation detection
========================
To detect the number of records created by a specific email address we
use the `_primary_email` attribute set on the model.

Task-2294034