### PR TITLE
[FIX] l10n_cl: define tax payer type as invisible if country not Chile

### DIFF
--- a/addons/l10n_cl/models/res_partner.py
+++ b/addons/l10n_cl/models/res_partner.py
@@ -16,6 +16,10 @@ class ResPartner(models.Model):
         ('4', _('Foreigner')),
     ]
 
+    country_code = fields.Char(
+        related='company_id.country_id.code',
+        help='Technical field used to hide/show fields regarding the localization')
+
     l10n_cl_sii_taxpayer_type = fields.Selection(
         _sii_taxpayer_types, 'Taxpayer Type', index=True,
         help='1 - VAT Affected (1st Category) (Most of the cases)\n'

--- a/addons/l10n_cl/models/res_partner.py
+++ b/addons/l10n_cl/models/res_partner.py
@@ -16,7 +16,7 @@ class ResPartner(models.Model):
         ('4', _('Foreigner')),
     ]
 
-    country_code = fields.Char(
+    l10n_cl_country_code = fields.Char(
         related='company_id.country_id.code',
         help='Technical field used to hide/show fields regarding the localization')
 

--- a/addons/l10n_cl/views/res_partner.xml
+++ b/addons/l10n_cl/views/res_partner.xml
@@ -16,8 +16,8 @@
                 <attribute name="placeholder">Región</attribute>
             </field>
             <field name="vat" position="after">
-                <field name="country_code" invisible="1"/>
-                <field name="l10n_cl_sii_taxpayer_type" attrs="{'invisible': [('country_code', '!=', 'CL')], 'readonly': [('parent_id', '!=', False)]}" placeholder="Tax Payer Type"/>
+                <field name="l10n_cl_country_code" invisible="1"/>
+                <field name="l10n_cl_sii_taxpayer_type" attrs="{'invisible': [('l10n_cl_country_code', '!=', 'CL')], 'readonly': [('parent_id', '!=', False)]}" placeholder="Tax Payer Type"/>
             </field>
         </field>
     </record>

--- a/addons/l10n_cl/views/res_partner.xml
+++ b/addons/l10n_cl/views/res_partner.xml
@@ -16,7 +16,8 @@
                 <attribute name="placeholder">Región</attribute>
             </field>
             <field name="vat" position="after">
-                <field name="l10n_cl_sii_taxpayer_type" attrs="{'readonly': [('parent_id', '!=', False)]}" placeholder="Tax Payer Type"/>
+                <field name="country_code" invisible="1"/>
+                <field name="l10n_cl_sii_taxpayer_type" attrs="{'invisible': [('country_code', '!=', 'CL')], 'readonly': [('parent_id', '!=', False)]}" placeholder="Tax Payer Type"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

A related field "l10n_cl_country_code" is defined in res.partner in order to hide the values.
Nevertheless as in stable this is the only field we can add here, the only problem to solve is that this would work only when partner is defined explicitely for the needed country.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
