### PR TITLE
[FIX] calendar: email calendar event attendees

### DIFF
--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -360,7 +360,7 @@
             <field name="model_id" ref="calendar.model_calendar_event"/>
             <field name="subject">{{object.name}}: Event update</field>
             <field name="email_from">{{ (object.user_id.email_formatted or user.email_formatted or '') }}</field>
-            <field name="email_to"></field>
+            <field name="email_to">{{ object._get_attendee_emails() }}</field>
             <field name="lang">{{ object.partner_id.lang }}</field>
             <field name="body_html" type="html">
 <div>

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -695,6 +695,11 @@ class Meeting(models.Model):
     # MAILING
     # ------------------------------------------------------------
 
+    def _get_attendee_emails(self):
+        """ Get comma-separated attendee email addresses. """
+        self.ensure_one()
+        return ",".join([e for e in self.attendee_ids.mapped("email") if e])
+
     def _sync_activities(self, fields):
         # update activities
         for event in self:


### PR DESCRIPTION
When clicking on the "email" button in the `calendar.event` form view, the `email_to` field should be filled with the list of attendee email addresses separated by a comma.

opw-2667016

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
