### PR TITLE
[FIX] sale_purchase : Disable auto-purchase when no vendor

### DIFF
--- a/addons/sale_purchase/models/sale_order.py
+++ b/addons/sale_purchase/models/sale_order.py
@@ -267,7 +267,12 @@ class SaleOrderLine(models.Model):
             # determine vendor of the order (take the first matching company and product)
             suppliers = line.product_id._select_seller(quantity=line.product_uom_qty, uom_id=line.product_uom)
             if not suppliers:
-                raise UserError(_("There is no vendor associated to the product %s. Please define a vendor for this product.") % (line.product_id.display_name,))
+                # Do not raise an error if there is no seller for the product in another company as service_to_purchase is product linked and not company linked,
+                # using it in interco operations lead to error when the company executing the service is reach through auto-validated SO/PO
+                if line.company_id == self.env.company:
+                    raise UserError(_("There is no vendor associated to the product %s. Please define a vendor for this product.") % (line.product_id.display_name,))
+                else:
+                    continue
             supplierinfo = suppliers[0]
             partner_supplier = supplierinfo.name  # yes, this field is not explicit .... it is a res.partner !
 


### PR DESCRIPTION
Issues :
Auto purchase is product-based and not company based which is problematic in the case of intercompany auto purchase of product from one company to another.
An error is raised when a product is auto-purchased without vendor, but as we cannot set auto purchase option differently in each company, it may cause an issue when handling mutliple companies.

Solve :
In the case of auto_purchase, we only purchase when at least vendor is set, this is not a true fix as it remove the error explaining the user what he can do in case of true mistake but a feedback will be written for future versions.
For more information on the problem, see : https://drive.google.com/file/d/1mp5BMOkUh25A0-kMLZDwhzSIeAlcjtAj/view

opw-2569192

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
