### PR TITLE
14.0 performance search one2many empty

### DIFF
--- a/doc/cla/individual/mt-software-de.md
+++ b/doc/cla/individual/mt-software-de.md
@@ -1,0 +1,11 @@
+Germany, 2021-10-19
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Michael Tietz mtietz@mt-software.de https://github.com/mt-software-de

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1591,9 +1591,10 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner".id
             FROM "res_partner"
-            WHERE ("res_partner"."id" IN (
-                SELECT "partner_id" FROM "res_partner_bank" WHERE "partner_id" IS NOT NULL
-            ))
+            WHERE EXISTS (
+                SELECT 1 FROM "res_partner_bank" AS "res_partner__bank_ids"
+                WHERE "res_partner__bank_ids"."partner_id" = "res_partner".id
+            )
             ORDER BY "res_partner"."id"
         ''']):
             self.Partner.search([('bank_ids', '!=', False)], order='id')
@@ -1601,9 +1602,10 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner".id
             FROM "res_partner"
-            WHERE ("res_partner"."id" NOT IN (
-                SELECT "partner_id" FROM "res_partner_bank" WHERE "partner_id" IS NOT NULL
-            ))
+            WHERE NOT EXISTS (
+                SELECT 1 FROM "res_partner_bank" AS "res_partner__bank_ids"
+                WHERE "res_partner__bank_ids"."partner_id" = "res_partner".id
+            )
             ORDER BY "res_partner"."id"
         ''']):
             self.Partner.search([('bank_ids', '=', False)], order='id')

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -786,9 +786,14 @@ class expression(object):
                 else:
                     if inverse_field.store and not (inverse_is_int and domain):
                         # rewrite condition to match records with/without lines
-                        op1 = 'inselect' if operator in NEGATIVE_TERM_OPERATORS else 'not inselect'
-                        subquery = f'SELECT "{inverse_field.name}" FROM "{comodel._table}" WHERE "{inverse_field.name}" IS NOT NULL'
-                        push(('id', op1, (subquery, [])), model, alias, internal=True)
+                        exists = 'EXISTS' if operator in NEGATIVE_TERM_OPERATORS else 'NOT EXISTS'
+                        rel_alias = _generate_table_alias(alias, field.name)
+                        push_result(f"""
+                            {exists} (
+                                SELECT 1 FROM "{comodel._table}" AS "{rel_alias}"
+                                WHERE "{rel_alias}"."{inverse_field.name}" = "{alias}".id
+                            )
+                        """, [])
                     else:
                         comodel_domain = [(inverse_field.name, '!=', False)]
                         if inverse_is_int and domain:


### PR DESCRIPTION
The name_search of product_template was very slow
one problem was the search for product_variant_ids = False
here i changed the expression.py using postgresql "exists" instead of "id in (select ..."

as reference here the amount of data
- 297487 entries in product_template
- 299006 entries in product_product