### PR TITLE
[FIX] auth_totp,mail,web: TOTP authentication with JSON-RPC

### DIFF
--- a/addons/mail/models/ir_http.py
+++ b/addons/mail/models/ir_http.py
@@ -18,7 +18,7 @@ class IrHttp(models.AbstractModel):
         assets_discuss_public_hash = HomeStaticTemplateHelpers.get_qweb_templates_checksum(debug=request.session.debug, bundle='mail.assets_discuss_public')
         result['cache_hashes']['assets_discuss_public'] = assets_discuss_public_hash
         guest = self.env.context.get('guest')
-        if self.env.user._is_public() and guest:
+        if not request.session.uid and guest:
             user_context = {'lang': guest.lang}
             mods = odoo.conf.server_wide_modules or []
             lang = user_context.get("lang")

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -26,7 +26,8 @@ class Http(models.AbstractModel):
         user = request.env.user
         version_info = odoo.service.common.exp_version()
 
-        user_context = request.session.get_context() if request.session.uid else {}
+        session_uid = request.session.uid
+        user_context = request.session.get_context() if session_uid else {}
         IrConfigSudo = self.env['ir.config_parameter'].sudo()
         max_file_upload_size = int(IrConfigSudo.get_param(
             'web.max_file_upload_size',
@@ -34,12 +35,12 @@ class Http(models.AbstractModel):
         ))
         mods = odoo.conf.server_wide_modules or []
         lang = user_context.get("lang")
-        translation_hash = request.env['ir.translation'].sudo().get_web_translations_hash(mods, lang) if request.session.uid else None
+        translation_hash = request.env['ir.translation'].sudo().get_web_translations_hash(mods, lang)
         session_info = {
-            "uid": request.session.uid,
-            "is_system": user._is_system() if request.session.uid else False,
-            "is_admin": user._is_admin() if request.session.uid else False,
-            "user_context": request.session.get_context() if request.session.uid else {},
+            "uid": session_uid,
+            "is_system": user._is_system() if session_uid else False,
+            "is_admin": user._is_admin() if session_uid else False,
+            "user_context": user_context,
             "db": request.session.db,
             "server_version": version_info.get('server_version'),
             "server_version_info": version_info.get('server_version_info'),
@@ -47,8 +48,8 @@ class Http(models.AbstractModel):
             "name": user.name,
             "username": user.login,
             "partner_display_name": user.partner_id.display_name,
-            "company_id": user.company_id.id if request.session.uid else None,  # YTI TODO: Remove this from the user context
-            "partner_id": user.partner_id.id if request.session.uid and user.partner_id else None,
+            "company_id": user.company_id.id if session_uid else None,  # YTI TODO: Remove this from the user context
+            "partner_id": user.partner_id.id if session_uid and user.partner_id else None,
             "web.base.url": IrConfigSudo.get_param('web.base.url', default=''),
             "active_ids_limit": int(IrConfigSudo.get_param('web.active_ids_limit', default='20000')),
             'profile_session': request.session.profile_session,

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -34,7 +34,7 @@ class Http(models.AbstractModel):
         ))
         mods = odoo.conf.server_wide_modules or []
         lang = user_context.get("lang")
-        translation_hash = request.env['ir.translation'].sudo().get_web_translations_hash(mods, lang)
+        translation_hash = request.env['ir.translation'].sudo().get_web_translations_hash(mods, lang) if request.session.uid else None
         session_info = {
             "uid": request.session.uid,
             "is_system": user._is_system() if request.session.uid else False,

--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -861,7 +861,7 @@ class IrTranslation(models.Model):
             mods = [x['name'] for x in self.env['ir.module.module'].sudo().search_read(
                 [('state', '=', 'installed')], ['name'])]
         if not lang:
-            lang = self._context["lang"]
+            lang = self._context.get("lang")
         langs = self.env['res.lang']._lang_get(lang)
         lang_params = None
         if langs:


### PR DESCRIPTION
Since [1] and [2], the mobile app gets this error when trying to login
on v15, while it was working fine in v14 with TOTP enabled.

The 'authenticate' JSON-RPC route tries to authenticate the user and
then call `session_info()`. As no UID is defined, some methods in
`session_info()` raise an exception and an unexpected error is sent:
* `_is_public()` -> "Expected singleton: res.users()"
* `get_web_translations_hash()` -> "lang"

In this fix, this exception is avoided and the proper result is sent,
allowing the authentication process to continue.

Steps to reproduce:
* Try to connect to an account with TOTP on the mobile app (v15+) => BUG

Refs:
[1] odoo/odoo@80d74e7ee0eab83dc5100e0776df09d04b882fec
[2] odoo/odoo@401fc7efe90fb99ebeef33db5d44d8b97be94ed5