### PR TITLE
[FIX] account: wrong outstanding Payments/Receipts amount in dashboard

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -736,6 +736,7 @@ class AccountJournal(models.Model):
             ('move_id.state', '!=', 'cancel'),
             ('reconciled', '=', False),
             ('journal_id', '=', self.id),
+            ('statement_id', '=', False),
         ]
         query = self.env['account.move.line']._where_calc(domain)
         tables, where_clause, where_params = query.get_sql()


### PR DESCRIPTION
It seems it is possible to have some journal entries booked on outstanding payments/receipts
accounts directly linked to statement lines and not to a registered payment. This can be done
with manual encodings, so we should exclude these entries when computing the total amount on
the dashboard.

Description of the issue/feature this PR addresses:

opw-2506576
opw-2543917

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
