### PR TITLE
[FIX] mail: fix closing behavior on chat window

### DIFF
--- a/addons/mail/static/src/components/discuss/discuss.js
+++ b/addons/mail/static/src/components/discuss/discuss.js
@@ -26,7 +26,7 @@ export class Discuss extends Component {
         this.discuss.update({ isOpen: true });
         if (this.discuss.thread) {
             this.trigger('o-push-state-action-manager');
-        } else if (!this._activeThreadCache && this.discuss.messaging.isInitialized) {
+        } else if (!this._activeThreadCache && this.discuss.messaging.isInitialized && !this.discuss.messaging.device.isMobile) {
             this.discuss.openInitThread();
         }
         if (


### PR DESCRIPTION
To reproduce this bug:

* Open a channel in Discuss (eg: general, or a livechat)
* Switch to mobile
* Reload the page

You cannot use the arrow to close the channel.

task-2685187