### PR TITLE
[FIX] website: make single snippet editable

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2315,6 +2315,7 @@ var SnippetsMenu = Widget.extend({
                     return dragSnip;
                 },
                 start: function () {
+                    self.trigger_up('menu_drag_and_drop_start');
                     self.options.wysiwyg.odooEditor.automaticStepUnactive();
                     self.$el.find('.oe_snippet_thumbnail').addClass('o_we_already_dragging');
 
@@ -2483,6 +2484,7 @@ var SnippetsMenu = Widget.extend({
                         dragAndDropResolve();
                         self.$el.find('.oe_snippet_thumbnail').removeClass('o_we_already_dragging');
                     }
+                    self.trigger_up('menu_drag_and_drop_stop');
                 },
             },
         });

--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -33,6 +33,8 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         edition_was_stopped: '_onEditionWasStopped',
         request_save: '_onSnippetRequestSave',
         request_cancel: '_onSnippetRequestCancel',
+        menu_drag_and_drop_start: '_onMenuDragAndDropStart',
+        menu_drag_and_drop_stop: '_onMenuDragAndDropStop',
     }),
 
     /**
@@ -488,6 +490,31 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         }
     },
     /**
+     * Called when a snippet is being dragged from the menu.
+     * Enables the contenteditable because the snippet can already
+     * be added to the page when its just being dragged.
+     * @private
+     * @param {OdooEvent} ev
+     */
+    _onMenuDragAndDropStart(ev) {
+        this._targetForEdition().find('.oe_structure.oe_empty, [data-oe-type="html"]')
+            .attr('contenteditable', true);
+    },
+    /**
+     * Called when the drag and drop from the menu is stopped.
+     * If it's empty when the drag and drop stopped, it means
+     * that its message should be re-added and its content editable should
+     * be back to false.
+     * @param {OdooEvent} ev 
+     */
+    _onMenuDragAndDropStop(ev) {
+        const $editable = this._targetForEdition().find('.oe_structure.oe_empty, [data-oe-type="html"]');
+        if (!$editable.children().length) {
+            $editable.empty();
+            this._addEditorMessages();
+        }
+    },
+    /**
      * Called when a snippet is dropped in the page. Notifies the WebsiteRoot
      * that is should start the public widgets for this snippet. Also marks the
      * wrapper element as non-empty and makes it editable.
@@ -496,8 +523,6 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
      * @param {OdooEvent} ev
      */
     _onSnippetDropped: function (ev) {
-        this._targetForEdition().find('.oe_structure.oe_empty, [data-oe-type="html"]')
-            .attr('contenteditable', true);
         ev.data.addPostDropAsync(new Promise(resolve => {
             this.trigger_up('widgets_start_request', {
                 editableMode: true,


### PR DESCRIPTION
Ever since #70610, when a page has a single snippet, (e.g Forum Home)
deleting it and dropping a new one prevents the edition of a newly
dropped single snippet.

This commit fixes this by slightly changing when we set the
contenteditable attribute to true, allowing the snippet to be edited.

task-2656320

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
