### PR TITLE
[FIX] tests: avoid chromium race conditions when saving screencast

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1017,10 +1017,11 @@ class ChromeBrowser():
 
     def start_screencast(self):
         if self.screencasts_dir:
+            self._logger.info("Starting screencast")
             os.makedirs(self.screencasts_dir, exist_ok=True)
             self.screencasts_frames_dir = os.path.join(self.screencasts_dir, 'frames')
             os.makedirs(self.screencasts_frames_dir, exist_ok=True)
-        self._websocket_send('Page.startScreencast')
+            self._websocket_send("Page.startScreencast")
 
     def set_cookie(self, name, value, path, domain):
         params = {'name': name, 'value': value, 'path': path, 'domain': domain}
@@ -1061,6 +1062,7 @@ class ChromeBrowser():
         return False
 
     def _wait_code_ok(self, code, timeout):
+        self.start_screencast()
         self._logger.info('Evaluate test code "%s"', code)
         code_id = self._websocket_send('Runtime.evaluate', params={'expression': code})
         start_time = time.time()
@@ -1330,9 +1332,6 @@ class HttpCase(TransactionCase):
             url = "%s%s" % (base_url, url_path or '/')
             self._logger.info('Open "%s" in browser', url)
 
-            if self.browser.screencasts_dir:
-                self._logger.info('Starting screencast')
-                self.browser.start_screencast()
             self.browser.navigate_to(url, wait_stop=not bool(ready))
 
             # Needed because tests like test01.js (qunit tests) are passing a ready


### PR DESCRIPTION
Before this patch, the screencast was started before running some other operations, such as navigate, that had to wait for responses with `._websocket_wait_id()`. That method discards any event that is not interesting for that specific call, but that means that some events that might be still interesting to future calls are lost forever (due to the async nature of event polling).

This means that some `Page.screencastFrame` events got triggered up before starting to listen for them, and thus got lost forever. Then, when the loop in `_wait_code_ok()` starts to listen for them, it won't notice it, so it won't send back the `Page.screencastFrameAck`, making Chromium never respond with the next screencast frame.

The end result was that, when this race condition happened, no screencast was produced.

Now, although the design of `_websocket_wait_id()` remains the same and is still conceptually buggy, at least we start the screencast just before starting to listen for it. The result is that no frames are lost and we always get the screencast frames.

A better fix would be to make `_websocket_wait_id()` properly handle its async nature. But that can be done tomorrow.

@Tecnativa TT31328


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
