### PR TITLE
[FIX] web_editor: wait editor loading in tests

### DIFF
--- a/addons/web_editor/static/tests/field_html_tests.js
+++ b/addons/web_editor/static/tests/field_html_tests.js
@@ -10,8 +10,18 @@ var core = require('web.core');
 var Wysiwyg = require('web_editor.wysiwyg');
 var MediaDialog = require('wysiwyg.widgets.MediaDialog');
 var LinkDialog = require('wysiwyg.widgets.LinkDialog');
+var FieldHtml = require('web_editor.field.html');
 
 var _t = core._t;
+
+FieldHtml.include({
+    _onLoadWysiwyg: function () {
+        this._super.apply(this, arguments);
+        if (FieldHtml._resolveTestPromise) {
+            FieldHtml._resolveTestPromise();
+        }
+    }
+});
 
 QUnit.module('web_editor', {}, function () {
 
@@ -167,8 +177,9 @@ QUnit.module('web_editor', {}, function () {
             assert.strictEqual($field.attr('style'), 'height: 100px',
                 "should have applied the style correctly");
 
+            const promise = new Promise((resolve) => FieldHtml._resolveTestPromise = resolve);
             await testUtils.form.clickEdit(form);
-            await new Promise((resolve)=>setTimeout(resolve, 100));
+            await promise;
             $field = form.$('.oe_form_field[name="body"]');
             assert.strictEqual($field.find('.note-editable').html(),
                 '<p>toto toto toto</p><p>tata</p>',
@@ -190,8 +201,9 @@ QUnit.module('web_editor', {}, function () {
                 res_id: 6,
             });
             // check that there is no error on clicking Edit
+            const promise = new Promise((resolve) => FieldHtml._resolveTestPromise = resolve);
             await testUtils.form.clickEdit(form);
-            await new Promise((resolve)=>setTimeout(resolve, 100));
+            await promise;
             assert.containsOnce(form, '.o_form_editable');
 
             form.destroy();
@@ -221,8 +233,9 @@ QUnit.module('web_editor', {}, function () {
                 }
             }, true);
 
+            const promise = new Promise((resolve) => FieldHtml._resolveTestPromise = resolve);
             await testUtils.form.clickEdit(form);
-            await new Promise((resolve)=>setTimeout(resolve, 100));
+            await promise;
             await testUtils.dom.click(form.$('.o_form_button_save'));
 
             form.destroy();
@@ -439,8 +452,9 @@ QUnit.module('web_editor', {}, function () {
                 '<p><a href="https://www.external.com" target="_blank">External website</a></p>',
                 "should have rendered a div with correct content in readonly");
 
+            const promise = new Promise((resolve) => FieldHtml._resolveTestPromise = resolve);
             await testUtils.form.clickEdit(form);
-            await new Promise((resolve)=>setTimeout(resolve, 100));
+            await promise;
             $field = form.$('.oe_form_field[name="body"]');
             // the dialog load some xml assets
             const defLinkDialog = testUtils.makeTestPromise();
@@ -487,8 +501,9 @@ QUnit.module('web_editor', {}, function () {
                 '<p><a href="' + window.location.href.replace(/&/g, "&amp;") + '/test">This website</a></p>',
                 "should have rendered a div with correct content in readonly");
 
+            const promise = new Promise((resolve) => FieldHtml._resolveTestPromise = resolve);
             await testUtils.form.clickEdit(form);
-            await new Promise((resolve)=>setTimeout(resolve, 100));
+            await promise;
             $field = form.$('.oe_form_field[name="body"]');
             // the dialog load some xml assets
             const defLinkDialog = testUtils.makeTestPromise();
@@ -535,8 +550,9 @@ QUnit.module('web_editor', {}, function () {
             assert.strictEqual($field.children('.o_readonly').html(), '<p>New external link</p>',
                 "should have rendered a div with correct content in readonly");
 
+            const promise = new Promise((resolve) => FieldHtml._resolveTestPromise = resolve);
             await testUtils.form.clickEdit(form);
-            await new Promise((resolve)=>setTimeout(resolve, 100));
+            await promise;
             $field = form.$('.oe_form_field[name="body"]');
             // the dialog load some xml assets
             const defLinkDialog = testUtils.makeTestPromise();
@@ -584,8 +600,9 @@ QUnit.module('web_editor', {}, function () {
             assert.strictEqual($field.children('.o_readonly').html(), '<p>New internal link</p>',
                 "should have rendered a div with correct content in readonly");
 
+            let promise = new Promise((resolve) => FieldHtml._resolveTestPromise = resolve);
             await testUtils.form.clickEdit(form);
-            await new Promise((resolve)=>setTimeout(resolve, 100));
+            await promise;
             $field = form.$('.oe_form_field[name="body"]');
             // the dialog load some xml assets
             const defLinkDialog = testUtils.makeTestPromise();
@@ -614,8 +631,9 @@ QUnit.module('web_editor', {}, function () {
                 '<p><a href="' + window.location.href.replace(/&/g, "&amp;") + '/test">New internal link</a></p>',
                 "the link should be created with the right format");
 
+            promise = new Promise((resolve) => FieldHtml._resolveTestPromise = resolve);
             await testUtils.form.clickEdit(form);
-            await new Promise((resolve)=>setTimeout(resolve, 100));
+            await promise;
 
             $field = form.$('.oe_form_field[name="body"]');
             pText = $field.find('.note-editable a').eq(0).contents()[0];


### PR DESCRIPTION
In a undeterministic circumstance, an element in the editor
is not found. It might be because the check is done before the
editor is fully loaded.

The commit 46c22143b22e204e93c70b21d002eb179be34a33 tried to
wait 100ms, but the bug continue to appear.

This commit only perform the check when the editor is fully
loaded. If the undeterministic bug continue to appear, it means
that the cause is different.

Task-2678110

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
