### PR TITLE
web_editor: module description is rendered incorrectly #78641

### DIFF
--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -9,7 +9,7 @@ Odoo Web Editor widget.
 ==========================
 
 """,
-    'depends': ['web', 'mail'],
+    'depends': ['web'],
     'data': [
         'security/ir.model.access.csv',
         'data/editor_assets.xml',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Html field widget is defined in "web_editor" module. In previous version, it has only dependency of "web" and now in v15 they have added also "mail" as dependency. Hence, web_editor needs to be installed with web module automatically.

Current behavior before PR:
Create Odoo instance without installing any modules
Open any module from within Odoo instance, via Apps (that has description)

Desired behavior after PR is merged:
It shows raw HTML (html widget) instead of rendered and formatted text.

Fixes #78641
