### PR TITLE
[FIX] l10n_es: make mod 303 consistent with the changes introduced in July 2021 with OSS

### DIFF
--- a/addons/l10n_es/__manifest__.py
+++ b/addons/l10n_es/__manifest__.py
@@ -14,7 +14,7 @@
 
 {
     "name" : "Spain - Accounting (PGCE 2008)",
-    "version" : "4.0",
+    "version" : "5.0",
     "author" : "Spanish Localization Team",
     'category': 'Accounting/Localizations/Account Charts',
     "description": """

--- a/addons/l10n_es/data/account_tax_data.xml
+++ b/addons/l10n_es/data/account_tax_data.xml
@@ -244,7 +244,28 @@
         <field name="country_id" ref="base.es"/>
     </record>
     <record id="mod_303_61" model="account.account.tag">
+        <!--Not used anymore since Q3 2021; replaced by grids 120, 122, 123 and 124-->
         <field name="name">mod303[61]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_303_120" model="account.account.tag">
+        <field name="name">mod303[120]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_303_122" model="account.account.tag">
+        <field name="name">mod303[122]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_303_123" model="account.account.tag">
+        <field name="name">mod303[123]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_303_124" model="account.account.tag">
+        <field name="name">mod303[124]</field>
         <field name="applicability">taxes</field>
         <field name="country_id" ref="base.es"/>
     </record>
@@ -1177,7 +1198,7 @@
     <record id="account_tax_template_s_iva_e" model="account.tax.template">
         <field name="description">Extracomunitario (Servicios)</field>
         <field name="type_tax_use">sale</field>
-        <field name="name">IVA 0% Prestación de servicios extracomunitaria</field>
+        <field name="name">IVA 0% Prestación de servicios extracomunitaria</field> <!--TODO OCO 122-->
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="0"/>
         <field name="amount_type">percent</field>
@@ -3597,7 +3618,7 @@
     </record>
     <record id="account_tax_template_s_iva0_isp" model="account.tax.template">
         <field name="description">IVA 0% ISP</field>
-        <field name="name">IVA 0% Venta con Inversión del Sujeto Pasivo</field>
+        <field name="name">IVA 0% Venta con Inversión del Sujeto Pasivo</field><!--TODO OCO 122-->
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount" eval="0"/>

--- a/addons/l10n_es/upgrades/14.0.5.0/post-61-tag-split-2021.py
+++ b/addons/l10n_es/upgrades/14.0.5.0/post-61-tag-split-2021.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    # For taxes coming from tax templates, replace grid 61 by the right tag.
+    # For the other ones, we can't guess what to use, and the user will have to change his
+    # config manually, possibly creating a ticket to ask to fix his accounting history.
+
+    def get_taxes_from_templates(templates):
+        cr.execute(f"""
+            SELECT array_agg(tax.id)
+            FROM account_tax tax
+            JOIN ir_model_data data
+                ON data.model = 'account.tax'
+                AND data.res_id = tax.id
+                AND data.module = 'l10n_es'
+                AND data.name ~ '^[0-9]*_({'|'.join(templates)})\\Z'
+        """)
+
+        return cr.fetchone()[0]
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    templates_mapping = {
+        'mod_303_120': ['account_tax_template_s_iva_ns', 'account_tax_template_s_iva_ns_b'],
+        'mod_303_122': ['account_tax_template_s_iva_e', 'account_tax_template_s_iva0_isp'],
+    }
+
+    # To run in a server action to fix issues on dbs with custom taxes,
+    # replace the content of this dict.
+    taxes_mapping = {
+        tag_name: get_taxes_from_templates(template_names)
+        for tag_name, template_names in templates_mapping.items()
+    }
+
+    old_tag = env.ref('l10n_es.mod_303_61')
+    for tag_name, tax_ids in taxes_mapping.items():
+        # Grid 61 is only for base repartition.
+        # If it was used for taxes repartition, we don't touch it (and it'll require manual check,
+        # as the BOE file probably won't pass government checks).
+
+        new_tag = env.ref(f'l10n_es.{tag_name}')
+
+        # Change tax config
+        cr.execute("""
+            UPDATE account_account_tag_account_tax_repartition_line_rel tax_rep_tag
+            SET account_account_tag_id = %s
+            FROM account_account_tag new_tag, account_tax_repartition_line repln
+            WHERE tax_rep_tag.account_account_tag_id = %s
+            AND repln.id = tax_rep_tag.account_tax_repartition_line_id
+            AND COALESCE(repln.invoice_tax_id, repln.refund_tax_id) IN %s
+        """, [new_tag.id, old_tag.id, tuple(tax_ids)])
+
+        # Change amls in history, starting at Q3 2021 (date of introduction for the new tags)
+
+        # Set tags
+        cr.execute("""
+            UPDATE account_account_tag_account_move_line_rel aml_tag
+            SET account_account_tag_id = %s
+            FROM account_move_line aml, account_move_line_account_tax_rel aml_tax
+            WHERE aml_tag.account_move_line_id = aml.id
+            AND aml_tax.account_move_line_id = aml.id
+            AND aml.date >= '2021-07-01'
+            AND aml_tax.account_tax_id IN %s
+            AND aml_tag.account_account_tag_id = %s
+        """, [new_tag.id, tuple(tax_ids), old_tag.id])
+
+        # Fix tax audit string
+        cr.execute("""
+            UPDATE account_move_line aml
+            SET tax_audit = REPLACE(tax_audit, %s, %s)
+            FROM account_account_tag_account_move_line_rel aml_tag
+            WHERE aml_tag.account_move_line_id = aml.id
+            AND aml_tag.account_account_tag_id = %s
+        """, [old_tag.name, f"{new_tag.name}:", new_tag.id])


### PR DESCRIPTION
Mod 303's grid 61 is now divided in 4 new lines: 120, 122, 123 and 124. Grid 61 isn't used anymore. This takes effect starting July 1st 2021; previous periods are unaffected.

Doc:

https://www.agenciatributaria.es/AEAT.internet/Inicio/Ayuda/Disenos_de_registro/Modelos_300_al_399/Modelos_300_al_399.shtml

https://iranon.es/modelo-303-cambios-a-partir-del-3t-y-mensual-de-julio-de-2021/

OPW 2662476

