### PR TITLE
[FIX] website{,_sale}: fix search product with several categories

### DIFF
--- a/addons/website/static/src/snippets/s_searchbar/000.js
+++ b/addons/website/static/src/snippets/s_searchbar/000.js
@@ -113,7 +113,13 @@ publicWidget.registry.searchBar = publicWidget.Widget.extend({
         res.results.forEach(record => {
             for (const fieldName of fieldNames) {
                 if (record[fieldName]) {
-                    record[fieldName] = Markup(record[fieldName]);
+                    if (typeof record[fieldName] === "object") {
+                        for (const fieldKey of Object.keys(record[fieldName])) {
+                            record[fieldName][fieldKey] = Markup(record[fieldName][fieldKey]);
+                        }
+                    } else {
+                        record[fieldName] = Markup(record[fieldName]);
+                    }
                 }
             }
         });

--- a/addons/website/static/src/snippets/s_searchbar/000.xml
+++ b/addons/website/static/src/snippets/s_searchbar/000.xml
@@ -22,7 +22,19 @@
                 <t t-set="extra_link" t-value="parts['extra_link'] and widget.displayExtraLink and result['extra_link_url'] and result['extra_link']"/>
                 <div t-attf-class="h6 font-weight-bold #{description ? '' : 'mb-0'}" t-out="result['name']"/>
                 <p t-if="description" class="mb-0" t-out="description"/>
-                <button t-if="extra_link" class="extra_link btn btn-link btn-sm" t-att-data-target="result['extra_link_url']" t-out="extra_link"/>
+                <t t-if="extra_link">
+                    <t t-if="!extra_link['extra_link_title']">
+                        <button t-if="extra_link" class="extra_link btn btn-link btn-sm"
+                                t-att-data-target="result['extra_link_url']" t-out="extra_link"/>
+                    </t>
+                    <t t-else="">
+                        <button class="btn btn-link btn-sm pr-0" disabled="disabled" t-out="extra_link['extra_link_title']"/>
+                        <t t-foreach="Object.keys(extra_link)" t-as="link">
+                            <button t-if="result['extra_link_url'][link]" class="extra_link btn btn-link btn-sm p-0"
+                                    t-att-data-target="result['extra_link_url'][link]" t-out="extra_link[link]"/>
+                        </t>
+                    </t>
+                </t>
             </div>
             <div t-if="parts['detail'] and widget.displayDetail" class="flex-shrink-0">
                 <t t-if="result['detail_strike']">

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2565,8 +2565,19 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
                 <t t-set="extra_link" t-value="result.get('extra_link_url') and result.get('extra_link')"/>
                 <div t-att-class="'h6 font-weight-bold %s' % ('' if description else 'mb-0')" t-out="result['name']"/>
                 <p t-if="description" class="mb-0" t-out="description"/>
-                <button t-if="extra_link" class="extra_link btn btn-link btn-sm" t-out="extra_link"
-                    t-attf-onclick="location.href='#{result.get('extra_link_url')}';return false;"/>
+                <t t-if="extra_link">
+                    <t t-if="not isinstance(extra_link, dict)">
+                        <button t-if="extra_link" class="extra_link btn btn-link btn-sm" t-out="extra_link"
+                            t-attf-onclick="location.href='#{result.get('extra_link_url')}';return false;"/>
+                    </t>
+                    <t t-else="">
+                        <button class="btn btn-link btn-sm pr-0" disabled="disabled" t-out="extra_link.get('extra_link_title')"/>
+                        <t t-foreach="extra_link" t-as="link">
+                            <button t-if="result['extra_link_url'].get(link)" class="extra_link btn btn-link btn-sm p-0" t-out="extra_link.get(link)"
+                                t-attf-onclick="location.href='#{result['extra_link_url'].get(link)}';return false;"/>
+                        </t>
+                    </t>
+                </t>
             </div>
             <div class="flex-shrink-0">
                 <t t-if="result.get('detail_strike')">

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -375,8 +375,8 @@ class ProductTemplate(models.Model):
             mapping['detail'] = {'name': 'price', 'type': 'html', 'display_currency': options['display_currency']}
             mapping['detail_strike'] = {'name': 'list_price', 'type': 'html', 'display_currency': options['display_currency']}
         if with_category:
-            mapping['extra_link'] = {'name': 'category', 'type': 'text', 'match': True}
-            mapping['extra_link_url'] = {'name': 'category_url', 'type': 'text'}
+            mapping['extra_link'] = {'name': 'category', 'type': 'dict', 'item_type': 'text'}
+            mapping['extra_link_url'] = {'name': 'category_url', 'type': 'dict', 'item_type': 'text'}
         return {
             'model': 'product.template',
             'base_domain': domains,
@@ -401,9 +401,12 @@ class ProductTemplate(models.Model):
             if with_image:
                 data['image_url'] = '/web/image/product.template/%s/image_128' % data['id']
             if with_category and product.public_categ_ids:
-                data['category'] = _('Category: %s', product.public_categ_ids.name)
-                slugs = [slug(category) for category in product.public_categ_ids]
-                data['category_url'] = '/shop/category/%s' % ','.join(slugs)
+                data['category'] = {'extra_link_title': _('Categories:') if len(product.public_categ_ids) > 1 else _('Category:')}
+                data['category_url'] = dict()
+                for categ in product.public_categ_ids:
+                    slug_categ = slug(categ)
+                    data['category'][slug_categ] = categ.name
+                    data['category_url'][slug_categ] = '/shop/category/%s' % slug_categ
         return results_data
 
     @api.model


### PR DESCRIPTION
This commit fixes an issue when there are several public categories on
a single product. Categories are shown side-by-side under product name
in the search bar.
This commit also fixes the issue where the `Category:X` text is matched
and highlighted whereas the search test is not used to match the product
categories.

Steps to reproduce :
    - Install eCommerce
    - Add several eCommerce Categories to a product
    - Go to shop
    - Search for the product in the searchbar
    - Traceback

Current Behavior :
    - Traceback when generating the results in the quick search bar.
      It's not expected to have several categories in the current
      implementation.
    - If all products have a unique category, then the text in
`Category:X` is matched and highlighted.

Desired Behavior :
    - No traceback
    - When there are multiple categories, an extra link should be
      present on each category rather than a unique link on all
      categories.
    - The product categories don't have to be matched.

task-268072

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
