### PR TITLE
[FIX] website: ensure unicity of find

### DIFF
--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -152,7 +152,9 @@ class IrModuleModule(models.Model):
                 # special case for attachment
                 # if module B override attachment from dependence A, we update it
                 if not find and model_name == 'ir.attachment':
-                    find = rec.copy_ids.search([('key', '=', rec.key), ('website_id', '=', website.id)])
+                    # In master, a unique constraint over (theme_template_id, website_id)
+                    # will be introduced, thus ensuring unicity of 'find'
+                    find = rec.copy_ids.search([('key', '=', rec.key), ('website_id', '=', website.id), ("original_id", "=", False)])
 
                 if find:
                     imd = self.env['ir.model.data'].search([('model', '=', find._name), ('res_id', '=', find.id)])


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
https://github.com/odoo/upgrade-specific/pull/1594

Current behavior before PR:
`find` treated as a single record, leading to `ValueError` at https://github.com/odoo/odoo/blob/14.0/addons/website/models/ir_module_module.py#L158 if it happens to contain more than one record.

Desired behavior after PR is merged:
<strike>Loop over `find` as it may contain more than one record.</strike>
Strengthen the search to ensure that find always contain one record.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr