### PR TITLE
[IMP] mail,*: change model declaration syntax

### DIFF
--- a/addons/calendar/static/src/models/activity/activity.js
+++ b/addons/calendar/static/src/models/activity/activity.js
@@ -1,17 +1,15 @@
 /** @odoo-module **/
 
-import {
-    registerClassPatchModel,
-    registerInstancePatchModel,
-    registerFieldPatchModel
-} from'@mail/model/model_core';
+import { addFields, patchModelMethods, patchRecordMethods } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/activity/activity';
 
-registerFieldPatchModel('mail.activity', 'calendar/static/src/models/activity/activity.js', {
+addFields('mail.activity', {
     calendar_event_id: attr({ default: false }),
 });
 
-registerClassPatchModel('mail.activity', 'calendar/static/src/models/activity/activity.js', {
+patchModelMethods('mail.activity', {
     /**
      * @override
      */
@@ -24,7 +22,7 @@ registerClassPatchModel('mail.activity', 'calendar/static/src/models/activity/ac
     },
 });
 
-registerInstancePatchModel('mail.activity', 'calendar/static/src/models/activity/activity.js', {
+patchRecordMethods('mail.activity', {
     /**
      * @override
      */
@@ -40,7 +38,6 @@ registerInstancePatchModel('mail.activity', 'calendar/static/src/models/activity
             this.delete();
         }
     },
-
     /**
      * In case the activity is linked to a meeting, we want to open the calendar view instead.
      *
@@ -59,5 +56,5 @@ registerInstancePatchModel('mail.activity', 'calendar/static/src/models/activity
                 action
             });
         }
-    }
+    },
 });

--- a/addons/crm_livechat/static/src/models/messaging_initializer/messaging_initializer.js
+++ b/addons/crm_livechat/static/src/models/messaging_initializer/messaging_initializer.js
@@ -1,9 +1,11 @@
 /** @odoo-module **/
 
-import { registerInstancePatchModel } from '@mail/model/model_core';
+import { patchRecordMethods } from '@mail/model/model_core';
 import { insert } from '@mail/model/model_field_command';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/messaging_initializer/messaging_initializer';
 
-registerInstancePatchModel('mail.messaging_initializer', 'crm_livechat', {
+patchRecordMethods('mail.messaging_initializer', {
     /**
      * @override
      */

--- a/addons/hr/static/src/models/employee/employee.js
+++ b/addons/hr/static/src/models/employee/employee.js
@@ -1,23 +1,18 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, one2one } from '@mail/model/model_field';
 import { insert, unlink } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class Employee extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'hr.employee',
+    identifyingFields: ['id'],
+    modelMethods: {
         /**
-         * @static
          * @param {Object} data
          * @returns {Object}
          */
-        static convertData(data) {
+        convertData(data) {
             const data2 = {};
             if ('id' in data) {
                 data2.id = data.id;
@@ -42,18 +37,16 @@ function factory(dependencies) {
                 }
             }
             return data2;
-        }
-
+        },
         /**
          * Performs the `read` RPC on the `hr.employee.public`.
          *
-         * @static
          * @param {Object} param0
          * @param {Object} param0.context
          * @param {string[]} param0.fields
          * @param {integer[]} param0.ids
          */
-        static async performRpcRead({ context, fields, ids }) {
+        async performRpcRead({ context, fields, ids }) {
             const employeesData = await this.env.services.rpc({
                 model: 'hr.employee.public',
                 method: 'read',
@@ -66,18 +59,16 @@ function factory(dependencies) {
             this.messaging.models['hr.employee'].insert(employeesData.map(employeeData =>
                 this.messaging.models['hr.employee'].convertData(employeeData)
             ));
-        }
-
+        },
         /**
          * Performs the `search_read` RPC on `hr.employee.public`.
          *
-         * @static
          * @param {Object} param0
          * @param {Object} param0.context
          * @param {Array[]} param0.domain
          * @param {string[]} param0.fields
          */
-        static async performRpcSearchRead({ context, domain, fields }) {
+        async performRpcSearchRead({ context, domain, fields }) {
             const employeesData = await this.env.services.rpc({
                 model: 'hr.employee.public',
                 method: 'search_read',
@@ -90,8 +81,9 @@ function factory(dependencies) {
             this.messaging.models['hr.employee'].insert(employeesData.map(employeeData =>
                 this.messaging.models['hr.employee'].convertData(employeeData)
             ));
-        }
-
+        },
+    },
+    recordMethods: {
         /**
          * Checks whether this employee has a related user and partner and links
          * them if applicable.
@@ -102,8 +94,7 @@ function factory(dependencies) {
                 fields: ['user_id', 'user_partner_id'],
                 context: { active_test: false },
             });
-        }
-
+        },
         /**
          * Gets the chat between the user of this employee and the current user.
          *
@@ -124,8 +115,7 @@ function factory(dependencies) {
                 return;
             }
             return this.user.getChat();
-        }
-
+        },
         /**
          * Opens a chat between the user of this employee and the current user
          * and returns it.
@@ -142,8 +132,7 @@ function factory(dependencies) {
             }
             await this.async(() => chat.open(options));
             return chat;
-        }
-
+        },
         /**
          * Opens the most appropriate view that is a profile for this employee.
          */
@@ -152,11 +141,9 @@ function factory(dependencies) {
                 id: this.id,
                 model: 'hr.employee.public',
             });
-        }
-
-    }
-
-    Employee.fields = {
+        },
+    },
+    fields: {
         /**
          * Whether an attempt was already made to fetch the user corresponding
          * to this employee. This prevents doing the same RPC multiple times.
@@ -184,11 +171,5 @@ function factory(dependencies) {
         user: one2one('mail.user', {
             inverse: 'employee',
         }),
-    };
-    Employee.identifyingFields = ['id'];
-    Employee.modelName = 'hr.employee';
-
-    return Employee;
-}
-
-registerNewModel('hr.employee', factory);
+    },
+});

--- a/addons/hr/static/src/models/messaging/messaging.js
+++ b/addons/hr/static/src/models/messaging/messaging.js
@@ -1,14 +1,10 @@
 /** @odoo-module **/
 
-import {
-    registerInstancePatchModel,
-} from '@mail/model/model_core';
+import { patchRecordMethods } from '@mail/model/model_core';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/messaging/messaging';
 
-registerInstancePatchModel('mail.messaging', 'hr/static/src/models/messaging/messaging.js', {
-    //--------------------------------------------------------------------------
-    // Public
-    //--------------------------------------------------------------------------
-
+patchRecordMethods('mail.messaging', {
     /**
      * @override
      * @param {integer} [param0.employeeId]

--- a/addons/hr/static/src/models/partner/partner.js
+++ b/addons/hr/static/src/models/partner/partner.js
@@ -1,16 +1,11 @@
 /** @odoo-module **/
 
-import {
-    registerInstancePatchModel,
-    registerFieldPatchModel,
-} from '@mail/model/model_core';
+import { addFields, addRecordMethods, patchRecordMethods } from '@mail/model/model_core';
 import { attr, one2one } from '@mail/model/model_field';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/partner/partner';
 
-registerInstancePatchModel('mail.partner', 'hr/static/src/models/partner/partner.js', {
-    //--------------------------------------------------------------------------
-    // Public
-    //--------------------------------------------------------------------------
-
+addRecordMethods('mail.partner', {
     /**
      * Checks whether this partner has a related employee and links them if
      * applicable.
@@ -23,6 +18,9 @@ registerInstancePatchModel('mail.partner', 'hr/static/src/models/partner/partner
         }));
         this.update({ hasCheckedEmployee: true });
     },
+});
+
+patchRecordMethods('mail.partner', {
     /**
      * When a partner is an employee, its employee profile contains more useful
      * information to know who he is than its partner profile.
@@ -42,7 +40,7 @@ registerInstancePatchModel('mail.partner', 'hr/static/src/models/partner/partner
     },
 });
 
-registerFieldPatchModel('mail.partner', 'hr/static/src/models/partner/partner.js', {
+addFields('mail.partner', {
     /**
      * Employee related to this partner. It is computed through
      * the inverse relation and should be considered read-only.

--- a/addons/hr/static/src/models/user/user.js
+++ b/addons/hr/static/src/models/user/user.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import {
-    registerFieldPatchModel,
-} from '@mail/model/model_core';
+import { addFields } from '@mail/model/model_core';
 import { one2one } from '@mail/model/model_field';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/user/user';
 
-registerFieldPatchModel('mail.user', 'hr/static/src/models/user/user.js', {
+addFields('mail.user', {
     /**
      * Employee related to this user.
      */

--- a/addons/hr_holidays/static/src/models/partner/partner.js
+++ b/addons/hr_holidays/static/src/models/partner/partner.js
@@ -1,17 +1,14 @@
-odoo.define('hr_holidays/static/src/models/partner/partner.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const {
-    registerClassPatchModel,
-    registerFieldPatchModel,
-    registerInstancePatchModel,
-} = require('@mail/model/model_core');
-const { attr } = require('@mail/model/model_field');
-const { clear } = require('@mail/model/model_field_command');
+import { addFields, addRecordMethods, patchModelMethods, patchRecordMethods } from '@mail/model/model_core';
+import { attr } from '@mail/model/model_field';
+import { clear } from '@mail/model/model_field_command';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/partner/partner';
 
-const { str_to_date } = require('web.time');
+import { str_to_date } from 'web.time';
 
-registerClassPatchModel('mail.partner', 'hr_holidays/static/src/models/partner/partner.js', {
+patchModelMethods('mail.partner', {
     /**
      * @override
      */
@@ -24,7 +21,7 @@ registerClassPatchModel('mail.partner', 'hr_holidays/static/src/models/partner/p
     },
 });
 
-registerInstancePatchModel('mail.partner', 'hr_holidays/static/src/models/partner/partner.js', {
+addRecordMethods('mail.partner', {
     /**
      * @private
      */
@@ -45,6 +42,9 @@ registerInstancePatchModel('mail.partner', 'hr_holidays/static/src/models/partne
         const formattedDate = date.toLocaleDateString(localeCode, options);
         return _.str.sprintf(this.env._t("Out of office until %s"), formattedDate);
     },
+});
+
+patchRecordMethods('mail.partner', {
     /**
      * @override
      */
@@ -56,7 +56,7 @@ registerInstancePatchModel('mail.partner', 'hr_holidays/static/src/models/partne
     },
 });
 
-registerFieldPatchModel('mail.partner', 'hr/static/src/models/partner/partner.js', {
+addFields('mail.partner', {
     /**
      * Date of end of the out of office period of the partner as string.
      * String is expected to use Odoo's date string format
@@ -69,6 +69,4 @@ registerFieldPatchModel('mail.partner', 'hr/static/src/models/partner/partner.js
     outOfOfficeText: attr({
         compute: '_computeOutOfOfficeText',
     }),
-});
-
 });

--- a/addons/im_livechat/static/src/models/chat_window/chat_window.js
+++ b/addons/im_livechat/static/src/models/chat_window/chat_window.js
@@ -1,9 +1,10 @@
 /** @odoo-module **/
 
-import { registerInstancePatchModel } from '@mail/model/model_core';
+import { patchRecordMethods } from '@mail/model/model_core';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/chat_window/chat_window';
 
-registerInstancePatchModel('mail.chat_window', 'im_livechat/static/src/models/chat_window/chat_window.js', {
-
+patchRecordMethods('mail.chat_window', {
     /**
      * @override
      */
@@ -19,5 +20,5 @@ registerInstancePatchModel('mail.chat_window', 'im_livechat/static/src/models/ch
             this.thread.unpin();
         }
         this._super({ notifyServer });
-    }
+    },
 });

--- a/addons/im_livechat/static/src/models/discuss/discuss.js
+++ b/addons/im_livechat/static/src/models/discuss/discuss.js
@@ -1,10 +1,11 @@
 /** @odoo-module **/
 
-import { registerFieldPatchModel, registerInstancePatchModel } from '@mail/model/model_core';
+import { addFields, patchRecordMethods } from '@mail/model/model_core';
 import { one2one } from '@mail/model/model_field';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/discuss/discuss';
 
-registerInstancePatchModel('mail.discuss', 'im_livechat/static/src/models/discuss/discuss.js', {
-
+patchRecordMethods('mail.discuss', {
     /**
      * @override
      */
@@ -16,7 +17,7 @@ registerInstancePatchModel('mail.discuss', 'im_livechat/static/src/models/discus
     },
 });
 
-registerFieldPatchModel('mail.discuss', 'im_livechat/static/src/models/discuss/discuss.js', {
+addFields('mail.discuss', {
     /**
      * Discuss sidebar category for `livechat` channel threads.
      */

--- a/addons/im_livechat/static/src/models/discuss_sidebar_category/discuss_sidebar_category.js
+++ b/addons/im_livechat/static/src/models/discuss_sidebar_category/discuss_sidebar_category.js
@@ -1,15 +1,17 @@
 /** @odoo-module **/
 
-import { registerFieldPatchModel, registerIdentifyingFieldsPatch } from '@mail/model/model_core';
+import { addFields, patchIdentifyingFields } from '@mail/model/model_core';
 import { one2one } from '@mail/model/model_field';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/discuss_sidebar_category/discuss_sidebar_category';
 
-registerFieldPatchModel('mail.discuss_sidebar_category', 'im_livechat', {
+addFields('mail.discuss_sidebar_category', {
     discussAsLivechat: one2one('mail.discuss', {
         inverse: 'categoryLivechat',
         readonly: true,
     }),
 });
 
-registerIdentifyingFieldsPatch('mail.discuss_sidebar_category', 'im_livechat', identifyingFields => {
+patchIdentifyingFields('mail.discuss_sidebar_category', identifyingFields => {
     identifyingFields[0].push('discussAsLivechat');
 });

--- a/addons/im_livechat/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
+++ b/addons/im_livechat/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
@@ -1,13 +1,10 @@
 /** @odoo-module **/
 
-import { registerInstancePatchModel } from '@mail/model/model_core';
+import { patchRecordMethods } from '@mail/model/model_core';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/discuss_sidebar_category_item/discuss_sidebar_category_item';
 
-registerInstancePatchModel('mail.discuss_sidebar_category_item', 'im_livechat/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js', {
-
-    //----------------------------------------------------------------------
-    // Private
-    //----------------------------------------------------------------------
-
+patchRecordMethods('mail.discuss_sidebar_category_item', {
     /**
      * @override
      */
@@ -20,7 +17,6 @@ registerInstancePatchModel('mail.discuss_sidebar_category_item', 'im_livechat/st
         }
         return this._super();
     },
-
     /**
      * @override
      */
@@ -30,7 +26,6 @@ registerInstancePatchModel('mail.discuss_sidebar_category_item', 'im_livechat/st
         }
         return this._super();
     },
-
     /**
      * @override
      */
@@ -40,7 +35,6 @@ registerInstancePatchModel('mail.discuss_sidebar_category_item', 'im_livechat/st
         }
         return this._super();
     },
-
     /**
      * @override
      */
@@ -50,5 +44,4 @@ registerInstancePatchModel('mail.discuss_sidebar_category_item', 'im_livechat/st
         }
         return this._super();
     },
-
 });

--- a/addons/im_livechat/static/src/models/messaging_initializer/messaging_initializer.js
+++ b/addons/im_livechat/static/src/models/messaging_initializer/messaging_initializer.js
@@ -1,9 +1,11 @@
 /** @odoo-module **/
 
-import { registerInstancePatchModel } from '@mail/model/model_core';
+import { patchRecordMethods } from '@mail/model/model_core';
 import { insert, insertAndReplace } from '@mail/model/model_field_command';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/messaging_initializer/messaging_initializer';
 
-registerInstancePatchModel('mail.messaging_initializer', 'im_livechat/static/src/models/messaging_initializer/messaging_initializer.js', {
+patchRecordMethods('mail.messaging_initializer', {
     /**
      * @override
      * @param {Object} resUsersSettings
@@ -22,7 +24,6 @@ registerInstancePatchModel('mail.messaging_initializer', 'im_livechat/static/src
         });
         this._super(...arguments);
     },
-
     /**
      * @override
      * @param {Object[]} [param0.channel_livechat=[]]

--- a/addons/im_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/im_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -1,13 +1,10 @@
 /** @odoo-module **/
 
-import { registerInstancePatchModel } from '@mail/model/model_core';
+import { patchRecordMethods } from '@mail/model/model_core';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/messaging_notification_handler/messaging_notification_handler';
 
-registerInstancePatchModel('mail.messaging_notification_handler', 'im_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js', {
-
-    //----------------------------------------------------------------------
-    // Private
-    //----------------------------------------------------------------------
-
+patchRecordMethods('mail.messaging_notification_handler', {
     /**
      * @override
      * @param {object} settings
@@ -21,7 +18,6 @@ registerInstancePatchModel('mail.messaging_notification_handler', 'im_livechat/s
         }
         this._super(settings);
     },
-
     /**
      * @override
      */

--- a/addons/im_livechat/static/src/models/partner/partner.js
+++ b/addons/im_livechat/static/src/models/partner/partner.js
@@ -1,15 +1,12 @@
 /** @odoo-module **/
 
-import { registerClassPatchModel } from '@mail/model/model_core';
+import { addModelMethods } from '@mail/model/model_core';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/partner/partner';
 
 let nextPublicId = -1;
 
-registerClassPatchModel('mail.partner', 'im_livechat/static/src/models/partner/partner.js', {
-
-    //----------------------------------------------------------------------
-    // Public
-    //----------------------------------------------------------------------
-
+addModelMethods('mail.partner', {
     getNextPublicId() {
         const id = nextPublicId;
         nextPublicId -= 1;

--- a/addons/im_livechat/static/src/models/thread/thread.js
+++ b/addons/im_livechat/static/src/models/thread/thread.js
@@ -1,17 +1,11 @@
 /** @odoo-module **/
 
-import {
-    registerClassPatchModel,
-    registerInstancePatchModel,
-} from '@mail/model/model_core';
+import { patchModelMethods, patchRecordMethods } from '@mail/model/model_core';
 import { insert, link, unlink } from '@mail/model/model_field_command';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/thread/thread';
 
-registerClassPatchModel('mail.thread', 'im_livechat/static/src/models/thread/thread.js', {
-
-    //----------------------------------------------------------------------
-    // Public
-    //----------------------------------------------------------------------
-
+patchModelMethods('mail.thread', {
     /**
      * @override
      */
@@ -58,12 +52,7 @@ registerClassPatchModel('mail.thread', 'im_livechat/static/src/models/thread/thr
     },
 });
 
-registerInstancePatchModel('mail.thread', 'im_livechat/static/src/models/thread/thread.js', {
-
-    //----------------------------------------------------------------------
-    // Private
-    //----------------------------------------------------------------------
-
+patchRecordMethods('mail.thread', {
     /**
      * @override
      */

--- a/addons/mail/static/src/components/dialog/dialog.xml
+++ b/addons/mail/static/src/components/dialog/dialog.xml
@@ -5,7 +5,7 @@
         <div class="o_Dialog">
             <t t-if="dialog">
                 <t
-                    t-component="constructor.components[dialog.record['constructor'].name]"
+                    t-component="{{ dialog.componentName }}"
                     class="o_Dialog_component"
                     t-props="{ localId: dialog.record.localId }"
                     t-ref="component"

--- a/addons/mail/static/src/model/model_core.js
+++ b/addons/mail/static/src/model/model_core.js
@@ -2,134 +2,395 @@
 
 /**
  * Module that contains registry for adding new models or patching models.
- * Useful for model manager in order to generate model classes.
+ * Useful for model manager in order to generate models.
  *
  * This code is not in model manager because other JS modules should populate
  * a registry, and it's difficult to ensure availability of the model manager
  * when these JS modules are deployed.
  */
 
-const registry = {};
+export const registry = new Map();
 
-//------------------------------------------------------------------------------
-// Private
-//------------------------------------------------------------------------------
 
 /**
- * @private
- * @param {string} modelName
- * @returns {Object}
+ * Concats `contextMessage` at the beginning of any error raising when calling
+ * `func`.
+ *
+ * @param {Function} func The (fallible) function to be called.
+ * @param {string} contextMessage Extra explanations to be added to the error
+ * message if any.
+ * @throws {Error} enriched with `contextMessage` if `func` raises an error.
  */
-function _getEntryFromModelName(modelName) {
-    if (!registry[modelName]) {
-        registry[modelName] = {
-            dependencies: [],
-            factory: undefined,
-            name: modelName,
-            patches: [],
-        };
+function addContextToErrors(func, contextMessage) {
+    try {
+        func();
+    } catch (error) {
+        error.message = contextMessage + error.message;
+        throw error;
     }
-    return registry[modelName];
 }
 
 /**
- * @private
- * @param {string} modelName
- * @param {string} patchName
- * @param {Object} patch
- * @param {Object} [param3={}]
- * @param {string} [param3.type='instance'] 'instance', 'class', 'field' or 'identifyingFields'
- */
-function _registerPatchModel(modelName, patchName, patch, { type = 'instance' } = {}) {
-    const entry = _getEntryFromModelName(modelName);
-    Object.assign(entry, {
-        patches: (entry.patches || []).concat([{
-            name: patchName,
-            patch,
-            type,
-        }]),
-    });
-}
-
-//------------------------------------------------------------------------------
-// Public
-//------------------------------------------------------------------------------
-
-/**
- * Register a patch for static methods in model.
+ * Adds the provided fields to the model specified by the `modelName`.
  *
- * @param {string} modelName
- * @param {string} patchName
- * @param {Object} patch
+ * @param {string} modelName The name of the model to which to add the fields.
+ * @param {Object} fields Fields to be added. key = field name, value = field attributes
  */
-function registerClassPatchModel(modelName, patchName, patch) {
-    _registerPatchModel(modelName, patchName, patch, { type: 'class' });
-}
-
-/**
- * Register a patch for fields in model.
- *
- * @param {string} modelName
- * @param {string} patchName
- * @param {Object} patch
- */
-function registerFieldPatchModel(modelName, patchName, patch) {
-    _registerPatchModel(modelName, patchName, patch, { type: 'field' });
-}
-
-/**
- * Register a patch for identifyignFields in model.
- *
- * @param {string} modelName
- * @param {string} patchName
- * @param {function} patch
- */
-function registerIdentifyingFieldsPatch(modelName, patchName, patch) {
-    _registerPatchModel(modelName, patchName, patch, { type: 'identifyingFields' });
-}
-
-/**
- * Register a patch for instance methods in model.
- *
- * @param {string} modelName
- * @param {string} patchName
- * @param {Object} patch
- */
-function registerInstancePatchModel(modelName, patchName, patch) {
-    _registerPatchModel(modelName, patchName, patch, { type: 'instance' });
-}
-
-/**
- * @param {string} name
- * @param {function} factory
- * @param {string[]} [dependencies=[]]
- */
-function registerNewModel(name, factory, dependencies = []) {
-    const entry = _getEntryFromModelName(name);
-    let entryDependencies = [...dependencies];
-    if (name !== 'mail.model') {
-        entryDependencies = [...new Set(entryDependencies.concat(['mail.model']))];
+export function addFields(modelName, fields) {
+    if (!registry.has(modelName)) {
+        throw new Error(`Cannot add fields to model "${modelName}": model must be registered before fields can be added.`);
     }
-    if (entry.factory) {
-        throw new Error(`Model "${name}" has already been registered!`);
+    const definition = registry.get(modelName);
+    for (const [fieldName, field] of Object.entries(fields)) {
+        addContextToErrors(() => {
+            assertNameIsAvailableOnRecords(fieldName, definition);
+        }, `Cannot add field "${fieldName}" to model "${modelName}": `);
+        definition.get('fields').set(fieldName, field);
     }
-    Object.assign(entry, {
-        dependencies: entryDependencies,
-        factory,
-        name,
-    });
 }
 
-//------------------------------------------------------------------------------
-// Export
-//------------------------------------------------------------------------------
+/**
+ * Adds the provided hooks to the model specified by the `modelName`.
+ *
+ * @param {string} modelName The name of the model to which to add the hooks.
+ * @param {Object} hooks Hooks to be added. key = name, value = handler
+ */
+export function addLifecycleHooks(modelName, hooks) {
+    if (!registry.has(modelName)) {
+        throw new Error(`Cannot add lifecycle hooks to model "${modelName}": model must be registered before lifecycle hooks can be added.`);
+    }
+    const definition = registry.get(modelName);
+    for (const [name, handler] of Object.entries(hooks)) {
+        addContextToErrors(() => {
+            assertIsFunction(handler);
+            assertIsValidHookName(name);
+            assertSectionDoesNotHaveKey('lifecycleHooks', name, definition);
+        }, `Cannot add lifecycle hook "${name}" to model "${modelName}":`);
+        definition.get('lifecycleHooks').set(name, handler);
+    }
+}
 
-export {
-    registerClassPatchModel,
-    registerFieldPatchModel,
-    registerInstancePatchModel,
-    registerIdentifyingFieldsPatch,
-    registerNewModel,
-    registry,
-};
+/**
+ * Adds the provided model getters to the model specified by the `modelName`.
+ *
+ * @deprecated Getters are only used in `mail.model` and are intended to
+ * provide fields such as `env` to all models by inheritance. The creation of
+ * these fields will be directly in the model manager in the future.
+ * Use fields instead.
+ * @param {string} modelName The name of the model to which to add the model getters.
+ * @param {Object} modelGetters Model getters to be added. key = name, value = getter
+ */
+export function addModelGetters(modelName, modelGetters) {
+    if (!registry.has(modelName)) {
+        throw new Error(`Cannot add record getters to model "${modelName}": model must be registered before record getters can be added.`);
+    }
+    const definition = registry.get(modelName);
+    for (const [getterName, getter] of Object.entries(modelGetters)) {
+        addContextToErrors(() => {
+            assertIsFunction(getter);
+            assertNameIsAvailableOnModel(getterName, definition);
+        }, `Cannot add model getter "${getterName}" to model "${modelName}": `);
+        definition.get('modelGetters').set(getterName, getter);
+    }
+}
 
+/**
+ * Adds the provided model methods to the model specified by the `modelName`.
+ *
+ * @param {string} modelName The name of the model to which to add the model methods.
+ * @param {Object} modelMethods Model methods to be added. key = name, value = method
+ */
+export function addModelMethods(modelName, modelMethods) {
+    if (!registry.has(modelName)) {
+        throw new Error(`Cannot add model methods to model "${modelName}": model must be registered before model methods can be added.`);
+    }
+    const definition = registry.get(modelName);
+    for (const [name, method] of Object.entries(modelMethods)) {
+        addContextToErrors(() => {
+            assertIsFunction(method);
+            assertNameIsAvailableOnModel(name, definition);
+        }, `Cannot add model method "${name}" to model "${modelName}": `);
+        definition.get('modelMethods').set(name, method);
+    }
+}
+
+/**
+ * Adds the provided onChanges to the model specified by the `modelName`.
+ *
+ * @param {string} modelName The name of the model to which to add onChanges.
+ * @param {OnChange[]} onChanges Array of onChanges to be added.
+ */
+export function addOnChanges(modelName, onChanges) {
+    if (!registry.has(modelName)) {
+        throw new Error(`Cannot add onChanges to model "${modelName}": model must be registered before onChanges can be added.`);
+    }
+    registry.get(modelName).get('onChanges').push(...onChanges);
+}
+
+/**
+ * Adds the provided record methods to the model specified by the `modelName`.
+ *
+ * @param {string} modelName The name of the model to which to add the methods.
+ * @param {Object} recordMethods Record methods to be added. key = name, value = method
+ */
+export function addRecordMethods(modelName, recordMethods) {
+    if (!registry.has(modelName)) {
+        throw new Error(`Cannot add record methods to model "${modelName}": model must be registered before record methods can be added.`);
+    }
+    const definition = registry.get(modelName);
+    for (const [name, method] of Object.entries(recordMethods)) {
+        addContextToErrors(() => {
+            assertIsFunction(method);
+            assertNameIsAvailableOnRecords(name, definition);
+        }, `Cannot add record method "${name}" to model "${modelName}": `);
+        definition.get('recordMethods').set(name, method);
+    }
+}
+
+/**
+ * Adds the provided record getters to the model specified by the `modelName`.
+ *
+ * @deprecated Getters are only used in `mail.model` and are intended to
+ * provide fields such as `env` to all records by inheritance. The creation of
+ * these fields will be directly in the model manager in the future.
+ * Use fields instead.
+ * @param {string} modelName The name of the model to which to add the record getters.
+ * @param {Object} recordGetters Record getters to be added. key = name, value = getter
+ */
+export function addRecordGetters(modelName, recordGetters) {
+    if (!registry.has(modelName)) {
+        throw new Error(`Cannot add record getters to model "${modelName}": model must be registered before record getters can be added.`);
+    }
+    const definition = registry.get(modelName);
+    for (const [getterName, getter] of Object.entries(recordGetters)) {
+        addContextToErrors(() => {
+            assertIsFunction(getter);
+            assertNameIsAvailableOnRecords(getterName, definition);
+        }, `Cannot add record getter "${getterName}" to model "${modelName}": `);
+        definition.get('recordGetters').set(getterName, getter);
+    }
+}
+
+/**
+ * Asserts that `toAssert` is typeof function.
+ *
+ * @param {any} toAssert
+ * @throws {Error} when `toAssert` is not typeof function.
+ */
+function assertIsFunction(toAssert) {
+    if (typeof toAssert !== 'function') {
+        throw new Error(`"${toAssert}" must be a function`);
+    }
+}
+
+/**
+ * Asserts that `name` is a valid hook name.
+ *
+ * @param {string} name The hook name to check.
+ * @throws {Error} if name is not an existing hook name.
+ */
+function assertIsValidHookName(name) {
+    const validHookNames = new Set(['_created', '_willCreate', '_willDelete']);
+    if (!validHookNames.has(name)) {
+        throw new Error("invalid hook name.");
+    }
+}
+
+/**
+ * Asserts that the provided `key` is not already defined within the section
+ * `sectionName` on the model `modelDefinition`.
+ *
+ * @param {string} sectionName The section of the `modelDefinition` to check into.
+ * @param {string} key The key to check for.
+ * @param {Object} modelDefinition The definition of the model to check.
+ */
+function assertSectionDoesNotHaveKey(sectionName, key, modelDefinition) {
+    if (modelDefinition.get(sectionName).has(key)) {
+        throw new Error(`"${key}" is already defined on "${sectionName}".`);
+    }
+}
+
+/**
+ * Asserts that the provided `key` has already been defined within the section
+ * `sectionName` on the model `modelDefinition`.
+ *
+ * @param {string} sectionName The section of the `modelDefinition` to check into.
+ * @param {string} key The key to check for.
+ * @param {Object} modelDefinition The definition of the model to check.
+ */
+function assertSectionHasKey(sectionName, key, modelDefinition) {
+    if (!modelDefinition.get(sectionName).has(key)) {
+        throw new Error(`"${key}" is not defined yet on "${sectionName}".`);
+    }
+}
+
+/**
+ * Asserts that `name` is not already used as a key on the model.
+ *
+ * @param {string} name The name of the key to check the availability.
+ * @param {Map} modelDefinition The model definition to look into.
+ * @throws {Error} when `name` is already used as a key on the model.
+ */
+function assertNameIsAvailableOnModel(name, modelDefinition) {
+    if (['modelGetters', 'modelMethods'].some(x => modelDefinition.get(x).has(name))) {
+        throw new Error(`there is already a key with this name on the model.`);
+    }
+}
+
+/**
+ * Asserts that `name` is not already used as a key on the records.
+ *
+ * @param {string} name The name of the key to check the availability.
+ * @param {Map} modelDefinition The model definition to look into.
+ * @throws {Error} when `name` is already used as a key on the records.
+ */
+function assertNameIsAvailableOnRecords(name, modelDefinition) {
+    if (['fields', 'recordGetters', 'recordMethods'].some(x => modelDefinition.get(x).has(name))) {
+        throw new Error(`there is already a key with this name on the records.`);
+    }
+}
+
+/**
+ * Applies the provided function to the identifying fields of the model
+ * specified by the `modelName`.
+ *
+ * @param {string} modelName The name of the model to which to apply the patch.
+ * @param {function} patch The function to be applied on the identifying fields.
+ */
+export function patchIdentifyingFields(modelName, patch) {
+    addContextToErrors(() => {
+        if (!registry.has(modelName)) {
+            throw new Error(`model must be registered before being patched.`);
+        }
+        assertIsFunction(patch);
+    }, `Cannot patch identifyingFields on model "${modelName}": `);
+    patch(registry.get(modelName).get('identifyingFields'));
+}
+
+/**
+ * Overrides the lifecycle hooks of the model specified by the `modelName`.
+ *
+ * @param {string} modelName The name of the model to which to apply the patch.
+ * @param {Object} hooks Lifecycle hooks to be overriden. key = name, value = handler
+ */
+export function patchLifecycleHooks(modelName, hooks) {
+    if (!registry.has(modelName)) {
+        throw new Error(`Cannot patch lifecycle hooks on model "${modelName}": model must be registered before being patched.`);
+    }
+    const definition = registry.get(modelName);
+    for (const [name, handler] of Object.entries(hooks)) {
+        addContextToErrors(() => {
+            assertIsFunction(handler);
+            assertSectionHasKey('lifecycleHooks', name, definition);
+        }, `Cannot patch lifecycle hook "${name}" on model "${modelName}": `);
+        const hookBeforePatch = definition.get('lifecycleHooks').get(name);
+        definition.get('lifecycleHooks').set(name, function (...args) {
+            this._super = hookBeforePatch;
+            return handler.call(this, ...args);
+        });
+    }
+}
+
+/**
+ * Overrides the model methods of the model specified by the `modelName`.
+ *
+ * @param {string} modelName The name of the model to which to apply the patch.
+ * @param {Object} methods Model methods to be overriden. key = name, value = method
+ */
+export function patchModelMethods(modelName, modelMethods) {
+    if (!registry.has(modelName)) {
+        throw new Error(`Cannot patch model methods on model "${modelName}": model must be registered before being patched.`);
+    }
+    const definition = registry.get(modelName);
+    for (const [name, method] of Object.entries(modelMethods)) {
+        addContextToErrors(() => {
+            assertIsFunction(method);
+            assertSectionHasKey('modelMethods', name, definition);
+        }, `Cannot patch model method "${name}" on model "${modelName}": `);
+        const methodBeforePatch = definition.get('modelMethods').get(name);
+        definition.get('modelMethods').set(name, function (...args) {
+            this._super = methodBeforePatch;
+            return method.call(this, ...args);
+        });
+    }
+}
+
+/**
+ * Overrides the record methods of the model specified by the `modelName`.
+ *
+ * @param {string} modelName The name of the model to which to apply the patch.
+ * @param {Object} methods Record methods to be overriden. key = name, value = method
+ */
+export function patchRecordMethods(modelName, recordMethods) {
+    if (!registry.has(modelName)) {
+        throw new Error(`Cannot patch record methods on model "${modelName}": model must be registered before being patched.`);
+    }
+    const definition = registry.get(modelName);
+    for (const [name, method] of Object.entries(recordMethods)) {
+        addContextToErrors(() => {
+            assertIsFunction(method);
+            assertSectionHasKey('recordMethods', name, definition);
+        }, `Cannot patch record method "${name}" on model "${modelName}": `);
+        const methodBeforePatch = definition.get('recordMethods').get(name);
+        definition.get('recordMethods').set(name, function (...args) {
+            this._super = methodBeforePatch;
+            return method.call(this, ...args);
+        });
+    }
+}
+
+/**
+ * @param {Object} definition The JSON definition of the model to register.
+ * @param {Object} [definition.fields]
+ * @param {string[]} definition.identifyingFields
+ * @param {Object} [definition.lifecycleHooks]
+ * @param {Object} [definition.modelGetters] Deprecated; use fields instead.
+ * @param {Object} [definition.modelMethods]
+ * @param {string} definition.name
+ * @param {OnChanges[]} [definition.onChanges]
+ * @param {Object} [definition.recordGetters] Deprecated; use fields instead.
+ * @param {Object} [definition.recordMethods]
+ */
+export function registerModel({ fields, identifyingFields, lifecycleHooks, modelGetters, modelMethods, name, onChanges, recordGetters, recordMethods }) {
+    if (!name) {
+        throw new Error("Model is lacking a name.");
+    }
+    if (!identifyingFields) {
+        throw new Error(`Cannot register model "${name}": definition is lacking identifying fields.`);
+    }
+    if (registry.has(name)) {
+        throw new Error(`Cannot register model "${name}": model has already been registered.`);
+    }
+    registry.set(name, new Map([
+        ['name', name],
+        ['identifyingFields', identifyingFields],
+        ['lifecycleHooks', new Map()],
+        ['modelMethods', new Map()],
+        ['modelGetters', new Map()],
+        ['recordMethods', new Map()],
+        ['recordGetters', new Map()],
+        ['fields', new Map()],
+        ['onChanges', []],
+    ]));
+    if (lifecycleHooks) {
+        addLifecycleHooks(name, lifecycleHooks);
+    }
+    if (modelMethods) {
+        addModelMethods(name, modelMethods);
+    }
+    if (modelGetters) {
+        addModelGetters(name, modelGetters);
+    }
+    if (recordMethods) {
+        addRecordMethods(name, recordMethods);
+    }
+    if (recordGetters) {
+        addRecordGetters(name, recordGetters);
+    }
+    if (fields) {
+        addFields(name, fields);
+    }
+    if (onChanges) {
+        addOnChanges(name, onChanges);
+    }
+}

--- a/addons/mail/static/src/model/model_field.js
+++ b/addons/mail/static/src/model/model_field.js
@@ -332,7 +332,7 @@ export class ModelField {
                         }
                         break;
                     default:
-                        throw new Error(`Field "${record.constructor.modelName}/${this.fieldName}"(${this.fieldType} type) does not support command "${commandName}"`);
+                        throw new Error(`Field "${record.constructor.name}/${this.fieldName}"(${this.fieldType} type) does not support command "${commandName}"`);
                 }
             } else if (this.fieldType === 'relation') {
                 switch (commandName) {
@@ -377,7 +377,7 @@ export class ModelField {
                         }
                         break;
                     default:
-                        throw new Error(`Field "${record.constructor.modelName}/${this.fieldName}"(${this.fieldType} type) does not support command "${commandName}"`);
+                        throw new Error(`Field "${record.constructor.name}/${this.fieldName}"(${this.fieldType} type) does not support command "${commandName}"`);
                 }
             }
         }

--- a/addons/mail/static/src/model/tests/test_models.js
+++ b/addons/mail/static/src/model/tests/test_models.js
@@ -1,14 +1,13 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2one, one2many, one2one } from '@mail/model/model_field';
 import { insertAndReplace } from '@mail/model/model_field_command';
 
-function factoryAddress(dependencies) {
-    class Address extends dependencies['mail.model'] {
-    }
-
-    Address.fields = {
+registerModel({
+    name: 'test.address',
+    identifyingFields: ['id'],
+    fields: {
         id: attr({
             readonly: true,
             required: true,
@@ -17,17 +16,13 @@ function factoryAddress(dependencies) {
         contact: one2one('test.contact', {
             inverse: 'address',
         }),
-    };
-    Address.identifyingFields = ['id'];
-    Address.modelName = 'test.address';
+    },
+});
 
-    return Address;
-}
-
-function factoryContact(dependencies) {
-    class Contact extends dependencies['mail.model'] {}
-
-    Contact.fields = {
+registerModel({
+    name: 'test.contact',
+    identifyingFields: ['id'],
+    fields: {
         id: attr({
             readonly: true,
             required: true,
@@ -47,33 +42,24 @@ function factoryContact(dependencies) {
         tasks: one2many('test.task', {
             inverse: 'responsible'
         }),
-    };
-    Contact.identifyingFields = ['id'];
-    Contact.modelName = 'test.contact';
+    },
+});
 
-    return Contact;
-}
-
-function factoryHobby(dependencies) {
-    class Hobby extends dependencies['mail.model'] {}
-
-    Hobby.fields = {
+registerModel({
+    name: 'test.hobby',
+    identifyingFields: ['description'],
+    fields: {
         description: attr({
             readonly: true,
             required: true,
         }),
-    };
-    Hobby.identifyingFields = ['description'];
-    Hobby.modelName = 'test.hobby';
+    },
+});
 
-    return Hobby;
-}
-
-function factoryTask(dependencies) {
-    class Task extends dependencies['mail.model'] {
-    }
-
-    Task.fields = {
+registerModel({
+    name: 'test.task',
+    identifyingFields: ['id'],
+    fields: {
         id: attr({
             readonly: true,
             required: true,
@@ -85,15 +71,5 @@ function factoryTask(dependencies) {
         responsible: many2one('test.contact', {
             inverse: 'tasks'
         }),
-    };
-    Task.identifyingFields = ['id'];
-    Task.modelName = 'test.task';
-
-    return Task;
-}
-
-registerNewModel('test.address', factoryAddress);
-registerNewModel('test.contact', factoryContact);
-registerNewModel('test.hobby', factoryHobby);
-registerNewModel('test.task', factoryTask);
-
+    },
+});

--- a/addons/mail/static/src/models/activity/activity.js
+++ b/addons/mail/static/src/models/activity/activity.js
@@ -1,40 +1,18 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2many, many2one } from '@mail/model/model_field';
 import { clear, insert, unlink, unlinkAll } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class Activity extends dependencies['mail.model'] {
-
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.activity',
+    identifyingFields: ['id'],
+    modelMethods: {
         /**
-         * Delete the record from database and locally.
-         */
-        async deleteServerRecord() {
-            await this.async(() => this.env.services.rpc({
-                model: 'mail.activity',
-                method: 'unlink',
-                args: [[this.id]],
-            }));
-            this.delete();
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
-        /**
-         * @static
          * @param {Object} data
          * @return {Object}
          */
-        static convertData(data) {
+        convertData(data) {
             const data2 = {};
             if ('activity_category' in data) {
                 data2.category = data.activity_category;
@@ -119,8 +97,20 @@ function factory(dependencies) {
             }
 
             return data2;
-        }
-
+        },
+    },
+    recordMethods: {
+        /**
+         * Delete the record from database and locally.
+         */
+        async deleteServerRecord() {
+            await this.async(() => this.env.services.rpc({
+                model: 'mail.activity',
+                method: 'unlink',
+                args: [[this.id]],
+            }));
+            this.delete();
+        },
         /**
          * Opens (legacy) form view dialog to edit current activity and updates
          * the activity when dialog is closed.
@@ -143,8 +133,7 @@ function factory(dependencies) {
                 action,
                 options: { on_close: () => this.fetchAndUpdate() },
             });
-        }
-
+        },
         async fetchAndUpdate() {
             const [data] = await this.async(() => this.env.services.rpc({
                 model: 'mail.activity',
@@ -162,8 +151,7 @@ function factory(dependencies) {
             if (shouldDelete) {
                 this.delete();
             }
-        }
-
+        },
         /**
          * @param {Object} param0
          * @param {mail.attachment[]} [param0.attachments=[]]
@@ -182,8 +170,7 @@ function factory(dependencies) {
             }));
             this.thread.refresh();
             this.delete();
-        }
-
+        },
         /**
          * @param {Object} param0
          * @param {string} param0.feedback
@@ -211,12 +198,7 @@ function factory(dependencies) {
                     },
                 },
             });
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -226,8 +208,7 @@ function factory(dependencies) {
                 return false;
             }
             return this.assignee.partner === this.messaging.currentPartner;
-        }
-
+        },
         /**
          * Wysiwyg editor put `<p><br></p>` even without a note on the activity.
          * This compute replaces this almost empty value by an actual empty
@@ -241,10 +222,9 @@ function factory(dependencies) {
                 return clear();
             }
             return this.note;
-        }
-    }
-
-    Activity.fields = {
+        },
+    },
+    fields: {
         assignee: many2one('mail.user'),
         attachments: many2many('mail.attachment', {
             inverse: 'activities',
@@ -306,11 +286,5 @@ function factory(dependencies) {
         type: many2one('mail.activity_type', {
             inverse: 'activities',
         }),
-    };
-    Activity.identifyingFields = ['id'];
-    Activity.modelName = 'mail.activity';
-
-    return Activity;
-}
-
-registerNewModel('mail.activity', factory);
+    },
+});

--- a/addons/mail/static/src/models/activity_box_view/activity_box_view.js
+++ b/addons/mail/static/src/models/activity_box_view/activity_box_view.js
@@ -1,35 +1,26 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, one2one } from '@mail/model/model_field';
-import { clear, link } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class ActivityBoxView extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.activity_box_view',
+    identifyingFields: ['chatter'],
+    lifecycleHooks: {
         _created() {
             // Bind necessary until OWL supports arrow function in handlers: https://github.com/odoo/owl/issues/876
             this.onClickActivityBoxTitle = this.onClickActivityBoxTitle.bind(this);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * Handles click on activity box title.
          */
         onClickActivityBoxTitle() {
             this.update({ isActivityListVisible: !this.isActivityListVisible });
-        }
-
-    }
-
-    ActivityBoxView.fields = {
+        },
+    },
+    fields: {
         chatter: one2one('mail.chatter', {
             inverse: 'activityBoxView',
             readonly: true,
@@ -38,11 +29,6 @@ function factory(dependencies) {
         isActivityListVisible: attr({
             default: true,
         }),
-    };
-    ActivityBoxView.identifyingFields = ['chatter'];
-    ActivityBoxView.modelName = 'mail.activity_box_view';
+    },  
 
-    return ActivityBoxView;
-}
-
-registerNewModel('mail.activity_box_view', factory);
+});

--- a/addons/mail/static/src/models/activity_type/activity_type.js
+++ b/addons/mail/static/src/models/activity_type/activity_type.js
@@ -1,14 +1,12 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, one2many } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class ActivityType extends dependencies['mail.model'] {
-    }
-
-    ActivityType.fields = {
+registerModel({
+    name: 'mail.activity_type',
+    identifyingFields: ['id'],
+    fields: {
         activities: one2many('mail.activity', {
             inverse: 'type',
         }),
@@ -17,11 +15,5 @@ function factory(dependencies) {
             readonly: true,
             required: true,
         }),
-    };
-    ActivityType.identifyingFields = ['id'];
-    ActivityType.modelName = 'mail.activity_type';
-
-    return ActivityType;
-}
-
-registerNewModel('mail.activity_type', factory);
+    },
+});

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -1,32 +1,25 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2many, many2one, one2many } from '@mail/model/model_field';
 import { clear, insert } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class Attachment extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.attachment',
+    identifyingFields: ['id'],
+    lifecycleHooks: {
         _created() {
             // Bind necessary until OWL supports arrow function in handlers: https://github.com/odoo/owl/issues/876
             this.onClickDownload = this.onClickDownload.bind(this);
-        }
-
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    modelMethods: {
         /**
          * @static
          * @param {Object} data
          * @return {Object}
          */
-        static convertData(data) {
+        convertData(data) {
             const data2 = {};
             if ('filename' in data) {
                 data2.filename = data.filename;
@@ -51,15 +44,15 @@ function factory(dependencies) {
                 data2.originThread = data.originThread;
             }
             return data2;
-        }
-
+        },
+    },
+    recordMethods: {
         /**
          * Send the attachment for the browser to download.
          */
         download() {
             this.env.services.navigate(`/web/content/ir.attachment/${this.id}/datas`, { download: true });
-        }
-
+        },
         /**
          * Handles click on download icon.
          *
@@ -68,8 +61,7 @@ function factory(dependencies) {
         onClickDownload(ev) {
             ev.stopPropagation();
             this.download();
-        }
-
+        },
         /**
          * Remove this attachment globally.
          */
@@ -94,12 +86,7 @@ function factory(dependencies) {
                 this.uploadingAbortController.abort();
             }
             this.delete();
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {string|undefined}
@@ -124,8 +111,7 @@ function factory(dependencies) {
                 return `https://www.youtube.com/embed/${token}`;
             }
             return `/web/content/${this.id}`;
-        }
-
+        },
         /**
          * @private
          * @returns {string|undefined}
@@ -136,8 +122,7 @@ function factory(dependencies) {
                 return displayName;
             }
             return clear();
-        }
-
+        },
         /**
          * @private
          * @returns {string}
@@ -148,8 +133,7 @@ function factory(dependencies) {
             }
             const accessToken = this.accessToken ? `?access_token=${this.accessToken}` : '';
             return `/web/content/ir.attachment/${this.id}/datas${accessToken}`;
-        }
-
+        },
         /**
          * @private
          * @returns {string|undefined}
@@ -160,8 +144,7 @@ function factory(dependencies) {
                 return extension;
             }
             return clear();
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -177,16 +160,14 @@ function factory(dependencies) {
                     (message.guestAuthor && message.guestAuthor === this.messaging.currentGuest)
                 ))
                 : true;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeIsPdf() {
             return this.mimetype === 'application/pdf';
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -202,8 +183,7 @@ function factory(dependencies) {
                 'image/x-icon',
             ];
             return imageMimetypes.includes(this.mimetype);
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -217,8 +197,7 @@ function factory(dependencies) {
                 'text/plain',
             ];
             return textMimeType.includes(this.mimetype);
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -231,32 +210,28 @@ function factory(dependencies) {
                 'video/webm',
             ];
             return videoMimeTypes.includes(this.mimetype);
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeIsUrl() {
             return this.type === 'url' && this.url;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeIsViewable() {
             return this.isText || this.isImage || this.isVideo || this.isPdf || this.isUrlYoutube;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeIsUrlYoutube() {
             return !!this.url && this.url.includes('youtu');
-        }
-
+        },
         /**
          * @deprecated
          * @private
@@ -264,8 +239,7 @@ function factory(dependencies) {
          */
         _computeMediaType() {
             return this.mimetype && this.mimetype.split('/').shift();
-        }
-
+        },
         /**
          * @private
          * @returns {AbortController|undefined}
@@ -284,10 +258,9 @@ function factory(dependencies) {
                 return this.uploadingAbortController;
             }
             return;
-        }
-    }
-
-    Attachment.fields = {
+        },
+    },
+    fields: {
         accessToken: attr(),
         activities: many2many('mail.activity', {
             inverse: 'attachments',
@@ -427,11 +400,5 @@ function factory(dependencies) {
             compute: '_computeUploadingAbortController',
         }),
         url: attr(),
-    };
-    Attachment.identifyingFields = ['id'];
-    Attachment.modelName = 'mail.attachment';
-
-    return Attachment;
-}
-
-registerNewModel('mail.attachment', factory);
+    },
+});

--- a/addons/mail/static/src/models/attachment_box_view/attachment_box_view.js
+++ b/addons/mail/static/src/models/attachment_box_view/attachment_box_view.js
@@ -1,48 +1,41 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, one2one } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class AttachmentBoxView extends dependencies['mail.model'] {
-
+registerModel({
+    name: 'mail.attachment_box_view',
+    identifyingFields: ['chatter'],
+    lifecycleHooks: {
         _created() {
             this.onAttachmentCreated = this.onAttachmentCreated.bind(this);
             this.onAttachmentRemoved = this.onAttachmentRemoved.bind(this);
             this.onClickAddAttachment = this.onClickAddAttachment.bind(this);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * Handles attachment created event.
          */
         onAttachmentCreated() {
             // FIXME Could be changed by spying attachments count (task-2252858)
             this.component.trigger('o-attachments-changed');
-        }
-
+        },
         /**
          * Handles attachment removed event.
          */
         onAttachmentRemoved() {
             // FIXME Could be changed by spying attachments count (task-2252858)
             this.component.trigger('o-attachments-changed');
-        }
-
+        },
         /**
          * Handles click on the "add attachment" button.
          */
         onClickAddAttachment() {
             this.fileUploaderRef.comp.openBrowserFileUploader();
-        }
-
-    }
-
-    AttachmentBoxView.fields = {
+        },
+    },
+    fields: {
         chatter: one2one('mail.chatter', {
             inverse: 'attachmentBoxView',
             readonly: true,
@@ -56,11 +49,5 @@ function factory(dependencies) {
          * States the OWL ref of the "fileUploader" of this attachment box.
          */
         fileUploaderRef: attr(),
-    };
-    AttachmentBoxView.identifyingFields = ['chatter'];
-    AttachmentBoxView.modelName = 'mail.attachment_box_view';
-
-    return AttachmentBoxView;
-}
-
-registerNewModel('mail.attachment_box_view', factory);
+    },
+});

--- a/addons/mail/static/src/models/attachment_card/attachment_card.js
+++ b/addons/mail/static/src/models/attachment_card/attachment_card.js
@@ -1,27 +1,21 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2one } from '@mail/model/model_field';
 import { insert, insertAndReplace, replace } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class AttachmentCard extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.attachment_card',
+    identifyingFields: ['attachmentList', 'attachment'],
+    lifecycleHooks: {
         _created() {
             // Bind necessary until OWL supports arrow function in handlers: https://github.com/odoo/owl/issues/876
             this.onClickUnlink = this.onClickUnlink.bind(this);
             this.onClickImage = this.onClickImage.bind(this);
             this.onDeleteConfirmDialogClosed = this.onDeleteConfirmDialogClosed.bind(this);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * Opens the attachment viewer when clicking on viewable attachment.
          *
@@ -39,8 +33,7 @@ function factory(dependencies) {
                     }),
                 }),
             });
-        }
-
+        },
         /**
          * Handles the click on delete attachment and open the confirm dialog.
          *
@@ -57,8 +50,7 @@ function factory(dependencies) {
             } else {
                 this.update({ hasDeleteConfirmDialog: true });
             }
-        }
-
+        },
         /**
          * Synchronizes the `hasDeleteConfirmDialog` when the dialog is closed.
          */
@@ -67,11 +59,9 @@ function factory(dependencies) {
                 return;
             }
             this.update({ hasDeleteConfirmDialog: false });
-        }
-
-    }
-
-    AttachmentCard.fields = {
+        },
+    },
+    fields: {
         /**
          * Determines the attachment of this card.
          */
@@ -98,11 +88,5 @@ function factory(dependencies) {
         hasDeleteConfirmDialog: attr({
             default: false,
         }),
-    };
-    AttachmentCard.identifyingFields = ['attachmentList', 'attachment'];
-    AttachmentCard.modelName = 'mail.attachment_card';
-
-    return AttachmentCard;
-}
-
-registerNewModel('mail.attachment_card', factory);
+    },
+});

--- a/addons/mail/static/src/models/attachment_image/attachment_image.js
+++ b/addons/mail/static/src/models/attachment_image/attachment_image.js
@@ -1,27 +1,21 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2one } from '@mail/model/model_field';
 import { clear, insert, insertAndReplace, replace } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class AttachmentImage extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.attachment_image',
+    identifyingFields: ['attachmentList', 'attachment'],
+    lifecycleHooks: {
         _created() {
             // Bind necessary until OWL supports arrow function in handlers: https://github.com/odoo/owl/issues/876
             this.onClickUnlink = this.onClickUnlink.bind(this);
             this.onDeleteConfirmDialogClosed = this.onDeleteConfirmDialogClosed.bind(this);
             this.onClickImage = this.onClickImage.bind(this);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * Opens the attachment viewer when clicking on viewable attachment.
          *
@@ -39,8 +33,7 @@ function factory(dependencies) {
                     }),
                 }),
             });
-        }
-
+        },
         /**
          * Handles the click on delete attachment and open the confirm dialog.
          *
@@ -57,8 +50,7 @@ function factory(dependencies) {
             } else {
                 this.update({ hasDeleteConfirmDialog: true });
             }
-        }
-
+        },
         /**
          * Synchronize the `hasDeleteConfirmDialog` when the dialog is closed.
          */
@@ -67,12 +59,7 @@ function factory(dependencies) {
                 return;
             }
             this.update({ hasDeleteConfirmDialog: false });
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {number}
@@ -90,8 +77,7 @@ function factory(dependencies) {
             if (this.attachmentList.message) {
                 return 300;
             }
-        }
-
+        },
         /**
          * @private
          * @returns {string}
@@ -105,8 +91,7 @@ function factory(dependencies) {
             }
             const accessToken = this.attachment.accessToken ? `?access_token=${this.attachment.accessToken}` : '';
             return `/web/image/${this.attachment.id}/${this.width}x${this.height}${accessToken}`;
-        }
-
+        },
         /**
          * Returns an arbitrary high value, this is effectively a max-width and
          * the height should be more constrained.
@@ -116,10 +101,9 @@ function factory(dependencies) {
          */
         _computeWidth() {
             return 1920;
-        }
-    }
-
-    AttachmentImage.fields = {
+        },
+    },
+    fields: {
         /**
          * Determines the attachment of this attachment image..
          */
@@ -163,11 +147,5 @@ function factory(dependencies) {
             compute: '_computeWidth',
             required: true,
         }),
-    };
-    AttachmentImage.identifyingFields = ['attachmentList', 'attachment'];
-    AttachmentImage.modelName = 'mail.attachment_image';
-
-    return AttachmentImage;
-}
-
-registerNewModel('mail.attachment_image', factory);
+    },
+});

--- a/addons/mail/static/src/models/attachment_list/attachment_list.js
+++ b/addons/mail/static/src/models/attachment_list/attachment_list.js
@@ -1,17 +1,27 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { many2many, many2one, one2many, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class AttachmentList extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.attachment_list',
+    identifyingFields: [['composerView', 'messageView', 'chatter']],
+    recordMethods: {
+        _computeAttachmentImages() {
+            return insertAndReplace(this.imageAttachments.map(attachment => {
+                return {
+                    attachment: replace(attachment),
+                };
+            }));
+        },
+        _computeAttachmentCards() {
+            return insertAndReplace(this.nonImageAttachments.map(attachment => {
+                return {
+                    attachment: replace(attachment),
+                };
+            }));
+        },
         /**
          * @returns {mail.attachment[]}
          */
@@ -26,48 +36,27 @@ function factory(dependencies) {
                 return replace(this.composerView.composer.attachments);
             }
             return clear();
-        }
-
-        _computeAttachmentImages() {
-            return insertAndReplace(this.imageAttachments.map(attachment => {
-                return {
-                    attachment: replace(attachment),
-                };
-            }));
-        }
-
-        _computeAttachmentCards() {
-            return insertAndReplace(this.nonImageAttachments.map(attachment => {
-                return {
-                    attachment: replace(attachment),
-                };
-            }));
-        }
-
+        },
         /**
          * @returns {mail.attachment[]}
          */
         _computeImageAttachments() {
             return replace(this.attachments.filter(attachment => attachment.isImage));
-        }
-
+        },
         /**
          * @returns {mail.attachment[]}
          */
         _computeNonImageAttachments() {
             return replace(this.attachments.filter(attachment => !attachment.isImage));
-        }
-
+        },
         /**
          * @returns {mail.attachment[]}
          */
         _computeViewableAttachments() {
             return replace(this.attachments.filter(attachment => attachment.isViewable));
-        }
-
-    }
-
-    AttachmentList.fields = {
+        },
+    },
+    fields: {
         /**
          * States the attachments to be displayed by this attachment list.
          */
@@ -140,11 +129,5 @@ function factory(dependencies) {
         viewableAttachments: many2many('mail.attachment', {
             compute: '_computeViewableAttachments',
         }),
-    };
-    AttachmentList.identifyingFields = [['composerView', 'messageView', 'chatter']];
-    AttachmentList.modelName = 'mail.attachment_list';
-
-    return AttachmentList;
-}
-
-registerNewModel('mail.attachment_list', factory);
+    },
+});

--- a/addons/mail/static/src/models/attachment_viewer/attachment_viewer.js
+++ b/addons/mail/static/src/models/attachment_viewer/attachment_viewer.js
@@ -1,16 +1,12 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2many, many2one, one2one } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class AttachmentViewer extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.attachment_viewer',
+    identifyingFields: ['attachmentList'],
+    recordMethods: {
         /**
          * Close the attachment viewer by closing its linked dialog.
          */
@@ -19,12 +15,7 @@ function factory(dependencies) {
             if (dialog) {
                 dialog.delete();
             }
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {string}
@@ -38,10 +29,9 @@ function factory(dependencies) {
             }
             const accessToken = this.attachment.accessToken ? `?access_token=${this.attachment.accessToken}` : '';
             return `/web/image/${this.attachment.id}${accessToken}`;
-        }
-    }
-
-    AttachmentViewer.fields = {
+        },
+    },
+    fields: {
         /**
          * Angle of the image. Changes when the user rotates it.
          */
@@ -86,11 +76,5 @@ function factory(dependencies) {
         scale: attr({
             default: 1,
         }),
-    };
-    AttachmentViewer.identifyingFields = ['attachmentList'];
-    AttachmentViewer.modelName = 'mail.attachment_viewer';
-
-    return AttachmentViewer;
-}
-
-registerNewModel('mail.attachment_viewer', factory);
+    },
+});

--- a/addons/mail/static/src/models/canned_response/canned_response.js
+++ b/addons/mail/static/src/models/canned_response/canned_response.js
@@ -1,13 +1,13 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
 import { cleanSearchTerm } from '@mail/utils/utils';
 
-function factory(dependencies) {
-
-    class CannedResponse extends dependencies['mail.model'] {
-
+registerModel({
+    name: 'mail.canned_response',
+    identifyingFields: ['id'],
+    modelMethods: {
         /**
          * Fetches canned responses matching the given search term to extend the
          * JS knowledge and to update the suggestion list accordingly.
@@ -15,26 +15,23 @@ function factory(dependencies) {
          * In practice all canned responses are already fetched at init so this
          * method does nothing.
          *
-         * @static
          * @param {string} searchTerm
          * @param {Object} [options={}]
          * @param {mail.thread} [options.thread] prioritize and/or restrict
          *  result in the context of given thread
          */
-        static fetchSuggestions(searchTerm, { thread } = {}) {}
-
+        fetchSuggestions(searchTerm, { thread } = {}) {},
         /**
          * Returns a sort function to determine the order of display of canned
          * responses in the suggestion list.
          *
-         * @static
          * @param {string} searchTerm
          * @param {Object} [options={}]
          * @param {mail.thread} [options.thread] prioritize result in the
          *  context of given thread
          * @returns {function}
          */
-        static getSuggestionSortFunction(searchTerm, { thread } = {}) {
+        getSuggestionSortFunction(searchTerm, { thread } = {}) {
             const cleanedSearchTerm = cleanSearchTerm(searchTerm);
             return (a, b) => {
                 const cleanedAName = cleanSearchTerm(a.source || '');
@@ -53,8 +50,7 @@ function factory(dependencies) {
                 }
                 return a.id - b.id;
             };
-        }
-
+        },
         /*
          * Returns canned responses that match the given search term.
          *
@@ -65,13 +61,14 @@ function factory(dependencies) {
          *  result in the context of given thread
          * @returns {[mail.canned_response[], mail.canned_response[]]}
          */
-        static searchSuggestions(searchTerm, { thread } = {}) {
+        searchSuggestions(searchTerm, { thread } = {}) {
             const cleanedSearchTerm = cleanSearchTerm(searchTerm);
             return [this.messaging.cannedResponses.filter(cannedResponse =>
                 cleanSearchTerm(cannedResponse.source).includes(cleanedSearchTerm)
             )];
-        }
-
+        },
+    },
+    recordMethods: {
         /**
          * Returns the text that identifies this canned response in a mention.
          *
@@ -79,11 +76,9 @@ function factory(dependencies) {
          */
         getMentionText() {
             return this.substitution;
-        }
-
-    }
-
-    CannedResponse.fields = {
+        },
+    },
+    fields: {
         id: attr({
             readonly: true,
             required: true,
@@ -97,11 +92,5 @@ function factory(dependencies) {
          * entered.
          */
         substitution: attr(),
-    };
-    CannedResponse.identifyingFields = ['id'];
-    CannedResponse.modelName = 'mail.canned_response';
-
-    return CannedResponse;
-}
-
-registerNewModel('mail.canned_response', factory);
+    },
+});

--- a/addons/mail/static/src/models/channel_command/channel_command.js
+++ b/addons/mail/static/src/models/channel_command/channel_command.js
@@ -1,13 +1,13 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
 import { cleanSearchTerm } from '@mail/utils/utils';
 
-function factory(dependencies) {
-
-    class ChannelCommand extends dependencies['mail.model'] {
-
+registerModel({
+    name: 'mail.channel_command',
+    identifyingFields: ['name'],
+    modelMethods: {
         /**
          * Fetches channel commands matching the given search term to extend the
          * JS knowledge and to update the suggestion list accordingly.
@@ -15,26 +15,23 @@ function factory(dependencies) {
          * In practice all channel commands are already fetched at init so this
          * method does nothing.
          *
-         * @static
          * @param {string} searchTerm
          * @param {Object} [options={}]
          * @param {mail.thread} [options.thread] prioritize and/or restrict
          *  result in the context of given thread
          */
-        static fetchSuggestions(searchTerm, { thread } = {}) {}
-
+        fetchSuggestions(searchTerm, { thread } = {}) {},
         /**
          * Returns a sort function to determine the order of display of channel
          * commands in the suggestion list.
          *
-         * @static
          * @param {string} searchTerm
          * @param {Object} [options={}]
          * @param {mail.thread} [options.thread] prioritize result in the
          *  context of given thread
          * @returns {function}
          */
-        static getSuggestionSortFunction(searchTerm, { thread } = {}) {
+        getSuggestionSortFunction(searchTerm, { thread } = {}) {
             const cleanedSearchTerm = cleanSearchTerm(searchTerm);
             return (a, b) => {
                 const isATypeSpecific = a.channel_types;
@@ -61,19 +58,17 @@ function factory(dependencies) {
                 }
                 return a.id - b.id;
             };
-        }
-
+        },
         /**
          * Returns channel commands that match the given search term.
          *
-         * @static
          * @param {string} searchTerm
          * @param {Object} [options={}]
          * @param {mail.thread} [options.thread] prioritize and/or restrict
          *  result in the context of given thread
          * @returns {[mail.channel_command[], mail.channel_command[]]}
          */
-        static searchSuggestions(searchTerm, { thread } = {}) {
+        searchSuggestions(searchTerm, { thread } = {}) {
             if (thread.model !== 'mail.channel') {
                 // channel commands are channel specific
                 return [[]];
@@ -88,12 +83,12 @@ function factory(dependencies) {
                 }
                 return true;
             })];
-        }
-
+        },
+    },
+    recordMethods: {
         /**
          * Executes this command on the given `mail.channel`.
          *
-         * @static
          * @param {Object} param0
          * @param {mail.thread} param0.channel
          * @param {Object} [param0.body='']
@@ -105,8 +100,7 @@ function factory(dependencies) {
                 args: [[channel.id]],
                 kwargs: { body },
             });
-        }
-
+        },
         /**
          * Returns the text that identifies this channel command in a mention.
          *
@@ -114,11 +108,9 @@ function factory(dependencies) {
          */
         getMentionText() {
             return this.name;
-        }
-
-    }
-
-    ChannelCommand.fields = {
+        },
+    },
+    fields: {
         /**
          * Determines on which channel types `this` is available.
          * Type of the channel (e.g. 'chat', 'channel' or 'groups')
@@ -146,11 +138,5 @@ function factory(dependencies) {
             readonly: true,
             required: true,
         }),
-    };
-    ChannelCommand.identifyingFields = ['name'];
-    ChannelCommand.modelName = 'mail.channel_command';
-
-    return ChannelCommand;
-}
-
-registerNewModel('mail.channel_command', factory);
+    },
+});

--- a/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
@@ -1,26 +1,21 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2many, many2one, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace, link, replace, unlink, unlinkAll } from '@mail/model/model_field_command';
 import { cleanSearchTerm } from '@mail/utils/utils';
 
-function factory(dependencies) {
-
-    class ChannelInvitationForm extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.channel_invitation_form',
+    identifyingFields: [['chatWindow', 'threadView']],
+    lifecycleHooks: {
         _created() {
             // Bind necessary until OWL supports arrow function in handlers: https://github.com/odoo/owl/issues/876
             this.onClickInvite = this.onClickInvite.bind(this);
             this.onInputSearch = this.onInputSearch.bind(this);
-        }
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * Handles click on the "invite" button.
          *
@@ -62,8 +57,7 @@ function factory(dependencies) {
                 selectedPartners: unlinkAll(),
             });
             this.delete();
-        }
-
+        },
         /**
          * @param {mail.partner} partner
          * @param {MouseEvent} ev
@@ -74,16 +68,14 @@ function factory(dependencies) {
                 return;
             }
             this.update({ selectedPartners: link(partner) });
-        }
-
+        },
         /**
          * @param {mail.partner} partner
          * @param {MouseEvent} ev
          */
         onClickSelectedPartner(partner, ev) {
             this.update({ selectedPartners: unlink(partner) });
-        }
-
+        },
         /**
          * Handles OWL update on this channel invitation form component.
          */
@@ -93,8 +85,7 @@ function factory(dependencies) {
                 this.searchInputRef.el.setSelectionRange(this.searchTerm.length, this.searchTerm.length);
                 this.update({ doFocusOnSearchInput: clear() });
             }
-        }
-
+        },
         /**
          * @param {mail.partner} partner
          * @param {InputEvent} ev
@@ -105,16 +96,14 @@ function factory(dependencies) {
                 return;
             }
             this.update({ selectedPartners: link(partner) });
-        }
-
+        },
         /**
          * @param {InputEvent} ev
          */
         async onInputSearch(ev) {
             this.update({ searchTerm: ev.target.value });
             this.searchPartnersToInvite();
-        }
-
+        },
         /**
          * Searches for partners to invite based on the current search term. If
          * a search is already in progress, waits until it is done to start a
@@ -157,12 +146,7 @@ function factory(dependencies) {
                     }
                 }
             }
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {string}
@@ -178,8 +162,7 @@ function factory(dependencies) {
                     return this.env._t("Invite to group chat");
             }
             return this.env._t("Invite to Channel");
-        }
-
+        },
         /**
          * @private
          * @returns {FieldCommand}
@@ -192,11 +175,9 @@ function factory(dependencies) {
                 return replace(this.chatWindow.thread);
             }
             return clear();
-        }
-
-    }
-
-    ChannelInvitationForm.fields = {
+        },
+    },
+    fields: {
         chatWindow: one2one('mail.chat_window', {
             inverse: 'channelInvitationForm',
             readonly: true,
@@ -274,11 +255,5 @@ function factory(dependencies) {
             inverse: 'channelInvitationForm',
             readonly: true,
         }),
-    };
-    ChannelInvitationForm.identifyingFields = [['chatWindow', 'threadView']];
-    ChannelInvitationForm.modelName = 'mail.channel_invitation_form';
-
-    return ChannelInvitationForm;
-}
-
-registerNewModel('mail.channel_invitation_form', factory);
+    },
+});

--- a/addons/mail/static/src/models/chat_window/chat_window.js
+++ b/addons/mail/static/src/models/chat_window/chat_window.js
@@ -1,31 +1,24 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2one, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace, link, unlink } from '@mail/model/model_field_command';
 import { markEventHandled } from '@mail/utils/utils';
 
-function factory(dependencies) {
-
-    class ChatWindow extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.chat_window',
+    identifyingFields: ['manager', ['thread', 'managerAsNewMessage']],
+    lifecycleHooks: {
         _created() {
-            super._created();
             // Bind necessary until OWL supports arrow function in handlers: https://github.com/odoo/owl/issues/876
             this.onClickHideInviteForm = this.onClickHideInviteForm.bind(this);
             this.onClickHideMemberList = this.onClickHideMemberList.bind(this);
             this.onClickShowInviteForm = this.onClickShowInviteForm.bind(this);
             this.onClickShowMemberList = this.onClickShowMemberList.bind(this);
             this.onFocusInNewMessageFormInput = this.onFocusInNewMessageFormInput.bind(this);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * Close this chat window.
          *
@@ -52,14 +45,12 @@ function factory(dependencies) {
             if (this.exists()) {
                 this.delete();
             }
-        }
-
+        },
         expand() {
             if (this.thread) {
                 this.thread.open({ expanded: true });
             }
-        }
-
+        },
         /**
          * Programmatically auto-focus an existing chat window.
          */
@@ -70,23 +61,20 @@ function factory(dependencies) {
             if (this.threadView && this.threadView.composerView) {
                 this.threadView.composerView.update({ doFocus: true });
             }
-        }
-
+        },
         focusNextVisibleUnfoldedChatWindow() {
             const nextVisibleUnfoldedChatWindow = this._getNextVisibleUnfoldedChatWindow();
             if (nextVisibleUnfoldedChatWindow) {
                 nextVisibleUnfoldedChatWindow.focus();
             }
-        }
-
+        },
         focusPreviousVisibleUnfoldedChatWindow() {
             const previousVisibleUnfoldedChatWindow =
                 this._getNextVisibleUnfoldedChatWindow({ reverse: true });
             if (previousVisibleUnfoldedChatWindow) {
                 previousVisibleUnfoldedChatWindow.focus();
             }
-        }
-
+        },
         /**
          * @param {Object} [param0={}]
          * @param {boolean} [param0.notifyServer]
@@ -101,8 +89,7 @@ function factory(dependencies) {
             if (this.thread && notifyServer && !this.messaging.currentGuest) {
                 this.thread.notifyFoldStateToServer('folded');
             }
-        }
-
+        },
         /**
          * Makes this chat window active, which consists of making it visible,
          * unfolding it, and focusing it if the user isn't on a mobile device.
@@ -115,8 +102,7 @@ function factory(dependencies) {
             if ((options && options.focus !== undefined) ? options.focus : !this.messaging.device.isMobileDevice) {
                 this.focus();
             }
-        }
-
+        },
         /**
          * Makes this chat window visible by swapping it with the last visible
          * chat window, or do nothing if it is already visible.
@@ -127,8 +113,7 @@ function factory(dependencies) {
             }
             const lastVisible = this.manager.lastVisible;
             this.manager.swap(this, lastVisible);
-        }
-
+        },
         /**
          * Handles click on the "stop adding users" button.
          *
@@ -137,8 +122,7 @@ function factory(dependencies) {
         onClickHideInviteForm(ev) {
             markEventHandled(ev, 'ChatWindow.onClickCommand');
             this.update({ channelInvitationForm: clear() });
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
@@ -148,8 +132,7 @@ function factory(dependencies) {
             if (this.threadViewer.threadView) {
                 this.threadViewer.threadView.addComponentHint('member-list-hidden');
             }
-        }
-
+        },
         /**
          * Handles click on the "add users" button.
          *
@@ -166,8 +149,7 @@ function factory(dependencies) {
             if (!this.messaging.isCurrentUserGuest) {
                 this.channelInvitationForm.searchPartnersToInvite();
             }
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
@@ -177,8 +159,7 @@ function factory(dependencies) {
                 channelInvitationForm: clear(),
                 isMemberListOpened: true,
             });
-        }
-
+        },
         /**
          * @param {Event} ev
          */
@@ -186,22 +167,19 @@ function factory(dependencies) {
             if (this.exists()) {
                 this.update({ isFocused: true });
             }
-        }
-
+        },
         /**
          * Swap this chat window with the previous one.
          */
         shiftPrev() {
             this.manager.shiftPrev(this);
-        }
-
+        },
         /**
          * Swap this chat window with the next one.
          */
         shiftNext() {
             this.manager.shiftNext(this);
-        }
-
+        },
         /**
          * @param {Object} [param0={}]
          * @param {boolean} [param0.notifyServer]
@@ -216,20 +194,14 @@ function factory(dependencies) {
             if (this.thread && notifyServer && !this.messaging.currentGuest) {
                 this.thread.notifyFoldStateToServer('open');
             }
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeHasCallButtons() {
             return Boolean(this.thread) && this.thread.rtcSessions.length === 0 && ['channel', 'chat', 'group'].includes(this.thread.channel_type);
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -239,16 +211,14 @@ function factory(dependencies) {
                 this.thread && this.thread.hasInviteFeature &&
                 this.messaging && this.messaging.device && this.messaging.device.isMobile
             );
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeHasNewMessageForm() {
             return this.isVisible && !this.isFolded && !this.thread;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -263,8 +233,7 @@ function factory(dependencies) {
                 return false;
             }
             return index < allVisible.length - 1;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -278,16 +247,14 @@ function factory(dependencies) {
                 return false;
             }
             return index > 0;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeHasThreadView() {
             return this.isVisible && !this.isFolded && !!this.thread && !this.isMemberListOpened && !this.channelInvitationForm;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -298,8 +265,7 @@ function factory(dependencies) {
                 return thread.foldState === 'folded';
             }
             return this.isFolded;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -309,8 +275,7 @@ function factory(dependencies) {
                 return false;
             }
             return this.manager.allOrderedVisible.includes(this);
-        }
-
+        },
         /**
          * @private
          * @returns {string}
@@ -320,8 +285,7 @@ function factory(dependencies) {
                 return this.thread.displayName;
             }
             return this.env._t("New message");
-        }
-
+        },
         /**
          * @private
          * @returns {mail.thread_viewer}
@@ -332,8 +296,7 @@ function factory(dependencies) {
                 hasThreadView: this.hasThreadView,
                 thread: this.thread ? link(this.thread) : unlink(),
             });
-        }
-
+        },
         /**
          * @private
          * @returns {integer|undefined}
@@ -348,8 +311,7 @@ function factory(dependencies) {
                 return clear();
             }
             return index;
-        }
-
+        },
         /**
          * @private
          * @returns {integer}
@@ -364,8 +326,7 @@ function factory(dependencies) {
                 return 0;
             }
             return visible[index].offset;
-        }
-
+        },
         /**
          * Cycles to the next possible visible and unfolded chat window starting
          * from the `currentChatWindow`, following the natural order based on the
@@ -407,11 +368,9 @@ function factory(dependencies) {
                 nextToFocus = orderedVisible[nextIndex];
             }
             return nextToFocus;
-        }
-
-    }
-
-    ChatWindow.fields = {
+        },
+    },
+    fields: {
         /**
          * Determines the channel invitation form displayed by this chat window
          * (if any). Only makes sense if hasInviteFeature is true.
@@ -536,11 +495,5 @@ function factory(dependencies) {
         visibleOffset: attr({
             compute: '_computeVisibleOffset',
         }),
-    };
-    ChatWindow.identifyingFields = ['manager', ['thread', 'managerAsNewMessage']];
-    ChatWindow.modelName = 'mail.chat_window';
-
-    return ChatWindow;
-}
-
-registerNewModel('mail.chat_window', factory);
+    },
+});

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -1,17 +1,13 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2many, many2one, one2many, one2one } from '@mail/model/model_field';
 import { clear, replace, unlink } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class Composer extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.composer',
+    identifyingFields: [['thread', 'messageViewInEditing']],
+    recordMethods: {
         /**
          * @private
          * @returns {mail.thread}
@@ -24,8 +20,7 @@ function factory(dependencies) {
                 return replace(this.thread);
             }
             return clear();
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -35,16 +30,14 @@ function factory(dependencies) {
                 return false;
             }
             return !this.hasUploadingAttachment && !this.isPostingMessage;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeHasUploadingAttachment() {
             return this.attachments.some(attachment => attachment.isUploading);
-        }
-
+        },
         /**
          * Detects if mentioned partners are still in the composer text input content
          * and removes them if not.
@@ -69,8 +62,7 @@ function factory(dependencies) {
                 }
             }
             return unlink(unmentionedPartners);
-        }
-
+        },
         /**
          * Detects if mentioned channels are still in the composer text input content
          * and removes them if not.
@@ -95,8 +87,7 @@ function factory(dependencies) {
                 }
             }
             return unlink(unmentionedChannels);
-        }
-
+        },
         /**
          * @private
          * @returns {mail.partner[]}
@@ -111,8 +102,7 @@ function factory(dependencies) {
                 }
             }
             return replace(recipients);
-        }
-
+        },
         /**
          * @private
          */
@@ -127,11 +117,9 @@ function factory(dependencies) {
                 textInputCursorStart: clear(),
                 textInputSelectionDirection: clear(),
             });
-        }
-
-    }
-
-    Composer.fields = {
+        },
+    },
+    fields: {
         activeThread: many2one('mail.thread', {
             compute: '_computeActiveThread',
             readonly: true,
@@ -215,11 +203,5 @@ function factory(dependencies) {
             inverse: 'composer',
             readonly: true,
         }),
-    };
-    Composer.identifyingFields = [['thread', 'messageViewInEditing']];
-    Composer.modelName = 'mail.composer';
-
-    return Composer;
-}
-
-registerNewModel('mail.composer', factory);
+    },
+});

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -1,21 +1,17 @@
 /** @odoo-module **/
 
 import { emojis } from '@mail/js/emojis';
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2many, many2one, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace, link, replace, unlink, unlinkAll } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 import { addLink, escapeAndCompactTextContent, parseAndTransform } from '@mail/js/utils';
 
-function factory(dependencies) {
-
-    class ComposerView extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.composer_view',
+    identifyingFields: [['threadView', 'messageViewInEditing', 'chatter']],
+    lifecycleHooks: {
         _willCreate() {
-            const res = super._willCreate(...arguments);
             /**
              * Determines whether there is a mention RPC currently in progress.
              * Useful to queue a new call if there is already one pending.
@@ -26,39 +22,25 @@ function factory(dependencies) {
              * RPC is done, if any.
              */
             this._nextMentionRpcFunction = undefined;
-            return res;
-        }
-
-        /**
-         * @override
-         */
-         _created() {
+        },
+        _created() {
             this.onClickCancelLink = this.onClickCancelLink.bind(this);
             this.onClickSaveLink = this.onClickSaveLink.bind(this);
             this.onClickStopReplying = this.onClickStopReplying.bind(this);
-        }
-
-        /**
-         * @override
-         */
+        },
         _willDelete() {
             // Clears the mention queue on deleting the record to prevent
             // unnecessary RPC.
             this._nextMentionRpcFunction = undefined;
-            return super._willDelete(...arguments);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * Closes the suggestion list.
          */
         closeSuggestions() {
             this.update({ suggestionDelimiterPosition: clear() });
-        }
-
+        },
         /**
          * Hides the composer, which only makes sense if the composer is
          * currently used as a Discuss Inbox reply composer or as message
@@ -75,8 +57,7 @@ function factory(dependencies) {
                 }
                 threadView.update({ replyingToMessageView: clear() });
             }
-        }
-
+        },
         /**
          * Called when current partner is inserting some input in composer.
          * Useful to notify current partner is currently typing something in the
@@ -100,8 +81,7 @@ function factory(dependencies) {
             } else {
                 this.composer.thread.registerCurrentPartnerIsTyping();
             }
-        }
-
+        },
         /**
          * Inserts text content in text input based on selection.
          *
@@ -127,8 +107,7 @@ function factory(dependencies) {
                 textInputCursorStart: this.composer.textInputCursorStart + content.length,
             });
             this.update({ suggestionDelimiterPosition });
-        }
-
+        },
         /**
          * Inserts the active suggestion at the current cursor position.
          */
@@ -162,7 +141,7 @@ function factory(dependencies) {
             // Specific cases for channel and partner mentions: the message with
             // the mention will appear in the target channel, or be notified to
             // the target partner.
-            switch (this.activeSuggestedRecord.constructor.modelName) {
+            switch (this.activeSuggestedRecord.constructor.name) {
                 case 'mail.thread':
                     Object.assign(updateData, { mentionedChannels: link(this.activeSuggestedRecord) });
                     break;
@@ -171,9 +150,7 @@ function factory(dependencies) {
                     break;
             }
             this.composer.update(updateData);
-        }
-
-
+        },
         /**
          * Handles click on the cancel link.
          *
@@ -182,9 +159,7 @@ function factory(dependencies) {
         onClickCancelLink(ev) {
             ev.preventDefault();
             this.discard();
-        }
-
-
+        },
         /**
          * Handles click on the save link.
          *
@@ -206,8 +181,7 @@ function factory(dependencies) {
                 return;
             }
             this.postMessage();
-        }
-
+        },
         /**
          * Handles click on the "stop replying" button.
          *
@@ -217,8 +191,7 @@ function factory(dependencies) {
             this.threadView.update({
                 replyingToMessageView: clear(),
             });
-        }
-
+        },
         /**
          * Open the full composer modal.
          */
@@ -255,8 +228,7 @@ function factory(dependencies) {
                 },
             };
             await this.env.bus.trigger('do-action', { action, options });
-        }
-
+        },
         /**
          * Post a message in provided composer's thread based on current composer fields values.
          */
@@ -359,8 +331,7 @@ function factory(dependencies) {
                     composer.update({ isPostingMessage: false });
                 }
             }
-        }
-
+        },
         /**
          * Sets the first suggestion as active. Main and extra records are
          * considered together.
@@ -369,8 +340,7 @@ function factory(dependencies) {
             const suggestedRecords = this.mainSuggestedRecords.concat(this.extraSuggestedRecords);
             const firstRecord = suggestedRecords[0];
             this.update({ activeSuggestedRecord: link(firstRecord) });
-        }
-
+        },
         /**
          * Sets the last suggestion as active. Main and extra records are
          * considered together.
@@ -379,8 +349,7 @@ function factory(dependencies) {
             const suggestedRecords = this.mainSuggestedRecords.concat(this.extraSuggestedRecords);
             const { length, [length - 1]: lastRecord } = suggestedRecords;
             this.update({ activeSuggestedRecord: link(lastRecord) });
-        }
-
+        },
         /**
          * Sets the next suggestion as active. Main and extra records are
          * considered together.
@@ -397,8 +366,7 @@ function factory(dependencies) {
             }
             const nextRecord = suggestedRecords[activeElementIndex + 1];
             this.update({ activeSuggestedRecord: link(nextRecord) });
-        }
-
+        },
         /**
          * Sets the previous suggestion as active. Main and extra records are
          * considered together.
@@ -415,8 +383,7 @@ function factory(dependencies) {
             }
             const previousRecord = suggestedRecords[activeElementIndex - 1];
             this.update({ activeSuggestedRecord: link(previousRecord) });
-        }
-
+        },
         /**
          * Update a posted message when the message is ready.
          */
@@ -447,12 +414,7 @@ function factory(dependencies) {
                     composer.update({ isPostingMessage: false });
                 }
             }
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * Clears the active suggested record on closing mentions or adapt it if
          * the active current record is no longer part of the suggestions.
@@ -476,8 +438,7 @@ function factory(dependencies) {
             const suggestedRecords = this.mainSuggestedRecords.concat(this.extraSuggestedRecords);
             const firstRecord = suggestedRecords[0];
             return link(firstRecord);
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -486,8 +447,7 @@ function factory(dependencies) {
             return (this.composer && this.composer.attachments.length > 0)
                 ? insertAndReplace()
                 : clear();
-        }
-
+        },
         /**
          * @private
          * @returns {FieldCommand}
@@ -509,8 +469,7 @@ function factory(dependencies) {
                 return replace(this.chatter.thread.composer);
             }
             return clear();
-        }
-
+        },
         /**
          * Clears the extra suggested record on closing mentions, and ensures
          * the extra list does not contain any element already present in the
@@ -524,16 +483,14 @@ function factory(dependencies) {
                 return unlinkAll();
             }
             return unlink(this.mainSuggestedRecords);
-        }
-
+        },
         /**
          * @private
          * @return {boolean}
          */
         _computeHasSuggestions() {
             return this.mainSuggestedRecords.length > 0 || this.extraSuggestedRecords.length > 0;
-        }
-
+        },
         /**
          * Clears the main suggested record on closing mentions.
          *
@@ -544,8 +501,7 @@ function factory(dependencies) {
             if (this.suggestionDelimiterPosition === undefined) {
                 return unlinkAll();
             }
-        }
-
+        },
         /**
          * @private
          * @returns {string}
@@ -560,8 +516,7 @@ function factory(dependencies) {
                 return this.env._t("Log");
             }
             return this.env._t("Send");
-        }
-
+        },
         /**
          * @private
          * @returns {string}
@@ -575,8 +530,7 @@ function factory(dependencies) {
                 return clear();
             }
             return this.composer.textInputContent[this.suggestionDelimiterPosition];
-        }
-
+        },
         /**
          * @private
          * @returns {string}
@@ -594,8 +548,7 @@ function factory(dependencies) {
                 default:
                     return clear();
             }
-        }
-
+        },
         /**
          * @private
          * @returns {string}
@@ -609,8 +562,7 @@ function factory(dependencies) {
                 return clear();
             }
             return this.composer.textInputContent.substring(this.suggestionDelimiterPosition + 1, this.composer.textInputCursorStart);
-        }
-
+        },
         /**
          * Executes the given async function, only when the last function
          * executed by this method terminates. If there is already a pending
@@ -635,9 +587,7 @@ function factory(dependencies) {
                     this._executeOrQueueFunction(this._nextMentionRpcFunction);
                 }
             }
-        }
-
-
+        },
         /**
          * @private
          * @param {string} htmlString
@@ -656,8 +606,7 @@ function factory(dependencies) {
                 }
             }
             return htmlString;
-        }
-
+        },
         /**
          *
          * Generates the html link related to the mentioned partner
@@ -706,8 +655,7 @@ function factory(dependencies) {
                 body = body.replace(mention.placeholder, link);
             }
             return body;
-        }
-
+        },
         /**
          * @private
          * @param {string} content html content
@@ -727,16 +675,14 @@ function factory(dependencies) {
                 });
             }
             return undefined;
-        }
-
+        },
         /**
          * Handles change of this composer. Useful to reset the state of the
          * composer text input.
          */
         _onChangeComposer() {
             this.composer.update({ isLastStateChangeProgrammatic: true });
-        }
-
+        },
         /**
          * @private
          */
@@ -784,8 +730,7 @@ function factory(dependencies) {
                 return;
             }
             return this.update({ suggestionDelimiterPosition: clear() });
-        }
-
+        },
         /**
          * Updates the suggestion state based on the currently saved composer
          * state (in particular content and cursor position).
@@ -825,8 +770,7 @@ function factory(dependencies) {
                     this.closeSuggestions();
                 }
             });
-        }
-
+        },
         /**
          * Updates the current suggestion list. This method should be called
          * whenever the UI has to be refreshed following change in state.
@@ -863,11 +807,9 @@ function factory(dependencies) {
                 hasToScrollToActiveSuggestion: true,
                 mainSuggestedRecords: replace(mainSuggestedRecords),
             });
-        }
-
-    }
-
-    ComposerView.fields = {
+        },
+    },
+    fields: {
         /**
          * Determines the suggested record that is currently active. This record
          * is highlighted in the UI and it will be the selected record if the
@@ -990,9 +932,8 @@ function factory(dependencies) {
             inverse: 'composerView',
             readonly: true,
         }),
-    };
-    ComposerView.identifyingFields = [['threadView', 'messageViewInEditing', 'chatter']];
-    ComposerView.onChanges = [
+    },
+    onChanges: [
         new OnChange({
             dependencies: ['composer'],
             methodName: '_onChangeComposer',
@@ -1005,10 +946,5 @@ function factory(dependencies) {
             dependencies: ['suggestionDelimiterPosition', 'suggestionModelName', 'suggestionSearchTerm', 'composer.activeThread'],
             methodName: '_onChangeUpdateSuggestionList',
         }),
-    ];
-    ComposerView.modelName = 'mail.composer_view';
-
-    return ComposerView;
-}
-
-registerNewModel('mail.composer_view', factory);
+    ],
+});

--- a/addons/mail/static/src/models/composer_view/tests/composer_view_qunit_tests.js
+++ b/addons/mail/static/src/models/composer_view/tests/composer_view_qunit_tests.js
@@ -1,25 +1,27 @@
 /** @odoo-module **/
 
-import { registerFieldPatchModel, registerIdentifyingFieldsPatch, registerInstancePatchModel } from '@mail/model/model_core';
+import { addFields, patchIdentifyingFields, patchRecordMethods } from '@mail/model/model_core';
 import { one2one } from '@mail/model/model_field';
 import { replace } from '@mail/model/model_field_command';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/composer_view/composer_view';
 
-registerInstancePatchModel('mail.composer_view', 'qunit', {
+patchRecordMethods('mail.composer_view', {
     _computeComposer() {
         if (this.qunitTest && this.qunitTest.composer) {
             return replace(this.qunitTest.composer);
         }
         return this._super();
-    }
+    },
 });
 
-registerFieldPatchModel('mail.composer_view', 'qunit', {
+addFields('mail.composer_view', {
     qunitTest: one2one('mail.qunit_test', {
         inverse: 'composerView',
         readonly: true,
     }),
 });
 
-registerIdentifyingFieldsPatch('mail.composer_view', 'qunit', identifyingFields => {
+patchIdentifyingFields('mail.composer_view', identifyingFields => {
     identifyingFields[0].push('qunitTest');
 });

--- a/addons/mail/static/src/models/country/country.js
+++ b/addons/mail/static/src/models/country/country.js
@@ -1,17 +1,13 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
 import { clear } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class Country extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.country',
+    identifyingFields: ['id'],
+    recordMethods: {
         /**
          * @private
          * @returns {string|undefined}
@@ -21,11 +17,9 @@ function factory(dependencies) {
                 return clear();
             }
             return `/base/static/img/country_flags/${this.code}.png`;
-        }
-
-    }
-
-    Country.fields = {
+        },
+    },
+    fields: {
         code: attr(),
         flagUrl: attr({
             compute: '_computeFlagUrl',
@@ -35,11 +29,5 @@ function factory(dependencies) {
             required: true,
         }),
         name: attr(),
-    };
-    Country.identifyingFields = ['id'];
-    Country.modelName = 'mail.country';
-
-    return Country;
-}
-
-registerNewModel('mail.country', factory);
+    },
+});

--- a/addons/mail/static/src/models/device/device.js
+++ b/addons/mail/static/src/models/device/device.js
@@ -1,34 +1,21 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class Device extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.device',
+    identifyingFields: ['messaging'],
+    lifecycleHooks: {
         _created() {
-            const res = super._created(...arguments);
             this._refresh();
             this._onResize = _.debounce(() => this._refresh(), 100);
-            return res;
-        }
-
-        /**
-         * @override
-         */
+        },
         _willDelete() {
             window.removeEventListener('resize', this._onResize);
-            return super._willDelete(...arguments);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * Called when messaging is started.
          */
@@ -36,12 +23,7 @@ function factory(dependencies) {
             // TODO FIXME Not using this.env.browser because it's proxified, and
             // addEventListener does not work on proxified window. task-2234596
             window.addEventListener('resize', this._onResize);
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          */
@@ -53,10 +35,9 @@ function factory(dependencies) {
                 isMobileDevice: this.messaging.device.isMobileDevice,
                 sizeClass: this.env.device.size_class,
             });
-        }
-    }
-
-    Device.fields = {
+        },
+    },
+    fields: {
         globalWindowInnerHeight: attr(),
         globalWindowInnerWidth: attr(),
         /**
@@ -76,11 +57,5 @@ function factory(dependencies) {
          * attribute.
          */
         sizeClass: attr(),
-    };
-    Device.identifyingFields = ['messaging'];
-    Device.modelName = 'mail.device';
-
-    return Device;
-}
-
-registerNewModel('mail.device', factory);
+    },
+});

--- a/addons/mail/static/src/models/dialog/dialog.js
+++ b/addons/mail/static/src/models/dialog/dialog.js
@@ -1,13 +1,13 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
-import { many2one, one2one } from '@mail/model/model_field';
-import { replace } from '@mail/model/model_field_command';
+import { registerModel } from '@mail/model/model_core';
+import { attr, many2one, one2one } from '@mail/model/model_field';
+import { clear, replace } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class Dialog extends dependencies['mail.model'] {
-
+registerModel({
+    name: 'mail.dialog',
+    identifyingFields: ['manager', ['attachmentViewer', 'followerSubtypeList']],
+    recordMethods: {
         /**
          * @private
          * @returns {FieldCommand}
@@ -19,14 +19,26 @@ function factory(dependencies) {
             if (this.followerSubtypeList) {
                 return replace(this.followerSubtypeList);
             }
-        }
-    }
-
-    Dialog.fields = {
+        },
+        _computeComponentName() {
+            if (this.attachmentViewer) {
+                return 'AttachmentViewer';
+            }
+            if (this.followerSubtypeList) {
+                return 'FollowerSubtypeList';
+            }
+            return clear();
+        },
+    },
+    fields: {
         attachmentViewer: one2one('mail.attachment_viewer', {
             isCausal: true,
             inverse: 'dialog',
             readonly: true,
+        }),
+        componentName: attr({
+            compute: '_computeComponentName',
+            required: true,
         }),
         followerSubtypeList: one2one('mail.follower_subtype_list', {
             isCausal: true,
@@ -48,11 +60,5 @@ function factory(dependencies) {
             readonly: true,
             required: true,
         }),
-    };
-    Dialog.identifyingFields = ['manager', ['attachmentViewer', 'followerSubtypeList']];
-    Dialog.modelName = 'mail.dialog';
-
-    return Dialog;
-}
-
-registerNewModel('mail.dialog', factory);
+    },
+});

--- a/addons/mail/static/src/models/dialog_manager/dialog_manager.js
+++ b/addons/mail/static/src/models/dialog_manager/dialog_manager.js
@@ -1,24 +1,16 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { one2many } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class DialogManager extends dependencies['mail.model'] {
-    }
-
-    DialogManager.fields = {
+registerModel({
+    name: 'mail.dialog_manager',
+    identifyingFields: ['messaging'],
+    fields: {
         // FIXME: dependent on implementation that uses insert order in relations!!
         dialogs: one2many('mail.dialog', {
             inverse: 'manager',
             isCausal: true,
         }),
-    };
-    DialogManager.identifyingFields = ['messaging'];
-    DialogManager.modelName = 'mail.dialog_manager';
-
-    return DialogManager;
-}
-
-registerNewModel('mail.dialog_manager', factory);
+    },
+});

--- a/addons/mail/static/src/models/discuss/discuss.js
+++ b/addons/mail/static/src/models/discuss/discuss.js
@@ -1,47 +1,37 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2one, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace, link, unlink } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class Discuss extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.discuss',
+    identifyingFields: ['messaging'],
+    lifecycleHooks: {
         _created() {
-            super._created();
             // Bind necessary until OWL supports arrow function in handlers: https://github.com/odoo/owl/issues/876
             this.onClickStartAMeetingButton = this.onClickStartAMeetingButton.bind(this);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         clearIsAddingItem() {
             this.update({
                 addingChannelValue: "",
                 isAddingChannel: false,
                 isAddingChat: false,
             });
-        }
-
+        },
         /**
          * Close the discuss app. Should reset its internal state.
          */
         close() {
             this.update({ isOpen: false });
-        }
-
+        },
         focus() {
             if (this.threadView && this.threadView.composerView) {
                 this.threadView.composerView.update({ doFocus: true });
             }
-        }
-
+        },
         /**
          * @param {Event} ev
          * @param {Object} ui
@@ -70,8 +60,7 @@ function factory(dependencies) {
                 channel.update({ isServerPinned: true });
                 channel.open();
             }
-        }
-
+        },
         /**
          * @param {Object} req
          * @param {string} req.term
@@ -107,8 +96,7 @@ function factory(dependencies) {
                 special: 'private'
             });
             res(items);
-        }
-
+        },
         /**
          * @param {Event} ev
          * @param {Object} ui
@@ -118,8 +106,7 @@ function factory(dependencies) {
         handleAddChatAutocompleteSelect(ev, ui) {
             this.messaging.openChat({ partnerId: ui.item.id });
             this.clearIsAddingItem();
-        }
-
+        },
         /**
          * @param {Object} req
          * @param {string} req.term
@@ -141,8 +128,7 @@ function factory(dependencies) {
                 keyword: value,
                 limit: 10,
             });
-        }
-
+        },
         /**
          * Handles click on the mobile "new chat" button.
          *
@@ -150,8 +136,7 @@ function factory(dependencies) {
          */
         onClickMobileNewChatButton(ev) {
             this.update({ isAddingChat: true });
-        }
-
+        },
         /**
          * Handles click on the mobile "new channel" button.
          *
@@ -159,8 +144,7 @@ function factory(dependencies) {
          */
         onClickMobileNewChannelButton(ev) {
             this.update({ isAddingChannel: true });
-        }
-
+        },
         /**
          * Handles click on the "Start a meeting" button.
          *
@@ -177,8 +161,7 @@ function factory(dependencies) {
                 return;
             }
             this.threadView.topbar.openInvitePopoverView();
-        }
-
+        },
         /**
          * Open thread from init active id. `initActiveId` is used to refer to
          * a thread that we may not have full data yet, such as when messaging
@@ -199,9 +182,7 @@ function factory(dependencies) {
             if (this.messaging.device.isMobile && thread.channel_type) {
                 this.update({ activeMobileNavbarTabId: thread.channel_type });
             }
-        }
-
-
+        },
         /**
          * Opens the given thread in Discuss, and opens Discuss if necessary.
          *
@@ -226,16 +207,14 @@ function factory(dependencies) {
                     },
                 });
             }
-        }
-
+        },
         /**
          * @param {mail.thread} thread
          * @returns {string}
          */
         threadToActiveId(thread) {
             return `${thread.model}_${thread.id}`;
-        }
-
+        },
         /**
          * @param {string} value
          */
@@ -246,12 +225,7 @@ function factory(dependencies) {
                 this.categoryChannel.open();
             }
             this.update({ sidebarQuickSearchValue: value });
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {string|undefined}
@@ -261,8 +235,7 @@ function factory(dependencies) {
                 return clear();
             }
             return this.threadToActiveId(this.thread);
-        }
-
+        },
         /**
          * @private
          * @returns {string}
@@ -272,8 +245,7 @@ function factory(dependencies) {
                 return "";
             }
             return this.addingChannelValue;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -292,8 +264,7 @@ function factory(dependencies) {
                 return false;
             }
             return true;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -303,8 +274,7 @@ function factory(dependencies) {
                 return false;
             }
             return this.isAddingChannel;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -314,8 +284,7 @@ function factory(dependencies) {
                 return false;
             }
             return this.isAddingChat;
-        }
-
+        },
         /**
          * Only pinned threads are allowed in discuss.
          *
@@ -326,8 +295,7 @@ function factory(dependencies) {
             if (!this.thread || !this.thread.isPinned) {
                 return unlink();
             }
-        }
-
+        },
         /**
          * @private
          * @returns {mail.thread_viewer}
@@ -339,10 +307,9 @@ function factory(dependencies) {
                 hasTopbar: true,
                 thread: this.thread ? link(this.thread) : unlink(),
             });
-        }
-    }
-
-    Discuss.fields = {
+        },
+    },
+    fields: {
         activeId: attr({
             compute: '_computeActiveId',
         }),
@@ -454,11 +421,5 @@ function factory(dependencies) {
             readonly: true,
             required: true,
         }),
-    };
-    Discuss.identifyingFields = ['messaging'];
-    Discuss.modelName = 'mail.discuss';
-
-    return Discuss;
-}
-
-registerNewModel('mail.discuss', factory);
+    },
+});

--- a/addons/mail/static/src/models/discuss_public_view/discuss_public_view.js
+++ b/addons/mail/static/src/models/discuss_public_view/discuss_public_view.js
@@ -1,17 +1,13 @@
 /** @odoo-module **/
 
 import { attr, one2one } from '@mail/model/model_field';
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { clear, insertAndReplace, link } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class DiscussPublicView extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.discuss_public_view',
+    identifyingFields: ['messaging'],
+    recordMethods: {
         /**
          * Creates and displays the thread view and clears the welcome view.
          */
@@ -34,8 +30,7 @@ function factory(dependencies) {
                 await this.channel.toggleCall({ startWithVideo: true });
                 await this.threadView.rtcCallViewer.activateFullScreen();
             }
-        }
-
+        },
         /**
          * Creates and displays the welcome view and clears the thread viewer.
          */
@@ -53,11 +48,9 @@ function factory(dependencies) {
                 this.welcomeView.mediaPreview.enableMicrophone();
                 this.welcomeView.mediaPreview.enableVideo();
             }
-        }
-
-    }
-
-    DiscussPublicView.fields = {
+        },
+    },
+    fields: {
         /**
          * States the channel linked to this discuss public view.
          */
@@ -97,11 +90,5 @@ function factory(dependencies) {
             inverse: 'discussPublicView',
             isCausal: true,
         }),
-    };
-    DiscussPublicView.identifyingFields = ['messaging'];
-    DiscussPublicView.modelName = 'mail.discuss_public_view';
-
-    return DiscussPublicView;
-}
-
-registerNewModel('mail.discuss_public_view', factory);
+    },
+});

--- a/addons/mail/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
@@ -1,29 +1,24 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2one } from '@mail/model/model_field';
 import { clear, link } from '@mail/model/model_field_command';
 import { isEventHandled } from '@mail/utils/utils';
 
 import Dialog from 'web.Dialog';
 
-function factory(dependencies) {
-    class DiscussSidebarCategoryItem extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.discuss_sidebar_category_item',
+    identifyingFields: ['category', 'channel'],
+    lifecycleHooks: {
         _created() {
             this.onClick = this.onClick.bind(this);
             this.onClickCommandLeave = this.onClickCommandLeave.bind(this);
             this.onClickCommandSettings = this.onClickCommandSettings.bind(this);
             this.onClickCommandUnpin = this.onClickCommandUnpin.bind(this);
-        }
-
-        //--------------------------------------------------------------------------
-        // Private
-        //--------------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * @private
          * @returns {string}
@@ -36,8 +31,7 @@ function factory(dependencies) {
                 case 'chat':
                     return this.channel.correspondent.avatarUrl;
             }
-        }
-
+        },
         /**
          * @private
          * @returns {mail.thread}
@@ -47,8 +41,7 @@ function factory(dependencies) {
                 id: this.channel.id,
                 model: 'mail.channel',
             }));
-        }
-
+        },
         /**
          * @private
          * @returns {integer}
@@ -61,8 +54,7 @@ function factory(dependencies) {
                 case 'group':
                     return this.channel.localMessageUnreadCounter;
             }
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -73,32 +65,28 @@ function factory(dependencies) {
                 !this.channel.message_needaction_counter &&
                 !this.channel.group_based_subscription
             );
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeHasSettingsCommand() {
             return this.channelType === 'channel';
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeHasUnpinCommand() {
             return this.channelType === 'chat' && !this.channel.localMessageUnreadCounter;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeIsActive() {
             return this.messaging.discuss && this.channel === this.messaging.discuss.thread;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -108,8 +96,7 @@ function factory(dependencies) {
                 return clear();
             }
             return this.channel.localMessageUnreadCounter > 0;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -123,19 +110,13 @@ function factory(dependencies) {
                 case 'group':
                     return false;
             }
-        }
-
-        //--------------------------------------------------------------------------
-        // Handlers
-        //--------------------------------------------------------------------------
-
+        },
         /**
          * @param {MouseEvent} ev
          */
         onClick(ev) {
             this.channel.open();
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
@@ -148,8 +129,7 @@ function factory(dependencies) {
                 await this._askLeaveGroupConfirmation();
             }
             this.channel.leave();
-        }
-
+        },
         /**
          * Redirects to channel form page when `settings` command is clicked.
          *
@@ -166,16 +146,14 @@ function factory(dependencies) {
                     target: 'current',
                 },
             });
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
         onClickCommandUnpin(ev) {
             ev.stopPropagation();
             this.channel.unsubscribe();
-        }
-
+        },
         /**
          * @private
          * @returns {Promise}
@@ -200,8 +178,7 @@ function factory(dependencies) {
                     }
                 );
             });
-        }
-
+        },
         /**
          * @private
          * @returns {Promise}
@@ -226,11 +203,9 @@ function factory(dependencies) {
                     }
                 );
             });
-        }
-
-    }
-
-    DiscussSidebarCategoryItem.fields = {
+        },
+    },
+    fields: {
         /**
          * Image URL for the related channel thread.
          */
@@ -301,12 +276,5 @@ function factory(dependencies) {
         channelType: attr({
             related: 'channel.channel_type',
         }),
-
-    };
-    DiscussSidebarCategoryItem.identifyingFields = ['category', 'channel'];
-    DiscussSidebarCategoryItem.modelName = 'mail.discuss_sidebar_category_item';
-
-    return DiscussSidebarCategoryItem;
-}
-
-registerNewModel('mail.discuss_sidebar_category_item', factory);
+    },
+});

--- a/addons/mail/static/src/models/follower/follower.js
+++ b/addons/mail/static/src/models/follower/follower.js
@@ -1,23 +1,18 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2many, many2one, one2many } from '@mail/model/model_field';
 import { clear, insert, insertAndReplace, link, replace, unlink, unlinkAll } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class Follower extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.follower',
+    identifyingFields: ['id'],
+    modelMethods: {
         /**
-         * @static
          * @param {Object} data
          * @returns {Object}
          */
-        static convertData(data) {
+        convertData(data) {
             const data2 = {};
             if ('id' in data) {
                 data2.id = data.id;
@@ -42,22 +37,21 @@ function factory(dependencies) {
                 }
             }
             return data2;
-        }
-
+        },
+    },
+    recordMethods: {
         /**
          *  Close subtypes dialog
          */
         closeSubtypes() {
             this.update({ subtypeList: clear() });
-        }
-
+        },
         /**
          * Opens the most appropriate view that is a profile for this follower.
          */
         async openProfile() {
             return this.partner.openProfile();
-        }
-
+        },
         /**
          * Remove this follower from its related thread.
          */
@@ -72,8 +66,7 @@ function factory(dependencies) {
             const followedThread = this.followedThread;
             this.delete();
             followedThread.fetchAndUpdateSuggestedRecipients();
-        }
-
+        },
         /**
          * @param {mail.follower_subtype} subtype
          */
@@ -81,8 +74,7 @@ function factory(dependencies) {
             if (!this.selectedSubtypes.includes(subtype)) {
                 this.update({ selectedSubtypes: link(subtype) });
             }
-        }
-
+        },
         /**
          * Show (editable) list of subtypes of this follower.
          */
@@ -110,8 +102,7 @@ function factory(dependencies) {
                     }),
                 }),
             });
-        }
-
+        },
         /**
          * @param {mail.follower_subtype} subtype
          */
@@ -119,8 +110,7 @@ function factory(dependencies) {
             if (this.selectedSubtypes.includes(subtype)) {
                 this.update({ selectedSubtypes: unlink(subtype) });
             }
-        }
-
+        },
         /**
          * Update server-side subscription of subtypes of this follower.
          */
@@ -146,11 +136,9 @@ function factory(dependencies) {
                 });
             }
             this.closeSubtypes();
-        }
-
-    }
-
-    Follower.fields = {
+        },
+    },
+    fields: {
         followedThread: many2one('mail.thread', {
             inverse: 'followers',
         }),
@@ -173,11 +161,5 @@ function factory(dependencies) {
             isCausal: true,
         }),
         subtypes: many2many('mail.follower_subtype'),
-    };
-    Follower.identifyingFields = ['id'];
-    Follower.modelName = 'mail.follower';
-
-    return Follower;
-}
-
-registerNewModel('mail.follower', factory);
+    },
+});

--- a/addons/mail/static/src/models/follower_subtype/follower_subtype.js
+++ b/addons/mail/static/src/models/follower_subtype/follower_subtype.js
@@ -1,22 +1,17 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class FollowerSubtype extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.follower_subtype',
+    identifyingFields: ['id'],
+    modelMethods: {
         /**
-         * @static
          * @param {Object} data
          * @returns {Object}
          */
-        static convertData(data) {
+        convertData(data) {
             const data2 = {};
             if ('default' in data) {
                 data2.isDefault = data.default;
@@ -40,11 +35,9 @@ function factory(dependencies) {
                 data2.sequence = data.sequence;
             }
             return data2;
-        }
-
-    }
-
-    FollowerSubtype.fields = {
+        },
+    },
+    fields: {
         id: attr({
             readonly: true,
             required: true,
@@ -61,11 +54,5 @@ function factory(dependencies) {
         // AKU FIXME: use relation instead
         resModel: attr(),
         sequence: attr(),
-    };
-    FollowerSubtype.identifyingFields = ['id'];
-    FollowerSubtype.modelName = 'mail.follower_subtype';
-
-    return FollowerSubtype;
-}
-
-registerNewModel('mail.follower_subtype', factory);
+    },
+});

--- a/addons/mail/static/src/models/follower_subtype_list/follower_subtype_list.js
+++ b/addons/mail/static/src/models/follower_subtype_list/follower_subtype_list.js
@@ -1,13 +1,12 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { many2one, one2one } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class FollowerSubtypeList extends dependencies['mail.model'] {}
-
-    FollowerSubtypeList.fields = {
+registerModel({
+    name: 'mail.follower_subtype_list',
+    identifyingFields: ['follower'],
+    fields: {
         /**
          * States the dialog displaying this follower subtype list.
          */
@@ -21,11 +20,5 @@ function factory(dependencies) {
             readonly: true,
             required: true,
         }),
-    };
-    FollowerSubtypeList.identifyingFields = ['follower'];
-    FollowerSubtypeList.modelName = 'mail.follower_subtype_list';
-
-    return FollowerSubtypeList;
-}
-
-registerNewModel('mail.follower_subtype_list', factory);
+    },
+});

--- a/addons/mail/static/src/models/guest/guest.js
+++ b/addons/mail/static/src/models/guest/guest.js
@@ -1,23 +1,18 @@
 /** @odoo-module **/
 
 import { attr, one2many, one2one } from '@mail/model/model_field';
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 
-function factory(dependencies) {
-
-    class Guest extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.guest',
+    identifyingFields: ['id'],
+    modelMethods: {
         /**
-         * @static
          * @param {Object} param0
          * @param {number} param0.id The id of the guest to rename.
          * @param {string} param0.name The new name to use to rename the guest.
          */
-        static async performRpcGuestUpdateName({ id, name }) {
+        async performRpcGuestUpdateName({ id, name }) {
             await this.env.services.rpc({
                 route: '/mail/guest/update_name',
                 params: {
@@ -25,23 +20,18 @@ function factory(dependencies) {
                     name,
                 },
             });
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * @private
          * @returns {string}
          */
         _computeAvatarUrl() {
             return `/web/image/mail.guest/${this.id}/avatar_128?unique=${this.name}`;
-        }
-
-    }
-
-    Guest.fields = {
+        },
+    },
+    fields: {
         authoredMessages: one2many('mail.message', {
             inverse: 'guestAuthor',
         }),
@@ -59,11 +49,5 @@ function factory(dependencies) {
         volumeSetting: one2one('mail.volume_setting', {
             inverse: 'guest',
         }),
-    };
-    Guest.identifyingFields = ['id'];
-    Guest.modelName = 'mail.guest';
-
-    return Guest;
-}
-
-registerNewModel('mail.guest', factory);
+    },
+});

--- a/addons/mail/static/src/models/locale/locale.js
+++ b/addons/mail/static/src/models/locale/locale.js
@@ -1,35 +1,28 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class Locale extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.locale',
+    identifyingFields: ['messaging'],
+    recordMethods: {
         /**
          * @private
          * @returns {string}
          */
         _computeLanguage() {
             return this.env._t.database.parameters.code;
-        }
-
+        },
         /**
          * @private
          * @returns {string}
          */
         _computeTextDirection() {
             return this.env._t.database.parameters.direction;
-        }
-
-    }
-
-    Locale.fields = {
+        },
+    },
+    fields: {
         /**
          * Language used by interface, formatted like {language ISO 2}_{country ISO 2} (eg: fr_FR).
          */
@@ -39,11 +32,5 @@ function factory(dependencies) {
         textDirection: attr({
             compute: '_computeTextDirection',
         }),
-    };
-    Locale.identifyingFields = ['messaging'];
-    Locale.modelName = 'mail.locale';
-
-    return Locale;
-}
-
-registerNewModel('mail.locale', factory);
+    },
+});

--- a/addons/mail/static/src/models/mail_template/mail_template.js
+++ b/addons/mail/static/src/models/mail_template/mail_template.js
@@ -1,16 +1,12 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2many } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class MailTemplate extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.mail_template',
+    identifyingFields: ['id'],
+    recordMethods: {
         /**
          * @param {mail.activity} activity
          */
@@ -37,8 +33,7 @@ function factory(dependencies) {
                     },
                 },
             });
-        }
-
+        },
         /**
          * @param {mail.activity} activity
          */
@@ -49,11 +44,9 @@ function factory(dependencies) {
                 args: [[activity.thread.id], this.id],
             }));
             activity.thread.refresh();
-        }
-
-    }
-
-    MailTemplate.fields = {
+        },
+    },
+    fields: {
         activities: many2many('mail.activity', {
             inverse: 'mailTemplates',
         }),
@@ -62,11 +55,5 @@ function factory(dependencies) {
             required: true,
         }),
         name: attr(),
-    };
-    MailTemplate.identifyingFields = ['id'];
-    MailTemplate.modelName = 'mail.mail_template';
-
-    return MailTemplate;
-}
-
-registerNewModel('mail.mail_template', factory);
+    },
+});

--- a/addons/mail/static/src/models/media_preview/media_preview.js
+++ b/addons/mail/static/src/models/media_preview/media_preview.js
@@ -1,41 +1,34 @@
 /** @odoo-module **/
 
 import { attr } from '@mail/model/model_field';
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 
-function factory(dependencies) {
-
-    class MediaPreview extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.media_preview',
+    identifyingFields: ['messaging'],
+    lifecycleHooks: {
         _created() {
-            super._created();
             // Bind necessary until OWL supports arrow function in handlers: https://github.com/odoo/owl/issues/876
             this.onClickDisableMicrophoneButton = this.onClickDisableMicrophoneButton.bind(this);
             this.onClickDisableVideoButton = this.onClickDisableVideoButton.bind(this);
             this.onClickEnableMicrophoneButton = this.onClickEnableMicrophoneButton.bind(this);
             this.onClickEnableVideoButton = this.onClickEnableVideoButton.bind(this);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    modelMethods: {
         /**
          * Iterates tracks of the provided MediaStream, calling the `stop`
          * method on each of them.
-         * 
-         * @static
-         * @param {MediaStream} mediaStream 
+         *
+         * @param {MediaStream} mediaStream
          */
-        static stopTracksOnMediaStream(mediaStream) {
+        stopTracksOnMediaStream(mediaStream) {
             for (const track of mediaStream.getTracks()) {
                 track.stop();
             }
-        }
-
+        },
+    },
+    recordMethods: {
         /**
          * Stops recording user's microphone.
          */
@@ -46,8 +39,7 @@ function factory(dependencies) {
             }
             this.messaging.models['mail.media_preview'].stopTracksOnMediaStream(this.audioStream);
             this.update({ audioStream: null });
-        }
-
+        },
         /**
          * Stops recording user's video device.
          */
@@ -58,8 +50,7 @@ function factory(dependencies) {
             }
             this.messaging.models['mail.media_preview'].stopTracksOnMediaStream(this.videoStream);
             this.update({ videoStream: null });
-        }
-
+        },
         /**
          * Asks for access to the user's microphone if not granted yet, then
          * starts recording and defines the resulting audio stream as the source
@@ -76,8 +67,7 @@ function factory(dependencies) {
             } catch {
                 // TODO: display popup asking the user to re-enable their mic
             }
-        }
-
+        },
         /**
          * Asks for access to the user's video device if not granted yet, then
          * starts recording and defines the resulting video stream as the source
@@ -94,43 +84,34 @@ function factory(dependencies) {
             } catch {
                 // TODO: display popup asking the user to re-enable their camera
             }
-        }
-
+        },
         /**
          * Handles click on the "disable microphone" button.
          */
         onClickDisableMicrophoneButton() {
             this.disableMicrophone();
-        }
-
+        },
         /**
          * Handles click on the "disable video" button.
          */
         onClickDisableVideoButton() {
             this.disableVideo();
-        }
-
+        },
         /**
          * Handles click on the "enable microphone" button.
          */
         onClickEnableMicrophoneButton() {
             this.enableMicrophone();
-        }
-
+        },
         /**
          * Handles click on the "enable video" button.
          */
         onClickEnableVideoButton() {
             this.enableVideo();
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
-         * @returns {boolean} 
+         * @returns {boolean}
          */
         _computeDoesBrowserSupportMediaDevices() {
             return Boolean(
@@ -138,34 +119,30 @@ function factory(dependencies) {
                 navigator.mediaDevices.getUserMedia &&
                 window.MediaStream
             );
-        }
-
+        },
         /**
          * @private
-         * @returns {boolean} 
+         * @returns {boolean}
          */
         _computeIsMicrophoneEnabled() {
             return this.audioStream !== null;
-        }
-
+        },
         /**
          * @private
-         * @returns {boolean} 
+         * @returns {boolean}
          */
         _computeIsVideoEnabled() {
             return this.videoStream !== null;
-        }
-
-    }
-
-    MediaPreview.fields = {
+        },
+    },
+    fields: {
         /**
          * Ref to the audio element used for the audio feedback.
          */
         audioRef: attr(),
         /**
          * The MediaStream from the microphone.
-         * 
+         *
          * Default set to null to be consistent with the default value of
          * `HTMLMediaElement.srcObject`.
          */
@@ -197,18 +174,12 @@ function factory(dependencies) {
         videoRef: attr(),
         /**
          * The MediaStream from the camera.
-         * 
+         *
          * Default set to null to be consistent with the default value of
          * `HTMLMediaElement.srcObject`.
          */
         videoStream: attr({
             default: null,
         }),
-    };
-    MediaPreview.identifyingFields = ['messaging'];
-    MediaPreview.modelName = 'mail.media_preview';
-
-    return MediaPreview;
-}
-
-registerNewModel('mail.media_preview', factory);
+    },
+});

--- a/addons/mail/static/src/models/message_action_list/message_action_list.js
+++ b/addons/mail/static/src/models/message_action_list/message_action_list.js
@@ -1,17 +1,14 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2one, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
 import { markEventHandled } from '@mail/utils/utils';
 
-function factory(dependencies) {
-
-    class MessageActionList extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.message_action_list',
+    identifyingFields: ['messageView'],
+    lifecycleHooks: {
         _created() {
             // bind handlers so they can be used in templates
             this.onClick = this.onClick.bind(this);
@@ -25,16 +22,16 @@ function factory(dependencies) {
             this.onClickToggleStar = this.onClickToggleStar.bind(this);
             this.onDeleteConfirmDialogClosed = this.onDeleteConfirmDialogClosed.bind(this);
             this.onEmojiSelection = this.onEmojiSelection.bind(this);
-        }
-
+        },
+    },
+    recordMethods: {
         /**
          * @private
          * @param {MouseEvent} ev
          */
         onClick(ev) {
             markEventHandled(ev, 'MessageActionList.Click');
-        }
-
+        },
         /**
          * @private
          * @param {MouseEvent} ev
@@ -44,48 +41,42 @@ function factory(dependencies) {
                 body: '',
                 attachment_ids: [],
             });
-        }
-
+        },
         /**
          * @private
          * @param {MouseEvent} ev
          */
         onClickDelete(ev) {
             this.update({ showDeleteConfirm: true });
-        }
-
+        },
         /**
          * @private
          * @param {MouseEvent} ev
          */
          onClickEdit(ev) {
             this.messageView.startEditing();
-        }
-
+        },
         /**
          * @private
          * @param {MouseEvent} ev
          */
         onClickMarkAsRead(ev) {
             this.message.markAsRead();
-        }
-
+        },
         /**
          * @private
          * @param {Event} ev
          */
         onReactionPopoverClosed(ev) {
             this.update({ isReactionPopoverOpened: false });
-        }
-
+        },
         /**
          * @private
          * @param {Event} ev
          */
         onReactionPopoverOpened(ev) {
             this.update({ isReactionPopoverOpened: true });
-        }
-
+        },
         /**
          * Opens the reply composer for this message (or closes it if it was
          * already opened).
@@ -96,24 +87,21 @@ function factory(dependencies) {
         onClickReplyTo(ev) {
             markEventHandled(ev, 'MessageActionList.replyTo');
             this.messageView.replyTo();
-        }
-
+        },
         /**
          * @private
          * @param {MouseEvent} ev
          */
         onClickToggleStar(ev) {
             this.message.toggleStar();
-        }
-
+        },
         /**
          * @private
          * @param {CustomEvent} ev
          */
         onDeleteConfirmDialogClosed(ev) {
             this.update({ showDeleteConfirm: false });
-        }
-
+        },
         /**
          * Handles `o-emoji-selection` event from the emoji popover.
          *
@@ -124,12 +112,7 @@ function factory(dependencies) {
          */
         onEmojiSelection(ev) {
             this.message.addReaction(ev.detail.unicode);
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -140,8 +123,7 @@ function factory(dependencies) {
                 this.messageView && this.messageView.threadView && this.messageView.threadView.thread &&
                 this.messageView.threadView.thread === this.messaging.inbox
             );
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -154,16 +136,14 @@ function factory(dependencies) {
                     this.messageView.threadView.thread.model === 'mail.channel'
                 )
             );
-        }
-
+        },
         _computeIsReactionPopoverOpened() {
             return Boolean(
                 this.reactionPopoverRef &&
                 this.reactionPopoverRef.comp &&
                 this.reactionPopoverRef.comp.state.displayed
             );
-        }
-
+        },
         /**
          * @private
          * @returns {mail.message_view}
@@ -172,11 +152,9 @@ function factory(dependencies) {
             return this.message
                 ? insertAndReplace({ message: replace(this.message) })
                 : clear();
-        }
-
-    }
-
-    MessageActionList.fields = {
+        },
+    },
+    fields: {
         /**
          * Determines whether this message action list has mark as read icon.
          */
@@ -228,11 +206,5 @@ function factory(dependencies) {
         showDeleteConfirm: attr({
             default: false,
         }),
-    };
-    MessageActionList.identifyingFields = ['messageView'];
-    MessageActionList.modelName = 'mail.message_action_list';
-
-    return MessageActionList;
-}
-
-registerNewModel('mail.message_action_list', factory);
+    },
+});

--- a/addons/mail/static/src/models/message_in_reply_to_view/message_in_reply_to_view.js
+++ b/addons/mail/static/src/models/message_in_reply_to_view/message_in_reply_to_view.js
@@ -1,26 +1,20 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
-import { attr, one2one } from '@mail/model/model_field';
-import { clear, replace } from '@mail/model/model_field_command';
+import { registerModel } from '@mail/model/model_core';
+import { one2one } from '@mail/model/model_field';
+import { replace } from '@mail/model/model_field_command';
 import { markEventHandled } from '@mail/utils/utils';
 
-function factory(dependencies) {
-
-    class MessageInReplyToView extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.message_in_reply_to_view',
+    identifyingFields: ['messageView'],
+    lifecycleHooks: {
         _created() {
             // bind handlers so they can be used in templates
             this.onClickReply = this.onClickReply.bind(this);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * @private
          * @param {MouseEvent} ev
@@ -40,21 +34,13 @@ function factory(dependencies) {
                 return;
             }
             threadView.addComponentHint('highlight-reply', parentMessageView);
-        }
-
-    }
-
-    MessageInReplyToView.fields = {
+        },
+    },
+    fields: {
         messageView: one2one('mail.message_view', {
             inverse: 'messageInReplyToView',
             readonly: true,
             required: true,
         }),
-    };
-    MessageInReplyToView.identifyingFields = ['messageView'];
-    MessageInReplyToView.modelName = 'mail.message_in_reply_to_view';
-
-    return MessageInReplyToView;
-}
-
-registerNewModel('mail.message_in_reply_to_view', factory);
+    },
+});

--- a/addons/mail/static/src/models/message_reaction_group/message_reaction_group.js
+++ b/addons/mail/static/src/models/message_reaction_group/message_reaction_group.js
@@ -1,26 +1,19 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2many, many2one } from '@mail/model/model_field';
 import { insertAndReplace } from '@mail/model/model_field_command';
 import { markEventHandled } from '@mail/utils/utils';
 
-function factory(dependencies) {
-
-    class MessageReactionGroup extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.message_reaction_group',
+    identifyingFields: ['message', 'content'],
+    lifecycleHooks: {
         _created() {
-            super._created();
             this.onClick = this.onClick.bind(this);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * Handles click on the reaction group.
          *
@@ -33,12 +26,7 @@ function factory(dependencies) {
             } else {
                 this.message.addReaction(this.content);
             }
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -48,16 +36,14 @@ function factory(dependencies) {
                 (this.messaging.currentPartner && this.partners.includes(this.messaging.currentPartner)) ||
                 (this.messaging.currentGuest && this.guests.includes(this.messaging.currentGuest))
             );
-        }
-
+        },
         /**
          * @private
          * @returns {FieldCommand}
          */
         _computeMessage() {
             return insertAndReplace({ id: this.messageId });
-        }
-
+        },
         /**
          * @private
          * @returns {string}
@@ -84,11 +70,9 @@ function factory(dependencies) {
                 default:
                     return _.str.sprintf(this.env._t('%s, %s, %s and %s other persons have reacted with %s'), firstUser, secondUser, thirdUser, length - 3, this.content);
             }
-        }
-
-    }
-
-    MessageReactionGroup.fields = {
+        },
+    },
+    fields: {
         content: attr({
             readonly: true,
             required: true,
@@ -121,11 +105,5 @@ function factory(dependencies) {
         summary: attr({
             compute: '_computeSummary',
         }),
-    };
-    MessageReactionGroup.identifyingFields = ['message', 'content'];
-    MessageReactionGroup.modelName = 'mail.message_reaction_group';
-
-    return MessageReactionGroup;
-}
-
-registerNewModel('mail.message_reaction_group', factory);
+    },
+});

--- a/addons/mail/static/src/models/message_seen_indicator/message_seen_indicator.js
+++ b/addons/mail/static/src/models/message_seen_indicator/message_seen_indicator.js
@@ -1,22 +1,17 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2many, many2one } from '@mail/model/model_field';
 import { replace, unlinkAll } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class MessageSeenIndicator extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.message_seen_indicator',
+    identifyingFields: ['thread', 'message'],
+    modelMethods: {
         /**
-         * @static
          * @param {mail.thread} [channel] the concerned thread
          */
-        static recomputeFetchedValues(channel = undefined) {
+        recomputeFetchedValues(channel = undefined) {
             const indicatorFindFunction = channel ? localIndicator => localIndicator.thread === channel : undefined;
             const indicators = this.messaging.models['mail.message_seen_indicator'].all(indicatorFindFunction);
             for (const indicator of indicators) {
@@ -26,13 +21,11 @@ function factory(dependencies) {
                     partnersThatHaveFetched: indicator._computePartnersThatHaveFetched(),
                 });
             }
-        }
-
+        },
         /**
-         * @static
          * @param {mail.thread} [channel] the concerned thread
          */
-        static recomputeSeenValues(channel = undefined) {
+        recomputeSeenValues(channel = undefined) {
             const indicatorFindFunction = channel ? localIndicator => localIndicator.thread === channel : undefined;
             const indicators = this.messaging.models['mail.message_seen_indicator'].all(indicatorFindFunction);
             for (const indicator of indicators) {
@@ -46,12 +39,9 @@ function factory(dependencies) {
                     partnersThatHaveSeen: indicator._computePartnersThatHaveSeen(),
                 });
             }
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * Manually called as not always called when necessary
          *
@@ -73,8 +63,7 @@ function factory(dependencies) {
                     )
             );
             return otherPartnerSeenInfosDidNotFetch.length === 0;
-        }
-
+        },
         /**
          * Manually called as not always called when necessary
          *
@@ -95,8 +84,7 @@ function factory(dependencies) {
                     )
             );
             return otherPartnerSeenInfosDidNotSee.length === 0;
-        }
-
+        },
         /**
          * Manually called as not always called when necessary
          *
@@ -116,8 +104,7 @@ function factory(dependencies) {
                     partnerSeenInfo.lastFetchedMessage.id >= this.message.id
             );
             return otherPartnerSeenInfosFetched.length > 0;
-        }
-
+        },
         /**
          * Manually called as not always called when necessary
          *
@@ -136,8 +123,7 @@ function factory(dependencies) {
                     partnerSeenInfo.lastSeenMessage.id >= this.message.id
             );
             return otherPartnerSeenInfosSeen.length > 0;
-        }
-
+        },
         /**
          * Manually called as not always called when necessary
          *
@@ -154,8 +140,7 @@ function factory(dependencies) {
                 return false;
             }
             return this.message.id < this.thread.lastCurrentPartnerMessageSeenByEveryone.id;
-        }
-
+        },
         /**
          * Manually called as not always called when necessary
          *
@@ -185,8 +170,7 @@ function factory(dependencies) {
                 return unlinkAll();
             }
             return replace(otherPartnersThatHaveFetched);
-        }
-
+        },
         /**
          * Manually called as not always called when necessary
          *
@@ -214,12 +198,9 @@ function factory(dependencies) {
                 return unlinkAll();
             }
             return replace(otherPartnersThatHaveSeen);
-        }
-    }
-
-    MessageSeenIndicator.modelName = 'mail.message_seen_indicator';
-
-    MessageSeenIndicator.fields = {
+        },
+    },
+    fields: {
         hasEveryoneFetched: attr({
             compute: '_computeHasEveryoneFetched',
             default: false,
@@ -263,9 +244,5 @@ function factory(dependencies) {
             readonly: true,
             required: true,
         }),
-    };
-    MessageSeenIndicator.identifyingFields = ['thread', 'message'];
-    return MessageSeenIndicator;
-}
-
-registerNewModel('mail.message_seen_indicator', factory);
+    },
+});

--- a/addons/mail/static/src/models/message_view/message_view.js
+++ b/addons/mail/static/src/models/message_view/message_view.js
@@ -1,13 +1,13 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2one, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class MessageView extends dependencies['mail.model'] {
-
+registerModel({
+    name: 'mail.message_view',
+    identifyingFields: [['threadView', 'messageActionListWithDelete'], 'message'],
+    recordMethods: {
         /**
          * Briefly highlights the message.
          */
@@ -19,8 +19,7 @@ function factory(dependencies) {
                     this.update({ isHighlighted: false });
                 }, 2000),
             });
-        }
-
+        },
         /**
          * Action to initiate reply to current messageView.
          */
@@ -41,8 +40,7 @@ function factory(dependencies) {
                     doFocus: true,
                 }),
             });
-        }
-
+        },
         /**
          * Starts editing this message.
          */
@@ -62,8 +60,7 @@ function factory(dependencies) {
                     doFocus: true,
                 }),
             });
-        }
-
+        },
         /**
          * Stops editing this message.
          */
@@ -75,12 +72,7 @@ function factory(dependencies) {
                 composerForEditing: clear(),
                 composerViewInEditing: clear(),
             });
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {FieldCommand}
@@ -89,8 +81,7 @@ function factory(dependencies) {
             return (this.message && this.message.attachments.length > 0)
                 ? insertAndReplace()
                 : clear();
-        }
-
+        },
         /**
          * @private
          * @returns {FieldCommand}
@@ -99,8 +90,7 @@ function factory(dependencies) {
             return (!this.messageActionListWithDelete)
                 ? insertAndReplace()
                 : clear();
-        }
-
+        },
         /**
          * @private
          * @returns {FieldCommand}
@@ -112,11 +102,9 @@ function factory(dependencies) {
                 this.message.originThread.model === 'mail.channel' &&
                 this.message.parentMessage
             ) ? insertAndReplace() : clear();
-        }
-
-    }
-
-    MessageView.fields = {
+        },
+    },
+    fields: {
         /**
          * Determines the attachment list displaying the attachments of this
          * message (if any).
@@ -200,11 +188,5 @@ function factory(dependencies) {
             inverse: 'messageViews',
             readonly: true,
         }),
-    };
-    MessageView.identifyingFields = [['threadView', 'messageActionListWithDelete'], 'message'];
-    MessageView.modelName = 'mail.message_view';
-
-    return MessageView;
-}
-
-registerNewModel('mail.message_view', factory);
+    },
+});

--- a/addons/mail/static/src/models/message_view/tests/message_view_qunit_tests.js
+++ b/addons/mail/static/src/models/message_view/tests/message_view_qunit_tests.js
@@ -1,15 +1,17 @@
 /** @odoo-module **/
 
-import { registerFieldPatchModel, registerIdentifyingFieldsPatch } from '@mail/model/model_core';
+import { addFields, patchIdentifyingFields } from '@mail/model/model_core';
 import { one2one } from '@mail/model/model_field';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/message_view/message_view';
 
-registerFieldPatchModel('mail.message_view', 'qunit', {
+addFields('mail.message_view', {
     qunitTest: one2one('mail.qunit_test', {
         inverse: 'messageView',
         readonly: true,
     }),
 });
 
-registerIdentifyingFieldsPatch('mail.message_view', 'qunit', identifyingFields => {
+patchIdentifyingFields('mail.message_view', identifyingFields => {
     identifyingFields[0].push('qunitTest');
 });

--- a/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
@@ -1,17 +1,13 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { executeGracefully } from '@mail/utils/utils';
 import { link, insert, insertAndReplace } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class MessagingInitializer extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.messaging_initializer',
+    identifyingFields: ['messaging'],
+    recordMethods: {
         /**
          * Fetch messaging data initially to populate the store specifically for
          * the current user. This includes pinned channels for instance.
@@ -50,12 +46,7 @@ function factory(dependencies) {
             if (this.messaging.autofetchPartnerImStatus) {
                 this.messaging.models['mail.partner'].startLoopFetchImStatus();
             }
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @param {Object} param0
@@ -125,8 +116,7 @@ function factory(dependencies) {
             discuss.update({ menu_id });
             // company related data
             this.messaging.update({ companyName });
-        }
-
+        },
         /**
          * @private
          * @param {Object[]} cannedResponsesData
@@ -135,8 +125,7 @@ function factory(dependencies) {
             this.messaging.update({
                 cannedResponses: insert(cannedResponsesData),
             });
-        }
-
+        },
         /**
          * @private
          * @param {Object[]} channelsData
@@ -167,8 +156,7 @@ function factory(dependencies) {
                     channel.pin();
                 }
             }));
-        }
-
+        },
         /**
          * @private
          */
@@ -193,8 +181,7 @@ function factory(dependencies) {
                     }
                 ]),
             });
-        }
-
+        },
         /**
          * @private
          * @param {Object} param0
@@ -207,8 +194,7 @@ function factory(dependencies) {
         }) {
             this.messaging.inbox.update({ counter: needaction_inbox_counter });
             this.messaging.starred.update({ counter: starred_counter });
-        }
-
+        },
         /**
          * @private
          * @param {Object} mailFailuresData
@@ -224,8 +210,7 @@ function factory(dependencies) {
                     message.update({ author: link(this.messaging.currentPartner) });
                 }
             }));
-        }
-
+        },
         /**
          * @param {object} resUsersSettings
          * @param {integer} resUsersSettings.id
@@ -282,8 +267,7 @@ function factory(dependencies) {
                     supportedChannelTypes: ['chat', 'group'],
                 }),
             });
-        }
-
+        },
         /**
          * @private
          * @param {Object} currentGuest
@@ -316,13 +300,6 @@ function factory(dependencies) {
                     publicPartner => this.messaging.models['mail.partner'].convertData(publicPartner)
                 )),
             });
-        }
-
-    }
-    MessagingInitializer.identifyingFields = ['messaging'];
-    MessagingInitializer.modelName = 'mail.messaging_initializer';
-
-    return MessagingInitializer;
-}
-
-registerNewModel('mail.messaging_initializer', factory);
+        },
+    },
+});

--- a/addons/mail/static/src/models/messaging_menu/messaging_menu.js
+++ b/addons/mail/static/src/models/messaging_menu/messaging_menu.js
@@ -1,31 +1,25 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class MessagingMenu extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.messaging_menu',
+    identifyingFields: ['messaging'],
+    recordMethods: {
         /**
          * Close the messaging menu. Should reset its internal state.
          */
         close() {
             this.update({ isOpen: false });
-        }
-
+        },
         /**
          * Toggle the visibility of the messaging menu "new message" input in
          * mobile.
          */
         toggleMobileNewMessage() {
             this.update({ isMobileNewMessageToggled: !this.isMobileNewMessageToggled });
-        }
-
+        },
         /**
          * Toggle whether the messaging menu is open or not.
          */
@@ -36,12 +30,7 @@ function factory(dependencies) {
                 // populate some needaction messages on threads.
                 this.messaging.inbox.cache.update({ isCacheRefreshRequested: true });
             }
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {integer}
@@ -62,11 +51,9 @@ function factory(dependencies) {
             );
             const notificationPemissionCounter = this.messaging.isNotificationPermissionDefault ? 1 : 0;
             return inboxCounter + unreadChannelsCounter + notificationGroupsCounter + notificationPemissionCounter;
-        }
-
-    }
-
-    MessagingMenu.fields = {
+        },
+    },
+    fields: {
         /**
          * Tab selected in the messaging menu.
          * Either 'all', 'chat' or 'channel'.
@@ -94,11 +81,5 @@ function factory(dependencies) {
         isOpen: attr({
             default: false,
         }),
-    };
-    MessagingMenu.identifyingFields = ['messaging'];
-    MessagingMenu.modelName = 'mail.messaging_menu';
-
-    return MessagingMenu;
-}
-
-registerNewModel('mail.messaging_menu', factory);
+    },
+});

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { decrement, increment, insert, insertAndReplace, link, replace, unlink } from '@mail/model/model_field_command';
 import { htmlToTextContentInline } from '@mail/js/utils';
 
@@ -9,25 +9,18 @@ import { Markup } from 'web.utils';
 
 const PREVIEW_MSG_MAX_SIZE = 350; // optimal for native English speakers
 
-function factory(dependencies) {
-
-    class MessagingNotificationHandler extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.messaging_notification_handler',
+    identifyingFields: ['messaging'],
+    lifecycleHooks: {
         _willDelete() {
             if (this.env.services['bus_service']) {
                 this.env.services['bus_service'].off('notification');
                 this.env.services['bus_service'].stopPolling();
             }
-            return super._willDelete(...arguments);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * Fetch messaging data initially to populate the store specifically for
          * the current users. This includes pinned channels for instance.
@@ -35,12 +28,7 @@ function factory(dependencies) {
         start() {
             this.env.services.bus_service.onNotification(null, notifs => this._handleNotifications(notifs));
             this.env.services.bus_service.startPolling();
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @param {Object[]} notifications
@@ -135,15 +123,13 @@ function factory(dependencies) {
                 }
             });
             await this.async(() => Promise.all(proms));
-        }
-
+        },
         /**
          * @abstract
          * @private
          * @param {Object} message
          */
-        _handleNotification(message) {}
-
+        _handleNotification(message) {},
         /**
          * @private
          * @param {Object} payload
@@ -154,8 +140,7 @@ function factory(dependencies) {
             if (attachment) {
                 attachment.delete();
             }
-        }
-
+        },
         /**
          * @private
          * @param {Object} param1
@@ -192,8 +177,7 @@ function factory(dependencies) {
             });
             // FIXME force the computing of message values (cf task-2261221)
             this.messaging.models['mail.message_seen_indicator'].recomputeFetchedValues(channel);
-        }
-
+        },
         /**
          * @private
          * @param {Object} payload
@@ -212,8 +196,7 @@ function factory(dependencies) {
                     type: 'info',
                 });
             }
-        }
-
+        },
         /**
          * @private
          * @param {object} payload
@@ -230,8 +213,7 @@ function factory(dependencies) {
                     lastInterestDateTime: str_to_datetime(last_interest_dt),
                 });
             }
-        }
-
+        },
         /**
          * @private
          * @param {Object} payload
@@ -295,8 +277,7 @@ function factory(dependencies) {
                     this.messaging.chatWindowManager.openThread(channel);
                 }
             }
-        }
-
+        },
         /**
          * Called when a channel has been seen, and the server responds with the
          * last message seen. Useful in order to track last message seen.
@@ -348,8 +329,7 @@ function factory(dependencies) {
                 // FIXME force the computing of message values (cf task-2261221)
                 this.messaging.models['mail.message_seen_indicator'].recomputeSeenValues(channel);
             }
-        }
-
+        },
         /**
          * @private
          * @param {Object} param1
@@ -388,16 +368,14 @@ function factory(dependencies) {
                 }
                 channel.unregisterOtherMemberTypingMember(partner);
             }
-        }
-
+        },
         /**
          * @private
          * @param {Object} channelData
          */
         _handleNotificationChannelUpdate(channelData) {
             this.messaging.models['mail.thread'].insert({ model: 'mail.channel', ...channelData });
-        }
-
+        },
         /**
          * @private
          * @param {object} settings
@@ -424,8 +402,7 @@ function factory(dependencies) {
                 pushToTalkKey: settings.push_to_talk_key,
                 voiceActiveDuration: settings.voice_active_duration,
             });
-        }
-
+        },
         /**
          * @private
          * @param {Object} data
@@ -439,8 +416,7 @@ function factory(dependencies) {
             if (originThread && message.isNeedaction) {
                 originThread.update({ message_needaction_counter: increment() });
             }
-        }
-
+        },
         /**
          * @private
          * @param {Object} data
@@ -451,8 +427,7 @@ function factory(dependencies) {
             for (const content of notifications) {
                 this.messaging.rtc.handleNotification(sender, content);
             }
-        }
-
+        },
         /**
          * @private
          * @param {Object} param1
@@ -469,8 +444,7 @@ function factory(dependencies) {
                 title,
                 type: warning ? 'warning' : 'danger',
             });
-        }
-
+        },
         /**
          * @private
          * @param {Object} data
@@ -480,8 +454,7 @@ function factory(dependencies) {
             this.messaging && this.messaging.userSetting.update({
                 volumeSettings: volumeSettings,
             });
-        }
-
+        },
         /**
          * @private
          * @param {Object} data
@@ -496,8 +469,7 @@ function factory(dependencies) {
                     type: 'warning',
                 });
             }
-        }
-
+        },
         /**
          * @private
          * @param {Object} data
@@ -510,8 +482,7 @@ function factory(dependencies) {
                 return;
             }
             channel.updateRtcSessions(rtcSessions);
-        }
-
+        },
         /**
          * @private
          * @param {Object} param0
@@ -524,8 +495,7 @@ function factory(dependencies) {
                     message.delete();
                 }
             }
-        }
-
+        },
         /**
          * @private
          * @param {Object} data
@@ -541,8 +511,7 @@ function factory(dependencies) {
                     message.update({ author: link(this.messaging.currentPartner) });
                 }
             }
-        }
-
+        },
         /**
          * @private
          * @param {Object} param0
@@ -584,8 +553,7 @@ function factory(dependencies) {
                 // messages on the server.
                 inbox.cache.update({ hasToLoadMessages: true });
             }
-        }
-
+        },
         /**
          * @private
          * @param {Object} param0
@@ -606,8 +574,7 @@ function factory(dependencies) {
                     counter: starred ? increment() : decrement(),
                 });
             }
-        }
-
+        },
         /**
          * On receiving a transient message, i.e. a message which does not come
          * from a member of the channel. Usually a log message, such as one
@@ -629,8 +596,7 @@ function factory(dependencies) {
                 isTransient: true,
             }));
             this._notifyThreadViewsMessageReceived(message);
-        }
-
+        },
         /**
          * @private
          * @param {Object} payload
@@ -652,8 +618,7 @@ function factory(dependencies) {
                 isServerPinned: false,
                 members: unlink(this.messaging.currentPartner)
             });
-        }
-
+        },
         /**
          * @private
          * @param {Object} payload
@@ -675,8 +640,7 @@ function factory(dependencies) {
                 isServerPinned: false,
                 members: unlink(this.messaging.currentPartner)
             });
-        }
-
+        },
         /**
          * @private
          * @param {Object} payload
@@ -695,8 +659,7 @@ function factory(dependencies) {
                 return;
             }
             this.messaging.chatWindowManager.openThread(chat);
-        }
-
+        },
         /**
          * @private
          * @param {Object} param0
@@ -745,8 +708,7 @@ function factory(dependencies) {
                 part: '_chat',
                 title: _.str.sprintf(titlePattern, messaging.outOfFocusUnreadMessageCounter),
             });
-        }
-
+        },
         /**
          * Notifies threadViews about the given message being just received.
          * This can allow them adjust their scroll position if applicable.
@@ -760,13 +722,6 @@ function factory(dependencies) {
                     threadView.addComponentHint('message-received', { message });
                 }
             }
-        }
-
-    }
-    MessagingNotificationHandler.identifyingFields = ['messaging'];
-    MessagingNotificationHandler.modelName = 'mail.messaging_notification_handler';
-
-    return MessagingNotificationHandler;
-}
-
-registerNewModel('mail.messaging_notification_handler', factory);
+        },
+    },
+});

--- a/addons/mail/static/src/models/notification/notification.js
+++ b/addons/mail/static/src/models/notification/notification.js
@@ -1,23 +1,18 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2one } from '@mail/model/model_field';
 import { clear, insert, insertAndReplace, unlinkAll } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class Notification extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.notification',
+    identifyingFields: ['id'],
+    modelMethods: {
         /**
-         * @static
          * @param {Object} data
          * @return {Object}
          */
-        static convertData(data) {
+        convertData(data) {
             const data2 = {};
             if ('failure_type' in data) {
                 data2.failure_type = data.failure_type;
@@ -42,16 +37,16 @@ function factory(dependencies) {
                 }
             }
             return data2;
-        }
-
+        },
+    },
+    recordMethods: {
         /**
          * @private
          * @returns {boolean}
          */
         _computeIsFailure() {
             return ['exception', 'bounce'].includes(this.notification_status);
-        }
-
+        },
         /**
          * @private
          * @returns {boolean|FieldCommand}
@@ -61,8 +56,7 @@ function factory(dependencies) {
                 return clear();
             }
             return this.messaging.currentPartner === this.message.author;
-        }
-
+        },
         /**
          * @private
          * @returns {FieldCommand}
@@ -82,11 +76,9 @@ function factory(dependencies) {
                 res_model: thread.model,
                 res_model_name: thread.model_name,
             });
-        }
-
-    }
-
-    Notification.fields = {
+        },
+    },
+    fields: {
         failure_type: attr(),
         id: attr({
             readonly: true,
@@ -108,11 +100,5 @@ function factory(dependencies) {
         notification_status: attr(),
         notification_type: attr(),
         partner: many2one('mail.partner'),
-    };
-    Notification.identifyingFields = ['id'];
-    Notification.modelName = 'mail.notification';
-
-    return Notification;
-}
-
-registerNewModel('mail.notification', factory);
+    },
+});

--- a/addons/mail/static/src/models/notification_group/notification_group.js
+++ b/addons/mail/static/src/models/notification_group/notification_group.js
@@ -1,18 +1,14 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2one, one2many } from '@mail/model/model_field';
 import { clear, insert, unlink } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 
-function factory(dependencies) {
-
-    class NotificationGroup extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.notification_group',
+    identifyingFields: ['res_model', 'res_id', 'notification_type'],
+    recordMethods: {
         /**
          * Opens the view that allows to cancel all notifications of the group.
          */
@@ -29,8 +25,7 @@ function factory(dependencies) {
                     },
                 },
             });
-        }
-
+        },
         /**
          * Opens the view that displays either the single record of the group or
          * all the records in the group.
@@ -41,12 +36,7 @@ function factory(dependencies) {
             } else {
                 this._openDocuments();
             }
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {mail.thread|undefined}
@@ -63,8 +53,7 @@ function factory(dependencies) {
                 id: notificationsThreadIds[0],
                 model: this.res_model,
             });
-        }
-
+        },
         /**
          * Compute the most recent date inside the notification messages.
          *
@@ -79,8 +68,7 @@ function factory(dependencies) {
                 return clear();
             }
             return moment.max(dates);
-        }
-
+        },
         /**
          * Compute the position of the group inside the notification list.
          *
@@ -89,8 +77,7 @@ function factory(dependencies) {
          */
         _computeSequence() {
             return -Math.max(...this.notifications.map(notification => notification.message.id));
-        }
-
+        },
         /**
          * @private
          */
@@ -98,8 +85,7 @@ function factory(dependencies) {
             if (this.notifications.length === 0) {
                 this.delete();
             }
-        }
-
+        },
         /**
          * Opens the view that displays all the records of the group.
          *
@@ -126,11 +112,9 @@ function factory(dependencies) {
                 // be closed to ensure the visibility of the view
                 this.messaging.messagingMenu.close();
             }
-        }
-
-    }
-
-    NotificationGroup.fields = {
+        },
+    },
+    fields: {
         /**
          * States the most recent date of all the notification message.
          */
@@ -162,18 +146,12 @@ function factory(dependencies) {
          */
         thread: many2one('mail.thread', {
             compute: '_computeThread',
-        })
-    };
-    NotificationGroup.identifyingFields = ['res_model', 'res_id', 'notification_type'];
-    NotificationGroup.onChanges = [
+        }),
+    },
+    onChanges: [
         new OnChange({
             dependencies: ['notifications'],
             methodName: '_onChangeNotifications',
         }),
-    ];
-    NotificationGroup.modelName = 'mail.notification_group';
-
-    return NotificationGroup;
-}
-
-registerNewModel('mail.notification_group', factory);
+    ],
+});

--- a/addons/mail/static/src/models/partner/partner.js
+++ b/addons/mail/static/src/models/partner/partner.js
@@ -1,25 +1,19 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2many, many2one, one2many, one2one } from '@mail/model/model_field';
 import { insert, link, unlinkAll } from '@mail/model/model_field_command';
 import { cleanSearchTerm } from '@mail/utils/utils';
 
-function factory(dependencies) {
-
-    class Partner extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.partner',
+    identifyingFields: ['id'],
+    modelMethods: {
         /**
-         * @static
-         * @private
          * @param {Object} data
          * @return {Object}
          */
-        static convertData(data) {
+        convertData(data) {
             const data2 = {};
             if ('active' in data) {
                 data2.active = data.active;
@@ -75,19 +69,17 @@ function factory(dependencies) {
             }
 
             return data2;
-        }
-
+        },
         /**
          * Fetches partners matching the given search term to extend the
          * JS knowledge and to update the suggestion list accordingly.
          *
-         * @static
          * @param {string} searchTerm
          * @param {Object} [options={}]
          * @param {mail.thread} [options.thread] prioritize and/or restrict
          *  result in the context of given thread
          */
-        static async fetchSuggestions(searchTerm, { thread } = {}) {
+        async fetchSuggestions(searchTerm, { thread } = {}) {
             const kwargs = { search: searchTerm };
             const isNonPublicChannel = thread && thread.model === 'mail.channel' && thread.public !== 'public';
             if (isNonPublicChannel) {
@@ -107,171 +99,18 @@ function factory(dependencies) {
             if (isNonPublicChannel) {
                 thread.update({ members: link(partners) });
             }
-        }
-
-        /**
-         * Search for partners matching `keyword`.
-         *
-         * @static
-         * @param {Object} param0
-         * @param {function} param0.callback
-         * @param {string} param0.keyword
-         * @param {integer} [param0.limit=10]
-         */
-        static async imSearch({ callback, keyword, limit = 10 }) {
-            // prefetched partners
-            let partners = [];
-            const cleanedSearchTerm = cleanSearchTerm(keyword);
-            const currentPartner = this.messaging.currentPartner;
-            for (const partner of this.all(partner => partner.active)) {
-                if (partners.length < limit) {
-                    if (
-                        partner !== currentPartner &&
-                        partner.name &&
-                        partner.user &&
-                        cleanSearchTerm(partner.name).includes(cleanedSearchTerm)
-                    ) {
-                        partners.push(partner);
-                    }
-                }
-            }
-            if (!partners.length) {
-                const partnersData = await this.env.services.rpc(
-                    {
-                        model: 'res.partner',
-                        method: 'im_search',
-                        args: [keyword, limit]
-                    },
-                    { shadow: true }
-                );
-                const newPartners = this.insert(partnersData.map(
-                    partnerData => this.convertData(partnerData)
-                ));
-                partners.push(...newPartners);
-            }
-            callback(partners);
-        }
-
-        /**
-         * Returns partners that match the given search term.
-         *
-         * @static
-         * @param {string} searchTerm
-         * @param {Object} [options={}]
-         * @param {mail.thread} [options.thread] prioritize and/or restrict
-         *  result in the context of given thread
-         * @returns {[mail.partner[], mail.partner[]]}
-         */
-        static searchSuggestions(searchTerm, { thread } = {}) {
-            let partners;
-            const isNonPublicChannel = thread && thread.model === 'mail.channel' && thread.public !== 'public';
-            if (isNonPublicChannel) {
-                // Only return the channel members when in the context of a
-                // non-public channel. Indeed, the message with the mention
-                // would be notified to the mentioned partner, so this prevents
-                // from inadvertently leaking the private message to the
-                // mentioned partner.
-                partners = thread.members;
-            } else {
-                partners = this.messaging.models['mail.partner'].all();
-            }
-            const cleanedSearchTerm = cleanSearchTerm(searchTerm);
-            const mainSuggestionList = [];
-            const extraSuggestionList = [];
-            for (const partner of partners) {
-                if (
-                    (!partner.active && partner !== this.messaging.partnerRoot) ||
-                    partner.id <= 0 ||
-                    this.messaging.publicPartners.includes(partner)
-                ) {
-                    // ignore archived partners (except OdooBot), temporary
-                    // partners (livechat guests), public partners (technical)
-                    continue;
-                }
-                if (
-                    (partner.nameOrDisplayName && cleanSearchTerm(partner.nameOrDisplayName).includes(cleanedSearchTerm)) ||
-                    (partner.email && cleanSearchTerm(partner.email).includes(cleanedSearchTerm))
-                ) {
-                    if (partner.user) {
-                        mainSuggestionList.push(partner);
-                    } else {
-                        extraSuggestionList.push(partner);
-                    }
-                }
-            }
-            return [mainSuggestionList, extraSuggestionList];
-        }
-
-        /**
-         * @static
-         */
-        static async startLoopFetchImStatus() {
-            await this._fetchImStatus();
-            this._loopFetchImStatus();
-        }
-
-        /**
-         * Checks whether this partner has a related user and links them if
-         * applicable.
-         */
-        async checkIsUser() {
-            const userIds = await this.async(() => this.env.services.rpc({
-                model: 'res.users',
-                method: 'search',
-                args: [[['partner_id', '=', this.id]]],
-                kwargs: {
-                    context: { active_test: false },
-                },
-            }, { shadow: true }));
-            this.update({ hasCheckedUser: true });
-            if (userIds.length > 0) {
-                this.update({ user: insert({ id: userIds[0] }) });
-            }
-        }
-
-        /**
-         * Gets the chat between the user of this partner and the current user.
-         *
-         * If a chat is not appropriate, a notification is displayed instead.
-         *
-         * @returns {mail.thread|undefined}
-         */
-        async getChat() {
-            if (!this.user && !this.hasCheckedUser) {
-                await this.async(() => this.checkIsUser());
-            }
-            // prevent chatting with non-users
-            if (!this.user) {
-                this.env.services['notification'].notify({
-                    message: this.env._t("You can only chat with partners that have a dedicated user."),
-                    type: 'info',
-                });
-                return;
-            }
-            return this.user.getChat();
-        }
-
-        /**
-         * Returns the text that identifies this partner in a mention.
-         *
-         * @returns {string}
-         */
-        getMentionText() {
-            return this.name;
-        }
-
+        },
         /**
          * Returns a sort function to determine the order of display of partners
          * in the suggestion list.
          *
-         * @static
          * @param {string} searchTerm
          * @param {Object} [options={}]
          * @param {mail.thread} [options.thread] prioritize result in the
          *  context of given thread
          * @returns {function}
          */
-        static getSuggestionSortFunction(searchTerm, { thread } = {}) {
+        getSuggestionSortFunction(searchTerm, { thread } = {}) {
             const cleanedSearchTerm = cleanSearchTerm(searchTerm);
             return (a, b) => {
                 const isAInternalUser = a.user && a.user.isInternalUser;
@@ -332,56 +171,104 @@ function factory(dependencies) {
                 }
                 return a.id - b.id;
             };
-        }
-
+        },
         /**
-         * Opens a chat between the user of this partner and the current user
-         * and returns it.
+         * Search for partners matching `keyword`.
          *
-         * If a chat is not appropriate, a notification is displayed instead.
-         *
-         * @param {Object} [options] forwarded to @see `mail.thread:open()`
-         * @returns {mail.thread|undefined}
+         * @param {Object} param0
+         * @param {function} param0.callback
+         * @param {string} param0.keyword
+         * @param {integer} [param0.limit=10]
          */
-        async openChat(options) {
-            const chat = await this.async(() => this.getChat());
-            if (!chat) {
-                return;
+        async imSearch({ callback, keyword, limit = 10 }) {
+            // prefetched partners
+            let partners = [];
+            const cleanedSearchTerm = cleanSearchTerm(keyword);
+            const currentPartner = this.messaging.currentPartner;
+            for (const partner of this.all(partner => partner.active)) {
+                if (partners.length < limit) {
+                    if (
+                        partner !== currentPartner &&
+                        partner.name &&
+                        partner.user &&
+                        cleanSearchTerm(partner.name).includes(cleanedSearchTerm)
+                    ) {
+                        partners.push(partner);
+                    }
+                }
             }
-            await this.async(() => chat.open(options));
-            return chat;
-        }
-
+            if (!partners.length) {
+                const partnersData = await this.env.services.rpc(
+                    {
+                        model: 'res.partner',
+                        method: 'im_search',
+                        args: [keyword, limit]
+                    },
+                    { shadow: true }
+                );
+                const newPartners = this.insert(partnersData.map(
+                    partnerData => this.convertData(partnerData)
+                ));
+                partners.push(...newPartners);
+            }
+            callback(partners);
+        },
         /**
-         * Opens the most appropriate view that is a profile for this partner.
+         * Returns partners that match the given search term.
+         *
+         * @param {string} searchTerm
+         * @param {Object} [options={}]
+         * @param {mail.thread} [options.thread] prioritize and/or restrict
+         *  result in the context of given thread
+         * @returns {[mail.partner[], mail.partner[]]}
          */
-        async openProfile() {
-            return this.messaging.openDocument({
-                id: this.id,
-                model: 'res.partner',
-            });
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        searchSuggestions(searchTerm, { thread } = {}) {
+            let partners;
+            const isNonPublicChannel = thread && thread.model === 'mail.channel' && thread.public !== 'public';
+            if (isNonPublicChannel) {
+                // Only return the channel members when in the context of a
+                // non-public channel. Indeed, the message with the mention
+                // would be notified to the mentioned partner, so this prevents
+                // from inadvertently leaking the private message to the
+                // mentioned partner.
+                partners = thread.members;
+            } else {
+                partners = this.messaging.models['mail.partner'].all();
+            }
+            const cleanedSearchTerm = cleanSearchTerm(searchTerm);
+            const mainSuggestionList = [];
+            const extraSuggestionList = [];
+            for (const partner of partners) {
+                if (
+                    (!partner.active && partner !== this.messaging.partnerRoot) ||
+                    partner.id <= 0 ||
+                    this.messaging.publicPartners.includes(partner)
+                ) {
+                    // ignore archived partners (except OdooBot), temporary
+                    // partners (livechat guests), public partners (technical)
+                    continue;
+                }
+                if (
+                    (partner.nameOrDisplayName && cleanSearchTerm(partner.nameOrDisplayName).includes(cleanedSearchTerm)) ||
+                    (partner.email && cleanSearchTerm(partner.email).includes(cleanedSearchTerm))
+                ) {
+                    if (partner.user) {
+                        mainSuggestionList.push(partner);
+                    } else {
+                        extraSuggestionList.push(partner);
+                    }
+                }
+            }
+            return [mainSuggestionList, extraSuggestionList];
+        },
+        async startLoopFetchImStatus() {
+            await this._fetchImStatus();
+            this._loopFetchImStatus();
+        },
         /**
          * @private
-         * @returns {string}
          */
-        _computeAvatarUrl() {
-            if (this === this.messaging.partnerRoot) {
-                return '/mail/static/src/img/odoobot.png';
-            }
-            return `/web/image/res.partner/${this.id}/avatar_128`;
-        }
-
-        /**
-         * @static
-         * @private
-         */
-        static async _fetchImStatus() {
+        async _fetchImStatus() {
             const partnerIds = [];
             for (const partner of this.all()) {
                 if (partner.im_status !== 'im_partner' && partner.id > 0) {
@@ -398,46 +285,124 @@ function factory(dependencies) {
                 },
             }, { shadow: true });
             this.insert(dataList);
-        }
-
+        },
         /**
-         * @static
          * @private
          */
-        static _loopFetchImStatus() {
+        _loopFetchImStatus() {
             setTimeout(async () => {
                 await this._fetchImStatus();
                 this._loopFetchImStatus();
             }, 50 * 1000);
-        }
-
+        },
+    },
+    recordMethods: {
+        /**
+         * Checks whether this partner has a related user and links them if
+         * applicable.
+         */
+        async checkIsUser() {
+            const userIds = await this.async(() => this.env.services.rpc({
+                model: 'res.users',
+                method: 'search',
+                args: [[['partner_id', '=', this.id]]],
+                kwargs: {
+                    context: { active_test: false },
+                },
+            }, { shadow: true }));
+            this.update({ hasCheckedUser: true });
+            if (userIds.length > 0) {
+                this.update({ user: insert({ id: userIds[0] }) });
+            }
+        },
+        /**
+         * Gets the chat between the user of this partner and the current user.
+         *
+         * If a chat is not appropriate, a notification is displayed instead.
+         *
+         * @returns {mail.thread|undefined}
+         */
+        async getChat() {
+            if (!this.user && !this.hasCheckedUser) {
+                await this.async(() => this.checkIsUser());
+            }
+            // prevent chatting with non-users
+            if (!this.user) {
+                this.env.services['notification'].notify({
+                    message: this.env._t("You can only chat with partners that have a dedicated user."),
+                    type: 'info',
+                });
+                return;
+            }
+            return this.user.getChat();
+        },
+        /**
+         * Returns the text that identifies this partner in a mention.
+         *
+         * @returns {string}
+         */
+        getMentionText() {
+            return this.name;
+        },
+        /**
+         * Opens a chat between the user of this partner and the current user
+         * and returns it.
+         *
+         * If a chat is not appropriate, a notification is displayed instead.
+         *
+         * @param {Object} [options] forwarded to @see `mail.thread:open()`
+         * @returns {mail.thread|undefined}
+         */
+        async openChat(options) {
+            const chat = await this.async(() => this.getChat());
+            if (!chat) {
+                return;
+            }
+            await this.async(() => chat.open(options));
+            return chat;
+        },
+        /**
+         * Opens the most appropriate view that is a profile for this partner.
+         */
+        async openProfile() {
+            return this.messaging.openDocument({
+                id: this.id,
+                model: 'res.partner',
+            });
+        },
+        /**
+         * @private
+         * @returns {string}
+         */
+        _computeAvatarUrl() {
+            if (this === this.messaging.partnerRoot) {
+                return '/mail/static/src/img/odoobot.png';
+            }
+            return `/web/image/res.partner/${this.id}/avatar_128`;
+        },
         /**
          * @private
          * @returns {string|undefined}
          */
         _computeDisplayName() {
             return this.display_name || this.user && this.user.display_name;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeIsOnline() {
             return ['online', 'away'].includes(this.im_status);
-        }
-
+        },
         /**
          * @private
          * @returns {string|undefined}
          */
         _computeNameOrDisplayName() {
             return this.name || this.display_name;
-        }
-
-    }
-
-    Partner.fields = {
+        },
+    },
+    fields: {
         active: attr({
             default: true,
         }),
@@ -494,11 +459,5 @@ function factory(dependencies) {
         volumeSetting: one2one('mail.volume_setting', {
             inverse: 'partner',
         }),
-    };
-    Partner.identifyingFields = ['id'];
-    Partner.modelName = 'mail.partner';
-
-    return Partner;
-}
-
-registerNewModel('mail.partner', factory);
+    },
+});

--- a/addons/mail/static/src/models/popover_view/popover_view.js
+++ b/addons/mail/static/src/models/popover_view/popover_view.js
@@ -1,30 +1,22 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, one2one } from '@mail/model/model_field';
 import { clear } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class PopoverView extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.popover_view',
+    identifyingFields: ['threadViewTopbarOwner', 'channelInvitationForm'],
+    lifecycleHooks: {
         _created() {
             this._onClickCaptureGlobal = this._onClickCaptureGlobal.bind(this);
             document.addEventListener('click', this._onClickCaptureGlobal, true);
-        }
-
+        },
         _willDelete() {
             document.removeEventListener('click', this._onClickCaptureGlobal, true);
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * @private
          * @returns {owl.Ref}
@@ -34,8 +26,7 @@ function factory(dependencies) {
                 return this.threadViewTopbarOwner.inviteButtonRef;
             }
             return clear();
-        }
-
+        },
         /**
          * @private
          * @returns {string}
@@ -45,8 +36,7 @@ function factory(dependencies) {
                 return 'bottom';
             }
             return clear();
-        }
-
+        },
         /**
          * Closes the popover when clicking outside, if appropriate.
          *
@@ -64,11 +54,9 @@ function factory(dependencies) {
                 return;
             }
             this.delete();
-        }
-
-    }
-
-    PopoverView.fields = {
+        },
+    },
+    fields: {
         /**
          * HTML element that is used as anchor position for this popover view.
          */
@@ -104,12 +92,5 @@ function factory(dependencies) {
             inverse: 'invitePopoverView',
             readonly: true,
         }),
-    };
-
-    PopoverView.identifyingFields = ['threadViewTopbarOwner', 'channelInvitationForm'];
-    PopoverView.modelName = 'mail.popover_view';
-
-    return PopoverView;
-}
-
-registerNewModel('mail.popover_view', factory);
+    },
+});

--- a/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
+++ b/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
@@ -1,34 +1,26 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2one, one2one } from '@mail/model/model_field';
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
-function factory(dependencies) {
-
-    class RtcCallParticipantCard extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.rtc_call_participant_card',
+    identifyingFields: ['relationalId'],
+    lifecycleHooks: {
         _created() {
-            super._created();
             this.onChangeVolume = this.onChangeVolume.bind(this);
             this.onClick = this.onClick.bind(this);
             this.onClickVolumeAnchor = this.onClickVolumeAnchor.bind(this);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * @param {Event} ev
          */
         onChangeVolume(ev) {
             this.rtcSession && this.rtcSession.setVolume(parseFloat(ev.target.value));
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
@@ -55,8 +47,7 @@ function factory(dependencies) {
                 return;
             }
             channel.update(channelData);
-        }
-
+        },
         /**
          * Handled by the popover component.
          *
@@ -64,12 +55,7 @@ function factory(dependencies) {
          */
         async onClickVolumeAnchor(ev) {
             markEventHandled(ev, 'CallParticipantCard.clickVolumeAnchor');
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {string}
@@ -87,8 +73,7 @@ function factory(dependencies) {
             if (this.invitedGuest) {
                 return `/mail/channel/${this.channel.id}/guest/${this.invitedGuest.id}/avatar_128?unique=${this.invitedGuest.name}`;
             }
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -96,24 +81,21 @@ function factory(dependencies) {
         _computeIsMinimized() {
             const callViewer = this.rtcCallViewerOfMainCard || this.rtcCallViewerOfTile;
             return Boolean(callViewer && callViewer.isMinimized);
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeIsInvitation() {
             return Boolean(this.invitedPartner || this.invitedGuest);
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeIsTalking() {
             return Boolean(this.rtcSession && this.rtcSession.isTalking && !this.rtcSession.isMuted);
-        }
-
+        },
         /**
          * @private
          * @returns {string}
@@ -128,11 +110,9 @@ function factory(dependencies) {
             if (this.invitedGuest) {
                 return this.invitedGuest.name;
             }
-        }
-
-    }
-
-    RtcCallParticipantCard.fields = {
+        },
+    },
+    fields: {
         /**
          * The relative url of the image that represents the card.
          */
@@ -204,11 +184,5 @@ function factory(dependencies) {
          * If set, this card represents a rtcSession.
          */
         rtcSession: many2one('mail.rtc_session'),
-    };
-    RtcCallParticipantCard.identifyingFields = ['relationalId'];
-    RtcCallParticipantCard.modelName = 'mail.rtc_call_participant_card';
-
-    return RtcCallParticipantCard;
-}
-
-registerNewModel('mail.rtc_call_participant_card', factory);
+    },
+});

--- a/addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js
+++ b/addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js
@@ -2,22 +2,18 @@
 
 import { browser } from "@web/core/browser/browser";
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, one2one, one2many } from '@mail/model/model_field';
 import { OnChange } from '@mail/model/model_onchange';
 import { clear, insert, insertAndReplace, link, unlink } from '@mail/model/model_field_command';
 
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
-function factory(dependencies) {
-
-    class RtcCallViewer extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.rtc_call_viewer',
+    identifyingFields: ['threadView'],
+    lifecycleHooks: {
         _created() {
-            super._created();
             this._timeoutId = undefined;
             this.onClick = this.onClick.bind(this);
             this.onLayoutSettingsDialogClosed = this.onLayoutSettingsDialogClosed.bind(this);
@@ -26,35 +22,25 @@ function factory(dependencies) {
             this.onRtcSettingsDialogClosed = this.onRtcSettingsDialogClosed.bind(this);
             this._onFullScreenChange = this._onFullScreenChange.bind(this);
             browser.addEventListener('fullscreenchange', this._onFullScreenChange);
-        }
-
-        /**
-         * @override
-         */
+        },
         _willDelete() {
             browser.clearTimeout(this._timeoutId);
             browser.removeEventListener('fullscreenchange', this._onFullScreenChange);
-            return super._willDelete(...arguments);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * @param {MouseEvent} ev
          */
         onClick(ev) {
             this._showOverlay();
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
         onLayoutSettingsDialogClosed(ev) {
             this.toggleLayoutMenu();
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
@@ -66,8 +52,7 @@ function factory(dependencies) {
                 return;
             }
             this._showOverlay();
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
@@ -80,15 +65,13 @@ function factory(dependencies) {
                 showOverlay: true,
             });
             browser.clearTimeout(this._timeoutId);
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
         onRtcSettingsDialogClosed(ev) {
             this.messaging.userSetting.rtcConfigurationMenu.toggle();
-        }
-
+        },
         async activateFullScreen() {
             const el = document.body;
             try {
@@ -111,8 +94,7 @@ function factory(dependencies) {
                     type: 'warning',
                 });
             }
-        }
-
+        },
         async deactivateFullScreen() {
             const fullScreenElement = document.webkitFullscreenElement || document.fullscreenElement;
             if (fullScreenElement) {
@@ -127,16 +109,14 @@ function factory(dependencies) {
             if (this.exists()) {
                 this.update({ isFullScreen: false });
             }
-        }
-
+        },
         toggleLayoutMenu() {
             if (!this.rtcLayoutMenu) {
                 this.update({ rtcLayoutMenu: insertAndReplace() });
                 return;
             }
             this.update({ rtcLayoutMenu: unlink() });
-        }
-
+        },
         //----------------------------------------------------------------------
         // Private
         //----------------------------------------------------------------------
@@ -149,8 +129,7 @@ function factory(dependencies) {
             const aspectRatio = rtcAspectRatio || 16 / 9;
             // if we are in minimized mode (round avatar frames), we treat the cards like squares.
             return this.isMinimized ? 1 : aspectRatio;
-        }
-
+        },
         /**
          * @private
          */
@@ -159,8 +138,7 @@ function factory(dependencies) {
                 this.isFullScreen ||
                 this.layout !== "tiled" && !this.threadView.compact
             );
-        }
-
+        },
         /**
          * @private
          */
@@ -172,8 +150,7 @@ function factory(dependencies) {
                 return false;
             }
             return !this.threadView.thread.rtc || this.threadView.thread.videoCount === 0;
-        }
-
+        },
         /**
          * @private
          */
@@ -201,8 +178,7 @@ function factory(dependencies) {
                 return 'spotlight';
             }
             return this.messaging.userSetting.rtcLayout;
-        }
-
+        },
         /**
          * @private
          */
@@ -218,8 +194,7 @@ function factory(dependencies) {
                 });
             }
             return unlink();
-        }
-
+        },
         /**
          * @private
          */
@@ -260,8 +235,7 @@ function factory(dependencies) {
                 });
             }
             return insertAndReplace(tileCards);
-        }
-
+        },
         /**
          * @private
          */
@@ -273,16 +247,14 @@ function factory(dependencies) {
                 }
                 f();
             }, delay);
-        }
-
+        },
         /**
          * @private
          */
         _onChangeRtcChannel() {
             this.deactivateFullScreen();
             this.update({ filterVideoGrid: false });
-        }
-
+        },
         /**
          * @private
          */
@@ -290,8 +262,7 @@ function factory(dependencies) {
             if (this.threadView.thread.videoCount === 0) {
                 this.update({ filterVideoGrid: false });
             }
-        }
-
+        },
         /**
          * Shows the overlay (buttons) for a set a mount of time.
          *
@@ -307,12 +278,7 @@ function factory(dependencies) {
                 }
                 this.update({ showOverlay: false });
             }, { delay: 3000 });
-        }
-
-        //----------------------------------------------------------------------
-        // Handlers
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          */
@@ -323,11 +289,9 @@ function factory(dependencies) {
                 return;
             }
             this.update({ isFullScreen: false });
-        }
-
-    }
-
-    RtcCallViewer.fields = {
+        },
+    },
+    fields: {
         /**
          * The aspect ratio of the tiles.
          */
@@ -414,9 +378,8 @@ function factory(dependencies) {
             compute: '_computeTileParticipantCards',
             inverse: 'rtcCallViewerOfTile',
         }),
-    };
-    RtcCallViewer.identifyingFields = ['threadView'];
-    RtcCallViewer.onChanges = [
+    },
+    onChanges: [
         new OnChange({
             dependencies: ['threadView.thread.rtc'],
             methodName: '_onChangeRtcChannel',
@@ -425,10 +388,5 @@ function factory(dependencies) {
             dependencies: ['threadView.thread.videoCount'],
             methodName: '_onChangeVideoCount',
         }),
-    ];
-    RtcCallViewer.modelName = 'mail.rtc_call_viewer';
-
-    return RtcCallViewer;
-}
-
-registerNewModel('mail.rtc_call_viewer', factory);
+    ],
+});

--- a/addons/mail/static/src/models/rtc_configuration_menu/rtc_configuration_menu.js
+++ b/addons/mail/static/src/models/rtc_configuration_menu/rtc_configuration_menu.js
@@ -2,45 +2,31 @@
 
 import { browser } from "@web/core/browser/browser";
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, one2one } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class RtcConfigurationMenu extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.rtc_configuration_menu',
+    identifyingFields: ['userSetting'],
+    lifecycleHooks: {
         _created() {
-            const res = super._created(...arguments);
             this._onKeyDown = this._onKeyDown.bind(this);
             this._onKeyUp = this._onKeyUp.bind(this);
             browser.addEventListener('keydown', this._onKeyDown);
             browser.addEventListener('keyup', this._onKeyUp);
-            return res;
-        }
-
-        /**
-         * @override
-         */
+        },
         _willDelete() {
             browser.removeEventListener('keydown', this._onKeyDown);
             browser.removeEventListener('keyup', this._onKeyUp);
-            return super._willDelete(...arguments);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * @param {String} value
          */
         onChangeDelay(value) {
             this.userSetting.setDelayValue(value);
-        }
-
+        },
         onChangePushToTalk() {
             if (this.userSetting.usePushToTalk) {
                 this.update({
@@ -48,36 +34,27 @@ function factory(dependencies) {
                 });
             }
             this.userSetting.togglePushToTalk();
-        }
-
+        },
         /**
          * @param {String} value
          */
         onChangeSelectAudioInput(value) {
             this.userSetting.setAudioInputDevice(value);
-        }
-
+        },
         /**
          * @param {String} value
          */
         onChangeThreshold(value) {
             this.userSetting.setThresholdValue(parseFloat(value));
-        }
-
+        },
         onClickRegisterKeyButton() {
             this.update({
                 isRegisteringKey: !this.isRegisteringKey,
             });
-        }
-
+        },
         toggle() {
             this.update({ isOpen: !this.isOpen });
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         _onKeyDown(ev) {
             if (!this.isRegisteringKey) {
                 return;
@@ -85,8 +62,7 @@ function factory(dependencies) {
             ev.stopPropagation();
             ev.preventDefault();
             this.userSetting.setPushToTalkKey(ev);
-        }
-
+        },
         _onKeyUp(ev) {
             if (!this.isRegisteringKey) {
                 return;
@@ -96,11 +72,9 @@ function factory(dependencies) {
             this.update({
                 isRegisteringKey: false,
             });
-        }
-
-    }
-
-    RtcConfigurationMenu.fields = {
+        },
+    },
+    fields: {
         isOpen: attr({
             default: false,
         }),
@@ -115,11 +89,5 @@ function factory(dependencies) {
             readonly: true,
             required: true,
         }),
-    };
-    RtcConfigurationMenu.identifyingFields = ['userSetting'];
-    RtcConfigurationMenu.modelName = 'mail.rtc_configuration_menu';
-
-    return RtcConfigurationMenu;
-}
-
-registerNewModel('mail.rtc_configuration_menu', factory);
+    },
+});

--- a/addons/mail/static/src/models/rtc_controller/rtc_controller.js
+++ b/addons/mail/static/src/models/rtc_controller/rtc_controller.js
@@ -1,18 +1,14 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, one2one } from '@mail/model/model_field';
 import { insertAndReplace } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class RtcController extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.rtc_controller',
+    identifyingFields: ['callViewer'],
+    lifecycleHooks: {
         _created() {
-            super._created();
             this.onClickCamera = this.onClickCamera.bind(this);
             this.onClickDeafen = this.onClickDeafen.bind(this);
             this.onClickMicrophone = this.onClickMicrophone.bind(this);
@@ -20,33 +16,27 @@ function factory(dependencies) {
             this.onClickScreen = this.onClickScreen.bind(this);
             this.onClickToggleAudioCall = this.onClickToggleAudioCall.bind(this);
             this.onClickToggleVideoCall = this.onClickToggleVideoCall.bind(this);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * @param {MouseEvent} ev
          */
         onClickCamera(ev) {
             this.messaging.rtc.toggleUserVideo();
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
         async onClickDeafen(ev) {
             await this.messaging.rtc.currentRtcSession.toggleDeaf();
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
         onClickMicrophone(ev) {
             this.messaging.rtc.toggleMicrophone();
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
@@ -55,15 +45,13 @@ function factory(dependencies) {
                 return;
             }
             await this.callViewer.threadView.thread.leaveCall();
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
         onClickScreen(ev) {
             this.messaging.rtc.toggleScreenShare();
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
@@ -72,8 +60,7 @@ function factory(dependencies) {
                 return;
             }
             await this.callViewer.threadView.thread.toggleCall();
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
@@ -84,22 +71,15 @@ function factory(dependencies) {
             await this.callViewer.threadView.thread.toggleCall({
                 startWithVideo: true,
             });
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          */
         _computeIsSmall() {
             return Boolean(this.callViewer && this.callViewer.threadView.compact && !this.callViewer.isFullScreen);
-        }
-
-    }
-
-    RtcController.fields = {
+        },
+    },
+    fields: {
         callViewer: one2one('mail.rtc_call_viewer', {
             inverse: 'rtcController',
             readonly: true,
@@ -114,11 +94,5 @@ function factory(dependencies) {
             isCausal: true,
             required: true,
         }),
-    };
-    RtcController.identifyingFields = ['callViewer'];
-    RtcController.modelName = 'mail.rtc_controller';
-
-    return RtcController;
-}
-
-registerNewModel('mail.rtc_controller', factory);
+    },
+});

--- a/addons/mail/static/src/models/rtc_layout_menu/rtc_layout_menu.js
+++ b/addons/mail/static/src/models/rtc_layout_menu/rtc_layout_menu.js
@@ -1,26 +1,19 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, one2one } from '@mail/model/model_field';
 import { clear } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class RtcLayoutMenu extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.rtc_layout_menu',
+    identifyingFields: ['callViewer'],
+    lifecycleHooks: {
         _created() {
-            super._created();
             this.onClickFilter = this.onClickFilter.bind(this);
             this.onClickLayout = this.onClickLayout.bind(this);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * @param {MouseEvent} ev
          */
@@ -41,8 +34,7 @@ function factory(dependencies) {
                     }
                     break;
             }
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
@@ -52,21 +44,13 @@ function factory(dependencies) {
                 rtcLayout: ev.target.value,
             });
             this.component.trigger('dialog-closed');
-        }
-
-    }
-
-    RtcLayoutMenu.fields = {
+        },
+    },
+    fields: {
         component: attr(),
         callViewer: one2one('mail.rtc_call_viewer', {
             inverse: 'rtcLayoutMenu',
             readonly: true,
         }),
-    };
-    RtcLayoutMenu.identifyingFields = ['callViewer'];
-    RtcLayoutMenu.modelName = 'mail.rtc_layout_menu';
-
-    return RtcLayoutMenu;
-}
-
-registerNewModel('mail.rtc_layout_menu', factory);
+    },
+});

--- a/addons/mail/static/src/models/rtc_option_list/rtc_option_list.js
+++ b/addons/mail/static/src/models/rtc_option_list/rtc_option_list.js
@@ -1,28 +1,21 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, one2one } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class RtcOptionList extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.rtc_option_list',
+    identifyingFields: ['rtcController'],
+    lifecycleHooks: {
         _created() {
-            super._created();
             this.onClickDownloadLogs = this.onClickDownloadLogs.bind(this);
             this.onClickActivateFullScreen = this.onClickActivateFullScreen.bind(this);
             this.onClickDeactivateFullScreen = this.onClickDeactivateFullScreen.bind(this);
             this.onClickLayout = this.onClickLayout.bind(this);
             this.onClickOptions = this.onClickOptions.bind(this);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * Creates and download a file that contains the logs of the current RTC call.
          *
@@ -42,43 +35,37 @@ function factory(dependencies) {
             a.click();
             window.URL.revokeObjectURL(url);
             this.component.trigger('o-popover-close');
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
         onClickActivateFullScreen(ev) {
             this.rtcController.callViewer.activateFullScreen();
             this.component.trigger('o-popover-close');
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
         onClickDeactivateFullScreen(ev) {
             this.rtcController.callViewer.deactivateFullScreen();
             this.component.trigger('o-popover-close');
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
         onClickLayout(ev) {
             this.rtcController.callViewer.toggleLayoutMenu();
             this.component.trigger('o-popover-close');
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
         onClickOptions(ev) {
             this.messaging.userSetting.rtcConfigurationMenu.toggle();
             this.component.trigger('o-popover-close');
-        }
-
-    }
-
-    RtcOptionList.fields = {
+        },
+    },
+    fields: {
         /**
          * States the OWL component of this option list.
          */
@@ -88,11 +75,5 @@ function factory(dependencies) {
             readonly: true,
             required: true,
         }),
-    };
-    RtcOptionList.identifyingFields = ['rtcController'];
-    RtcOptionList.modelName = 'mail.rtc_option_list';
-
-    return RtcOptionList;
-}
-
-registerNewModel('mail.rtc_option_list', factory);
+    },
+});

--- a/addons/mail/static/src/models/rtc_peer_notification/rtc_peer_notification.js
+++ b/addons/mail/static/src/models/rtc_peer_notification/rtc_peer_notification.js
@@ -1,14 +1,12 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class RTCPeerNotification extends dependencies['mail.model'] {
-    }
-
-    RTCPeerNotification.fields = {
+registerModel({
+    name: 'mail.rtc_peer_notification',
+    identifyingFields: ['id'],
+    fields: {
         channelId: attr({
             readonly: true,
             required: true,
@@ -37,11 +35,5 @@ function factory(dependencies) {
             readonly: true,
             required: true,
         }),
-    };
-    RTCPeerNotification.identifyingFields = ['id'];
-    RTCPeerNotification.modelName = 'mail.rtc_peer_notification';
-
-    return RTCPeerNotification;
-}
-
-registerNewModel('mail.rtc_peer_notification', factory);
+    },
+});

--- a/addons/mail/static/src/models/rtc_session/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session/rtc_session.js
@@ -2,34 +2,22 @@
 
 import { browser } from "@web/core/browser/browser";
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2one, one2one, one2many } from '@mail/model/model_field';
 import { clear } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class RtcSession extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.rtc_session',
+    identifyingFields: ['id'],
+    lifecycleHooks: {
         _created() {
-            super._created();
             this._timeoutId = undefined;
-        }
-
-        /**
-         * @override
-         */
+        },
         _willDelete() {
             this.reset();
-            return super._willDelete(...arguments);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * restores the session to its default values
          */
@@ -41,8 +29,7 @@ function factory(dependencies) {
                 audioElement: clear(),
                 isTalking: clear(),
             });
-        }
-
+        },
         /**
          * cleanly removes the video stream of the session
          */
@@ -55,8 +42,7 @@ function factory(dependencies) {
             this.update({
                 videoStream: clear(),
             });
-        }
-
+        },
         /**
          * @param {Object} param0
          * @param {MediaStream} param0.audioStream
@@ -106,8 +92,7 @@ function factory(dependencies) {
                 }
                 console.error(error);
             }
-        }
-
+        },
         /**
          * @param {number} volume
          */
@@ -137,8 +122,7 @@ function factory(dependencies) {
                 guestId: this.guest && this.guest.id,
                 volume,
             });
-        }
-
+        },
         /**
          * Toggles the deaf state of the current session, this must be a session
          * of the current partner.
@@ -165,8 +149,7 @@ function factory(dependencies) {
                     requestAudioDevice: false,
                 }));
             }
-        }
-
+        },
         /**
          * updates the record and notifies the server of the change
          *
@@ -199,12 +182,7 @@ function factory(dependencies) {
                     );
                 });
             }, 3000);
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {string}
@@ -219,8 +197,7 @@ function factory(dependencies) {
             if (this.guest) {
                 return `/mail/channel/${this.channel.id}/guest/${this.guest.id}/avatar_128?unique=${this.guest.name}`;
             }
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -231,8 +208,7 @@ function factory(dependencies) {
             }
             return (this.partner && this.messaging.currentPartner === this.partner) ||
                 (this.guest && this.messaging.currentGuest === this.guest);
-        }
-
+        },
         /**
          * @private
          * @returns {string}
@@ -244,16 +220,14 @@ function factory(dependencies) {
             if (this.guest) {
                 return this.guest.name;
             }
-        }
-
+        },
         /**
          * @private
          * @returns {string}
          */
         _computePeerToken() {
             return String(this.id);
-        }
-
+        },
         /**
          * @private
          * @returns {number} float
@@ -267,8 +241,7 @@ function factory(dependencies) {
             if (this.audioElement) {
                 return this.audioElement.volume;
             }
-        }
-
+        },
         /**
          * @private
          */
@@ -280,8 +253,7 @@ function factory(dependencies) {
                 }
                 f();
             }, delay);
-        }
-
+        },
         /**
          * cleanly removes the audio stream of the session
          *
@@ -305,11 +277,9 @@ function factory(dependencies) {
                 audioStream: clear(),
                 isAudioInError: false,
             });
-        }
-
-    }
-
-    RtcSession.fields = {
+        },
+    },
+    fields: {
         /**
          * HTMLAudioElement that plays and control the audioStream of the user,
          * it is not mounted on the DOM as it can operate from the JS.
@@ -452,11 +422,5 @@ function factory(dependencies) {
             default: 0.5,
             compute: '_computeVolume',
         }),
-    };
-    RtcSession.identifyingFields = ['id'];
-    RtcSession.modelName = 'mail.rtc_session';
-
-    return RtcSession;
-}
-
-registerNewModel('mail.rtc_session', factory);
+    },
+});

--- a/addons/mail/static/src/models/sound_effect/sound_effect.js
+++ b/addons/mail/static/src/models/sound_effect/sound_effect.js
@@ -1,16 +1,12 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class SoundEffect extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.sound_effect',
+    identifyingFields: ['path', 'filename'],
+    recordMethods: {
         /**
          * @param {Object} param0
          * @param {boolean} [param0.loop] true if we want to make the audio loop, will only stop if stop() is called
@@ -31,8 +27,7 @@ function factory(dependencies) {
             this.audio.loop = loop;
             this.audio.volume = volume;
             Promise.resolve(this.audio.play()).catch(()=>{});
-        }
-
+        },
         /**
          * Resets the audio to the start of the track and pauses it.
          */
@@ -41,11 +36,9 @@ function factory(dependencies) {
                 this.audio.pause();
                 this.audio.currentTime = 0;
             }
-        }
-
-    }
-
-    SoundEffect.fields = {
+        },
+    },
+    fields: {
         /**
          * HTMLAudioElement
          * Does not require to be mounted on the DOM to operate.
@@ -69,11 +62,5 @@ function factory(dependencies) {
             readonly: true,
             required: true,
         }),
-    };
-    SoundEffect.identifyingFields = ['path', 'filename'];
-    SoundEffect.modelName = 'mail.sound_effect';
-
-    return SoundEffect;
-}
-
-registerNewModel('mail.sound_effect', factory);
+    },
+});

--- a/addons/mail/static/src/models/sound_effects/sound_effects.js
+++ b/addons/mail/static/src/models/sound_effects/sound_effects.js
@@ -1,15 +1,13 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { one2one } from '@mail/model/model_field';
 import { insertAndReplace } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class SoundEffects extends dependencies['mail.model'] {
-    }
-
-    SoundEffects.fields = {
+registerModel({
+    name: 'mail.sound_effects',
+    identifyingFields: ['messaging'],
+    fields: {
         channelJoin: one2one('mail.sound_effect', {
             default: insertAndReplace({ filename: 'channel_01_in' }),
             isCausal: true,
@@ -38,11 +36,5 @@ function factory(dependencies) {
             default: insertAndReplace({ filename: 'share_02' }),
             isCausal: true,
         }),
-    };
-    SoundEffects.identifyingFields = ['messaging'];
-    SoundEffects.modelName = 'mail.sound_effects';
-
-    return SoundEffects;
-}
-
-registerNewModel('mail.sound_effects', factory);
+    },
+});

--- a/addons/mail/static/src/models/suggested_recipient_info/suggested_recipient_info.js
+++ b/addons/mail/static/src/models/suggested_recipient_info/suggested_recipient_info.js
@@ -1,16 +1,12 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2one } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class SuggestedRecipientInfo extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // private
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.suggested_recipient_info',
+    identifyingFields: ['id'],
+    recordMethods: {
         /**
          * Prevents selecting a recipient that does not have a partner.
          *
@@ -19,19 +15,16 @@ function factory(dependencies) {
          */
         _computeIsSelected() {
             return this.partner ? this.isSelected : false;
-        }
-
+        },
         /**
          * @private
          * @returns {string}
          */
         _computeName() {
             return this.partner && this.partner.nameOrDisplayName || this.name;
-        }
-
-    }
-
-    SuggestedRecipientInfo.fields = {
+        },
+    },
+    fields: {
         /**
          * Determines the email of `this`. It serves as visual clue when
          * displaying `this`, and also serves as default partner email when
@@ -80,11 +73,5 @@ function factory(dependencies) {
             inverse: 'suggestedRecipientInfoList',
             required: true,
         }),
-    };
-    SuggestedRecipientInfo.identifyingFields = ['id'];
-    SuggestedRecipientInfo.modelName = 'mail.suggested_recipient_info';
-
-    return SuggestedRecipientInfo;
-}
-
-registerNewModel('mail.suggested_recipient_info', factory);
+    },
+});

--- a/addons/mail/static/src/models/thread_cache/thread_cache.js
+++ b/addons/mail/static/src/models/thread_cache/thread_cache.js
@@ -1,18 +1,14 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2many, many2one, one2many, one2one } from '@mail/model/model_field';
 import { link, replace, unlink, unlinkAll } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 
-function factory(dependencies) {
-
-    class ThreadCache extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.thread_cache',
+    identifyingFields: ['thread'],
+    recordMethods: {
         async loadMoreMessages() {
             if (this.isAllHistoryLoaded || this.isLoading) {
                 return;
@@ -44,8 +40,7 @@ function factory(dependencies) {
                 }
             }
             this.update({ isLoadingMore: false });
-        }
-
+        },
         /**
          * @returns {mail.message[]|undefined}
          */
@@ -66,12 +61,7 @@ function factory(dependencies) {
                 threadView.addComponentHint('new-messages-loaded', { fetchedMessages });
             }
             return fetchedMessages;
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {mail.message[]}
@@ -87,8 +77,7 @@ function factory(dependencies) {
                 }
             }
             return unlink(toUnlinkMessages);
-        }
-
+        },
         /**
          * @private
          * @returns {mail.message|undefined}
@@ -102,8 +91,7 @@ function factory(dependencies) {
                 return unlink();
             }
             return link(lastFetchedMessage);
-        }
-
+        },
         /**
          * @private
          * @returns {mail.message|undefined}
@@ -117,8 +105,7 @@ function factory(dependencies) {
                 return unlink();
             }
             return link(lastMessage);
-        }
-
+        },
         /**
          * @private
          * @returns {mail.message[]}
@@ -136,24 +123,21 @@ function factory(dependencies) {
                 );
             }
             return replace(this.fetchedMessages.concat(newerMessages));
-        }
-
+        },
         /**
          * @private
          * @returns {mail.message[]}
          */
         _computeOrderedFetchedMessages() {
             return replace(this.fetchedMessages.sort((m1, m2) => m1.id < m2.id ? -1 : 1));
-        }
-
+        },
         /**
          * @private
          * @returns {mail.message[]}
          */
         _computeOrderedMessages() {
             return replace(this.messages.sort((m1, m2) => m1.id < m2.id ? -1 : 1));
-        }
-
+        },
         /**
          *
          * @private
@@ -161,8 +145,7 @@ function factory(dependencies) {
          */
         _computeOrderedNonEmptyMessages() {
             return replace(this.orderedMessages.filter(message => !message.isEmpty));
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -205,8 +188,7 @@ function factory(dependencies) {
             }
             res.hasToLoadMessages = true;
             return res;
-        }
-
+        },
         /**
          * @private
          * @param {Object} [param0={}]
@@ -252,8 +234,7 @@ function factory(dependencies) {
                 threadCache: this,
             });
             return messages;
-        }
-
+        },
         /**
          * Split method for `_computeHasToLoadMessages` because it has to write
          * on 2 fields at once which is not supported by standard compute.
@@ -262,8 +243,7 @@ function factory(dependencies) {
          */
         _onChangeForHasToLoadMessages() {
             this.update(this._computeHasToLoadMessages());
-        }
-
+        },
         /**
          * Calls "mark all as read" when this thread becomes displayed in a
          * view (which is notified by `isMarkAllAsReadRequested` being `true`),
@@ -300,8 +280,7 @@ function factory(dependencies) {
                 ['model', '=', this.thread.model],
                 ['res_id', '=', this.thread.id],
             ]);
-        }
-
+        },
         /**
          * Loads this thread cache, by fetching the most recent messages in this
          * conversation.
@@ -316,11 +295,9 @@ function factory(dependencies) {
             for (const threadView of this.threadViews) {
                 threadView.addComponentHint('messages-loaded', { fetchedMessages });
             }
-        }
-
-    }
-
-    ThreadCache.fields = {
+        },
+    },
+    fields: {
         /**
          * List of messages that have been fetched by this cache.
          *
@@ -435,9 +412,8 @@ function factory(dependencies) {
         threadViews: one2many('mail.thread_view', {
             inverse: 'threadCache',
         }),
-    };
-    ThreadCache.identifyingFields = ['thread'];
-    ThreadCache.onChanges = [
+    },
+    onChanges: [
         new OnChange({
             dependencies: ['hasLoadingFailed', 'isCacheRefreshRequested', 'isLoaded', 'isLoading', 'thread.isTemporary', 'threadViews'],
             methodName: '_onChangeForHasToLoadMessages',
@@ -450,10 +426,5 @@ function factory(dependencies) {
             dependencies: ['hasToLoadMessages'],
             methodName: '_onHasToLoadMessagesChanged',
         }),
-    ];
-    ThreadCache.modelName = 'mail.thread_cache';
-
-    return ThreadCache;
-}
-
-registerNewModel('mail.thread_cache', factory);
+    ],
+});

--- a/addons/mail/static/src/models/thread_partner_seen_info/thread_partner_seen_info.js
+++ b/addons/mail/static/src/models/thread_partner_seen_info/thread_partner_seen_info.js
@@ -1,14 +1,12 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { many2one } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class ThreadPartnerSeenInfo extends dependencies['mail.model'] {
-    }
-
-    ThreadPartnerSeenInfo.fields = {
+registerModel({
+    name: 'mail.thread_partner_seen_info',
+    identifyingFields: ['thread', 'partner'],
+    fields: {
         lastFetchedMessage: many2one('mail.message'),
         lastSeenMessage: many2one('mail.message'),
         /**
@@ -27,11 +25,5 @@ function factory(dependencies) {
             readonly: true,
             required: true,
         }),
-    };
-    ThreadPartnerSeenInfo.identifyingFields = ['thread', 'partner'];
-    ThreadPartnerSeenInfo.modelName = 'mail.thread_partner_seen_info';
-
-    return ThreadPartnerSeenInfo;
-}
-
-registerNewModel('mail.thread_partner_seen_info', factory);
+    },
+});

--- a/addons/mail/static/src/models/thread_view/tests/thread_viewer_qunit_tests.js
+++ b/addons/mail/static/src/models/thread_view/tests/thread_viewer_qunit_tests.js
@@ -1,15 +1,17 @@
 /** @odoo-module **/
 
-import { registerFieldPatchModel, registerIdentifyingFieldsPatch } from '@mail/model/model_core';
+import { addFields, patchIdentifyingFields } from '@mail/model/model_core';
 import { one2one } from '@mail/model/model_field';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/thread_view/thread_viewer';
 
-registerFieldPatchModel('mail.thread_viewer', 'qunit', {
+addFields('mail.thread_viewer', {
     qunitTest: one2one('mail.qunit_test', {
         inverse: 'threadViewer',
         readonly: true,
     }),
 });
 
-registerIdentifyingFieldsPatch('mail.thread_viewer', 'qunit', identifyingFields => {
+patchIdentifyingFields('mail.thread_viewer', identifyingFields => {
     identifyingFields[0].push('qunitTest');
 });

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -1,34 +1,23 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { RecordDeletedError } from '@mail/model/model_errors';
 import { attr, many2many, many2one, one2many, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace, link, replace, unlink, update } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 
-function factory(dependencies) {
-
-    class ThreadView extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.thread_view',
+    identifyingFields: ['threadViewer'],
+    lifecycleHooks: {
         _created() {
             this._loaderTimeout = undefined;
-        }
-
-        /**
-         * @override
-         */
+        },
         _willDelete() {
             this.env.browser.clearTimeout(this._loaderTimeout);
-            return super._willDelete(...arguments);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * This function register a hint for the component related to this
          * record. Hints are information on changes around this viewer that
@@ -46,8 +35,7 @@ function factory(dependencies) {
             this.update({
                 componentHintList: this.componentHintList.concat([hint]),
             });
-        }
-
+        },
         /**
          * @param {mail.message} message
          */
@@ -55,8 +43,7 @@ function factory(dependencies) {
             if (!this.lastVisibleMessage || this.lastVisibleMessage.id < message.id) {
                 this.update({ lastVisibleMessage: link(message) });
             }
-        }
-
+        },
         /**
          * @param {Object} hint
          */
@@ -68,8 +55,7 @@ function factory(dependencies) {
                 hint,
                 threadViewer: this.threadViewer,
             });
-        }
-
+        },
         /**
          * Starts editing the last message of this thread from the current user.
          */
@@ -80,12 +66,7 @@ function factory(dependencies) {
             if (messageView) {
                 messageView.startEditing();
             }
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          */
@@ -93,11 +74,7 @@ function factory(dependencies) {
             return (this.thread && this.thread.model === 'mail.channel' && this.thread.rtcSessions.length > 0)
                 ? insertAndReplace()
                 : clear();
-        }
-
-        /**
-         * @private
-
+        },
         /**
          * @private
          * @returns {FieldCommand}
@@ -110,16 +87,14 @@ function factory(dependencies) {
                 return clear();
             }
             return insertAndReplace();
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeHasSquashCloseMessages() {
             return Boolean(this.threadViewer && !this.threadViewer.chatter && this.thread && this.thread.model !== 'mail.box');
-        }
-
+        },
         /**
          * @private
          * @returns {mail.message_view[]}
@@ -142,8 +117,7 @@ function factory(dependencies) {
                 prevMessage = message;
             }
             return insertAndReplace(messageViewsData);
-        }
-
+        },
         /**
          * @private
          * @returns {string[]}
@@ -166,8 +140,7 @@ function factory(dependencies) {
                 return ['ctrl-enter', 'meta-enter'];
             }
             return ['enter'];
-        }
-
+        },
         /**
          * @private
          * @returns {integer|undefined}
@@ -181,8 +154,7 @@ function factory(dependencies) {
                 return threadCacheInitialScrollHeight;
             }
             return clear();
-        }
-
+        },
         /**
          * @private
          * @returns {integer|undefined}
@@ -196,8 +168,7 @@ function factory(dependencies) {
                 return threadCacheInitialScrollPosition;
             }
             return clear();
-        }
-
+        },
         /**
          * Not a real field, used to trigger `thread.markAsSeen` when one of
          * the dependencies changes.
@@ -232,15 +203,13 @@ function factory(dependencies) {
                     throw e;
                 }
             });
-        }
-
+        },
         /**
          * @private
          */
         _computeTopbar() {
             return this.hasTopbar ? insertAndReplace() : clear();
-        }
-
+        },
         /**
          * @private
          */
@@ -255,8 +224,7 @@ function factory(dependencies) {
                 });
             }
             this.update({ lastVisibleMessage: unlink() });
-        }
-
+        },
         /**
          * @private
          */
@@ -279,8 +247,7 @@ function factory(dependencies) {
             }
             this.env.browser.clearTimeout(this._loaderTimeout);
             this.update({ isLoading: false, isPreparingLoading: false });
-        }
-
+        },
         /**
          * @param {mail.message} prevMessage
          * @param {mail.message} message
@@ -336,11 +303,9 @@ function factory(dependencies) {
                 return false;
             }
             return true;
-        }
-
-    }
-
-    ThreadView.fields = {
+        },
+    },
+    fields: {
         compact: attr({
             related: 'threadViewer.compact',
         }),
@@ -550,9 +515,8 @@ function factory(dependencies) {
             isCausal: true,
             readonly: true,
         }),
-    };
-    ThreadView.identifyingFields = ['threadViewer'];
-    ThreadView.onChanges = [
+    },
+    onChanges: [
         new OnChange({
             dependencies: ['threadCache'],
             methodName: '_onThreadCacheChanged',
@@ -565,10 +529,5 @@ function factory(dependencies) {
             dependencies: ['hasComposerFocus', 'lastMessage', 'thread.lastNonTransientMessage', 'lastVisibleMessage', 'threadCache'],
             methodName: '_computeThreadShouldBeSetAsSeen',
         }),
-    ];
-    ThreadView.modelName = 'mail.thread_view';
-
-    return ThreadView;
-}
-
-registerNewModel('mail.thread_view', factory);
+    ],
+});

--- a/addons/mail/static/src/models/thread_view/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_view/thread_viewer.js
@@ -1,17 +1,13 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2one, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class ThreadViewer extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.thread_viewer',
+    identifyingFields: [['chatter', 'chatWindow', 'discuss', 'discussPublicView']],
+    recordMethods: {
         /**
          * @param {integer} scrollHeight
          * @param {mail.thread_cache} threadCache
@@ -32,8 +28,7 @@ function factory(dependencies) {
                     [threadCache.localId]: scrollHeight,
                 }),
             });
-        }
-
+        },
         /**
          * @param {integer} scrollTop
          * @param {mail.thread_cache} threadCache
@@ -54,23 +49,16 @@ function factory(dependencies) {
                     [threadCache.localId]: scrollTop,
                 }),
             });
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {mail.thread_viewer|undefined}
          */
         _computeThreadView() {
             return this.hasThreadView ? insertAndReplace() : clear();
-        }
-
-    }
-
-    ThreadViewer.fields = {
+        },
+    },
+    fields: {
         chatter: one2one('mail.chatter', {
             inverse: 'threadViewer',
             readonly: true,
@@ -161,11 +149,5 @@ function factory(dependencies) {
             inverse: 'threadViewer',
             isCausal: true,
         }),
-    };
-    ThreadViewer.identifyingFields = [['chatter', 'chatWindow', 'discuss', 'discussPublicView']];
-    ThreadViewer.modelName = 'mail.thread_viewer';
-
-    return ThreadViewer;
-}
-
-registerNewModel('mail.thread_viewer', factory);
+    },
+});

--- a/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
+++ b/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
@@ -1,16 +1,13 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2one, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class ThreadViewTopbar extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.thread_view_topbar',
+    identifyingFields: ['threadView'],
+    lifecycleHooks: {
         _created() {
             // Bind necessary until OWL supports arrow function in handlers: https://github.com/odoo/owl/issues/876
             this.onClickHideMemberList = this.onClickHideMemberList.bind(this);
@@ -35,31 +32,21 @@ function factory(dependencies) {
             this.onMouseEnterTopbarThreadDescription = this.onMouseEnterTopbarThreadDescription.bind(this);
             this.onMouseLeaveTopbarThreadDescription = this.onMouseLeaveTopbarThreadDescription.bind(this);
             document.addEventListener('click', this._onClickCaptureGlobal, true);
-            return super._created();
-        }
-
-        /**
-         * @override
-         */
+        },
         _willDelete() {
             document.removeEventListener('click', this._onClickCaptureGlobal, true);
-            return super._willDelete();
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
-       /**
+        },
+    },
+    recordMethods: {
+        /**
          * Handles click on the "hide member list" button.
          *
          * @param {Event} ev
          */
-        onClickHideMemberList(ev) {
+         onClickHideMemberList(ev) {
             this.threadView.update({ isMemberListOpened: false });
             this.threadView.addComponentHint('member-list-hidden');
-        }
-
+        },
         /**
          * Handles click on the "mark all as read" button of Inbox.
          *
@@ -67,8 +54,7 @@ function factory(dependencies) {
          */
         onClickInboxMarkAllAsRead(ev) {
             this.messaging.models['mail.message'].markAllAsRead();
-        }
-
+        },
         /**
          * Handles click on the "invite" button.
          *
@@ -80,8 +66,7 @@ function factory(dependencies) {
             } else {
                 this.openInvitePopoverView();
             }
-        }
-
+        },
         /**
          * Handles click on the "show member list" button.
          *
@@ -89,8 +74,7 @@ function factory(dependencies) {
          */
         onClickShowMemberList(ev) {
             this.threadView.update({ isMemberListOpened: true });
-        }
-
+        },
         /**
          * Handles click on the "thread name" of this top bar.
          *
@@ -114,8 +98,7 @@ function factory(dependencies) {
                 isMouseOverThreadName: false,
                 pendingThreadName: this.thread.displayName,
             });
-        }
-
+        },
         /**
          * Handles click on the "thread description" of this top bar.
          *
@@ -139,8 +122,7 @@ function factory(dependencies) {
                 isMouseOverThreadDescription: false,
                 pendingThreadDescription: this.thread.description || "",
             });
-        }
-
+        },
         /**
          * Handles click on the "unstar all" button of Starred box.
          *
@@ -148,8 +130,7 @@ function factory(dependencies) {
          */
         onClickUnstarAll(ev) {
             this.messaging.models['mail.message'].unstarAll();
-        }
-
+        },
         /**
          * Handles click on the guest name.
          *
@@ -169,8 +150,7 @@ function factory(dependencies) {
                 isMouseOverUserName: false,
                 pendingGuestName: this.messaging.currentGuest.name,
             });
-        }
-
+        },
         /**
          * Handles OWL update on this top bar component.
          */
@@ -235,15 +215,13 @@ function factory(dependencies) {
                     doSetSelectionStartOnThreadDescriptionInput: clear(),
                 });
             }
-        }
-
+        },
         /**
          * @param {KeyboardEvent} ev
          */
         onInputGuestNameInput(ev) {
             this.update({ pendingGuestName: this.guestNameInputRef.el.value });
-        }
-
+        },
         /**
          * Handles input on the "thread name" input of this top bar.
          *
@@ -251,8 +229,7 @@ function factory(dependencies) {
          */
         onInputThreadNameInput(ev) {
             this.update({ pendingThreadName: ev.target.value });
-        }
-
+        },
         /**
          * Handles input on the "thread description" input of this top bar.
          *
@@ -260,8 +237,7 @@ function factory(dependencies) {
          */
         onInputThreadDescriptionInput(ev) {
             this.update({ pendingThreadDescription: ev.target.value });
-        }
-
+        },
         /**
          * Handles keydown on the "guest name" input of this top bar.
          *
@@ -278,8 +254,7 @@ function factory(dependencies) {
                     this._resetGuestNameInput();
                     break;
             }
-        }
-
+        },
         /**
          * Handles keydown on the "thread name" input of this top bar.
          *
@@ -294,8 +269,7 @@ function factory(dependencies) {
                     this._discardThreadRename();
                     break;
             }
-        }
-
+        },
         /**
          * Handles keydown on the "thread description" input of this top bar.
          *
@@ -310,8 +284,7 @@ function factory(dependencies) {
                     this._discardThreadChangeDescription();
                     break;
             }
-        }
-
+        },
         /**
          * Handles mouseenter on the "thread name" of this top bar.
          *
@@ -322,8 +295,7 @@ function factory(dependencies) {
                 return;
             }
             this.update({ isMouseOverThreadName: true });
-        }
-
+        },
         /**
          * Handles mouseenter on the "thread description" of this top bar.
          *
@@ -334,8 +306,7 @@ function factory(dependencies) {
                 return;
             }
             this.update({ isMouseOverThreadDescription: true });
-        }
-
+        },
         /**
          * Handles mouseenter on the "user name" of this top bar.
          *
@@ -343,8 +314,7 @@ function factory(dependencies) {
          */
         onMouseEnterUserName(ev) {
             this.update({ isMouseOverUserName: true });
-        }
-
+        },
         /**
          * Handles mouseleave on the "thread name" of this top bar.
          *
@@ -352,8 +322,7 @@ function factory(dependencies) {
          */
         onMouseLeaveTopbarThreadName(ev) {
             this.update({ isMouseOverThreadName: false });
-        }
-
+        },
         /**
          * Handles mouseleave on the "thread description" of this top bar.
          *
@@ -361,8 +330,7 @@ function factory(dependencies) {
          */
         onMouseLeaveTopbarThreadDescription(ev) {
             this.update({ isMouseOverThreadDescription: false });
-        }
-
+        },
         /**
          * Handles mouseleave on the "user name" of this top bar.
          *
@@ -370,8 +338,7 @@ function factory(dependencies) {
          */
         onMouseLeaveUserName(ev) {
             this.update({ isMouseOverUserName: false });
-        }
-
+        },
         /**
          * Open the invite popover view in this thread view topbar.
          */
@@ -387,12 +354,7 @@ function factory(dependencies) {
             }
             this.threadView.channelInvitationForm.update({ doFocusOnSearchInput: true });
             this.threadView.channelInvitationForm.searchPartnersToInvite();
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          */
@@ -404,8 +366,7 @@ function factory(dependencies) {
                 });
             }
             this._resetGuestNameInput();
-        }
-
+        },
         /**
          * @private
          */
@@ -424,8 +385,7 @@ function factory(dependencies) {
             if (this.thread.channel_type === 'group' && newName !== this.thread.name) {
                 this.thread.rename(newName);
             }
-        }
-
+        },
         /**
          * @private
          */
@@ -438,8 +398,7 @@ function factory(dependencies) {
             if (newDescription !== this.thread.description) {
                 this.thread.changeDescription(newDescription);
             }
-        }
-
+        },
         /**
          * @private
          * @returns {string}
@@ -452,8 +411,7 @@ function factory(dependencies) {
                 return `/mail/channel/${this.thread.id}/guest/${this.messaging.currentGuest.id}/avatar_128?unique=${this.messaging.currentGuest.name}`;
             }
             return this.messaging.currentPartner.avatarUrl;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
@@ -463,8 +421,7 @@ function factory(dependencies) {
                 this.messaging.currentGuest &&
                 this.pendingGuestName !== this.messaging.currentGuest.name
             );
-        }
-
+        },
         /**
          * @private
          */
@@ -473,8 +430,7 @@ function factory(dependencies) {
                 isEditingThreadName: false,
                 pendingThreadName: clear(),
             });
-        }
-
+        },
         /**
          * @private
          */
@@ -483,8 +439,7 @@ function factory(dependencies) {
                 isEditingThreadDescription: false,
                 pendingThreadDescription: clear(),
             });
-        }
-
+        },
         /**
          * @private
          * @param {MouseEvent} ev
@@ -503,8 +458,7 @@ function factory(dependencies) {
             if (this.isEditingThreadDescription && this.threadDescriptionInputRef.el && !this.threadDescriptionInputRef.el.contains(ev.target)) {
                 this._applyThreadChangeDescription();
             }
-        }
-
+        },
         /**
          * @private
          */
@@ -513,11 +467,9 @@ function factory(dependencies) {
                 isEditingGuestName: false,
                 pendingGuestName: clear(),
             });
-        }
-
-    }
-
-    ThreadViewTopbar.fields = {
+        },
+    },
+    fields: {
         /**
          * States the URL of the profile picture of the current user.
          */
@@ -559,7 +511,7 @@ function factory(dependencies) {
          * an instruction to set a new selection. Must be set together with
          * `doSetSelectionEndOnThreadDescriptionInput` and `doSetSelectionStartOnThreadDescriptionInput`
          * to have an effect.
-         */ 
+         */
         doSetSelectionDirectionOnThreadDescriptionInput: attr(),
         /**
          * Determines the ending position where to place the selection on this
@@ -727,11 +679,5 @@ function factory(dependencies) {
             readonly: true,
             required: true,
         }),
-    };
-    ThreadViewTopbar.identifyingFields = ['threadView'];
-    ThreadViewTopbar.modelName = 'mail.thread_view_topbar';
-
-    return ThreadViewTopbar;
-}
-
-registerNewModel('mail.thread_view_topbar', factory);
+    },
+});

--- a/addons/mail/static/src/models/user/user.js
+++ b/addons/mail/static/src/models/user/user.js
@@ -1,23 +1,18 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, one2one } from '@mail/model/model_field';
 import { insert, unlink } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class User extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.user',
+    identifyingFields: ['id'],
+    modelMethods: {
         /**
-         * @static
          * @param {Object} data
          * @returns {Object}
          */
-        static convertData(data) {
+        convertData(data) {
             const data2 = {};
             if ('id' in data) {
                 data2.id = data.id;
@@ -35,18 +30,16 @@ function factory(dependencies) {
                 }
             }
             return data2;
-        }
-
+        },
         /**
          * Performs the `read` RPC on `res.users`.
          *
-         * @static
          * @param {Object} param0
          * @param {Object} param0.context
          * @param {string[]} param0.fields
          * @param {integer[]} param0.ids
          */
-        static async performRpcRead({ context, fields, ids }) {
+        async performRpcRead({ context, fields, ids }) {
             const usersData = await this.env.services.rpc({
                 model: 'res.users',
                 method: 'read',
@@ -59,8 +52,9 @@ function factory(dependencies) {
             return this.messaging.models['mail.user'].insert(usersData.map(userData =>
                 this.messaging.models['mail.user'].convertData(userData)
             ));
-        }
-
+        },
+    },
+    recordMethods: {
         /**
          * Fetches the partner of this user.
          */
@@ -70,8 +64,7 @@ function factory(dependencies) {
                 fields: ['partner_id'],
                 context: { active_test: false },
             });
-        }
-
+        },
         /**
          * Gets the chat between this user and the current user.
          *
@@ -118,8 +111,7 @@ function factory(dependencies) {
                 return;
             }
             return chat;
-        }
-
+        },
         /**
          * Opens a chat between this user and the current user and returns it.
          *
@@ -135,8 +127,7 @@ function factory(dependencies) {
             }
             await this.async(() => chat.open(options));
             return chat;
-        }
-
+        },
         /**
          * Opens the most appropriate view that is a profile for this user.
          * Because user is a rather technical model to allow login, it's the
@@ -160,30 +151,23 @@ function factory(dependencies) {
                 return;
             }
             return this.partner.openProfile();
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {string|undefined}
          */
         _computeDisplayName() {
             return this.display_name || this.partner && this.partner.display_name;
-        }
-
+        },
         /**
          * @private
          * @returns {string|undefined}
          */
         _computeNameOrDisplayName() {
             return this.partner && this.partner.nameOrDisplayName || this.display_name;
-        }
-    }
-
-    User.fields = {
+        },
+    },
+    fields: {
         id: attr({
             readonly: true,
             required: true,
@@ -210,11 +194,5 @@ function factory(dependencies) {
          * Id of this user's res.users.settings record.
          */
         resUsersSettingsId: attr(),
-    };
-    User.identifyingFields = ['id'];
-    User.modelName = 'mail.user';
-
-    return User;
-}
-
-registerNewModel('mail.user', factory);
+    },
+});

--- a/addons/mail/static/src/models/volume_setting/volume_setting.js
+++ b/addons/mail/static/src/models/volume_setting/volume_setting.js
@@ -1,18 +1,13 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, one2one, many2one } from '@mail/model/model_field';
-import { insert } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 
-function factory(dependencies) {
-
-    class VolumeSetting extends dependencies['mail.model'] {
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+registerModel({
+    name: 'mail.volume_setting',
+    identifyingFields: ['id'],
+    recordMethods: {
         /**
          * @private
          */
@@ -30,10 +25,9 @@ function factory(dependencies) {
                     rtcSession.audioElement.volume = this.volume;
                 }
             }
-        }
-    }
-
-    VolumeSetting.fields = {
+        },
+    },
+    fields: {
         guest: one2one('mail.guest', {
             inverse: 'volumeSetting',
         }),
@@ -51,18 +45,11 @@ function factory(dependencies) {
         volume: attr({
             default: 0.5,
         }),
-    };
-    VolumeSetting.identifyingFields = ['id'];
-    VolumeSetting.onChanges = [
+    },
+    onChanges: [
         new OnChange({
             dependencies: ['volume'],
             methodName: '_onChangeVolume',
         }),
-    ];
-
-    VolumeSetting.modelName = 'mail.volume_setting';
-
-    return VolumeSetting;
-}
-
-registerNewModel('mail.volume_setting', factory);
+    ],
+});

--- a/addons/mail/static/src/models/welcome_view/welcome_view.js
+++ b/addons/mail/static/src/models/welcome_view/welcome_view.js
@@ -1,33 +1,26 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
+const getNextGuestNameInputId = (function () {
+    let id = 0;
+    return () => ++id;
+})();
 
-    const getNextGuestNameInputId = (function () {
-        let id = 0;
-        return () => ++id;
-    })();
-
-    class WelcomeView extends dependencies['mail.model'] {
-
-        /**
-         * @override
-         */
+registerModel({
+    name: 'mail.welcome_view',
+    identifyingFields: ['messaging'],
+    lifecycleHooks: {
         _created() {
-            super._created();
             // Bind necessary until OWL supports arrow function in handlers: https://github.com/odoo/owl/issues/876
             this.onClickJoinButton = this.onClickJoinButton.bind(this);
             this.onInputGuestNameInput = this.onInputGuestNameInput.bind(this);
             this.onKeydownGuestNameInput = this.onKeydownGuestNameInput.bind(this);
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * Updates guest if needed then displays the thread view instead of the
          * welcome view.
@@ -43,29 +36,25 @@ function factory(dependencies) {
                 await this.performRpcAddGuestAsMember();
             }
             this.discussPublicView.switchToThreadView();
-        }
-
+        },
         /**
          * @param {MouseEvent} ev
          */
         onClickJoinButton(ev) {
             this.joinChannel();
-        }
-
+        },
         /**
          * Handles OWL update on this WelcomeView component.
          */
         onComponentUpdate() {
             this._handleFocus();
-        }
-
+        },
         /**
          * @param {KeyboardEvent} ev
          */
         onInputGuestNameInput(ev) {
             this._updateGuestNameWithInputValue();
-        }
-
+        },
         /**
          * @param {KeyboardEvent} ev
          */
@@ -73,8 +62,7 @@ function factory(dependencies) {
             if (ev.key === 'Enter') {
                 this.joinChannel();
             }
-        }
-
+        },
         /**
          * Adds the current guest to members of the channel linked to this
          * welcome view.
@@ -87,36 +75,28 @@ function factory(dependencies) {
                     channel_uuid: this.channel.uuid,
                 },
             });
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
         /**
          * @private
          * @returns {string}
          */
         _computeGuestNameInputUniqueId() {
             return `o_WelcomeView_guestNameInput_${getNextGuestNameInputId()}`;
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeHasGuestNameChanged() {
             return Boolean(this.messaging.currentGuest && this.originalGuestName !== this.pendingGuestName);
-        }
-
+        },
         /**
          * @private
          * @returns {boolean}
          */
         _computeIsJoinButtonDisabled() {
             return Boolean(this.messaging.currentGuest && this.pendingGuestName.trim() === '');
-        }
-
+        },
         /**
          * @private
          * @returns {FieldCommand}
@@ -125,8 +105,7 @@ function factory(dependencies) {
             return (this.channel && this.channel.defaultDisplayMode === 'video_full_screen')
                 ? insertAndReplace()
                 : clear();
-        }
-
+        },
         /**
          * @private
          */
@@ -141,8 +120,7 @@ function factory(dependencies) {
                 const { length } = (this.pendingGuestName || '');
                 this.guestNameInputRef.el.setSelectionRange(length, length);
             }
-        }
-
+        },
         /**
          * Updates `pendingGuestName` with the value of the input element
          * referred by `guestNameInputRef`.
@@ -151,11 +129,9 @@ function factory(dependencies) {
          */
         _updateGuestNameWithInputValue() {
             this.update({ pendingGuestName: this.guestNameInputRef.el.value });
-        }
-
-    }
-
-    WelcomeView.fields = {
+        },
+    },
+    fields: {
         /**
          * States the channel to redirect to once the user clicks on the
          * 'joinButton'.
@@ -232,11 +208,5 @@ function factory(dependencies) {
          * channel by clicking on the 'joinButton'.
          */
         pendingGuestName: attr(),
-    };
-    WelcomeView.identifyingFields = ['messaging'];
-    WelcomeView.modelName = 'mail.welcome_view';
-
-    return WelcomeView;
-}
-
-registerNewModel('mail.welcome_view', factory);
+    },
+});

--- a/addons/mail/static/tests/qunit_test.js
+++ b/addons/mail/static/tests/qunit_test.js
@@ -1,14 +1,12 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { one2one } from '@mail/model/model_field';
 
-function factory(dependencies) {
-
-    class QUnitTest extends dependencies['mail.model'] {
-    }
-
-    QUnitTest.fields = {
+registerModel({
+    name: 'mail.qunit_test',
+    identifyingFields: [], // singleton acceptable (only one test at a time)
+    fields: {
         composer: one2one('mail.composer', {
             isCausal: true,
         }),
@@ -24,11 +22,5 @@ function factory(dependencies) {
             inverse: 'qunitTest',
             isCausal: true,
         }),
-    };
-    QUnitTest.identifyingFields = []; // singleton acceptable (only one test at a time)
-    QUnitTest.modelName = 'mail.qunit_test';
-
-    return QUnitTest;
-}
-
-registerNewModel('mail.qunit_test', factory);
+    },
+});

--- a/addons/mail_bot/static/src/models/messaging_initializer/messaging_initializer.js
+++ b/addons/mail_bot/static/src/models/messaging_initializer/messaging_initializer.js
@@ -1,12 +1,10 @@
 /** @odoo-module **/
 
-import { registerInstancePatchModel } from '@mail/model/model_core';
+import { addRecordMethods, patchRecordMethods } from '@mail/model/model_core';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/messaging_initializer/messaging_initializer';
 
-registerInstancePatchModel('mail.messaging_initializer', 'mail_bot/static/src/models/messaging_initializer/messaging_initializer.js', {
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
+addRecordMethods('mail.messaging_initializer', {
     /**
      * @private
      */
@@ -20,7 +18,9 @@ registerInstancePatchModel('mail.messaging_initializer', 'mail_bot/static/src/mo
         }
         this.env.session.odoobot_initialized = true;
     },
+});
 
+patchRecordMethods('mail.messaging_initializer', {
     /**
      * @override
      */

--- a/addons/sms/static/src/models/message/message.js
+++ b/addons/sms/static/src/models/message/message.js
@@ -1,15 +1,10 @@
 /** @odoo-module **/
 
-import {
-    registerInstancePatchModel,
-} from '@mail/model/model_core';
+import { patchRecordMethods } from '@mail/model/model_core';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/message/message';
 
-registerInstancePatchModel('mail.message', 'sms/static/src/models/message/message.js', {
-
-    //--------------------------------------------------------------------------
-    // Public
-    //--------------------------------------------------------------------------
-
+patchRecordMethods('mail.message', {
     /**
      * @override
      */

--- a/addons/sms/static/src/models/notification_group/notification_group.js
+++ b/addons/sms/static/src/models/notification_group/notification_group.js
@@ -1,15 +1,10 @@
 /** @odoo-module **/
 
-import {
-    registerInstancePatchModel,
-} from '@mail/model/model_core';
+import { patchRecordMethods } from '@mail/model/model_core';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/notification_group/notification_group';
 
-registerInstancePatchModel('mail.notification_group', 'sms/static/src/models/notification_group/notification_group.js', {
-
-    //--------------------------------------------------------------------------
-    // Public
-    //--------------------------------------------------------------------------
-
+patchRecordMethods('mail.notification_group', {
     /**
      * @override
      */
@@ -27,11 +22,6 @@ registerInstancePatchModel('mail.notification_group', 'sms/static/src/models/not
             },
         });
     },
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
     /**
      * @override
      */

--- a/addons/snailmail/static/src/models/message/message.js
+++ b/addons/snailmail/static/src/models/message/message.js
@@ -1,13 +1,10 @@
 /** @odoo-module **/
 
-import { registerInstancePatchModel } from '@mail/model/model_core';
+import { addRecordMethods } from '@mail/model/model_core';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/message/message';
 
-registerInstancePatchModel('mail.message', 'snailmail/static/src/models/message.message.js', {
-
-    //----------------------------------------------------------------------
-    // Public
-    //----------------------------------------------------------------------
-
+addRecordMethods('mail.message', {
     /**
      * Cancels the 'snailmail.letter' corresponding to this message.
      *

--- a/addons/snailmail/static/src/models/messaging/messaging.js
+++ b/addons/snailmail/static/src/models/messaging/messaging.js
@@ -1,12 +1,11 @@
 /** @odoo-module **/
 
-import {
-    registerInstancePatchModel,
-    registerFieldPatchModel,
-} from '@mail/model/model_core';
+import { addFields, addRecordMethods } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/messaging/messaging';
 
-registerInstancePatchModel('mail.messaging', 'snailmail/static/src/models/messaging/messaging.js', {
+addRecordMethods('mail.messaging', {
     async fetchSnailmailCreditsUrl() {
         const snailmail_credits_url = await this.async(() => this.env.services.rpc({
             model: 'iap.account',
@@ -29,7 +28,7 @@ registerInstancePatchModel('mail.messaging', 'snailmail/static/src/models/messag
     },
 });
 
-registerFieldPatchModel('mail.messaging', 'snailmail/static/src/models/messaging/messaging.js', {
+addFields('mail.messaging', {
     snailmail_credits_url: attr(),
     snailmail_credits_url_trial: attr(),
 });

--- a/addons/snailmail/static/src/models/notification_group/notification_group.js
+++ b/addons/snailmail/static/src/models/notification_group/notification_group.js
@@ -1,15 +1,10 @@
 /** @odoo-module **/
 
-import {
-    registerInstancePatchModel,
-} from '@mail/model/model_core';
+import { patchRecordMethods } from '@mail/model/model_core';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/notification_group/notification_group';
 
-registerInstancePatchModel('mail.notification_group', 'snailmail/static/src/models/notification_group/notification_group.js', {
-
-    //--------------------------------------------------------------------------
-    // Public
-    //--------------------------------------------------------------------------
-
+patchRecordMethods('mail.notification_group', {
     /**
      * @override
      */
@@ -27,11 +22,6 @@ registerInstancePatchModel('mail.notification_group', 'snailmail/static/src/mode
             },
         });
     },
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
     /**
      * @override
      */

--- a/addons/website_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/website_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -1,13 +1,10 @@
 /** @odoo-module **/
 
-import { registerInstancePatchModel } from '@mail/model/model_core';
+import { patchRecordMethods } from '@mail/model/model_core';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/messaging_notification_handler/messaging_notification_handler';
 
-registerInstancePatchModel('mail.messaging_notification_handler', 'website_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js', {
-
-    //----------------------------------------------------------------------
-    // Private
-    //----------------------------------------------------------------------
-
+patchRecordMethods('mail.messaging_notification_handler', {
     /**
      * @override
      */

--- a/addons/website_livechat/static/src/models/thread/thread.js
+++ b/addons/website_livechat/static/src/models/thread/thread.js
@@ -1,18 +1,12 @@
 /** @odoo-module **/
 
-import {
-    registerClassPatchModel,
-    registerFieldPatchModel,
-} from '@mail/model/model_core';
+import { addFields, patchModelMethods } from '@mail/model/model_core';
 import { many2one } from '@mail/model/model_field';
 import { insert, unlink } from '@mail/model/model_field_command';
+// ensure that the model definition is loaded before the patch
+import '@mail/models/thread/thread';
 
-registerClassPatchModel('mail.thread', 'website_livechat/static/src/models/thread/thread.js', {
-
-    //----------------------------------------------------------------------
-    // Public
-    //----------------------------------------------------------------------
-
+patchModelMethods('mail.thread', {
     /**
      * @override
      */
@@ -27,10 +21,9 @@ registerClassPatchModel('mail.thread', 'website_livechat/static/src/models/threa
         }
         return data2;
     },
-
 });
 
-registerFieldPatchModel('mail.thread', 'website_livechat/static/src/models/thread/thread.js', {
+addFields('mail.thread', {
     /**
      * Visitor connected to the livechat.
      */

--- a/addons/website_livechat/static/src/models/visitor/visitor.js
+++ b/addons/website_livechat/static/src/models/visitor/visitor.js
@@ -1,20 +1,14 @@
 /** @odoo-module **/
 
-import { registerNewModel } from '@mail/model/model_core';
+import { registerModel } from '@mail/model/model_core';
 import { attr, many2one, one2many } from '@mail/model/model_field';
 import { insert, link, unlink } from '@mail/model/model_field_command';
 
-function factory(dependencies) {
-
-    class Visitor extends dependencies['mail.model'] {
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
-        /**
-         * @override
-         */
-        static convertData(data) {
+registerModel({
+    name: 'website_livechat.visitor',
+    identifyingFields: ['id'],
+    modelMethods: {
+        convertData(data) {
             const data2 = {};
             if ('country_id' in data) {
                 if (data.country_id) {
@@ -52,12 +46,9 @@ function factory(dependencies) {
                 data2.website_name = data.website_name;
             }
             return data2;
-        }
-
-        //----------------------------------------------------------------------
-        // Private
-        //----------------------------------------------------------------------
-
+        },
+    },
+    recordMethods: {
         /**
          * @private
          * @returns {string}
@@ -67,8 +58,7 @@ function factory(dependencies) {
                 return '/mail/static/src/img/smiley/avatar.jpg';
             }
             return this.partner.avatarUrl;
-        }
-
+        },
         /**
          * @private
          * @returns {mail.country}
@@ -81,8 +71,7 @@ function factory(dependencies) {
                 return link(this.country);
             }
             return unlink();
-        }
-
+        },
         /**
          * @private
          * @returns {string}
@@ -92,10 +81,9 @@ function factory(dependencies) {
                 return this.partner.nameOrDisplayName;
             }
             return this.display_name;
-        }
-    }
-
-    Visitor.fields = {
+        },
+    },
+    fields: {
         /**
          * Url to the avatar of the visitor.
          */
@@ -148,11 +136,5 @@ function factory(dependencies) {
          * Name of the website on which the visitor is connected. (Ex: "Website 1")
          */
         website_name: attr(),
-    };
-    Visitor.identifyingFields = ['id'];
-    Visitor.modelName = 'website_livechat.visitor';
-
-    return Visitor;
-}
-
-registerNewModel('website_livechat.visitor', factory);
+    },
+});


### PR DESCRIPTION
\* = calendar, crm_livechat, hr, hr_holidays, im_livechat, mail_bot, sms, snailmail, website_livechat
Task-2695223

# Change models declaration ─ Changelog

This commit will change the declaration of the models with the aim of getting closer to a plain JSON-object. It allows us to eliminate a wide portion of boilerplate code, making the declaration shorter, more declarative and less redundant, but mainly, it prepares the ground for further changes.

## What's changing?

### Business code

+ The entire model definition is done using a plain javascript object: no more classes, no more *factory* functions.
+ Definition objects follow this structure:
```
{
	name: 'mail.example',
	identifyingFields: [],
	lifecycleHooks: {},
	modelMethods: {
		example() {},
	},
	recordMethods: {
		example() {},
	},
	fields: {},
	onChanges: [],
}
```
please try to stick to this order. Unused keys can be omitted.
+ Lifecycle hooks and onChanges are no longer reachable from the business code.
+ `registerNewModel` has been renamed to `registerModel`.
+ `registerModel` does not require the name of the model anymore; its only argument is the definition object.

Here's an example of a model declaration after the changes:

<details>
	<summary>Click to show</summary>

```js
registerModel({
    name: 'mail.guest',
    identifyingFields: ['id'],
    modelMethods: {
        /**
         * @param {Object} param0
         * @param {number} param0.id The id of the guest to rename.
         * @param {string} param0.name The new name to use to rename the guest.
         */
        async performRpcGuestUpdateName({ id, name }) {
            await this.env.services.rpc({
                route: '/mail/guest/update_name',
                params: {
                    guest_id: id,
                    name,
                },
            });
        }
    },
    recordMethods: {
        /**
         * @private
         * @returns {string}
         */
        _computeAvatarUrl() {
            return `/web/image/mail.guest/${this.id}/avatar_128?unique=${this.name}`;
        }
    },
    fields: {
        authoredMessages: one2many('mail.message', {
            inverse: 'guestAuthor',
        }),
        avatarUrl: attr({
            compute: '_computeAvatarUrl',
        }),
        id: attr({
            required: true,
            readonly: true,
        }),
        name: attr(),
    },
});
```
</details>

+ Patch functions have been renamed:

|Old names|New names|
|---|---|
|registerClassPatchModel|patchModelMethods|
|registerFieldPatchModel|addFields|
|registerIdentifyingFieldsPatch|patchIdentifyingFields|
|registerInstancePatchModel|patchRecordMethods|
+ Furthermore, there is now a distinction between adding and patching methods. Use addRecordMethods to add new record methods, and patchRecordMethods to override existing methods, ditto for the model methods. This is intended to prevent unintentional overwriting of an existing method.
+ Patching fields is no longer permitted, you can only add new ones.
+ When patching a model, a dummy import of the file containing the original definition must be done to ensure that the definition is registered first. This is bad, but this is the only tradeoff to these changes, I promise. Hopefully, it won't be necessary in the future.
+ `patchName` is no longer needed.

Here's an example of patch after the changes:
<details>
	<summary>Click to show</summary>

```js
// ensure that the model definition is loaded before the patch
import '@mail/models/activity/activity';

addFields('mail.activity', {
    /**
     * String to store the mobile number in a call activity.
     */
    mobile: attr(),
    /**
     * String to store the phone number in a call activity.
     */
    phone: attr(),
});

addLifecycleHooks('mail.activity', {
    _created() {
        this._onReloadChatter = this._onReloadChatter.bind(this);
        this.env.bus.on('voip_reload_chatter', undefined, this._onReloadChatter);
    },
    _willDelete() {
        this.env.bus.off('voip_reload_chatter', undefined, this._onReloadChatter);
    },
});

addRecordMethods('mail.activity', {
    /**
     * @private
     */
    _onReloadChatter() {
        if (!this.thread) {
            return;
        }
        this.thread.refreshActivities();
        this.thread.refresh();
    },
});


patchModelMethods('mail.activity', {
    /**
     * @override
     */
    convertData(data) {
        const data2 = this._super(data);
        if ('mobile' in data) {
            data2.mobile = data.mobile;
        }
        if ('phone' in data) {
            data2.phone = data.phone;
        }
        return data2;
    },
});

```
</details>

### Models framework

+ All the code related to dependencies has been removed.
+ Patches are now directly applied to the model definitions, rather than registered then applied at models generation.
+ There is no more factory function, meaning that the data retrieved from the registry are the original model definition. Please never mutate it.
+ The registry now uses Map rather than plain objects.