### PR TITLE
[FIX] stock: add an automated way to fix unreserve issue

### DIFF
--- a/addons/stock/data/stock_data.xml
+++ b/addons/stock/data/stock_data.xml
@@ -10,7 +10,123 @@
             <field name="name">Last In First Out (LIFO)</field>
             <field name="method">lifo</field>
         </record>
-        
+        <record  id="stock_quant_stock_move_line_desynchronization" model="ir.actions.server">
+            <field name="name">Correct inconsistencies for reservation</field>
+            <field name="model_id" ref="base.model_ir_actions_server"/>
+            <field name="state">code</field>
+            <field name="code">
+quants = env['stock.quant'].sudo().search([])
+
+move_line_ids = []
+move_line_to_recompute_ids = []
+
+logging = ''
+
+for quant in quants:
+
+    move_lines = env['stock.move.line'].search([
+        ('product_id', '=', quant.product_id.id),
+        ('location_id', '=', quant.location_id.id),
+        ('lot_id', '=', quant.lot_id.id),
+        ('package_id', '=', quant.package_id.id),
+        ('owner_id', '=', quant.owner_id.id),
+        ('product_qty', '!=', 0),
+        ])
+
+    move_line_ids += move_lines.ids
+    reserved_on_move_lines = sum(move_lines.mapped('product_qty'))
+    move_line_str = str.join(', ', [str(move_line_id) for move_line_id in move_lines.ids])
+
+    if quant.location_id.should_bypass_reservation():
+        # If a quant is in a location that should bypass the reservation, its `reserved_quantity` field
+        # should be 0.
+        if quant.reserved_quantity != 0:
+            logging += "Problematic quant found: %s (quantity: %s, reserved_quantity: %s)\n" % (quant.id, quant.quantity, quant.reserved_quantity)
+            logging += "its `reserved_quantity` field is not 0 while its location should bypass the reservation\n"
+            if move_lines:
+                logging += "These move lines are reserved on it: %s (sum of the reservation: %s)\n" % (move_line_str, reserved_on_move_lines)
+            else:
+                logging += "no move lines are reserved on it, you can safely reset its `reserved_quantity` to 0\n"
+            logging += '******************\n'
+            quant.write({'reserved_quantity': 0})
+    else:
+        # If a quant is in a reservable location, its `reserved_quantity` should be exactly the sum
+        # of the `product_qty` of all the partially_available / assigned move lines with the same
+        # characteristics.
+
+        if quant.reserved_quantity == 0:
+            if move_lines:
+                logging += "Problematic quant found: %s (quantity: %s, reserved_quantity: %s)\n" % (quant.id, quant.quantity, quant.reserved_quantity)
+                logging += "its `reserved_quantity` field is 0 while these move lines are reserved on it: %s (sum of the reservation: %s)\n" % (move_line_str, reserved_on_move_lines)
+                logging += '******************\n'
+                move_lines.with_context(bypass_reservation_update=True).sudo().write({'product_uom_qty': 0})
+                move_line_to_recompute_ids += move_lines.ids
+        elif quant.reserved_quantity &lt; 0:
+            logging += "Problematic quant found: %s (quantity: %s, reserved_quantity: %s)\n" % (quant.id, quant.quantity, quant.reserved_quantity)
+            logging += "its `reserved_quantity` field is negative while it should not happen\n"
+            quant.write({'reserved_quantity': 0})
+            if move_lines:
+                logging += "These move lines are reserved on it: %s (sum of the reservation: %s)\n" % (move_line_str, reserved_on_move_lines)
+                move_lines.with_context(bypass_reservation_update=True).sudo().write({'product_uom_qty': 0})
+                move_line_to_recompute_ids += move_lines.ids
+            logging += '******************\n'
+        else:
+            if reserved_on_move_lines != quant.reserved_quantity:
+                logging += "Problematic quant found: %s (quantity: %s, reserved_quantity: %s)\n" % (quant.id, quant.quantity, quant.reserved_quantity)
+                logging += "its `reserved_quantity` does not reflect the move lines reservation\n"
+                logging += "These move lines are reserved on it: %s (sum of the reservation: %s)\n" % (move_line_str, reserved_on_move_lines)
+                logging += '******************\n'
+                move_lines.with_context(bypass_reservation_update=True).sudo().write({'product_uom_qty': 0})
+                move_line_to_recompute_ids += move_lines.ids
+                quant.write({'reserved_quantity': 0})
+            else:
+                if any(move_line.product_qty &lt; 0 for move_line in
+                       move_lines):
+                    logging += "Problematic quant found: %s (quantity: %s, reserved_quantity: %s)\n" % (quant.id, quant.quantity, quant.reserved_quantity)
+                    logging += "its `reserved_quantity` correctly reflects the move lines reservation but some are negatives\n"
+                    logging += "These move lines are reserved on it: %s (sum of the reservation: %s)\n" % (move_line_str, reserved_on_move_lines)
+                    logging += '******************\n'
+                    move_lines.with_context(bypass_reservation_update=True).sudo().write({'product_uom_qty': 0})
+                    move_line_to_recompute_ids += move_lines.ids
+                    quant.write({'reserved_quantity': 0})
+
+move_lines = env['stock.move.line'].search([('product_id.type', '=',
+        'product'), ('product_qty', '!=', 0), ('id', 'not in',
+        move_line_ids)])
+
+move_lines_to_unreserve = []
+
+for move_line in move_lines:
+    if not move_line.location_id.should_bypass_reservation():
+        logging += "Problematic move line found: %s (reserved_quantity: %s)\n" % (move_line.id, move_line.product_qty)
+        logging += "There is no exiting quants despite its `reserved_quantity`\n"
+        logging += '******************\n'
+        move_lines_to_unreserve.append(move_line.id)
+        move_line_to_recompute_ids.append(move_line.id)
+
+if len(move_lines_to_unreserve) &gt; 0:
+    env.cr.execute("""
+            UPDATE stock_move_line SET product_uom_qty = 0, product_qty = 0 WHERE id in %s ;
+        """
+                   % (tuple(move_lines_to_unreserve), ))
+
+if logging:
+    env['ir.logging'].sudo().create({
+        'name': 'Unreserve stock.quant and stock.move.line',
+        'type': 'server',
+        'level': 'DEBUG',
+        'dbname': env.cr.dbname,
+        'message': logging,
+        'func': '_update_reserved_quantity',
+        'path': 'addons/stock/models/stock_quant.py',
+        'line': '0',
+    })
+
+if move_line_to_recompute_ids:
+    env['stock.move.line'].browse(move_line_to_recompute_ids).move_id._recompute_state()
+
+            </field>
+        </record>
                 <!--
     Resource: stock.location
     -->

--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -2820,14 +2820,22 @@ msgstr ""
 #: code:addons/stock/models/stock_quant.py:0
 #, python-format
 msgid ""
-"It is not possible to reserve more products of %s than you have in stock."
+"It is not possible to unreserve more products of %s than you have in stock."
+"The correction could unreserve some operations with problematics products."
 msgstr ""
 
 #. module: stock
 #: code:addons/stock/models/stock_quant.py:0
 #, python-format
 msgid ""
-"It is not possible to unreserve more products of %s than you have in stock."
+"It is not possible to unreserve more products of %s than you have in stock. Contact an administrator."
+msgstr ""
+
+#. module: stock
+#: code:addons/stock/models/stock_quant.py:0
+#, python-format
+msgid ""
+"Try our automated action to fix it"
 msgstr ""
 
 #. module: stock

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -4,7 +4,7 @@
 from psycopg2 import OperationalError, Error
 
 from odoo import api, fields, models, _
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import RedirectWarning, UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools.float_utils import float_compare, float_is_zero, float_round
 
@@ -473,7 +473,16 @@ class StockQuant(models.Model):
             # if we want to unreserve
             available_quantity = sum(quants.mapped('reserved_quantity'))
             if float_compare(abs(quantity), available_quantity, precision_rounding=rounding) > 0:
-                raise UserError(_('It is not possible to unreserve more products of %s than you have in stock.') % product_id.display_name)
+                action_fix_unreserve = self.env.ref(
+                    'stock.stock_quant_stock_move_line_desynchronization', raise_if_not_found=False)
+                if action_fix_unreserve and self.user_has_groups('base.group_system'):
+                    raise RedirectWarning(
+                        _("""It is not possible to unreserve more products of %s than you have in stock.
+The correction could unreserve some operations with problematics products.""") % product_id.display_name,
+                        action_fix_unreserve.id,
+                        _('Automated action to fix it'))
+                else:
+                    raise UserError(_('It is not possible to unreserve more products of %s than you have in stock. Contact an administrator.') % product_id.display_name)
         else:
             return reserved_quants
 

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 
 from odoo.exceptions import ValidationError
 from odoo.tests.common import SavepointCase
-from odoo.exceptions import AccessError, UserError
+from odoo.exceptions import AccessError, RedirectWarning, UserError
 
 
 class StockQuant(SavepointCase):
@@ -431,7 +431,7 @@ class StockQuant(SavepointCase):
         with self.assertRaises(UserError):
             self.env['stock.quant']._update_reserved_quantity(self.product, self.stock_location, 1.0)
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product, self.stock_location), 0.0)
-        with self.assertRaises(UserError):
+        with self.assertRaises(RedirectWarning):
             self.env['stock.quant']._update_reserved_quantity(self.product, self.stock_location, -1.0, strict=True)
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product, self.stock_location), 0.0)
 
@@ -476,7 +476,7 @@ class StockQuant(SavepointCase):
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product_serial, self.stock_location, strict=True), 1.0)
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product_serial, self.stock_location, lot_id=lot1), 2.0)
 
-        with self.assertRaises(UserError):
+        with self.assertRaises(RedirectWarning):
             self.env['stock.quant']._update_reserved_quantity(self.product_serial, self.stock_location, -1.0, strict=True)
 
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product_serial, self.stock_location), 2.0)


### PR DESCRIPTION
It happens that the `stock.quant.reserved_quantity` and `stock.move.line.product_qty`
for the same parameters are not equals (due to some bugs in the past)

It could implies that it doesn't exist enough reserved quantity on the
quant when a user try to unreserve a stock.move.line resulting in the
UserError 'It is not possible to unreserve more products of %s than you
have in stock'

However on current stable version (13.0 and 14.0) a lot of PR already
fixed a lot of issue as:
odoo/odoo#69377
odoo/odoo#66347
odoo/odoo#61758
odoo/odoo#54355
odoo/odoo#43180
odoo/odoo#70975
for example (there is more than that)

So the idea is to provide a way to unlock the database manually for
stable but not in the new version to be able to analyse them and find
possible bugs responssible for the desynchronization.

The server action check all the quants and their relative move line
to check if match correctly. If not it will remove the reservation
from both. It could remove the reservation from some `pickings` and
`stock.move`

related to odoo/odoo#62139
