### PR TITLE
[FIX] account: Issue #77996 | currency symbol not displayed in Subtotal and total amount

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -198,7 +198,7 @@
                     <td class="text-right">
                         <span
                             t-att-class="oe_subtotal_footer_separator"
-                            t-esc="subtotal['amount']"
+                            t-esc="subtotal['formatted_amount']"
                         />
                     </td>
                 </tr>
@@ -211,7 +211,7 @@
             <tr class="border-black o_total">
                 <td><strong>Total</strong></td>
                 <td class="text-right">
-                    <span t-esc="tax_totals['amount_total']"/>
+                    <span t-esc="tax_totals['formatted_amount_total']"/>
                 </td>
             </tr>
         </template>


### PR DESCRIPTION


Description of the issue/feature this PR addresses:
Fixes #77996 

**Current behavior before PR:**
Under account.document_tax_totals template the subtotal and total were using the float amounts for printing.

There was the formatted currency returned from _compute_tax_totals_json but not printed.
![Odoo - S00007](https://user-images.githubusercontent.com/32053757/137902973-8353fd37-1306-4570-ad66-3ffd6b769705.png)
![Order - S00007 (](https://user-images.githubusercontent.com/32053757/137902988-fdb45f04-371c-45fb-8483-8a198f039e81.png)
![Screenshot-from-2021-10-19-16-53-20](https://user-images.githubusercontent.com/32053757/137903005-88cb1e62-1c63-4989-b3c9-5c7230227bd1.png)


**Desired behavior after PR is merged:**
This commit uses the formatted_amount and formatted_amount_total keys to display the amount with currency on PDF and portal view.
![image](https://user-images.githubusercontent.com/32053757/137903259-9f3a4f7f-9213-4a8b-a8ff-54b6e4b9b9d7.png)
![image](https://user-images.githubusercontent.com/32053757/137903409-d30e2004-6d5e-4e57-a6e8-b9fc9a29b94a.png)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
