### PR TITLE
[FIX] account: auto_install modules based on localizations

### DIFF
--- a/addons/account/__init__.py
+++ b/addons/account/__init__.py
@@ -48,19 +48,6 @@ def _auto_install_l10n(env):
                 module_list.append('l10n_' + country_code.lower())
             else:
                 module_list.append('l10n_generic_coa')
-        if country_code in ['US', 'CA']:
-            module_list.append('account_check_printing')
-        if country_code in SYSCOHADA_LIST + [
-            'AT', 'BE', 'CA', 'CO', 'DE', 'EC', 'ES', 'ET', 'FR', 'GR', 'IT', 'LU', 'MX', 'NL', 'NO',
-            'PL', 'PT', 'RO', 'SI', 'TR', 'GB', 'VE', 'VN'
-            ]:
-            module_list.append('base_vat')
-        if country_code == 'MX':
-            module_list.append('l10n_mx_edi')
-        if country_code == 'IT':
-            module_list.append('l10n_it_edi_sdicoop')
-        if country_code == 'SA':
-            module_list.append('l10n_sa_invoice')
 
         module_ids = env['ir.module.module'].search([('name', 'in', module_list), ('state', '=', 'uninstalled')])
         module_ids.sudo().button_install()

--- a/addons/l10n_it_edi/__manifest__.py
+++ b/addons/l10n_it_edi/__manifest__.py
@@ -10,6 +10,7 @@
         'fetchmail',
         'account_edi'
     ],
+    'auto_install': True,
     'author': 'Odoo',
     'description': """
 E-invoice implementation

--- a/addons/l10n_it_edi_sdicoop/__manifest__.py
+++ b/addons/l10n_it_edi_sdicoop/__manifest__.py
@@ -22,5 +22,6 @@ and then fetched by this module.
         'views/res_config_settings_views.xml',
     ],
     'post_init_hook': '_disable_pec_mail_post_init',
+    'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/l10n_sa_invoice/__manifest__.py
+++ b/addons/l10n_sa_invoice/__manifest__.py
@@ -14,4 +14,5 @@
         'views/view_move_form.xml',
         'views/report_invoice.xml',
     ],
+    'auto_install': True,
 }


### PR DESCRIPTION
Always check if modules need to be installed, based on a localization.

It was partially implemented in the post init hook, but the modules were
not installed correctly if we installed some localizations afterwards.

For instance, considering this list of modules:
* `account`
* `account_accountant` depending on `account`
* `account_reports` depending on `account_accountant`, auto installed
* `account_saft` depending on `account_reports`
* `l10n_lu` depending on `account`
* `l10n_lu_reports` depending on `l10n_lu` and `account_saft`, auto
  installed

If we install `account_accountant` and `l10n_lu`, `l10n_lu_reports` was
not installed because `account_saft` is not auto installed.

A fix similar was partially implemented in the post init hook of
`account` but it didn't work when installing new chart templates after
the initialisation of the database.
For instance, the module `base_vat` is needed in a big part of Europe
and Africa.
But if we initialized the database with a company in the US, then
created a company in one country requiring the `base_vat` module, it was
not installed automatically.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
