### PR TITLE
[FIX] web: title missing on reload

### DIFF
--- a/addons/web/static/src/js/chrome/action_manager.js
+++ b/addons/web/static/src/js/chrome/action_manager.js
@@ -734,9 +734,17 @@ var ActionManager = Widget.extend({
         var controller = this.controllers[controllerID];
         if (controller) {
             var action = this.actions[controller.actionID];
-            if (action.target === 'new' || action.pushState === false) {
-                // do not push state for actions in target="new" or for actions
-                // that have been explicitly marked as not pushable
+            if (action.target === 'new') {
+                // do not push state for actions in target="new"
+                return;
+            }
+            if (action.pushState === false) {
+                // do not push state for actions that have been explicitly
+                // marked as not pushable but trigger the title change
+                this.trigger_up('set_title_part', {
+                    part: "action",
+                    title: controller.widget.getTitle()
+                });
                 return;
             }
             state = _.extend({}, state, this._getControllerState(controller.jsID));


### PR DESCRIPTION
This commit fixes an issue of the webclient where the tab
was missing the name of the action in the title after a
fresh load of the page.
e.g. after a reload or when duplicating a tab in sales, the
title was 'Odoo' instead of 'S00001 - Odoo'.

Description of the issue/feature this PR addresses:
https://github.com/akretion/odoo-usability/pull/153#issuecomment-951828515
Current behavior before PR:
When the user refresh the page, the title is simply 'Odoo'
Desired behavior after PR is merged:
After a refresh, the title is unchanged. e.g. 'Quotations - Odoo'

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
