### PR TITLE
[FIX] web_tour, website{_*}: avoid reviving destroyed tip and other tour fixes

### DIFF
--- a/addons/web_tour/static/src/js/tip.js
+++ b/addons/web_tour/static/src/js/tip.js
@@ -115,6 +115,10 @@ var Tip = Widget.extend({
         this.$el.toggleClass('d-none', !!this.info.hidden);
         this.el.classList.add('o_tooltip_visible');
         core.bus.on("resize", this, _.debounce(function () {
+            if (this.isDestroyed()) {
+                // Because of the debounce, destroy() might have been called in the meantime.
+                return;
+            }
             if (this.tip_opened) {
                 this._to_bubble_mode(true);
             } else {
@@ -203,6 +207,11 @@ var Tip = Widget.extend({
      */
     _updatePosition: function (forceReposition = false) {
         if (this.info.hidden) {
+            return;
+        }
+        if (this.isDestroyed()) {
+            // TODO This should not be needed if the chain of events leading
+            // here was fully cancelled by destroy().
             return;
         }
         let halfHeight = 0;

--- a/addons/web_tour/static/src/js/tip.js
+++ b/addons/web_tour/static/src/js/tip.js
@@ -180,6 +180,17 @@ var Tip = Widget.extend({
     },
 
     //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * @return {boolean} true if tip is visible
+     */
+    isShown() {
+        return this.el && !this.info.hidden;
+    },
+
+    //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
 
@@ -406,6 +417,10 @@ var Tip = Widget.extend({
         }
         $consumeEventAnchors.on(consumeEvent + ".anchor", (function (e) {
             if (e.type !== "mousedown" || e.which === 1) { // only left click
+                if (this.info.consumeVisibleOnly && !this.isShown()) {
+                    // Do not consume non-displayed tips.
+                    return;
+                }
                 this.trigger("tip_consumed");
                 this._unbind_anchor_events();
             }

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -136,6 +136,7 @@ function changePaddingSize(direction) {
     return {
         trigger: `.oe_overlay.ui-draggable.o_we_overlay_sticky.oe_active .o_handle.${paddingDirection}`,
         content: _.str.sprintf(_t("<b>Slide</b> this button to change the %s padding"), direction),
+        consumeEvent: 'mousedown',
         position: position,
     };
 }

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -39,8 +39,9 @@ tour.register('rte_translator', {
     extra_trigger: 'html[lang*="pa-GB"]',
 }, {
     content: "Open new page menu",
-    trigger: '#new-content-menu > a',
+    trigger: "body:has(#o_new_content_menu_choices.o_hidden) #new-content-menu > a",
     extra_trigger: 'a[data-action="edit"]',
+    consumeVisibleOnly: true,
 }, {
     content: "click on new page",
     trigger: 'a[data-action="new_page"]',

--- a/addons/website_blog/static/src/js/tours/website_blog.js
+++ b/addons/website_blog/static/src/js/tours/website_blog.js
@@ -9,10 +9,10 @@ odoo.define("website_blog.tour", function (require) {
     tour.register("blog", {
         url: "/",
     }, [{
-        trigger: '#new-content-menu > a',
+        trigger: "body:has(#o_new_content_menu_choices.o_hidden) #new-content-menu > a",
         content: _t("Click here to add new content to your website."),
+        consumeVisibleOnly: true,
         position: 'bottom',
-
     }, {
         trigger: "a[data-action=new_blog_post]",
         content: _t("Select this menu item to create a new blog post."),

--- a/addons/website_blog/static/src/js/tours/website_blog.js
+++ b/addons/website_blog/static/src/js/tours/website_blog.js
@@ -38,6 +38,7 @@ odoo.define("website_blog.tour", function (require) {
         position: "top",
     }, {
         trigger: ".o_select_media_dialog .o_existing_attachment_cell:first img",
+        alt_trigger: ".o_select_media_dialog .o_we_existing_attachments",
         extra_trigger: '.modal:has(.o_existing_attachment_cell:first)',
         content: _t("Choose an image from the library."),
         position: "top",

--- a/addons/website_blog/static/src/js/tours/website_blog.js
+++ b/addons/website_blog/static/src/js/tours/website_blog.js
@@ -31,7 +31,7 @@ odoo.define("website_blog.tour", function (require) {
         trigger: "we-button[data-background]:nth(1)",
         extra_trigger: "#wrap div[data-oe-expression=\"blog_post.name\"]:not(:containsExact(\"\"))",
         content: _t("Set a blog post <b>cover</b>."),
-        position: "right",
+        position: "top",
     }, {
         trigger: ".o_select_media_dialog .o_we_search",
         content: _t("Search for an image. (eg: type \"business\")"),

--- a/addons/website_sale/static/src/js/tours/website_sale_shop.js
+++ b/addons/website_sale/static/src/js/tours/website_sale_shop.js
@@ -7,9 +7,10 @@ odoo.define("website_sale.tour_shop", function (require) {
     // return the steps, used for backend and frontend
 
     return [{
-        trigger: "#new-content-menu > a",
+        trigger: "body:has(#o_new_content_menu_choices.o_hidden) #new-content-menu > a",
         content: _t("Let's create your first product."),
         extra_trigger: ".js_sale",
+        consumeVisibleOnly: true,
         position: "bottom",
     }, {
         trigger: "a[data-action=new_product]",

--- a/addons/website_slides/static/src/js/tours/slides_tour.js
+++ b/addons/website_slides/static/src/js/tours/slides_tour.js
@@ -9,8 +9,9 @@ var tour = require('web_tour.tour');
 tour.register('slides_tour', {
     url: '/slides',
 }, [{
-    trigger: '#new-content-menu > a',
+    trigger: "body:has(#o_new_content_menu_choices.o_hidden) #new-content-menu > a",
     content: _t("Welcome on your course's home page. It's still empty for now. Click on \"<b>New</b>\" to write your first course."),
+    consumeVisibleOnly: true,
     position: 'bottom',
 }, {
     trigger: 'a[data-action="new_slide_channel"]',


### PR DESCRIPTION
website{_*}: website, website_blog, website_sale, website_slides

Before this commit tips could be revived after being destroyed if a
resize event occurred, because the resize was being debounced and could
trigger a request to rebuild the bubble mode of the tip.

After this commit the resize debounce is cancelled if the tip was
destroyed in the meantime.

However another unidentified reason still manages to trigger an
asynchronous re-creation of the tip after destroy() is called, even
though all timeouts are cleared.
The following remaining sequence has been identified:
- mouseenter.anchor is triggered: but this is disabled during destroy
- it calls _to_info_mode() which registers the timer_in timeout: but
this timeout is cleared during destroy
- it calls _build_info_mode() which registers the _transitionEndTimer
timeout: but this timeout is cleared during destroy
- it calls _onTransitionEnd() which calls _updatePosition() which
revives the tip

Therefore an additional guard is added to prevent _updatePosition() from
being executed if destroy() was called.
Note that the mouseleave > to_bubble_mode chain being symmetrical to
this one, it is likely that it could also happen.

This PR also fixes the following issues:
- "+New" steps now only appear if the new content menu is not opened
- Only the visible "+New" step is consumed (instead of all colliding steps)
- The blog tour step about selecting an image now accepts any of the image (instead of only the first one)
- Move blog cover selection step on top of button. (instead of right which was outside the display)

task-2728994 (was task-2675252)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
