### PR TITLE
[IMP] base: add company name for record rule error

### DIFF
--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -230,12 +230,7 @@ class IrRule(models.Model):
         resolution_info = _("Contact your administrator to request access if necessary.")
 
         if not self.env.user.has_group('base.group_no_one') or not self.env.user.has_group('base.group_user'):
-            msg = """{operation_error}
-
-{resolution_info}""".format(
-                operation_error=operation_error,
-                resolution_info=resolution_info)
-            return AccessError(msg)
+            return AccessError(f"{operation_error}\n\n{resolution_info}")
 
         # This extended AccessError is only displayed in debug mode.
         # Note that by default, public and portal users do not have
@@ -243,35 +238,32 @@ class IrRule(models.Model):
         # so it is relatively safe here to include the list of rules and record names.
         rules = self._get_failing(records, mode=operation).sudo()
 
-        records_description = ', '.join(['%s (id=%s)' % (rec.display_name, rec.id) for rec in records[:6].sudo()])
+        records_sudo = records[:6].sudo()
+        company_related = any('company_id' in (r.domain_force or '') for r in rules)
+
+        def get_record_description(rec):
+            # If the user has access to the company of the record, add this
+            # information in the description to help them to change company
+            if company_related and 'company_id' in rec and rec.company_id in self.env.user.company_ids:
+                return f'{rec.display_name} (id={rec.id}, company={rec.company_id.display_name})'
+            return f'{rec.display_name} (id={rec.id})'
+
+        records_description = ', '.join(get_record_description(rec) for rec in records_sudo)
         failing_records = _("Records: %s", records_description)
 
-        user_description = '%s (id=%s)' % (self.env.user.name, self.env.user.id)
+        user_description = f'{self.env.user.name} (id={self.env.user.id})'
         failing_user = _("User: %s", user_description)
 
-        rules_description = '\n'.join('- %s' % rule.name for rule in rules)
+        rules_description = '\n'.join(f'- {rule.name}' for rule in rules)
         failing_rules = _("This restriction is due to the following rules:\n%s", rules_description)
-        if any('company_id' in (r.domain_force or []) for r in rules):
+        if company_related:
             failing_rules += "\n\n" + _('Note: this might be a multi-company issue.')
-
-        msg = """{operation_error}
-
-{failing_records}
-{failing_user}
-
-{failing_rules}
-
-{resolution_info}""".format(
-                operation_error=operation_error,
-                failing_records=failing_records,
-                failing_user=failing_user,
-                failing_rules=failing_rules,
-                resolution_info=resolution_info)
 
         # clean up the cache of records prefetched with display_name above
         for record in records[:6]:
             record._cache.clear()
 
+        msg = f"{operation_error}\n\n{failing_records}\n{failing_user}\n\n{failing_rules}\n\n{resolution_info}"
         return AccessError(msg)
 
 

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -32,14 +32,6 @@ class IrRule(models.Model):
          'Rule must have at least one checked access right !'),
     ]
 
-    def _eval_context_for_combinations(self):
-        """Returns a dictionary to use as evaluation context for
-           ir.rule domains, when the goal is to obtain python lists
-           that are easier to parse and combine, but not to
-           actually execute them."""
-        return {'user': tools.unquote('user'),
-                'time': tools.unquote('time')}
-
     @api.model
     def _eval_context(self):
         """Returns a dictionary to use as evaluation context for
@@ -169,27 +161,8 @@ class IrRule(models.Model):
 
     @api.model
     def clear_cache(self):
-        """ Deprecated, use `clear_caches` instead. """
+        warnings.warn("Deprecated IrRule.clear_cache(), use IrRule.clear_caches() instead", DeprecationWarning)
         self.clear_caches()
-
-    @api.model
-    def domain_get(self, model_name, mode='read'):
-        # this method is now unsafe, since it returns a list of tables which
-        # does not contain the joins present in the generated Query object
-        warnings.warn(
-            "Unsafe and deprecated IrRule.domain_get(), "
-            "use IrRule._compute_domain() and expression().query instead",
-            DeprecationWarning,
-        )
-        dom = self._compute_domain(model_name, mode)
-        if dom:
-            # _where_calc is called as superuser. This means that rules can
-            # involve objects on which the real uid has no acces rights.
-            # This means also there is no implicit restriction (e.g. an object
-            # references another object the user can't see).
-            query = self.env[model_name].sudo()._where_calc(dom, active_test=False)
-            return query.where_clause, query.where_clause_params, query.tables
-        return [], [], ['"%s"' % self.env[model_name]._table]
 
     def unlink(self):
         res = super(IrRule, self).unlink()

--- a/odoo/addons/test_access_rights/ir.model.access.csv
+++ b/odoo/addons/test_access_rights/ir.model.access.csv
@@ -2,6 +2,7 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_test_access_right_some_obj,access_test_access_right_some_obj,model_test_access_right_some_obj,,1,1,1,1
 access_test_access_right_container,access_test_access_right_container,model_test_access_right_container,,1,1,1,1
 access_test_access_right_parent,access_test_access_right_parent,model_test_access_right_parent,,1,1,1,1
+access_test_access_right_child,access_test_access_right_child,model_test_access_right_child,,1,1,1,1
 access_test_access_right_obj_categ,access_test_access_right_obj_categ,model_test_access_right_obj_categ,,1,1,1,1
 access_test_ticket_portal,access_test_ticket_portal,model_test_access_right_ticket,base.group_portal,1,0,0,0
 access_test_ticket_user,access_test_ticket_user,model_test_access_right_ticket,base.group_user,1,1,1,1

--- a/odoo/addons/test_access_rights/models.py
+++ b/odoo/addons/test_access_rights/models.py
@@ -31,6 +31,12 @@ class Parent(models.Model):
 
     obj_id = fields.Many2one('test_access_right.some_obj', required=True, ondelete='restrict')
 
+class Child(models.Model):
+    _name = 'test_access_right.child'
+    _description = 'Object for testing company ir rule'
+
+    parent_id = fields.Many2one('test_access_right.some_obj')
+
 class ObjCateg(models.Model):
     _name = 'test_access_right.obj_categ'
     _description = "Context dependent searchable model"

--- a/odoo/addons/test_access_rights/tests/test_feedback.py
+++ b/odoo/addons/test_access_rights/tests/test_feedback.py
@@ -303,9 +303,10 @@ This restriction is due to the following rules:
 Contact your administrator to request access if necessary.""" % (self.record.display_name, self.record.id, self.user.name, self.user.id)
         )
 
-    def test_warn_company(self):
+    def test_warn_company_no_access(self):
         """ If one of the failing rules mentions company_id, add a note that
-        this might be a multi-company issue.
+        this might be a multi-company issue, but the user doesn't access to this company
+        then no information about the company is showed.
         """
         self.env.ref('base.group_no_one').write({'users': [Command.link(self.user.id)]})
         self.env.ref('base.group_user').write({'users': [Command.link(self.user.id)]})
@@ -328,32 +329,66 @@ Note: this might be a multi-company issue.
 Contact your administrator to request access if necessary.""" % (self.record.display_name, self.record.id, self.user.name, self.user.id)
         )
 
-    def test_read(self):
-        """ because of prefetching, read() goes through a different codepath
-        to apply rules
+    def test_warn_company_no_company_field(self):
+        """ If one of the failing rules mentions company_id, add a note that
+        this might be a multi-company issue, but the record doesn't have company_id field
+        then no information about the company is showed.
         """
         self.env.ref('base.group_no_one').write({'users': [Command.link(self.user.id)]})
         self.env.ref('base.group_user').write({'users': [Command.link(self.user.id)]})
-        self._make_rule('rule 0', "[('company_id', '=', user.company_id.id)]", attr='read')
-        self._make_rule('rule 1', '[("val", "=", 1)]', global_=True, attr='read')
+        ChildModel = self.env['test_access_right.child'].sudo()
+        self.env['ir.rule'].create({
+            'name': 'rule 0',
+            'model_id': self.env['ir.model'].search([('model', '=', ChildModel._name)]).id,
+            'groups': [],
+            'domain_force': '[("parent_id.company_id", "=", user.company_id.id)]',
+            'perm_read': True,
+        })
+        self.record.sudo().company_id = self.env['res.company'].create({'name': 'Brosse Inc.'})
+        self.user.sudo().company_ids = [Command.link(self.record.company_id.id)]
+        child_record = ChildModel.create({'parent_id': self.record.id}).with_user(self.user)
         with self.assertRaises(AccessError) as ctx:
-            _ = self.record.val
+            _ = child_record.parent_id
         self.assertEqual(
             ctx.exception.args[0],
-            """Due to security restrictions, you are not allowed to access 'Object For Test Access Right' (test_access_right.some_obj) records.
+            """Due to security restrictions, you are not allowed to access 'Object for testing company ir rule' (test_access_right.child) records.
 
 Records: %s (id=%s)
 User: %s (id=%s)
 
 This restriction is due to the following rules:
 - rule 0
-- rule 1
 
 Note: this might be a multi-company issue.
 
-Contact your administrator to request access if necessary.""" % (self.record.display_name, self.record.id, self.user.name, self.user.id)
+Contact your administrator to request access if necessary.""" % (child_record.display_name, child_record.id, self.user.name, self.user.id)
         )
 
+    def test_warn_company_access(self):
+        """ because of prefetching, read() goes through a different codepath
+        to apply rules
+        """
+        self.env.ref('base.group_no_one').write({'users': [Command.link(self.user.id)]})
+        self.env.ref('base.group_user').write({'users': [Command.link(self.user.id)]})
+        self.record.sudo().company_id = self.env['res.company'].create({'name': 'Brosse Inc.'})
+        self.user.sudo().company_ids = [Command.link(self.record.company_id.id)]
+        self._make_rule('rule 0', "[('company_id', '=', user.company_id.id)]", attr='read')
+        with self.assertRaises(AccessError) as ctx:
+            _ = self.record.val
+        self.assertEqual(
+            ctx.exception.args[0],
+            """Due to security restrictions, you are not allowed to access 'Object For Test Access Right' (test_access_right.some_obj) records.
+
+Records: %s (id=%s, company=%s)
+User: %s (id=%s)
+
+This restriction is due to the following rules:
+- rule 0
+
+Note: this might be a multi-company issue.
+
+Contact your administrator to request access if necessary.""" % (self.record.display_name, self.record.id, self.record.sudo().company_id.display_name, self.user.name, self.user.id)
+        )
         p = self.env['test_access_right.parent'].create({'obj_id': self.record.id})
         p.flush()
         p.invalidate_cache()


### PR DESCRIPTION
In debug mode, when a company ir.rule raise a exception
for one or multiple records, a feedback message is
display with limited records information.
Add company name to these information to help the user to change
his current company to the correct one directly.

task-2628865