### PR TITLE
[FIX] website: accept default template key in dynamic snippets

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet/options.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/options.js
@@ -18,6 +18,8 @@ const dynamicSnippetOptions = options.Class.extend({
         // name of the model of the currently selected filter, used to fetch templates
         this.currentModelName = undefined;
         this.dynamicFilterTemplates = {};
+        // Indicates that some current options are a default selection.
+        this.isOptionDefault = {};
     },
     /**
      *
@@ -170,6 +172,7 @@ const dynamicSnippetOptions = options.Class.extend({
                 const selectedFilterId = this.$target.get(0).dataset['filterId'];
                 if (!this.dynamicFilters[selectedFilterId]) {
                     this.$target.get(0).dataset['filterId'] = dynamicFilters[0].id;
+                    this.isOptionDefault['filterId'] = true;
                 }
             }
         }
@@ -206,6 +209,7 @@ const dynamicSnippetOptions = options.Class.extend({
             const selectedTemplateId = this.$target.get(0).dataset['templateKey'];
             if (!this.dynamicFilterTemplates[selectedTemplateId]) {
                 this.$target.get(0).dataset['templateKey'] = dynamicFilterTemplates[0].key;
+                this.isOptionDefault['templateKey'] = true;
                 setTimeout(() => {
                     this._templateUpdated(dynamicFilterTemplates[0].key, selectedTemplateId);
                     this._refreshPublicWidgets();
@@ -281,8 +285,13 @@ const dynamicSnippetOptions = options.Class.extend({
      * @private
      */
     _setOptionValue: function (optionName, value) {
-        if (this.$target.get(0).dataset[optionName] === undefined) {
+        const selectedTemplateId = this.$target.get(0).dataset['templateKey'];
+        if (this.$target.get(0).dataset[optionName] === undefined || this.isOptionDefault[optionName]) {
             this.$target.get(0).dataset[optionName] = value;
+            this.isOptionDefault[optionName] = false;
+        }
+        if (optionName === 'templateKey') {
+            this._templateUpdated(value, selectedTemplateId);
         }
     },
 });


### PR DESCRIPTION
Before this commit the "first" template key was selected by default
before the default options were being considered. Because of this,
setting a specific default template key was always ignored since a
template was already selected.

After this commit the widget keeps track of which value is actually a
default one, allowing for setting a specific default for the template
key.

task-2680578

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
