### PR TITLE
[FIX] {purchase_,sale_}stock, stock: round qty in report

### DIFF
--- a/addons/purchase_stock/report/report_stock_forecasted.xml
+++ b/addons/purchase_stock/report/report_stock_forecasted.xml
@@ -4,7 +4,7 @@
         <xpath expr="//tr[@name='draft_picking_in']" position="after">
             <tr t-if="docs['draft_purchase_qty']" name="draft_po_in">
                 <td colspan="2">Draft PO</td>
-                <td t-esc="docs['draft_purchase_qty']" class="text-right"/>
+                <td t-esc="docs['draft_purchase_qty']" class="text-right" t-options='{"widget": "float", "decimal_precision": "Product Unit of Measure"}'/>
                 <td t-esc="docs['uom']" groups="uom.group_uom"/>
             </tr>
         </xpath>

--- a/addons/sale_stock/report/report_stock_forecasted.xml
+++ b/addons/sale_stock/report/report_stock_forecasted.xml
@@ -4,7 +4,7 @@
         <xpath expr="//tr[@name='draft_picking_out']" position="after">
             <tr t-if="docs['draft_sale_qty']" name="draft_so_out">
                 <td colspan="2">Draft SO</td>
-                <td t-esc="-docs['draft_sale_qty']" class="text-right"/>
+                <td t-esc="-docs['draft_sale_qty']" class="text-right" t-options='{"widget": "float", "decimal_precision": "Product Unit of Measure"}'/>
                 <td t-esc="docs['uom']" groups="uom.group_uom"/>
             </tr>
         </xpath>

--- a/addons/stock/report/report_stock_forecasted.xml
+++ b/addons/stock/report/report_stock_forecasted.xml
@@ -58,21 +58,21 @@
             <div class="row">
                 <div class="mx-3 text-center">
                     <div class="h3">
-                        <t t-esc="docs['quantity_on_hand']"/>
+                        <t t-esc="docs['quantity_on_hand']" t-options='{"widget": "float", "decimal_precision": "Product Unit of Measure"}'/>
                         <t t-esc="docs['uom']" groups="uom.group_uom"/>
                     </div>
                     <div>On Hand</div>
                 </div>
                 <div t-attf-class="mx-3 text-center #{docs['virtual_available'] &lt; 0 and 'text-danger'}">
                     <div class="h3">
-                        <t t-esc="docs['virtual_available']"/>
+                        <t t-esc="docs['virtual_available']" t-options='{"widget": "float", "decimal_precision": "Product Unit of Measure"}'/>
                         <t t-esc="docs['uom']" groups="uom.group_uom"/>
                     </div>
                     <div>Forecasted</div>
                 </div>
                 <div name="pending_forecasted" t-attf-class="mx-3 text-center #{future_virtual_available &lt; 0 and 'text-danger'}">
                     <div class="h3">
-                        <t t-esc="future_virtual_available"/>
+                        <t t-esc="future_virtual_available" t-options='{"widget": "float", "decimal_precision": "Product Unit of Measure"}'/>
                         <t t-esc="docs['uom']" groups="uom.group_uom"/>
                     </div>
                     <div>Forecasted<br/>+ Pending</div>
@@ -145,26 +145,26 @@
                     <thead>
                         <tr class="o_forecasted_row">
                             <td colspan="2">Forecasted Inventory</td>
-                            <td t-esc="docs['virtual_available']" class="text-right"/>
+                            <td t-esc="docs['virtual_available']" class="text-right" t-options='{"widget": "float", "decimal_precision": "Product Unit of Measure"}'/>
                             <td t-esc="docs['uom']" groups="uom.group_uom"/>
                         </tr>
                     </thead>
                     <tbody t-if="docs['qty']['in']">
                         <tr t-if="docs['draft_picking_qty']['in']" name="draft_picking_in">
                             <td colspan="2">Incoming Draft Transfer</td>
-                            <td t-esc="docs['draft_picking_qty']['in']" class="text-right"/>
+                            <td t-esc="docs['draft_picking_qty']['in']" class="text-right" t-options='{"widget": "float", "decimal_precision": "Product Unit of Measure"}'/>
                             <td t-esc="docs['uom']" groups="uom.group_uom"/>
                         </tr>
                         <tr t-if="docs['draft_picking_qty']['out']" name="draft_picking_out">
                             <td colspan="2">Outgoing Draft Transfer</td>
-                            <td t-esc="-docs['draft_picking_qty']['out']" class="text-right"/>
+                            <td t-esc="-docs['draft_picking_qty']['out']" class="text-right" t-options='{"widget": "float", "decimal_precision": "Product Unit of Measure"}'/>
                             <td t-esc="docs['uom']" groups="uom.group_uom"/>
                         </tr>
                     </tbody>
                     <thead>
                         <tr class="o_forecasted_row">
                             <td colspan="2">Forecasted with Pending</td>
-                            <td t-esc="future_virtual_available" class="text-right"/>
+                            <td t-esc="future_virtual_available" class="text-right" t-options='{"widget": "float", "decimal_precision": "Product Unit of Measure"}'/>
                             <td t-esc="docs['uom']" groups="uom.group_uom"/>
                         </tr>
                     </thead>


### PR DESCRIPTION
Due to floating point limitation, the quantities displayed in the
forecasted report should be formatted to ensure the rounding.

Issue example:
(Need stock)
1. Create a storable product P
2. Update its quantity to 7.1
3. Consult the Forecasted Report

Error:
Quantities are "7.1000000000000005 Units". In this case, the
floating-point issue comes from the method `float_round()`

Another example:
(Need purchase_stock)
1. Create a storable product P
2. Update its quantity to 0.1
3. Create a PO with 0.2 x P
4. Consult the Forecasted Report

Error:
The "Forecasted + Pending" quantity is 0.30000000000000004 Units. This
field is directly computed while rendering the report, it's the sum of
0.1 and 0.2 which, in python, results in 0.30000000000000004
(floating-point issue)

Since the rounding of these quantities are actually based on the decimal
precision of the UoM, this commit may slightly change the report.
Suppose the generic precision is .001 and the precision of "Units" is
0.01: if the quantity is 12.34, one zero will be added in the report:
12.340. However, these unnecessary zeros do not change the information
that is initially displayed. Moreover, the UoM precision can not be
greater than the generic precision, so we will never lose a part of the
quantity to display.

OPW-2611892