### PR TITLE
[FIX] mail: impossible to unlink some mail.message

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1238,7 +1238,7 @@ class Message(models.Model):
         for record in self:
             model = model or record.model
             res_id = res_id or record.res_id
-            if issubclass(self.pool[model], self.pool['mail.thread']):
+            if model in self.pool and issubclass(self.pool[model], self.pool['mail.thread']):
                 self.env[model].invalidate_cache(fnames=[
                     'message_ids',
                     'message_unread',


### PR DESCRIPTION
If the model doesn't exist anymore, it is impossible to unlink some mail.message.

@pimodoo @rco-odoo 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
