### PR TITLE
[FIX] web: space in number are invalid [POC]

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -498,8 +498,15 @@ var NumericField = InputField.extend({
      * @param {Object} [options]
      */
     _setValue: function (value, options) {
+        if (core._t.database.parameters.thousands_sep) {
+            var escapedSep = _.str.escapeRegExp(core._t.database.parameters.thousands_sep);
+            value = value.replace(new RegExp(escapedSep, 'g'), '');
+        }
+        if (core._t.database.parameters.decimal_point) {
+            value = value.replace(core._t.database.parameters.decimal_point, '.');
+        }
+        value = value.replace(/[^0-9.+*/()^=-]/g, '')
         var originalValue = value;
-        value = value.trim();
         if (value.startsWith('=')) {
             try {
                 // Evaluate the formula


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When you copy past a number in number field, if the past value contains any space, unbreakable space, currency symbol, tabulation, ... the field became red. It is specially the case in France where the thousands separator is a space.
You loose time to remove every wrong character.
This PR remove all not "number" character.

Before
https://user-images.githubusercontent.com/16716992/140330591-7692f801-ad46-4fdc-807c-dd9eccd99294.mov

After
https://user-images.githubusercontent.com/16716992/140331032-90700eb5-5a19-4918-b9c7-908de8a6fb3a.mov


Note : it is a POC

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
