### PR TITLE
[FIX] sale: properly show order rejection feedback on sale portal

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -281,7 +281,7 @@
                         <t t-else="">Your order has been signed.</t>
                     </div>
 
-                    <div t-if="message == 'cant_reject' and sale_order.has_to_be_signed()" class="alert alert-danger alert-dismissable d-print-none" role="alert">
+                    <div t-if="message == 'cant_reject'" class="alert alert-danger alert-dismissable d-print-none" role="alert">
                         <button type="button" class="close" data-dismiss="alert" aria-label="Close">×</button>
                         Your order is not in a state to be rejected.
                     </div>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
There is no message shown to guest user on portal when he tries to reject a quotation.

**Current behavior before PR:**
When a guest user tried to reject am order in quotation state the popup just closed and did not give him any feedback or message that why the order is not getting cancelled.

**Desired behavior after PR is merged:**
In the /decline controller there is already a check via has_to_be_signed() method. If the check fails `message=cant_reject` is added to query_string.
On the XML side there is another check made towards has_to_be_signed method which will not render the message.

This commit removes the duplicate check from XML side and the message is now shown correctly to the portal user.

Fixes #79205

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
