### PR TITLE
[FIX] web_editor: fix link label edition

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -31,6 +31,8 @@ const Link = Widget.extend({
             title: _t("Link to"),
         }, this.options));
 
+        this._setLinkContent = true;
+
         this.data = data || {};
         this.isButton = this.data.isButton;
         this.$button = $button;
@@ -201,7 +203,7 @@ const Link = Widget.extend({
         if (!this.$link.attr('target')) {
             this.$link[0].removeAttribute('target');
         }
-        if (data.content !== this.data.originalText || data.url !== this.data.url) {
+        if (this._setLinkContent && (data.content !== this.data.originalText || data.url !== this.data.url)) {
             const content = (data.content && data.content.length) ? data.content : data.url;
             // If there is a this.data.originalText, it means that we selected
             // the text and we could not change the content through the text

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -78,7 +78,9 @@ const LinkTools = Link.extend({
 
     applyLinkToDom() {
         this._observer.disconnect();
+        this.options.wysiwyg.odooEditor.observerActive();
         this._super(...arguments);
+        this.options.wysiwyg.odooEditor.observerUnactive();
         this._observer.observe(this._link, {subtree: true, childList: true, characterData: true});
     },
 

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -245,7 +245,7 @@ const Wysiwyg = Widget.extend({
         // Ensure the Toolbar always have the correct layout in note.
         this._updateEditorUI();
 
-        this.$root.on('mousedown', (ev) => {
+        this.$root.on('click', (ev) => {
             const $target = $(ev.target);
 
             // Keep popover open if clicked inside it, but not on a button

--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -1,0 +1,69 @@
+/** @odoo-module */
+
+import tour from 'web_tour.tour';
+import wTourUtils from 'website.tour_utils';
+
+const clickOnImgStep = {
+    content: "Click somewhere else to save.",
+    trigger: '#wrap .s_text_image img',
+};
+
+tour.register('link_tools', {
+    test: true,
+    url: '/?enable_editor=1',
+}, [
+    // 1. Create a new link from scratch.
+    wTourUtils.dragNDrop({
+        id: 's_text_image',
+        name: 'Text - Image',
+    }),
+    {
+        content: "Replace first paragraph, to insert a new link",
+        trigger: '#wrap .s_text_image p',
+        run: 'text Go to odoo: '
+    },
+    {
+        content: "Open link tools",
+        trigger: "#toolbar #create-link",
+    },
+    {
+        content: "Type the link URL odoo.com",
+        trigger: '#o_link_dialog_url_input',
+        run: 'text odoo.com'
+    },
+    clickOnImgStep,
+    // 2. Edit the link with the link tools.
+    {
+        content: "Click on the newly created link, change content to odoo website",
+        trigger: '.s_text_image a[href="http://odoo.com"]:contains("odoo.com")',
+        run: 'text odoo website',
+    },
+    {
+        content: "Link tools, should be open, change the url",
+        trigger: '#o_link_dialog_url_input',
+        run: 'text odoo.be'
+    },
+    clickOnImgStep,
+    ...wTourUtils.clickOnSave(),
+    // 3. Edit a link after saving the page.
+    wTourUtils.clickOnEdit(),
+    {
+        content: "The new link content should be odoo website and url odoo.be",
+        extra_trigger: "#oe_snippets.o_loaded",
+        trigger: '.s_text_image a[href="http://odoo.be"]:contains("odoo website")',
+    },
+    {
+        content: "The new link content should be odoo website and url odoo.be",
+        trigger: '#toolbar button[data-original-title="Link Style"]',
+    },
+    {
+        content: "Click on the secondary style button.",
+        trigger: '#toolbar we-button[data-value="secondary"]',
+    },
+    ...wTourUtils.clickOnSave(),
+    {
+        content: "The link should have the secondary button style.",
+        trigger: '.s_text_image a.btn.btn-secondary[href="http://odoo.be"]:contains("odoo website")',
+        run: () => {}, // It's a check.
+    }
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -275,3 +275,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_14_carousel_snippet_content_removal(self):
         self.start_tour("/", "carousel_content_removal", login='admin')
+
+    def test_15_website_link_tools(self):
+        self.start_tour("/", "link_tools", login="admin")


### PR DESCRIPTION
When editing the link label from a website page, and then changing its
url from the link tools, the label was reset to what it was before the
edition. This commit fixes it by keeping the label consistent when
changing the link options from the link tools.

Some changes were made in the Link widget to choose what content to
display for the link:
- When a label is needed, the link text content will be the label input
value.
- When a link is created on some text, the content of the link will be
selected text. Same for the edition of a link.
- When a link is created from scratch, the text content will be the url,
as long as the url input is focused. Then the user can edit the link
content from the DOM.

task-2680461



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
