### PR TITLE
[FIX] point_of_sale: better error when closing with invoices not posted

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -5645,6 +5645,14 @@ msgstr ""
 #. module: point_of_sale
 #: code:addons/point_of_sale/models/pos_session.py:0
 #, python-format
+msgid ""
+"You cannot close the POS when invoices are not posted.\n"
+"Invoices: %s"
+msgstr ""
+
+#. module: point_of_sale
+#: code:addons/point_of_sale/models/pos_session.py:0
+#, python-format
 msgid "You cannot close the POS when orders are still in draft"
 msgstr ""
 

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -190,6 +190,14 @@ class PosSession(models.Model):
                 raise UserError(_("Some Cash Registers are already posted. Please reset them to new in order to close the session.\n"
                                   "Cash Registers: %r", list(statement.name for statement in closed_statement_ids)))
 
+    def _check_invoices_are_posted(self):
+        unposted_invoices = self.order_ids.account_move.filtered(lambda x: x.state != 'posted')
+        if unposted_invoices:
+            raise UserError(_('You cannot close the POS when invoices are not posted.\n'
+                              'Invoices: %s') % str.join('\n',
+                                                         ['%s - %s' % (invoice.name, invoice.state) for invoice in
+                                                          unposted_invoices]))
+
     @api.model
     def create(self, values):
         config_id = values.get('config_id') or self.env.context.get('default_config_id')
@@ -318,6 +326,7 @@ class PosSession(models.Model):
             if self.state == 'closed':
                 raise UserError(_('This session is already closed.'))
             self._check_if_no_draft_orders()
+            self._check_invoices_are_posted()
             if self.update_stock_at_closing:
                 self._create_picking_at_end_of_session()
             # Users without any accounting rights won't be able to create the journal entry. If this


### PR DESCRIPTION
A pos.session cannot be closed if there is any draft|cancel account.move
associated to one of its pos.order.
The check is done during the reconciliation.

This commit checks the invoices state at the very beginning of the closing
and gives a more complete error message with the invoices name and state.
With this info, the customer can check the invoices without asking the support.

Steps to reproduce:
- Have a V14 with point_of_sale and account_accountant (It is not reproducible in V13)
- Go to Point of Sale / Configuration / Point of Sale
	- Open a pos.config PC
		- Check "Invoicing"
- Go to Point of Sale
	- Open a pos.session PS related to PC
		- Process a sell until the payment screen (pos.order PO)
		- At the payment screen, select any customer and invoice the order
		- Validate
		- Close PS
- Go to Point of Sale / Orders / Orders
	- Open PO
		- Open the invoice associated
			- Click "Reset to draft"
- Go to Point of Sale / Sessions
	- Open PS
		- Click "Close session & Post entries"

opw-2658654