### PR TITLE
[FIX] mail: notification is displayed properly

### DIFF
--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -824,6 +824,7 @@ function factory(dependencies) {
             channel.update({ isServerPinned: false });
             this.env.services['notification'].notify({
                 message,
+                messageIsHtml: true,
                 type: 'info',
             });
         }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Notification is not displayed properly after leaving the channel or unpin the conversation.

Current behaviour before PR:
Notification was displayed with html tag inside of it.

![image](https://user-images.githubusercontent.com/32053757/138046705-4cac7b9e-118c-4409-82d7-32643f2a34aa.png)

Desired behaviour after PR is merged:
HTML Notification will converted in to original text.

![image](https://user-images.githubusercontent.com/32053757/138046624-66b5b38c-0812-4724-a6d9-7f82aa7405a5.png)

Fixes #78271

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
