### PR TITLE
[IMP] crm,website_crm_{iap_reveal, partner_assign}: organize reportin…

### DIFF
--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -23,6 +23,13 @@
                 <pivot string="Leads Analysis" sample="1">
                     <field name="create_date" interval="month" type="row"/>
                     <field name="team_id" type="col"/>
+                    <field name="color" invisible="1"/>
+                    <field name="message_bounce" invisible="1"/>
+                    <field name="probability" invisible="1"/>
+                    <field name="automated_probability" invisible="1"/>
+                    <field name="recurring_revenue_monthly" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_revenue_monthly_prorated" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_revenue" groups="crm.group_use_recurring_revenues"/>
                 </pivot>
             </field>
         </record>
@@ -50,6 +57,12 @@
                     <field name="create_date" interval="month"/>
                     <field name="team_id"/>
                     <field name="color" invisible="1"/>
+                    <field name="automated_probability" invisible="1"/>
+                    <field name="message_bounce" invisible="1"/>
+                    <field name="probability" invisible="1"/>
+                    <field name="recurring_revenue_monthly" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_revenue_monthly_prorated" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_revenue" groups="crm.group_use_recurring_revenues"/>
                 </graph>
             </field>
         </record>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -900,6 +900,9 @@
                     <field name="day_close" invisible="1"/>
                     <field name="message_bounce" invisible="1"/>
                     <field name="probability" invisible="1"/>
+                    <field name="recurring_revenue_monthly" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_revenue_monthly_prorated" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_revenue" groups="crm.group_use_recurring_revenues"/>
                 </graph>
             </field>
         </record>
@@ -912,8 +915,13 @@
                     <field name="create_date" interval="month" type="row"/>
                     <field name="stage_id" type="col"/>
                     <field name="expected_revenue" type="measure"/>
-                    <field name="recurring_revenue_monthly" type="measure" groups="crm.group_use_recurring_revenues"/>
                     <field name="color" invisible="1"/>
+                    <field name="automated_probability" invisible="1"/>
+                    <field name="message_bounce" invisible="1"/>
+                    <field name="probability" invisible="1"/>
+                    <field name="recurring_revenue_monthly" type="measure" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_revenue_monthly_prorated" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_revenue" groups="crm.group_use_recurring_revenues"/>
                 </pivot>
             </field>
         </record>
@@ -933,6 +941,9 @@
                     <field name="day_close" invisible="1"/>
                     <field name="message_bounce" invisible="1"/>
                     <field name="probability" invisible="1"/>
+                    <field name="recurring_revenue_monthly" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_revenue_monthly_prorated" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_revenue" groups="crm.group_use_recurring_revenues"/>
                 </pivot>
             </field>
         </record>

--- a/addons/website_crm_iap_reveal/views/crm_lead_views.xml
+++ b/addons/website_crm_iap_reveal/views/crm_lead_views.xml
@@ -66,4 +66,38 @@
             </xpath>
         </field>
     </record>
+
+    <record id="crm_lead_view_graph_report_forecast" model="ir.ui.view">
+        <field name="name">crm.lead.view.graph.forecast.inherit.website.crm.iap.reveal</field>
+        <field name="model">crm.lead</field>
+        <field name="inherit_id" ref="crm.crm_lead_view_graph_forecast"/>
+        <field name="arch" type="xml">
+            <xpath expr="//graph" position="inside">
+                <field name="reveal_iap_credits" invisible="1"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="crm_lead_view_pivot_forecast" model="ir.ui.view">
+        <field name="name">crm.lead.view.pivot.forecast.inherit.website.crm.iap.reveal</field>
+        <field name="model">crm.lead</field>
+        <field name="inherit_id" ref="crm.crm_lead_view_pivot_forecast"/>
+        <field name="arch" type="xml">
+            <xpath expr="//pivot" position="inside">
+                <field name="reveal_iap_credits" invisible="1"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="crm_opportunity_report_view_pivot_lead" model="ir.ui.view">
+        <field name="name">crm.opportunity.report.view.pivot.lead.inherit.website.crm.iap.reveal</field>
+        <field name="model">crm.lead</field>
+        <field name="inherit_id" ref="crm.crm_opportunity_report_view_pivot_lead"/>
+        <field name="arch" type="xml">
+            <xpath expr="//pivot" position="inside">
+                <field name="reveal_iap_credits" invisible="1"/>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>

--- a/addons/website_crm_partner_assign/views/crm_lead_views.xml
+++ b/addons/website_crm_partner_assign/views/crm_lead_views.xml
@@ -101,10 +101,46 @@
             </field>
         </record>
 
+        <record id="crm_opportunity_report_view_pivot_lead" model="ir.ui.view">
+            <field name="name">crm.opportunity.report.view.pivot.lead.inherit.partner_assign</field>
+            <field name="model">crm.lead</field>
+            <field name="inherit_id" ref="crm.crm_opportunity_report_view_pivot_lead"/>
+            <field name="arch" type="xml">
+                <xpath expr="//pivot" position="inside">
+                    <field name="partner_latitude" invisible="1"/>
+                    <field name="partner_longitude" invisible="1"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="crm_lead_view_pivot_forecast" model="ir.ui.view">
+            <field name="name">crm.lead.view.pivot.forecast.inherit.website.crm.partner.assign</field>
+            <field name="model">crm.lead</field>
+            <field name="inherit_id" ref="crm.crm_lead_view_pivot_forecast"/>
+            <field name="arch" type="xml">
+                <xpath expr="//pivot" position="inside">
+                    <field name="partner_latitude" invisible="1"/>
+                    <field name="partner_longitude" invisible="1"/>
+                </xpath>
+            </field>
+        </record>
+
         <record id="crm_lead_view_graph" model="ir.ui.view">
             <field name="name">crm.lead.view.graph.inherit.partner.assign</field>
             <field name="model">crm.lead</field>
             <field name="inherit_id" ref="crm.crm_lead_view_graph"/>
+            <field name="arch" type="xml">
+                <xpath expr="//graph" position="inside">
+                    <field name="partner_latitude" invisible="1"/>
+                    <field name="partner_longitude" invisible="1"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="crm_lead_view_graph_forecast" model="ir.ui.view">
+            <field name="name">crm.lead.view.graph.forecast.inherit.website.crm.partner.assign</field>
+            <field name="model">crm.lead</field>
+            <field name="inherit_id" ref="crm.crm_lead_view_graph_forecast"/>
             <field name="arch" type="xml">
                 <xpath expr="//graph" position="inside">
                     <field name="partner_latitude" invisible="1"/>


### PR DESCRIPTION
…g measures

PURPOSE

To remove the unnecessary measures from reports. Expected MRR, Prorated MRR,
and Recurring Revenues measures will show if the Recurring Revenue is
activated(User activates the Recurring Revenue).


SPECIFICATIONS

With this commit, we removed the unnecessary measures from Forecast and Leads
reports. So, users can get the quickly data. We are adding the group for
Expected MRR, Prorated MRR, and Recurring Revenues measures.
These measures will show if Recurring Revenue is activated.

This is the goal of this commit.

PR #79167
enterprise PR https://github.com/odoo/enterprise/pull/21981
Task-2674367

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
