### PR TITLE
[FIX] web: Fix components position in modal

### DIFF
--- a/addons/web/static/src/legacy/scss/bootstrap_review.scss
+++ b/addons/web/static/src/legacy/scss/bootstrap_review.scss
@@ -74,8 +74,6 @@
     }
     .modal-body {
         overflow: auto;
-        // fix iOS issue https://github.com/scottjehl/Device-Bugs/issues/8
-        -webkit-transform: translate3d(0, 0, 0);
         min-height: 0;
     }
 }


### PR DESCRIPTION
When a components is in a modal (filter dropdown in the Search More modal for example), it will be shifted from the toggler button.
This is due to a `-webkit-transform: translate3d (0, 0, 0);` applied on the `modal-body`
which influences the `position: fixed` attribute of `.o-popper-position` in the `dropdown-menu`

```
It is positioned relative to the initial containing block established by the viewport,
except when one of its ancestors has a transform, perspective,
or filter property set to something other than none (see the CSS Transforms Spec),
in which case that ancestor behaves as the containing block. 
```

See: https://developer.mozilla.org/en-US/docs/Web/CSS/position

the translate3d was applied with https://github.com/odoo/odoo/pull/20314
As the bug is no longer exists, we can remove this style.

opw-2668638