### PR TITLE
[14.0] Add test for footer replace.

### DIFF
--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -1210,6 +1210,62 @@ class TestViews(ViewCase):
                 ),
                 string="Replacement title"))
 
+    def test_view_inheritance_footer_replace(self):
+        view1 = self.View.create({
+            'name': "bob",
+            'model': 'ir.ui.view',
+            'arch': """
+                <form string="Base title">
+                    <separator name="separator" string="Separator" colspan="4"/>
+                    <footer>
+                        <button name="action_archive" type="object" string="Next button" class="btn-primary"/>
+                        <button string="Skip" special="cancel" class="btn-secondary"/>
+                    </footer>
+                </form>
+            """
+        })
+        view2 = self.View.create({
+            'name': "edmund",
+            'model': 'ir.ui.view',
+            'inherit_id': view1.id,
+            'arch': """
+                <data>
+                    <form position="attributes">
+                        <attribute name="string">Replacement title</attribute>
+                    </form>
+                    <footer position="replace"/>
+                    <separator name="separator" position="replace">
+                        <p>Replacement data</p>
+                    </separator>
+                </data>
+            """
+        })
+        view3 = self.View.create({
+            'name': 'jake',
+            'model': 'ir.ui.view',
+            'inherit_id': view2.id,
+            'arch': """
+                <footer position="attributes">
+                    <attribute name="thing">bob tata lolo</attribute>
+                    <attribute name="thing" add="bibi and co" remove="tata" separator=" " />
+                    <attribute name="otherthing">bob, tata,lolo</attribute>
+                    <attribute name="otherthing" remove="tata, bob"/>
+                </footer>
+            """
+        })
+
+        view = self.View.with_context(check_view_ids=[view2.id, view3.id]) \
+                        .fields_view_get(view2.id, view_type='form')
+        self.assertEqual(view['type'], 'form')
+        self.assertEqual(
+            etree.fromstring(
+                view['arch'],
+                parser=etree.XMLParser(remove_blank_text=True)
+            ),
+            E.form(
+                E.p("Replacement data"),
+                string="Replacement title"))
+
     def test_view_inheritance_text_inside(self):
         """ Test view inheritance when adding elements and text. """
         view1 = self.View.create({


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In commit https://github.com/odoo/odoo/pull/78820/files there was added a new section of footer attributes, the view in inheriting another view that uses footer position="replace", so basically the inherited view is failing to load since footer doesn't exists anymore in the view.

We encounter this on some migrated database from previous versions, as i checked in a new database everything is fine, but when update "hr" module on an existing database it is failing.

I added a unit test for this and it is also failing because of this, so in what pre-condition on new database this is not failing?

`2021-10-31 06:13:41,068 2110795 INFO xxxxxxx odoo.modules.loading: loading hr/views/res_users.xml 
2021-10-31 06:13:41,221 2110795 DEBUG xxxxxxx odoo.tools.translate: translation went wrong for ""Element '%s' cannot be located in parent view"", skipped 
2021-10-31 06:13:41,226 2110795 INFO xxxxxxx odoo.addons.base.models.ir_ui_view: Element '<footer>' cannot be located in parent view

View name: res.users.preferences.form.inherit
Error context:
 view: ir.ui.view(7231,)
 xmlid: res_users_view_form_profile
 view.model: res.users
 view.parent: ir.ui.view(7229,)
 file: /opt/odoo/odoo/addons/hr/views/res_users.xml
 
2021-10-31 06:13:41,230 2110795 WARNING xxxxxxx odoo.modules.loading: Transient module states were reset 
2021-10-31 06:13:41,231 2110795 ERROR xxxxxxx odoo.modules.registry: Failed to load registry 
2021-10-31 06:13:41,231 2110795 CRITICAL xxxxxxx odoo.service.server: Failed to initialize database `xxxxxxx`. 
Traceback (most recent call last):
  File "/opt/odoo/odoo/odoo/tools/convert.py", line 677, in _tag_root
    f(rec)
  File "/opt/odoo/odoo/odoo/tools/convert.py", line 580, in _tag_record
    record = model._load_records([data], self.mode == 'update')
  File "/opt/odoo/odoo/odoo/models.py", line 4201, in _load_records
    data['record']._load_records_write(data['values'])
  File "/opt/odoo/odoo/odoo/addons/base/models/ir_ui_view.py", line 1842, in _load_records_write
    super(View, self)._load_records_write(values)
  File "/opt/odoo/odoo/odoo/models.py", line 4138, in _load_records_write
    self.write(values)
  File "/opt/odoo/odoo/odoo/addons/base/models/ir_ui_view.py", line 500, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "/opt/odoo/odoo/odoo/models.py", line 3696, in write
    fields[0].determine_inverse(real_recs)
  File "/opt/odoo/odoo/odoo/fields.py", line 1187, in determine_inverse
    getattr(records, self.inverse)()
  File "/opt/odoo/odoo/odoo/addons/base/models/ir_ui_view.py", line 300, in _inverse_arch
    view.write(data)
  File "/opt/odoo/odoo/odoo/addons/base/models/ir_ui_view.py", line 500, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "/opt/odoo/odoo/odoo/models.py", line 3686, in write
    real_recs._validate_fields(vals, inverse_fields)
  File "/opt/odoo/odoo/odoo/models.py", line 1266, in _validate_fields
    check(self)
  File "/opt/odoo/odoo/odoo/addons/base/models/ir_ui_view.py", line 408, in _check_xml
    raise ValidationError(_(
  File "/opt/odoo/odoo/odoo/addons/base/models/ir_ui_view.py", line 385, in _check_xml
    view_def = view.read_combined(['arch'])
  File "/opt/odoo/odoo/odoo/addons/base/models/ir_ui_view.py", line 809, in read_combined
    arch = root.apply_view_inheritance(arch_tree, self.model)
  File "/opt/odoo/odoo/odoo/addons/base/models/ir_ui_view.py", line 750, in apply_view_inheritance
    return self._apply_view_inheritance(source, inherit_tree)
  File "/opt/odoo/odoo/odoo/addons/base/models/ir_ui_view.py", line 758, in _apply_view_inheritance
    source = view.apply_inheritance_specs(source, arch_tree)
  File "/opt/odoo/odoo/odoo/addons/base/models/ir_ui_view.py", line 735, in apply_inheritance_specs
    self.handle_view_error(str(e))
  File "/opt/odoo/odoo/odoo/addons/base/models/ir_ui_view.py", line 673, in handle_view_error
    raise ValueError(formatted_message).with_traceback(from_traceback) from from_exception
odoo.exceptions.ValidationError: Error while validating view:

Element '<footer>' cannot be located in parent view

View name: res.users.preferences.form.inherit
Error context:
 view: ir.ui.view(7231,)
 xmlid: res_users_view_form_profile
 view.model: res.users
 view.parent: ir.ui.view(7229,)
 file: /opt/odoo/odoo/addons/hr/views/res_users.xml


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/odoo/odoo/service/server.py", line 1199, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/opt/odoo/odoo/odoo/modules/registry.py", line 89, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/odoo/odoo/odoo/modules/loading.py", line 455, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/opt/odoo/odoo/odoo/modules/loading.py", line 347, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/opt/odoo/odoo/odoo/modules/loading.py", line 222, in load_module_graph
    load_data(cr, idref, mode, kind='data', package=package)
  File "/opt/odoo/odoo/odoo/modules/loading.py", line 69, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/opt/odoo/odoo/odoo/tools/convert.py", line 733, in convert_file
    convert_xml_import(cr, module, fp, idref, mode, noupdate)
  File "/opt/odoo/odoo/odoo/tools/convert.py", line 799, in convert_xml_import
    obj.parse(doc.getroot())
  File "/opt/odoo/odoo/odoo/tools/convert.py", line 719, in parse
    self._tag_root(de)
  File "/opt/odoo/odoo/odoo/tools/convert.py", line 677, in _tag_root
    f(rec)
  File "/opt/odoo/odoo/odoo/tools/convert.py", line 681, in _tag_root
    raise ParseError('while parsing %s:%s, near\n%s' % (
odoo.tools.convert.ParseError: while parsing /opt/odoo/odoo/addons/hr/views/res_users.xml:35, near
<record id="res_users_view_form_profile" model="ir.ui.view">
            <field name="name">res.users.preferences.form.inherit</field>
            <field name="model">res.users</field>
            <field name="inherit_id" ref="res_users_view_form_simple_modif"/>
            <field name="arch" type="xml">
                <data><form position="attributes">
                    <attribute name="create">false</attribute>
                    <attribute name="js_class">hr_employee_profile_form</attribute>
                </form>
                <footer position="attributes">
                    <attribute name="invisible">1</attribute>
                </footer>
                <notebook position="replace">
                        <field name="hr_presence_state" invisible="1"/>
                        <header>
                        </header>
                        <sheet>$0</sheet>
                </notebook>
                <notebook position="before">
                    <div class="oe_button_box" name="button_box">
                        <button id="hr_presence_button" class="oe_stat_button" disabled="1" invisible="context.get('from_my_profile', False)" attrs="{'invisible': [('hr_presence_state', '=', 'absent')]}">
                            <div role="img" class="fa fa-fw fa-circle text-success o_button_icon" attrs="{'invisible': [('hr_presence_state', '!=', 'present')]}" aria-label="Available" title="Available"/>
                            <div role="img" class="fa fa-fw fa-circle text-warning o_button_icon" attrs="{'invisible': [('hr_presence_state', '!=', 'to_define')]}" aria-label="Away" title="Away"/>
                            <div role="img" class="fa fa-fw fa-circle text-danger o_button_icon" attrs="{'invisible': [('hr_presence_state', '!=', 'absent')]}" aria-label="Not available" title="Not available"/>

                            <div class="o_stat_info" attrs="{'invisible': [('hr_presence_state', '=', 'present')]}">
                                <span class="o_stat_text">
                                    Not Connected
                                </span>
                            </div>
                            <div class="o_stat_info" attrs="{'invisible': [('hr_presence_state', '!=', 'present')]}">
                                <span class="o_stat_value" attrs="{'invisible': [('last_activity_time', '=', False)]}">
                                    <field name="last_activity_time"/>
                                </span>
                                <span class="o_stat_value" attrs="{'invisible': [('last_activity_time', '!=', False)]}">
                                    <field name="last_activity"/>
                                </span>
                                <span class="o_stat_text">Connected Since</span>
                            </div>
                        </button>
                    </div>
                    <field name="image_1920" widget="image" class="oe_avatar" options="{&quot;zoom&quot;: true, &quot;preview_image&quot;:&quot;image_128&quot;}"/>
                    <div class="oe_title">
                        <h1>
                            <field name="name" placeholder="Employee's Name" required="True" readonly="context.get('from_my_profile', False)"/>
                        </h1>
                    </div>
                    <div class="row">
                        <h2 class="col-6">
                            <field name="job_title" placeholder="Job Position" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                        </h2>
                    </div>
                    <group>
                        <group>
                            <field name="can_edit" invisible="1"/>
                            <field name="mobile_phone" widget="phone" attrs="{'readonly': [('can_edit', '=', False)]}" options="{'enable_sms': false}"/>
                            <field name="work_phone" widget="phone" attrs="{'readonly': [('can_edit', '=', False)]}" options="{'enable_sms': false}"/>
                        </group>
                        <group>
                            <field name="work_email" widget="email" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                            <field name="work_location" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                            <field name="company_id" invisible="1"/>
                        </group>
                        <group>
                            <field name="employee_parent_id" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                            <field name="coach_id" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                        </group>
                    </group>
                </notebook>
                <notebook position="inside">
                    <page name="public" string="Work Information">
                        <div id="o_work_employee_container"> <!-- These two div are used to position org_chart -->
                            <div id="o_work_employee_main">
                                <group string="Location">
                                    <field name="department_id" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                    <field name="address_id" context="{'show_address': 1}" options="{&quot;always_reload&quot;: True, &quot;highlight_first_line&quot;: True}" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                </group>
                                <group name="managers" string="Approvers" class="hide-group-if-empty">
                                    <!-- overridden in other modules -->
                                </group>
                            </div>
                        </div>
                    </page>
                    <page name="personal_information" string="Private Information">
                        <group>
                            <group string="Contact Information">
                                <field name="employee_ids" invisible="1"/>
                                <field name="address_home_id" context="{                                         'show_address': 1,                                         'default_employee_ids': employee_ids,                                         'default_type': 'private',                                         'form_view_ref': 'base.res_partner_view_form_private'}" options="{&quot;always_reload&quot;: True, &quot;highlight_first_line&quot;: True}" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                <field name="private_email" string="Email" attrs="{'readonly': [('can_edit', '=', False)], 'invisible': [('address_home_id', '=', False)]}"/>
                                <field name="employee_phone" string="Phone" class="o_force_ltr" attrs="{'readonly': [('can_edit', '=', False)], 'invisible': [('address_home_id', '=', False)]}" options="{'enable_sms': false}"/>
                                <field name="employee_bank_account_id" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                <field name="km_home_work" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                            </group>
                            <group string="Citizenship">
                                <field name="employee_country_id" options="{&quot;no_open&quot;: True, &quot;no_create&quot;: True}" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                <field name="identification_id" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                <field name="passport_id" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                <field name="gender" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                <field name="birthday" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                <field name="place_of_birth" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                <field name="country_of_birth" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                            </group>
                            <group string="Marital Status">
                                <field name="marital" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                <field name="spouse_complete_name" attrs="{'invisible': [('marital', 'not in', ['married', 'cohabitant'])], 'readonly': [('can_edit', '=', False)]}"/>
                                <field name="spouse_birthdate" attrs="{'invisible': [('marital', 'not in', ['married', 'cohabitant'])], 'readonly': [('can_edit', '=', False)]}"/>
                            </group>
                            <group string="Education">
                                <field name="certificate" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                <field name="study_field" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                <field name="study_school" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                            </group>
                            <group string="Dependant">
                                <field name="children" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                            </group>
                            <group string="Emergency">
                                <field name="emergency_contact" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                <field name="emergency_phone" widget="phone" attrs="{'readonly': [('can_edit', '=', False)]}" options="{'enable_sms': false}"/>
                            </group>
                            <group string="Work Permit" name="work_permit">
                                <field name="visa_no" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                <field name="permit_no" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                <field name="visa_expire" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                            </group>
                        </group>
                    </page>
                     <page name="hr_settings" string="HR Settings">
                        <group>
                            <group string="Status" name="active_group" invisible="1"/>
                            <group string="Attendance" name="identification_group">
                                <field name="pin" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                <field name="barcode" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                            </group>
                        </group>
                    </page>
                </notebook>
            </data></field>
        </record>
^C2021-10-31 06:13:44,497 2110795 INFO xxxxxxx odoo.service.server: Initiating shutdown `

Current behavior before PR:

The update of database failed since the footer element is not found

Desired behavior after PR is merged:

The load of the view should work.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
