### PR TITLE
[14.0][FIX] Keep original kwargs intact for reuse on retry

### DIFF
--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import api, models
 from odoo.addons.base.tests.common import SavepointCaseWithUserDemo
 from odoo.tools import mute_logger
 from odoo.exceptions import AccessError
@@ -520,3 +520,14 @@ class TestAPI(SavepointCaseWithUserDemo):
         # sort by inverse name, with a field name
         by_name_ids = [p.id for p in sorted(ps, key=lambda p: p.name, reverse=True)]
         self.assertEqual(ps.sorted('name', reverse=True).ids, by_name_ids)
+
+
+class TestExternalAPI(SavepointCaseWithUserDemo):
+
+    def test_call_kw(self):
+        """kwargs is not modified by the execution of the call"""
+        partner = self.env['res.partner'].create({'name': 'MyPartner1'})
+        args = (partner.ids, ['name'])
+        kwargs = {'context': {'test': True}}
+        api.call_kw(self.env['res.partner'], 'read', args, kwargs)
+        self.assertEqual(kwargs, {'context': {'test': True}})

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -285,6 +285,9 @@ def split_context(method, args, kwargs):
     """ Extract the context from a pair of positional and keyword arguments.
         Return a triple ``context, args, kwargs``.
     """
+    # altering kwargs is a cause of errors, for instance when retrying a request
+    # after a serialization error: the retry is done without context!
+    kwargs = kwargs.copy()
     return kwargs.pop('context', None), args, kwargs
 
 


### PR DESCRIPTION
_Description of the issue/feature this PR addresses:_
If a concurrency error occurs, a request is retried up to 5 times with the same arguments. Retries are executed without the original context, leading to multi company errors and other errors

_Current behavior before PR:_
kwargs is modified in-place

_Desired behavior after PR is merged:_
kwargs is intact for reuse on retry.

To demonstrate the problem, I altered a method to force a concurrency error.
When first passing through https://github.com/odoo/odoo/blob/14.0/odoo/service/model.py#L94, here are the values of the arguments:

args: ()
kwargs: {'args': [[2]], 'kwargs': {'context': {'lang': 'en_US', 'tz': 'Europe/Amsterdam', 'uid': 2, 'allowed_company_ids': [2, 1]}}, 'method': 'update_module', 'model': 'base.module.update'}

The concurrency error occurs:
```
odoo.service.model: bla, retry 1/5 in 0.7940 sec...
```

At this point, the call is retried with the following values. Note the missing context:

args: ()
kwargs: {'args': [[2]], 'kwargs': {}, 'method': 'update_module', 'model': 'base.module.update'}

Retrying a call with a different context can lead to a different result in many cases.

opw-2679805

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
