### PR TITLE
[FIX] calendar: use given attendee states at event creation

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -46,7 +46,9 @@ class Attendee(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         for values in vals_list:
-            if values.get('partner_id') == self.env.user.partner_id.id:
+            # by default, if no state is given for the attendee corresponding to the current user
+            # that means he's the event organizer so we can set his state to "accepted"
+            if 'state' not in values and values.get('partner_id') == self.env.user.partner_id.id:
                 values['state'] = 'accepted'
             if not values.get("email") and values.get("common_name"):
                 common_nameval = values.get("common_name").split(':')

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -707,8 +707,12 @@ class Meeting(models.Model):
                                 activity_vals['user_id'] = user_id
                             values['activity_ids'] = [(0, 0, activity_vals)]
 
+        # Add commands to create attendees from partners (if present) if no attendee command
+        # is already given (coming from Google event for example).
         vals_list = [
-            dict(vals, attendee_ids=self._attendees_values(vals['partner_ids'])) if 'partner_ids' in vals else vals
+            dict(vals, attendee_ids=self._attendees_values(vals['partner_ids']))
+            if 'partner_ids' in vals and 'attendee_ids' not in vals
+            else vals
             for vals in vals_list
         ]
         recurrence_fields = self._get_recurrent_fields()


### PR DESCRIPTION
When an event is created from an external calendar account such as Google or Outlook, attendee info such as email and state may be given, and should be taken into account.

For example, if the current user who is syncing his calendar is not the organizer of the event, his attendee state should be set to 'needsAction' and not automatically set to 'accepted'.

opw-2489815

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
