### PR TITLE
[FIX] l10n_es: Replace grid 61 by the proper tag on tax templates

### DIFF
--- a/addons/l10n_es/data/account_tax_data.xml
+++ b/addons/l10n_es/data/account_tax_data.xml
@@ -1139,7 +1139,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_61')],
+                'tag_ids': [ref('mod_303_120')],
             }),
 
             (0,0, {
@@ -1152,7 +1152,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_61')],
+                'tag_ids': [ref('mod_303_120')],
             }),
 
             (0,0, {
@@ -1173,7 +1173,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_61')],
+                'tag_ids': [ref('mod_303_120')],
             }),
 
             (0,0, {
@@ -1186,7 +1186,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_61')],
+                'tag_ids': [ref('mod_303_120')],
             }),
 
             (0,0, {
@@ -1198,7 +1198,7 @@
     <record id="account_tax_template_s_iva_e" model="account.tax.template">
         <field name="description">Extracomunitario (Servicios)</field>
         <field name="type_tax_use">sale</field>
-        <field name="name">IVA 0% Prestación de servicios extracomunitaria</field> <!--TODO OCO 122-->
+        <field name="name">IVA 0% Prestación de servicios extracomunitaria</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="0"/>
         <field name="amount_type">percent</field>
@@ -1207,7 +1207,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_61')],
+                'tag_ids': [ref('mod_303_122')],
             }),
 
             (0,0, {
@@ -1220,7 +1220,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_61')],
+                'tag_ids': [ref('mod_303_122')],
             }),
 
             (0,0, {
@@ -3618,7 +3618,7 @@
     </record>
     <record id="account_tax_template_s_iva0_isp" model="account.tax.template">
         <field name="description">IVA 0% ISP</field>
-        <field name="name">IVA 0% Venta con Inversión del Sujeto Pasivo</field><!--TODO OCO 122-->
+        <field name="name">IVA 0% Venta con Inversión del Sujeto Pasivo</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount" eval="0"/>
@@ -3628,7 +3628,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_61')],
+                'tag_ids': [ref('mod_303_122')],
             }),
 
             (0,0, {
@@ -3641,7 +3641,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_61')],
+                'tag_ids': [ref('mod_303_122')],
             }),
 
             (0,0, {


### PR DESCRIPTION
Fix https://github.com/odoo/odoo/commit/b40216a8ae8fefd03311b2884e7b83644baac0a1 was merged though partially ready.