### PR TITLE
[IMP] survey: add background option per section

### DIFF
--- a/addons/survey/__manifest__.py
+++ b/addons/survey/__manifest__.py
@@ -68,6 +68,7 @@ sent mails with personal token for the invitation of the survey.
             'survey/static/src/js/survey_timer.js',
             'survey/static/src/js/survey_breadcrumb.js',
             'survey/static/src/js/survey_form.js',
+            'survey/static/src/js/survey_preload_image_mixin.js',
             'survey/static/src/js/survey_print.js',
             'survey/static/src/js/survey_result.js',
             ('include', 'web._assets_helpers'),

--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -484,16 +484,17 @@ class Survey(http.Controller):
         if answer_sudo.survey_time_limit_reached or survey_sudo.questions_layout == 'one_page':
             answer_sudo._mark_done()
         elif 'previous_page_id' in post:
+            # when going back, save the last displayed to reload the survey where the user left it.
+            answer_sudo.write({'last_displayed_page_id': post['previous_page_id']})
             # Go back to specific page using the breadcrumb. Lines are saved and survey continues
             return self._prepare_question_html(survey_sudo, answer_sudo, **post)
         else:
-            vals = {'last_displayed_page_id': page_or_question_id}
             if not answer_sudo.is_session_answer:
                 next_page = survey_sudo._get_next_page_or_question(answer_sudo, page_or_question_id)
                 if not next_page:
                     answer_sudo._mark_done()
 
-            answer_sudo.write(vals)
+            answer_sudo.write({'last_displayed_page_id': page_or_question_id})
 
         return self._prepare_question_html(survey_sudo, answer_sudo)
 

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -54,7 +54,8 @@ class Survey(models.Model):
     description_done = fields.Html(
         "End Message", translate=True,
         help="This message will be displayed when survey is completed")
-    background_image = fields.Binary("Background Image")
+    background_image = fields.Image("Background Image")
+    background_image_url = fields.Char('Background Url', compute="_compute_background_image_url")
     active = fields.Boolean("Active", default=True)
     user_id = fields.Many2one(
         'res.users', string='Responsible',
@@ -170,6 +171,12 @@ class Survey(models.Model):
             'The attempts limit needs to be a positive number if the survey has a limited number of attempts.'),
         ('badge_uniq', 'unique (certification_badge_id)', "The badge for each survey should be unique!"),
     ]
+
+    @api.depends('background_image', 'access_token')
+    def _compute_background_image_url(self):
+        self.background_image_url = False
+        for survey in self.filtered(lambda survey: survey.background_image and survey.access_token):
+            survey.background_image_url = "/survey/%s/get_background_image" % survey.access_token
 
     def _compute_users_can_signup(self):
         signup_allowed = self.env['res.users'].sudo()._get_signup_invitation_scope() == 'b2c'

--- a/addons/survey/static/src/js/fields_form_page_description.js
+++ b/addons/survey/static/src/js/fields_form_page_description.js
@@ -22,7 +22,7 @@ var FormDescriptionPage = FieldChar.extend({
         var $button = $(
             '<div class="input-group-append">\
                 <button type="button" title="Open section" class="btn oe_edit_only o_icon_button">\
-                    <i class="fa fa-fw o_button_icon fa-info-circle"/>\
+                    <i class="fa fa-fw o_button_icon fa-external-link"/>\
                 </button>\
             </div>'
         );

--- a/addons/survey/static/src/js/survey_preload_image_mixin.js
+++ b/addons/survey/static/src/js/survey_preload_image_mixin.js
@@ -1,0 +1,34 @@
+odoo.define('survey.preload_image_mixin', function (require) {
+"use strict";
+
+
+return {
+    /**
+    * Load the target section background and render it when loaded.
+    *
+    * This method is used to pre-load the image during the questions transitions (fade out) in order
+    * to be sure the image is fully loaded when setting it as background of the next question and
+    * finally display it (fade in)
+    *
+    * This idea is to wait until new background is loaded before changing the background
+    * (to avoid flickering or loading latency)
+    *
+    * @param {string} imageUrl
+    * @private
+    */
+     _preloadBackground: async function (imageUrl) {
+        var resolvePreload;
+
+        // We have to manually create a promise here because the "onload" API does not provide one.
+        var preloadPromise = new Promise(function (resolve, reject) {resolvePreload = resolve;});
+        var background = new Image();
+        background.onload = function () {
+            resolvePreload(imageUrl);
+        };
+        background.src = imageUrl;
+
+        return preloadPromise;
+    }
+};
+
+});

--- a/addons/survey/static/src/scss/survey_templates_form.scss
+++ b/addons/survey/static/src/scss/survey_templates_form.scss
@@ -14,6 +14,22 @@ nav#oe_main_menu_navbar {
 /**********************************************************
                         Common Style
  **********************************************************/
+// the survey background image takes all the page background, with a translucent white overlay (box-shadow)
+// When changing the background from one section to another, the overlay will become opaque to simulate a fade out of
+// the background image. This ensure a smooth transition from one background to another, likewise the question
+// transition.
+.o_survey_background {
+    height: 100%;
+    overflow: auto;
+    transition: box-shadow 0.3s ease-in-out;
+    box-shadow: inset 0 0 0 10000px rgba(255,255,255,.7);
+    background: no-repeat fixed center;
+    background-size: cover;
+    &.o_survey_background_transition {
+        box-shadow: inset 0 0 0 10000px rgba(255,255,255,1);
+    }
+}
+
 .o_survey_wrap {
     min-height: 100%;
 }

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -13,6 +13,10 @@
                 <field name="sequence" invisible="1"/>
                 <field name="scoring_type" invisible="1"/>
                 <sheet>
+                    <div class="float-right d-flex flex-column text-center" attrs="{'invisible': [('is_page', '=', False)]}">
+                        <label for="background_image"/>
+                        <field name="background_image" widget="image" class="oe_avatar"/>
+                    </div>
                     <div class="oe_title" style="width: 100%;">
                         <label for="title" string="Section" attrs="{'invisible': [('is_page', '=', False)]}"/>
                         <label for="title" string="Question" attrs="{'invisible': [('is_page', '=', True)]}"/>

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -68,6 +68,7 @@
                                 <tree decoration-bf="is_page" editable="bottom">
                                     <field name="sequence" widget="handle"/>
                                     <field name="title" widget="survey_description_page"/>
+                                    <field name="background_image" invisible="1"/>
                                     <field name="question_type" />
                                     <field name="is_page" invisible="1"/>
                                     <field name="questions_selection" invisible="1"/>

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -8,7 +8,15 @@
             <t t-set="no_livechat" t-value="True"/>
         </xpath>
         <xpath expr="//div[@id='wrapwrap']" position="attributes">
-            <attribute name="t-att-style" add="(('height: 100%; overflow: auto; background: url(' + '/survey/get_background_image/%s/%s' % (survey.access_token, answer.access_token) + ') no-repeat fixed center; box-shadow: inset 0 0 0 10000px rgba(255,255,255,.7); background-size: cover;') if survey and survey.background_image and answer else 'height: 100%; overflow: auto;')"/>
+            <attribute name="t-att-style"
+                       add="(('background-image: url(' + question.background_image_url + ');')
+                             if question and question.background_image_url
+                             else ('background-image: url(' + page.background_image_url + ');')
+                             if page and page.background_image_url
+                             else ('background-image: url(' + survey.background_image_url + ');')
+                             if survey.background_image_url
+                             else '')"/>
+            <attribute name="t-att-class" add="'o_survey_background'"/>
         </xpath>
         <xpath expr="//head/t[@t-call-assets][last()]" position="after">
             <t t-call-assets="survey.survey_assets" lazy_load="True"/>
@@ -84,6 +92,11 @@
 
     <template id="survey_fill_form" name="Survey: main page content">
         <t t-set="survey_form_readonly" t-value="answer.state == 'done'"/>
+        <t t-set="background_image_url"
+           t-value="question.background_image_url
+                    if question else page.background_image_url
+                    if page else survey.background_image_url
+                    if survey.background_image_url else False"/>
         <form role="form" method="post" t-att-name="survey.id"
                 class="d-flex flex-grow-1 align-items-center"
                 t-att-data-answer-token="answer.access_token"
@@ -96,7 +109,8 @@
                 t-att-data-is-page-description="bool(question and question.is_page and not is_html_empty(question.description))"
                 t-att-data-questions-layout="survey.questions_layout"
                 t-att-data-triggered-questions-by-answer="json.dumps(triggered_questions_by_answer)"
-                t-att-data-selected-answers="json.dumps(selected_answers)">
+                t-att-data-selected-answers="json.dumps(selected_answers)"
+                t-att-data-refresh-background="any(page.background_image for page in survey.page_ids)">
             <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
             <input type="hidden" name="token" t-att-value="answer.access_token" />
             <div class="o_survey_error alert alert-danger d-none" role="alert">

--- a/addons/survey/views/survey_templates_print.xml
+++ b/addons/survey/views/survey_templates_print.xml
@@ -46,6 +46,8 @@
                                     </div>
                                 </t>
                             </t>
+                            <!--Set question to false to avoid background miss match as last question is still in context and is used in survey.layout t-call.-->
+                            <t t-set="question" t-value="False"/>
                         </fieldset>
                     </div>
                 </div>

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -7,7 +7,13 @@
             <t t-set="no_livechat" t-value="True"/>
         </xpath>
         <xpath expr="//div[@id='wrapwrap']" position="attributes">
-            <attribute name="t-att-style" add="('height: 100%; overflow: auto; background: url(' + '/web/image/survey.survey/%s/background_image' % survey.id + ') no-repeat fixed center; box-shadow: inset 0 0 0 10000px rgba(255,255,255,.7); background-size: cover;') if survey and survey.background_image else 'height: 100%; overflow: auto;'"/>
+            <attribute name="t-att-style"
+                       add="(('background-image: url(' + survey.session_question_id.background_image_url + ');')
+                             if survey.session_question_id and survey.session_question_id.background_image_url
+                             else ('background-image: url(' + survey.background_image_url + ');')
+                             if survey.background_image_url
+                             else '')"/>
+            <attribute name="t-att-class" add="'o_survey_background'"/>
         </xpath>
         <xpath expr="//head/t[@t-call-assets][last()]" position="after">
             <t t-call-assets="survey.survey_assets" lazy_load="True"/>
@@ -76,7 +82,8 @@
             t-att-data-is-last-question="is_last_question"
             t-att-data-current-screen="'question' if is_scored_question else 'userInputs'"
             t-att-data-show-bar-chart="show_bar_chart"
-            t-att-data-show-text-answers="show_text_answers">
+            t-att-data-show-text-answers="show_text_answers"
+            t-att-data-refresh-background="any(page.background_image for page in survey.page_ids)">
             <div class="o_survey_question_header flex-wrap px-3 w-100 d-flex justify-content-between align-items-center position-absolute">
                 <h3>
                     <span>Go to <a t-att-href="survey.session_link" t-esc="survey.session_link" target="_blank" /></span>
@@ -137,6 +144,8 @@
                     </div>
                 </div>
                 <div class="o_survey_session_leaderboard w-100 flex-column flex-grow-1" style="display: none;">
+                    <!--Set question to false to avoid background miss match when no question are displayed.-->
+                    <t t-set="question" t-value="False"/>
                     <div class="d-flex">
                         <h1 class="o_survey_session_leaderboard_title flex-grow-1">
                             <span t-if="is_last_question">Final Leaderboard</span>


### PR DESCRIPTION
This PR adds the background per section feature.
If the section to display has a background image configured, the background
will be refreshed using that section background image.
If the section has no background, the survey background is used.
The background is refreshed at the same time that the next question is loaded.

To ease technical maintenance and to keep it simple, the background is always
faded out/in at each page change only if there are some sections on the
survey that has a specific background image. If no background image are set on
the survey sections, the background will never be faded out.

Note: The next section to display depends on free text (section with
description) configuration and on conditional questions.
The next section to display can be the next question's section or directly
the next question itself (if the question is a section).

Also, when going back, after this PR, the last displayed page is saved in order to
reload the survey exactly where the user left it, instead of loading the survey
at the latest question of the survey displayed to the user.

Typically, if the user goes back and leave the survey on question 4, after
reaching the question 7, instead of reloading the survey on question 7,
the survey will be reloaded on question 4, where the user left the survey.

Task-2225393