### PR TITLE
[FIX] Fix typo in 24% IRPF tax

### DIFF
--- a/addons/l10n_es/data/account_tax_data.xml
+++ b/addons/l10n_es/data/account_tax_data.xml
@@ -2589,7 +2589,7 @@
     </record>
     <record id="account_tax_template_p_irpf24" model="account.tax.template">
         <field name="type_tax_use">purchase</field>
-        <field name="name">Retenciones IRPF 14%</field>
+        <field name="name">Retenciones IRPF 24%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="-24"/>
         <field name="amount_type">percent</field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 24% IRPF for purchases had a Typo

Current behavior before PR: 24% was presented as a 14% percentage

Desired behavior after PR is merged: 24% will be presented as a 24%, as it should be




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
