### PR TITLE
[IMP] account(_edi): Detect when an invoice is ready to be sent

### DIFF
--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -166,8 +166,10 @@ class AccountEdiDocument(models.Model):
         state = documents[0].state
         if doc_type == 'invoice':
             if state == 'to_send':
-                edi_result = edi_format._post_invoice_edi(documents.move_id)
-                _postprocess_post_edi_results(documents, edi_result)
+                invoices = documents.move_id
+                with invoices._send_only_when_ready():
+                    edi_result = edi_format._post_invoice_edi(invoices)
+                    _postprocess_post_edi_results(documents, edi_result)
             elif state == 'to_cancel':
                 edi_result = edi_format._cancel_invoice_edi(documents.move_id)
                 _postprocess_cancel_edi_results(documents, edi_result)

--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -411,6 +411,17 @@ class AccountMove(models.Model):
         self.env['account.edi.document'].create(edi_document_vals_list)
         self.edi_document_ids._process_documents_no_web_services()
 
+    def _is_ready_to_be_sent(self):
+        # OVERRIDE
+        # Prevent a mail to be sent to the customer if the EDI document is not sent.
+        res = super()._is_ready_to_be_sent()
+
+        if not res:
+            return False
+
+        edi_documents_to_send = self.edi_document_ids.filtered(lambda x: x.state == 'to_send')
+        return not bool(edi_documents_to_send)
+
     def _post(self, soft=True):
         # OVERRIDE
         # Set the electronic document to be posted and post immediately for synchronous formats.

--- a/addons/account_edi/tests/test_edi.py
+++ b/addons/account_edi/tests/test_edi.py
@@ -278,3 +278,17 @@ class TestAccountEdi(AccountEdiTestCommon, CronMixinCase):
             vals['invoice_line_vals_list'][0]['tax_detail_vals_list'][0]['tag_ids'], set(account_tag.ids))
         self.assertEqual(
             vals['invoice_line_vals_list'][0]['tax_detail_vals_list'][0]['tags'].name, "Test Tag")
+
+    def test_invoice_ready_to_be_sent(self):
+        def _is_needed_for_invoice(edi_format, invoice):
+            return True
+
+        with self.mock_edi(
+                _needs_web_services_method=_generate_mocked_needs_web_services(True),
+                _is_required_for_invoice_method=_is_needed_for_invoice,
+        ):
+            self.invoice.action_post()
+            doc = self.invoice._get_edi_document(self.edi_format)
+            self.assertFalse(self.invoice._is_ready_to_be_sent())
+            doc._process_documents_web_services(with_commit=False)
+            self.assertTrue(self.invoice._is_ready_to_be_sent())


### PR DESCRIPTION
In some flow like subscription, invoices are sent by mail automatically to the customer.
Sometimes, the invoice must be approved by the government before sending the mail like the Mexican EDI.
This commit aims to add a custom method to detect when an invoice is ready to be sent to the customer.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
