### PR TITLE
[IMP] {project}: change the gross margin stat button displayed value

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -763,7 +763,7 @@ class Project(models.Model):
                 'number': format_amount(self.env, self.analytic_account_balance, self.company_id.currency_id),
                 'action_type': 'object',
                 'action': 'action_view_analytic_account_entries',
-                'show': True,
+                'show': self.analytic_account_balance > 0,
                 'sequence': 18,
             })
         return buttons

--- a/addons/sale_timesheet/__manifest__.py
+++ b/addons/sale_timesheet/__manifest__.py
@@ -21,6 +21,7 @@ have real delivered quantities in sales orders.
         'views/account_invoice_views.xml',
         'views/sale_order_views.xml',
         'views/product_views.xml',
+        'views/project_views.xml',
         'views/project_task_views.xml',
         'views/project_update_templates.xml',
         'views/hr_timesheet_views.xml',

--- a/addons/sale_timesheet/views/project_views.xml
+++ b/addons/sale_timesheet/views/project_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_edit_project_inherit_form" model="ir.ui.view">
+        <field name="name">project.project.view.inherit</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.edit_project"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_view_analytic_account_entries']" position="replace">
+                <button class="oe_stat_button" type="object" name="action_view_analytic_account_entries" icon="fa-usd" attrs="{'invisible': [('analytic_account_id', '=', False)]}" groups="analytic.group_analytic_accounting">
+                    <div class="o_form_field o_stat_info">
+                        <span class="o_stat_value">
+                            <field name="margin"/>
+                        </span>
+                        <span class="o_stat_text">Gross Margin</span>
+                    </div>
+                </button>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
The Gross Margin stat button now displays the same value as the margin shown
in the profitability report in project update (it takes into account all the
AAL linked to the AA of the project).

task-2671576

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
