### PR TITLE
[FIX] web:weird behaviour when change id in url

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1286,8 +1286,11 @@ function makeActionManager(env) {
             const view = _getView(viewType);
             if (view) {
                 // Params valid and view found => performs a "switchView"
-                await switchView(viewType, props);
-                return true;
+                return new Promise(function (resolve) {
+                    switchView(viewType, props)
+                        .then(resolve.bind(this, true))
+                        .catch(resolve.bind(this, false));
+                });
             }
         } else {
             const actionParams = _getActionParams();

--- a/addons/web/static/tests/webclient/actions/load_state_tests.js
+++ b/addons/web/static/tests/webclient/actions/load_state_tests.js
@@ -240,6 +240,63 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps(["/web/webclient/load_menus", "load_views", "read"]);
     });
 
+    QUnit.test("properly load default view if record is not available", async function (assert) {
+        assert.expect(12);
+        serverData.actions[6] = {
+            id: 6,
+            xml_id: "action_6",
+            name: "Partner",
+            res_model: "partner",
+            type: "ir.actions.act_window",
+            views: [[false, "kanban"], [false, "form"]],
+        };
+        serverData.menus[2] = {
+            id: 2,
+            children: [],
+            name: "App1",
+            appID: 1,
+            actionID: 6,
+        };
+        const mockRPC = async function (route, args) {
+            assert.step((args && args.method) || route);
+        };
+        const webClient = await createWebClient({ serverData, mockRPC });
+        await doAction(webClient, 6);
+        await testUtils.dom.click($(webClient.el).find(".o_kanban_view .o_kanban_record:first"));
+        await legacyExtraNextTick();
+        assert.containsOnce(webClient, ".o_form_view");
+        assert.strictEqual(
+            $(webClient.el).find(".o_control_panel .breadcrumb-item:last").text(),
+            "First record",
+            "should have opened the first record"
+        );
+        // enter wrong record id in url
+        webClient.env.bus.trigger("test:hashchange", {
+            id: 1001,
+            model: "partner",
+            action: 6,
+            menu_id: 2,
+
+        });
+        await testUtils.nextTick();
+        await legacyExtraNextTick();
+        assert.containsOnce(webClient, ".o_kanban_view");
+        assert.strictEqual(
+            $(webClient.el).find(".o_control_panel .breadcrumb-item").text(),
+            "Partner",
+            "should have opened the partner kanban view"
+        );
+        assert.verifySteps([
+            "/web/webclient/load_menus",
+            "/web/action/load",
+            "load_views",
+            "/web/dataset/search_read",
+            "read",
+            "read",
+            "/web/dataset/search_read"
+        ]);
+    });
+
     QUnit.test("properly load records with existing first APP", async function (assert) {
         assert.expect(7);
         const mockRPC = async function (route, args) {


### PR DESCRIPTION
with this commit, we fixes issue when change id in url and record not found.

Currently when we change id in url and record is not found it stay on same page,
but when use go back to main page of app and try to click another record, it
does not open any record until refresh. it's because promise failure case is not
maintained, so we return false when promise get failed so now it redirect on
dashboard of app.

task-2667987

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
