### PR TITLE
[FIX] project: copy display_project_id of subtasks

### DIFF
--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -145,7 +145,7 @@ class ProjectTaskRecurrence(models.Model):
     def _get_recurring_fields(self):
         return ['message_partner_ids', 'company_id', 'description', 'displayed_image_id', 'email_cc',
                 'parent_id', 'partner_email', 'partner_id', 'partner_phone', 'planned_hours',
-                'project_id', 'project_privacy_visibility', 'sequence', 'tag_ids', 'recurrence_id',
+                'project_id', 'display_project_id', 'project_privacy_visibility', 'sequence', 'tag_ids', 'recurrence_id',
                 'name', 'recurring_task', 'analytic_account_id']
 
     def _get_weekdays(self, n=1):


### PR DESCRIPTION
Prior to this commit, when a subtask is copied through the recurrence,
it loses its display_project_id in the copied sub-tasks.

Current Behavior

The display project id is left empty.

Expected Behavior

The display project id is copied.

task-2672243

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
