### PR TITLE
[FIX] stock: orderpoint doubled qty to order

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -399,7 +399,7 @@ msgid "A Manufacturing Order is already done or cancelled."
 msgstr ""
 
 #. module: mrp
-#: code:addons/mrp/models/stock_warehouse.py:0
+#: code:addons/mrp/models/stock_orderpoint.py:0
 #, python-format
 msgid ""
 "A product with a kit-type bill of materials can not have a reordering rule."

--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.exceptions import ValidationError, UserError
+from odoo.exceptions import UserError
 
 
 class StockWarehouse(models.Model):
@@ -296,13 +296,3 @@ class StockWarehouse(models.Model):
             if warehouse.manufacture_pull_id and name:
                 warehouse.manufacture_pull_id.write({'name': warehouse.manufacture_pull_id.name.replace(warehouse.name, name, 1)})
         return res
-
-class Orderpoint(models.Model):
-    _inherit = "stock.warehouse.orderpoint"
-
-    @api.constrains('product_id')
-    def check_product_is_not_kit(self):
-        if self.env['mrp.bom'].search(['|', ('product_id', 'in', self.product_id.ids),
-                                            '&', ('product_id', '=', False), ('product_tmpl_id', 'in', self.product_id.product_tmpl_id.ids),
-                                       ('type', '=', 'phantom')], count=True):
-            raise ValidationError(_("A product with a kit-type bill of materials can not have a reordering rule."))

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -412,7 +412,7 @@ class StockWarehouseOrderpoint(models.Model):
             lot_stock_id = lot_stock_id_by_warehouse[warehouse]
             orderpoint_id = orderpoint_by_product_location.get((product, lot_stock_id))
             if orderpoint_id:
-                self.env['stock.warehouse.orderpoint'].browse(orderpoint_id).qty_forecast += product_qty
+                self.env['stock.warehouse.orderpoint'].browse(orderpoint_id)._compute_qty()
             else:
                 orderpoint_values = self.env['stock.warehouse.orderpoint']._get_orderpoint_values(product, lot_stock_id)
                 orderpoint_values.update({


### PR DESCRIPTION
How to reproduce:
- Creates a product and creates an orderpoint for this product with the following value:
  - min & max at 0;
   - trigger manually;
  - multiple at 1;
- Creates a delivery for this product and confirms it;
- Open the Replenishment
        => You should see the orderpoint for this product with the qty. to order equals to the qty. to delivery.
- Set the qty. to order to 0 and re-open the Replenishment
        => The qty. to order is now the double of the qty. to delivered.
    
The quantity to delivered should be equals to the forecast demand.
The bug was due to the write on the field `qty_forecast` in the method `_get_orderpoint_action`. As it's a compute field, its value is computed before to increment its value, so the `qty_forecast` will be equals to the demand qty. then we add to it the product qty. and so, the forecast quantity is wrong when we compute the `qty_to_order`.
    
task-2674053