### PR TITLE
[FIX] web: Display properly company phone in report

### DIFF
--- a/addons/web/static/src/scss/report.scss
+++ b/addons/web/static/src/scss/report.scss
@@ -13,9 +13,6 @@ body {
     font-family: $o-company-font;
 }
 
-span.o_force_ltr {
-    display: inline-block;
-}
 .o_force_ltr, .o_field_phone {
     unicode-bidi: embed; // ensure element has level of embedding for direction
     /*rtl:ignore*/

--- a/addons/web/static/src/scss/ui.scss
+++ b/addons/web/static/src/scss/ui.scss
@@ -88,9 +88,6 @@
     pointer-events: none;
 }
 
-span.o_force_ltr {
-    display: inline-block;
-}
 .o_force_ltr, .o_field_phone {
     unicode-bidi: embed; // ensure element has level of embedding for direction
     /*rtl:ignore*/


### PR DESCRIPTION
Steps to reproduce :

  - Install Sales
  - Modify the report, use the theme "Clean" and the font "Open Sans"
  - Modify the company phone to: +41 26 322 01 02
  - Print a quotation

Issue :

  Company phone is on 2 lines

Cause :

  CSS issue with wkhtmltopdf.

Solution :

  Replace CSS display value `inline-block` by `inline`.

cherry-pick of: https://github.com/odoo/odoo/commit/d462f13e0c1c04e792895bba9f2edfb35d9ee9d3

ref commit: https://github.com/odoo/odoo/commit/5b022f433a44e627541d30ae21d7a867f4a3a6ff
opw-2567836