### PR TITLE
[IMP] fleet: unsubscribe previous driver

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -264,6 +264,9 @@ class FleetVehicle(models.Model):
             for vehicle in self.filtered(lambda v: v.driver_id.id != driver_id):
                 vehicle.create_driver_history(vals)
                 if vehicle.driver_id:
+                    # unsubscribe old driver in case it was subscribed
+                    partners_to_unsubscribe = vehicle.driver_id.ids
+                    vehicle.message_unsubscribe(partner_ids=partners_to_unsubscribe)
                     vehicle.activity_schedule(
                         'mail.mail_activity_data_todo',
                         user_id=vehicle.manager_id.id or self.env.user.id,

--- a/addons/hr_fleet/models/fleet_vehicle.py
+++ b/addons/hr_fleet/models/fleet_vehicle.py
@@ -97,14 +97,6 @@ class FleetVehicle(models.Model):
 
     def write(self, vals):
         self._update_create_write_vals(vals)
-        if 'driver_employee_id' in vals:
-            for vehicle in self:
-                if vehicle.driver_employee_id and vehicle.driver_employee_id.id != vals['driver_employee_id']:
-                    partners_to_unsubscribe = vehicle.driver_id.ids
-                    employee = vehicle.driver_employee_id
-                    if employee and employee.user_id.partner_id:
-                        partners_to_unsubscribe.append(employee.user_id.partner_id.id)
-                    vehicle.message_unsubscribe(partner_ids=partners_to_unsubscribe)
         return super().write(vals)
 
     def action_open_employee(self):


### PR DESCRIPTION
Before, the previous driver was unsubscribed only if he was an employee as well.

Now, we unsubscribe any partner who is a previous driver.

task - 2674029


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
