### PR TITLE
[FIX] core: related field attributes

### DIFF
--- a/odoo/addons/test_new_api/models.py
+++ b/odoo/addons/test_new_api/models.py
@@ -345,6 +345,7 @@ class Foo(models.Model):
     name = fields.Char()
     value1 = fields.Integer(change_default=True)
     value2 = fields.Integer()
+    text = fields.Char(trim=False)
 
 
 class Bar(models.Model):
@@ -355,6 +356,8 @@ class Bar(models.Model):
     foo = fields.Many2one('test_new_api.foo', compute='_compute_foo', search='_search_foo')
     value1 = fields.Integer(related='foo.value1', readonly=False)
     value2 = fields.Integer(related='foo.value2', readonly=False)
+    text1 = fields.Char('Text1', related='foo.text', readonly=False)
+    text2 = fields.Char('Text2', related='foo.text', readonly=False, trim=True)
 
     @api.depends('name')
     def _compute_foo(self):

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -1051,6 +1051,25 @@ class TestFields(common.TransactionCase):
         discussion_field = discussion.fields_get(['name'])['name']
         self.assertEqual(message_field['help'], discussion_field['help'])
 
+    def test_25_related_attributes(self):
+        """ test the attributes of related fields """
+        text = self.registry['test_new_api.foo'].text
+        self.assertFalse(text.trim, "The target field is defined with trim=False")
+
+        # trim=True is the default on the field's class
+        self.assertTrue(type(text).trim, "By default, a Char field has trim=True")
+
+        # the parameter 'trim' is not set in text1's definition, so the field
+        # retrieves its value from text.trim
+        text1 = self.registry['test_new_api.bar'].text1
+        self.assertFalse(text1.trim, "The related field retrieves trim=False from target")
+
+        # KNOWN ISSUE: text2 is defined with trim=True, however its value is
+        # taken from text.trim because True is the default on the field's class
+        text2 = self.registry['test_new_api.bar'].text2
+        self.assertFalse(text2.trim,
+                         "The related field was defined with trim=True, but takes its value from target")
+
     def test_25_related_single(self):
         """ test related fields with a single field in the path. """
         record = self.env['test_new_api.related'].create({'name': 'A'})

--- a/odoo/addons/test_new_api/tests/test_schema.py
+++ b/odoo/addons/test_new_api/tests/test_schema.py
@@ -117,7 +117,7 @@ class TestSchema(common.TransactionCase):
         columns_data = self.get_columns_data('test_new_api_foo')
         self.assertEqual(set(columns_data),
                          {'id', 'create_date', 'create_uid', 'write_date',
-                          'write_uid', 'name', 'value1', 'value2'})
+                          'write_uid', 'name', 'value1', 'value2', 'text'})
 
         # retrieve schema data about the table's foreign keys
         foreign_keys = self.get_foreign_keys('test_new_api_foo')

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -505,7 +505,9 @@ class Field(MetaField('DummyField', (object,), {})):
 
         # copy attributes from field to self (string, help, etc.)
         for attr, prop in self.related_attrs:
-            if not getattr(self, attr):
+            # check whether 'attr' is explicitly set on self (from its field
+            # definition) with a value different from its default value
+            if getattr(self, attr) == self._slots[attr]:
                 setattr(self, attr, getattr(field, prop))
 
         for attr, value in field._attrs.items():


### PR DESCRIPTION
A related field copies the attributes from its target field, except for the attributes defined on the related field itself.  The implementation of this feature was not working properly for attributes with a truthy default value.

This commit fixes the issue, but in an incomplete way.  If an attribute on a related field has its default value, it will be overridden by the attribute from its target field.  So one cannot "force" an attribute on a related field to its default value.