### PR TITLE
[IMP] website_event_(track, meet): better display countdown time

### DIFF
--- a/addons/website_event_exhibitor/static/src/xml/event_exhibitor_connect.xml
+++ b/addons/website_event_exhibitor/static/src/xml/event_exhibitor_connect.xml
@@ -18,7 +18,11 @@
                         Event <span t-esc="widget.sponsorData.event_name" class="font-weight-bold"/>
                         <span t-if="widget.sponsorData.event_start_today">
                             starts in
-                            <span t-esc="widget.sponsorData.event_start_remaining"/> minutes
+                            <span t-if="widget.sponsorData.event_start_remaining &gt;= 1" t-esc="widget.sponsorData.event_start_remaining"
+                                t-options="{'widget': 'duration', 'digital': False, 'unit': 'minute', 'round': 'minute'}"/>
+                            <t t-else="">
+                                a few seconds
+                            </t>.
                         </span>
                         <span class="my-0" t-else="">
                             starts on <span t-esc="widget.sponsorData.event_date_begin_located"/>

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
@@ -42,8 +42,11 @@
                 Event <span t-esc="sponsor.event_id.name" class="font-weight-bold"/>
                 <span t-if="sponsor.event_id.start_today">
                     starts in
-                    <span t-esc="sponsor.event_id.start_remaining"
-                        t-options="{'widget': 'duration', 'digital': True, 'unit': 'minute', 'round': 'minute'}"/>.
+                    <span t-if="sponsor.event_id.start_remaining &gt;= 1" t-esc="sponsor.event_id.start_remaining"
+                        t-options="{'widget': 'duration', 'digital': False, 'unit': 'minute', 'round': 'minute'}"/>
+                    <t t-else="">
+                        a few seconds
+                    </t>.
                 </span>
                 <span class="my-0" t-else="">
                     starts on

--- a/addons/website_event_meet/views/event_meet_templates_page.xml
+++ b/addons/website_event_meet/views/event_meet_templates_page.xml
@@ -42,8 +42,11 @@
                 The event <span t-esc="meeting_room.event_id.name" class="font-weight-bold"/>
                 <span t-if="meeting_room.event_id.start_today">
                     starts in
-                    <span t-esc="meeting_room.event_id.start_remaining"
-                        t-options="{'widget': 'duration', 'digital': True, 'unit': 'minute', 'round': 'minute'}"/>.
+                    <span t-if="meeting_room.event_id.start_remaining &gt;= 1" t-esc="meeting_room.event_id.start_remaining"
+                        t-options="{'widget': 'duration', 'digital': False, 'unit': 'minute', 'round': 'minute'}"/>
+                    <t t-else="">
+                        a few seconds
+                    </t>.
                 </span>
                 <span class="my-0" t-else="meeting_room.event_id.start_today">
                     starts on

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -364,14 +364,17 @@
                     <span class="text-muted text-truncate" t-field="track.partner_name" itemprop="performer"/>
                     <!-- Starts -->
                     <span class="text-muted ml-auto">
-                        <t t-if="track.is_track_upcoming &gt; 0">In
+                        <t t-if="track.track_start_remaining &gt;= 60">In
                             <span class="text-muted ml-auto" t-field="track.track_start_remaining" itemprop="duration"
                                 t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'second', 'round': 'minute'}"/>
                         </t>
-                        <t t-else="">
+                        <t t-elif="track.track_start_relative &gt;= 60">
                             <span class="text-muted ml-auto" t-field="track.track_start_relative" itemprop="duration"
                                 t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'second', 'round': 'minute'}"/>
                             ago
+                        </t>
+                        <t t-else="">
+                            Starting now!
                         </t>
                     </span>
                 </div>

--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -37,8 +37,11 @@
                 Event <span t-esc="track.event_id.name" class="font-weight-bold"/>
                 <span t-if="track.event_id.start_today">
                     starts in
-                    <span t-esc="track.event_id.start_remaining"
+                    <span t-if="track.event_id.start_remaining &gt;= 1" t-esc="track.event_id.start_remaining"
                         t-options="{'widget': 'duration', 'digital': False, 'unit': 'minute', 'round': 'minute'}"/>
+                    <t t-else="">
+                        a few seconds
+                    </t>.
                 </span>
                 <span t-else="">
                     starts on


### PR DESCRIPTION
Purpose
=======
Change weird formatting sometimes showing "In" or "ago" without
displaying any text, give user better awereness of when a room/track
starts or has started.

Specifications
=============
Change widget in website_event_meet to digital: False, display "Starting
now!" if track starts/has started within less than 60sec, display info
box showing when page was last refreshed.

Task-2677865