### PR TITLE
[FIX] stock: display 'Order Once' if qty > 0

### DIFF
--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -59,9 +59,9 @@
                 <field name="product_uom_name" string="UoM" groups="uom.group_uom"/>
                 <field name="company_id" optional="hide" readonly="1" groups="base.group_multi_company"/>
                 <button name="action_replenish" string="Order Once" type="object" class="o_replenish_buttons" icon="fa-truck"
-                    attrs="{'invisible': [('qty_to_order', '&lt;', 1.0)]}"/>
+                    attrs="{'invisible': [('qty_to_order', '&lt;=', 0.0)]}"/>
                 <button name="action_replenish_auto" string="Automate Orders" type="object" class="o_replenish_buttons" icon="fa-refresh"
-                    attrs="{'invisible': ['|', ('qty_to_order', '&lt;', 1.0), ('trigger', '=', 'auto')]}"/>
+                    attrs="{'invisible': ['|', ('qty_to_order', '&lt;=', 0.0), ('trigger', '=', 'auto')]}"/>
                 <button name="%(action_orderpoint_snooze)d" string="Snooze" type="action" class="text-warning" icon="fa-bell-slash"
                     attrs="{'invisible': [('trigger', '!=', 'manual')]}" context="{'default_orderpoint_ids': [id]}"/>
             </tree>


### PR DESCRIPTION
If the multiple quantity of a RR is less than 1.0, the buttons 'Order
Once' and 'Automate Orders' may remain invisible

(Need sale_management,purchase_stock)
1. Create a product P
    - Type: Storable
    - Add a vendor
    - Routes: Buy
    - Reordering rule:
        - Trigger: Manual
        - Min Quantity: 0
        - Max Quantity: 0
        - Multiple Quantity: 0.01
2. Create and confirm a sale order with 0.50 x P
3. Inventory > Operations > Replenishment

Error: P is present, its qty to order is 0.50, however the button 'Order
Once' is not displayed

OPW-2612472