### PR TITLE
Revert "[FIX] hr_fleet: Don't notify future_driver_id as Changed Driver"

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -326,7 +326,7 @@ class FleetVehicle(models.Model):
 
     def _track_subtype(self, init_values):
         self.ensure_one()
-        if 'driver_id' in init_values:
+        if 'driver_id' in init_values or 'future_driver_id' in init_values:
             return self.env.ref('fleet.mt_fleet_driver_updated')
         return super(FleetVehicle, self)._track_subtype(init_values)
 


### PR DESCRIPTION
This reverts commit 2e58d23e760313dbf58ce6a90f26b7160db460d8.

Actually the fleet officers want to be notified.

The correct way to handle the original issue is to ping the employees
via their documents, instead of on the fleet.vehicle, to avoid setting
them as followers of the car.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
