### PR TITLE
[FIX] project: prevent duplication of project update stat button

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -357,18 +357,6 @@
                                 </span>
                             </div>
                         </button>
-                        <button class="oe_stat_button" name="%(project.project_update_all_action)d" type="action" groups="project.group_project_manager">
-                            <div class="pl-4">
-                                <field name="last_update_color" invisible="1"/>
-                                <field name="last_update_status" widget="status_with_color" options="{'color_field': 'last_update_color'}"/>
-                            </div>
-                        </button>
-                        <button class="oe_stat_button o_project_not_clickable" disabled="disabled" groups="!project.group_project_manager">
-                            <div class="pl-4">
-                                <field name="last_update_color" invisible="1"/>
-                                <field name="last_update_status" widget="status_with_color" options="{'color_field': 'last_update_color', 'no_quick_edit': 1}"/>
-                            </div>
-                        </button>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title">


### PR DESCRIPTION
Prior to this fix:

    The project update stat button is duplicated.

After this fix:

    The project update stat button is no more duplicated.

task-2684233

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
