### PR TITLE
[FIX] purchase: display POs maching same commercial partner

### DIFF
--- a/addons/purchase/views/account_move_views.xml
+++ b/addons/purchase/views/account_move_views.xml
@@ -14,7 +14,7 @@
                 <field name="purchase_vendor_bill_id" nolabel="1"
                        attrs="{'invisible': ['|', ('state','!=','draft'), ('move_type', '!=', 'in_invoice')]}"
                        class="oe_edit_only"
-                       domain="partner_id and [('company_id', '=', company_id), ('partner_id','child_of', [partner_id])] or [('company_id', '=', company_id)]"
+                       domain="partner_id and [('company_id', '=', company_id), ('partner_id.commercial_partner_id', '=', commercial_partner_id)] or [('company_id', '=', company_id)]"
                        placeholder="Select a purchase order or an old bill"
                        context="{'show_total_amount': True}"
                        options="{'no_create': True, 'no_open': True}"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- The "Auto-complete" bills field does not show all POs for the Vendor that are waiting for invoices.

Current behavior before PR:

1. Create PO1 Vendor = "Supplier"
2. Create PO2 Vendor = "Supplier, John Doe"
3. Create Invoice for PO2
4. In the PO2 Invoice, "Auto-Complete" field try to select PO1, but it is not shown.

Desired behavior after PR is merged:

- The "Auto-complete" bills field shows all POs for the Vendor that are waiting for invoices.

opw-2684409

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
