### PR TITLE
[IMP] mail: enforce the definition of identifying fields in models

### DIFF
--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -1014,6 +1014,9 @@ export class ModelManager {
             * Contains all records. key is local id, while value is the record.
             */
             Model.__records = {};
+            if (!Model.hasOwnProperty('identifyingFields')) {
+                throw new Error(`${Model} is lacking identifying fields.`);
+            }
             Model.__identifyingFields = Model.identifyingFields;
             const identifyingFieldsFlattened = new Set();
             for (const identifyingElement of Model.identifyingFields) {


### PR DESCRIPTION
Ensure that all models have their own explicit definition of identifying fields. Prior to this commit, if a model did not have identifying fields, the ones in mail.model were used implicitly because of the inheritance.