### PR TITLE
[FIX] core: avoid useless setup_models at install

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -168,17 +168,18 @@ def load_module_graph(cr, graph, status=None, perform_checks=True,
             module_log_level = logging.INFO
         _logger.log(module_log_level, 'Loading module %s (%d/%d)', module_name, index, module_count)
 
+        new_install = package.state == 'to install'
         if needs_update:
-            if package.name != 'base':
-                registry.setup_models(cr)
-            migrations.migrate_module(package, 'pre')
+            if not new_install:
+                if package.name != 'base':
+                    registry.setup_models(cr)
+                migrations.migrate_module(package, 'pre')
             if package.name != 'base':
                 env = api.Environment(cr, SUPERUSER_ID, {})
                 env['base'].flush()
 
         load_openerp_module(package.name)
 
-        new_install = package.state == 'to install'
         if new_install:
             py_module = sys.modules['odoo.addons.%s' % (module_name,)]
             pre_init = package.info.get('pre_init_hook')


### PR DESCRIPTION
When installing a database with all modules in enterprise, install take around 20 minutes and almost half of that is spent in the `setup_model` method.

There is actually two calls to `setup_models` for each module.

One of them was introduced in b5c50fa824aff2718dc212b0145a59dc951481b9 and only looks useful when upgrading a module with migration scripts.

This first fix proposes to skip `setup_models` if the module state is `to install`.

Enterpise installation goes from ~20 to ~15 minutes