### PR TITLE
[FIX] *sale*: exception when cancel SO

### DIFF
--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -28,10 +28,10 @@ class SaleOrder(models.Model):
                     .with_context(default_sale_order_id=so.id) \
                     ._for_xml_id('event_sale.action_sale_order_event_registration')
         return res
-    
-    def action_cancel(self):
+
+    def _action_cancel(self):
         self.order_line._cancel_associated_registrations()
-        return super(SaleOrder, self).action_cancel()
+        return super()._action_cancel()
 
     def action_view_attendee_list(self):
         action = self.env["ir.actions.actions"]._for_xml_id("event.event_registration_action_tree")

--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -818,6 +818,9 @@ Reason(s) of this behavior could be:
                 'context': {'default_order_id': self.id},
                 'target': 'new'
             }
+        return self._action_cancel()
+
+    def _action_cancel(self):
         inv = self.invoice_ids.filtered(lambda inv: inv.state == 'draft')
         inv.button_cancel()
         return self.write({'state': 'cancel'})

--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -49,8 +49,8 @@ class SaleOrder(models.Model):
         self._send_reward_coupon_mail()
         return super(SaleOrder, self).action_confirm()
 
-    def action_cancel(self):
-        res = super(SaleOrder, self).action_cancel()
+    def _action_cancel(self):
+        res = super()._action_cancel()
         self.generated_coupon_ids.write({'state': 'expired'})
         self.applied_coupon_ids.write({'state': 'new'})
         self.applied_coupon_ids.sales_order_id = False

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -207,10 +207,7 @@ class SaleOrder(models.Model):
         action['context'] = dict(self._context, default_partner_id=self.partner_id.id, default_picking_type_id=picking_id.picking_type_id.id, default_origin=self.name, default_group_id=picking_id.group_id.id)
         return action
 
-    def action_cancel(self):
-        res = super(SaleOrder, self).action_cancel()
-        if(isinstance(res, dict)):
-            return res
+    def _action_cancel(self):
         documents = None
         for sale_order in self:
             if sale_order.state == 'sale' and sale_order.order_line:
@@ -225,7 +222,7 @@ class SaleOrder(models.Model):
                         continue
                 filtered_documents[(parent, responsible)] = rendering_context
             self._log_decrease_ordered_quantity(filtered_documents, cancel=True)
-        return res
+        return super()._action_cancel()
 
     def _prepare_invoice(self):
         invoice_vals = super(SaleOrder, self)._prepare_invoice()


### PR DESCRIPTION
The commit ca7d5701c6a46f7781bdc9af9f2d26cca880eb93 fixes issue with backorder being to quickly canceled but as it call `action_cancel` before the condition who's looking on the SO state, the condition can never be matched as the SO state will always be `cancel`.
So, the exception about the SO being cancelled will not be logged on following documents.

How to reproduce:
  - Create a product and enable route MTO + Manufacture on it and create     a BoM for this product;
  - Create a SO for this product and confirm it;
  - Cancel the SO and check the generated MO => There is no exception about the cancellation of the SO.

This commit fixes this issue and doesn't impact the previous fix.

task-2657799