### PR TITLE
[FIX] crm: set 'date_closed' while marking lead as lost

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -676,7 +676,7 @@ class Lead(models.Model):
         # stage change with new stage: update probability and date_closed
         if vals.get('probability', 0) >= 100 or not vals.get('active', True):
             vals['date_closed'] = fields.Datetime.now()
-        elif 'probability' in vals:
+        elif vals.get('probability', 0) > 0:
             vals['date_closed'] = False
 
         if any(field in ['active', 'stage_id'] for field in vals):

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime
+from freezegun import freeze_time
+
 from odoo.addons.crm.models.crm_lead import PARTNER_FIELDS_TO_SYNC, PARTNER_ADDRESS_FIELDS_TO_SYNC
 from odoo.addons.crm.tests.common import TestCrmCommon, INCOMING_EMAIL
 from odoo.addons.phone_validation.tools.phone_validation import phone_format
@@ -450,6 +453,14 @@ class TestCRMLead(TestCrmCommon):
         lead.action_set_won()
         self.assertEqual(lead.probability, 100.0)
         self.assertEqual(lead.stage_id, self.stage_gen_won)  # generic won stage has lower sequence than team won stage
+
+    @users('user_sales_leads')
+    @freeze_time("2012-01-14")
+    def test_crm_lead_lost_date_closed(self):
+        self.assertFalse(self.lead_1.date_closed, "Initially, closed date is not set")
+        # Mark the lead as lost
+        self.lead_1.action_set_lost()
+        self.assertEqual(self.lead_1.date_closed, datetime.now(), "Closed date is updated after marking lead as lost")
 
     @users('user_sales_leads')
     def test_crm_lead_update_contact(self):


### PR DESCRIPTION
PURPOSE

Update the `date_closed` field when lead is won or lost.

SPECIFICATIONS

The goal of this commit is to update the `date_closed` field when lead is
 won or lost.

It used to work in prior version because we used to set `active` and
`probability` together from `action_set_lost` method.

But now, won and lost action are handled with `toggle_active` method.
In case of the lost leads, it first sets the `active` field to False,
and the `date_closed` is correctly updated by write method. After that,
it sets the `probability` to 0, and during that the write method sets
the `date_closed` to False.

This commit fixes the issue by updating `date_closed` field from write
method, only if the `probability` is greater than zero, and thus not
discarding the already set value.

LINKS

PR #79125
TaskID-2343223

