### PR TITLE
[FIX] web_editor: correctly move snippets on a popup

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -107,7 +107,10 @@ var SnippetEditor = Widget.extend({
                     },
                 },
             });
-            this.draggableComponent = new SmoothScrollOnDrag(this, this.$el, $().getScrollingElement(), smoothScrollOptions);
+            const modalAncestorEl = this.$target[0].closest('.modal');
+            const $scrollTarget = modalAncestorEl && $(modalAncestorEl)
+                || $().getScrollingElement();
+            this.draggableComponent = new SmoothScrollOnDrag(this, this.$el, $scrollTarget, smoothScrollOptions);
         } else {
             this.$('.o_overlay_move_options').addClass('d-none');
             $customize.find('.oe_snippet_clone').addClass('d-none');
@@ -721,10 +724,6 @@ var SnippetEditor = Widget.extend({
                 }
             },
         });
-
-        // If a modal is open, the scroll target must be that modal
-        const $openModal = self.$editable.find('.modal:visible');
-        self.draggableComponent.$scrollTarget = $openModal.length ? $openModal : self.$scrollingElement;
 
         // Trigger a scroll on the draggable element so that jQuery updates
         // the position of the drop zones.


### PR DESCRIPTION
Inside a scrollable popup, the scroll was not correctly triggered when
moving one of its snippets through drag and drop.

This commits correctly defines the SmoothScrollOnDrag.$scrollTarget when
a modal is shown.

task-2431469



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
