### PR TITLE
[FIX] point_of_sale: close sessions via xml-rpc

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -252,6 +252,7 @@ class PosSession(models.Model):
             session.write({'state': 'closing_control', 'stop_at': fields.Datetime.now()})
             if not session.config_id.cash_control:
                 session.action_pos_session_close()
+        return True
 
     def _check_pos_session_balance(self):
         for session in self:


### PR DESCRIPTION
Some of the support scripts use xml-rpc calls to work
on pos.session on Saas or SH databases
(especially when needed to upload lot of offline orders
in smaller batches)
These scripts should be allowed to close any rescue session
created during this process programmatically via xml-rpc.

Our xml-rpc protocol does not allow to call function that
return nothing

X-original-commit: b12f1c1b04835d774d562804160e52140d6059ea

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
