### PR TITLE
[FIX] sale: update downpayment SOL after refund

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1226,7 +1226,7 @@ class SaleOrderLine(models.Model):
             else:
                 line.qty_to_invoice = 0
 
-    @api.depends('invoice_lines.move_id.state', 'invoice_lines.quantity', 'untaxed_amount_to_invoice')
+    @api.depends('invoice_lines.move_id.state', 'invoice_lines.quantity')
     def _get_invoice_qty(self):
         """
         Compute the quantity invoiced. If case of a refund, the quantity invoiced is decreased. Note
@@ -1241,8 +1241,7 @@ class SaleOrderLine(models.Model):
                     if invoice_line.move_id.move_type == 'out_invoice':
                         qty_invoiced += invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_uom)
                     elif invoice_line.move_id.move_type == 'out_refund':
-                        if not line.is_downpayment or line.untaxed_amount_to_invoice == 0 :
-                            qty_invoiced -= invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_uom)
+                        qty_invoiced -= invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_uom)
             line.qty_invoiced = qty_invoiced
 
     @api.depends('price_unit', 'discount')


### PR DESCRIPTION
How to reproduce the problem:
- Install the Sales and Invoicing apps
- Create a simple SO with a product
- Create Invoice -> Down Payment (percentage) 30% -> confirm
- On the SO -> Create Invoice -> with Deduct down Payment -> confirm
- On that invoice -> Add Credit Note -> Reverse -> confirm
On the SO, the Down payment is not counted as invoiced, even tough it
was already paid and not refunded. If the user wants to create a new
invoice, the system will create one with the full price (not taking the
already invoiced Down Payment into account).

Cause of the problem : when computing the quantity to invoice for
the SO, a condition was avoiding preventing the down payment invoice
line to be taken into account in a way that it was just ignored.
I don't really understand the reason for this condition, as
it specifically ignores the down payments, while it should not be
ignored.
When creating the draft for the refund invoice, the down payment's SOL
is correctly updated as `line.untaxed_amount_to_invoice == 0` is true.
But when confirming the invoice, the values changed and the condition
is thus not met anymore.

opw-2491225