### PR TITLE
[IMP] l10n_ch: skip adding reports to invoice email

### DIFF
--- a/addons/l10n_ch/models/mail_template.py
+++ b/addons/l10n_ch/models/mail_template.py
@@ -30,7 +30,8 @@ class MailTemplate(models.Model):
                 inv_print_name = self._render_field('report_name', record.ids, compute_lang=True)[record.id]
                 new_attachments = []
 
-                if record.move_type == 'out_invoice' and record.partner_bank_id._eligible_for_qr_code('ch_qr', record.partner_id, record.currency_id):
+                include_qr_report = 'l10n_ch.l10n_ch_qr_report' not in self.env.context.get('l10n_ch_mail_skip_report', [])
+                if include_qr_report and record.move_type == 'out_invoice' and record.partner_bank_id._eligible_for_qr_code('ch_qr', record.partner_id, record.currency_id):
                     # We add an attachment containing the QR-bill
                     qr_report_name = 'QR-bill-' + inv_print_name + '.pdf'
                     qr_pdf = self.env.ref('l10n_ch.l10n_ch_qr_report')._render_qweb_pdf(record.ids)[0]


### PR DESCRIPTION
When sending an invoice by email the reports for ISR and QR are
automatically added if it is possible.

But for some systems, those reports are already joined to the base
report linked to the template and adding them is redudant.

This improvement adds the option to skip the addition of those reports
through a context variable.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
