### PR TITLE
[FIX] mrp_workorder: fix the WO planned date

### DIFF
--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -251,6 +251,8 @@ class MrpWorkcenter(models.Model):
                     else:
                         # Decrease a part of the remaining duration
                         remaining -= interval_minutes
+                        # Go to the next available interval because the possible current interval duration has been used
+                        break
         return False, 'Not available slot 700 days after the planned start'
 
     def action_archive(self):


### PR DESCRIPTION
we recently fixed this issue via this commit: https://github.com/odoo/odoo/pull/78377/commits/f3bb0dcc013960d6a43b9182b7daa5d33cab5aaa
But we forgot to add a “break” in the loop in order to go to the next available interval when the current interval duration has been used

the test has been modified to better cover the use case

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
