### PR TITLE
[IMP] survey: add question placeholder

### DIFF
--- a/addons/survey/data/survey_demo_certification.xml
+++ b/addons/survey/data/survey_demo_certification.xml
@@ -169,6 +169,7 @@
             <field name="sequence">6</field>
             <field name="title">Do you think we have missing products in our catalog? (not rated)</field>
             <field name="question_type">text_box</field>
+            <field name="question_placeholder">If yes, explain what you think is missing, give examples.</field>
         </record>
         <!-- Page 2 -->
         <record model="survey.question" id="vendor_certification_page_2">
@@ -338,6 +339,7 @@
             <field name="is_scored_question" eval="True" />
             <field name="answer_datetime">2021-01-07 00:00:01</field>
             <field name="answer_score">1.0</field>
+            <field name="question_placeholder">Beware of leap years !</field>
         </record>
         <!-- Question and predefined answer 12 -->
         <record model="survey.question" id="vendor_certification_page_3_question_4">

--- a/addons/survey/data/survey_demo_feedback.xml
+++ b/addons/survey/data/survey_demo_feedback.xml
@@ -28,6 +28,7 @@
         <field name="sequence">2</field>
         <field name="title">Where do you live ?</field>
         <field name="question_type">char_box</field>
+        <field name="question_placeholder">Brussels</field>
         <field name="constr_mandatory" eval="False"/>
     </record>
     <record model="survey.question" id="survey_feedback_p1_q2">

--- a/addons/survey/data/survey_demo_quiz.xml
+++ b/addons/survey/data/survey_demo_quiz.xml
@@ -33,12 +33,14 @@
         <field name="constr_mandatory" eval="True"/>
         <field name="validation_email" eval="True"/>
         <field name="save_as_email" eval="True"/>
+        <field name="question_placeholder">ex@mple.com</field>
     </record>
     <record id="survey_demo_quiz_p1_q2" model="survey.question">
         <field name="survey_id" ref="survey_demo_quiz"/>
         <field name="sequence">3</field>
         <field name="title">What is your nickname ?</field>
         <field name="question_type">char_box</field>
+        <field name="question_placeholder">Don't be shy, be wild!</field>
         <field name="constr_mandatory" eval="True"/>
         <field name="save_as_nickname" eval="True"/>
     </record>
@@ -47,6 +49,7 @@
         <field name="sequence">4</field>
         <field name="title">Where are you from ?</field>
         <field name="question_type">char_box</field>
+        <field name="question_placeholder">Brussels, Belgium</field>
         <field name="constr_mandatory" eval="True"/>
     </record>
     <record id="survey_demo_quiz_p1_q4" model="survey.question">

--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -57,6 +57,7 @@ class SurveyQuestion(models.Model):
     description = fields.Html(
         'Description', translate=True, sanitize=False,  # TDE TODO: sanitize but find a way to keep youtube iframe media stuff
         help="Use this field to add additional explanations about your question or to illustrate it with pictures or a video")
+    question_placeholder = fields.Char("Placeholder", translate=True, compute="_compute_question_placeholder", store=True, readonly=False)
     survey_id = fields.Many2one('survey.survey', string='Survey', ondelete='cascade')
     scoring_type = fields.Selection(related='survey_id.scoring_type', string='Scoring Type', readonly=True)
     sequence = fields.Integer('Sequence', default=10)
@@ -170,6 +171,13 @@ class SurveyQuestion(models.Model):
         ('scored_date_have_answers', "CHECK (is_scored_question != True OR question_type != 'date' OR answer_date is not null)",
             'All "Is a scored question = True" and "Question Type: Date" questions need an answer')
     ]
+
+    @api.depends('question_type')
+    def _compute_question_placeholder(self):
+        for question in self:
+            if question.question_type in ('simple_choice', 'multiple_choice', 'matrix') \
+                    or not question.question_placeholder:  # avoid CacheMiss errors
+                question.question_placeholder = False
 
     @api.depends('is_page')
     def _compute_question_type(self):

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -174,19 +174,19 @@
                                     <field name="matrix_subtype" attrs="{'invisible':[('question_type','not in',['matrix'])],'required':[('question_type','=','matrix')]}"/>
                                 </group>
                             </group>
-                            <group>
-                                <group string="Display" attrs="{'invisible':[('question_type','not in',['simple_choice', 'multiple_choice'])]}">
-                                    <field name="column_nb" string="Number of columns"/>
-                                    <field name="allow_value_image"/>
-                                </group>
-                                <group string="Conditional Display" attrs="{'invisible': [('questions_selection', '=', 'random')]}">
-                                    <field name="is_conditional"/>
-                                    <field name="triggering_question_id"  options="{'no_open': True, 'no_create': True}"
-                                           attrs="{'invisible': [('is_conditional','=', False)], 'required': [('is_conditional','=', True)]}"/>
-                                    <field name="triggering_answer_id" options="{'no_open': True, 'no_create': True}"
-                                           attrs="{'invisible': ['|', ('is_conditional','=', False), ('triggering_question_id','=', False)],
-                                                   'required': [('is_conditional','=', True)]}"/>
-                                </group>
+                            <group string="Display" attrs="{'invisible':[('question_type','=', 'matrix')]}">
+                                <field name="question_placeholder" attrs="{'invisible': [('question_type', 'not in', ['text_box', 'char_box', 'date', 'datetime', 'numerical_box'])]}"
+                                       placeholder="When set, this text will appear in the field to help participants answer."/>
+                                <field name="column_nb" string="Number of columns" attrs="{'invisible':[('question_type','not in',['simple_choice', 'multiple_choice'])]}"/>
+                                <field name="allow_value_image" attrs="{'invisible':[('question_type','not in',['simple_choice', 'multiple_choice'])]}"/>
+                            </group>
+                            <group string="Conditional Display" attrs="{'invisible': [('questions_selection', '=', 'random')]}">
+                                <field name="is_conditional"/>
+                                <field name="triggering_question_id"  options="{'no_open': True, 'no_create': True}"
+                                       attrs="{'invisible': [('is_conditional','=', False)], 'required': [('is_conditional','=', True)]}"/>
+                                <field name="triggering_answer_id" options="{'no_open': True, 'no_create': True}"
+                                       attrs="{'invisible': ['|', ('is_conditional','=', False), ('triggering_question_id','=', False)],
+                                               'required': [('is_conditional','=', True)]}"/>
                             </group>
                             <group string="Allow Comments" attrs="{'invisible':[('question_type','not in',['simple_choice','multiple_choice', 'matrix'])]}">
                                 <field name='comments_allowed' />

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -330,7 +330,8 @@
 
     <template id="question_text_box" name="Question: free text box">
         <div class="o_survey_comment_container p-0">
-            <textarea class="form-control o_survey_question_text_box bg-transparent text-dark rounded-0 p-0" rows="3" t-att-name="question.id"
+            <textarea class="form-control o_survey_question_text_box bg-transparent text-dark rounded-0 p-0" rows="3"
+                      t-att-name="question.id" t-att-placeholder="question.question_placeholder"
                       t-att-data-question-type="question.question_type"><t t-if="answer_lines" t-esc="answer_lines[0].value_text_box or None"/></textarea>
         </div>
     </template>
@@ -338,7 +339,8 @@
     <template id="question_char_box" name="Question: text box">
         <div class="o_survey_comment_container p-0">
             <input t-att-type="'email' if question.validation_email else 'text'"
-               class="form-control o_survey_question_text_box bg-transparent text-dark rounded-0 p-0" t-att-name="question.id"
+               class="form-control o_survey_question_text_box bg-transparent text-dark rounded-0 p-0"
+               t-att-name="question.id" t-att-placeholder="question.question_placeholder"
                t-att-value="answer_lines[0].value_char_box if answer_lines else None"
                t-att-data-question-type="question.question_type"
                t-att-data-validation-length-min="question.validation_length_min if question.validation_required else False"
@@ -348,7 +350,8 @@
 
     <template id="question_numerical_box" name="Question: numerical box">
         <input type="number" step="any" class="form-control o_survey_question_numerical_box bg-transparent text-dark rounded-0 p-0"
-               t-att-name="question.id" t-att-value="answer_lines[0].value_numerical_box if answer_lines else None"
+               t-att-name="question.id" t-att-placeholder="question.question_placeholder"
+               t-att-value="answer_lines[0].value_numerical_box if answer_lines else None"
                t-att-data-question-type="question.question_type"
                t-att-data-validation-float-min="question.validation_min_float_value if question.validation_required else False"
                t-att-data-validation-float-max="question.validation_max_float_value if question.validation_required else False"/>
@@ -359,7 +362,8 @@
                 t-att-data-mindate="question.validation_min_date"
                 t-att-data-maxdate="question.validation_max_date">
             <input type="text" class="form-control datetimepicker-input o_survey_question_date bg-transparent text-dark rounded-0 p-0"
-                   t-attf-data-target="#datetimepicker_#{question.id}" t-att-name="question.id"
+                   t-attf-data-target="#datetimepicker_#{question.id}"
+                   t-att-name="question.id" t-att-placeholder="question.question_placeholder"
                    t-att-value="format_date(answer_lines[0].value_date) if answer_lines else None"
                    t-att-data-question-type="question.question_type"/>
             <div t-if="not survey_form_readonly" class="input-group-append position-absolute" t-attf-data-target="#datetimepicker_#{question.id}" data-toggle="datetimepicker">
@@ -373,7 +377,8 @@
                 t-att-data-mindate="question.validation_min_datetime"
                 t-att-data-maxdate="question.validation_max_datetime">
             <input type="text" class="form-control datetimepicker-input o_survey_question_datetime bg-transparent text-dark rounded-0 p-0"
-                   t-attf-data-target="#datetimepicker_#{question.id}" t-att-name="question.id"
+                   t-attf-data-target="#datetimepicker_#{question.id}"
+                   t-att-name="question.id" t-att-placeholder="question.question_placeholder"
                    t-att-value="format_datetime(answer_lines[0].value_datetime) if answer_lines else None"
                    t-att-data-question-type="question.question_type"/>
             <div t-if="not survey_form_readonly" class="input-group-append position-absolute" t-attf-data-target="#datetimepicker_#{question.id}" data-toggle="datetimepicker">


### PR DESCRIPTION
Purpose
=======

As an Interviewer, I want my questions to be as clear as possible.
To this end, I would like to be able to detail a bit which kind of answers I
expect.

Specifications
============

For all the question types that require an input, display a char field
"Placeholder" in the Answers tab with a field helper that says:
"When set, this text will appear in the field to help participants answer."
Then on the survey, display the placeholder in the question input zone.

Task-2671388