### PR TITLE
[CLA] Changed github username of Danny de Jong.

### DIFF
--- a/doc/cla/corporate/therp.md
+++ b/doc/cla/corporate/therp.md
@@ -25,5 +25,5 @@ List of contributors:
 *  George Daramouskas gdaramouskas@therp.nl https://github.com/daramousk
 *  Nikos Tsirintanis ntsirintanis@therp.nl https://github.com/ntsirintanis
 *  Jan Verbeek jverbeek@therp.nl https://github.com/janverb
-*  Danny de Jong ddejong@therp.nl https://github.com/bamilab
+*  Danny de Jong ddejong@therp.nl https://github.com/ddejong-therp
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
I have moved from using my personal github account to using my corporate github account for anything odoo related.
Thus, my old username is not useful anymore.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
