### PR TITLE
[FIX] hr_holidays : no traceback when validate -> refuse -> to draft leave

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -650,7 +650,7 @@ class HolidaysRequest(models.Model):
     @api.constrains('state', 'number_of_days', 'holiday_status_id')
     def _check_holidays(self):
         for holiday in self:
-            if holiday.holiday_type != 'employee' or not holiday.employee_id or holiday.holiday_status_id.requires_allocation == 'no':
+            if holiday.holiday_type != 'employee' or not holiday.employee_id or not holiday.holiday_status_id or holiday.holiday_status_id.requires_allocation == 'no':
                 continue
             mapped_days = holiday.holiday_status_id.get_employees_days([holiday.employee_id.id], holiday.date_from)
             leave_days = mapped_days[holiday.employee_id.id][holiday.holiday_status_id.id]


### PR DESCRIPTION
Current Behaviour :

Go to Time off -> Approvals -> Time Off -> create one time off of type 'Annual Time Off 2021' for employees Anita, Abigail and Audrey -> validate -> refuse -> set to draft -> Traceback

Behaviour after the PR :

No traceback

opw-26842777


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
