### PR TITLE
[FIX] calendar - Wrong email to is set in mail template

### DIFF
--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -360,7 +360,7 @@
             <field name="model_id" ref="calendar.model_calendar_event"/>
             <field name="subject">{{object.name}}: Event update</field>
             <field name="email_from">{{ (object.user_id.email_formatted or user.email_formatted or '') }}</field>
-            <field name="email_to">{{('' if object.partner_id.email and object.partner_id.email == object.email else object.email) }}</field>
+            <field name="email_to">{{ object.partner_id.email_formatted or '' }}</field>
             <field name="lang">{{ object.partner_id.lang }}</field>
             <field name="body_html" type="html">
 <div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes #77927

**Current behavior before PR:**
On the calendar form view, When the clicked on "Email" button it gave an error to the user.
![issue_reproduce_77927](https://user-images.githubusercontent.com/32053757/138452474-bfd3f36b-ece9-4eb3-8b1d-e4c6c16fb728.gif)



**Desired behavior after PR is merged:**
On click "Email" button user can see a mail compo
![issue_solve_77927](https://user-images.githubusercontent.com/32053757/138452562-c69d7a30-c4ae-46b2-af2f-11e3bcc31d46.gif)
se wizard.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
