### PR TITLE
[FIX] sale_stock,stock_account: ignore SVL without any qty

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -628,6 +628,8 @@ class ProductProduct(models.Model):
         qty_to_take_on_candidates = qty_to_invoice
         tmp_value = 0  # to accumulate the value taken on the candidates
         for candidate in candidates:
+            if not candidate.quantity:
+                continue
             candidate_quantity = abs(candidate.quantity)
             if candidate.stock_move_id.id in returned_quantities:
                 candidate_quantity -= returned_quantities[candidate.stock_move_id.id]


### PR DESCRIPTION
In some conditions, confirming an invoice will raise an Odoo Server
Error due to a division by zero.

To reproduce the issue:
(Need sale_management)
1. Create a product category PC:
    - Costing Method: Average Cost (AVCO)
    - Inventory Valuation: Automated
2. Create a product P:
    - Product Type: Storable
    - Category: PC
    - Cost: 50
3. Create a sale order SO:
    - 5 x P
4. Confirm and process the delivery D
5. Edit P:
    - Cost: 40
6. Open D and create a return R:
    - 1 x P without "Update quantities on SO/PO"
7. Process R
8. In Inventory, create a transfer T:
    - Operation Type: Receipt
    - 1 x P
9. Process T
10. Back to SO, create an invoice and post it

Error: an Odoo Server Error is raised: "ZeroDivisionError: float
division by zero"

When validating the transfer T, a stock valuation layer is created with
a zero quantity and is linked to the first SO.order_line.move_ids (i.e.,
the SM from Stock to Customer with 5 x P)
https://github.com/odoo/odoo/blob/dfab388fdf8c7597774ff1738a1b09295c12fb49/addons/stock_account/models/product.py#L439-L450

Then, when posting the invoice, this SVL is used to make a division:
https://github.com/odoo/odoo/blob/dfab388fdf8c7597774ff1738a1b09295c12fb49/addons/stock_account/models/product.py#L690-L691

In such cases, we should ignore this SVL and use the standard price:
https://github.com/odoo/odoo/blob/dfab388fdf8c7597774ff1738a1b09295c12fb49/addons/stock_account/models/product.py#L695-L699

OPW-2647921
OPW-2646419

v13 backport of: odoo/odoo#77842

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
