### PR TITLE
[FIX] web: list_editable/FieldO2M: onSuccess at the right time

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -1869,7 +1869,7 @@ var FieldOne2Many = FieldX2Many.extend({
                         index = self.value.data.length - 1;
                     }
                     var newID = self.value.data[index].id;
-                    self.renderer.editRecord(newID);
+                    return self.renderer.editRecord(newID);
                 }
             }
         });

--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -315,7 +315,7 @@ ListRenderer.include({
     editRecord: function (recordID) {
         var $row = this._getRow(recordID);
         var rowIndex = $row.prop('rowIndex') - 1;
-        this._selectCell(rowIndex, 0);
+        return this._selectCell(rowIndex, 0);
     },
     /**
      * Gives focus to a specific cell, given its row and its related column.


### PR DESCRIPTION
When changing a value for a o2m (list) within a form, the _setValue
returned a Promise that did not take into account the real rendering of
the list renderer.

The use case at hand is:
- enable product configurator
- have a product with options
- add that product in a SO
- add the option as well through the product configurator
- confirm the configurator

The configurator triggers a add_record event, with an onSuccess callback

Before this commit, the onSuccess callback was called too early, when the previous
rendering operations were not finished yet.

After this commit, the onSuccess is executed when the list renderer is really ready