### PR TITLE
[FIX] hr_holidays: Allocated extra days should stay constant

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -72,7 +72,7 @@ class HolidaysAllocation(models.Model):
         'Number of Days', compute='_compute_from_holiday_status_id', store=True, readonly=False, tracking=True, default=1,
         help='Duration in days. Reference field to use when necessary.')
     number_of_days_display = fields.Float(
-        'Duration (days)', compute='_compute_number_of_days_display',
+        'Duration (days)', default=1,
         states={'draft': [('readonly', False)], 'confirm': [('readonly', False)]},
         help="If Accrual Allocation: Number of days allocated in addition to the ones you will get via the accrual' system.")
     number_of_hours_display = fields.Float(
@@ -261,11 +261,6 @@ class HolidaysAllocation(models.Model):
             leave_type = allocation.holiday_status_id.with_context(employee_id=allocation.employee_id.id)
             allocation.max_leaves = leave_type.max_leaves
             allocation.leaves_taken = leave_type.leaves_taken
-
-    @api.depends('number_of_days')
-    def _compute_number_of_days_display(self):
-        for allocation in self:
-            allocation.number_of_days_display = allocation.number_of_days
 
     @api.depends('number_of_days', 'employee_id')
     def _compute_number_of_hours_display(self):


### PR DESCRIPTION
### Expected Behavior
When allocating some leave days with an accrual method, the displayed extra days should always stay the same even if the total amount of allocated days changes in time.

### Observed behaviour
In V14, the extra days evolve following the total number of allocated days.

### Reproducibility
This bug can be reproduced following these steps:
1. Create a new leave allocation, with an accrual method
2. Set the amount as 1 hour per working day and set the number of extra days 0
3. Change the date of your computer to the next working day
4. Wait for Odoo to trigger the update of the allocated days (a message should appears in the terminal)
5. Refresh the page of the allocation, the extra days number should have been updated

### Problem Root Cause
The problem comes from the fact we display allocation.number_of_days_display in the form, which was automaticcaly updated to be equal to allocation.number_of_days. This was an issue as the number_of_days is updated by the accrual rule.


### Related tickets
opw-2627964


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
