### PR TITLE
Add the document name

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -15,7 +15,7 @@
 
                 <div class="page">
                     <h2>
-                        <span t-field="o.name"/>
+                        Delivery slip: <span t-field="o.name"/>
                     </h2>
                     <table class="table table-sm">
                         <thead>


### PR DESCRIPTION
Add the document name (delivery slip) prior to the delivery slip number, in order to clarify the kind of the document you are printing

Description of the issue/feature this PR addresses:
The delivery slip document hasn't name in the header.

Current behavior before PR:
The document only has the delivery slip number in the header.

Desired behavior after PR is merged:
The document has the words "Delivery slip: " before the number, in the header




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
