### PR TITLE
[FIX] delivery : translate 'Free Shipping'

### DIFF
--- a/addons/delivery/i18n/delivery.pot
+++ b/addons/delivery/i18n/delivery.pot
@@ -22,6 +22,12 @@ msgid " (Estimated Cost: %s )"
 msgstr ""
 
 #. module: delivery
+#: code:addons/delivery/models/sale_order.py:0
+#, python-format
+msgid "Free Shipping"
+msgstr ""
+
+#. module: delivery
 #: model_terms:ir.ui.view,arch_db:delivery.view_quant_package_weight_form
 msgid "(computed:"
 msgstr ""

--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -117,7 +117,7 @@ class SaleOrder(models.Model):
         else:
             values['price_unit'] = price_unit
         if carrier.free_over and self.currency_id.is_zero(price_unit) :
-            values['name'] += '\n' + 'Free Shipping'
+            values['name'] += '\n' + _('Free Shipping')
         if self.order_line:
             values['sequence'] = self.order_line[-1].sequence + 1
 


### PR DESCRIPTION
Problem : Free Shipping is not translated in delivery

New Behaviour : Free shipping will now be translated

opw-2679727

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
