### PR TITLE
[FIX] web_editor: properly display the state of list in the toolbar #77690

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1865,14 +1865,16 @@ export class OdooEditor extends EventTarget {
                 }
             }
         }
-        const listMode = getListMode(block.parentElement);
-        const listDropdownButton = this.toolbar.querySelector('#listDropdownButton');
-        if (listDropdownButton) {
-            if (listMode) {
-                listDropdownButton.classList.remove('fa-list-ul', 'fa-list-ol', 'fa-tasks');
-                listDropdownButton.classList.add(listUIClasses[listMode]);
+        if (block) {
+            const listMode = getListMode(block.parentElement);
+            const listDropdownButton = this.toolbar.querySelector('#listDropdownButton');
+            if (listDropdownButton) {
+                if (listMode) {
+                    listDropdownButton.classList.remove('fa-list-ul', 'fa-list-ol', 'fa-tasks');
+                    listDropdownButton.classList.add(listUIClasses[listMode]);
+                }
+                listDropdownButton.closest('button').classList.toggle('active', block.tagName === 'LI');
             }
-            listDropdownButton.closest('button').classList.toggle('active', block.tagName === 'LI');
         }
         if (!activeLabel) {
             // If no element from the text style dropdown was marked as active,

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1834,7 +1834,7 @@ export class OdooEditor extends EventTarget {
             }
         }
         this.updateColorpickerLabels();
-
+        const listUIClasses = {UL: 'fa-list-ul', OL: 'fa-list-ol', CL: 'fa-tasks'};
         const block = closestBlock(sel.anchorNode);
         let activeLabel = undefined;
         for (const [style, tag, isList] of [
@@ -1864,6 +1864,15 @@ export class OdooEditor extends EventTarget {
                     activeLabel = button.textContent;
                 }
             }
+        }
+        const listMode = getListMode(block.parentElement);
+        const listDropdownButton = this.toolbar.querySelector('#listDropdownButton');
+        if (listDropdownButton) {
+            if (listMode) {
+                listDropdownButton.classList.remove('fa-list-ul', 'fa-list-ol', 'fa-tasks');
+                listDropdownButton.classList.add(listUIClasses[listMode]);
+            }
+            listDropdownButton.closest('button').classList.toggle('active', block.tagName === 'LI');
         }
         if (!activeLabel) {
             // If no element from the text style dropdown was marked as active,

--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -115,9 +115,9 @@
             </div>
 
             <div id="list" class="btn-group">
-                <div data-call="toggleList" data-arg1="UL" title="Toggle unordered list" class="oe-toggle-unordered fa fa-list-ul fa-fw btn"></div>
-                <div data-call="toggleList" data-arg1="OL" title="Toggle ordered list" class="oe-toggle-ordered fa fa-list-ol fa-fw btn"></div>
-                <div data-call="toggleList" data-arg1="CL" title="Toggle checklist" class="oe-toggle-checklist btn fa-fw">
+                <div id="unordered" data-call="toggleList" data-arg1="UL" title="Toggle unordered list" class="oe-toggle-unordered fa fa-list-ul fa-fw btn"></div>
+                <div id="ordered" data-call="toggleList" data-arg1="OL" title="Toggle ordered list" class="oe-toggle-ordered fa fa-list-ol fa-fw btn"></div>
+                <div id="checklist" data-call="toggleList" data-arg1="CL" title="Toggle checklist" class="oe-toggle-checklist btn fa-fw">
                     <div class="small">
                         <div class="fa fa-square-o d-block small"/>
                         <div class="fa fa-check-square d-block small"/>


### PR DESCRIPTION
When selecting text in a list, the toolbar should show that a list is selected, and which type. It however failed to do that, which is fixed with this commit.

task-2638422

Manual forward port of https://github.com/odoo/odoo/pull/77738 and https://github.com/odoo/odoo/pull/77773.