### PR TITLE
[IMP] website_slide: change sample text

### DIFF
--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -580,6 +580,14 @@ $truncate-limits: 2, 3, 10;
     height: 20vh;
 }
 
+.o_wslides_body .form-control::-webkit-input-placeholder {
+    color: $gray-500;
+}
+
+.o_wslides_body .form-control:focus::-webkit-input-placeholder {
+    opacity: 0;
+}
+
 // Embed PDFViewer
 // **************************************************
 #PDFViewer.o_wslides_fs_pdf_viewer {

--- a/addons/website_slides/static/src/xml/slide_management.xml
+++ b/addons/website_slides/static/src/xml/slide_management.xml
@@ -21,7 +21,7 @@
                 <div class="form-group row">
                     <label for="section_name" class="col-sm-3 col-form-label">Section name</label>
                     <div class="col-sm-9">
-                        <input type="text" autocomplete="off" class="form-control" name="name" id="section_name" required="required" placeholder="e.g. Introduction"/>
+                        <input type="text" autocomplete="off" class="form-control" name="name" id="section_name" required="required" placeholder='e.g. "Introduction"'/>
                     </div>
                 </div>
             </form>

--- a/addons/website_slides/static/src/xml/website_slides_channel.xml
+++ b/addons/website_slides/static/src/xml/website_slides_channel.xml
@@ -8,7 +8,7 @@
                 <input type="hidden" name="csrf_token" t-att-value="csrf_token"/>
                 <div class="form-group">
                     <label for="title" class="col-form-label">Title</label>
-                    <input type="text" class="form-control" autocomplete="off" name="name" id="title" placeholder="Computer Science for kids" required="1"/>
+                    <input type="text" class="form-control" autocomplete="off" name="name" id="title" placeholder='e.g. "Computer Science for kids"' required="1"/>
                     <p id="title-required" class="text-danger mt-1 mb-0 d-none">Please fill in this field</p>
                 </div>
                 <div class="form-group">
@@ -30,9 +30,9 @@
                 </div>
                 <div class="form-group">
                     <label for="title">Description</label>
-                    <textarea rows="1" class="form-control" name="description" id="description"
-                              placeholder="Common tasks for a computer scientist is asking the right questions and answering
-                              questions. In this course, you'll study those topics with activities about mathematics, science and logic." />
+                    <textarea rows="2" class="form-control" name="description" id="description"
+                              placeholder='e.g. "Common tasks for a computer scientist is asking the right questions.
+                              In this course, you will study those topics with activities about mathematics, science and logic."' />
                 </div>
                 <label id="communication-label">Review</label>
                 <div class="form-group">

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -65,7 +65,7 @@
                         <field name="image_1920" widget="image" class="oe_avatar" options="{'preview_image': 'image_128'}"/>
                         <div class="oe_title">
                             <label for="name" string="Course Title"/>
-                            <h1><field name="name" default_focus="1" placeholder="e.g. Computer Science for kids"/></h1>
+                            <h1><field name="name" default_focus="1" placeholder='e.g. "Computer Science for kids"'/></h1>
                         </div>
                         <div>
                             <field name="active" invisible="1"/>

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -419,7 +419,8 @@
                     <span class="text-muted">Common tasks for a computer scientist</span>
                 </div>
             </div>
-            <ul class="list-unstyled pb-1 border-top">
+            <ul class="list-unstyled pb-1 border-top card">
+                <div class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                 <li class="o_wslides_slides_list_slide bg-white-50 border-top-0 d-flex align-items-center pl-2 py-1 pr-2">
                     <i class="fa fa-file-text py-2 mx-2"/>
                     <div class="text-truncate mr-auto">
@@ -454,7 +455,8 @@
                     <span class="text-muted">Parts of computer science</span>
                 </div>
             </div>
-            <ul class="list-unstyled pb-1 border-top">
+            <ul class="list-unstyled pb-1 border-top card">
+                <div class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                 <li class="o_wslides_slides_list_slide bg-white-50 border-top-0 d-flex align-items-center pl-2 py-1 pr-2">
                     <i class="fa fa-file-pdf-o py-2 mx-2"/>
                     <div class="text-truncate mr-auto">


### PR DESCRIPTION
Purpose
=======
Make placeholder look more like sample text to avoid users confusing it
with actual text, add "Sample" ribbon to default course context to avoid
confusing some users.

Specifications
=============
Change default placeholder text, add css rule for placeholders in
website_slide to make the colour lighter and disappear on focus.

PR: /pull/78845
Task-2674361