### PR TITLE
[FIX] mrp : BoM report

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -110,7 +110,7 @@ class ReportBomStructure(models.AbstractModel):
             # Use the product template instead of the variant
             price = bom.product_tmpl_id.uom_id._compute_price(bom.product_tmpl_id.with_company(company).standard_price, bom.product_uom_id) * bom_quantity
             attachments = self.env['mrp.document'].search([('res_model', '=', 'product.template'), ('res_id', '=', bom.product_tmpl_id.id)])
-        operations = self._get_operation_line(bom, float_round(bom_quantity / bom.product_qty, precision_rounding=1, rounding_method='UP'), 0)
+        operations = self._get_operation_line(bom, float_round(bom_quantity, precision_rounding=1, rounding_method='UP'), 0)
         lines = {
             'bom': bom,
             'bom_qty': bom_quantity,
@@ -141,7 +141,7 @@ class ReportBomStructure(models.AbstractModel):
             company = bom.company_id or self.env.company
             price = line.product_id.uom_id._compute_price(line.product_id.with_company(company).standard_price, line.product_uom_id) * line_quantity
             if line.child_bom_id:
-                factor = line.product_uom_id._compute_quantity(line_quantity, line.child_bom_id.product_uom_id) / line.child_bom_id.product_qty
+                factor = line.product_uom_id._compute_quantity(line_quantity, line.child_bom_id.product_uom_id)
                 sub_total = self._get_price(line.child_bom_id, factor, line.product_id)
             else:
                 sub_total = price
@@ -172,7 +172,7 @@ class ReportBomStructure(models.AbstractModel):
         qty = bom.product_uom_id._compute_quantity(qty, bom.product_tmpl_id.uom_id)
         for operation in bom.operation_ids:
             operation_cycle = float_round(qty / operation.workcenter_id.capacity, precision_rounding=1, rounding_method='UP')
-            duration_expected = operation_cycle * operation.time_cycle + operation.workcenter_id.time_stop + operation.workcenter_id.time_start
+            duration_expected = operation_cycle * (operation.time_cycle + (operation.workcenter_id.time_stop + operation.workcenter_id.time_start))
             total = ((duration_expected / 60.0) * operation.workcenter_id.costs_hour)
             operations.append({
                 'level': level or 0,
@@ -200,11 +200,11 @@ class ReportBomStructure(models.AbstractModel):
             if line._skip_bom_line(product):
                 continue
             if line.child_bom_id:
-                qty = line.product_uom_id._compute_quantity(line.product_qty * factor, line.child_bom_id.product_uom_id) / line.child_bom_id.product_qty
+                qty = line.product_uom_id._compute_quantity(line.product_qty * (factor / bom.product_qty) , line.child_bom_id.product_uom_id) / line.child_bom_id.product_qty
                 sub_price = self._get_price(line.child_bom_id, qty, line.product_id)
                 price += sub_price
             else:
-                prod_qty = line.product_qty * factor
+                prod_qty = line.product_qty * factor / bom.product_qty
                 company = bom.company_id or self.env.company
                 not_rounded_price = line.product_id.uom_id._compute_price(line.product_id.with_context(force_comany=company.id).standard_price, line.product_uom_id) * prod_qty
                 price += company.currency_id.round(not_rounded_price)


### PR DESCRIPTION
Current behavior:
When creating a BOM with quantity different than 1 (here 12) with operation duration 1 minute and work center capacity 23
The BoM Structure & Cost report only changes the time for the operation when the quantity is > 276
However, when planning a MO the expected duration changes to 2 minutes when the quantity is > 23

Expected behavior:
Expected duration should be the same in the MO and BoM report

Steps to reproduce:
- BOM with quantity different than 1 (here 12)
- operation duration 1 minute
- work center capacity 23
- go in BoM report

opw-2610702

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
