### PR TITLE
[FIX] website_sale: search in website_description instead of description

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -179,7 +179,7 @@ class WebsiteSale(http.Controller):
                     [('product_variant_ids.default_code', 'ilike', srch)]
                 ]
                 if search_in_description:
-                    subdomains.append([('description', 'ilike', srch)])
+                    subdomains.append([('website_description', 'ilike', srch)])
                     subdomains.append([('description_sale', 'ilike', srch)])
                 domains.append(expression.OR(subdomains))
 


### PR DESCRIPTION
Steps to reproduce :

  - Install E-commerce module
  - Go to Website -> Products -> Products
  - Edit product `Acoustic Bloc Screens`
  - Type "my product" in Internal Notes an save
  - Go to the Shop
  - In the search bar, type "my product"

Issue :

  `Acoustic Bloc Screens` is in the search results list

Cause :

  An 'ilike' for 'description' is added to the domain.

Solution :

  Replace 'description' by 'website_description' field in the domain.

opw-2649754