### PR TITLE
[FIX] sale_stock_margin: use data of SOL's company

### DIFF
--- a/addons/sale_stock_margin/models/sale_order_line.py
+++ b/addons/sale_stock_margin/models/sale_order_line.py
@@ -11,14 +11,15 @@ class SaleOrderLine(models.Model):
     def _compute_purchase_price(self):
         lines_without_moves = self.browse()
         for line in self:
+            product = line.product_id.with_company(line.company_id)
             if not line.move_ids:
                 lines_without_moves |= line
-            elif line.product_id.categ_id.property_cost_method != 'standard':
-                purch_price = line.product_id.with_company(line.company_id)._compute_average_price(0, line.product_uom_qty, line.move_ids)
-                if line.product_uom and line.product_uom != line.product_id.uom_id:
-                    purch_price = line.product_id.uom_id._compute_price(purch_price, line.product_uom)
+            elif product.categ_id.property_cost_method != 'standard':
+                purch_price = product._compute_average_price(0, line.product_uom_qty, line.move_ids)
+                if line.product_uom and line.product_uom != product.uom_id:
+                    purch_price = product.uom_id._compute_price(purch_price, line.product_uom)
                 to_cur = line.currency_id or line.order_id.currency_id
-                line.purchase_price = line.product_id.cost_currency_id._convert(
+                line.purchase_price = product.cost_currency_id._convert(
                     from_amount=purch_price,
                     to_currency=to_cur,
                     company=line.company_id or self.env.company,


### PR DESCRIPTION
In a multi-company and multi-currency environment, the computation of
the purchase price may be based on the incorrect company (and thus lead
to incorrect results)

To reproduce the issue:
(Use demo data)
1. In Settings:
    - Enable "Multi-Currencies"
2. Update "My Company (Chicago)":
    - Currency: EUR
3. Edit currencies' rate for all companies(!):
    - USD: 1.0
    - EUR: 3.0
4. Create a product category PC:
    - Costing Method: FIFO
5. Create a product P:
    - Type: Storable
    - Category: PC
6. Switch to "My Company (Chicago)"
    - Note that in this company, the costing method of PC is "Standard
Price"
7. Edit P:
    - Cost: 10
8. Create a sale order SO:
    - Pricelist: EUR
    - Lines (add Cost columns):
        - 1 x P (Note that cost is 10€)
9. Confirm SO

Error: The sale order line is incorrect, the cost is now 30€. A rate
conversion has been applied on the amount

In `_compute_purchase_price`, several fields/methods depend on the SOL's
company: `property_cost_method`, `_compute_average_price`,
`cost_currency_id`. Therefore, we should include this specific company
in the environment of the product

OPW-2659265