### PR TITLE
[REV] mail: memleak model manager in tests

### DIFF
--- a/addons/mail/static/src/utils/test_utils.js
+++ b/addons/mail/static/src/utils/test_utils.js
@@ -24,7 +24,6 @@ import {
     mock,
 } from 'web.test_utils';
 import Widget from 'web.Widget';
-import { registerCleanup } from '@web/../tests/helpers/cleanup';
 import { createWebClient, getActionManagerServerData } from "@web/../tests/webclient/helpers";
 
 import LegacyRegistry from "web.Registry";
@@ -318,6 +317,9 @@ function afterEach(self) {
     if (self.widget) {
         self.widget.destroy();
         self.widget = undefined;
+    }
+    if (self.messaging) {
+        self.messaging.delete();
     }
     self.env = undefined;
     self.unpatch();
@@ -775,14 +777,6 @@ async function start(param0 = {}) {
     }
     returnCallbacks.forEach(callback => callback(result));
     await waitUntilEventPromise;
-    registerCleanup(() => {
-        if (modelManager.messaging) {
-            modelManager.messaging.delete();
-        }
-        if (widget) {
-            widget.destroy();
-        }
-    });
     return {
         ...result,
         createComposerComponent: getCreateComposerComponent({ components, env: testEnv, modelManager, widget }),


### PR DESCRIPTION
This reverts commit 4c18e2d09a372e975c2133516cc9bdd1880b2c1b.

This commit makes a barcode qunit test crash non-deterministically,
but quite frequently (50% of the time).
At the time of reverting this commit, we still don't know how this
commit affects this barcode test, but it's urgent to resolve by
revert and understand more in depth what are the causes.
