### PR TITLE
[FIX] web_editor: fix the beforeunload warning

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -200,6 +200,12 @@ const Wysiwyg = Widget.extend({
         if (this.options.getContentEditableAreas) {
             $(this.options.getContentEditableAreas()).find('*').off('mousedown mouseup click');
         }
+
+        window.onbeforeunload = (event) => {
+            if (this.isDirty()) {
+                return _t('This document is not saved!');
+            }
+        };
         // The toolbar must be configured after the snippetMenu is loaded
         // because if snippetMenu is loaded in an iframe, binding of the color
         // buttons must use the jquery loaded in that iframe. See


### PR DESCRIPTION
The warning shown on beforeunload when quiting a page during edition
was missing since the new editor merge.

task-2666177

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
