### PR TITLE
[FIX] tools: avoid rounding float if useless

### DIFF
--- a/odoo/tools/float_utils.py
+++ b/odoo/tools/float_utils.py
@@ -70,6 +70,8 @@ def float_round(value, precision_digits=None, precision_rounding=None, rounding_
     # Credit: discussion with OpenERP community members on bug 882036
 
     normalized_value = value / rounding_factor # normalize
+    if not normalized_value % 1:
+        return value
     sign = math.copysign(1.0, normalized_value)
     epsilon_magnitude = math.log(abs(normalized_value), 2)
     epsilon = 2**(epsilon_magnitude-52)


### PR DESCRIPTION
When trying to round a value unnecessarily, it can sometimes become
different. This can lead to inconsistent behaviors.

Example with purchase_stock in 14.0:
1. In Settings, enable "Units of Measure"
2. Create a product P:
    - Type: Storable
    - UoM: m
3. Create a purchase order PO:
    - 7.01 x P
4. Confirm PO and process the picking
5. Consult the Forecast Report of P

Error: Quantities are 7.1000000000000005 instead of 7.1

In the above flow, `float_round` is called several times, including by
`Float.convert_to_cache` and `UoM._compute_quantity`
https://github.com/odoo/odoo/blob/de81cc386d3a7f85b192a60b19477fcec8097624/odoo/fields.py#L1334-L1340
https://github.com/odoo/odoo/blob/51ead4b2d52e0faec2065b475dac7f376328c425/addons/uom/models/uom_uom.py#L168-L171
However, here is the issue:
`float_round(7.1, precision_rounding=0.01) == 7.1000000000000005`
Therefore, incorrect values are returned by the cache or UoM conversion

In such case, we could avoid rounding the value unnecessarily (and thus
returning an incorrect value).

OPW-2611892