### PR TITLE
[FIX] stock: always show draft outs in forecasted report

### DIFF
--- a/addons/stock/report/report_stock_forecasted.xml
+++ b/addons/stock/report/report_stock_forecasted.xml
@@ -149,7 +149,7 @@
                             <td t-esc="docs['uom']" groups="uom.group_uom"/>
                         </tr>
                     </thead>
-                    <tbody t-if="docs['qty']['in']">
+                    <tbody t-if="docs['qty']['in'] or docs['qty']['out']">
                         <tr t-if="docs['draft_picking_qty']['in']" name="draft_picking_in">
                             <td colspan="2">Incoming Draft Transfer</td>
                             <td t-esc="docs['draft_picking_qty']['in']" class="text-right" t-options='{"widget": "float", "decimal_precision": "Product Unit of Measure"}'/>


### PR DESCRIPTION
Fix a small logic bug which made it so draft outs would only show only
if there were also draft ins.

Fixes: odoo/odoo#78872

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
