### PR TITLE
[FIX] base: impossible to upgrade a large database

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -952,8 +952,7 @@ class Partner(models.Model):
     def _display_address_depends(self):
         # field dependencies of method _display_address()
         return self._formatting_address_fields() + [
-            'country_id.address_format', 'country_id.code', 'country_id.name',
-            'company_name', 'state_id.code', 'state_id.name',
+            'country_id', 'company_name', 'state_id',
         ]
 
     @api.model


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- in database with million of res.partner
- upgrade base
--> Issue: a big trigger is generate during loading base/data/res.country.state.csv
And take lot of time and odoo can be crach

@rco-odoo 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
