### PR TITLE
[IMP] website_event(_sale): improve event confirmation page

### DIFF
--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -332,7 +332,7 @@
             <div class="row mb-3">
                 <div class="col-12">
                     <h3>Registration confirmed!</h3>
-                    <span class="h4 text-muted" t-out="event.name"/>
+                    <u><a class="h4 text-primary" t-out="event.name" t-att-href="event.website_url" /></u>
                 </div>
             </div>
             <div class="row mb-3 o_wereg_confirmed_attendees">

--- a/addons/website_event_sale/controllers/__init__.py
+++ b/addons/website_event_sale/controllers/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import main
+from . import sale

--- a/addons/website_event_sale/controllers/sale.py
+++ b/addons/website_event_sale/controllers/sale.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+
+
+class WebsiteEventSale(WebsiteSale):
+
+    def _prepare_shop_payment_confirmation_values(self, order):
+        values = super(WebsiteEventSale,
+                       self)._prepare_shop_payment_confirmation_values(order)
+        values['events'] = order.order_line.event_id
+        return values

--- a/addons/website_event_sale/views/website_sale_templates.xml
+++ b/addons/website_event_sale/views/website_sale_templates.xml
@@ -37,4 +37,47 @@
         </xpath>
     </template>
 
+    <template id="event_confirmation" inherit_id="website_sale.confirmation">
+        <xpath expr="//div[@id='oe_structure_website_sale_confirmation_2']" position="inside">
+            <t t-if="events">
+                <section class="s_title pt40" data-snippet="s_title" data-name="Title">
+                    <div class="s_allow_columns container">
+                        <h4>
+                            We are looking forward to meeting you at the following <t t-if="len(events) == 1">event</t><t t-else="">events</t>:
+                        </h4>
+                    </div>
+                </section>
+                <section class="pb32 o_cc o_cc2 o_colored_level bg-transparent">
+                    <div class="s_nb_column_fixed s_col_no_bgcolor o_wevent_index" t-foreach="events" t-as="event">
+                        <div class="col-lg-12 card mt-3 mx-auto item pt16 pb16">
+                            <div class="row s_col_no_bgcolor no-gutters align-items-center o_cc1">
+                                <div class="col-lg-4 align-self-stretch d-block o_wevent_events_list">
+                                    <t t-call="website.record_cover">
+                                        <t t-set="_record" t-value="event" />
+                                        <div class="o_wevent_event_date position-absolute bg-white shadow-sm text-dark">
+                                            <span t-field="event.with_context(tz=event.date_tz).date_begin" t-options="{'format': 'LLL'}" class="o_wevent_event_month" />
+                                            <span t-field="event.with_context(tz=event.date_tz).date_begin" t-options="{'format': 'dd'}" class="o_wevent_event_day oe_hide_on_date_edit" />
+                                        </div>
+                                        <small class="o_wevent_participating bg-success">
+                                            <i class="fa fa-check mr-2" />
+                                            Registered
+                                        </small>
+                                        <small t-if="not event.website_published" class="o_wevent_unpublished bg-danger">
+                                            <i class="fa fa-ban mr-2" />
+                                            Unpublished
+                                        </small>
+                                    </t>
+                                </div>
+                                <div class="col-lg-8 p-4">
+                                    <h3 t-esc="event.name" />
+                                    <a class="btn btn-primary mb-2" t-attf-href="/event/#{ slug(event) }">Go to Event</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </t>
+        </xpath>
+    </template>
+
 </odoo>

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1107,12 +1107,20 @@ class WebsiteSale(http.Controller):
         sale_order_id = request.session.get('sale_last_order_id')
         if sale_order_id:
             order = request.env['sale.order'].sudo().browse(sale_order_id)
-            return request.render("website_sale.confirmation", {
-                'order': order,
-                'order_tracking_info': self.order_2_return_dict(order),
-            })
+            values = self._prepare_shop_payment_confirmation_values(order)
+            return request.render("website_sale.confirmation", values)
         else:
             return request.redirect('/shop')
+
+    def _prepare_shop_payment_confirmation_values(self, order):
+        """
+        This method is called in the payment process route in order to prepare the dict
+        containing the values to be rendered by the confirmation template.
+        """
+        return {
+            'order': order,
+            'order_tracking_info': self.order_2_return_dict(order),
+        }
 
     @http.route(['/shop/print'], type='http', auth="public", website=True, sitemap=False)
     def print_saleorder(self, **kwargs):


### PR DESCRIPTION
Purpose
=======
Avoid having "dead-ends" when registering to an event.

Specifications
=============
Add link to event to registration confirmation for free events.
Display list of each bought event on the confirmation page for paid
events.

Task-2657635
