### PR TITLE
[FIX] crm: prevent division by zero in lead probability computation

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1453,6 +1453,9 @@ class Lead(models.Model):
                     total_won = team_won if field == 'stage_id' else field_result['won_total']
                     total_lost = team_lost if field == 'stage_id' else field_result['lost_total']
 
+                    # if one count = 0, we cannot compute lead probability
+                    if not total_won or not total_lost:
+                        continue
                     s_lead_won *= value_result['won'] / total_won
                     s_lead_lost *= value_result['lost'] / total_lost
 


### PR DESCRIPTION
If for some reason we cannot compute lead probability, we should simply
continue to the next value without causing a division by zero.

This commit is a backport of part of https://github.com/odoo/odoo/pull/76110.

Task-2674586