### PR TITLE
[FIX] hr_expense: Error when create new expense product.

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -510,6 +510,7 @@
                             <group string="General Information">
                                 <field name="active" invisible="1"/>
                                 <field name="type" invisible="1"/>
+                                <field name="detailed_type" invisible="1"/>
                                 <field name="list_price"/>
                                 <field name="standard_price" help="When the cost of an expense product is different than 0, then the user using this product won't be able to change the amount of the expense, only the quantity. Use a cost different than 0 for expense categories funded by the company at fixed cost like allowances for mileage, per diem, accomodation or meal."/>
                                 <field name="uom_id" groups="uom.group_uom" options="{'no_create': True}"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When create expense product, it raise validation error.
The issue was mandatory field of product was not available on form view.

Fixes: #78498 

Current behavior before PR:

![137537577-402ef96c-891b-4844-95e6-b5f41c855ce5](https://user-images.githubusercontent.com/32053757/138259533-ae0e65c8-6eb5-4cc2-a4a6-fc55ffd39c2a.png)


Desired behavior after PR is merged:

Able to create expense product.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
