### PR TITLE
[FIX] sale_product_configurator: show modal only once  w/ mode = options

### DIFF
--- a/addons/sale_product_configurator/static/src/js/product_configurator_renderer.js
+++ b/addons/sale_product_configurator/static/src/js/product_configurator_renderer.js
@@ -54,7 +54,9 @@ var ProductConfiguratorFormRenderer = FormRenderer.extend(VariantMixin, {
 
         this.triggerVariantChange($configuratorContainer);
         this._applyCustomValues();
-        this.trigger_up('handle_add');
+        if (this.state.context.configuratorMode !== 'options') {
+            this.trigger_up('handle_add');
+        }
     },
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When the product configurator option is enabled and a product
that has no variants but has optional products is opened, there
are two modals one on top of the other because of an extra
trigger of a handler.

**Current behavior before PR:**
The modal shows up twice, and needs to be closed twice.

**Desired behavior after PR is merged:**
The modal only shows up once and behaves as expected.


opw-2678887

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
