### PR TITLE
[FIX] web_editor: delete unicode character

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/deleteBackward.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/deleteBackward.js
@@ -35,9 +35,11 @@ Text.prototype.oDeleteBackward = function (offset, alreadyMoved = false) {
         return;
     }
 
-    // First, split around the character where the backspace occurs
-    const firstSplitOffset = splitTextNode(this, offset - 1);
-    const secondSplitOffset = splitTextNode(parentNode.childNodes[firstSplitOffset], 1);
+    // Get the size of the unicode character to remove.
+    const charSize = [...this.nodeValue.slice(0, offset)].pop().length;
+    // Split around the character where the backspace occurs.
+    const firstSplitOffset = splitTextNode(this, offset - charSize);
+    const secondSplitOffset = splitTextNode(parentNode.childNodes[firstSplitOffset], charSize);
     const middleNode = parentNode.childNodes[firstSplitOffset];
 
     // Do remove the character, then restore the state of the surrounding parts.


### PR DESCRIPTION
Before this commit, when trying to delete one
unicode character (e.g. 😍), only one javascript character was delete
but one unicode character (e.g. 😍) could be two javascript characters
as the javascript string is coded in utf-16.

This commit fixes that by calculating the size of one unicode character
from the javascript string.

Task-2658890

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
