### PR TITLE
[FIX] web_editor: always show codeview button

### DIFF
--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -215,11 +215,8 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
      * Toggle the code view and update the UI.
      *
      * @param {JQuery} $codeview
-     * @param {JQuery} [$codeviewButton] include the button to move it back and
-     *                                   forth between the toolbar and the code
-     *                                   view.
      */
-    _toggleCodeView: function ($codeview, $codeviewButton) {
+    _toggleCodeView: function ($codeview) {
         this.wysiwyg.odooEditor.observerUnactive();
         $codeview.height(this.$content.height());
         $codeview.toggleClass('d-none');
@@ -228,16 +225,9 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
             this.wysiwyg.odooEditor.observerActive();
             this.wysiwyg.setValue($codeview.val());
             this.wysiwyg.odooEditor.historyStep();
-            if ($codeviewButton) {
-                this.wysiwyg.toolbar.$el.append($codeviewButton);
-            }
         } else {
             $codeview.val(this.$content.html());
             this.wysiwyg.odooEditor.observerActive();
-            if ($codeviewButton) {
-                $codeview.after($codeviewButton);
-                this.wysiwyg.toolbar.$el.css({ visibility: 'hidden' });
-            }
         }
     },
     /**
@@ -525,17 +515,20 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
         });
         this.$el.append($button);
         if (odoo.debug && this.nodeOptions.codeview) {
-            const $codeviewButton = $(`
+            const $codeviewButtonToolbar = $(`
                 <div id="codeview-btn-group" class="btn-group">
                     <button class="o_codeview_btn btn btn-primary">
                         <i class="fa fa-code"></i>
                     </button>
                 </div>
             `);
+            this.$floatingCodeViewButton = $codeviewButtonToolbar.clone();
             this._$codeview = $('<textarea class="o_codeview d-none"/>');
             this.wysiwyg.$editable.after(this._$codeview);
-            this.wysiwyg.toolbar.$el.append($codeviewButton);
-            $codeviewButton.click(() => this._toggleCodeView(this._$codeview, $codeviewButton));
+            this._$codeview.after(this.$floatingCodeViewButton);
+            this.wysiwyg.toolbar.$el.append($codeviewButtonToolbar);
+            $codeviewButtonToolbar.click(() => this._toggleCodeView(this._$codeview));
+            this.$floatingCodeViewButton.click(() => this._toggleCodeView(this._$codeview));
         }
     },
     /**


### PR DESCRIPTION
When activating the editor code view, the button is hidden in
the floating toolbar. This commit always shows the button when
the codeview is activated for a particual html field.

Task-2672259

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
