### PR TITLE
[FIX] website, web_editor: batch of fixes

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1826,7 +1826,7 @@ body.editor_enable.editor_has_snippets {
                     grid-column: 1/span 2;
                     grid-row: 3;
                     background: none;
-                    -webkit-appearance: none;
+                    appearance: none;
                     cursor: ew-resize;
                     @supports (-moz-appearance:none) {
                         margin-top: 2px;
@@ -1836,7 +1836,7 @@ body.editor_enable.editor_has_snippets {
                         pointer-events: auto;
                         border: 1.5px solid rgba(255, 255, 255, 0.8);
                         background: currentColor;
-                        -webkit-appearance: none;
+                        appearance: none;
                         box-shadow: 0px 0px 0px #000000;
                         height: 20px;
                         width: 12px;
@@ -1880,6 +1880,7 @@ body.editor_enable.editor_has_snippets {
             .o_remove_color {
                 font-size: 14px !important;
                 text-align: center !important;
+                padding: 0;
             }
         }
     }

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -352,6 +352,7 @@ body.editor_enable.editor_has_snippets {
     > #o_scroll {
         background-color: $o-we-sidebar-blocks-content-bg;
         padding: 0 $o-we-sidebar-blocks-content-spacing;
+        height: 100%; // give enough space for tips pointing at snippets after a snippet search
         z-index: 1;
 
         .o_panel, .o_panel_header {

--- a/addons/website/static/src/components/configurator/configurator.xml
+++ b/addons/website/static/src/components/configurator/configurator.xml
@@ -154,12 +154,12 @@
         <div class="container-fluid pt-3 pb-2">
             <img class="ml-lg-5" style="height: 31px; width: 99px;" src="/website/static/src/img/odoo_logo.svg" title="Odoo Logo"/>
         </div>
-        <div class="o_configurator_screen_content container d-flex flex-grow-1 align-items-center">
-            <div class="m-auto">
-                <div class="o_configurator_typing_text o_configurator_show_fast pl-2">Add <b class="text-info">Pages</b> and <b class="text-warning">Features</b></div>
-                <h5 class="o_configurator_show_fast text-muted pl-2">You'll be able to create your pages later on.</h5>
-                <div class="page_feature_selection o_configurator_show">
-                    <div class="w-100 page_feature_selection container d-flex flex-wrap py2 py-lg-3">
+        <div class="o_configurator_screen_content overflow-hidden container d-flex flex-grow-1 align-items-center">
+            <div class="m-auto d-flex mh-100 flex-column">
+                <div class="o_configurator_typing_text o_configurator_show_fast">Add <b class="text-info">Pages</b> and <b class="text-warning">Features</b></div>
+                <h5 class="o_configurator_show_fast text-muted pb-lg-3">You'll be able to create your pages later on.</h5>
+                <div class="page_feature_selection o_configurator_show overflow-auto mt-lg-3 mx-n2">
+                    <div class="w-100 page_feature_selection d-flex flex-wrap">
                         <t t-foreach="getters.getFeatures()" t-as="feature" t-key="feature_index">
                             <t t-set='isInstalled' t-value="feature.module_state == 'installed'"/>
                             <div class="p-2 w-100 w-md-50 w-lg-25" t-if="feature.type != 'empty'">
@@ -182,7 +182,7 @@
                         </t>
                     </div>
                 </div>
-                <div class="text-right">
+                <div class="text-right border-top pt-2">
                     <button class="btn btn-primary btn-lg ml-3" t-on-click="buildWebsite()">Build my website</button>
                 </div>
             </div>

--- a/addons/website/static/src/scss/configurator.scss
+++ b/addons/website/static/src/scss/configurator.scss
@@ -61,6 +61,8 @@
             animation: configuratorFadeIn .35s;
         }
 
+        // TODO review in master, this seems useless and had to be overridden
+        // in stable templates. All the templates can be improved.
         .o_configurator_screen_content {
             overflow-y: auto;
         }

--- a/addons/website/static/src/scss/website.ui.scss
+++ b/addons/website/static/src/scss/website.ui.scss
@@ -96,14 +96,13 @@ body.o_connected_user {
         font-size: inherit;
         border-radius: 0;
         color: $dropdown-link-active-color;
+        max-height: 500px; // Fallback
+        max-height: calc(90vh - #{$o-navbar-height});
+        overflow: auto;
     }
     #oe_applications .dropdown-menu {
         // Compensate #oe_applications's padding
         margin-left: $dropdown-item-padding-x * -0.5;
-
-        max-height: 500px; // Fallback
-        max-height: calc(90vh - #{$o-navbar-height});
-        overflow: auto;
     }
 
     .o_menu_sections {


### PR DESCRIPTION
This pull request contains 3 commits that fix some behaviours that appeared in 15.0:

### Commit 1 : [FIX] website: restore scrollbar for some menus

After [1], the dropdown menu of the main navbar for certains menus
(e.g customize on /shop) didn't have scrollbars anymore, making it hard
to navigate on smaller resolution devices.

This commit restores that.

[1] : 1971bf39810468b2b67e2ecd3c86c663d5cffcfd

---
### Commit 2 :  [FIX] website: always display build my website button
This commit moves the position of the build my website button in the
configurator so that it's always visible, even with low resolution
displays and mobile phones

---
### Commit 3 : [FIX] web_editor: fix gradient slider infinite resize and safari support
Prior to this commit, if three colors were selected for a gradient and
the user would click on the third color, if that color had a value of
100%, in certain condition the picker would resize infinitely.
Also prior to this commit, the color picker slider was not supported
well under safari

This commit fixes the SCSS rules in order to fix those behaviours.

task-2670809
