### PR TITLE
[FIX] web: router: do not push unnecessary entries in history

### DIFF
--- a/addons/web/static/src/core/browser/router_service.js
+++ b/addons/web/static/src/core/browser/router_service.js
@@ -6,6 +6,16 @@ import { objectToUrlEncodedString } from "../utils/urls";
 import { browser } from "./browser";
 
 /**
+ * Casts the given string to a number if possible.
+ *
+ * @param {string} value
+ * @returns {string|number}
+ */
+function cast(value) {
+    return !value || isNaN(value) ? value : Number(value);
+}
+
+/**
  * @typedef {{ [key: string]: string }} Query
  * @typedef {{ [key: string]: any }} Route
  */
@@ -16,7 +26,7 @@ function parseString(str) {
     for (let part of parts) {
         const [key, value] = part.split("=");
         const decoded = decodeURIComponent(value || "");
-        result[key] = !decoded || isNaN(decoded) ? decoded : Number(decoded);
+        result[key] = cast(decoded);
     }
     return result;
 }
@@ -64,7 +74,11 @@ function computeNewRoute(hash, replace, currentRoute) {
 }
 
 function sanitizeHash(hash) {
-    return Object.fromEntries(Object.entries(hash).filter(([, v]) => v !== undefined));
+    return Object.fromEntries(
+        Object.entries(hash)
+            .filter(([, v]) => v !== undefined)
+            .map(([k, v]) => [k, cast(v)])
+    );
 }
 
 /**

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1312,7 +1312,7 @@ function makeActionManager(env) {
         if (action.context) {
             const activeId = action.context.active_id;
             if (activeId) {
-                newState.active_id = `${activeId}`;
+                newState.active_id = activeId;
             }
             const activeIds = action.context.active_ids;
             // we don't push active_ids if it's a single element array containing
@@ -1325,7 +1325,7 @@ function makeActionManager(env) {
             const props = controller.props;
             newState.model = props.resModel;
             newState.view_type = props.type;
-            newState.id = props.resId ? `${props.resId}` : undefined;
+            newState.id = props.resId || undefined;
         }
         env.services.router.pushState(newState, { replace: true });
     }

--- a/addons/web/static/tests/core/router_service_tests.js
+++ b/addons/web/static/tests/core/router_service_tests.js
@@ -267,3 +267,16 @@ QUnit.test("do not re-push when hash is same", async (assert) => {
     await nextTick();
     assert.verifySteps([]);
 });
+
+QUnit.test("do not re-push when hash is same (with integers as strings)", async (assert) => {
+    const onPushState = () => assert.step("pushed state");
+    const router = await createRouter({ onPushState });
+
+    router.pushState({ k1: 1, k2: "2" });
+    await nextTick();
+    assert.verifySteps(["pushed state"]);
+
+    router.pushState({ k2: 2, k1: "1" });
+    await nextTick();
+    assert.verifySteps([]);
+});

--- a/addons/web/static/tests/webclient/switch_company_menu_tests.js
+++ b/addons/web/static/tests/webclient/switch_company_menu_tests.js
@@ -154,20 +154,21 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
     });
 
     QUnit.test("single company selected: toggling it off will keep it", async (assert) => {
-        assert.expect(10);
+        assert.expect(12);
 
-        const prom = makeDeferred();
-        function onPushState(url) {
-            assert.step(url.split("#")[1]);
-            prom.resolve();
-        }
-        const scMenu = await createSwitchCompanyMenu({ onPushState });
+        patchWithCleanup(browser, {
+            setTimeout(fn) {
+                return fn(); // s.t. we can directly assert changes in the hash
+            },
+        });
+        const scMenu = await createSwitchCompanyMenu();
 
         /**
          *   [x] **Company 1**
          *   [ ] Company 2
          *   [ ] Company 3
          */
+        assert.deepEqual(scMenu.env.services.router.current.hash, { cids: 1 });
         assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
         await click(scMenu.el.querySelector(".dropdown-toggle"));
@@ -181,11 +182,12 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
          *   [ ] Company 3
          */
         await click(scMenu.el.querySelectorAll(".toggle_company")[0]);
+        assert.deepEqual(scMenu.env.services.router.current.hash, { cids: 1 });
+        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1]);
+        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
         assert.containsOnce(scMenu.el, ".dropdown-menu", "dropdown is still opened");
         assert.containsN(scMenu.el, "[data-company-id] .fa-check-square", 0);
         assert.containsN(scMenu.el, "[data-company-id] .fa-square-o", 3);
-        await prom;
-        assert.verifySteps(["cids=1"]);
     });
 
     QUnit.test("single company mode: companies can be logged in", async (assert) => {


### PR DESCRIPTION
Before this commit, the router didn't considered as equal an
integer value given as an integer or as a string (e.g. "1" or 1),
whereas form the url point of view, it's exactly the same, and the
information is lost anyway.

As a consequence, pushing something like { id: "1" } in the url
that already contained id=1 created a new entry in the history,
which isn't what we want as the url is the same.

This commit fixes the issue by converting string values into
numbers when it is possible.

This commit also changes the way the action service pushes the id
and active_id in the url, as there's no need to pass string values
anymore (this was the case in the early days of the wowl branch).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
