### PR TITLE
[FIX] l10n_es: check if chart of account is installed in migration

### DIFF
--- a/addons/l10n_es/migrations/13.0.5.0/post-61-tag-split-2021.py
+++ b/addons/l10n_es/migrations/13.0.5.0/post-61-tag-split-2021.py
@@ -30,10 +30,11 @@ def migrate(cr, version):
 
     # To run in a server action to fix issues on dbs with custom taxes,
     # replace the content of this dict.
-    taxes_mapping = {
-        tag_name: get_taxes_from_templates(template_names)
-        for tag_name, template_names in templates_mapping.items()
-    }
+    taxes_mapping = {}
+    for tag_name, template_names in taxes_mapping.items():
+        taxes_from_templates = get_taxes_from_templates(template_names)
+        if taxes_from_templates:
+            taxes_mapping[tag_name] = taxes_from_templates
 
     old_tag = env.ref('l10n_es.mod_303_61')
     for tag_name, tax_ids in taxes_mapping.items():


### PR DESCRIPTION
In last added migration script in https://github.com/odoo/odoo/commit/b40216a8ae8fefd03311b2884e7b83644baac0a1, the code assumes the chart of account of l10n_es is installed. But happens that you may have installed several l10n_* modules, including l10n_es, but not having the chart of l10n_es installed (you have installed the chart of another module).

In this case, then the update crashes because `tax_ids` is None and `tuple(tax_ids)` crashes!

**Description of the issue/feature this PR addresses:** If you have installed l10n_es, but not its chart of accounts, then this migration code breaks when executed.

**Current behavior before PR:** The update of l10n_es crashes.

**Desired behavior after PR is merged:** The update of l10n_es doesn't crash.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr