### PR TITLE
[REM] configurator, themes: safari svg previews readability

### DIFF
--- a/addons/website/static/src/scss/configurator.scss
+++ b/addons/website/static/src/scss/configurator.scss
@@ -270,15 +270,6 @@
             .theme_svg_container svg {
                 width: 100%;
                 height: auto;
-
-                // Handle text and other components readability when
-                // placed over a coloured bg. Both the element and the
-                // underlying bg must have the same color, eg [FILL="#FFF"].
-                .svgc_text {
-                    filter: saturate(0) invert(1) contrast(1000%);
-                    -moz-filter: saturate(0) invert(1) contrast(1000%);
-                    -webkit-filter: saturate(0) invert(1) contrast(1000%);
-                }
             }
 
             .button_area {


### PR DESCRIPTION
In Safari (14+) the CSS workaround to make block "readables" over any bg
is broken. By replacing the current CSS workaround by an appropriate
SVG filter in each themes svg, the problem will be fixed.
This commit will remove the CSS workaround.

This change is related to an update of all themes on [PR#521](https://github.com/odoo/design-themes/pull/521) in the
design-themes repo.

task-2667028
