### PR TITLE
[FIX] account_edi: tax (included) amount shows as discount in CFDI

### DIFF
--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -563,15 +563,20 @@ class AccountMoveLine(models.Model):
         def convert(amount):
             return self.currency_id._convert(amount, self.company_currency_id, self.company_id, self.date)
 
+        if self.discount == 100.0:
+            gross_price_subtotal = self.currency_id.round(self.price_unit * self.quantity)
+        else:
+            gross_price_subtotal = self.currency_id.round(self.price_subtotal / (1 - self.discount / 100.0))
+
         res = {
             'line': self,
-            'price_unit_after_discount': self.price_unit * (1 - (self.discount / 100.0)),
-            'price_subtotal_before_discount': self.currency_id.round(self.price_unit * self.quantity),
+            'price_unit_after_discount': self.currency_id.round(self.price_unit * (1 - (self.discount / 100.0))),
+            'price_subtotal_before_discount': gross_price_subtotal,
             'price_subtotal_unit': self.currency_id.round(self.price_subtotal / self.quantity) if self.quantity else 0.0,
             'price_total_unit': self.currency_id.round(self.price_total / self.quantity) if self.quantity else 0.0,
+            'price_discount': gross_price_subtotal - self.price_subtotal,
+            'gross_price_total_unit': self.currency_id.round(gross_price_subtotal / self.quantity) if self.quantity else 0.0,
         }
-
-        res['price_discount'] = res['price_subtotal_before_discount'] - self.price_subtotal
 
         # Tax details.
         tax_detail_per_tax = {}


### PR DESCRIPTION
1. Configure MX company, make sure testing certificate and vat are loaded into the company
2. Sign an invoice with 16% included in price

No errors will be shown but opening the resulting CFDI xml will show a
discount "Descuento" equal to the tax amount, which is incorrect

opw-2665082

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
