### PR TITLE
[FIX] hr_holidays: delete holidays in correct states

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_popover.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_popover.js
@@ -9,7 +9,7 @@ export const TimeOffCalendarPopover = CalendarPopover.extend({
     init(parent, eventInfo) {
         this._super(...arguments);
         const state = this.event.extendedProps.record.state;
-        this.canDelete = state && ['validate', 'refuse'].includes(state);
+        this.canDelete = state && !['validate', 'refuse'].includes(state);
         this.canEdit = state !== undefined;
         this.displayFields = [];
 


### PR DESCRIPTION
On the month, week or day time off calendar views, the delete button appears when the time off is in approved or refused state and does not when the time off is in other states.
The behavior should be the opposite.

https://www.awesomescreenshot.com/video/5681852?key=2b2136139c3fadd1006b98c0f4be920c

task-2671598


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
