### PR TITLE
[FIX] hr_holidays: responsible cant see leave request

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -649,7 +649,7 @@
             'search_default_my_team_leaves':1,
             'search_default_approve':1}
         </field>
-        <field name="domain">['|', '|', '&amp;', ('employee_id.leave_manager_id', '=', uid), ('holiday_status_id.validation_type', '=', 'manager'), '&amp;', ('holiday_status_id.responsible_id', '=', uid), ('holiday_status_id.validation_type', '=', 'hr'), '&amp;', '|', ('holiday_status_id.responsible_id', '=', uid), ('holiday_status_id.responsible_id', '=', uid), ('holiday_status_id.validation_type', '=', 'both')]</field>
+        <field name="domain">['|', '|', '&amp;', ('employee_id.leave_manager_id', '=', uid), ('holiday_status_id.validation_type', '=', 'manager'), '&amp;', ('holiday_status_id.responsible_id', '=', uid), ('holiday_status_id.validation_type', '=', 'hr'), '&amp;', '|', ('holiday_status_id.responsible_id', '=', uid), ('employee_id.leave_manager_id', '=', uid), ('holiday_status_id.validation_type', '=', 'both')]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a new time off request


### PR DESCRIPTION
### Expected behaviour

A time-off responsible should be able to see the leave-request to validate, even if he is only reponsible and not leave-manager, at least as long as the leave validation is set on 'both' or 'time-off responsible'

### Observed behaviour

If the leave validation is set on 'both' (and not on 'time-off responsible' only), the time-off responsible cannot see these leave request in the "To Approve" view, and only the leave-manager can see them.

### Problem Root Cause

The issue is coming from a wrong domain definition (cf commit diff).

### Related issue(s)

opw-2595054


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

--
@fw-bot ignore