### PR TITLE
[FIX] hr_holidays

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -272,6 +272,7 @@ class HolidaysType(models.Model):
             employee_id = self.env.user.employee_id.id
         return employee_id
 
+    @api.depends_context('employee_id', 'default_employee_id')
     def _compute_leaves(self):
         data_days = {}
         employee_id = self._get_contextual_employee_id()


### PR DESCRIPTION
- fix updating context cannot recompute _compute_leaves method

Description of the issue/feature this PR addresses:
- Select multiple hr.leave.allocation and use export function will export a wrong leaves_taken

Current behavior before PR:
- leaves_taken will not compute again even provide different context

Desired behavior after PR is merged:
- leaves_taken should be computed correctly based on the context



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
