### PR TITLE
[FIX] stock : product location search more consistent

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -223,6 +223,9 @@ class Product(models.Model):
             for item in values:
                 if isinstance(item, int):
                     ids.add(item)
+                elif model == 'stock.location':
+                    domain = expression.OR([[('name', 'ilike', item)], domain])
+                    domain = expression.OR([[('complete_name', 'ilike', item)], domain])
                 else:
                     domain = expression.OR([[('name', 'ilike', item)], domain])
             if domain:


### PR DESCRIPTION
Current behaviour :
Searching on a location's complete name in stock.quant is enabled but not on product.product (for inventory report)

Behaviour after the PR :
Searching on a location's complete name is enabled for both search.

opw-2666202


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
