### PR TITLE
[IMP] stock: display the SM's date on picking form 

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -373,7 +373,7 @@
                                     <field name="display_assign_serial" invisible="1"/>
                                     <field name="product_id" required="1" context="{'default_type': 'product'}" attrs="{'readonly': ['|', '&amp;', ('state', '!=', 'draft'), ('additional', '=', False), ('has_move_lines', '=', True)]}"/>
                                     <field name="description_picking" string="Description" optional="hide"/>
-                                    <field name="date" invisible="1"/>
+                                    <field name="date" optional="hide"/>
                                     <field name="date_deadline" optional="hide"/>
                                     <field name="is_initial_demand_editable" invisible="1"/>
                                     <field name="is_quantity_done_editable" invisible="1"/>


### PR DESCRIPTION
Adding the date of a SM on the picking form allows a user to reschedule
the delivery of a specific product instead of rescheduling the delivery
of all products.

Linked to OPW-2651828