### PR TITLE
[IMP] core: use cache for mro in setup_models

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -58,14 +58,13 @@ def resolve_mro(model, name, predicate):
         classes are ignored.
     """
     result = []
-    for cls in type(model).mro():
-        if not is_registry_class(cls):
-            value = cls.__dict__.get(name, Default)
-            if value is Default:
-                continue
-            if not predicate(value):
-                break
-            result.append(value)
+    for cls in model._model_classes:
+        value = cls.__dict__.get(name, Default)
+        if value is Default:
+            continue
+        if not predicate(value):
+            break
+        result.append(value)
     return result
 
 
@@ -4100,6 +4099,6 @@ def apply_required(model, field_name):
 # pylint: disable=wrong-import-position
 from .exceptions import AccessError, MissingError, UserError
 from .models import (
-    check_pg_name, expand_ids, is_definition_class, is_registry_class,
+    check_pg_name, expand_ids, is_definition_class,
     BaseModel, IdType, NewId, PREFETCH_MAX,
 )

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -193,18 +193,19 @@ def load_module_graph(cr, graph, status=None, perform_checks=True,
             mode = 'init'
 
         loaded_modules.append(package.name)
-        if needs_update:
-            models_updated |= set(model_names)
-            models_to_check -= set(model_names)
-            registry.setup_models(cr)
-            registry.init_models(cr, model_names, {'module': package.name}, new_install)
-        elif package.state != 'to remove':
-            # The current module has simply been loaded. The models extended by this module
-            # and for which we updated the schema, must have their schema checked again.
-            # This is because the extension may have changed the model,
-            # e.g. adding required=True to an existing field, but the schema has not been
-            # updated by this module because it's not marked as 'to upgrade/to install'.
-            models_to_check |= set(model_names) & models_updated
+        if model_names:
+            if needs_update:
+                models_updated |= set(model_names)
+                models_to_check -= set(model_names)
+                registry.setup_models(cr)
+                registry.init_models(cr, model_names, {'module': package.name}, new_install)
+            elif package.state != 'to remove':
+                # The current module has simply been loaded. The models extended by this module
+                # and for which we updated the schema, must have their schema checked again.
+                # This is because the extension may have changed the model,
+                # e.g. adding required=True to an existing field, but the schema has not been
+                # updated by this module because it's not marked as 'to upgrade/to install'.
+                models_to_check |= set(model_names) & models_updated
 
         idref = {}
 


### PR DESCRIPTION
With a lot of module installed setup_models can be quite slow.
One of the reason for that are the calls to resolve_mro.

This operation is fast, but called for a lot of models/fields this become an important part of get_depends and setup_base.

- This is call once for each models in setup_base
- This is call more than once for each computed_field in get_depends.

The use of a cache shows significative performance improvements.

During the install of a database with all modules, the install times is reduced by ~20%

setup_models of a full_install 
 ~5 minutes before this pr
 ~2:30 minutes with first commit (mro cache)

A slight improvement of init_models should be observed too, but negligeable. 

Second commit (skip modules without declared models) should slighly speedup install
