### PR TITLE
[FIX] web_editor: don't show the active style entry if absent

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1886,14 +1886,18 @@ export class OdooEditor extends EventTarget {
                 listDropdownButton.closest('button').classList.toggle('active', block.tagName === 'LI');
             }
         }
-        if (!activeLabel) {
-            // If no element from the text style dropdown was marked as active,
-            // mark the paragraph one as active and use its label.
-            const firstButtonEl = this.toolbar.querySelector('#paragraph');
-            firstButtonEl.classList.add('active');
-            activeLabel = firstButtonEl.textContent;
+
+        const styleSection = this.toolbar.querySelector('#style');
+        if (styleSection) {
+            if (!activeLabel) {
+                // If no element from the text style dropdown was marked as active,
+                // mark the paragraph one as active and use its label.
+                const firstButtonEl = styleSection.querySelector('#paragraph');
+                firstButtonEl.classList.add('active');
+                activeLabel = firstButtonEl.textContent;
+            }
+            styleSection.querySelector('button span').textContent = activeLabel;
         }
-        this.toolbar.querySelector('#style button span').textContent = activeLabel;
 
         const linkNode = getInSelection(this.document, 'a');
         const linkButton = this.toolbar.querySelector('#createLink');


### PR DESCRIPTION
Steps to follow

  - Edit a report with studio
  - Add an inline text element
  - Select it
  - Select the text in the sidebar
  -> An error is raised

Cause of the issue

  firstButtonEl is undefined because the style section is not always
  present in the toolbar

opw-2674302