### PR TITLE
[FIX] web_editor: properly fix link selection

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -133,7 +133,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
         // named so they are handled properly by the snippets menu.
         this.$content.find('.o_layout').addBack().data('name', 'Mailing');
         // We don't want to drop snippets directly within the wysiwyg.
-        this.$content.removeClass('o_editable').addClass('o_not_editable')
+        this.$content.removeClass('o_editable');
     },
     /**
      * Returns true if the editable area is empty.


### PR DESCRIPTION
There is a fix in the editor to fix link selection (see
_fixLinkMutatedElements). Prior to this commit, in mass mailing
the main editable element had the class `o_not_editable`.
This class on the editable disabled the link fix.

Also, it was semantically strange to have the editable being
`o_not_editable`.

Task-2684360

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
