### PR TITLE
[FIX] stock: don't show "Set Quantity" when `show_reserve=False`

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -233,7 +233,7 @@
                     <button name="action_assign" attrs="{'invisible': [('show_check_availability', '=', False)]}" string="Check Availability" type="object" class="oe_highlight" groups="base.group_user"/>
                     <button name="button_validate" attrs="{'invisible': ['|', ('state', 'in', ('waiting','confirmed')), ('show_validate', '=', False)]}" string="Validate" type="object" class="oe_highlight" groups="stock.group_stock_user"/>
                     <button name="button_validate" attrs="{'invisible': ['|', ('state', 'not in', ('waiting', 'confirmed')), ('show_validate', '=', False)]}" string="Validate" type="object" groups="stock.group_stock_user" class="o_btn_validate"/>
-                    <button name="action_set_quantities_to_reservation" attrs="{'invisible': ['|', ('show_validate', '=', False), ('immediate_transfer', '=', True)]}" string="Set quantities" type="object" groups="stock.group_stock_user" class="o_btn_validate"/>
+                    <button name="action_set_quantities_to_reservation" attrs="{'invisible': ['|', '|', ('show_validate', '=', False), ('immediate_transfer', '=', True), ('show_reserved', '!=', True)]}" string="Set quantities" type="object" groups="stock.group_stock_user" class="o_btn_validate"/>
                     <widget name="signature" string="Sign" highlight="1"
                             attrs="{'invisible': ['|', '|', ('id', '=', False), ('picking_type_code', '!=', 'outgoing'), ('state', '!=', 'done')]}"
                             full_name="partner_id" groups="stock.group_stock_sign_delivery"/>


### PR DESCRIPTION
This fix applies to incoming pickings only (since they are the only use
case where `show_reserve` can be False). Steps to reproduce:

1. Activate "Packages" setting (by default, `show_reserve` for receipts
   is False).
2. Create a new Planned Transfer receipt and add a product + a demand
   qty.
3. Confirm + push "Set Quantity" button + push "Put in Pack"

Expected result: Done amount is set to demand qty + its corresponding
   move line is in a new package.
Actual result: "Put In Pack" throws a UserError about no Done quantities
   being done (even though everywhere on the form it says qtys are done)

The issue is due to the "Set Quantity" button directly editing the
`picking.move_lines_ids` which isn't editable/visible in the form view
when `show_reserve=False`. We could force the "Put in Pack" to work in
this case (i.e. check if `any(move_line_ids != 0)`), but then we run
into the issue of the move lines not being visible at all if
`show_operations` is activated and forcing them to be visible will defeat
the whole purpose of the `show_reserve` setting.

TLDR: the simpliest solution is to not make this button available when
`show_reserve=False`

Task: 2674905

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
