### PR TITLE
[FIX] web: restore proper alignment and spacing of navbar's user avatar 👌

### DIFF
--- a/addons/web/static/src/webclient/user_menu/user_menu.scss
+++ b/addons/web/static/src/webclient/user_menu/user_menu.scss
@@ -5,6 +5,6 @@
     height: 26px;
     width: 26px;
     object-fit: cover;
-    transform: translateY(-2px);
+    margin-right: 5px;
   }
 }


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Restore proper alignment and spacing of user avatar, after https://github.com/odoo/odoo/commit/0573acae2306bf5da2005852da9323ddc59e5431

**Current behavior before PR:**
![before](https://user-images.githubusercontent.com/1914185/137979485-f01fe992-a77d-4377-ac81-78d7050b3102.png)

**Desired behavior after PR is merged:**
![after](https://user-images.githubusercontent.com/1914185/137979501-09fac017-1d38-43b4-92c5-569d746175b1.png)


ping @aab-odoo 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
