### PR TITLE
[FIX] sale_stock: Remove incoming picking from Sale Order customer portal

### DIFF
--- a/addons/sale_stock/views/sale_stock_portal_template.xml
+++ b/addons/sale_stock/views/sale_stock_portal_template.xml
@@ -14,7 +14,7 @@
                     <strong>Delivery Orders</strong>
                 </div>
                 <div>
-                    <t t-foreach="sale_order.picking_ids.filtered(lambda picking: picking.picking_type_id.code != 'internal')" t-as="i">
+                    <t t-foreach="sale_order.picking_ids.filtered(lambda picking: picking.picking_type_id.code not in ['internal', 'incoming'])" t-as="i">
                         <t t-set="delivery_report_url" t-value="'/my/picking/pdf/%s?%s' % (i.id, keep_query())"/>
                         <div class="d-flex flex-wrap align-items-center justify-content-between o_sale_stock_picking">
                             <div>


### PR DESCRIPTION
- Description of the issue/feature this PR addresses:
When a SO is created for a product with the Buy route having “Propagation of Procurement Group: Propagate”, a PO is created at the same time.
You then have access to the SO and PO transfer from the SO form.
However the PO transfer is also visible on the customer view, which may not be an information we want the customer to know.

- Current behavior before PR:
![image](https://user-images.githubusercontent.com/29302288/138897252-87aba3c7-5b1d-4485-90e6-b94e28fe13e0.png)
Customer can see PO transfer.

- Desired behavior after PR is merged:
![image](https://user-images.githubusercontent.com/29302288/138897608-252292e8-cc00-41af-84da-b52e12bf69a2.png)
By filtering out incoming picking order in the portal template, we keep the PO transfer in the SO form, and remove it from the customer view


opw-2635778
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
