### PR TITLE
[FIX] hr_expense: allow posting of expenses without error

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -495,9 +495,9 @@ Or send your receipts at <a href="mailto:%(email)s?subject=Lunch%%20with%%20cust
         self.ensure_one()
         account_dest = self.env['account.account']
         if self.payment_mode == 'company_account':
-            if not self.sheet_id.bank_journal_id.payment_credit_account_id:
+            if not self.sheet_id.bank_journal_id.company_id.account_journal_payment_credit_account_id:
                 raise UserError(_("No Outstanding Payments Account found for the %s journal, please configure one.") % (self.sheet_id.bank_journal_id.name))
-            account_dest = self.sheet_id.bank_journal_id.payment_credit_account_id.id
+            account_dest = self.sheet_id.bank_journal_id.company_id.account_journal_payment_credit_account_id.id
         else:
             if not self.employee_id.sudo().address_home_id:
                 raise UserError(_("No Home Address found for the employee %s, please configure one.") % (self.employee_id.name))


### PR DESCRIPTION
Small fixup of https://github.com/odoo/odoo/commit/04522f01e6fdbf82a657b32b312449fd7d756f79#diff-5e2dc39b3b508222892a48d869e4c958557e1881f6d54d7590831f9132ac68a9

Field payment_credit_account_id was refactored at company level.

Description of the issue/feature this PR addresses:
opw-2671241

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
