### PR TITLE
[FIX] purchase_requisition : PO Agreements wrong qty ordered

### DIFF
--- a/addons/purchase_requisition/models/purchase_requisition.py
+++ b/addons/purchase_requisition/models/purchase_requisition.py
@@ -235,6 +235,7 @@ class PurchaseRequisitionLine(models.Model):
 
     @api.depends('requisition_id.purchase_ids.state')
     def _compute_ordered_qty(self):
+        line_found = set()
         for line in self:
             total = 0.0
             for po in line.requisition_id.purchase_ids.filtered(lambda purchase_order: purchase_order.state in ['purchase', 'done']):
@@ -243,7 +244,11 @@ class PurchaseRequisitionLine(models.Model):
                         total += po_line.product_uom._compute_quantity(po_line.product_qty, line.product_uom_id)
                     else:
                         total += po_line.product_qty
-            line.qty_ordered = total
+            if line.product_id not in line_found :
+                line.qty_ordered = total
+                line_found.add(line.product_id)
+            else:
+                line.qty_ordered = 0
 
     @api.onchange('product_id')
     def _onchange_product_id(self):


### PR DESCRIPTION
Current behavior:
If you have 2 time the same product in the agreement and you confirm an order with just one line of this item
the 2 lines in the agreement will have the quantity.

Expected behavior:
Only the ordered item should have the quantity applied. In this case the products are compared with the price and
product ID. If you modify the price in the PO the first line of the agreement will have the quantity by default.

Steps to reproduce:
1. Create a new Purchase Agreement
-Add two lines with the same product
- First line has a scheduled date and price that are different from the second line
2. Generate RFQ and confirm PO with only the first product line and a set quantity
3. Once the PO has been confirmed, going back to the Purchase Agreement, the ordered quantities on both lines will be the same, although the PO was generated for only the first line.

opw-2627898

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
