### PR TITLE
[FIX] mail: fix attachment removed when editing message

### DIFF
--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -433,7 +433,7 @@ function factory(dependencies) {
             body = this._generateEmojisOnHtml(body);
             let data = {
                 body: body,
-                attachment_ids: composer.attachments.concat(this.messageViewInEditing.message.originThread.attachments).map(attachment => attachment.id),
+                attachment_ids: composer.attachments.concat(this.messageViewInEditing.message.attachments).map(attachment => attachment.id),
             };
             try {
                 composer.update({ isPostingMessage: true });


### PR DESCRIPTION
when a message or logenote with attachment(s) is edited attachment gets removed
even if user does not want to delete attachment.

after this commit,
editing message text will update only message and attachment will not be removed.
attachment will be deleted only when user wants to delete it

https://drive.google.com/file/d/1ILmaP3DpbI9YvyUYG2h2L5lI1Ld_zrDT/view?usp=sharing

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
