### PR TITLE
[FIX] crm: display only events linked to the actual opportunity

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -896,8 +896,10 @@ class Lead(models.Model):
         partner_ids = self.env.user.partner_id.ids
         if self.partner_id:
             partner_ids.append(self.partner_id.id)
+        current_opportunity_id = self.id if self.type == 'opportunity' else False
         action['context'] = {
-            'default_opportunity_id': self.id if self.type == 'opportunity' else False,
+            'search_default_opportunity_id': current_opportunity_id,
+            'default_opportunity_id': current_opportunity_id,
             'default_partner_id': self.partner_id.id,
             'default_partner_ids': partner_ids,
             'default_attendee_ids': [(0, 0, {'partner_id': pid}) for pid in partner_ids],


### PR DESCRIPTION
When an user clicks on the Meeting tab to open the calendar,
it should onyl display the events linked to the opportunity.

task-2665863