### PR TITLE
[FIX] mrp : Removing a workorder broke the continuity

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -242,6 +242,13 @@ class MrpWorkorder(models.Model):
         # Removes references to workorder to avoid Validation Error
         (self.mapped('move_raw_ids') | self.mapped('move_finished_ids')).write({'workorder_id': False})
         self.mapped('leave_id').unlink()
+        previous_wos = self.env['mrp.workorder'].search([
+            ('next_work_order_id', 'in', self.ids),
+            ('id', 'not in', self.ids)
+        ])
+        for pw in previous_wos:
+            while pw.next_work_order_id and pw.next_work_order_id in self:
+                pw.next_work_order_id = pw.next_work_order_id.next_work_order_id
         return super(MrpWorkorder, self).unlink()
 
     def _get_real_uom_qty(self, qty, to_production_uom=False):


### PR DESCRIPTION
Unlinking a workorder which was in the middle of a chain of workorder created two subchains which both created a product when reaching their new respective ends.

The issue was solve by assuring that when we a link is remove from a workorder chain, their adjacent workorders are linked together using "next_workorder_id".

opw-2669514

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
