### PR TITLE
[IMP] base_setup,project: remove module_pad field in settings

### DIFF
--- a/addons/base_setup/models/res_config_settings.py
+++ b/addons/base_setup/models/res_config_settings.py
@@ -32,7 +32,6 @@ class ResConfigSettings(models.TransientModel):
     # TODO: remove in master
     module_base_gengo = fields.Boolean("Translate Your Website with Gengo")
     module_account_inter_company_rules = fields.Boolean("Manage Inter Company")
-    module_pad = fields.Boolean("Collaborative Pads")
     module_voip = fields.Boolean("Asterisk (VoIP)")
     module_web_unsplash = fields.Boolean("Unsplash Image Library")
     module_partner_autocomplete = fields.Boolean("Partner Autocomplete")

--- a/addons/base_setup/views/res_config_settings_views.xml
+++ b/addons/base_setup/views/res_config_settings_views.xml
@@ -236,20 +236,6 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="external_pads_setting">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_pad"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_pad"/>
-                                    <div class="text-muted">
-                                        Use external pads in Odoo Notes
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('module_pad','=',False)]}" id="msg_module_pad">
-                                        <div class="text-warning mt16"><strong>Save</strong> this page and come back here to set up the feature.</div>
-                                    </div>
-                                </div>
-                            </div>
                             <div class="col-12 col-lg-6 o_setting_box" id="sync_google_calendar_setting">
                                 <div class="o_setting_left_pane">
                                     <field name="module_google_calendar" />

--- a/addons/project/views/res_config_settings_views.xml
+++ b/addons/project/views/res_config_settings_views.xml
@@ -10,17 +10,6 @@
                 <div class="app_settings_block" data-string="Project" string="Project" data-key="project" groups="project.group_project_manager">
                         <h2>Tasks Management</h2>
                         <div class="row mt16 o_settings_container" id="tasks_management">
-                            <div id="use_collaborative_pad" class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_pad"/>
-                                </div>
-                                <div class="o_setting_right_pane" name="pad_project_right_pane">
-                                    <label for="module_pad"/>
-                                    <div class="text-muted">
-                                        Edit tasks' description collaboratively in real time. See each author's text in a distinct color.
-                                    </div>
-                                </div>
-                            </div>
                             <div class="col-12 col-lg-6 o_setting_box">
                                 <div class="o_setting_left_pane">
                                     <field name="group_subtask_project"/>


### PR DESCRIPTION
Since the etherpad is removed in #76467, the module_pad field is
useless in the settings for Notes and Project apps.

This commit removes this field.

task-2643861

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
