### PR TITLE
[IMP] resource: assign a search_range for calendar_end

### DIFF
--- a/addons/resource/tests/test_resource.py
+++ b/addons/resource/tests/test_resource.py
@@ -493,7 +493,7 @@ class TestResMixin(TestResourceCommon):
         )
         self.assertEqual(result[self.john], (
             datetime_tz(2020, 4, 3, 8, 0, 0, tzinfo=self.john.tz),
-            None,
+            datetime_tz(2020, 4, 3, 23, 0, 0, tzinfo=self.john.tz),
         ))
 
         result = self.john._adjust_to_calendar(
@@ -501,9 +501,27 @@ class TestResMixin(TestResourceCommon):
             datetime_tz(2020, 4, 3, 14, 0, 0, tzinfo=self.john.tz),
         )
         self.assertEqual(result[self.john], (
-            None,
+            datetime_tz(2020, 4, 3, 8, 0, 0, tzinfo=self.john.tz),
             datetime_tz(2020, 4, 3, 13, 0, 0, tzinfo=self.john.tz),
         ))
+
+        result = self.john._adjust_to_calendar(
+            datetime_tz(2020, 3, 31, 0, 0, 0, tzinfo=self.john.tz),  # search between Tuesday and Thursday
+            datetime_tz(2020, 4, 2, 23, 59, 59, tzinfo=self.john.tz),
+        )
+        self.assertEqual(result[self.john], (
+            datetime_tz(2020, 3, 31, 8, 0, tzinfo=self.john.tz),
+            datetime_tz(2020, 3, 31, 16, 0, tzinfo=self.john.tz),
+        ))
+
+        result = self.john._adjust_to_calendar(
+            datetime_tz(2020, 3, 31, 0, 0, 0, tzinfo=self.john.tz),  # search between Tuesday and Friday
+            datetime_tz(2020, 4, 3, 23, 59, 59, tzinfo=self.john.tz),
+        )
+        result = self.john._adjust_to_calendar(
+            datetime_tz(2020, 3, 31, 8, 0, 0, tzinfo=self.john.tz),
+            datetime_tz(2020, 4, 3, 23, 0, 0, tzinfo=self.john.tz),
+        )
 
     def test_adjust_calendar_timezone_after(self):
         # Calendar:


### PR DESCRIPTION
Assign a search_range for calendar_end in the _adjust_to_calendar method in all conditions.
The search_range was only assigned a value if the start and end are on the same date before.

The _adjust_to_calendar method receives a start and end from midnight to midnight in the resource timezone.
Start and end datetimes can be set on a different day via the Gantt view set in month or year for example.
This commit ensures that a search_range is always assigned to find the calendar_end and not only when start and end are on the same day.
This allows to find the end of a shift searched over two days if the employee is only working one day.

task-2628876

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
