### PR TITLE
[IMP] crm: add chatter on team member view to display trackings

### DIFF
--- a/addons/crm/models/crm_team_member.py
+++ b/addons/crm/models/crm_team_member.py
@@ -15,7 +15,7 @@ from odoo.osv import expression
 _logger = logging.getLogger(__name__)
 
 
-class Team(models.Model):
+class TeamMember(models.Model):
     _inherit = 'crm.team.member'
 
     # assignment

--- a/addons/sales_team/models/crm_team_member.py
+++ b/addons/sales_team/models/crm_team_member.py
@@ -137,6 +137,9 @@ class CrmTeamMember(models.Model):
                 else:
                     member.member_warning = False
 
+    # ------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------
 
     @api.model_create_multi
     def create(self, values_list):
@@ -146,11 +149,17 @@ class CrmTeamMember(models.Model):
             archived (a warning already told it in form view);
           * creating a membership already existing as archived: do nothing as
             people can manage them from specific menu "Members";
+
+        Also remove autofollow on create. No need to follow team members
+        when creating them as chatter is mainly used for information purpose
+        (tracked fields).
         """
         is_membership_multi = self.env['ir.config_parameter'].sudo().get_param('sales_team.membership_multi', False)
         if not is_membership_multi:
             self._synchronize_memberships(values_list)
-        return super(CrmTeamMember, self).create(values_list)
+        return super(CrmTeamMember, self.with_context(
+            mail_create_nosubscribe=True
+        )).create(values_list)
 
     def write(self, values):
         """ Specific behavior about active. If you change user_id / team_id user

--- a/addons/sales_team/views/crm_team_member_views.xml
+++ b/addons/sales_team/views/crm_team_member_views.xml
@@ -128,6 +128,10 @@
                         </group>
                     </group>
                 </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids"/>
+                    <field name="message_ids"/>
+                </div>
             </form>
         </field>
     </record>


### PR DESCRIPTION
Currently no chatter is added on team member form views. Indeed this model is
mainly technical and accessed through a dedicated menu in configuration.

However some fields are tracked and being able to see tracking information is
important in day to day dealing of team members. This is why we add chatter
on team members form view.

We also add context key to avoid autofollow when creating team members. As
information is mainly present for tracking and information no need to add
extra followers automaticallyK

Task-2679897
