### PR TITLE
[FIX] account_facturx: Don't import the delivery address

### DIFF
--- a/addons/account_facturx/models/account_move.py
+++ b/addons/account_facturx/models/account_move.py
@@ -156,10 +156,6 @@ class AccountMove(models.Model):
             partner_type = invoice_form.journal_id.type == 'purchase' and 'SellerTradeParty' or 'BuyerTradeParty'
             invoice_form.partner_id = find_partner(partner_type)
 
-            # Delivery Partner
-            if 'partner_shipping_id' in self._fields:
-                invoice_form.partner_shipping_id = find_partner('ShipToTradeParty')
-
             # Reference.
             elements = tree.xpath('//rsm:ExchangedDocument/ram:ID', namespaces=tree.nsmap)
             if elements:


### PR DESCRIPTION
When exporting, the delivery address is put inside the xml.
This field is added by the 'sale' module and is not supposed to be displayed for vendor bill.
However, even if this field isn't displayed, the factur-x module was setting the wrong delivery address on it.

issue: 2668902

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
