### PR TITLE
[FIX] sale_mrp: avoid creating useless picking

### DIFF
--- a/addons/sale_mrp/models/sale_mrp.py
+++ b/addons/sale_mrp/models/sale_mrp.py
@@ -96,6 +96,6 @@ class SaleOrderLine(models.Model):
         # and after update, and return the difference. We don't take into account what was already
         # sent, or any other exceptional case.
         bom = self.env['mrp.bom']._bom_find(product=self.product_id, bom_type='phantom')
-        if bom and previous_product_uom_qty:
-            return previous_product_uom_qty and previous_product_uom_qty.get(self.id, 0.0)
+        if bom:
+            return previous_product_uom_qty and previous_product_uom_qty.get(self.id, 0.0) or self.qty_delivered
         return super(SaleOrderLine, self)._get_qty_procurement(previous_product_uom_qty=previous_product_uom_qty)


### PR DESCRIPTION
Steps to reproduce the bug:
- Install sale_management and sale_mrp
- Create a product with BOM, which is a KIT and add any product in BOM line
- Create a SO for the product > Confirm
- Validate the delivery
- Cancel the SO >  Set to Quotation > Reconfirm

Problem:
A new delivery order is generated while the ordered quantity = delivered quantity
This is because `_get_qty_procurement` wrongly computed the product quantity based on the moves quantities in the kit case.

opw-2647856




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
