### PR TITLE
[FIX] survey: question not define in survey.layout on print route

### DIFF
--- a/addons/survey/views/survey_templates_print.xml
+++ b/addons/survey/views/survey_templates_print.xml
@@ -15,6 +15,7 @@
                     </div>
                     <div role="form">
                         <fieldset disabled="disabled">
+                            <t t-set="question" t-value="False" />
                             <t t-foreach='survey.question_and_page_ids' t-as='question'>
                                 <t t-if="question.is_page and
                                             (any(q in questions_to_display for q in question.question_ids)


### PR DESCRIPTION
How to reproduce issue
-----------------------

- Create a survey with more than one question
  - Layout: One page per question
- Complete a first survey
- Start a second survey but don't finish it

- Click on see result
- Click on the answer of the uncompleted answer

you got a traceback
'NoneType' object has no attribute 'id'

Node: <t t-set="page_number" t-value="page_ids.index(question.id)"/>

Why this is happening ?
-----------------------

question is define in survey_page_print template inside a foreach.
The scope of question thus is limited to this foreach.

Solution
--------

Declare question before the foreach in a t-set





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
