### PR TITLE
[IMP] payment: hide tokens for disabled acquirers.

### DIFF
--- a/addons/payment/tests/http_common.py
+++ b/addons/payment/tests/http_common.py
@@ -151,8 +151,8 @@ class PaymentHttpCommon(PaymentTestUtils, HttpCase):
         url = self._build_url(uri)
         return self._make_http_get_request(url, {})
 
-    def get_tx_manage_context(self, **route_kwargs):
-        response = self.portal_payment_method(**route_kwargs)
+    def get_tx_manage_context(self):
+        response = self.portal_payment_method()
 
         self.assertEqual(response.status_code, 200)
 


### PR DESCRIPTION
Saved payments methods for disabled acquirers are no longer visible on the customer
portal. It was fustrating for the customer to see saved payment methods that he was
no longer able to use as they are disabled.
Now the use should only be able to see payment methods that he can indeed use.


Task-2679695
