### PR TITLE
[IMP] web_editor: allow shapes on gifs

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -25,6 +25,8 @@ const {
     applyModifications,
     removeOnImageChangeAttrs,
     isImageSupportedForProcessing,
+    createDataURL,
+    isGif,
 } = require('web_editor.image_processing');
 
 var qweb = core.qweb;
@@ -5004,10 +5006,11 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
      /**
      * @private
      * @param {HTMLImageElement} img
+     * @param {Boolean} [strict=false]
      * @returns {Boolean}
      */
-    _isImageSupportedForProcessing(img) {
-        return isImageSupportedForProcessing(this._getImageMimetype(img));
+    _isImageSupportedForProcessing(img, strict = false) {
+        return isImageSupportedForProcessing(this._getImageMimetype(img), strict);
     },
     /**
      * @override
@@ -5015,7 +5018,7 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
     _computeWidgetVisibility(widgetName, params) {
         if (this._isImageProcessingWidget(widgetName, params)) {
             const img = this._getImg();
-            return this._isImageSupportedForProcessing(img);
+            return this._isImageSupportedForProcessing(img, true);
         }
         return this._super(...arguments);
     },
@@ -5091,10 +5094,14 @@ registry.ImageTools = ImageHandlerOption.extend({
     async crop() {
         this.trigger_up('hide_overlay');
         this.trigger_up('disable_loading_effect');
-        new weWidgets.ImageCropWidget(this, this.$target[0]).appendTo(this.options.wysiwyg.odooEditor.document.body);
+        const img = this._getImg();
+        new weWidgets.ImageCropWidget(this, img, {mimetype: this._getImageMimetype(img)}).appendTo(this.options.wysiwyg.odooEditor.document.body);
 
         await new Promise(resolve => {
             this.$target.one('image_cropper_destroyed', async () => {
+                if (isGif(this._getImageMimetype(img))) {
+                    img.dataset[img.dataset.shape ? 'originalMimetype' : 'mimetype'] = 'image/png';
+                }
                 await this._reapplyCurrentShape();
                 resolve();
             });
@@ -5131,7 +5138,8 @@ registry.ImageTools = ImageHandlerOption.extend({
      * @see this.selectClass for parameters
      */
     async resetCrop() {
-        const cropper = new weWidgets.ImageCropWidget(this, this.$target[0]);
+        const img = this._getImg();
+        const cropper = new weWidgets.ImageCropWidget(this, img, {mimetype: this._getImageMimetype(img)});
         await cropper.appendTo(this.options.wysiwyg.odooEditor.document.body);
         await cropper.reset();
         await this._reapplyCurrentShape();
@@ -5299,13 +5307,7 @@ registry.ImageTools = ImageHandlerOption.extend({
         const blob = new Blob([svg.outerHTML], {
             type: 'image/svg+xml',
         });
-
-        const reader = new FileReader();
-        const readPromise = new Promise(resolve => {
-            reader.addEventListener('load', () => resolve(reader.result));
-        });
-        reader.readAsDataURL(blob);
-        const dataURL = await readPromise;
+        const dataURL = await createDataURL(blob);
         const imgFilename = (img.dataset.originalSrc.split('/').pop()).split('.')[0];
         img.dataset.fileName = `${imgFilename}.svg`;
         return loadImage(dataURL, img);
@@ -5439,7 +5441,7 @@ registry.ImageTools = ImageHandlerOption.extend({
      * @override
      */
     _getImageMimetype(img) {
-        if (img.dataset.shape) {
+        if (img.dataset.shape && img.dataset.originalMimetype) {
             return img.dataset.originalMimetype;
         }
         return this._super(...arguments);
@@ -5505,7 +5507,10 @@ registry.ImageTools = ImageHandlerOption.extend({
      * @override
      */
     _isImageProcessingWidget(widgetName, params) {
-        return this._super(...arguments) || widgetName === 'shape_img_opt';
+        if (widgetName === 'shape_img_opt') {
+            return !isGif(this._getImageMimetype(this._getImg()));
+        }
+        return this._super(...arguments);
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop_widget.js
@@ -19,7 +19,7 @@ const ImageCropWidget = Widget.extend({
     /**
      * @constructor
      */
-    init(parent, media) {
+    init(parent, media, options = {}) {
         this._super(...arguments);
         this.media = media;
         this.$media = $(media);
@@ -37,7 +37,8 @@ const ImageCropWidget = Widget.extend({
         const data = Object.assign({}, media.dataset);
         this.initialSrc = src;
         this.aspectRatio = data.aspectRatio || "0/0";
-        this.mimetype = data.mimetype || src.endsWith('.png') ? 'image/png' : 'image/jpeg';
+        const mimetype = data.mimetype || src.endsWith('.png') ? 'image/png' : 'image/jpeg';
+        this.mimetype = options.mimetype || mimetype;
     },
     /**
      * @override
@@ -145,7 +146,7 @@ const ImageCropWidget = Widget.extend({
             }
         });
         delete this.media.dataset.resizeWidth;
-        this.initialSrc = await applyModifications(this.media);
+        this.initialSrc = await applyModifications(this.media, {forceModification: true, mimetype: this.mimetype});
         this.media.classList.toggle('o_we_image_cropped', cropped);
         this.$media.trigger('image_cropped');
         this.destroy();


### PR DESCRIPTION
To apply shapes on images, we need to store them
(in base64) inside the shape SVG, but before that,
we need to use 'applyModifications()' to get the
dataURL that contains the image with applied filters
and size options...(see ImageOptimize > _writeShape).
But since we can't handle GIFs on applyModifications(),
we get a single frame of the animation as a result...

The goal of this commit is to skip the updates from
'applyModification()' (when the target is a .GIF) and
only apply the shape.

This way, other "data-attributes" options should be
disabled for GIFs and only shapes option is allowed.

task-2679905
