### PR TITLE
[IMP] hr_holidays: show all employees in list view

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -206,6 +206,7 @@ class HolidaysRequest(models.Model):
         inverse='_inverse_supported_attachment_ids')
     supported_attachment_ids_count = fields.Integer(compute='_compute_supported_attachment_ids')
     # UX fields
+    all_employee_ids = fields.Many2many('hr.employee', compute='_compute_all_employees')
     leave_type_request_unit = fields.Selection(related='holiday_status_id.request_unit', readonly=True)
     leave_type_support_document = fields.Boolean(related="holiday_status_id.support_document")
     # Interface fields used when not using hour-based computation
@@ -290,6 +291,11 @@ class HolidaysRequest(models.Model):
         tools.create_index(self._cr, 'hr_leave_date_to_date_from_index',
                            self._table, ['date_to', 'date_from'])
         return res
+
+    @api.depends('employee_id', 'employee_ids')
+    def _compute_all_employees(self):
+        for leave in self:
+            leave.all_employee_ids = leave.employee_id | leave.employee_ids
 
     @api.depends_context('uid')
     def _compute_description(self):

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -469,7 +469,8 @@
         <field name="model">hr.leave</field>
         <field name="arch" type="xml">
             <tree string="Time Off Requests" sample="1">
-                <field name="employee_id" widget="many2one_avatar_employee" decoration-muted="not active_employee"/>
+                <field name="employee_id" invisible="1" />
+                <field name="all_employee_ids" widget="many2many_avatar_employee" decoration-muted="not active_employee" string="Employees" />
                 <field name="department_id" optional="hidden"/>
                 <field name="holiday_type" string="Mode" groups="base.group_no_one"/>
                 <field name="holiday_status_id" class="font-weight-bold"/>


### PR DESCRIPTION
A time off for multiple employees was not showing who the employees were
in the list view.

Now it shows the avatar of all employees in the list view.

TaskID: 2674062

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
