### PR TITLE
[FIX] mrp: allow backorder immediate production for SN product

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1555,7 +1555,7 @@ class MrpProduction(models.Model):
         action = {
             'res_model': 'mrp.production',
             'type': 'ir.actions.act_window',
-            'context': dict(context, mo_ids_to_backorder=None)
+            'context': dict(context, mo_ids_to_backorder=None, button_mark_done_production_ids=None)
         }
         if len(backorders) == 1:
             action.update({


### PR DESCRIPTION
Steps to reproduce:
1. Create Manufacturing Order with quantity >1 of Serial Tracked product
2. Press Mark done. (One Product will be immediated produced with a new
   SN auto-created)
3. Create Backorder
4. Press Mark done on the backorder

Expected Result:
Backorder will also be able to immediate produce and auto-create a new SN

Actual Result:
Usererror because env is still referring to original MO and tries to
produce the same SN again.

Fixes: odoo/odoo#78134



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
