### PR TITLE
[REM] website: configurator, remove css workaround safari svg previews

### DIFF
--- a/addons/website/static/src/scss/configurator.scss
+++ b/addons/website/static/src/scss/configurator.scss
@@ -272,15 +272,6 @@
             .theme_svg_container svg {
                 width: 100%;
                 height: auto;
-
-                // Handle text and other components readability when
-                // placed over a coloured bg. Both the element and the
-                // underlying bg must have the same color, eg [FILL="#FFF"].
-                .svgc_text {
-                    filter: saturate(0) invert(1) contrast(1000%);
-                    -moz-filter: saturate(0) invert(1) contrast(1000%);
-                    -webkit-filter: saturate(0) invert(1) contrast(1000%);
-                }
             }
 
             .button_area {


### PR DESCRIPTION
In Safari (14+) the CSS workaround to make block "readables" over any bg
is broken. By replacing the current CSS workaround by an appropriate
SVG filter in each themes svg, the problem will be fixed.
This commit will remove the CSS workaround.

This change is related to an update of all themes on [PR#522](https://github.com/odoo/design-themes/pull/522) in the
design-themes repo.

task-2667028

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
