### PR TITLE
[FIX] website, *: fix elements position in fullscreen or/and edit mode

### DIFF
--- a/addons/web/static/src/js/libs/jquery.js
+++ b/addons/web/static/src/js/libs/jquery.js
@@ -153,7 +153,10 @@ $.fn.extend({
             }
             const scrollableEl = isScrollElement ? el : $(el).parent().closestScrollable()[0];
             const style = window.getComputedStyle(el);
-            const newValue = parseInt(style[cssProperty]) + scrollableEl.offsetWidth - scrollableEl.clientWidth;
+            const borderLeftWidth = parseInt(style.borderLeftWidth.replace('px', ''));
+            const borderRightWidth = parseInt(style.borderRightWidth.replace('px', ''));
+            const bordersWidth = borderLeftWidth + borderRightWidth;
+            const newValue = parseInt(style[cssProperty]) + scrollableEl.offsetWidth - scrollableEl.clientWidth - bordersWidth;
             el.style.setProperty(cssProperty, `${newValue}px`, 'important');
         }
     },

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1004,7 +1004,7 @@ header {
                 }
             }
 
-            .o_connected_user:not(.editor_has_snippets) header & {
+            .o_connected_user:not(.editor_has_snippets):not(.o_fullscreen) header & {
                 top: -$o-navbar-height;
                 padding-top: $o-navbar-height;
             }
@@ -1098,7 +1098,7 @@ header {
                 }
             }
         }
-        body.o_connected_user {
+        body.o_connected_user:not(.o_fullscreen) {
             &:not(.editor_has_snippets) #wrapwrap > header {
                 top: $o-navbar-height;
             }

--- a/addons/website_livechat/static/src/bugfix/public_bugfix.scss
+++ b/addons/website_livechat/static/src/bugfix/public_bugfix.scss
@@ -5,10 +5,18 @@
 * in its own file in master.
 */
 
-.editor_has_snippets {
+.editor_has_snippets:not(.o_fullscreen) {
     .o_livechat_button, .o_thread_window {
         // TODO add this in an edit-mode only file in master (in 14.0 that asset
         // would be website.assets_wysiwyg...)
         right: $o-we-sidebar-width !important;
+    }
+}
+
+@if o-website-value('header-template') == 'sidebar' and $-hamburger-right {
+    @include media-breakpoint-up(lg) {
+        .o_livechat_button, .o_thread_window {
+            transform: translate(- o-website-value('sidebar-width'));
+        }
     }
 }


### PR DESCRIPTION
Before this commit, some elements (e.g. sidebar, livechat button) were
not correctly positioned in edit mode or/and full screen mode.

task-2677132

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
