### PR TITLE
[FIX] sale_quotation_builder: quotation_description sanitize_attributes=False

### DIFF
--- a/addons/sale_quotation_builder/models/product_template.py
+++ b/addons/sale_quotation_builder/models/product_template.py
@@ -12,7 +12,7 @@ class ProductTemplate(models.Model):
         translate=html_translate, help="The quotation description (not used on eCommerce)")
 
     quotation_description = fields.Html('Quotation Description', compute='_compute_quotation_description',
-        help="This field uses the Quotation Only Description if it is defined, otherwise it will try to read the eCommerce Description.")
+        sanitize_attributes=False, help="This field uses the Quotation Only Description if it is defined, otherwise it will try to read the eCommerce Description.")
 
     def _compute_quotation_description(self):
         for record in self:


### PR DESCRIPTION
The quotation_description field on the sale order is copied from the product template, where it already is sanitize_attributes=False, and it has to stay like that because otherwise widgets like "tab" or "accordion" cannot be rendered correctly.

This is also linked to a bug in the ORM where the _related_attrs weren't copied correctly.

Related ORM PR: https://github.com/odoo/odoo/pull/78687
Ticket link: https://www.odoo.com/web#id=2487749&model=project.task

opw-2487749