### PR TITLE
[FIX] crm: fix typo in ValidationError

### DIFF
--- a/addons/crm/models/crm_team_member.py
+++ b/addons/crm/models/crm_team_member.py
@@ -45,7 +45,7 @@ class Team(models.Model):
                 if domain:
                     self.env['crm.lead'].search(domain, limit=1)
             except Exception:
-                raise exceptions.ValidationEreror(_(
+                raise exceptions.ValidationError(_(
                     'Member assignment domain for user %(user)s and team %(team)s is incorrectly formatted',
                     user=member.user_id.name, team=member.crm_team_id.name
                 ))


### PR DESCRIPTION

The validation error raise "AttributeError: module 'odoo.exceptions' has no attribute 'ValidationEreror'"
Instead the the correct message 
"Member assignment domain for user %(user)s and team %(team)s is incorrectly formatted





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
