### PR TITLE
[FIX] web_editor: properly remove hint on mass_mailing

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2269,7 +2269,7 @@ export class OdooEditor extends EventTarget {
 
     clean() {
         this.observerUnactive();
-        for (const hint of document.querySelectorAll('.oe-hint')) {
+        for (const hint of this.document.querySelectorAll('.oe-hint')) {
             hint.classList.remove('oe-hint', 'oe-command-temporary-hint');
             hint.removeAttribute('placeholder');
         }
@@ -2297,7 +2297,7 @@ export class OdooEditor extends EventTarget {
             'CL LI': 'To-do',
         };
 
-        for (const hint of document.querySelectorAll('.oe-hint')) {
+        for (const hint of this.document.querySelectorAll('.oe-hint')) {
             if (hint.classList.contains('oe-command-temporary-hint') || !isEmptyBlock(hint)) {
                 this.observerUnactive();
                 hint.classList.remove('oe-hint', 'oe-command-temporary-hint');


### PR DESCRIPTION
Before this commit, the editor hint were not properly
removed because the queryselector was made on
the wrong document.

Task-2678410




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
