### PR TITLE
[FIX] web: remove a useless import

### DIFF
--- a/addons/web/static/tests/helpers/utils.js
+++ b/addons/web/static/tests/helpers/utils.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { browser } from "@web/core/browser/browser";
-import { hasTouch, isMacOS } from "@web/core/browser/feature_detection";
+import { isMacOS } from "@web/core/browser/feature_detection";
 import { patch, unpatch } from "@web/core/utils/patch";
 import { registerCleanup } from "./cleanup";
 import { download } from "@web/core/network/download";


### PR DESCRIPTION
This commit removes a useless import from the
tests helper.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
