### PR TITLE
Fix description reset issue

### DIFF
--- a/addons/sale_product_matrix/models/sale_order.py
+++ b/addons/sale_product_matrix/models/sale_order.py
@@ -111,7 +111,7 @@ class SaleOrder(models.Model):
             if new_lines:
                 res = False
                 self.update(dict(order_line=new_lines))
-                product_ids = [d[2].get('product_id') for d in new_lines if d[2] is dict]
+                product_ids = [d[2].get('product_id') for d in new_lines if isinstance(d[2], dict)]
                 for line in self.order_line.filtered(lambda line: line.product_id.id in product_ids):
                     res = line.product_id_change() or res
                     line._onchange_discount()

--- a/addons/sale_product_matrix/models/sale_order.py
+++ b/addons/sale_product_matrix/models/sale_order.py
@@ -111,7 +111,8 @@ class SaleOrder(models.Model):
             if new_lines:
                 res = False
                 self.update(dict(order_line=new_lines))
-                for line in self.order_line.filtered(lambda line: line.product_template_id == product_template):
+                product_ids = [d[2].get('product_id') for d in new_lines if d[2] is dict]
+                for line in self.order_line.filtered(lambda line: line.product_id.id in product_ids):
                     res = line.product_id_change() or res
                     line._onchange_discount()
                     line._onchange_product_id_set_customer_lead()

--- a/doc/cla/corporate/jimsports.md
+++ b/doc/cla/corporate/jimsports.md
@@ -1,0 +1,15 @@
+Spain, 2021/10/22
+
+Jimsports agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Pablo Luaces <pablo.luaces@gmail.com> https://github.com/pablo-lp
+
+List of contributors:
+
+Pablo Luaces <pablo.luaces@gmail.com> https://github.com/pablo-lp

--- a/doc/cla/corporate/jimsports.md
+++ b/doc/cla/corporate/jimsports.md
@@ -8,8 +8,8 @@ declaration.
 
 Signed,
 
-Pablo Luaces <pablo.luaces@gmail.com> https://github.com/pablo-lp
+Pablo Luaces <pablo@jimsports.com> https://github.com/pablo-lp
 
 List of contributors:
 
-Pablo Luaces <pablo.luaces@gmail.com> https://github.com/pablo-lp
+Pablo Luaces <pablo@jimsports.com> https://github.com/pablo-lp


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

https://github.com/odoo/odoo/issues/78824

Current behavior before PR:

Adding another variant deletes the descriptions in the variants of the same template

Desired behavior after PR is merged:

Keep the description of the lines that have not changed

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
