### PR TITLE
[IMP] Finish a text edit step in a tour when clicked

### DIFF
--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -164,7 +164,7 @@ function clickOnText(snippet, element, position = "bottom") {
         content: Markup(_t("<b>Click on a text</b> to start editing it.")),
         position: position,
         run: "text",
-        consumeEvent: "input",
+        consumeEvent: "click",
     };
 }
 


### PR DESCRIPTION
The idea of a text edit step is considered clearly communicated to the end user from the moment the trigger is clicked ( as opposed to the step waiting for actual input from the end user). This way an end user can finish the tour faster without actually having prepared custom text content yet.

Backport of https://github.com/odoo/odoo/pull/77720

task-2580338