### PR TITLE
[FIX] hr_holidays: make holidays count consistent on employee form

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -101,7 +101,7 @@ class HrEmployeeBase(models.AbstractModel):
             ('employee_id', 'in', self.ids),
             ('holiday_status_id.active', '=', True),
             ('holiday_status_id.requires_allocation', '=', 'yes'),
-            ('state', '=', 'validate'),
+            ('state', 'not in', ('cancel', 'refuse')),
             '|',
             ('holiday_allocation_id.date_to', '=', False),
             ('holiday_allocation_id.date_to', '>=', current_date),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The holidays count on the employee form is not consistent with the count on the dashboard.
The count on the employee form counts the holidays left based on the approved holiday.
The count on the time off dashboard counts all the holidays that are not cancelled or refused.
The time off counts should be consistent across the different screens.

Current behavior before PR:
The employee form smart button displays the count of time off based on the approved time off
The time off dashboard displays the count of time off based on the time off that are not cancelled or refused

Desired behavior after PR is merged:
The count of time off is consistent across the different screens with the time off count based on the time off that are not cancelled or refused

Task-2670658

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
