### PR TITLE
[FIX] mail: fix wrong escaping of html entities when create link


### DIFF
--- a/addons/mail/static/src/js/utils.js
+++ b/addons/mail/static/src/js/utils.js
@@ -43,6 +43,25 @@ function _parseAndTransform(nodes, transformFunction) {
     }).join("");
 }
 
+/**
+ * Escape < > & as html entities (copy from _.escape with less escaped characters)
+ *
+ * @param {string}
+ * @return {string}
+ */
+var _escapeEntities = (function () {
+    var map = {"&":"&amp;","<":"&lt;",">":"&gt;"};
+    var escaper = function(match) {
+        return map[match];
+    };
+    var testRegexp = RegExp('(?:&|<|>)');
+    var replaceRegexp = RegExp('(?:&|<|>)', 'g');
+    return function(string) {
+        string = string == null ? '' : '' + string;
+        return testRegexp.test(string) ? string.replace(replaceRegexp, escaper) : string;
+    };
+})();
+
 // Suggested URL Javascript regex of http://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
 // Adapted to make http(s):// not required if (and only if) www. is given. So `should.notmatch` does not match.
 // And further extended to include Latin-1 Supplement, Latin Extended-A, Latin Extended-B and Latin Extended Additional.
@@ -63,10 +82,17 @@ function linkify(text, attrs) {
     attrs = _.map(attrs, function (value, key) {
         return key + '="' + _.escape(value) + '"';
     }).join(' ');
-    return text.replace(urlRegexp, function (url) {
-        var href = (!/^https?:\/\//i.test(url)) ? "http://" + url : url;
-        return '<a ' + attrs + ' href="' + href + '">' + url + '</a>';
-    });
+    var curIndex = 0;
+    var result = "";
+    var match;
+    while ((match = urlRegexp.exec(text)) !== null) {
+        result += _escapeEntities(text.slice(curIndex, match.index));
+        var url = match[0];
+        var href = (!/^https?:\/\//i.test(url)) ? "http://" + _.escape(url) : _.escape(url);
+        result += '<a ' + attrs + ' href="' + href + '">' + _escapeEntities(url) + '</a>';
+        curIndex = match.index + match[0].length;
+    }
+    return result + _escapeEntities(text.slice(curIndex));
 }
 
 function addLink(node, transformChildren) {

--- a/addons/mail/static/tests/mail_utils_tests.js
+++ b/addons/mail/static/tests/mail_utils_tests.js
@@ -35,6 +35,37 @@ QUnit.test('add_link utility function', function (assert) {
     });
 });
 
+QUnit.test('addLink: utility function and special entities', function (assert) {
+    assert.expect(8);
+
+    var testInputs = {
+        // textContent not unescaped
+        '<p>https://example.com/?&amp;currency_id</p>':
+        '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/?&amp;currency_id">https://example.com/?&amp;currency_id</a></p>',
+        // entities not unescaped
+        '&amp; &amp;amp; &gt; &lt;': '&amp; &amp;amp; &gt; &lt;',
+        // > and " not linkified since they are not in URL regex
+        '<p>https://example.com/&gt;</p>':
+        '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/">https://example.com/</a>&gt;</p>',
+        '<p>https://example.com/"hello"&gt;</p>':
+        '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/">https://example.com/</a>"hello"&gt;</p>',
+        // & and ' linkified since they are in URL regex
+        '<p>https://example.com/&amp;hello</p>':
+        '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/&amp;hello">https://example.com/&amp;hello</a></p>',
+        '<p>https://example.com/\'yeah\'</p>':
+        '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/\'yeah\'">https://example.com/\'yeah\'</a></p>',
+        // normal character should not be escaped
+        ':\'(': ':\'(',
+        // special character in smileys should be escaped
+        '&lt;3': '&lt;3',
+    };
+
+    _.each(testInputs, function (result, content) {
+        var output = utils.parseAndTransform(content, utils.addLink);
+        assert.strictEqual(output, result);
+    });
+});
+
 QUnit.test('addLink: linkify inside text node (1 occurrence)', function (assert) {
     assert.expect(5);
 


### PR DESCRIPTION
Issue: `node.data` is an unescaped text content and used as an escaped
content just after (set `innerHTML`) which remove some of the escaping.

Without the fix, the 2 new first assertions would fail:

- first one with 'https://example.com/?¤cy_id' instead of
  'https://example.com/?&amp;currency_id' in the text node

- second one with `&amp;` replaced by & and `&gt;` replaced by >

other assertions ensure that use case before the fix (special char and
URL regex, smileys, ...) still work the same after the fix.

opw-2525028