### PR TITLE
15.0 website slides traceback grant access faba

### DIFF
--- a/addons/website_slides/static/src/components/activity/activity.js
+++ b/addons/website_slides/static/src/components/activity/activity.js
@@ -20,7 +20,10 @@ patch(Activity.prototype, 'website_slides/static/src/components/activity/activit
             args: [[this.activity.thread.id]],
             kwargs: { partner_id: this.activity.requestingPartner.id },
         });
-        this.trigger('reload');
+        if (this.activity) {
+            this.activity.delete();
+        }
+        this.trigger('reload', { keepChanges: true });
     },
     /**
      * @private
@@ -32,6 +35,9 @@ patch(Activity.prototype, 'website_slides/static/src/components/activity/activit
             args: [[this.activity.thread.id]],
             kwargs: { partner_id: this.activity.requestingPartner.id },
         });
-        this.trigger('reload');
+        if (this.activity) {
+            this.activity.delete();
+        }
+        this.trigger('reload', { keepChanges: true });
     },
 });


### PR DESCRIPTION
Purpose
=======
Avoid getting a traceback when granting access to an event as a course
responsible.

Specifications
=============
Remove activity after making rpc in _onGrantAccess and _onRefuseAccess
in website_slides/static/src/components/activity/activity.js

Thanks a lot to @seb-odoo for his great help.
Task-2676752