### PR TITLE
[FIX] stock: inventory adjustments fixes

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -556,8 +556,9 @@ class StockQuant(models.Model):
         if self.location_id:
             return
         if self.product_id.tracking in ['lot', 'serial']:
-            previous_quants = self.env['stock.quant'].search(
-                [('product_id', '=', self.product_id.id)], limit=1, order='create_date desc')
+            previous_quants = self.env['stock.quant'].search([
+                ('product_id', '=', self.product_id.id),
+                ('location_id.usage', 'in', ['internal', 'transit'])], limit=1, order='create_date desc')
             if previous_quants:
                 self.location_id = previous_quants.location_id
         if not self.location_id:

--- a/addons/stock/wizard/stock_track_confirmation.py
+++ b/addons/stock/wizard/stock_track_confirmation.py
@@ -13,8 +13,8 @@ class StockTrackConfirmation(models.TransientModel):
     product_ids = fields.Many2many('product.product', string='Products')
 
     def action_confirm(self):
-        for confirmation in self:
-            confirmation.quant_ids._apply_inventory()
+        self.quant_ids._apply_inventory()
+        self.quant_ids.inventory_quantity_set = False
 
     @api.onchange('product_ids')
     def _onchange_quants(self):


### PR DESCRIPTION
 - When locations are activated, fix not being able to add a quant for tracked products just after
creating one from the 'update quantity' window due to Inventory Adjustment location being auto-selected [since it is the last quant]
 - Fix quant not properly making fields invisible after confirming from the stock track
confirmation window

Task-Id: 2674732

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
