### PR TITLE
[FIX] sale_mrp: fix manufacturing order smart button

### DIFF
--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -295,6 +295,9 @@ class TestSaleMrpFlow(ValuationReconciliationTestCommon):
         order = order_form.save()
         order.action_confirm()
 
+        # Verify buttons are working as expected
+        self.assertEqual(order.mrp_production_count, 2, "User should see the correct number of manufacture orders in smart button")
+
         # ===============================================================================
         #  Sales order of 10 Dozen product A should create production order
         #  like ..

--- a/addons/sale_mrp/tests/test_sale_mrp_procurement.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_procurement.py
@@ -65,6 +65,9 @@ class TestSaleMrpProcurement(TransactionCase):
         # I confirm the sale order
         sale_order_so0.action_confirm()
 
+        # Verify buttons are working as expected
+        self.assertEqual(sale_order_so0.mrp_production_count, 1, "User should see the correct number of manufacture orders in smart button")
+
         # I verify that a manufacturing order has been generated, and that its name and reference are correct
         mo = self.env['mrp.production'].search([('origin', 'like', sale_order_so0.name)], limit=1)
         self.assertTrue(mo, 'Manufacturing order has not been generated')
@@ -161,6 +164,9 @@ class TestSaleMrpProcurement(TransactionCase):
         sale_order_so0 = so_form.save()
 
         sale_order_so0.action_confirm()
+
+        # Verify buttons are working as expected
+        self.assertEqual(sale_order_so0.mrp_production_count, 3, "User should see the correct number of manufacture orders in smart button")
 
         pickings = sale_order_so0.picking_ids
 


### PR DESCRIPTION
Commit
odoo@96b56ea
managed to fix 3-step manufacturing smart button in sale order
but 1-step and 2-step manufacturing are having the same issue now

opw-2645042

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
