### PR TITLE
[FIX] web: incorrect object in render_values

### DIFF
--- a/addons/web/models/base_document_layout.py
+++ b/addons/web/models/base_document_layout.py
@@ -119,7 +119,7 @@ class BaseDocumentLayout(models.TransientModel):
                     wizard_with_logo = wizard
                 preview_css = self._get_css_for_preview(styles, wizard_with_logo.id)
                 ir_ui_view = wizard_with_logo.env['ir.ui.view']
-                wizard.preview = ir_ui_view._render_template('web.report_invoice_wizard_preview', {'company': wizard_with_logo, 'preview_css': preview_css})
+                wizard.preview = ir_ui_view._render_template('web.report_invoice_wizard_preview', {'company': wizard_with_logo.company_id, 'preview_css': preview_css})
             else:
                 wizard.preview = False
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
The render value is wrongly assigned with the wizard instead of the company field of the wizard

**Current behavior before PR:**
In case the company field is used in the preview with a field not available in the wizard a traceback blows up the onchange

**Desired behavior after PR is merged:**
Working as expected...

Info: @wt-io-it

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
