### PR TITLE
[ADD] Payment_authorize: add refund for Authorize.

### DIFF
--- a/addons/payment_authorize/data/payment_acquirer_data.xml
+++ b/addons/payment_authorize/data/payment_acquirer_data.xml
@@ -6,7 +6,7 @@
         <field name="inline_form_view_id" ref="inline_form"/>
         <field name="support_authorization">True</field>
         <field name="support_fees_computation">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">full_only</field>
         <field name="support_tokenization">True</field>
         <field name="allow_tokenization">True</field>
     </record>

--- a/addons/payment_authorize/models/authorize_request.py
+++ b/addons/payment_authorize/models/authorize_request.py
@@ -259,7 +259,7 @@ class AuthorizeAPI:
                 }
             }
 
-    def _get_transaction_details(self, transaction_id):
+    def get_transaction_details(self, transaction_id):
         """ Return detailed information about a specific transaction. Useful to issue refunds.
 
         :param str transaction_id: transaction id
@@ -316,18 +316,13 @@ class AuthorizeAPI:
         :return: a dict containing the response code, transaction id and transaction type
         :rtype: dict
         """
-        tx_details = self._get_transaction_details(transaction_id)
+        tx_details = self.get_transaction_details(transaction_id)
 
         if tx_details and tx_details.get('err_code'):
             return {
                 'x_response_code': self.AUTH_ERROR_STATUS,
                 'x_response_reason_text': tx_details.get('err_msg')
             }
-
-        # Void transaction not yet settled instead of issuing a refund
-        # (spoiler alert: a refund on a non settled transaction will throw an error)
-        if tx_details.get('transaction', {}).get('transactionStatus') in ['authorizedPendingCapture', 'capturedPendingSettlement']:
-            return self.void(transaction_id)
 
         card = tx_details.get('transaction', {}).get('payment', {}).get('creditCard', {}).get('cardNumber')
         response = self._make_request('createTransactionRequest', {


### PR DESCRIPTION
[ADD] payment_authorize: add refund for Authorize.
    
    Users can now ask for a refund from Odoo for their transactions done
    through Authorize.net. A refund will be triggered from Odoo when
    necessary.
    Only full refunds are possible.
    Note that unsettled transactions will be voided as they cannot be
    refunded.


Task - 2678757



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
