### PR TITLE
[FIX] delivery_mondialrelay: fix typo in method name

### DIFF
--- a/addons/delivery_mondialrelay/models/delivery_carrier.py
+++ b/addons/delivery_mondialrelay/models/delivery_carrier.py
@@ -26,4 +26,4 @@ class DeliveryCarrierMondialRelay(models.Model):
                 'track': picking.carrier_tracking_ref,
                 'lang': (picking.partner_id.lang or 'fr').split('_')[0],
             }
-        return super().based_on_rule_get_tracking_link(picking)
+        return super().base_on_rule_get_tracking_link(picking)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
