### PR TITLE
[FIX] l10n_fr_pos_cert: Ensure country set on company before opening POS

### DIFF
--- a/addons/l10n_fr_pos_cert/models/pos.py
+++ b/addons/l10n_fr_pos_cert/models/pos.py
@@ -14,9 +14,12 @@ class pos_config(models.Model):
     _inherit = 'pos.config'
 
     def open_ui(self):
-        for config in self.filtered(lambda c: c.company_id._is_accounting_unalterable()):
-            if config.current_session_id:
-                config.current_session_id._check_session_timing()
+        for config in self:
+            if not config.company_id.country_id:
+                raise UserError(_("You have to set a country in your company setting."))
+            if config.company_id._is_accounting_unalterable():
+                if config.current_session_id:
+                    config.current_session_id._check_session_timing()
         return super(pos_config, self).open_ui()
 
 


### PR DESCRIPTION
Before this fix, if the country is not set on the company
the loading of the session may stall at some point.

A check is added and will prevent to start a session if the country
is not set.

opw-2557989