### PR TITLE
[FIX] web

### DIFF
--- a/addons/web/static/src/core/network/rpc_service.js
+++ b/addons/web/static/src/core/network/rpc_service.js
@@ -31,7 +31,7 @@ export function makeErrorFromResponse(reponse) {
     const { code, data: errorData, message, type: subType } = reponse;
     const { context: data_context, name: data_name } = errorData || {};
     const { exception_class } = data_context || {};
-    const exception_class_name = exception_class || data_name;
+    const exception_class_name = data_name !== 'odoo.exceptions.UserError' ? exception_class || data_name : data_name;
     const error = new RPCError();
     error.exceptionName = exception_class_name;
     error.subType = subType;


### PR DESCRIPTION
- Show warning dialog for base_automation

Description of the issue/feature this PR addresses:
- Automated action cannot raise UserError anymore
- In odoo 14, it was supposed to raise a warning with the warning dialog template like 'odoo.exceptions.UserError'. 
- However in odoo 15, it will only so a base.automation error dialog even user only want to show the warning dialog.

Step to reproduce:
- Install base_automation module
- Install an app for the base_automation to trigger (e.g. Sales)
- Turn on debug mode
- Go to Automated Actions
- Create an action with Action To Do is Execute Python Code and the Trigger is On Creation & Update
- Set the model to your app (e.g. SalesOrder)
- Put `raise UserError('Test')` in Python Code section
- Go back to the app, try to create a new record in the model you set for the automated action to trigger
- Compare the result with odoo14

Current behavior before PR:
- It will show an error dialog which show a message with RPC error
![current](https://user-images.githubusercontent.com/85471608/140673916-c2f71d1c-048a-409b-8968-5d397eede2ad.png)

Desired behavior after PR is merged:
- It should show an User Warning like 14.0 version
![desire](https://user-images.githubusercontent.com/85471608/140673920-a723251f-86a3-482f-a7a9-80d180acec97.png)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-p
r
