### PR TITLE
[IMP] crm: improve the UX of the crm form view

### DIFF
--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -84,6 +84,7 @@
             'crm/static/src/js/systray_activity_menu.js',
             'crm/static/src/js/tours/crm.js',
             'crm/static/src/scss/crm.scss',
+            'crm/static/src/scss/crm_form.scss',
             'crm/static/src/scss/crm_team_member_views.scss',
         ],
         'web.assets_tests': [

--- a/addons/crm/static/src/js/crm_form.js
+++ b/addons/crm/static/src/js/crm_form.js
@@ -11,8 +11,22 @@
     import FormController from 'web.FormController';
     import FormView from 'web.FormView';
     import viewRegistry from 'web.view_registry';
+    import { bus } from 'web.core';
 
     var CrmFormController = FormController.extend({
+        init() {
+            this._super(...arguments);
+            bus.on('DOM_updated', this, () => {
+                const $editable = this.$el.find('.note-editable:visible');
+                if ($editable.length) {
+                    let offset = $editable.offset().top;
+                    offset += this.$el.find('.o_wysiwyg_resizer').outerHeight() || 0;
+                    offset += parseInt(this.$el.find('.o_form_sheet').css('margin-bottom') || 0, 10);
+                    $editable.outerHeight(Math.max(200, window.innerHeight - offset - 3));
+                }
+            });
+        },
+
         /**
          * Main method used when saving the record hitting the "Save" button.
          * We check if the stage_id field was altered and if we need to display a rainbowman

--- a/addons/crm/static/src/scss/crm_form.scss
+++ b/addons/crm/static/src/scss/crm_form.scss
@@ -1,0 +1,13 @@
+.o_lead_opportunity_form {
+    .o_notebook {
+        .note-editable,
+        .o_wysiwyg_resizer {
+            border: 0;
+        }
+        .oe_form_field_html.oe_edit_only {
+            margin-bottom: -50px;
+            margin-left: -$o-horizontal-padding;
+            margin-right: -$o-horizontal-padding;
+        }
+    }
+}

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -50,7 +50,18 @@
                         <div class="oe_title">
                             <label for="name" string="Lead" attrs="{'invisible': [('type', '=', 'opportunity')]}"/>
                             <label for="name" attrs="{'invisible': [('type', '=', 'lead')]}"/>
-                            <h1><field class="o_text_overflow" name="name" placeholder="e.g. Product Pricing"/></h1>
+                            <h1 class="oe_read_only">
+                                <field class="o_text_overflow pr-3" name="name" placeholder="e.g. Product Pricing"/>
+                                <field name="priority" attrs="{'invisible': [('type', '=', 'lead')]}" widget="priority"/>
+                            </h1>
+                            <h1 class="row oe_edit_only">
+                                <div class="col">
+                                    <field class="o_text_overflow" name="name" placeholder="e.g. Product Pricing"/>
+                                </div>
+                                <div class="col-3">
+                                    <field name="priority" attrs="{'invisible': [('type', '=', 'lead')]}" widget="priority"/>
+                                </div>
+                            </h1>
                             <h2 class="o_row no-gutters align-items-end">
                                 <div class="col" attrs="{'invisible': [('type', '=', 'lead')]}">
                                     <label for="expected_revenue" class="oe_edit_only" />
@@ -230,15 +241,18 @@
                                     <field name="mobile" widget="phone" string="Mobile"/>
                                 </div>
                             </group>
-                            <group attrs="{'invisible': [('type', '=', 'lead')]}">
-                                <field name="date_deadline"/>
-                                <field name="priority" widget="priority"/>
-                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
-                            </group>
                             <group>
-                                <field name="user_id"
-                                    context="{'default_sales_team_id': team_id}" widget="many2one_avatar_user"/>
-                                <field name="team_id" options="{'no_open': True, 'no_create': True}"/>
+                                <field name="date_deadline" attrs="{'invisible': [('type', '=', 'lead')]}"/>
+                                <label for="user_id"/>
+                                <div class="o_row">
+                                    <div class="o_col">
+                                        <field name="user_id" context="{'default_sales_team_id': team_id}" widget="many2one_avatar_user"/>
+                                    </div>
+                                    <div class="o_col">
+                                        <field name="team_id" options="{'no_open': True, 'no_create': True}"/>
+                                    </div>
+                                </div>
+                                <field name="tag_ids" widget="many2many_tags" attrs="{'invisible': [('type', '=', 'lead')]}" options="{'color_field': 'color', 'no_create_edit': True}"/>
                                 <field name="type" invisible="1"/>
                             </group>
                             <group name="lead_priority" attrs="{'invisible': [('type', '=', 'opportunity')]}">
@@ -248,14 +262,14 @@
                             <group name="opportunity_info" attrs="{'invisible': [('type', '=', 'lead')]}">
                                 <field name="lost_reason" attrs="{'invisible': [('active', '=', True)]}"/>
                                 <field name="date_conversion" invisible="1"/>
-                                <field name="company_id" groups="base.group_multi_company"/>
                                 <field name="user_company_ids" invisible="1"/>
                             </group>
                         </group>
 
                         <notebook>
                             <page string="Internal Notes" name="internal_notes">
-                                <field name="description" placeholder="Add a description..."/>
+                                <field name="description" class="oe_read_only" placeholder="Add a description..."/>
+                                <field name="description" class="oe_edit_only" placeholder="Add a description..."/>
                             </page>
                             <page name="extra" string="Extra Info" attrs="{'invisible': [('type', '=', 'opportunity')]}">
                                 <group>
@@ -280,6 +294,7 @@
                             <page name="lead" string="Extra Information" attrs="{'invisible': [('type', '=', 'lead')]}">
                                 <group>
                                     <group string="Contact Information">
+                                        <field name="company_id" groups="base.group_multi_company"/>
                                         <field name="partner_name"/>
                                         <label for="street_page_lead" string="Address"/>
                                         <div class="o_address_format">


### PR DESCRIPTION
When the user opens the CRM form view, there will be unusable space below the internal notes. To improve the UX, we will automatically resize the editor to fill the gap between the form view and the outer window.

We will also reorder some fields:
- The priority will be put next to the title.
- The salesperson and the team will be put next to each other on the same line.

By reordering the fields, the fields will take less vertical space and there will be more emphasis on the internal notes which is the most important field of the view as it helps the user qualifying the lead or the opportunity.

task-2677144

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
