### PR TITLE
[FIX] mrp: compute MO's components status

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -296,7 +296,7 @@ class MrpProduction(models.Model):
         # Force to prefetch more than 1000 by 1000
         all_raw_moves._fields['forecast_availability'].compute_value(all_raw_moves)
         for production in productions:
-            if any(float_compare(move.forecast_availability, 0 if move.state == 'draft' else move.product_qty, move.product_id.uom_id.rounding) == -1 for move in production.move_raw_ids):
+            if any(float_compare(move.forecast_availability, 0 if move.state == 'draft' else move.product_qty, precision_rounding=move.product_id.uom_id.rounding) == -1 for move in production.move_raw_ids):
                 production.components_availability = _('Not Available')
                 production.components_availability_state = 'late'
             else:


### PR DESCRIPTION
The component status of a MO is not correctly computed

To reproduce the issue:
(Use demo data)
1. Create and confirm a MO for 1 x [FURN_9666] Table
2. Unlock and edit the target of To Consume Qty:
    - For [FURN_8522] Table Top: 0.1
    - For [FURN_2333] Table Leg: 0.1

Error: The Component Status of the MO becomes "Available" while Table
Top and Table Leg are not available.

Due to the signature of `float_compare`:
https://github.com/odoo/odoo/blob/56f8c1c0487bf95325ca859e2f266d1beed28ad4/odoo/tools/float_utils.py#L127
`move.product_id.uom_id.rounding` is implicitly given to
`precision_digits`, which is incorrect.

OPW-2669931