### PR TITLE
[FIX] web_editor: avoid error popup when saving incomplete link dialog

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
@@ -197,6 +197,10 @@ const LinkDialog = Dialog.extend({
      */
     save: function () {
         this.linkWidget.save();
+        if (!this.linkWidget.final_data) {
+            // Invalid form content: do not proceed with save.
+            return;
+        }
         this.final_data = this.linkWidget.final_data;
         return this._super(...arguments);
     },


### PR DESCRIPTION
Before this commit saving an incomplete link dialog triggered the
display of a stacktrace error popup.

After this commit saving is cancelled when an attempt at saving an
incomplete link dialog is done. The incorrect fields already did display
their error status.

task-2675252

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
