### PR TITLE
[FIX] mrp : Bom report wrong operation time

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -110,7 +110,7 @@ class ReportBomStructure(models.AbstractModel):
             # Use the product template instead of the variant
             price = bom.product_tmpl_id.uom_id._compute_price(bom.product_tmpl_id.with_company(company).standard_price, bom.product_uom_id) * bom_quantity
             attachments = self.env['mrp.document'].search([('res_model', '=', 'product.template'), ('res_id', '=', bom.product_tmpl_id.id)])
-        operations = self._get_operation_line(bom, float_round(bom_quantity / bom.product_qty, precision_rounding=1, rounding_method='UP'), 0)
+        operations = self._get_operation_line(bom, float_round(bom_quantity, precision_rounding=1, rounding_method='UP'), 0)
         lines = {
             'bom': bom,
             'bom_qty': bom_quantity,


### PR DESCRIPTION
Current behavior :
When you have a BoM for 12 item (and an operation with 1 min duration)
 and a workcenter with a capacity of 23. When you go into the report
the duration is 1 minute until you set the quantity to 277

Expected behavior :
The duration should change when you set the quantity to 24

Steps to reproduce :
- BOM with quantity different than 1 (here 12)
- operation duration 1 minute
- work center capacity 23
- Go in Bom report and duration is not right when you set a quantity above 23

opw-2610702

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
