### PR TITLE
[FIX] calendar: fix recurrence name

### DIFF
--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -153,8 +153,9 @@ class RecurrenceRule(models.Model):
                 on = _("on %s") % ", ".join([day_name for day_name in day_strings])
             elif recurrence.rrule_type == 'monthly':
                 if recurrence.month_by == 'day':
-                    weekday_label = dict(BYDAY_SELECTION)[recurrence.byday]
-                    on = _("on the %(position)s %(weekday)s", position=recurrence.byday, weekday=weekday_label)
+                    position_label = dict(BYDAY_SELECTION)[recurrence.byday]
+                    weekday_label = dict(WEEKDAY_SELECTION)[recurrence.weekday]
+                    on = _("on the %(position)s %(weekday)s", position=position_label, weekday=weekday_label)
                 else:
                     on = _("day %s", recurrence.day)
             else:


### PR DESCRIPTION
change the wrong recurrence name like
"Every 1 Months on the -1 Last for 3 events"
to
"Every 1 Months on the Last Thursday for 3 events"

before this task,
If you create a recurrence event and invite another partner in calendar with
* Repeat Every: xxx "Months"
* Day of Month: Day of month: Last Thurday
The recurrence name in the email would be like
"Every 1 Months on the -1 Last for 3 events"

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
