### PR TITLE
[FIX] base: invalid UNIQUE constraint just warn

### DIFF
--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -341,7 +341,9 @@ class Registry(Mapping):
             try:
                 func(*args, **kwargs)
             except Exception as e:
-                _schema.error(*e.args)
+                # warn only, this is not a deployment showstopper, and
+                # can sometimes be a transient error
+                _schema.warning(*e.args)
 
     def init_models(self, cr, model_names, context, install=True):
         """ Initialize a list of models (given by their name). Call methods


### PR DESCRIPTION
When a submodule overrides an old UNIQUE constraint with a new one,
records in that module may respect the new one and not the old one.
As the old module is updated, it would fail giving SQL warnings,
and therefore blocking the Odoo.sh CI pipeline.
```
i.e. website_sale (old): res_users_login_key -> ['login', 'website_id']
             base (new): res_users_login_key -> ['login']
```
With this patch, we check if the new constraint is overriding
an old one which is more permissive. In that case, we verify
that the records of the table won't break the new constraint
before applying it.

This approach tries to limit the performance impact of the checks
by holding a cache with all the old UNIQUE constraints in the database.

Ticket link: https://www.odoo.com/web#id=2489483&model=project.task

opw-2489483