### PR TITLE
[FIX] mrp : Auto-fill Number of SN for mass produce

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1758,6 +1758,7 @@ class MrpProduction(models.Model):
             'default_production_id': self.id,
             'default_expected_qty': self.product_qty,
             'default_next_serial_number': next_serial,
+            'default_next_serial_count': self.product_qty - self.qty_produced,
         }
         return action
 


### PR DESCRIPTION
Current Behaviour :
When mass producing with SN, the default number of SN to generate is set to 0.|

Behaviour after the PR :
When mass producing with SN, the default number of SN to generate is the number of item to produce.

opw-2680306

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
