### PR TITLE
[FIX] web: define trusted_host thanks to current URL

### DIFF
--- a/addons/web/static/src/js/report/client_action.js
+++ b/addons/web/static/src/js/report/client_action.js
@@ -43,7 +43,7 @@ var ReportAction = AbstractAction.extend({
             $buttons: this.$buttons,
         };
         return Promise.all([this._super.apply(this, arguments), session.is_bound]).then(async function () {
-            var web_base_url = session['web.base.url'];
+            var web_base_url = window.origin;
             var trusted_host = utils.get_host_from_url(web_base_url);
             var trusted_protocol = utils.get_protocol_from_url(web_base_url);
             self.trusted_origin = utils.build_origin(trusted_protocol, trusted_host);

--- a/addons/web/static/src/js/report/report.js
+++ b/addons/web/static/src/js/report/report.js
@@ -13,7 +13,7 @@ $(document.body)
     .addClass('container-fluid')
     .removeClass('container');
 
-var web_base_url = $('html').attr('web-base-url');
+var web_base_url = window.origin;
 var trusted_host = utils.get_host_from_url(web_base_url);
 var trusted_protocol = utils.get_protocol_from_url(web_base_url);
 var trusted_origin = utils.build_origin(trusted_protocol, trusted_host);


### PR DESCRIPTION
In a multi-website + multi-domain environment, when a non-admin user clicks on a link, the new page may not load.

To reproduce the issue:
(Need stock. Use demo data)
1. Login as admin
2. In Settings, set the Domain of the website:
    - Use the currently-used domain (let URL01 be this domain)
3. Create a second website:
    - Must have another domain (let URL02 be this domain)
4. Browse the DB using URL02
5. Login as demo
6. Consult the Forecasted Report of [FURN_7800] Desk Combination
7. Try to open "WH/OUT/00009"

Error: Nothing happens although the page should be redirected to the
order. In the browser console, an error message is displayed: "Failed to
execute 'postMessage' on 'DOMWindow': The target origin provided
('http://localhost:8069') does not match the recipient window's origin
('http://yourcompany.com:8069')."

When logging in as admin, the config parameter `web.base.url` is defined
with the URL used (URL01):
https://github.com/odoo/odoo/blob/4736344a57e176ed38f4b22cd100b3957d122818/odoo/addons/base/models/res_users.py#L717-L724

Then, when logging in as demo with another URL (URL02), since he's not
an administrator, the config parameter is not overwritten.
So, when clicking on the delivery order (step 5), an action is executed:
https://github.com/odoo/odoo/blob/b492bde6a121be1c15ed90ce0827fcfd72a12f5c/addons/web/static/src/js/report/report.js#L37-L41
where `trusted_origin` is based on `web.base.url`:
https://github.com/odoo/odoo/blob/2dbe39aed5361341cdc87607e671ef19234e0196/odoo/addons/base/models/ir_actions_report.py#L580
This explains why `trusted_origin` is URL01 and thus why the error is
raised.

Also, suppose `trusted_origin` has a correct value (URL02), there is
another issue: when the client action receives the message, a condition
will ensure that the message origin and the origin of the action are the
same:
https://github.com/odoo/odoo/blob/d3854dbf7a6e0c0f9ac00c11716908bc175808d7/addons/web/static/src/js/report/client_action.js#L73-L76
Here, `this.trusted_origin` is also URL01 because of
https://github.com/odoo/odoo/blob/62f2a62b7265645dee91c276c5171b402c0a44fa/addons/web/models/ir_http.py#L48
So this variable definition needs to be updated too.

OPW-2615024