### PR TITLE
[IMP][14.0] website_event_track: duplicate field

### DIFF
--- a/addons/website_event_track/models/event_track_stage.py
+++ b/addons/website_event_track/models/event_track_stage.py
@@ -25,5 +25,4 @@ class TrackStage(models.Model):
         string='Done Stage',
         help='Done tracks are automatically published so that they are available in frontend.')
     is_cancel = fields.Boolean(string='Canceled Stage')
-    is_done = fields.Boolean()
     color = fields.Integer(string='Color')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In code, module `website_event_track` -> model `event.track.stage` . I see duplicate field `is_done`
I want to contribute this module.

![119120312-5753de00-ba56-11eb-9864-f9ff00f53589](https://user-images.githubusercontent.com/26604325/138434782-57e8e638-f752-44fe-9b9d-df20cdffae7c.png)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
