### PR TITLE
[FIX] hw_drivers: fix open cashbox with mapped action

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver.py
@@ -250,7 +250,7 @@ class PrinterDriver(Driver):
         title = commands['title'] % b'IoTBox Status'
         self.print_raw(commands['center'] + title + b'\n' + wlan.encode() + mac.encode() + ip.encode() + homepage.encode() + pairing_code.encode() + commands['cut'])
 
-    def open_cashbox(self):
+    def open_cashbox(self, data):
         """Sends a signal to the current printer to open the connected cashbox."""
         commands = RECEIPT_PRINTER_COMMANDS[self.receipt_protocol]
         for drawer in commands['drawers']:


### PR DESCRIPTION
In the new version of Odoo and in the drivers we "map" the actions.
The "mapped" functions must take at least 2 variables as parameters; Self and Data

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
