### PR TITLE
[FIX] hr_holidays : Only show allocable leaves in allocation requests form

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -91,7 +91,7 @@
                     <group>
                         <group>
                             <field name="type_request_unit" invisible="1"/>
-                            <field name="holiday_status_id" context="{'employee_id':employee_id, 'default_date_from':current_date}"/>
+                            <field name="holiday_status_id" context="{'employee_id':employee_id, 'default_date_from':current_date}" domain="[('employee_requests', '=', 'yes')]"/>
 
                             <field name="allocation_type" invisible="1" widget="radio"
                                 attrs="{'readonly': ['|', ('is_officer', '=', False), ('state', 'not in', ('draft', 'confirm'))]}"/>


### PR DESCRIPTION
Current Behaviour :
Employee can request any type of leave.

Behaviour after the PR:
Employee are only shown leave that they can request.

opw-2684670

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
