### PR TITLE
[IMP] project: private task visibility for users

### DIFF
--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -95,9 +95,12 @@
     </record>
 
     <record model="ir.rule" id="project_manager_all_project_tasks_rule">
-        <field name="name">Project/Task: project manager: see all</field>
+        <field name="name">Project/Task: project manager: see all tasks linked to a project or its own tasks</field>
         <field name="model_id" ref="model_project_task"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[
+            '|', ('project_id', '!=', False),
+                 ('user_ids', 'in', user.id),
+        ]</field>
         <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
     </record>
 


### PR DESCRIPTION
**PURPOSE**

In project, private tasks (with no project) are visible to other users even if
they have project admin rights.

**SPECIFICATION**

Private tasks will not be visible to other users even if they have project admin
rights.

**Task**-2656512