### PR TITLE
[FIX] project*: fix groups on computed field

### DIFF
--- a/addons/account_sale_timesheet/models/project.py
+++ b/addons/account_sale_timesheet/models/project.py
@@ -6,7 +6,7 @@ from odoo import fields, models, _
 class Project(models.Model):
     _inherit = 'project.project'
 
-    invoice_count = fields.Integer(related='analytic_account_id.invoice_count')
+    invoice_count = fields.Integer(related='analytic_account_id.invoice_count', groups='account.group_account_readonly')
 
     # ----------------------------
     #  Project Updates

--- a/addons/project_hr_expense/models/project.py
+++ b/addons/project_hr_expense/models/project.py
@@ -6,7 +6,7 @@ from odoo import api, fields, models, _
 class Project(models.Model):
     _inherit = 'project.project'
 
-    expenses_count = fields.Integer('# Expenses', compute='_compute_expenses_count')
+    expenses_count = fields.Integer('# Expenses', compute='_compute_expenses_count', groups='hr_expense.group_hr_expense_team_approver')
 
     @api.depends('analytic_account_id')
     def _compute_expenses_count(self):

--- a/addons/project_mrp/models/project.py
+++ b/addons/project_mrp/models/project.py
@@ -7,9 +7,9 @@ from odoo import fields, models, _
 class Project(models.Model):
     _inherit = "project.project"
 
-    production_count = fields.Integer(related="analytic_account_id.production_count")
-    workorder_count = fields.Integer(related="analytic_account_id.workorder_count")
-    bom_count = fields.Integer(related="analytic_account_id.bom_count")
+    production_count = fields.Integer(related="analytic_account_id.production_count", groups='mrp.group_mrp_user')
+    workorder_count = fields.Integer(related="analytic_account_id.workorder_count", groups='mrp.group_mrp_user')
+    bom_count = fields.Integer(related="analytic_account_id.bom_count", groups='mrp.group_mrp_user')
 
     def action_view_mrp_production(self):
         self.ensure_one()

--- a/addons/project_purchase/models/project.py
+++ b/addons/project_purchase/models/project.py
@@ -7,7 +7,7 @@ from odoo import api, fields, models, _
 class Project(models.Model):
     _inherit = "project.project"
 
-    purchase_orders_count = fields.Integer('# Purchase Orders', compute='_compute_purchase_orders_count')
+    purchase_orders_count = fields.Integer('# Purchase Orders', compute='_compute_purchase_orders_count', groups='purchase.group_purchase_user')
 
     @api.depends('analytic_account_id')
     def _compute_purchase_orders_count(self):

--- a/addons/sale_project_account/models/project.py
+++ b/addons/sale_project_account/models/project.py
@@ -6,7 +6,7 @@ from odoo import fields, models, _
 class Project(models.Model):
     _inherit = 'project.project'
 
-    vendor_bill_count = fields.Integer(related='analytic_account_id.vendor_bill_count')
+    vendor_bill_count = fields.Integer(related='analytic_account_id.vendor_bill_count', groups='account.group_account_readonly')
 
     # ----------------------------
     # Actions


### PR DESCRIPTION
*: account_sale_timesheet,
   project_hr_expense,
   project_mrp,
   project_purchase,
   sale_project_account

This commit fixes issue regarding fields in project form stat buttons.
Those fields are evaluated in any cases, and should rather be computed
only when the user has the right group.

Steps to reproduce :
1) Install project with one of this bridge
2) Connect with a user with only the group_project_admin right
3) Go to the form view
4) Issue:
An internal user with the group "Project Administrator" is unable to
access the form view of a project because of missing rights on the
X model.

Desired Behavior
================
The stat button should not be shown and the field not computed.

opw-2675514

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
