### PR TITLE
[IMP] stock: orderpoint by date instead of time

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -351,11 +351,12 @@ class StockWarehouseOrderpoint(models.Model):
             pwh_per_day[(lead_days, warehouse)].append(product.id)
         # group product by lead_days and warehouse in order to read virtual_available
         # in batch
+        today = fields.datetime.now().replace(hour=23, minute=59, second=59)
         for (days, warehouse), p_ids in pwh_per_day.items():
             products = self.env['product.product'].browse(p_ids)
             qties = products.with_context(
                 warehouse=warehouse.id,
-                to_date=fields.datetime.now() + relativedelta.relativedelta(days=days)
+                to_date=today + relativedelta.relativedelta(days=days)
             ).read(['virtual_available'])
             for qty in qties:
                 if float_compare(qty['virtual_available'], 0, precision_rounding=product.uom_id.rounding) >= 0:


### PR DESCRIPTION
Before this commit, the Replenishment orderpoints `qty_to_order` are computed according to a precise forecast which take the time in count.
For example, if you plan a consumption for a product with a purchase lead time of 2 days for the 2021-12-12 at 12:30, if the current date is 2021-12-10, the orderpoint for this product will have a quantity to order once the hour is meet too but not before. With this commit, it will take the forecast for the day regardless the time.

task-2652920