### PR TITLE
[FIX] website_sale: fix a traceback on saving

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -771,6 +771,7 @@ publicWidget.registry.WebsiteSaleLayout = publicWidget.Widget.extend({
      * @param {Event} ev
      */
     _onApplyShopLayoutChange: function (ev) {
+        const wysiwyg =  $('#wrapwrap').data('wysiwyg');
         var switchToList = $(ev.currentTarget).find('.o_wsale_apply_list input').is(':checked');
         if (!this.editableMode) {
             this._rpc({
@@ -779,6 +780,10 @@ publicWidget.registry.WebsiteSaleLayout = publicWidget.Widget.extend({
                     'layout_mode': switchToList ? 'list' : 'grid',
                 },
             });
+        } else {
+            // If in edit mode, we need to stop the observer so that it
+            // doesn't apply o_dirty to every products that are in the list.
+            wysiwyg.odooEditor.observerUnactive();
         }
         var $grid = this.$('#products_grid');
         // Disable transition on all list elements, then switch to the new
@@ -789,6 +794,9 @@ publicWidget.registry.WebsiteSaleLayout = publicWidget.Widget.extend({
         $grid.toggleClass('o_wsale_layout_list', switchToList);
         void $grid[0].offsetWidth;
         $grid.find('*').css('transition', '');
+        if (this.editableMode) {
+            wysiwyg.odooEditor.observerActive();
+        }
     },
 });
 


### PR DESCRIPTION
Prior to this commit, when editing the product list,
saving after switching to list view would cause a traceback.
This was caused because switching to list view would flag every field
(so every product) as o_dirty which means they would be saved.
Some elements of the page shouldn't be edited but would also be
flagged as o_dirty causing the traceback.

task-2670809


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
