### PR TITLE
[FIX] point_of_sale: impossible to close session

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -333,7 +333,7 @@ class PosSession(models.Model):
                 # Set the uninvoiced orders' state to 'done'
                 self.env['pos.order'].search([('session_id', '=', self.id), ('state', '=', 'paid')]).write({'state': 'done'})
             else:
-                self.move_id.unlink()
+                self.move_id.sudo().unlink()
         else:
             statement = self.cash_register_id
             if not self.config_id.cash_control:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Open session with cash control
- Set 300 €
- Close session
- Add Cash 50€
- Close session
- Set end Cash at 350 €

--> It raise an error

@caburj @pimodoo 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
