### PR TITLE
[FIX] stock: reserve from forecasted report

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1896,6 +1896,29 @@ class StockMove(models.Model):
         self.ensure_one()
         return self.state != 'draft' or (self.picking_id.immediate_transfer and self.state == 'draft')
 
+    def _track_move_from_forecast_report(self, model, product_id):
+        moves_before_reservation = []
+        product_ids = [product_id]
+        if model == 'product.template':
+            product_ids = self.env['product.product'].search([('product_tmpl_id', '=', product_id)]).ids
+        for move in self:
+            if move.product_id.id not in product_ids or \
+               move.state in ('draft', 'cancel', 'done') or not move.product_uom_qty or \
+               float_compare(move.reserved_availability, move.product_uom_qty, precision_digits=move.product_uom.rounding) == 0.0:
+                continue
+            moves_before_reservation.append((move, move.reserved_availability))
+        return moves_before_reservation
+
+    def _generate_flags_for_forecast_report(self, moves_before_reservation):
+        should_refresh = False
+        should_alert = False
+        for move, previous_reserved_qty in moves_before_reservation:
+            if not should_refresh and float_compare(move.reserved_availability, previous_reserved_qty, precision_digits=move.product_uom.rounding) != 0.0:
+                should_refresh = True
+            elif not should_alert and float_compare(move.reserved_availability, previous_reserved_qty, precision_digits=move.product_uom.rounding) == 0.0:
+                should_alert = True
+        return dict(should_refresh=should_refresh, should_alert=should_alert)
+
     def _trigger_scheduler(self):
         """ Check for auto-triggered orderpoints and trigger them. """
         if not self or self.env['ir.config_parameter'].sudo().get_param('stock.no_auto_scheduler'):

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -762,6 +762,32 @@ class Picking(models.Model):
 
         return True
 
+    def action_assign_from_forecast_report(self):
+        """ Calls `action_assign` but also keeps track of reservations to know
+        if there is reservations who can't be fully done.
+
+        :returns: a dict of flags to pass to the client.
+        :rtype: dict
+        """
+        should_refresh = False
+        should_alert = False
+        picking_names = set()
+        moves_before_reservation = []
+        for move in self.move_lines:
+            if move.state in ('draft', 'cancel', 'done') or not move.product_uom_qty or \
+               float_compare(move.reserved_availability, move.product_uom_qty, precision_digits=move.product_uom.rounding) == 0.0:
+                continue
+            moves_before_reservation.append((move, move.reserved_availability))
+        self.action_assign()
+
+        for move, previous_reserved_qty in moves_before_reservation:
+            if not should_refresh and float_compare(move.reserved_availability, previous_reserved_qty, precision_digits=move.product_uom.rounding) != 0.0:
+                should_refresh = True
+            if float_compare(move.reserved_availability, move.product_uom_qty, precision_digits=move.product_uom.rounding) != 0.0:
+                should_alert = True
+                picking_names.add(move.picking_id.display_name)
+        return dict(should_refresh=should_refresh, should_alert=should_alert, picking_names=list(picking_names))
+
     def action_cancel(self):
         self.mapped('move_lines')._action_cancel()
         self.write({'is_locked': True})

--- a/addons/stock/report/report_stock_forecasted.xml
+++ b/addons/stock/report/report_stock_forecasted.xml
@@ -135,7 +135,8 @@
                             </td>
                             <td t-esc="line['receipt_date'] or ''"
                                 t-attf-class="#{line['is_late'] and 'o_grid_warning'}"/>
-                            <td t-if="docs['multiple_product']" t-esc="line['product']['display_name']"/>
+                            <td t-if="docs['multiple_product']" t-esc="line['product']['display_name']"
+                                t-att-data-product-id="line['product']['id']"/>
                             <td class="text-right"><t t-if="not line['replenishment_filled']">- </t><t t-esc="line['quantity']" t-options="{'widget': 'float', 'precision': precision}"/></td>
                             <td t-attf-class="#{not line['replenishment_filled'] and 'o_grid_warning'}" name="usedby_cell">
                                 <button t-if="line['move_out'] and line['move_out'].picking_id"

--- a/addons/stock/static/src/js/report_stock_forecasted.js
+++ b/addons/stock/static/src/js/report_stock_forecasted.js
@@ -340,11 +340,23 @@ const ReplenishReport = clientAction.extend({
     _onClickReserve: function(ev) {
         const model = ev.target.getAttribute('model');
         const modelId = parseInt(ev.target.getAttribute('model-id'));
-        return this._rpc( {
+        return this._rpc({
             model,
             args: [[modelId]],
-            method: 'action_assign'
-        }).then(() => this._reloadReport());
+            method: 'action_assign_from_forecast_report',
+        }).then(res => {
+            if (res.should_refresh) {
+                this._reloadReport();
+            }
+            if (res.should_alert) {
+                const title = _t("Reservation is not processed");
+                const message = _.str.sprintf(
+                    _t(`The reservation can not be fully processed for the following transfer(s): %s.
+                    Please check the product stock location meets your transfers's needs.`),
+                    res.picking_names.join(', '));
+                this.displayNotification({ title, message, type: 'danger' });
+            }
+        });
     }
 
 });


### PR DESCRIPTION
Before this commit, on the product forecasted report, the Reserve button is always displayed even when isn't not possible to make reservation for a picking.
This fix doesn't change that but will at least inform the user the reservation can't be done and avoid to refresh the report if no change is done at the reservation's level.

How to reproduce:
  - Enable multi-location;
  - Create a product and add some quantity in the loc. WH/Stock;
  - Create a delivery for this product from a sublocation of WH/Stock (WH/Stock/Shelf 2 for example);
  - Open the product's forecasted report => As there is some available qty. (in WH/Stock), it will show the "Reserve" button, but as the delivery source is a sublocation of WH/Stock, it can't reserve it.
    It will refresh the report like the reservation is done but nothing happened.