### PR TITLE
[FIX] base: fixes layout designer not containing company data

### DIFF
--- a/addons/web/models/base_document_layout.py
+++ b/addons/web/models/base_document_layout.py
@@ -35,19 +35,11 @@ class BaseDocumentLayout(models.TransientModel):
     @api.model
     def _default_company_details(self):
         company = self.env.company
-        default_address_format = "%(company_name)s\n%(street)s\n%(city)s %(state_code)s %(zip)s\n%(country_name)s"
-        address_format = company.country_id.address_format or default_address_format
+        address_format, company_data = company.partner_id._prepare_display_address()
+        # company_name may *still* be missing from prepared address in case commercial_company_name is falsy
         if 'company_name' not in address_format:
             address_format = '%(company_name)s\n' + address_format
-        company_data = {
-            "company_name": company.name or "",
-            "street": company.street or "",
-            "street2": "",
-            "city": company.city or "",
-            "state_code": company.state_id.name or "",
-            "zip": company.zip or "",
-            "country_name": company.country_id.name or "",
-        }
+            company_data['company_name'] = company_data['company_name'] or company.name
         return Markup(nl2br(address_format)) % company_data
 
     company_id = fields.Many2one(

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -983,17 +983,7 @@ class Partner(models.Model):
     def _get_address_format(self):
         return self.country_id.address_format or self._get_default_address_format()
 
-    def _display_address(self, without_company=False):
-
-        '''
-        The purpose of this function is to build and return an address formatted accordingly to the
-        standards of the country where it belongs.
-
-        :param address: browse record of the res.partner to format
-        :returns: the address formatted in a display that fit its country habits (or the default ones
-            if not country is specified)
-        :rtype: string
-        '''
+    def _prepare_display_address(self, without_company=False):
         # get the information that will be injected into the display format
         # get the address format
         address_format = self._get_address_format()
@@ -1010,6 +1000,19 @@ class Partner(models.Model):
             args['company_name'] = ''
         elif self.commercial_company_name:
             address_format = '%(company_name)s\n' + address_format
+        return address_format, args
+
+    def _display_address(self, without_company=False):
+        '''
+        The purpose of this function is to build and return an address formatted accordingly to the
+        standards of the country where it belongs.
+
+        :param without_company: if address contains company
+        :returns: the address formatted in a display that fit its country habits (or the default ones
+            if not country is specified)
+        :rtype: string
+        '''
+        address_format, args = self._prepare_display_address(without_company)
         return address_format % args
 
     def _display_address_depends(self):


### PR DESCRIPTION
In https://github.com/odoo/odoo/pull/78652 a fix was made in the layout designer guaranteeing that the company_details field followed the correct address format set by the company. However, this fix didn't take into account all company data, making some `format_address`es raise a `KeyError`. This PR fixes that by using the company_date defined in `_display_address`.

Fixes https://github.com/odoo/odoo/issues/78942

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
