### PR TITLE
[14.0][FIX] hr_expense, _compute_amount_residual()

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -138,7 +138,7 @@ class HrExpense(models.Model):
             else:
                 residual_field = 'amount_residual_currency'
             payment_term_lines = expense.sheet_id.account_move_id.line_ids \
-                .filtered(lambda line: line.expense_id == self and line.account_internal_type in ('receivable', 'payable'))
+                .filtered(lambda line: line.expense_id == expense and line.account_internal_type in ('receivable', 'payable'))
             expense.amount_residual = -sum(payment_term_lines.mapped(residual_field))
 
     @api.depends('date', 'total_amount', 'company_currency_id')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This bug will happen, i.e., in our extended module, when we have > 1 expenses which is AR/AP.

Current behavior before PR:
residual will be compute incorrectly (become zero)

Desired behavior after PR is merged:
residual will be computed correctly, for case > 1 expenses with AR/AP

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
