### PR TITLE
[FIX] project: remove a traceback when moving a project to a stage with a with an email template

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -559,7 +559,7 @@ class Project(models.Model):
         if self.user_has_groups('project.group_project_stages') and 'stage_id' in changes and project.stage_id.mail_template_id:
             res['stage_id'] = (project.stage_id.mail_template_id, {
                 'auto_delete_message': True,
-                'subtype_id': self.env['ir.model.data'].xmlid_to_res_id('mail.mt_note'),
+                'subtype_id': self.env['ir.model.data']._xmlid_to_res_id('mail.mt_note'),
                 'email_layout_xmlid': 'mail.mail_notification_light',
             })
         return res


### PR DESCRIPTION
Steps to reproduce:
==============
1) Go to Project app and create a project A if you don't have any project.
2) Go to Project > Configuration > Settings.
3) Enable the "Project Stages" feature.
4) Go to Project > Configuration > Project Stages.
5) Show the Email template field in the list view and set a template on a stage. (create a stage before this step if none exists)
6) Go to the main view of Project App.
7) Move Project A to the stage with the template set.

Expected Behavior:
==============
The system should use the template for the mail tracking.

Current Behavior:
============
Traceback because the method `xmlid_to_res_id` does not exist in `ir.model.data`.

Task-2677199