### PR TITLE
[FIX] mrp_subcontracting: impossible to know witch product

### DIFF
--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -43,7 +43,7 @@ class MrpProduction(models.Model):
             raise UserError(_('You must enter a serial number for %s') % self.product_id.name)
         for sml in self.move_raw_ids.move_line_ids:
             if sml.tracking != 'none' and not sml.lot_id:
-                raise UserError(_('You must enter a serial number for each line of %s') % sml.product_id.name)
+                raise UserError(_('You must enter a serial number for each line of %s') % sml.product_id.display_name)
         self._update_finished_move()
         quantity_issues = self._get_quantity_produced_issues()
         if quantity_issues:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fine tuning of https://github.com/odoo/odoo/pull/78062
In case you use product with variante, `display_name` is better than `name`.

@ajf-odoo




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
