### PR TITLE
[FIX] stock: always fully fill _prepare_move_line_vals() dictionnary

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1101,7 +1101,7 @@ class StockMove(models.Model):
             'location_dest_id': location_dest_id,
             'picking_id': self.picking_id.id,
         }
-        if quantity:
+        if quantity is not None:
             rounding = self.env['decimal.precision'].precision_get('Product Unit of Measure')
             uom_quantity = self.product_id.uom_id._compute_quantity(quantity, self.product_uom, rounding_method='HALF-UP')
             uom_quantity = float_round(uom_quantity, precision_digits=rounding)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In mrp.production view form, during the production you add a new product that will be consumed. You add a new product line (stock.move)
and set a quantity. 

Current behavior before PR:
When you try to validate the MO, an error is raised : "It is not possible to unreserve more products of %s than you have in stock"
If quantity is 0 product_uom_qty is not properly defined which leads to funny business in onchange mechanism that sets a reserved qty to 1. If you edit the product_uom_qty again the reserved qty will raise to 2 and so on. You then have a mismatch which causes the error.

Desired behavior after PR is merged:
Reserved quantity will stay 0.

Task-2661296


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
