### PR TITLE
[FIX] sale_coupon: Prevent already encoded-expired coupons to be used

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -393,6 +393,11 @@ class SaleOrder(models.Model):
         # delete reward line coming from an archived coupon (it will never be updated/removed when recomputing the order)
         invalid_lines = order.order_line.filtered(lambda line: line.is_reward_line and line.product_id.id not in reward_product_ids)
 
+        # Remove coupons that are now expired
+        expired_coupons = order.applied_coupon_ids.filtered(
+            lambda coupon: coupon.expiration_date and coupon.expiration_date < fields.Date.today())
+        programs_to_remove |= expired_coupons.program_id
+
         if programs_to_remove:
             product_ids_to_remove = programs_to_remove.discount_line_product_id.ids
 


### PR DESCRIPTION
TaskID: 2439224

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
