### PR TITLE
[FIX] hr_expense: allow to create Expense Products

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -495,6 +495,7 @@
                         <field name='product_variant_count' invisible='1'/>
                         <field name="id" invisible="True"/>
                         <field name="image_1920" widget="image" class="oe_avatar" options="{'image_preview': 'image_128'}"/>
+                        <field name="detailed_type" invisible="1"/>
                         <div class="oe_title">
                             <label for="name" string="Product Name"/>
                             <h1><field name="name" placeholder="e.g. Lunch"/></h1>


### PR DESCRIPTION
Since commit `37eb0dfbb54` it was no longer possible to create Expense
Products. The field `detailed_type` was not present in the view hence it
didn't get its default value of 'service'.

TaskID: 2678961

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
