### PR TITLE
[ADD][14.0] l10n_fr_fec : add translations

### DIFF
--- a/addons/l10n_fr_fec/i18n/fr.po
+++ b/addons/l10n_fr_fec/i18n/fr.po
@@ -1,35 +1,154 @@
-# Translation of OpenERP Server.
+# Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* l10n_fr_fec
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: OpenERP Server 7.0\n"
+"Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-02-03 10:31+0000\n"
-"PO-Revision-Date: 2014-02-03 10:27+0000\n"
-"Last-Translator: <>\n"
+"POT-Creation-Date: 2021-10-27 14:45+0000\n"
+"PO-Revision-Date: 2021-10-27 14:45+0000\n"
+"Last-Translator: Rémi CAZENAVE <remi@le-filament.com>, 2021\n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
 #. module: l10n_fr_fec
-#: view:account.fr.fec:0
-msgid "FEC File Generation"
-msgstr "Génération Fichier FEC"
-
-#. module: l10n_fr_fec
-#: view:account.fr.fec:0
-msgid "The encoding of this text file is UTF-8."
-msgstr "Ce fichier texte est encodé en UTF-8."
-
-#. module: l10n_fr_fec
-#: model:ir.model,name:l10n_fr_fec.model_account_fr_fec
-msgid "Ficher Echange Informatise"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "# 10"
 msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "# 11"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "# 12"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "# 13"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "# 14"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "# 15"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "# 16"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "# 17"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "Cancel"
+msgstr "Annuler"
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "Column"
+msgstr "Colonne"
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "Comment"
+msgstr "Note"
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "CompAuxLib"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "CompAuxNum"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "CompteLib"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "CompteNum"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model:ir.model.fields,field_description:l10n_fr_fec.field_account_fr_fec__create_uid
+msgid "Created by"
+msgstr "Créé par"
+
+#. module: l10n_fr_fec
+#: model:ir.model.fields,field_description:l10n_fr_fec.field_account_fr_fec__create_date
+msgid "Created on"
+msgstr "Créé le"
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "Credit"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "DateLet"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "Debit"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model:ir.model.fields,field_description:l10n_fr_fec.field_account_fr_fec__display_name
+msgid "Display Name"
+msgstr "Nom Affiché"
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "EcritureDate"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "EcritureLet"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "EcritureLib"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "EcritureNum"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model:ir.model.fields,field_description:l10n_fr_fec.field_account_fr_fec__date_to
+msgid "End Date"
+msgstr "Date de fin"
+
+#. module: l10n_fr_fec
+#: model:ir.model.fields,field_description:l10n_fr_fec.field_account_fr_fec__export_type
+msgid "Export Type"
+msgstr "Type d'Export"
 
 #. module: l10n_fr_fec
 #: model:ir.actions.act_window,name:l10n_fr_fec.account_fr_fec_action
@@ -38,90 +157,170 @@ msgid "FEC"
 msgstr ""
 
 #. module: l10n_fr_fec
-#: code:addons/l10n_fr_fec/wizard/fec.py:175
-#: code:addons/l10n_fr_fec/wizard/fec.py:179
-#, python-format
-msgid "Error:"
-msgstr "Erreur :"
-
-#. module: l10n_fr_fec
-#: field:account.fr.fec,state:0
-msgid "State"
-msgstr ""
-
-#. module: l10n_fr_fec
-#: field:account.fr.fec,filename:0
-msgid "Filename"
-msgstr "Nom du fichier"
-
-#. module: l10n_fr_fec
-#: field:account.fr.fec,fec_data:0
+#: model:ir.model.fields,field_description:l10n_fr_fec.field_account_fr_fec__fec_data
 msgid "FEC File"
 msgstr "Fichier FEC"
 
 #. module: l10n_fr_fec
-#: field:account.fr.fec,fiscalyear_id:0
-msgid "Fiscal Year"
-msgstr "Année fiscale"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "FEC File Generation"
+msgstr "Génération du fichier FEC"
 
 #. module: l10n_fr_fec
-#: field:account.fr.fec,type:0
-msgid "Company Type"
-msgstr "Type de société"
-
-#. module: l10n_fr_fec
-#: selection:account.fr.fec,state:0
-msgid "Done"
-msgstr ""
-
-#. module: l10n_fr_fec
-#: selection:account.fr.fec,state:0
-msgid "Draft"
-msgstr ""
-
-#. module: l10n_fr_fec
-#: code:addons/l10n_fr_fec/wizard/fec.py:176
+#: code:addons/l10n_fr_fec/wizard/account_fr_fec.py:0
 #, python-format
-msgid "Missing VAT number for company %s"
-msgstr "Numéro de TVA manquant sur la société %s"
+msgid "FEC is for French companies only !"
+msgstr "FEC n'est que pour les sociétés françaises !"
 
 #. module: l10n_fr_fec
-#: view:account.fr.fec:0
-msgid "Cancel"
-msgstr "Annuler"
-
-#. module: l10n_fr_fec
-#: view:account.fr.fec:0
-msgid "Close"
-msgstr "Fermer"
-
-#. module: l10n_fr_fec
-#: selection:account.fr.fec,type:0
-msgid "I.S. ou I.R. aux BIC"
+#: model:ir.model,name:l10n_fr_fec.model_account_fr_fec
+msgid "Ficher Echange Informatise"
 msgstr ""
 
 #. module: l10n_fr_fec
-#: view:account.fr.fec:0
+#: model:ir.model.fields,field_description:l10n_fr_fec.field_account_fr_fec__filename
+msgid "Filename"
+msgstr "Nom du fichier"
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
 msgid "Generate"
 msgstr "Générer"
 
 #. module: l10n_fr_fec
-#: code:addons/l10n_fr_fec/wizard/fec.py:180
+#: model:ir.model.fields,field_description:l10n_fr_fec.field_account_fr_fec__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "Idevise"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "JournalCode"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "JournalLib"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model:ir.model.fields,field_description:l10n_fr_fec.field_account_fr_fec____last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: l10n_fr_fec
+#: model:ir.model.fields,field_description:l10n_fr_fec.field_account_fr_fec__write_uid
+msgid "Last Updated by"
+msgstr "Dernière mise à jour par"
+
+#. module: l10n_fr_fec
+#: model:ir.model.fields,field_description:l10n_fr_fec.field_account_fr_fec__write_date
+msgid "Last Updated on"
+msgstr "Dernière mise à jour le"
+
+#. module: l10n_fr_fec
+#: code:addons/l10n_fr_fec/wizard/account_fr_fec.py:0
 #, python-format
-msgid "FEC is for French companies only !"
-msgstr "Le FEC est uniquement pour les sociétés françaises !"
+msgid "Missing VAT number for company %s"
+msgstr "Numéro de TVA manquant pour la société %s"
 
 #. module: l10n_fr_fec
-#: selection:account.fr.fec,export_type:0
-msgid "Official FEC report (posted entries only)"
-msgstr "Rapport FEC officiel (entrées postées uniquement)"
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "Montantdevise"
+msgstr ""
 
 #. module: l10n_fr_fec
-#: selection:account.fr.fec,export_type:0
+#: model:ir.model.fields.selection,name:l10n_fr_fec.selection__account_fr_fec__export_type__nonofficial
 msgid "Non-official FEC report (posted and unposted entries)"
-msgstr "Rapport FEC non-officiel (entrées postées et non-postées)"
+msgstr "Rapport FEC non-officiel (avec à la fois les entrées comptabilisées et non comptabilisées)"
 
 #. module: l10n_fr_fec
-#: field:account.fr.fec,export_type:0
-msgid "Export Type"
-msgstr "Type d'export"
+#: model:ir.model.fields.selection,name:l10n_fr_fec.selection__account_fr_fec__export_type__official
+msgid "Official FEC report (posted entries only)"
+msgstr "Rapport FEC officiel (uniquement les entrées comptabilisées)"
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "Options"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "PieceDate"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "PieceRef"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model:ir.model.fields,field_description:l10n_fr_fec.field_account_fr_fec__date_from
+msgid "Start Date"
+msgstr "Date de début"
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "Technical Info"
+msgstr "Information Technique"
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "Technical Name"
+msgstr "Nom Technique"
+
+#. module: l10n_fr_fec
+#: model:ir.model.fields,field_description:l10n_fr_fec.field_account_fr_fec__test_file
+msgid "Test File"
+msgstr "Fichier de Test"
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid ""
+"The encoding of this text file is UTF-8. The structure of file is CSV "
+"separated by pipe '|'."
+msgstr ""
+"L'encodage de ce fichier texte est UTF-8. La structure du fichier est CSV "
+"séparé par un pipe '|'."
+
+#. module: l10n_fr_fec
+#: code:addons/l10n_fr_fec/wizard/account_fr_fec.py:0
+#, python-format
+msgid "The start date must be inferior to the end date."
+msgstr "La date de début doit être avant la date de fin."
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "ValidDate"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid "We use partner.id"
+msgstr "Nous utilisons partner.id"
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid ""
+"When you download a FEC file, the lock date is set to the end date.\n"
+"                If you want to test the FEC file generation, please tick the test file checkbox."
+msgstr ""
+"Quand vous téléchargez un fichier FEC, la date de verrouillage est configurée avec la date de fin.\n
+"                Si vous voulez tester la génération du fichier FEC, cliquez sur la coche Fichier de Test."
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid ""
+"You are in test mode. The FEC file generation will not set the lock date."
+msgstr ""
+"Vous êtes en mode test. La génération du fichier FEC ne configurera la date de verrouillage."
+
+#. module: l10n_fr_fec
+#: code:addons/l10n_fr_fec/wizard/account_fr_fec.py:0
+#, python-format
+msgid "You could not set the start date or the end date in the future."
+msgstr "Vous ne pouvez pas utiliser une date de début ou de fin dans le futur."

--- a/addons/l10n_fr_fec/i18n/l10n_fr_fec.pot
+++ b/addons/l10n_fr_fec/i18n/l10n_fr_fec.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 13.0\n"
+"Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-29 15:06+0000\n"
-"PO-Revision-Date: 2020-01-29 15:06+0000\n"
+"POT-Creation-Date: 2021-10-27 14:43+0000\n"
+"PO-Revision-Date: 2021-10-27 14:43+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -274,10 +274,21 @@ msgid "Technical Name"
 msgstr ""
 
 #. module: l10n_fr_fec
+#: model:ir.model.fields,field_description:l10n_fr_fec.field_account_fr_fec__test_file
+msgid "Test File"
+msgstr ""
+
+#. module: l10n_fr_fec
 #: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
 msgid ""
 "The encoding of this text file is UTF-8. The structure of file is CSV "
 "separated by pipe '|'."
+msgstr ""
+
+#. module: l10n_fr_fec
+#: code:addons/l10n_fr_fec/wizard/account_fr_fec.py:0
+#, python-format
+msgid "The start date must be inferior to the end date."
 msgstr ""
 
 #. module: l10n_fr_fec
@@ -288,4 +299,23 @@ msgstr ""
 #. module: l10n_fr_fec
 #: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
 msgid "We use partner.id"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid ""
+"When you download a FEC file, the lock date is set to the end date.\n"
+"                If you want to test the FEC file generation, please tick the test file checkbox."
+msgstr ""
+
+#. module: l10n_fr_fec
+#: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+msgid ""
+"You are in test mode. The FEC file generation will not set the lock date."
+msgstr ""
+
+#. module: l10n_fr_fec
+#: code:addons/l10n_fr_fec/wizard/account_fr_fec.py:0
+#, python-format
+msgid "You could not set the start date or the end date in the future."
 msgstr ""


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Missing translations in French

Current behavior before PR: Terms for this French module are in English

Desired behavior after PR is merged: Terms are properly translated


@mart-e I have created another PR on l10n_fr_fec as suggested in #78932


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
