### PR TITLE
Reduce unnecessary domain conditions

### DIFF
--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -158,9 +158,13 @@ class IrRule(models.Model):
                 group_domains.append(dom)
 
         # combine global domains and group domains
-        if not group_domains:
-            return expression.AND(global_domains)
-        return expression.AND(global_domains + [expression.OR(group_domains)])
+        if group_domains:
+            domain = expression.AND(global_domains + [expression.OR(group_domains)])
+        else:
+            domain = expression.AND(global_domains)
+        domain = expression.simple_domain(domain)
+        return domain
+
 
     def _compute_domain_context_values(self):
         for k in self._compute_domain_keys():

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4400,6 +4400,7 @@ Fields:
             to_flush[self._name].update(fields)
         # also take into account the fields in the record rules
         domain = list(domain) + (self.env['ir.rule']._compute_domain(self._name, 'read') or [])
+        domain = expression.simple_domain(domain)
         for arg in domain:
             if isinstance(arg, str):
                 continue

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -223,10 +223,12 @@ def expand_stack(stack):
     return domain
 
 
+
 def simple_domain(domain):
     if not domain:
         return domain
     stack = []
+
     for token in reversed(distribute_not(normalize_domain(domain))):
         if token == '&':
             if FALSE_LEAF in stack[-2:]:
@@ -252,6 +254,15 @@ def simple_domain(domain):
                     stack.append(x)
             else:
                 stack.append([LEAF_FLAG, [token, stack.pop(), stack.pop()]])
+        elif token == '!':
+            x = stack.pop()
+            if x == TRUE_LEAF:
+                stack.append(FALSE_LEAF)
+            elif x == FALSE_LEAF:
+                stack.append(TRUE_LEAF)
+            else:
+                stack.append([LEAF_FLAG, [token, x]])
+            print(stack)
         elif token[1] == 'in' and not token[2]:
             stack.append(FALSE_LEAF)
         elif token[1] == 'not in' and not token[2]:

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -262,7 +262,6 @@ def simple_domain(domain):
                 stack.append(TRUE_LEAF)
             else:
                 stack.append([LEAF_FLAG, [token, x]])
-            print(stack)
         elif token[1] == 'in' and not token[2]:
             stack.append(FALSE_LEAF)
         elif token[1] == 'not in' and not token[2]:

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -234,7 +234,8 @@ def simple_domain(domain):
                 stack.pop()
                 stack.append(FALSE_LEAF)
             elif TRUE_LEAF in stack[-2:]:
-                if (x := stack.pop()) != TRUE_LEAF:
+                x = stack.pop()
+                if x != TRUE_LEAF:
                     stack.pop()
                     stack.append(x)
             else:
@@ -245,7 +246,8 @@ def simple_domain(domain):
                 stack.pop()
                 stack.append(TRUE_LEAF)
             elif FALSE_LEAF in stack[-2:]:
-                if (x := stack.pop()) != FALSE_LEAF:
+                x = stack.pop()
+                if x != FALSE_LEAF:
                     stack.pop()
                     stack.append(x)
             else:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Reduce queries to the database by reducing unnecessary domain conditions.

Current behavior before PR:

Desired behavior after PR is merged:

```py
from odoo.osv.expression import simple_domain


def same(domain, bomain):
    assert simple_domain(domain) == bomain


if __name__ == '__main__':
    same(
        domain=[('x_id', 'in', []), ('department_id.office_id', 'not in', [1, 2]), ('company_id', '=', 1)],
        bomain=[(0, '=', 1)],
    )
    same(
        domain=['|', ('x_id', 'in', []), ('department_id.office_id', 'not in', [1, 2]), ('company_id', '=', 1)],
        bomain=['&', ('department_id.office_id', 'not in', [1, 2]), ('company_id', '=', 1)],
    )
    same(
        domain=['!', ('x_id', 'in', []), ('department_id.office_id', 'not in', [1, 2]), ('company_id', '=', 1)],
        bomain=['&', ('department_id.office_id', 'not in', [1, 2]), ('company_id', '=', 1)],
    )
    same(
        domain=[('x_id', 'not in', []), ('department_id.office_id', 'not in', [1, 2]), ('company_id', '=', 1)],
        bomain=['&', ('department_id.office_id', 'not in', [1, 2]), ('company_id', '=', 1)],
    )
    same(
        domain=['|', ('x_id', 'not in', []), ('department_id.office_id', 'not in', [1, 2]), ('company_id', '=', 1)],
        bomain=[('company_id', '=', 1)],
    )

```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
