### PR TITLE
[IMP] stock_account: set default stock JE name

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -449,6 +449,7 @@ class StockMove(models.Model):
         if move_lines:
             date = self._context.get('force_period_date', fields.Date.context_today(self))
             new_account_move = AccountMove.sudo().create({
+                'name': '/',
                 'journal_id': journal_id,
                 'line_ids': move_lines,
                 'date': date,


### PR DESCRIPTION
Without having default name, a computation will be invoked during creation of move. With this change, computation will be delayed until posting move

Current behavior before PR:

By not having a default name, computation will be invoked by [this line](https://github.com/odoo/odoo/blob/f34e441578bd2ba93dff1feffe6cafee633b9d32/addons/account/models/account_move.py#L1986). Setting default name will cause the behavior of recomputing sequence to be performed inside the `post` method

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
