### PR TITLE
[FIX] web_editor: disable command hints on navigation items

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -116,8 +116,12 @@ const Wysiwyg = Widget.extend({
                 }
             },
             isHintBlacklisted: node => {
-                return node.hasAttribute &&
-                    (node.hasAttribute('data-target') || node.hasAttribute('data-oe-model'));
+                return (node.classList && node.classList.contains('nav-item')) || (
+                    node.hasAttribute && (
+                        node.hasAttribute('data-target') ||
+                        node.hasAttribute('data-oe-model')
+                    )
+                );
             },
             filterMutationRecords: (records) => {
                 return records.filter((record) => {


### PR DESCRIPTION
Before this commit a "List" command hint was set as placeholder in
navigation items without content upon selection of the header menu. This
showed up when using the sidebar template of the header menu.

After this commit the command hints are blacklisted for nav-items.

task-2677310

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
