### PR TITLE
[FIX] web_editor: resize the codeview with the field_html resize handle

### DIFF
--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -213,6 +213,10 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
         $codeview.toggleClass('d-none');
         this.$content.toggleClass('d-none');
         if ($codeview.hasClass('d-none')) {
+            if (this.resizerHandleObserver) {
+                this.resizerHandleObserver.disconnect();
+                delete this.resizerHandleObserver;
+            }
             this.wysiwyg.odooEditor.observerActive();
             this.wysiwyg.setValue($codeview.val());
             this.wysiwyg.odooEditor.historyStep();
@@ -220,6 +224,14 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
                 this.wysiwyg.toolbar.$el.append($codeviewButton);
             }
         } else {
+            this.resizerHandleObserver = new MutationObserver((mutations, observer) => {
+                for (let mutation of mutations) {
+                    if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
+                        $codeview[0].style.height = this.$content[0].style.height;
+                    }
+                }
+            });
+            this.resizerHandleObserver.observe(this.$content[0], {attributes: true});
             $codeview.val(this.$content.html());
             this.wysiwyg.odooEditor.observerActive();
             if ($codeviewButton) {


### PR DESCRIPTION
Steps to follow

  - Go to email templates
  - Select some text
  - Click on the code button
  - Resize the editor
  -> Nothing happens

Cause of the issue

  The default view of the editor is resized but not the code view

Solution

  Change the code view height with the default view

opw-2669259
