### PR TITLE
[FIX] web: scrolling to anchor working badly

### DIFF
--- a/addons/web/static/src/core/utils/scrolling.js
+++ b/addons/web/static/src/core/utils/scrolling.js
@@ -22,14 +22,14 @@ export function scrollTo(element, scrollable = null) {
 
     // Scrollbar is present ?
     if (scrollable.scrollHeight > scrollable.clientHeight) {
-        const scrollBottom = scrollable.clientHeight + scrollable.scrollTop;
-        const elementBottom = element.offsetTop + element.offsetHeight;
+        const scrollBottom = scrollable.getBoundingClientRect().bottom;
+        const elementBottom = element.getBoundingClientRect().bottom;
         if (elementBottom > scrollBottom) {
             // Scroll down
-            scrollable.scrollTop = elementBottom - scrollable.clientHeight;
-        } else if (element.offsetTop < scrollable.scrollTop) {
+            scrollable.scrollTop = elementBottom - scrollable.getBoundingClientRect().height;
+        } else if (element.getBoundingClientRect().top < scrollable.getBoundingClientRect().top) {
             // Scroll up
-            scrollable.scrollTop = element.offsetTop;
+            scrollable.scrollTop = element.getBoundingClientRect().top;
         }
     }
 }

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -162,6 +162,7 @@ export class View extends Component {
             view[0] = viewDescription.viewId;
             searchViewDescription = viewDescriptions.search;
             if (loadSearchView) {
+                searchViewId = searchViewId || searchViewDescription.viewId;
                 if (!searchViewArch) {
                     searchViewArch = searchViewDescription.arch;
                     searchViewFields = searchViewDescription.fields;
@@ -235,7 +236,7 @@ export class View extends Component {
             }
         }
 
-        // prepare the WithSearh component props
+        // prepare the WithSearch component props
         this.withSearchProps = {
             ...this.props,
             Component: ViewClass,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This commit fixes a bug when you clicked on an anchor link

Current behavior before PR:
e.g. an <a> tag with an href="#anchor". The scroll to the element with id="anchor" didn't happen because the position of the element was not found correctly.

Desired behavior after PR is merged:
The fix uses getBoundingCLientRect to get more precise positions and dimensions of the element with the anchor. It is now possible to get the scrollable area scroll to the element position once you've clicked on a link related to the anchor.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
