### PR TITLE
[IMP] calendar: inform user about event attendees with invalid email addresses

### DIFF
--- a/addons/calendar/tests/test_attendees.py
+++ b/addons/calendar/tests/test_attendees.py
@@ -68,3 +68,21 @@ class TestEventNotifications(TransactionCase):
         self.assertNotIn(self.partner, self.event.attendee_ids.partner_id, "It should have removed the attendee")
         self.assertNotIn(self.partner, self.event.message_follower_ids.partner_id, "It should have unsubscribed the partner")
         self.assertIn(partner_bis, self.event.attendee_ids.partner_id, "It should have left the attendee")
+
+    def test_attendee_without_email(self):
+        self.partner.email = False
+        self.event.partner_ids = self.partner
+
+        self.assertTrue(self.event.attendee_ids)
+        self.assertEqual(self.event.attendee_ids.partner_id, self.partner)
+        self.assertTrue(self.event.invalid_email_partner_ids)
+        self.assertEqual(self.event.invalid_email_partner_ids, self.partner)
+
+    def test_attendee_with_invalid_email(self):
+        self.partner.email = "I'm an invalid email"
+        self.event.partner_ids = self.partner
+
+        self.assertTrue(self.event.attendee_ids)
+        self.assertEqual(self.event.attendee_ids.partner_id, self.partner)
+        self.assertTrue(self.event.invalid_email_partner_ids)
+        self.assertEqual(self.event.invalid_email_partner_ids, self.partner)

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -136,6 +136,10 @@
                             <button name="action_open_composer" help="Send Email to attendees" type="object" string=" EMAIL" icon="fa-envelope"/>
                         </div>
                     </div>
+                    <div class="alert alert-warning o_form_header mt-2" attrs="{'invisible': [('invalid_email_partner_ids', '=', [])]}" role="status">
+                        <p><strong>The following attendees have invalid email addresses and won't receive any email notifications:</strong></p>
+                        <field name="invalid_email_partner_ids" widget="many2manyattendee" class="oe_inline o_calendar_attendees"/>
+                    </div>
                     <notebook>
                         <page name="page_details" string="Meeting Details">
                             <group>


### PR DESCRIPTION
If some attendees of an event have an empty or invalid email address, the organizer of this event should be informed that these attendees won't receive any email notifications.

opw-2667016

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
