### PR TITLE
[FIX] mail: cleanup model manager after each test

### DIFF
--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -183,6 +183,21 @@ export class ModelManager {
         return allRecords;
     }
 
+    cleanup() {
+        this._createdRecordsComputes = new Set();
+        this._createdRecordsCreated = new Set();
+        this._createdRecordsOnChange = new Set();
+        this._listeners = new Set();
+        this._listenersObservingAllByModel = new Map();
+        this._listenersObservingLocalId = new Map();
+        this._listenersObservingFieldOfLocalId = new Map();
+        this._listenersToNotifyAfterUpdateCycle = new Map();
+        this._listenersToNotifyInUpdateCycle = new Map();
+        this._localIdsObservedByListener = new Map();
+        this.models = {};
+        this._updatedRecordsCheckRequired = new Set();
+    }
+
     /**
      * @deprecated use insert instead
      */

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -31,6 +31,14 @@ function factory(dependencies) {
         }
 
         /**
+         * This method deletes this record.
+         */
+         delete() {
+            super.delete();
+            this.modelManager.cleanup();
+        }
+
+        /**
          * Starts messaging and related records.
          */
         async start() {

--- a/addons/mail/static/tests/chatter_tests.js
+++ b/addons/mail/static/tests/chatter_tests.js
@@ -105,7 +105,7 @@ QUnit.module('Chatter', {
 QUnit.test('list activity widget with no activity', async function (assert) {
     assert.expect(5);
 
-    const { widget: list } = await start({
+    const { env, widget: list } = await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -117,6 +117,7 @@ QUnit.test('list activity widget with no activity', async function (assert) {
         },
         session: { uid: 2 },
     });
+    this.env = env;
 
     assert.containsOnce(list, '.o_mail_activity .o_activity_color_default');
     assert.strictEqual(list.$('.o_activity_summary').text(), '');
@@ -151,7 +152,7 @@ QUnit.test('list activity widget with activities', async function (assert) {
         activity_type_id: 2,
     });
 
-    const { widget: list } = await start({
+    const { env, widget: list } = await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -162,6 +163,7 @@ QUnit.test('list activity widget with activities', async function (assert) {
             return this._super(...arguments);
         },
     });
+    this.env = env;
 
     const $firstRow = list.$('.o_data_row:first');
     assert.containsOnce($firstRow, '.o_mail_activity .o_activity_color_today.fa-phone');
@@ -194,7 +196,7 @@ QUnit.test('list activity widget with exception', async function (assert) {
         activity_exception_icon: 'fa-warning',
     });
 
-    const { widget: list } = await start({
+    const { env, widget: list } = await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -205,6 +207,7 @@ QUnit.test('list activity widget with exception', async function (assert) {
             return this._super(...arguments);
         },
     });
+    this.env = env;
 
     assert.containsOnce(list, '.o_activity_color_today.text-warning.fa-warning');
     assert.strictEqual(list.$('.o_activity_summary').text(), 'Warning');
@@ -252,7 +255,7 @@ QUnit.test('list activity widget: open dropdown', async function (assert) {
         }
     );
 
-    const { widget: list } = await start({
+    const { env, widget: list } = await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -282,6 +285,7 @@ QUnit.test('list activity widget: open dropdown', async function (assert) {
             switch_view: () => assert.step('switch_view'),
         },
     });
+    this.env = env;
 
     assert.strictEqual(list.$('.o_activity_summary').text(), 'Call with Al');
 
@@ -353,7 +357,7 @@ QUnit.test('list activity exception widget with activity', async function (asser
         }
     );
 
-    const { widget: list } = await start({
+    const { env, widget: list } = await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -363,6 +367,7 @@ QUnit.test('list activity exception widget with activity', async function (asser
                 '<field name="activity_exception_decoration" widget="activity_exception"/> ' +
             '</tree>',
     });
+    this.env = env;
 
     assert.containsN(list, '.o_data_row', 2, "should have two records");
     assert.doesNotHaveClass(list.$('.o_data_row:eq(0) .o_activity_exception_cell div'), 'fa-warning',
@@ -437,7 +442,8 @@ QUnit.test('fieldmany2many tags email', function (assert) {
         archs: {
             'partner_type,false,form': '<form string="Types"><field name="display_name"/><field name="email"/></form>',
         },
-    }).then(async function ({ widget: form }) {
+    }).then(async ({ env, widget: form }) => {
+        this.env = env;
         // should read it 3 times (1 with the form view, one with the form dialog and one after save)
         assert.verifySteps(['[12,14]', '[14]', '[14]']);
         await testUtils.nextTick();
@@ -472,7 +478,7 @@ QUnit.test('fieldmany2many tags email (edition)', async function (assert) {
     const user11 = this.data['res.users'].records.find(user => user.id === 11);
     user11.timmy = [12];
 
-    var { widget: form } = await start({
+    var { env, widget: form } = await start({
         hasView: true,
         View: FormView,
         model: 'res.users',
@@ -498,6 +504,7 @@ QUnit.test('fieldmany2many tags email (edition)', async function (assert) {
             'partner_type,false,form': '<form string="Types"><field name="display_name"/><field name="email"/></form>',
         },
     });
+    this.env = env;
 
     assert.verifySteps(['[12]']);
     assert.containsOnce(form, '.o_field_many2manytags[name="timmy"] .badge.o_tag_color_0',
@@ -538,7 +545,7 @@ QUnit.test('many2many_tags_email widget can load more than 40 records', async fu
         user11.partner_ids.push(i);
     }
 
-    const { widget: form } = await start({
+    const { env, widget: form } = await start({
         hasView: true,
         View: FormView,
         model: 'res.users',
@@ -546,6 +553,7 @@ QUnit.test('many2many_tags_email widget can load more than 40 records', async fu
         arch: '<form><field name="partner_ids" widget="many2many_tags"/></form>',
         res_id: 11,
     });
+    this.env = env;
 
     assert.strictEqual(form.$('.o_field_widget[name="partner_ids"] .badge').length, 100);
 

--- a/addons/mail/static/tests/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/m2x_avatar_user_tests.js
@@ -57,7 +57,7 @@ QUnit.module('mail', {}, function () {
     QUnit.test('many2one_avatar_user widget in list view', async function (assert) {
         assert.expect(5);
 
-        const { widget: list } = await start({
+        const { env, widget: list } = await start({
             hasView: true,
             View: ListView,
             model: 'foo',
@@ -70,6 +70,7 @@ QUnit.module('mail', {}, function () {
                 return this._super(...arguments);
             },
         });
+        this.env = env;
 
         mock.intercept(list, 'open_record', () => {
             assert.step('open record');
@@ -100,7 +101,7 @@ QUnit.module('mail', {}, function () {
     QUnit.test('many2one_avatar_user widget in kanban view', async function (assert) {
         assert.expect(6);
 
-        const { widget: kanban } = await start({
+        const { env, widget: kanban } = await start({
             hasView: true,
             View: KanbanView,
             model: 'foo',
@@ -116,6 +117,7 @@ QUnit.module('mail', {}, function () {
                     </templates>
                 </kanban>`,
         });
+        this.env = env;
 
         assert.strictEqual(kanban.$('.o_kanban_record').text().trim(), '');
         assert.containsN(kanban, '.o_m2o_avatar', 4);
@@ -130,7 +132,7 @@ QUnit.module('mail', {}, function () {
     QUnit.test('many2many_avatar_user widget in form view', async function (assert) {
         assert.expect(7);
 
-        const { widget: form } = await start({
+        const { env, widget: form } = await start({
             hasView: true,
             View: FormView,
             model: 'foo',
@@ -144,6 +146,7 @@ QUnit.module('mail', {}, function () {
             },
             res_id: 1,
         });
+        this.env = env;
 
         assert.containsN(form, '.o_field_many2manytags.avatar.o_field_widget .badge', 2,
             "should have 2 records");
@@ -168,7 +171,7 @@ QUnit.module('mail', {}, function () {
 
         this.data.foo.records[1].user_ids = [11];
 
-        const { widget: list } = await start({
+        const { env, widget: list } = await start({
             hasView: true,
             View: ListView,
             model: 'foo',
@@ -176,6 +179,7 @@ QUnit.module('mail', {}, function () {
             arch: '<tree editable="top"><field name="user_ids" widget="many2many_avatar_user"/></tree>',
             res_id: 1,
         });
+        this.env = env;
 
         assert.containsN(list, '.o_data_row:eq(0) .o_field_many2manytags.avatar.o_field_widget .o_m2m_avatar', 2,
             "should have 2 records");
@@ -193,7 +197,7 @@ QUnit.module('mail', {}, function () {
     QUnit.test('many2many_avatar_user widget in list view', async function (assert) {
         assert.expect(8);
 
-        const { widget: list } = await start({
+        const { env, widget: list } = await start({
             hasView: true,
             View: ListView,
             model: 'foo',
@@ -206,6 +210,7 @@ QUnit.module('mail', {}, function () {
                 return this._super(...arguments);
             },
         });
+        this.env = env;
 
         mock.intercept(list, 'open_record', () => {
             assert.step('open record');
@@ -242,7 +247,7 @@ QUnit.module('mail', {}, function () {
         this.data['res.users'].records.push({ id: 15, name: "Tapu", partner_id: 11 },);
         this.data.foo.records[2].user_ids = [11, 23, 7, 15];
 
-        const { widget: kanban } = await start({
+        const { env, widget: kanban } = await start({
             hasView: true,
             View: KanbanView,
             model: 'foo',
@@ -271,6 +276,7 @@ QUnit.module('mail', {}, function () {
                 return this._super(...arguments);
             },
         });
+        this.env = env;
 
         mock.intercept(kanban, 'open_record', () => {
             assert.step('open record');
@@ -313,7 +319,7 @@ QUnit.module('mail', {}, function () {
     QUnit.test('many2one_avatar_user widget in list view with no_open_chat set to true', async function (assert) {
         assert.expect(3);
 
-        const { widget: list } = await start({
+        const { env, widget: list } = await start({
             hasView: true,
             View: ListView,
             model: 'foo',
@@ -326,6 +332,7 @@ QUnit.module('mail', {}, function () {
                 return this._super(...arguments);
             },
         });
+        this.env = env;
 
         mock.intercept(list, 'open_record', () => {
             assert.step('open record');
@@ -351,7 +358,7 @@ QUnit.module('mail', {}, function () {
     QUnit.test('many2one_avatar_user widget in kanban view', async function (assert) {
         assert.expect(3);
 
-        const { widget: kanban } = await start({
+        const { env, widget: kanban } = await start({
             hasView: true,
             View: KanbanView,
             model: 'foo',
@@ -367,6 +374,7 @@ QUnit.module('mail', {}, function () {
                     </templates>
                 </kanban>`,
         });
+        this.env = env;
 
         assert.strictEqual(kanban.$('.o_kanban_record').text().trim(), '');
         assert.containsN(kanban, '.o_m2o_avatar', 4);
@@ -383,7 +391,7 @@ QUnit.module('mail', {}, function () {
     QUnit.test('many2many_avatar_user widget in form view', async function (assert) {
         assert.expect(5);
 
-        const { widget: form } = await start({
+        const { env, widget: form } = await start({
             hasView: true,
             View: FormView,
             model: 'foo',
@@ -397,6 +405,7 @@ QUnit.module('mail', {}, function () {
             },
             res_id: 1,
         });
+        this.env = env;
 
         assert.containsN(form, '.o_field_many2manytags.avatar.o_field_widget .badge', 2,
             "should have 2 records");

--- a/addons/mail/static/tests/systray/systray_activity_menu_tests.js
+++ b/addons/mail/static/tests/systray/systray_activity_menu_tests.js
@@ -91,7 +91,7 @@ QUnit.module('ActivityMenu', {
 QUnit.test('activity menu widget: menu with no records', async function (assert) {
     assert.expect(1);
 
-    const { widget } = await start({
+    const { env, widget } = await start({
         data: this.data,
         mockRPC: function (route, args) {
             if (args.method === 'systray_get_activities') {
@@ -100,6 +100,7 @@ QUnit.test('activity menu widget: menu with no records', async function (assert)
             return this._super(route, args);
         },
     });
+    this.env = env;
     const activityMenu = new ActivityMenu(widget);
     await activityMenu.appendTo($('#qunit-fixture'));
     await testUtils.nextTick();
@@ -111,7 +112,7 @@ QUnit.test('activity menu widget: activity menu with 3 records', async function 
     assert.expect(10);
     var self = this;
 
-    const { widget } = await start({
+    const { env, widget } = await start({
         data: this.data,
         mockRPC: function (route, args) {
             if (args.method === 'systray_get_activities') {
@@ -120,6 +121,7 @@ QUnit.test('activity menu widget: activity menu with 3 records', async function 
             return this._super(route, args);
         },
     });
+    this.env = env;
     var activityMenu = new ActivityMenu(widget);
     await activityMenu.appendTo($('#qunit-fixture'));
     await testUtils.nextTick();
@@ -173,7 +175,7 @@ QUnit.test('activity menu widget: activity view icon', async function (assert) {
     assert.expect(12);
     var self = this;
 
-    const { widget } = await start({
+    const { env, widget } = await start({
         data: this.data,
         mockRPC: function (route, args) {
             if (args.method === 'systray_get_activities') {
@@ -183,6 +185,7 @@ QUnit.test('activity menu widget: activity view icon', async function (assert) {
         },
         session: this.session,
     });
+    this.env = env;
     var activityMenu = new ActivityMenu(widget);
     await activityMenu.appendTo($('#qunit-fixture'));
     await testUtils.nextTick();
@@ -234,7 +237,7 @@ QUnit.test('activity menu widget: activity view icon', async function (assert) {
 QUnit.test('activity menu widget: close on messaging menu click', async function (assert) {
     assert.expect(2);
 
-    const { createMessagingMenuComponent, widget } = await start({
+    const { createMessagingMenuComponent, env, widget } = await start({
         data: this.data,
         async mockRPC(route, args) {
             if (args.method === 'systray_get_activities') {
@@ -243,6 +246,7 @@ QUnit.test('activity menu widget: close on messaging menu click', async function
             return this._super(route, args);
         },
     });
+    this.env = env;
     await createMessagingMenuComponent();
     const activityMenu = new ActivityMenu(widget);
     await activityMenu.appendTo($('#qunit-fixture'));


### PR DESCRIPTION
Before this commit, if there are memory leaks involving the owl env,
the model manager had high memory footprint, even when the messaging
record is deleted.

This commit considerably reduces size of model manager when the
messaging record is deleted.

This commit also solved memory leaks on tests that were not properly
deleting the messaging record.

When running all mail qunit tests:

```
          |  snapshot size  |  model managers
          |                 |  (retained size)
----------+-----------------+------------------
  before  |      100 mb     |        31 %
  after   |       55 mb     |         4 %
```
