### PR TITLE
[FIX] mail: progress bar if from parameters


### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -308,7 +308,9 @@ class MailActivityMixin(models.AbstractModel):
             where_clause=where_clause or '1=1',
             group_by=', '.join(groupby_terms),
         )
-        self.env.cr.execute(select_query, [tz] * 3 + where_params)
+        num_from_params = from_clause.count('%s')
+        where_params[num_from_params:num_from_params] = [tz] * 3 # timezone after from parameters
+        self.env.cr.execute(select_query, where_params)
         fetched_data = self.env.cr.dictfetchall()
         self._read_group_resolve_many2x_fields(fetched_data, annotated_groupbys)
         data = [


### PR DESCRIPTION

If there was parameters in the from clause, there was a possible error
when reading progress bar for activities.

eg. grouping product.product by "Routes" raise an error because we have
in FORM clause like:

    FROM … ON … AND "product_template__route_ids"."route_id" IN
    (SELECT … WHERE … OR ("stock_location_route"."company_id" in %s))

so when we add timezone to parameters, it should be after FROM clause
parameters and before WHERE clause parameters.

opw-2674179
