### PR TITLE
[FIX] web_editor: add perf. optimization when toggling editor options

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -281,6 +281,16 @@ const UserValueWidget = Widget.extend({
             // and just be ignored.
             return;
         }
+        if (!this.el.classList.contains('o_we_widget_opened')) {
+            // Small optimization: it would normally not matter asking to
+            // remove a class of an element if it does not already have it but
+            // in this case we do more: we trigger_up an event and ask to close
+            // all sub widgets. When we ask the editor to close all widgets...
+            // it makes sense not letting every sub button of every select
+            // trigger_up an event. This allows to avoid tens of thousands of
+            // instructions being done at each click in the editor.
+            return;
+        }
         this.trigger_up('user_value_widget_closing');
         this.el.classList.remove('o_we_widget_opened');
         this._userValueWidgets.forEach(widget => widget.close());


### PR DESCRIPTION
This allows to avoid tens of thousands of instructions being done at
each click in the editor.

At multiple places, the editor is asked to close all its widgets (for
example, when clicking on another snippet to edit). The original cost
of that action was to remove a class on each widget, which is a very
primitive action. But in the end we had to do more to close a widget: we
trigger_up an event and ask to close all sub widgets. When we ask the
editor to close all widgets... it makes sense not letting every sub
button of every select trigger_up an event.
