### PR TITLE
[FIX] pos_restaurant: Order button should go green after unskip order…

### DIFF
--- a/addons/pos_restaurant/static/src/js/multiprint.js
+++ b/addons/pos_restaurant/static/src/js/multiprint.js
@@ -214,7 +214,9 @@ models.Order = models.Order.extend({
             var old  = {};
             var found = false;
             for(var id in old_res) {
-                if(old_res[id].product_id === curr.product_id){
+                const old_line_id = id.split('|')[0];
+                const new_line_id = line_hash.split('|')[0];
+                if(old_line_id === new_line_id){
                     found = true;
                     old = old_res[id];
                     break;


### PR DESCRIPTION
### Expected behavior 
The order button should go green and active when you 'unskipped' an orderline

### Current behavior 
The order button doesn't go green and can't be clicked when an orderline is 'unskipped'


### Steps to reproduce the error
First of all, you need to setup a PoS Restaurant with these options :
- Bar/Restaurant
- Enable `Table Management`
- Enable and setup `Order Printer` with IP Address and choose Categories to be printed on.

After that :
1. Open a restaurant session
2. Pick a table
3. Select a product and put it on hold
4. Select the **same** product and order it
5. 'Unskipped' the product from step 3

Order button should be green and active but is unactive so the order can't be sent

### Reason
Previously, the condition was only based on the product_id so error occurs when multiline of the same product are handled. We need to verify if it's the same orderline

opw-2557518