### PR TITLE
[REF] web_editor: clarify method names

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2230,7 +2230,7 @@ export class OdooEditor extends EventTarget {
         this._computeHistorySelection();
 
         const selection = this.document.getSelection();
-        this._updateToolbar(this._isSelectionInEditable(selection));
+        this._updateToolbar(!selection.isCollapsed && this._isSelectionInEditable(selection));
 
         if (this._currentMouseState === 'mouseup') {
             this._fixFontAwesomeSelection();
@@ -2252,9 +2252,7 @@ export class OdooEditor extends EventTarget {
      * @returns {boolean}
      */
     _isSelectionInEditable(selection) {
-        return !selection.isCollapsed &&
-            this.editable.contains(selection.anchorNode) &&
-            this.editable.contains(selection.focusNode);
+        return this.editable.contains(selection.anchorNode) && this.editable.contains(selection.focusNode);
     }
     getCurrentCollaborativeSelection() {
         const selection = this._latestComputedSelection || this._computeHistorySelection();


### PR DESCRIPTION
The name _isSelectionInEditable suggested any selection but
it was only when the selection wasn't collapsed which is missleading.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
