### PR TITLE
[FIX] mail: activity view=>no tz for deadline date


### DIFF
--- a/addons/mail/static/src/js/views/activity/activity_cell.js
+++ b/addons/mail/static/src/js/views/activity/activity_cell.js
@@ -14,7 +14,7 @@ odoo.define("mail.ActivityCell", function (require) {
         _render() {
             // replace clock by closest deadline
             const $date = $('<div class="o_closest_deadline">');
-            const date = new Date(this.record.data.closest_deadline);
+            const date = moment(this.record.data.closest_deadline).toDate();
             // To remove year only if current year
             if (moment().year() === moment(date).year()) {
                 $date.text(date.toLocaleDateString(moment().locale(), {


### PR DESCRIPTION

In activity view, the deadline date that has no timezone is formatted
from UTC to local timezone, so if the timezone is negative, we display
by error the previous day (eg. 24 october instead of 25 october).

With this commmit, we interpret the date in local timezone so there is
no timezone issue.

note: no test added since this only happen on browser with negative
timezone which would be hard to test.

note: this was fixed similarily in 13.0 with 0735547086 but must have
been lost in a refactoring.

opw-2629681
