### PR TITLE
[FIX] hr_expense: QR code shouldn't be shown on tablet

### DIFF
--- a/addons/hr_expense/static/src/js/expense_views.js
+++ b/addons/hr_expense/static/src/js/expense_views.js
@@ -39,7 +39,7 @@ odoo.define('hr_expense.expenses.tree', function (require) {
             };
             this.$el.find('img.o_expense_apple_store').on('click', function(event) {
                 event.preventDefault();
-                if (!config.device.isMobile) {
+                if (!config.device.isMobileDevice) {
                     self.do_action(_.extend(action_desktop, {params: {'url': apple_url}}));
                 } else {
                     self.do_action({type: 'ir.actions.act_url', url: apple_url});
@@ -47,7 +47,7 @@ odoo.define('hr_expense.expenses.tree', function (require) {
             });
             this.$el.find('img.o_expense_google_store').on('click', function(event) {
                 event.preventDefault();
-                if (!config.device.isMobile) {
+                if (!config.device.isMobileDevice) {
                     self.do_action(_.extend(action_desktop, {params: {'url': google_url}}));
                 } else {
                     self.do_action({type: 'ir.actions.act_url', url: google_url});


### PR DESCRIPTION
On tablet, the call-to-action to install the app shouldn't show the QR
code... to be scanned by the tablet itself.

This commit fixes it by using the platform detection instead of the
screen size.

Steps to reproduce:
- Open "Expenses" on tablet
- ensure no records are listed (use filters if needed)
- click on the call-to-action to one of the app store
=> opens the QR code's modal instead of going directly to the store

task-2349194