### PR TITLE
[IMP] crm: display lead reporting on all leads even if not group_use_lead

### DIFF
--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -67,6 +67,10 @@
                     <filter name="filter_opportunity" string="Opportunities" domain="[('type','=','opportunity')]" help="Show only opportunities" groups="crm.group_use_lead"/>
                     <filter name="filter_lead" string="Leads" domain="[('type','=', 'lead')]" help="Show only leads" groups="crm.group_use_lead"/>
                     <separator/>
+                    <filter string="Active" name="filter_active"
+                            domain="[('active', '=', True)]"/>
+                    <filter string="Inactive" name="filter_inactive"
+                            domain="[('active', '=', False)]"/>
                     <filter string="Won" name="won"
                             domain="[('probability', '=', 100)]"/>
                     <filter string="Lost" name="lost"
@@ -111,6 +115,23 @@
             </field>
         </record>
 
+        <record id="crm_lead_view_tree_reporting" model="ir.ui.view">
+            <field name="name">crm.lead.tree.lead.reporting</field>
+            <field name="model">crm.lead</field>
+            <field name="inherit_id" ref="crm.crm_case_tree_view_leads"/>
+            <field name="mode">primary</field>
+            <field name="priority">24</field>
+            <field name="arch" type="xml">
+                <xpath expr="field[@name='city']" position="attributes">
+                    <attribute name="optional">hide</attribute>
+                </xpath>
+                <xpath expr="field[@name='probability']" position="before">
+                    <field name="type" groups="crm.group_use_lead" optional="show"/>
+                    <field name="stage_id" optional="show"/>
+                </xpath>
+            </field>
+        </record>
+
         <record id="crm_opportunity_report_action" model="ir.actions.act_window">
             <field name="name">Pipeline Analysis</field>
             <field name="res_model">crm.lead</field>
@@ -137,8 +158,8 @@
             <field name="view_mode">graph,pivot,tree</field>
             <field name="search_view_id" ref="crm.crm_opportunity_report_view_search"/>
             <field name="context">{
-                'default_type': 'lead',
-                'search_default_filter_lead': True,
+                'search_default_filter_active': 1,
+                'search_default_filter_inactive': 1,
                 'search_default_filter_create_date': 1,
             }</field>
             <field name="view_ids"
@@ -146,7 +167,7 @@
                           (0, 0, {'view_mode': 'graph', 'view_id': ref('crm_opportunity_report_view_graph_lead')}),
                           (0, 0, {'view_mode': 'pivot', 'view_id': ref('crm_opportunity_report_view_pivot_lead')}),
                           (0, 0, {'view_mode': 'form', 'view_id': ref('crm_lead_view_form')}),
-                          (0, 0, {'view_mode': 'tree', 'view_id': ref('crm_case_tree_view_leads')}),
+                          (0, 0, {'view_mode': 'tree', 'view_id': ref('crm_lead_view_tree_reporting')}),
                          ]"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">

--- a/addons/crm/views/crm_menu_views.xml
+++ b/addons/crm/views/crm_menu_views.xml
@@ -70,17 +70,16 @@
         action="crm.action_opportunity_forecast"
         sequence="1"/>
     <menuitem
-        id="crm_opportunity_report_menu_lead"
-        name="Leads"
-        parent="crm_menu_report"
-        action="crm.crm_opportunity_report_action_lead"
-        groups="crm.group_use_lead"
-        sequence="2"/>
-    <menuitem
         id="crm_opportunity_report_menu" 
         name="Pipeline"
         parent="crm_menu_report"
         action="crm.crm_opportunity_report_action"
+        sequence="2"/>
+    <menuitem
+        id="crm_opportunity_report_menu_lead"
+        name="Leads"
+        parent="crm_menu_report"
+        action="crm.crm_opportunity_report_action_lead"
         sequence="3"/>
     <menuitem
         id="crm_activity_report_menu"

--- a/addons/crm/views/crm_team_views.xml
+++ b/addons/crm/views/crm_team_views.xml
@@ -101,7 +101,7 @@
         <record id="action_report_crm_lead_salesteam_view_tree" model="ir.actions.act_window.view">
             <field name="sequence">4</field>
             <field name="view_mode">tree</field>
-            <field name="view_id" ref="crm_case_tree_view_leads"/>
+            <field name="view_id" ref="crm_lead_view_tree_reporting"/>
             <field name="act_window_id" ref="action_report_crm_lead_salesteam"/>
         </record>
 


### PR DESCRIPTION
Purpose
=======

As a Lead Manager, I do not really care about what's in the "Lead Pipeline"
since this does not exist. Instead, I want to keep an eye on all the leads that
entered the CRM to see how well they are doing and how they are spread.

Specifications
==============

- Remove the group on the Reporting
	> Leads menu item, this menu can be used with Opportunities only

- Move it below the Pipeline report

- By default, this menu shows all crm.lead :
   - no matter the type (lead/opp) but with the filters in the search view
     if needed
   - no matter if won/active/lost (but again, filters allow me to change that
     if needed)
   - Default grouped by month creation date
   - Filtered on records created this year to avoid displaying 10 years of CRM
     usage - already done

=> The difference if I activate leads is that then I have the extra filters, ...
but this is already valid if I'm only working with opportunities

Task-2671372