### PR TITLE
[FIX] mrp: restrict _post_process_scheduler search domain

### DIFF
--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -96,5 +96,6 @@ class StockWarehouseOrderpoint(models.Model):
         self.env['mrp.production'].sudo().search([
             ('orderpoint_id', 'in', self.ids),
             ('move_raw_ids', '!=', False),
+            ('state', '=', 'draft'),
         ]).action_confirm()
         return super()._post_process_scheduler()


### PR DESCRIPTION
`stock.orderpoint._post_process_scheduler` confirms
productions after procurements have been run.

This avoids conflict between
procurements, conflicts that can happen e.g. in
the purchase_mrp module.

However, currently action_confirm might
also be called on done or cancelled productions.
That can happen if there are already been lots
of procurements for the same product/orderpoint,
i.e. MO with the same values have been created multiple times.

To avoid this, add `('state', '=', 'draft')` in the search_domain.

#### speed-up

In a customer DB with 16k mrp.production, the search in `_post_process_scheduler` returns
4190 productions, so calling `action_confirm` on a new MO takes around 1 min.

After the PR, the search only returns the 4 new productions created in `_run_manufacture`, 
making `action_confirm` run in ~700ms.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
