### PR TITLE
[FIX] sale_timesheet: remove empty sections from project updates

### DIFF
--- a/addons/project/views/project_update_templates.xml
+++ b/addons/project/views/project_update_templates.xml
@@ -19,7 +19,7 @@
 <h1 style="font-weight: bolder;">Activities</h1>
 </div>
 
-<div name="milestone">
+<div name="milestone" t-if="milestones['show_section']">
 <t t-if="milestones['show_section']">
 <br/>
 <h3 style="font-weight: bolder"><u>Milestones</u></h3>

--- a/addons/sale_timesheet/models/project_update.py
+++ b/addons/sale_timesheet/models/project_update.py
@@ -67,8 +67,7 @@ class ProjectUpdate(models.Model):
     @api.model
     def _get_profitability_values(self, project):
         costs_revenues = project.analytic_account_id and project.allow_billable
-        timesheets = project.allow_timesheets and self.user_has_groups('hr_timesheet.group_hr_timesheet_user')
-        if not (self.user_has_groups('project.group_project_manager') and (costs_revenues or timesheets)):
+        if not (self.user_has_groups('project.group_project_manager') and costs_revenues):
             return {}
         profitability = project._get_profitability_common()
         return {


### PR DESCRIPTION
With the sale_timesheet module installed, some Project Updates can contain an "Activities" section in the description, despite there being no activities to be shown, and some empty divs.

This PR will remove all of those unnecessary sections, which also spares us an expensive call to `project._get_profitability_common()`.

Task-2675389
