### PR TITLE
[IMP] l10n_au: tax report headings

### DIFF
--- a/addons/l10n_au/data/account_tax_report_data.xml
+++ b/addons/l10n_au/data/account_tax_report_data.xml
@@ -4,6 +4,7 @@
     <record id="account_tax_report_gstrpt_sale_total" model="account.tax.report.line">
         <field name="name">GST amounts you owe the Tax Office from sales</field>
         <field name="sequence" eval="1"/>
+        <field name="formula">None</field>
         <field name="country_id" ref="base.au"/>
     </record>
 
@@ -78,6 +79,7 @@
 
     <record id="account_tax_report_gstrpt_g9" model="account.tax.report.line">
         <field name="name">G9: GST on sales (G8 divided by eleven)</field>
+        <field name="code">G9</field>
         <field name="sequence" eval="10"/>
         <field name="formula">((G1-(G2+G3+G4))+G7)/11</field>
         <field name="parent_id" ref="account_tax_report_gstrpt_sale_total"/>
@@ -88,6 +90,7 @@
     <record id="account_tax_report_gstrpt_purchase_total" model="account.tax.report.line">
         <field name="name">GST amounts the Tax Office owes you from purchases</field>
         <field name="sequence" eval="101"/>
+        <field name="formula">None</field>
         <field name="country_id" ref="base.au"/>
     </record>
 
@@ -190,23 +193,66 @@
         <field name="tag_name">ONLY</field>
         <field name="code">ONLY</field>
         <field name="sequence" eval="113"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_g20a"/>
+        <field name="parent_id" ref="account_tax_report_gstrpt_purchase_total"/>
         <field name="country_id" ref="base.au"/>
     </record>
 
     <record id="account_tax_report_gstrpt_g20b" model="account.tax.report.line">
         <field name="name">G20: GST on purchases</field>
         <field name="formula">(((G10+G11)-(G13+G14+G15)+G18)/11)+ONLY</field>
+        <field name="code">G20</field>
         <field name="sequence" eval="114"/>
+        <field name="parent_id" ref="account_tax_report_gstrpt_purchase_total"/>
         <field name="country_id" ref="base.au"/>
     </record>
+
+
+    <!-- Summary -->
+    <record id="account_tax_report_gstrpt_summary" model="account.tax.report.line">
+        <field name="name">Summary</field>
+        <field name="sequence" eval="201"/>
+        <field name="formula">None</field>
+        <field name="country_id" ref="base.au"/>
+    </record>
+
+    <record id="account_tax_report_gstrpt_summary_1a" model="account.tax.report.line">
+        <field name="name">1A: GST on sales</field>
+        <field name="code">1A</field>
+        <field name="sequence" eval="201"/>
+        <field name="formula">((G1-(G2+G3+G4))+G7)/11</field>
+        <field name="parent_id" eval="account_tax_report_gstrpt_summary"/>
+        <field name="country_id" ref="base.au"/>
+    </record>
+
+    <record id="account_tax_report_gstrpt_summary_1b" model="account.tax.report.line">
+        <field name="name">1B: GST on purchases</field>
+        <field name="code">1B</field>
+        <field name="sequence" eval="202"/>
+        <field name="formula">(((G10+G11)-(G13+G14+G15)+G18)/11)+ONLY</field>
+        <field name="parent_id" eval="account_tax_report_gstrpt_summary"/>
+        <field name="country_id" ref="base.au"/>
+    </record>
+
+    <record id="account_tax_report_gstrpt_summary_9" model="account.tax.report.line">
+        <field name="name">9: Your payment</field>
+        <field name="sequence" eval="203"/>
+        <field name="formula">(((G1-(G2+G3+G4))+G7)/11)-((((G10+G11)-(G13+G14+G15)+G18)/11)+ONLY)</field>
+        <field name="parent_id" eval="account_tax_report_gstrpt_summary"/>
+        <field name="country_id" ref="base.au"/>
+    </record>
+
 
     <!-- Comparison -->
     <record id="account_tax_report_gstrpt_comparison" model="account.tax.report.line">
         <field name="name">Comparison</field>
-        <field name="tag_name">Comparison</field>
-        <field name="sequence" eval="201"/>
+        <field name="tag_name" eval="False"/>
+        <field name="sequence" eval="301"/>
+        <field name="parent_id" eval="False"/>
         <field name="country_id" ref="base.au"/>
+    </record>
+
+    <record id="account_tax_report_gstrpt_comparison" model="account.tax.report.line">
+        <field name="formula">None</field>
     </record>
 
     <record id="account_tax_report_gstrpt_comparison_worksheet" model="account.tax.report.line">


### PR DESCRIPTION
- Provide consistent formatting of totals - amounts owed to the ATO and
amounts owed by the ATO are now formatted the same.

- Also, the titles are NOT subtotals of the rows below, leading to
misleading sales / purchase totals (which are not transferred to
BAS in any case).

Description of the issue/feature this PR addresses:

Inconsistent formatting of BAS Tax Report Headings / Totals

Current behavior before PR:

Headings had meaningless unreportable subtotal figures
Total lines were formatted inconsistently

Desired behavior after PR is merged:

Remove unneeded figures and standardise 2 subtotals



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
