### PR TITLE
[FIX] hr_holidays: default_employee_ids undefined when making an allocation request

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar.js
@@ -134,7 +134,6 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
                     res_model: "hr.leave.allocation",
                     view_id: ids,
                     context: {
-                        'default_employee_ids': self.context.employee_id,
                         'default_state': 'confirm',
                     },
                     title: _t("New Allocation"),


### PR DESCRIPTION
Steps to follow

  - Go to the time off app
  - Click on the allocation request button
  - Edit the Time Off Type
  -> A stacktrace appears

Cause of the issue

  The action use the context.employee_id when creating the dialog.
  This is set when coming directly from the employee app and clicking on
  the time off smart button.
  It is undefined when going directly to the time off app.

Solution

  if context.employee_id is undefined, use the id of the employee
  related to the current user.

opw-2682568