### PR TITLE
[FIX] web_editor: remove overlay of link

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -60,7 +60,7 @@ const LinkTools = Link.extend({
         if (!this.el) {
             return this._super(...arguments);
         }
-        this.$link.removeClass('oe_edited_link');
+        $(this.options.wysiwyg.odooEditor.document).find('.oe_edited_link').removeClass('oe_edited_link');
         const $contents = this.$link.contents();
         if (!this.$link.attr('href') && !this.colorCombinationClass) {
             $contents.unwrap();


### PR DESCRIPTION
Before this commit, in the website builder or in mass_mailing, when
creating a link then hitting enter, then click somewhere in the page,
the outline was not removed from all the links.

In mass mailing, the overlay was never removed. Not even upon save.

Task-2682176

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
