### PR TITLE
[IMP] payment: improve auth and capture

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -392,7 +392,10 @@ class PaymentPortal(portal.CustomerPortal):
             elif tx_sudo.state == 'pending':
                 status = 'warning'
                 message = tx_sudo.acquirer_id.pending_msg
-            elif tx_sudo.state in ('authorized', 'done'):
+            elif tx_sudo.state == 'authorized':
+                status = 'success'
+                message = tx_sudo.acquirer_id.auth_msg
+            elif tx_sudo.state == 'done':
                 status = 'success'
                 message = tx_sudo.acquirer_id.done_msg
             elif tx_sudo.state == 'cancel':

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -431,6 +431,7 @@
                         <ul class="list-group mb-4">
                             <t t-foreach="invoices" t-as="i">
                                 <t t-set="report_url" t-value="i.get_portal_url(report_type='pdf', download=True)"/>
+                                <t t-set="authorized_tx_ids" t-value="i.transaction_ids.filtered(lambda tx: tx.state == 'authorized')"/>
                                 <div class="d-flex flex-wrap align-items-center justify-content-between">
                                     <div>
                                         <a t-att-href="report_url">
@@ -440,6 +441,9 @@
                                     </div>
                                     <span t-if="i.payment_state in ('paid', 'in_payment')" class="small badge text-bg-success orders_label_text_align">
                                         <i class="fa fa-fw fa-check"/> <b>Paid</b>
+                                    </span>
+                                    <span t-elif="authorized_tx_ids" class="small badge text-bg-success orders_label_text_align">
+                                        <i class="fa fa-fw fa-check"/> <b>Authorized</b>
                                     </span>
                                     <span t-else="" class="small badge text-bg-info orders_label_text_align">
                                         <i class="fa fa-fw fa-clock-o"/> <b>Waiting Payment</b>


### PR DESCRIPTION
[IMP] sale: show the 'Authorized' badge on invoices in the portal

When a customer paid for an invoice linked to an SO and the transaction
was authorized, the badge 'Waiting Payment' would still be shown on the
list of linked invoices in the portal view of the SO. Since authorized
transactions are considered as confirmed payments, the 'Authorized'
badge is now shown instead.

[FIX] payment: show the specific message for authorized transactions 

When a customer paid a transaction through the `/payment/pay` route and
the transaction was authorized, the message for confirmed transactions
would be shown on the `/payment/confirmation` route instead of the one
specific to authorized transactions.

task-2527323