### PR TITLE
[FIX] stock: display float with correct decimal

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -204,7 +204,8 @@
                 </p>
             </td>
             <td class="text-center" name="move_line_aggregated_qty_done">
-                <span t-esc="aggregated_lines[line]['qty_done']"/>
+                <span t-esc="aggregated_lines[line]['qty_done']"
+                    t-options="{'widget': 'float', 'decimal_precision': 'Product Unit of Measure'}"/>
                 <span t-esc="aggregated_lines[line]['product_uom']"/>
             </td>
         </tr>


### PR DESCRIPTION
(:information_source:  Backport from https://github.com/odoo/odoo/commit/fbf76c1f27afbb836b1b0e9e84cf160d65777d41)

### Expected behavior 
Quantities are displayed in the same way on the delivery note regardless the stock picking stage.

### Current behavior 
Quantities aren't displayed in the same way on the delivery note depending on the stock picking stage. (e.g. `2.00 Units` units when picking is in `Ready` stage but `2.0 Units` when picking is in `Done` stage)

### Steps to reproduce the error
- Create a RFQ with few units of a Storable Product (e.g. 2 units)
- Go to the Receipt and print the Delivery Slip and look at the quantities printed (e.g. 2.00)
- Validate the Receipt and print the Delivery Slip again, quantities printed have changed (e.g. 2.0)

### Note
This is a backport of a v15 commit (https://github.com/odoo/odoo/commit/fbf76c1f27afbb836b1b0e9e84cf160d65777d41) as he hasn't been applied on v14. (Issue does **not** happen on v13)

### Sample files 
#### Before fix
[invalid_receipt_done.pdf](https://github.com/odoo/odoo/files/7396925/invalid_receipt_done.pdf)
[invalid_receipt_ready.pdf](https://github.com/odoo/odoo/files/7396926/invalid_receipt_ready.pdf)
#### After fix
[valid_receipt_done.pdf](https://github.com/odoo/odoo/files/7396938/valid_receipt_done.pdf)
[valid_receipt_ready.pdf](https://github.com/odoo/odoo/files/7396940/valid_receipt_ready.pdf)

opw-2578120