### PR TITLE
[FIX] web: fixed word breaking in pie chart tooltip of graph view

### DIFF
--- a/addons/web/static/src/legacy/scss/graph_view.scss
+++ b/addons/web/static/src/legacy/scss/graph_view.scss
@@ -23,7 +23,6 @@
         padding:10px;
         z-index: 2;
         pointer-events: none;
-        word-break: break-all;
     }
 
     div.o_graph_custom_tooltip {

--- a/addons/web/static/src/views/graph/graph_view.scss
+++ b/addons/web/static/src/views/graph/graph_view.scss
@@ -24,7 +24,6 @@
     padding: 10px;
     z-index: 2;
     pointer-events: none;
-    word-break: break-all;
   }
 
   div.o_graph_custom_tooltip {


### PR DESCRIPTION
Currently, words are not breaking properly when reaching at the
end of a line in the pie chart tooltip. It happens because of the
'word-break: break-all;' property used in the o_tooltip_legend class.
and this property breaks the words at any character to prevent overflows.

So this commit fixes the issue by removing the word-break property
so that the CSS automatically applies the default line break rules.

TaskID-2677129