### PR TITLE
[IMP] base,crm: properly set sales person and sales team on partner

### DIFF
--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -8,7 +8,11 @@ class Partner(models.Model):
     _name = 'res.partner'
     _inherit = 'res.partner'
 
-    team_id = fields.Many2one('crm.team', string='Sales Team', ondelete="set null")
+    team_id = fields.Many2one(
+        'crm.team', string='Sales Team',
+        compute='_compute_team_id',
+        precompute=True,  # avoid queries post-create
+        ondelete='set null', readonly=False, store=True)
     opportunity_ids = fields.One2many('crm.lead', 'partner_id', string='Opportunities', domain=[('type', '=', 'opportunity')])
     opportunity_count = fields.Integer("Opportunity", compute='_compute_opportunity_count')
 
@@ -33,6 +37,11 @@ class Partner(models.Model):
                     zip=lead.zip,
                 )
         return rec
+
+    @api.depends('parent_id')
+    def _compute_team_id(self):
+        for partner in self.filtered(lambda partner: not partner.team_id and partner.company_type == 'person' and partner.parent_id.team_id):
+            partner.team_id = partner.parent_id.team_id
 
     def _compute_opportunity_count(self):
         # retrieve all children partners and prefetch 'parent_id' on them

--- a/addons/crm/tests/__init__.py
+++ b/addons/crm/tests/__init__.py
@@ -15,3 +15,4 @@ from . import test_crm_lead_smart_calendar
 from . import test_crm_ui
 from . import test_crm_pls
 from . import test_performances
+from . import test_res_partner

--- a/addons/crm/tests/test_res_partner.py
+++ b/addons/crm/tests/test_res_partner.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.crm.tests.common import TestCrmCommon
+from odoo.tests.common import Form
+from odoo.tests import tagged, users
+
+
+@tagged('res_partner')
+class TestPartner(TestCrmCommon):
+
+    @users('user_sales_leads')
+    def test_parent_sync_sales_rep(self):
+        """ Test team_id / user_id sync from parent to children if the contact
+        is a person. Company children are not updated. """
+        contact_company = self.contact_company.with_env(self.env)
+        contact_company_1 = self.contact_company_1.with_env(self.env)
+        self.assertFalse(contact_company.team_id)
+        self.assertFalse(contact_company.user_id)
+        self.assertFalse(contact_company_1.team_id)
+        self.assertFalse(contact_company_1.user_id)
+
+        child = self.contact_1.with_env(self.env)
+        self.assertEqual(child.parent_id, self.contact_company_1)
+        self.assertFalse(child.team_id)
+        self.assertFalse(child.user_id)
+
+        # update comppany sales rep info
+        contact_company.user_id = self.env.uid
+        contact_company.team_id = self.sales_team_1.id
+
+        # change child parent: shold update sales rep info
+        child.parent_id = contact_company.id
+        self.assertEqual(child.user_id, self.env.user)
+
+        # test form tool
+        partner_form = Form(self.env['res.partner'], 'base.view_partner_form')
+        partner_form.parent_id = contact_company
+        partner_form.company_type = 'person'
+        partner_form.name = 'Hermes Conrad'
+        self.assertEqual(partner_form.team_id, self.sales_team_1)
+        self.assertEqual(partner_form.user_id, self.env.user)
+        partner_form.parent_id = contact_company_1
+        self.assertEqual(partner_form.team_id, self.sales_team_1)
+        self.assertEqual(partner_form.user_id, self.env.user)
+
+        # test form tool
+        partner_form = Form(self.env['res.partner'], 'base.view_partner_form')
+        partner_form.company_type = 'company'
+        partner_form.parent_id = contact_company
+        partner_form.name = 'Mom Corp'
+        self.assertFalse(partner_form.team_id)
+        self.assertFalse(partner_form.user_id)

--- a/addons/crm/views/res_partner_views.xml
+++ b/addons/crm/views/res_partner_views.xml
@@ -44,6 +44,9 @@
                             <field string="Opportunities" name="opportunity_count" widget="statinfo"/>
                         </button>
                     </div>
+                    <field name="parent_id" position="attributes">
+                        <attribute name="context">{'default_is_company': True, 'show_vat': True, 'default_user_id': user_id, 'default_team_id': team_id}</attribute>
+                    </field>
                 </data>
             </field>
         </record>

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -157,3 +157,23 @@ class TestPartner(TransactionCase):
         self.assertFalse(self.env.ref('base.public_user').active)
         self.assertFalse(self.env.ref('base.public_partner').active)
         self.assertTrue(self.env.ref('base.public_partner').is_public)
+
+    def test_onchange_parent_sync_user(self):
+        company_1 = self.env['res.company'].create({'name': 'company_1'})
+        test_user = self.env['res.users'].create({
+            'name': 'This user',
+            'login': 'thisu',
+            'email': 'this.user@example.com',
+            'company_id': company_1.id,
+            'company_ids': [company_1.id],
+        })
+        test_parent_partner = self.env['res.partner'].create({
+            'company_type': 'company',
+            'name': 'Micheline',
+            'user_id': test_user.id,
+        })
+        with Form(self.env['res.partner']) as partner_form:
+            partner_form.parent_id = test_parent_partner
+            partner_form.company_type = 'person'
+            partner_form.name = 'Philip'
+            self.assertEqual(partner_form.user_id, test_parent_partner.user_id)

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -84,6 +84,7 @@
                     <field name="is_company" invisible="1"/>
                     <field name="type" invisible="1"/>
                     <field name="avatar_128" invisible="1"/>
+                    <field name="user_id" invisible="1"/>
                     <field name="image_1920" widget='image' class="oe_avatar" options='{"preview_image": "avatar_128"}'/>
                     <div class="oe_title">
                         <field name="company_type" options="{'horizontal': true}" widget="radio" groups="base.group_no_one"/>
@@ -94,7 +95,7 @@
                         <field name="parent_id"
                             widget="res_partner_many2one"
                             placeholder="Company Name..."
-                            domain="[('is_company', '=', True)]" context="{'default_is_company': True, 'show_vat': True}"
+                            domain="[('is_company', '=', True)]" context="{'default_is_company': True, 'show_vat': True, 'default_user_id': user_id}"
                             attrs="{'invisible': [('is_company','=', True)]}"/>
                     </div>
                     <group>


### PR DESCRIPTION
PURPOSE

The Salesperson and sales team values should be set on the individual partner
and the parent company if the parent company is linked with an
individual partner. This salesperson will display on the portal to show who will
handle the process.

SPECIFICATIONS

The Salesperson and sales team are set on contact/partner form view.
This salesperson is showing on the portal view(website). This value shows
who will handle the process. No contact will show on the portal if the
salesperson is not set on individual contact/partner.

With this commit, we have done two points. 
1) If salesperson and sales team values are set on individual contact/partner, 
pass these values to a parent company which is created from
here(individual contact/partner).
2) If the parent company is manually linked to an individual partner and
the salesperson and sales team are not set on an individual, these values
are getting from the parent company and set on individual contact/partner.

This is the goal of this commit.

PR #78696
Task-2636290

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr