### PR TITLE
[FIX] base: catch PDFs that fail on PdfFileWriter.write()

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -661,11 +661,13 @@ class IrActionsReport(models.Model):
     def _get_unreadable_pdfs(self, streams):
         unreadable_streams = []
 
-        writer = PdfFileWriter()
         for stream in streams:
+            writer = PdfFileWriter()
+            result_stream = io.BytesIO()
             try:
                 reader = PdfFileReader(stream)
                 writer.appendPagesFromReader(reader)
+                writer.write(result_stream)
             except utils.PdfReadError:
                 unreadable_streams.append(stream)
 


### PR DESCRIPTION
### Issue:
- Our functionality for merging PDFs from multiple vendor bills relies on PyPDF2. It is well-known that PyPDF2 is sometimes unable to manipulate even perfectly normal PDFs. To provide a helpful error message to the user when this happens (i.e. give them the names of the vendor bills corresponding to the offending pdfs), the `_get_unreadeable_pdfs()` function is called right before we try to merge the PDFs in `_merge_pdfs`. This function is meant to identify the offending PDFs and provide them to the user.
- However, _get_unreadable_pdfs did not notice the problem with 3 of my customer's pdfs, because the error was only triggered once the PdfFileWriter.write function was called in _merge_pdfs. This function, however, is not called in _get_unreadable_pdfs, therefore, it did not notice that anything was wrong.

### Fix:
- Change _get_unreadable_pdfs so that it also makes a call to PdfFileWriter.write
- As soon as PdfFileWriter.write fails once, it will continue failing when we append more PDF streams to the PdfFileWriter. I therefore suggest initialising a different PdfFileWriter at each iteration of the for loop in order for an offending PDF to not cause a false positive on subsequent PDFs.
