### PR TITLE
[IMP] website(_forum/_profile): remove _get_http_domain method

### DIFF
--- a/addons/website/controllers/backend.py
+++ b/addons/website/controllers/backend.py
@@ -28,8 +28,7 @@ class WebsiteBackend(http.Controller):
         multi_website = request.env.user.has_group('website.group_multi_website')
         websites = multi_website and request.env['website'].search([]) or current_website
         dashboard_data['websites'] = websites.read(['id', 'name'])
-        for rec, website in zip(websites, dashboard_data['websites']):
-            website['domain'] = rec._get_http_domain()
+        for website in dashboard_data['websites']:
             if website['id'] == current_website.id:
                 website['selected'] = True
 

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -108,10 +108,10 @@ class Website(Home):
 
         if not isredir and website.domain:
             domain_from = request.httprequest.environ.get('HTTP_HOST', '')
-            domain_to = werkzeug.urls.url_parse(website._get_http_domain()).netloc
+            domain_to = werkzeug.urls.url_parse(website.domain).netloc
             if domain_from != domain_to:
                 # redirect to correct domain for a correct routing map
-                url_to = werkzeug.urls.url_join(website._get_http_domain(), '/website/force/%s?isredir=1&path=%s' % (website.id, path))
+                url_to = werkzeug.urls.url_join(website.domain, '/website/force/%s?isredir=1&path=%s' % (website.id, path))
                 return request.redirect(url_to)
         website._force()
         return request.redirect(path)

--- a/addons/website/models/ir_model.py
+++ b/addons/website/models/ir_model.py
@@ -27,11 +27,11 @@ class BaseModel(models.AbstractModel):
 
         if self._name == 'website':
             # Note that website_1.company_id.website_id might not be website_1
-            return self._get_http_domain() or super().get_base_url()
+            return self.domain or super().get_base_url()
         if 'website_id' in self and self.website_id.domain:
-            return self.website_id._get_http_domain()
+            return self.website_id.domain
         if 'company_id' in self and self.company_id.website_id.domain:
-            return self.company_id.website_id._get_http_domain()
+            return self.company_id.website_id.domain
         return super().get_base_url()
 
     def get_website_meta(self):

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -447,9 +447,9 @@ class View(models.Model):
 
             cur = Website.get_current_website()
             if self.env.user.has_group('website.group_website_publisher') and self.env.user.has_group('website.group_multi_website'):
-                qcontext['multi_website_websites_current'] = {'website_id': cur.id, 'name': cur.name, 'domain': cur._get_http_domain()}
+                qcontext['multi_website_websites_current'] = cur.name
                 qcontext['multi_website_websites'] = [
-                    {'website_id': website.id, 'name': website.name, 'domain': website._get_http_domain()}
+                    {'website_id': website.id, 'name': website.name, 'domain': website.domain}
                     for website in Website.search([]) if website != cur
                 ]
 

--- a/addons/website/models/res_config_settings.py
+++ b/addons/website/models/res_config_settings.py
@@ -179,12 +179,12 @@ class ResConfigSettings(models.TransientModel):
         }
 
     def action_ping_sitemap(self):
-        if not self.website_id._get_http_domain():
+        if not self.website_id.domain:
             raise UserError(_("You haven't defined your domain"))
 
         return {
             'type': 'ir.actions.act_url',
-            'url': 'http://www.google.com/ping?sitemap=%s/sitemap.xml' % self.website_id._get_http_domain(),
+            'url': 'http://www.google.com/ping?sitemap=%s/sitemap.xml' % self.website_id.domain,
             'target': 'new',
         }
 

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -976,7 +976,7 @@ class Website(models.Model):
             is host:port in the version of `url_parse` we use."""
             # Here we add http:// to the domain if it's not set because
             # `url_parse` expects it to be set to correctly return the `netloc`.
-            website_domain = urls.url_parse(website._get_http_domain()).netloc
+            website_domain = urls.url_parse(website.domain or '').netloc
             if ignore_port:
                 website_domain = _remove_port(website_domain)
                 domain_name = _remove_port(domain_name)
@@ -1285,18 +1285,6 @@ class Website(models.Model):
             'url': path,
             'target': 'self',
         }
-
-    def _get_http_domain(self):
-        """Get the domain of the current website, prefixed by http if no
-        scheme is specified.
-
-        Empty string if no domain is specified on the website.
-        """
-        self.ensure_one()
-        if not self.domain:
-            return ''
-        res = urls.url_parse(self.domain)
-        return 'http://' + self.domain if not res.scheme else self.domain
 
     def _get_canonical_url_localized(self, lang, canonical_params):
         """Returns the canonical URL for the current request with translatable

--- a/addons/website/views/website_navbar_templates.xml
+++ b/addons/website/views/website_navbar_templates.xml
@@ -88,12 +88,12 @@
                         <a class="dropdown-toggle" data-toggle="dropdown" href="#" accesskey="w">
                             <i class="fa fa-globe d-lg-none"/>
                             <span class="d-none d-lg-inline-block">
-                                <t t-esc="multi_website_websites_current['name']"/>
+                                <t t-esc="multi_website_websites_current"/>
                             </span>
                         </a>
                         <div class="dropdown-menu" role="menu">
                             <div class="d-lg-none dropdown-item active">
-                                <span t-esc="multi_website_websites_current['name']"/>
+                                <span t-esc="multi_website_websites_current"/>
                             </div>
                             <t t-foreach="multi_website_websites" t-as="multi_website_website">
                                 <a role="menuitem" href="#"

--- a/addons/website_forum/views/website_forum_profile.xml
+++ b/addons/website_forum/views/website_forum_profile.xml
@@ -12,7 +12,7 @@
     <template id="user_profile_sub_nav" inherit_id="website_profile.user_profile_sub_nav">
         <xpath expr="//nav" position="before">
             <div t-if="request.params.get('forum_origin')" class="o_wprofile_all_users_nav_btn_container col pr-0 flex-grow-0">
-                <a t-att-href="request.website._get_http_domain() + request.params.get('forum_origin')"
+                <a t-att-href="(request.website.domain or '') + request.params.get('forum_origin')"
                     class="o_wprofile_all_users_nav_btn btn text-nowrap">
                     <i class="fa fa-chevron-left small"/> Back
                 </a>

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -394,7 +394,7 @@
                 <nav t-if="request.params.get('url_origin') and request.params.get('name_origin')" aria-label="breadcrumb">
                     <ol class="breadcrumb p-0 bg-white">
                         <li class="breadcrumb-item">
-                            <a t-att-href="request.website._get_http_domain() + request.params.get('url_origin')" t-esc="request.params.get('name_origin')"/>
+                            <a t-att-href="(request.website.domain or '') + request.params.get('url_origin')" t-esc="request.params.get('name_origin')"/>
                         </li>
                         <li class="breadcrumb-item">Badges</li>
                     </ol>


### PR DESCRIPTION
Before Odoo saas-14.4, one should call `_get_http_domain()` on website to get
its domain. Indeed, that method was in charge of cleaning that domain, as it
was done with commit [1].

Since Odoo saas-14.4, that cleaning is automatically performed on domain before
saving it into database, thanks to commit [2].

Thus, we can now remove the `_get_http_domain()` and use directly the domain as
it is considered clean.

Note that migrated databases coming from version older than Odoo saas-14.4
could still have an incorrect domain (trailing slash, no scheme..).
This will be handled during migration with [3].

[1]: https://github.com/odoo/odoo/commit/3ad775aab717b395a5d11527aeb3596af66afa99
[2]: https://github.com/odoo/odoo/commit/042c95b0219bb0aa13e73385e092fa76ff1a1b0a
[3]: https://github.com/odoo/upgrade/pull/2951

task-2674684
