### PR TITLE
[FIX] web: missing dependency in assets_frontend

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -218,6 +218,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/src/core/utils/transitions.scss',  # included early because used by other files
             'web/static/src/core/**/*',
             ('remove', 'web/static/src/core/commands/**/*'),
+            ('remove', 'web/static/src/core/debug/debug_menu.js'),
             'web/static/src/public/error_notifications.js',
 
             'web/static/src/legacy/scss/base_frontend.scss',


### PR DESCRIPTION
The commit 6135b04 forgot to remove from the assets_frontend bundle
the DebugMenu which depends from the @web/core/commands/... features.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
