### PR TITLE
[FIX] account: currency symbol not displayed in Subtotal and total amount

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -198,7 +198,7 @@
                     <td class="text-right">
                         <span
                             t-att-class="oe_subtotal_footer_separator"
-                            t-esc="subtotal['amount']"
+                            t-esc="subtotal['formatted_amount']"
                         />
                     </td>
                 </tr>
@@ -211,7 +211,7 @@
             <tr class="border-black o_total">
                 <td><strong>Total</strong></td>
                 <td class="text-right">
-                    <span t-esc="tax_totals['amount_total']"/>
+                    <span t-esc="tax_totals['formatted_amount_total']"/>
                 </td>
             </tr>
         </template>


### PR DESCRIPTION
Under account.document_tax_totals template the subtotal and total were using the float amounts for printing.

There was the formatted currency returned from _compute_tax_totals_json but not printed.
This commit uses the formatted_amount and formatted_amount_total keys to display the amount with currency on PDF and portal view.

closes #77996




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
