### PR TITLE
[FIX] mail: allow saving of guest volumes

### DIFF
--- a/addons/mail/models/res_users_settings_volumes.py
+++ b/addons/mail/models/res_users_settings_volumes.py
@@ -21,3 +21,17 @@ class ResUsersSettingsVolumes(models.Model):
     _sql_constraints = [
         ("partner_or_guest_exists", "CHECK((partner_id IS NOT NULL AND guest_id IS NULL) OR (partner_id IS NULL AND guest_id IS NOT NULL))", "A volume setting must have a partner or a guest."),
     ]
+
+    def _discuss_users_settings_volume_format(self):
+        return [{
+            'id': volume_setting.id,
+            'volume': volume_setting.volume,
+            'guest': [('insert-and-replace', {
+                'id': volume_setting.guest_id.id,
+                'name': volume_setting.guest_id.name,
+            })] if volume_setting.guest_id else [('clear',)],
+            'partner_id': [('insert-and-replace', {
+                'id': volume_setting.partner_id.id,
+                'name': volume_setting.partner_id.name,
+            })] if volume_setting.partner_id else [('clear',)]
+        } for volume_setting in self]

--- a/addons/mail/static/src/models/guest/guest.js
+++ b/addons/mail/static/src/models/guest/guest.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { attr, one2many } from '@mail/model/model_field';
+import { attr, one2many, one2one } from '@mail/model/model_field';
 import { registerNewModel } from '@mail/model/model_core';
 
 function factory(dependencies) {
@@ -53,6 +53,12 @@ function factory(dependencies) {
             readonly: true,
         }),
         name: attr(),
+        rtcSessions: one2many('mail.rtc_session', {
+            inverse: 'guest',
+        }),
+        volumeSetting: one2one('mail.volume_setting', {
+            inverse: 'guest',
+        }),
     };
     Guest.identifyingFields = ['id'];
     Guest.modelName = 'mail.guest';

--- a/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
@@ -253,7 +253,7 @@ function factory(dependencies) {
                     usePushToTalk: use_push_to_talk,
                     pushToTalkKey: push_to_talk_key,
                     voiceActiveDuration: voice_active_duration,
-                    volumeSettings: insert(volume_settings.map(volumeSetting => this.messaging.models['mail.volume_setting'].convertData(volumeSetting))),
+                    volumeSettings: volume_settings,
                 }),
             });
             this.messaging.discuss.update({

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -422,7 +422,6 @@ function factory(dependencies) {
                 usePushToTalk: settings.use_push_to_talk,
                 pushToTalkKey: settings.push_to_talk_key,
                 voiceActiveDuration: settings.voice_active_duration,
-                volumeSettings: settings.volume_settings && insert(settings.volume_settings.map(volumeSetting => this.messaging.models['mail.volume_setting'].convertData(volumeSetting))),
             });
         }
 

--- a/addons/mail/static/src/models/user_setting/user_setting.js
+++ b/addons/mail/static/src/models/user_setting/user_setting.js
@@ -144,10 +144,12 @@ function factory(dependencies) {
         }
 
         /**
-         * @param {mail.partner} partner
-         * @param {number} volume
+         * @param {Object} param0
+         * @param {number} [param0.guestId]
+         * @param {number} [param0.partnerId]
+         * @param {number} param0.volume
          */
-        async saveVolumeSetting(partnerId, volume) {
+        async saveVolumeSetting({ guestId, partnerId, volume }) {
             this._debounce(async () => {
                 await this.async(() => this.env.services.rpc(
                     {
@@ -158,6 +160,9 @@ function factory(dependencies) {
                             partnerId,
                             volume,
                         ],
+                        kwargs: {
+                            guest_id: guestId,
+                        },
                     },
                     { shadow: true },
                 ));

--- a/addons/mail/static/src/models/volume_setting/volume_setting.js
+++ b/addons/mail/static/src/models/volume_setting/volume_setting.js
@@ -9,37 +9,6 @@ function factory(dependencies) {
 
     class VolumeSetting extends dependencies['mail.model'] {
 
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
-        /**
-         * @static
-         * @param {Object} data
-         * @returns {Object}
-         */
-        static convertData(data) {
-            const data2 = {};
-            if ('volume' in data) {
-                data2.volume = data.volume;
-            }
-            if ('id' in data) {
-                data2.id = data.id;
-            }
-
-            // relations
-            if ('partner_id' in data) {
-                const partnerNameGet = data['partner_id'];
-                const partnerData = {
-                    display_name: partnerNameGet[1],
-                    id: partnerNameGet[0],
-                };
-                data2.partner = insert(partnerData);
-            }
-            return data2;
-        }
-
         //----------------------------------------------------------------------
         // Private
         //----------------------------------------------------------------------
@@ -48,7 +17,15 @@ function factory(dependencies) {
          * @private
          */
         _onChangeVolume() {
-            for (const rtcSession of this.partner.rtcSessions) {
+            let rtcSessions;
+            if (this.partner) {
+                rtcSessions = this.partner.rtcSessions;
+            } else if (this.guest) {
+                rtcSessions = this.guest.rtcSessions;
+            } else {
+                return;
+            }
+            for (const rtcSession of rtcSessions) {
                 if (rtcSession.audioElement) {
                     rtcSession.audioElement.volume = this.volume;
                 }
@@ -57,13 +34,15 @@ function factory(dependencies) {
     }
 
     VolumeSetting.fields = {
+        guest: one2one('mail.guest', {
+            inverse: 'volumeSetting',
+        }),
         id: attr({
             readonly: true,
             required: true,
         }),
         partner: one2one('mail.partner', {
             inverse: 'volumeSetting',
-            required: true,
         }),
         userSetting: many2one('mail.user_setting', {
             inverse: 'volumeSettings',


### PR DESCRIPTION
Before this commit, it wasn't possible to save the volume
of guests, the backend was already implemented but the
feature hasn't been implemented in the frontend, this commit
fixes this issue by completing the implementation.

taskId-2679227


