### PR TITLE
[IMP] mrp: don't update qty_done after manual change

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -690,7 +690,7 @@ class MrpProduction(models.Model):
 
     @api.onchange('qty_producing', 'lot_producing_id')
     def _onchange_producing(self):
-        self._set_qty_producing()
+        self.with_context(check_manual_change=True)._set_qty_producing()
 
     @api.onchange('lot_producing_id')
     def _onchange_lot_producing(self):

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -8,7 +8,7 @@ import json
 
 from odoo import api, fields, models, _, SUPERUSER_ID
 from odoo.exceptions import UserError
-from odoo.tools import float_compare, float_round, format_datetime
+from odoo.tools import float_compare, float_round, float_is_zero, format_datetime
 
 
 class MrpWorkorder(models.Model):
@@ -529,7 +529,7 @@ class MrpWorkorder(models.Model):
 
         if self.product_tracking == 'serial':
             self.qty_producing = 1.0
-        else:
+        elif float_is_zero(self.qty_producing, precision_rounding=self.product_uom_id.rounding):
             self.qty_producing = self.qty_remaining
 
         self.env['mrp.workcenter.productivity'].create(

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -379,6 +379,9 @@ class StockMove(models.Model):
             return True
         if self.has_tracking != 'none' or self.state == 'done':
             return True
+        # Don't update qty_done when already manually changed
+        if self._context.get('check_manual_change') and float_compare(self._origin.should_consume_qty, self.quantity_done, precision_rounding=self.product_uom.rounding):
+            return True
         return False
 
     def _should_bypass_reservation(self, forced_location=False):


### PR DESCRIPTION
When qty_done != should_consume_qty, we consider it's a manual change
from the user. When there is a manual change, we won't update the
qty_done while we change qty_producing.

Task-2659233

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
