### PR TITLE
[FIX] web_editor, website: only save dirty element

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -374,6 +374,7 @@ export class OdooEditor extends EventTarget {
         clearTimeout(this.observerTimeout);
         this.observer.disconnect();
         this.observerFlush();
+        this.dispatchEvent(new Event('observerUnactive'));
     }
     observerFlush() {
         this.observerApply(this.observer.takeRecords());
@@ -403,6 +404,7 @@ export class OdooEditor extends EventTarget {
             characterData: true,
             characterDataOldValue: true,
         });
+        this.dispatchEvent(new Event('observerActive'));
     }
 
     observerApply(records) {
@@ -484,6 +486,9 @@ export class OdooEditor extends EventTarget {
             if (record.type === 'attributes') {
                 // Skip the attributes change on the dom.
                 if (record.target === this.editable) continue;
+                if (record.attributeName === 'contenteditable') {
+                    continue;
+                }
 
                 attributeCache.set(record.target, attributeCache.get(record.target) || {});
                 if (

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -813,6 +813,7 @@ var SnippetEditor = Widget.extend({
      * @private
      */
     _onDragAndDropStart: function () {
+        this.wysiwyg.odooEditor.observerUnactive('dragAndDropMoveSnippet');
         this.trigger_up('drag_and_drop_start');
         this.options.wysiwyg.odooEditor.automaticStepUnactive();
         var self = this;
@@ -924,6 +925,7 @@ var SnippetEditor = Widget.extend({
         this.$body.removeClass('move-important');
         $clone.remove();
 
+        this.wysiwyg.odooEditor.observerActive('dragAndDropMoveSnippet');
         if (this.dropped) {
             if (prev) {
                 this.$target.insertAfter(prev);
@@ -2271,6 +2273,7 @@ var SnippetsMenu = Widget.extend({
                 start: function () {
                     self.options.wysiwyg.odooEditor.automaticStepUnactive();
                     self.$el.find('.oe_snippet_thumbnail').addClass('o_we_already_dragging');
+                    self.options.wysiwyg.odooEditor.observerUnactive('dragAndDropCreateSnippet');
 
                     dropped = false;
                     $snippet = $(this);
@@ -2359,6 +2362,7 @@ var SnippetsMenu = Widget.extend({
                     }
 
                     self.getEditableArea().find('.oe_drop_zone').droppable('destroy').remove();
+                    self.options.wysiwyg.odooEditor.observerActive('dragAndDropCreateSnippet');
 
                     if (dropped) {
                         var prev = $toInsert.first()[0].previousSibling;
@@ -2377,7 +2381,11 @@ var SnippetsMenu = Widget.extend({
                         }
 
                         var $target = $toInsert;
+
+                        self.options.wysiwyg.odooEditor.observerUnactive('dragAndDropCreateSnippet');
                         await self._scrollToSnippet($target);
+                        self.options.wysiwyg.odooEditor.observerActive('dragAndDropCreateSnippet');
+
 
                         _.defer(async function () {
                             // Free the mutex now to allow following operations

--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -102,7 +102,10 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         if (this._saving) {
             return false;
         }
-        this.observer.disconnect();
+        if (this.observer) {
+            this.observer.disconnect();
+            this.observer = undefined;
+        }
         var self = this;
         this._saving = true;
         this.trigger_up('edition_will_stopped');
@@ -269,11 +272,7 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
 
         // 1. Make sure every .o_not_editable is not editable.
         // 2. Observe changes to mark dirty structures and fields.
-        this.observer = new MutationObserver(records => {
-            this.wysiwyg.odooEditor.observerUnactive();
-            $('#wrap').find('.o_not_editable[contenteditable!=false]').attr('contenteditable', false);
-            this.wysiwyg.odooEditor.observerActive();
-
+        const processRecords = (records) => {
             records = this.wysiwyg.odooEditor.filterMutationRecords(records);
             // Skip the step for this stack because if the editor undo the first
             // step that has a dirty element, the following code would have
@@ -293,15 +292,29 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
                     }
                 });
             }
-        });
+        };
+        this.observer = new MutationObserver(processRecords);
+        const observe = () => {
+            if (this.observer) {
+                this.observer.observe(document.body, {
+                    childList: true,
+                    subtree: true,
+                    attributes: true,
+                    attributeOldValue: true,
+                    characterData: true,
+                });
+            }
+        }
+        observe();
 
-        this.observer.observe(document.body, {
-            childList: true,
-            subtree: true,
-            attributes: true,
-            attributeOldValue: true,
-            characterData: true,
-        });
+        this.wysiwyg.odooEditor.addEventListener('observerUnactive', () => {
+            if (this.observer) {
+                processRecords(this.observer.takeRecords());
+                this.observer.disconnect();
+            }
+        })
+        this.wysiwyg.odooEditor.addEventListener('observerActive', observe)
+
         $('body').addClass('editor_started');
     },
 
@@ -427,7 +440,10 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         this.trigger_up('widgets_stop_request', {
             $target: this._targetForEdition(),
         });
-        this.observer.disconnect();
+        if (this.observer) {
+            this.observer.disconnect();
+            this.observer = undefined;
+        }
     },
     /**
      * Called when edition was stopped. Notifies the


### PR DESCRIPTION
Before this commit, when inserting a new snippet or moving a snippet
that was already in the page would temporarily create hooks (`we-hook`)
in the page. The insertion of thoses hooks would trigger mutation
in the dirty observer (observer defined in edit.js) and mark all
oe_structure for which a hook was temporarily inserted.
Thus, creating unnecessary views in the backend.

Now, the code skip the mutations of the drag and drop hooks.

Task-2567752




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
