### PR TITLE
[FIX] website: avoid calling external services during test

### DIFF
--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -24,6 +24,7 @@ class TestSnippets(odoo.tests.HttpCase):
         data_snippet_els = html_template.xpath("//*[@class='o_panel' and not(contains(@class, 'd-none'))]//*[@data-snippet]")
         blacklist = [
             's_facebook_page',  # avoid call to external services (facebook.com)
+            's_map', # avoid call to maps.google.com
         ]
         snippets_names = ','.join([el.attrib['data-snippet'] for el in data_snippet_els if el.attrib['data-snippet'] not in blacklist])
         self.start_tour("/?enable_editor=1&snippets_names=%s" % snippets_names, "snippets_all_drag_and_drop", login='admin', timeout=300)


### PR DESCRIPTION
`s_map` snippet is calling maps.google.com which might be the reason this tour
experience some race condition when trying to drag and drop the
`s_newsletter_subscribe_form` (which happen after the `s_map` snippet was
dropped).

When the race condition happen, we can see on the screenshot that the snippet
was drag & dropped into the footer instead of the `s_text_image` inside the
`#wrap` as it should be (see comment on first step of the test).
The reason the snippet is not dropped where it should be is because the `s_map`
was not removed as it should have been (seeing the screenshot), so the page was
scrolled and the footer became the first available and visible `o_editable`.

The `s_map` snippet is probably still in the DOM (despite a step is in charge
of removing it) because it is recreated after the google maps server reply,
which sometimes is probably taking an unexpected long time.

Anyway, external services should never be called during tests, removing the
snippet from the tour is an "easy" first step to try to fix the race
condition.
