### PR TITLE
[FIX] mrp : bom report duration for dozens

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -169,6 +169,7 @@ class ReportBomStructure(models.AbstractModel):
     def _get_operation_line(self, bom, qty, level):
         operations = []
         total = 0.0
+        qty = bom.product_uom_id._compute_quantity(qty, bom.product_tmpl_id.uom_id)
         for operation in bom.operation_ids:
             operation_cycle = float_round(qty / operation.workcenter_id.capacity, precision_rounding=1, rounding_method='UP')
             duration_expected = operation_cycle * operation.time_cycle + operation.workcenter_id.time_stop + operation.workcenter_id.time_start


### PR DESCRIPTION
Current behavior :
When a bom is created with uom set as dozens the report
operations time is not correct. For exemple if the operation
time is 10 minutes. The operation time for a dozen should be
120, but at the moment it's 10 minutes

Steps to reproduce:
Have a product in units.
Create a bill of materials in dozens.
Have a operation where the workstation that has a capacity of 1.
Look at the Bill of material cost and structure even though it uses a dozen it shows
the operation time for one unit.

opw-2669899


I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
