### PR TITLE
[FIX] point_of_sale: singleton error

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -258,9 +258,8 @@ class PosSession(models.Model):
             if not session.start_at:
                 values['start_at'] = fields.Datetime.now()
             if session.config_id.cash_control and not session.rescue:
-                last_sessions = self.env['pos.session'].search([('config_id', '=', self.config_id.id)]).ids
-                # last session includes the new one already.
-                self.cash_register_id.balance_start = self.env['pos.session'].browse(last_sessions[1]).cash_register_id.balance_end_real if len(last_sessions) > 1 else 0
+                last_session = self.search([('config_id', '=', session.config_id.id), ('id', '!=', session.id)], limit=1)
+                session.cash_register_id.balance_start = last_session.cash_register_id.balance_end_real if last_session else 0
                 values['state'] = 'opening_control'
             else:
                 values['state'] = 'opened'


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Issue 1: fix singleton error if open pos session en batch
Issue 2: in large database, search all pos.session to get just one is useless.

@pimodoo @caburj 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
