### PR TITLE
[FIX] website: replace columns with extended backgrounds with shapes

### DIFF
--- a/addons/website/static/src/snippets/s_mega_menu_little_icons/001.scss
+++ b/addons/website/static/src/snippets/s_mega_menu_little_icons/001.scss
@@ -1,0 +1,7 @@
+.s_mega_menu_little_icons[data-vcss='001'] {
+    .nav-link {
+        @include hover-focus {
+            background: rgba(0, 0, 0, .05);
+        }
+    }
+}

--- a/addons/website/static/src/snippets/s_mega_menu_menus_logos/001.scss
+++ b/addons/website/static/src/snippets/s_mega_menu_menus_logos/001.scss
@@ -1,0 +1,6 @@
+.s_mega_menu_menus_logos[data-vcss='001'] {
+    .s_mega_menu_menus_logos_wrapper {
+        // Apply color transparency to match with the preset used
+        border-color: rgba(0, 0, 0, .05) !important;
+    }
+}

--- a/addons/website/views/snippets/s_mega_menu_little_icons.xml
+++ b/addons/website/views/snippets/s_mega_menu_little_icons.xml
@@ -2,7 +2,8 @@
 <odoo>
 
 <template id="s_mega_menu_little_icons" name="Menu - Little icons" groups="base.group_user">
-    <section class="s_mega_menu_little_icons overflow-hidden">
+    <section class="s_mega_menu_little_icons overflow-hidden" data-vcss="001" data-oe-shape-data="{'shape':'web_editor/Origins/09_001','flip':[]}">
+        <div class="o_we_shape o_web_editor_Origins_09_001"/>
         <div class="container">
             <div class="row">
                 <div class="col-12 col-sm py-2 d-flex align-items-center">
@@ -53,7 +54,7 @@
                         </a>
                     </nav>
                 </div>
-                <div class="col-lg-4 p-4 s_mega_menu_gray_area">
+                <div class="col-lg-4 p-4">
                     <h4 class="o_default_snippet_text">The team</h4>
                     <p class="text-muted o_default_snippet_text">
                         <font style="font-size: 14px;">Created in 2021, the company is young and dynamic. Discover the composition of the team and their skills.</font>
@@ -69,6 +70,13 @@
     <field name="name">Menu - Little icons 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
     <field name="path">website/static/src/snippets/s_mega_menu_little_icons/000.scss</field>
+    <field name="active" eval="False"/>
+</record>
+
+<record id="website.s_mega_menu_little_icons_001_scss" model="ir.asset">
+    <field name="name">Menu - Little icons 001 SCSS</field>
+    <field name="bundle">web.assets_frontend</field>
+    <field name="path">website/static/src/snippets/s_mega_menu_little_icons/001.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_mega_menu_menus_logos.xml
+++ b/addons/website/views/snippets/s_mega_menu_menus_logos.xml
@@ -2,7 +2,8 @@
 <odoo>
 
 <template id="s_mega_menu_menus_logos" name="Menus &amp; logos" groups="base.group_user">
-    <section class="s_mega_menu_menus_logos overflow-hidden">
+    <section class="s_mega_menu_menus_logos overflow-hidden" data-vcss="001" data-oe-shape-data="{'shape':'web_editor/Origins/09_001','flip':[]}">
+        <div class="o_we_shape o_web_editor_Origins_09_001"/>
         <div class="container">
             <div class="row">
                 <div class="col-12 col-lg-8">
@@ -58,7 +59,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-12 col-lg-4 py-4 d-flex align-items-center justify-content-center s_mega_menu_gray_area">
+                <div class="col-12 col-lg-4 py-4 d-flex align-items-center justify-content-center">
                     <a href="#" class="nav-link o_default_snippet_text text-center px-0" data-name="Menu Item">
                         <img src="/web/image/website.s_mega_menu_menus_logos_default_image" class="mb-3 rounded shadow img-fluid" alt=""/>
                         <h4 class="o_default_snippet_text">Spring collection has arrived !</h4>
@@ -85,6 +86,13 @@
     <field name="name">Menus &amp; logos 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
     <field name="path">website/static/src/snippets/s_mega_menu_menus_logos/000.scss</field>
+    <field name="active" eval="False"/>
+</record>
+
+<record id="website.s_mega_menu_menus_logos_001_scss" model="ir.asset">
+    <field name="name">Menus &amp; logos 001 SCSS</field>
+    <field name="bundle">web.assets_frontend</field>
+    <field name="path">website/static/src/snippets/s_mega_menu_menus_logos/001.scss</field>
 </record>
 
 </odoo>


### PR DESCRIPTION
[1] introduced templates with columns with 'overflowing' backgrounds,
using pseudo elements. These are not easily editable. For the template
to be fully editable, it is simpler to use background shapes.

task-2668908

[1]: 63a3ba4



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
