### PR TITLE
[IMP] core: allow empty import

### DIFF
--- a/odoo/tools/js_transpiler.py
+++ b/odoo/tools/js_transpiler.py
@@ -346,7 +346,7 @@ IMPORT_BASIC_RE = re.compile(r"""
     ^
     (?P<space>\s*)                      # space and empty line
     import\s+                           # import
-    (?P<object>{(\s*\w+\s*,?\s*)+})\s*  # { a, b, c as x, ... }
+    (?P<object>{(\s*\w*\s*,?\s*)*})\s*  # { a, b, c as x, ... }
     from\s*                             # from
     (?P<path>(?P<quote>["'`])([^"'`]+)(?P=quote))   # "file path" ("some/path")
     """, re.MULTILINE | re.VERBOSE)


### PR DESCRIPTION
This commit will allow empty import like this:
```js
import {} from "path";
```
which is valid according to the ECMAScript standard.
