### PR TITLE
[FIX] pos_restaurant: submit order lines only once

### DIFF
--- a/addons/pos_restaurant/static/src/js/multiprint.js
+++ b/addons/pos_restaurant/static/src/js/multiprint.js
@@ -171,9 +171,7 @@ models.Order = models.Order.extend({
             var old  = {};
             var found = false;
             for(var id in old_res) {
-                const old_line_id = id.split('|')[0];
-                const new_line_id = line_hash.split('|')[0];
-                if(old_line_id === new_line_id){
+                if(old_res[id].product_id === curr.product_id){
                     found = true;
                     old = old_res[id];
                     break;


### PR DESCRIPTION
This commit reverts [1]. Otherwise, the same order lines may be
submitted several times.

To reproduce the issue:
(Use demo data)
1. Point of Sale > Configuration > Order Printers, edit Kitchen Printer:
    - Printed Product Categories: Food
2. Edit the POS Bar:
    - Enable Order Printer
3. Start a session of POS Bar
4. Select table T1
5. Add a Bacon Burger and submit the order
6. Open another table
7. Reopen table T1
8. Add a Cheese Burger and submit the order

Error: The ticket sent to the kitchen has the bacon burger and the
cheese burger. Only the last one should be sent to the kitchen

When selecting a table, a RPC call gets all information about the
current order. In the server response, the orderlines are sent as new
records:
https://github.com/odoo/odoo/blob/629a4f34ea66f10a981f4b25d5d69281f62853b6/addons/pos_restaurant/models/pos_order.py#L88
Therefore, the orderlines will have a new ID. However, since [1], the
lines identifiers are used to know which lines have changed. This
explains why the bacon burger is sent twice.

[1] aa81072e7fa1eafe794cfa5a2ccce328483a692c

OPW-2678701