### PR TITLE
[FIX] payment_authorize: Deprecate redirect flow

### DIFF
--- a/addons/payment_authorize/data/payment_acquirer_data.xml
+++ b/addons/payment_authorize/data/payment_acquirer_data.xml
@@ -10,10 +10,9 @@
             <field name="view_template_id" ref="authorize_form"/>
             <field name="registration_view_template_id" ref="authorize_s2s_form"/>
             <field name="environment">test</field>
-            <field name="pre_msg"><![CDATA[
-<p>You will be redirected to the Authorize website after clicking on the payment button.</p>]]></field>
             <field name='authorize_login'>dummy</field>
             <field name="authorize_transaction_key">dummy</field>
+            <field name="payment_flow">s2s</field>
         </record>
 
     </data>

--- a/addons/payment_authorize/i18n/payment_authorize.pot
+++ b/addons/payment_authorize/i18n/payment_authorize.pot
@@ -168,6 +168,11 @@ msgid "The Customer Profile creation in Authorize.NET failed."
 msgstr ""
 
 #. module: payment_authorize
+#: sql_constraint:payment.acquirer:0
+msgid "The \"Redirection to the acquirer website\" payment flow is deprecated for Authorize.net. Please choose the \"Payment From Odoo\" flow."
+msgstr ""
+
+#. module: payment_authorize
 #: code:addons/payment_authorize/controllers/main.py:58
 #, python-format
 msgid "The transaction cannot be processed because some contact details are missing or invalid: "
@@ -181,6 +186,12 @@ msgstr ""
 #. module: payment_authorize
 #: model:ir.model.fields,help:payment_authorize.field_payment_token__save_token
 msgid "This option allows customers to save their credit card as a payment token and to reuse it for a later purchase. If you manage subscriptions (recurring invoicing), you need it to automatically charge the customer when you issue an invoice."
+msgstr ""
+
+#. module: payment_authorize
+#: code:addons/payment_authorize/models/payment.py:0
+#, python-format
+msgid "This payment method has been deprecated, please select another payment method or contact the administrator."
 msgstr ""
 
 #. module: payment_authorize

--- a/addons/payment_authorize/i18n/payment_authorize.pot
+++ b/addons/payment_authorize/i18n/payment_authorize.pot
@@ -169,7 +169,9 @@ msgstr ""
 
 #. module: payment_authorize
 #: sql_constraint:payment.acquirer:0
-msgid "The \"Redirection to the acquirer website\" payment flow is deprecated for Authorize.net. Please choose the \"Payment From Odoo\" flow."
+msgid ""
+"The \"%s\" payment flow is deprecated for Authorize.net. Please choose the \"%s\" flow.\n"
+"Acquirer names: %s"
 msgstr ""
 
 #. module: payment_authorize

--- a/addons/payment_authorize/models/payment.py
+++ b/addons/payment_authorize/models/payment.py
@@ -29,7 +29,7 @@ class PaymentAcquirerAuthorize(models.Model):
 
     @api.constrains('payment_flow')
     def _check_authorize_payment_flow(self):
-        for acquirer in self.filtered(lambda x: x.provider == "authorize"):
+        for acquirer in self.filtered(lambda x: x.provider == "authorize" and x.website_published):
             if acquirer.payment_flow == 'form':
                 raise UserError(_('The "Redirection to the acquirer website" payment flow is deprecated for Authorize.net. Please choose the "Payment From Odoo" flow.'))
 
@@ -196,8 +196,11 @@ class PaymentAcquirerAuthorize(models.Model):
 
     @api.multi
     def write(self, values):
-        super(PaymentAcquirerAuthorize, self).write(values)
+        res = super(PaymentAcquirerAuthorize, self).write(values)
+        # force the constraint check for any update on acquirers to alert
+        # as soon as possible if the acquirer cannot work in its current state
         self._check_authorize_payment_flow()
+        return res
 
     def render(self, reference, amount, currency_id, partner_id=False, values=None):
         try:

--- a/addons/payment_authorize/models/payment.py
+++ b/addons/payment_authorize/models/payment.py
@@ -29,7 +29,7 @@ class PaymentAcquirerAuthorize(models.Model):
 
     @api.constrains('payment_flow')
     def _check_authorize_payment_flow(self):
-        for acquirer in self:
+        for acquirer in self.filtered(lambda x: x.provider == "authorize"):
             if acquirer.payment_flow == 'form':
                 raise UserError(_('The "Redirection to the acquirer website" payment flow is deprecated for Authorize.net. Please choose the "Payment From Odoo" flow.'))
 

--- a/addons/payment_authorize/models/payment.py
+++ b/addons/payment_authorize/models/payment.py
@@ -31,8 +31,9 @@ class PaymentAcquirerAuthorize(models.Model):
     def _check_authorize_payment_flow(self):
         form_authorize_acquirers = self.filtered(lambda x: x.provider == "authorize" and x.payment_flow == "form")
         if form_authorize_acquirers:
-            form_string = [t[1] for t in self._fields['payment_flow']._description_selection(self.env) if t[0] == 'form'][0]
-            s2s_string = [t[1] for t in self._fields['payment_flow']._description_selection(self.env) if t[0] == 's2s'][0]
+            payment_flow_desc = {value: desc for value, desc in self._fields['payment_flow']._description_selection(self.env)}
+            form_string = payment_flow_desc.get('form', "Redirection to the acquirer website")
+            s2s_string = payment_flow_desc.get('s2s', "Payment from Odoo")
             raise UserError(_('The "%s" payment flow is deprecated for Authorize.net. Please choose the "%s" flow.\n'
                               'Acquirer names: %s' % (form_string, s2s_string, '\n'.join(form_authorize_acquirers.mapped('name')))))
 


### PR DESCRIPTION
After Authorize documentation, the redirection flow
as developed in Odoo is not supported anymore.
See https://developer.authorize.net/api/upgrade_guide.html#HTTP_GET

This is a try without touching any views to avoid
the need to update the module.

OPW-2671238