### PR TITLE
[FIX] web: missing default template when editing ControlPanel from an Owl view

### DIFF
--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -162,6 +162,7 @@ export class View extends Component {
             view[0] = viewDescription.viewId;
             searchViewDescription = viewDescriptions.search;
             if (loadSearchView) {
+                searchViewId = searchViewId || searchViewDescription.viewId;
                 if (!searchViewArch) {
                     searchViewArch = searchViewDescription.arch;
                     searchViewFields = searchViewDescription.fields;
@@ -235,7 +236,7 @@ export class View extends Component {
             }
         }
 
-        // prepare the WithSearh component props
+        // prepare the WithSearch component props
         this.withSearchProps = {
             ...this.props,
             Component: ViewClass,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This fix adresses an issue when editing the control panel from Owl based views. 

Current behavior before PR:
Currently, if you don't have a custom view set, the template editor will appear blank as the component misses its searchViewId value from its props.

Desired behavior after PR is merged:
The searchViewId is available from the props.info of the view component as expected. Then you can edit the search template and get the default template

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
