### PR TITLE
[FIX] mrp_subcontracting, stock: don't change loc when dupe SN

### DIFF
--- a/addons/mrp_subcontracting/i18n/mrp_subcontracting.pot
+++ b/addons/mrp_subcontracting/i18n/mrp_subcontracting.pot
@@ -107,6 +107,13 @@ msgstr ""
 msgid "Mandatory"
 msgstr ""
 
+#. module: stock
+#: code:addons/mrp_subcontracting/models/stock_move_line.py:0
+#, python-format
+msgid ""
+"Make sure you validate or adapt the related resupply picking to your subcontractor in order to avoid inconsistencies in your stock."
+msgstr ""
+
 #. module: mrp_subcontracting
 #: code:addons/mrp_subcontracting/models/stock_picking.py:0
 #, python-format

--- a/addons/mrp_subcontracting/models/__init__.py
+++ b/addons/mrp_subcontracting/models/__init__.py
@@ -5,6 +5,7 @@ from . import product
 from . import res_company
 from . import res_partner
 from . import stock_move
+from . import stock_move_line
 from . import stock_picking
 from . import stock_quant
 from . import stock_rule

--- a/addons/mrp_subcontracting/models/stock_move_line.py
+++ b/addons/mrp_subcontracting/models/stock_move_line.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+from odoo import _, api, models
+
+
+class StockMoveLine(models.Model):
+    _inherit = 'stock.move.line'
+
+    @api.onchange('lot_name', 'lot_id')
+    def _onchange_serial_number(self):
+        current_location_id = self.location_id
+        res = super()._onchange_serial_number()
+        if res and not self.lot_name and self.company_id.subcontracting_location_id == current_location_id:
+            # we want to avoid auto-updating source location in this case + change the warning message
+            self.location_id = current_location_id
+            res['warning']['message'] = res['warning']['message'].split("\n\n", 1)[0] + "\n\n" + \
+                _("Make sure you validate or adapt the related resupply picking to your subcontractor in order to avoid inconsistencies in your stock.")
+        return res

--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -6498,7 +6498,8 @@ msgstr ""
 #: code:addons/stock/models/stock_quant.py:0
 #, python-format
 msgid ""
-"Serial number (%s) is not located in %s, but is located in location(s): %s. "
+"Serial number (%s) is not located in %s, but is located in location(s): %s.\n"
+"\n"
 "Please correct this to prevent inconsistent data."
 msgstr ""
 
@@ -6506,7 +6507,8 @@ msgstr ""
 #: code:addons/stock/models/stock_quant.py:0
 #, python-format
 msgid ""
-"Serial number (%s) is not located in %s, but is located in location(s): %s. "
+"Serial number (%s) is not located in %s, but is located in location(s): %s.\n"
+"\n"
 "Source location for this move will be changed to %s"
 msgstr ""
 
@@ -7204,7 +7206,7 @@ msgstr ""
 msgid ""
 "The Serial Number (%s) is already used in these location(s): %s.\n"
 "\n"
-"Is this expected? For example this can occur if a delivery operation is validated before its corresponding receipt operation is validated. In this case the issue will be solved automatically once all steps are completed. Otherwise, the serial numbershould be corrected to prevent inconsistent data."
+"Is this expected? For example this can occur if a delivery operation is validated before its corresponding receipt operation is validated. In this case the issue will be solved automatically once all steps are completed. Otherwise, the serial number should be corrected to prevent inconsistent data."
 msgstr ""
 
 #. module: stock

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -920,7 +920,7 @@ class StockQuant(models.Model):
                     message =  _('The Serial Number (%s) is already used in these location(s): %s.\n\n'
                                  'Is this expected? For example this can occur if a delivery operation is validated '
                                  'before its corresponding receipt operation is validated. In this case the issue will be solved '
-                                 'automatically once all steps are completed. Otherwise, the serial numbershould be corrected to '
+                                 'automatically once all steps are completed. Otherwise, the serial number should be corrected to '
                                  'prevent inconsistent data.',
                                  lot_id.name, ', '.join(sn_locations.mapped('display_name')))
 
@@ -938,11 +938,13 @@ class StockQuant(models.Model):
                                 recommended_location = location
                                 break
                     if recommended_location:
-                        message = _('Serial number (%s) is not located in %s, but is located in location(s): %s. Source location for this move will be changed to %s',
-                        lot_id.name, source_location_id.display_name, ', '.join(sn_locations.mapped('display_name')), recommended_location.display_name)
+                        message = _('Serial number (%s) is not located in %s, but is located in location(s): %s.\n\n'
+                                    'Source location for this move will be changed to %s',
+                                    lot_id.name, source_location_id.display_name, ', '.join(sn_locations.mapped('display_name')), recommended_location.display_name)
                     else:
-                        message = _('Serial number (%s) is not located in %s, but is located in location(s): %s. Please correct this to prevent inconsistent data.',
-                        lot_id.name, source_location_id.display_name, ', '.join(sn_locations.mapped('display_name')))
+                        message = _('Serial number (%s) is not located in %s, but is located in location(s): %s.\n\n'
+                                    'Please correct this to prevent inconsistent data.',
+                                    lot_id.name, source_location_id.display_name, ', '.join(sn_locations.mapped('display_name')))
         return message, recommended_location
 
 


### PR DESCRIPTION
Previous task: odoo/odoo#61287 improved warnings for when using a
duplicate SN, including an auto-update of the source location when
appropriate. Unfortunately the auto-update is too risky when registering
a subcontracting SN tracked components.

Instead, we no longer update the source location when in a
subcontracting situation and update the warning message to match the
expected flow to fix the issue.

Task: 2669180

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
