### PR TITLE
[IMP] sign: improve ui for buttons

### DIFF
--- a/addons/web/static/src/legacy/js/views/signature_dialog.js
+++ b/addons/web/static/src/legacy/js/views/signature_dialog.js
@@ -36,7 +36,7 @@ var SignatureDialog = Dialog.extend({
 
         if (!options.buttons) {
             options.buttons = [];
-            options.buttons.push({text: _t("Adopt and Sign"), classes: "btn-primary", disabled: true, click: function (e) {
+            options.buttons.push({text: _t("Adopt & Sign"), classes: "btn-primary", disabled: true, click: function (e) {
                 self._onConfirm();
             }});
             options.buttons.push({text: _t("Cancel"), close: true});

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -1297,7 +1297,7 @@
         </div>
         <div class="o_sign_signature card-body"/>
     </div>
-    <div class="mt16 small">By clicking Adopt and Sign, I agree that the chosen signature/initials will be a valid electronic representation of my hand-written signature/initials for all purposes when it is used on documents, including legally binding contracts.</div>
+    <div class="mt16 small">By clicking Adopt &amp; Sign, I agree that the chosen signature/initials will be a valid electronic representation of my hand-written signature/initials for all purposes when it is used on documents, including legally binding contracts.</div>
 
     <div class="o_sign_font_dialog card">
         <div class="card-header">Styles</div>

--- a/addons/web/static/src/legacy/xml/name_and_signature.xml
+++ b/addons/web/static/src/legacy/xml/name_and_signature.xml
@@ -103,6 +103,6 @@
     <div t-name="web.signature_dialog">
         <div class="o_web_sign_name_and_signature"/>
 
-        <div class="mt16 small">By clicking Adopt and Sign, I agree that the chosen signature/initials will be a valid electronic representation of my hand-written signature/initials for all purposes when it is used on documents, including legally binding contracts.</div>
+        <div class="mt16 small">By clicking Adopt &amp; Sign, I agree that the chosen signature/initials will be a valid electronic representation of my hand-written signature/initials for all purposes when it is used on documents, including legally binding contracts.</div>
     </div>
 </templates>


### PR DESCRIPTION
Put "Sign Now", "Send" and "Share" into the dropdown menu of "Action" button when the window is too small
Add add "Send" "Sign Now" and "Share" buttons in the list view
Make green saving Kanban in the center of the screen when the window is too small
Change the order of buttons for signature popover
Make "width: 30%" css only for buttons for signature popover to avoid text overflow
change 'Adopt and Sign' to 'Adopt & Sign'

before this commit: there are some overflow and misalignment for buttons

task-2630720

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
