### PR TITLE
[FIX] pos_restaurant

### DIFF
--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -10,6 +10,7 @@ from odoo import api, fields, models
 class PosOrderLine(models.Model):
     _inherit = 'pos.order.line'
 
+    changes_uid = fields.Char()
     note = fields.Char('Note added by the waiter.')
     mp_skip = fields.Boolean('Skip line when sending ticket to kitchen printers.')
     mp_dirty = fields.Boolean()
@@ -59,6 +60,7 @@ class PosOrder(models.Model):
             'mp_skip',
             'mp_dirty',
             'full_product_name',
+            'changes_uid'
         ]
 
     def _get_order_lines(self, orders):

--- a/addons/pos_restaurant/static/src/js/multiprint.js
+++ b/addons/pos_restaurant/static/src/js/multiprint.js
@@ -71,6 +71,9 @@ models.Orderline = models.Orderline.extend({
             // not to be sent to the kitchen
             this.mp_skip  = false;
         }
+        if (!this.changes_uid) {
+            this.changes_uid = `${this.product.id}${Date.now()}`;
+        }
     },
     // can this orderline be potentially printed ?
     printable: function() {
@@ -80,11 +83,13 @@ models.Orderline = models.Orderline.extend({
         _super_orderline.init_from_JSON.apply(this,arguments);
         this.mp_dirty = json.mp_dirty;
         this.mp_skip  = json.mp_skip;
+        if (json.changes_uid) this.changes_uid = json.changes_uid;
     },
     export_as_JSON: function() {
         var json = _super_orderline.export_as_JSON.apply(this,arguments);
         json.mp_dirty = this.mp_dirty;
         json.mp_skip  = this.mp_skip;
+        json.changes_uid = this.changes_uid;
         return json;
     },
     set_quantity: function(quantity) {
@@ -117,9 +122,9 @@ models.Orderline = models.Orderline.extend({
     },
     get_line_diff_hash: function(){
         if (this.get_note()) {
-            return this.id + '|' + this.get_note();
+            return this.changes_uid + '|' + this.get_note();
         } else {
-            return '' + this.id;
+            return '' + this.changes_uid;
         }
     },
 });


### PR DESCRIPTION
Environment:

pos.config:
- is bar/restaurant
- Order Printer

-----------------------------------------

Steps:

1) open a table add some lines and click on the "Order" button
2) exit the table
3) enter the table again. All of the orderlines will be considered to be changes.

-----------------------------------------

Why is this an issue?

In addons/pos_resturant/static/src/js/multiprint.js in models.Order::computeChanges(), there is an algorithm that computes changes based on Orderline id's. Which does not make sense since those id's change all the time. For example, I managed to change them in 2 ways:
1- exit and re-enter the table
2- change the order from the ticket button on top

-----------------------------------------

Damage done:

Our customer runs a busy restaurant. Therefore, order changes are frequent. Whenever the waiter pushes a change, the whole order is sent to the kitchen instead of the simple change. This is, allegedly, costing the customer a great deal of money daily since multiple orders get prepared by accident

-----------------------------------------

Suggested solution:

Instead of comparing orders based on id's, create a new field on pos.order.line (changes_uid). Whenever a new Orderline is added, generate a new unique id (using the time, the order uid, or similar) and add it to all of the functions that are used for syncing with the backend (init_from_JSON, export_as_JSON in the frontend, and _order_fields, _get_fields_for_draft_order in the backend)

Now in "addons/pos_resturant/static/src/js/multiprint.js", there's a
funciton get_line_diff_hash() at line 118. replace every instance of
"this.id" with "this.changes_uid" and it should work

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
