### PR TITLE
[FIX] product: properly trigger computation of computed fields

### DIFF
--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -93,6 +93,7 @@
             <field name="arch" type="xml">
                 <form string="Pricelist Rule">
                     <sheet>
+                        <field name="name" invisible="1"/>
                         <group name="pricelist_rule_computation" groups="product.group_sale_pricelist" string="Price Computation">
                             <group name="pricelist_rule_method">
                                 <field name="compute_price" string="Computation" widget="radio"/>
@@ -105,6 +106,7 @@
                         </group>
                         <group name="pricelist_rule_base" groups="product.group_sale_pricelist">
                             <group>
+                                <field name="price" invisible="1"/>
                                 <field name="fixed_price" widget="monetary" attrs="{'invisible':[('compute_price', '!=', 'fixed')]}"/>
                                 <label for="percent_price" string="Discount" attrs="{'invisible':[('compute_price', '!=', 'percentage')]}"/>
                                 <div class="o_row" attrs="{'invisible':[('compute_price', '!=', 'percentage')]}">


### PR DESCRIPTION
The two fields (name & price) were only updated on pricelist (`product.pricelist`) save, not when the rules were updated (`product.pricelist.item`).

The reason was that name and price are compute fields, which were added to the tree view but not added to the form view.

This commit adds "name" and "price" to the `product.pricelist.item` form view and hence the values will be updated as soon as the popup form is saved.

Fixes: #78488

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
