### PR TITLE
[FIX] web_tour: fix tip position on text content

### DIFF
--- a/addons/web_tour/static/src/js/tip.js
+++ b/addons/web_tour/static/src/js/tip.js
@@ -321,7 +321,7 @@ var Tip = Widget.extend({
                     const {top} = props;
                     let {left} = props;
                     const anchorEl = this.$anchor[0];
-                    if (this.CENTER_ON_TEXT_TAGS.includes(anchorEl.nodeName)) {
+                    if (this.CENTER_ON_TEXT_TAGS.includes(anchorEl.nodeName) && anchorEl.hasChildNodes()) {
                         const textContainerWidth = anchorEl.getBoundingClientRect().width;
                         const textNode = anchorEl.firstChild;
                         const range = document.createRange();


### PR DESCRIPTION
After the update in [1], the tip is centered on text content
instead of text container to prevent asymmetry caused by text
alignment.

The goal of this commit is to prevent tours from failing when
the target node is empty[2] by centering the tip on text content
only when the target "hasChildNodes".

[1]: https://github.com/odoo/odoo/commit/ea3b1ec9a0984560f8fce5b5a04f6f24347f97c4
[2]: e.g. After #66844 : The blog will have title as `<h1>` tag
which is empty by default > which makes 'blog' tour fail.

task-2454130
