### PR TITLE
[FIX] test_website_slides_full: activate variants to avoid deinstalla…

### DIFF
--- a/addons/test_website_slides_full/__manifest__.py
+++ b/addons/test_website_slides_full/__manifest__.py
@@ -16,6 +16,9 @@ certification flow including purchase, certification, failure and success.
         'website_slides_survey',
         'payment_test'
     ],
+    'data': [
+        'data/res_groups_data.xml',
+    ],
     'demo': [
         'data/product_demo.xml',
     ],

--- a/addons/test_website_slides_full/data/res_groups_data.xml
+++ b/addons/test_website_slides_full/data/res_groups_data.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <!-- We want to activate product variant by default for testing product
+             configurator. Otherwise Odoo want to de-install the whole module due
+             to dependency chain. -->
+        <record id="base.group_user" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('product.group_product_variant'))]"/>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
…tion

We want to activate product variant by default for testing product configurator.
Otherwise Odoo want to de-install the whole module due to dependency chain.

Task-2677144
