### PR TITLE
[FIX] project: onchange is not being applied correctly

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1820,7 +1820,7 @@ class Task(models.Model):
 
             Use the project partner_id if any, or else the parent task partner_id.
         """
-        for task in self.filtered(lambda task: not task.partner_id):
+        for task in self:
             # When the task has a parent task, the display_project_id can be False or the project choose by the user for this task.
             project = task.display_project_id if task.parent_id and task.display_project_id else task.project_id
             task.partner_id = self._get_default_partner_id(project, task.parent_id)

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -118,9 +118,8 @@ class ProjectTask(models.Model):
     @api.depends('commercial_partner_id', 'sale_line_id.order_partner_id.commercial_partner_id', 'parent_id.sale_line_id', 'project_id.sale_line_id')
     def _compute_sale_line(self):
         for task in self:
-            if not task.sale_line_id:
-                # if the display_project_id is set then it means the task is classic task or a subtask with another project than its parent.
-                task.sale_line_id = task.display_project_id.sale_line_id or task.parent_id.sale_line_id or task.project_id.sale_line_id
+            # if the display_project_id is set then it means the task is classic task or a subtask with another project than its parent.
+            task.sale_line_id = task.display_project_id.sale_line_id or task.parent_id.sale_line_id or task.project_id.sale_line_id
             # check sale_line_id and customer are coherent
             if task.sale_line_id.order_partner_id.commercial_partner_id != task.partner_id.commercial_partner_id:
                 task.sale_line_id = False


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On change is not being applied on customer & Sale order item when project is changed

Current behavior before PR:
Onchange of project_id doesn't change the customer/sale order item even if it is assigned to project

Desired behavior after PR is merged:
On change will be applied on both customer and sale order item in project task form

Fixes https://github.com/odoo/odoo/issues/78755

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
