### PR TITLE
[FIX] web_editor: enable selection under toolbar triangle

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/style.css
+++ b/addons/web_editor/static/lib/odoo-editor/src/style.css
@@ -43,6 +43,7 @@
     border: transparent 10px solid;
     border-top: #222222 10px solid;
     z-index: 0;
+    pointer-events: none;
 }
 .oe-toolbar .button-group {
     display: inline-block;


### PR DESCRIPTION
In the editor, there was a little spot where it was impossible to
click in order to select a text.

Task-2684378




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
