### PR TITLE
[FIX] sale_project: relabel correctly sale_order_id

### DIFF
--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -94,7 +94,9 @@
                 <field name="sale_order_id" string="Sale Order" filter_domain="['|', ('sale_order_id', 'ilike', self), ('sale_line_id', 'ilike', self)]"/>
             </xpath>
             <xpath expr="//search/group/filter[@name='customer']" position="after">
-                <filter string="Sales Order Item" name="sale_order_id" context="{'group_by': 'sale_order_id'}"/>
+                <!-- TODO: Remove me in master -->
+                <filter string="Sales Order" name="sale_order_id" context="{'group_by': 'sale_order_id'}" invisible="1"/>
+                <filter string="Sales Order Item" name="sale_line_id" context="{'group_by': 'sale_line_id'}"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Prior to this commit

    sale_order_id filter was shown as `Sales Order Item`.

After this commit:

    sale_order_id filter is shown as `Sales Order`.

task-2685356

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
