### PR TITLE
[IMP] stock(_picking_batch): improve set/clear qty button

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1846,6 +1846,9 @@ class StockMove(models.Model):
                     continue
                 move_line.qty_done = move_line.product_uom_qty
 
+    def _clear_quantities_to_zero(self):
+        self.filtered(lambda m: m.state in ('partially_available', 'assigned')).move_line_ids.qty_done = 0
+
     def _adjust_procure_method(self):
         """ This method will try to apply the procure method MTO on some moves if
         a compatible MTO route is found. Else the procure method will be set to MTS

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -236,13 +236,16 @@
                 <field name="has_packages" invisible="1"/>
                 <field name="picking_type_entire_packs" invisible="1"/>
                 <field name="use_create_lots" invisible="1"/>
+                <field name="show_set_qty_button" invisible="1"/>
+                <field name="show_clear_qty_button" invisible="1"/>
 
                 <header>
                     <button name="action_confirm" attrs="{'invisible': [('show_mark_as_todo', '=', False)]}" string="Mark as Todo" type="object" class="oe_highlight" groups="base.group_user" data-hotkey="x"/>
                     <button name="action_assign" attrs="{'invisible': [('show_check_availability', '=', False)]}" string="Check Availability" type="object" class="oe_highlight" groups="base.group_user"/>
                     <button name="button_validate" attrs="{'invisible': ['|', ('state', 'in', ('waiting','confirmed')), ('show_validate', '=', False)]}" string="Validate" type="object" class="oe_highlight" groups="stock.group_stock_user" data-hotkey="v"/>
                     <button name="button_validate" attrs="{'invisible': ['|', ('state', 'not in', ('waiting', 'confirmed')), ('show_validate', '=', False)]}" string="Validate" type="object" groups="stock.group_stock_user" class="o_btn_validate" data-hotkey="v"/>
-                    <button name="action_set_quantities_to_reservation" attrs="{'invisible': ['|', ('show_validate', '=', False), ('immediate_transfer', '=', True)]}" string="Set quantities" type="object" groups="stock.group_stock_user" class="o_btn_validate" data-hotkey="g"/>
+                    <button name="action_set_quantities_to_reservation" attrs="{'invisible': [('show_set_qty_button', '=', False)]}" string="Set quantities" type="object" groups="stock.group_stock_user" class="o_btn_validate" data-hotkey="g"/>
+                    <button name="action_clear_quantities_to_zero" attrs="{'invisible': [('show_clear_qty_button', '=', False)]}" string="Clear quantities" type="object" groups="stock.group_stock_user" class="o_btn_validate" data-hotkey="g"/>
                     <widget name="signature" string="Sign" highlight="1"
                             attrs="{'invisible': ['|', '|', ('id', '=', False), ('picking_type_code', '!=', 'outgoing'), ('state', '!=', 'done')]}"
                             full_name="partner_id" groups="stock.group_stock_sign_delivery"/>

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -87,6 +87,8 @@
                 <field name="show_allocation" invisible="1"/>
                 <field name="picking_type_code" invisible="1"/>
                 <field name="is_wave" invisible="1"/>
+                <field name="show_set_qty_button" invisible="1"/>
+                <field name="show_clear_qty_button" invisible="1"/>
                 <header>
                     <button name="action_confirm" states="draft" string="Confirm" type="object" class="oe_highlight"/>
                     <button name="action_done" string="Validate" type="object" class="oe_highlight"
@@ -109,10 +111,9 @@
                                     ('show_check_availability', '=', False),
                                     ('show_validate', '=', False)]}"/>
                     <button name="action_set_quantities_to_reservation" string="Set quantities" type="object"
-                        attrs="{'invisible': [
-                            '|',
-                                ('state', '!=', 'in_progress'),
-                                ('show_validate', '=', False)]}"/>
+                        attrs="{'invisible': [('show_set_qty_button', '=', False)]}"/>
+                    <button name="action_clear_quantities_to_zero" string="Clear quantities" type="object"
+                        attrs="{'invisible': [('show_clear_qty_button', '=', False)]}"/>
                     <button name="action_assign" string="Check Availability" type="object"
                         attrs="{'invisible': [
                             '|',


### PR DESCRIPTION
Add a "clear qty" button to revert the change by "set qty" button in
(batch) picking.
On the move, Whenever the qty_done != reserved, we consider it a
manual change from the user. "set/clear qty" buttons won't change the
line with manual change.
Show "set qty" button when there are moves with 0 qty_done and non-zero
reserved. Show "clear qty" button when we don't show "set qty" button
and there are moves with qty done == reserved but the number is not 0.

Task-2659233





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
