### PR TITLE
rename the string of timesheet_cost field in employee

### DIFF
--- a/addons/hr_timesheet/models/hr_employee.py
+++ b/addons/hr_timesheet/models/hr_employee.py
@@ -7,6 +7,6 @@ from odoo import fields, models
 class HrEmployee(models.Model):
     _inherit = 'hr.employee'
 
-    timesheet_cost = fields.Monetary('Timesheet Cost', currency_field='currency_id',
+    timesheet_cost = fields.Monetary('Cost', currency_field='currency_id',
     	groups="hr.group_hr_user", default=0.0)
     currency_id = fields.Many2one('res.currency', related='company_id.currency_id', readonly=True)


### PR DESCRIPTION
 hr_timesheet: rename the string of timesheet_cost field in employee

- The string of timesheet_cost field is cost instead of Timesheet Cost.

task-2531442
closes odoo/odoo#79016
