### PR TITLE
Optimize search on many2one fields

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1418,6 +1418,23 @@ class TestMany2one(TransactionCase):
         ''']):
             self.Partner.search([('company_id', 'like', self.company.name)])
 
+        with self.assertQueries([
+            '''
+                SELECT "res_company".id
+                FROM "res_company"
+                WHERE (("res_company"."name"::text not like %s)
+                    OR "res_company"."name" IS NULL)
+                ORDER BY "res_company"."sequence" ,"res_company"."name"
+            ''',
+            '''
+                SELECT "res_partner".id
+                FROM "res_partner"
+                WHERE (("res_partner"."company_id" IN (%s)) OR "res_partner"."company_id" IS NULL)
+                ORDER BY "res_partner"."display_name"
+            '''
+        ]):
+            self.Partner.search([('company_id', 'not like', "blablabla")])
+
 
 class TestOne2many(TransactionCase):
     def setUp(self):

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1418,21 +1418,16 @@ class TestMany2one(TransactionCase):
         ''']):
             self.Partner.search([('company_id', 'like', self.company.name)])
 
-        with self.assertQueries([
-            '''
-                SELECT "res_company".id
-                FROM "res_company"
-                WHERE (("res_company"."name"::text not like %s)
-                    OR "res_company"."name" IS NULL)
-                ORDER BY "res_company"."sequence" ,"res_company"."name"
-            ''',
-            '''
+        with self.assertQueries(['''
                 SELECT "res_partner".id
                 FROM "res_partner"
-                WHERE (("res_partner"."company_id" IN (%s)) OR "res_partner"."company_id" IS NULL)
+                WHERE (("res_partner"."company_id" IN (
+                    SELECT "res_company".id
+                    FROM "res_company"
+                    WHERE (("res_company"."name"::text not like %s) OR "res_company"."name" IS NULL))
+                ) OR "res_partner"."company_id" IS NULL)
                 ORDER BY "res_partner"."display_name"
-            '''
-        ]):
+        ''']):
             self.Partner.search([('company_id', 'not like', "blablabla")])
 
 

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -504,8 +504,6 @@ class expression(object):
                 :var obj comodel: relational model of field (field.comodel)
                     (res_partner.bank_ids -> res.partner.bank)
         """
-        cr, uid, context, su = self.root_model.env.args
-
         def to_ids(value, comodel, leaf):
             """ Normalize a single id or name, or a list of those, into a list of ids
                 :param {int,long,basestring,list,tuple} value:


### PR DESCRIPTION
[IMP] base: improve search on many2one with string values and negative operators

Currently, the domain expression on a many2one field with
negative operator + string values leads to a extra SQL request on the
target model of the many2one which is not optimal and lead to
performance degradation.

Example:
--------
With a simple model A with a one2many (`b_id`) targeting model B (with
a field `b_name` and `_rec_name = b_name`):
The `A.search([('b_id', 'not like', 'OneName')])` will
generate two SQL requests:
- A _name_search on model B and returning ids who match
`('b_name', 'not like', 'OneName')`.
- A other on the model A with the application of the result
of the first one `('b_id', 'in', <returning ids> + [False])`.

Solution:
---------
Avoid the extra SQL request (the first one) and use subquery instead.
We do it by translate the `('b_id', 'in', <returning ids> + [False])`
expression into ['|', ('b_id', 'in', _subquery), ('b_id', '=', False)]

task-2671476