### PR TITLE
[IMP] hr: display employees kanban from department

### DIFF
--- a/addons/hr/models/hr_department.py
+++ b/addons/hr/models/hr_department.py
@@ -91,3 +91,18 @@ class Department(models.Model):
                 ('parent_id', '=', department.manager_id.id)
             ])
         employees.write({'parent_id': manager_id})
+
+    def get_formview_action(self, access_uid=None):
+        res = super().get_formview_action(access_uid=access_uid)
+        if (not self.user_has_groups('hr.group_hr_user') and
+           self.env.context.get('open_employees_kanban', False)):
+            res.update({
+                'name': self.name,
+                'res_model': 'hr.employee.public',
+                'view_type': 'kanban',
+                'view_mode': 'kanban',
+                'views': [(False, 'kanban'), (False, 'form')],
+                'context': {'searchpanel_default_department_id': self.id},
+                'res_id': False,
+            })
+        return res

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -59,7 +59,7 @@
                                     <field name="work_email" widget="email"/>
                                 </group>
                                 <group>
-                                    <field name="department_id"/>
+                                    <field name="department_id" context="{'open_employees_kanban': 1}"/>
                                     <field name="employee_type"/>
                                     <field name="company_id" groups="base.group_multi_company"/>
                                     <field name="parent_id"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Display the kanban view of the employees when clicking on the department from the employee form

Current behavior before PR:
Clicking on the department from the employee form displays the default form for the department

Desired behavior after PR is merged:
Clicking on the department from the employee form displays the kanban views with the employees of the department

task-2678198

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
