### PR TITLE
[IMP] lunch: add possibility to notify users on arrival

### DIFF
--- a/addons/lunch/data/lunch_data.xml
+++ b/addons/lunch/data/lunch_data.xml
@@ -53,6 +53,15 @@
         <field name="state">code</field>
         <field name="code">records.action_cancel()</field>
     </record>
+
+    <record id="lunch_order_action_notify" model="ir.actions.server">
+        <field name="name">Lunch: Send notifications</field>
+        <field name="model_id" ref="model_lunch_order"/>
+        <field name="binding_model_id" ref="model_lunch_order"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">records.action_notify()</field>
+    </record>
 </data>
 
 </odoo>

--- a/addons/lunch/models/res_company.py
+++ b/addons/lunch/models/res_company.py
@@ -8,3 +8,6 @@ class Company(models.Model):
     _inherit = 'res.company'
 
     lunch_minimum_threshold = fields.Float()
+    lunch_notify_message = fields.Html(
+        default="""Your lunch has been delivered.
+Enjoy your meal!""", translate=True)

--- a/addons/lunch/models/res_config_settings.py
+++ b/addons/lunch/models/res_config_settings.py
@@ -9,3 +9,4 @@ class ResConfigSettings(models.TransientModel):
 
     currency_id = fields.Many2one('res.currency', related='company_id.currency_id')
     company_lunch_minimum_threshold = fields.Float(string="Maximum Allowed Overdraft", readonly=False, related='company_id.lunch_minimum_threshold')
+    company_lunch_notify_message = fields.Html(string="Lunch notification message", readonly=False, related="company_id.lunch_notify_message")

--- a/addons/lunch/views/lunch_orders_views.xml
+++ b/addons/lunch/views/lunch_orders_views.xml
@@ -46,10 +46,12 @@
                 <field name='state'/>
                 <field name="company_id" groups="base.group_multi_company"/>
                 <field name="display_reorder_button" invisible="1"/>
+                <field name="notified" invisible="1"/>
                 <button name="action_reorder" string="Re-order" type="object" icon="fa-history" attrs="{'invisible': [('display_reorder_button', '=', False)]}" groups="lunch.group_lunch_user"/>
                 <button name="action_confirm" string="Confirm" type="object" icon="fa-check" attrs="{'invisible': [('state', '!=', 'ordered')]}" groups="lunch.group_lunch_manager"/>
                 <button name="action_cancel" string="Cancel" type="object" icon="fa-times" attrs="{'invisible': [('state', 'in', ['cancelled', 'confirmed'])]}" groups="lunch.group_lunch_manager"/>
                 <button name="action_reset" string="Reset" type="object" icon="fa-undo" attrs="{'invisible': [('state', '!=', 'cancelled')]}" groups="lunch.group_lunch_manager"/>
+                <button name="action_notify" string="Send Notification" type="object" icon="fa-envelope" attrs="{'invisible': ['|', ('state', '!=', 'confirmed'), ('notified', '=', True)]}" groups="lunch.group_lunch_manager"/>
             </tree>
         </field>
     </record>
@@ -66,6 +68,7 @@
                 <field name="date"/>
                 <field name="company_id"/>
                 <field name="currency_id"/>
+                <field name="notified"/>
                 <templates>
                     <t t-name="kanban-box">
                         <div class="oe_kanban_global_click">
@@ -96,6 +99,9 @@
                                     </a>
                                     <a class="btn btn-sm btn-danger" role="button" name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state','=','cancelled')]}" groups="lunch.group_lunch_manager">
                                         <i class="fa fa-times" role="img" aria-label="Cancel button" title="Cancel button"/>
+                                    </a>
+                                    <a class="btn btn-sm btn-info" role="button" name="action_notify" string="Send Notification" type="object" attrs="{'invisible': ['|', ('state', '!=', 'confirmed'), ('notified', '=', True)]}" groups="lunch.group_lunch_manager">
+                                        <i class="fa fa-envelope" role="img" aria-label="Send notification" title="Send notification"/>
                                     </a>
                                 </div>
                                 <div class="col-6">

--- a/addons/lunch/views/res_config_settings.xml
+++ b/addons/lunch/views/res_config_settings.xml
@@ -28,6 +28,22 @@
                             </div>
                         </div>
                     </div>
+                    <div class="row mt16 o_settings_container" name="lunch_notification_setting_container">
+                        <div class="col-12 col-lg-6 o_setting_box" id="lunch_notification">
+                            <div class="o_setting_right_pane">
+                                <span class="o_form_label">Reception notification</span>
+                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
+                                <div class="text-mutex">
+                                    Send this message to your users when their order has been delivered.
+                                </div>
+                                <div class="content-group">
+                                    <div class="mt16 row">
+                                        <field name="company_lunch_notify_message" widget="html" class="col col-lg w-100"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
There was no way for the lunch manager to notify users that their meal
had arrived prior to this commit besides manually sending a message to
the concerned users.
There now is a dedicated button after the order has been confirmed by
the lunch managed to send notifications.

TaskId-2587476
