### PR TITLE
[FIX] l10n_au: ABN number for demo company

### DIFF
--- a/addons/l10n_au/demo/demo_company.xml
+++ b/addons/l10n_au/demo/demo_company.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="partner_demo_company_au" model="res.partner">
         <field name="name">AU Company</field>
-        <field name="vat">13041750</field>
+        <field name="vat">11 225 459 588</field>
         <field name="street">Henry Lawson Drive</field>
         <field name="city">Home Rule</field>
         <field name="country_id" ref="base.au"/>


### PR DESCRIPTION
The number that was there before was a TFN, not an ABN because of
confusion between those two tax numbers.
See
https://github.com/arthurdejong/python-stdnum/commit/cc3a970e893ebe6635982bcd49c48e6549cb5ac3
https://github.com/odoo/odoo/commit/a72f7222c9f5987a20461be9c837e3de73801ff7




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
