### PR TITLE
[FIX] crm: fix randomness in assign tests

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -808,17 +808,17 @@ class Lead(models.Model):
             if 'stage_id' in vals:
                 if vals['stage_id'] in won_stage_ids:
                     if lead.probability == 0:
-                        leads_leave_lost |= lead
-                    leads_reach_won |= lead
+                        leads_leave_lost += lead
+                    leads_reach_won += lead
                 elif lead.stage_id.id in won_stage_ids and lead.active:  # a lead can be lost at won_stage
-                    leads_leave_won |= lead
+                    leads_leave_won += lead
             if 'active' in vals:
                 if not vals['active'] and lead.active:  # archive lead
                     if lead.stage_id.id in won_stage_ids and lead not in leads_leave_won:
-                        leads_leave_won |= lead
-                    leads_reach_lost |= lead
+                        leads_leave_won += lead
+                    leads_reach_lost += lead
                 elif vals['active'] and not lead.active:  # restore lead
-                    leads_leave_lost |= lead
+                    leads_leave_lost += lead
 
         leads_reach_won._pls_increment_frequencies(to_state='won')
         leads_leave_won._pls_increment_frequencies(from_state='won')
@@ -940,7 +940,7 @@ class Lead(models.Model):
             if not stage_id:
                 stage_id = next((stage for stage in reversed(won_stages) if stage.sequence <= lead.stage_id.sequence), won_stages)
             if stage_id in leads_by_won_stage:
-                leads_by_won_stage[stage_id] |= lead
+                leads_by_won_stage[stage_id] += lead
             else:
                 leads_by_won_stage[stage_id] = lead
         for won_stage_id, leads in leads_by_won_stage.items():

--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import random
+
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from unittest.mock import patch
@@ -54,7 +56,7 @@ class TestLeadAssignCommon(TestLeadConvertCommon):
         self.assertEqual(self.sales_team_convert_m2.lead_month_count, 0)
 
 
-@tagged('lead_assign', '-standard')
+@tagged('lead_assign')
 class TestLeadAssign(TestLeadAssignCommon):
     """ Test lead assignment feature added in saas-14.2 """
 
@@ -177,6 +179,9 @@ class TestLeadAssign(TestLeadAssignCommon):
     def test_assign_duplicates(self):
         """ Test assign process with duplicates on partner. Allow to ensure notably
         that de duplication is effectively performed. """
+        # fix the seed and avoid randomness
+        random.seed(1940)
+
         leads = self._create_leads_batch(
             lead_type='lead',
             user_ids=[False],
@@ -206,10 +211,8 @@ class TestLeadAssign(TestLeadAssignCommon):
         leads_stc = leads.filtered_domain([('team_id', '=', self.sales_team_convert.id)])
 
         # check random globally assigned enough leads to team
-        self.assertLessEqual(len(leads_st1), 83)  # 75 * 122 / 165 * 1.5 (because random)
-        self.assertLessEqual(len(leads_stc), 100)  # 90 * 122 / 165 * 1.5 (because random)
-        self.assertGreaterEqual(len(leads_st1), 27)  # 75 * 122 / 165 * 0.5 (because random)
-        self.assertGreaterEqual(len(leads_stc), 33)  # 90 * 122 / 165 * 0.5 (because random)
+        self.assertEqual(len(leads_st1), 76)
+        self.assertEqual(len(leads_stc), 46)
         self.assertEqual(len(leads_st1) + len(leads_stc), len(leads))  # Make sure all lead are assigned
 
         # salespersons assign
@@ -233,6 +236,9 @@ class TestLeadAssign(TestLeadAssignCommon):
 
     @mute_logger('odoo.models.unlink')
     def test_assign_no_duplicates(self):
+        # fix the seed and avoid randomness
+        random.seed(1945)
+
         leads = self._create_leads_batch(
             lead_type='lead',
             user_ids=[False],
@@ -262,10 +268,8 @@ class TestLeadAssign(TestLeadAssignCommon):
         self.assertEqual(len(leads), 150)
 
         # check random globally assigned enough leads to team
-        self.assertLessEqual(len(leads_st1), 102)  # 75 * 150 / 165 * 1.5 (because random)
-        self.assertLessEqual(len(leads_stc), 123)  # 90 * 150 / 165 * 1.5 (because random)
-        self.assertGreaterEqual(len(leads_st1), 34)  # 75 * 150 / 165 * 0.5 (because random)
-        self.assertGreaterEqual(len(leads_stc), 41)  # 90 * 150 / 165 * 0.5 (because random)
+        self.assertEqual(len(leads_st1), 104)
+        self.assertEqual(len(leads_stc), 46)
         self.assertEqual(len(leads_st1) + len(leads_stc), len(leads))  # Make sure all lead are assigned
 
         # salespersons assign
@@ -274,12 +278,15 @@ class TestLeadAssign(TestLeadAssignCommon):
         self.assertMemberAssign(self.sales_team_1_m2, 4)  # 15 max on 2 days (1) + compensation (2.8)
         self.assertMemberAssign(self.sales_team_1_m3, 4)  # 15 max on 2 days (1) + compensation (2.8)
         self.assertMemberAssign(self.sales_team_convert_m1, 8)  # 30 max on 15 (2) + compensation (5.6)
-        self.assertMemberAssign(self.sales_team_convert_m2, 15)  # 60 max on 15 (4) + compsantion (11.2)
+        self.assertMemberAssign(self.sales_team_convert_m2, 15)  # 60 max on 15 (4) + compensation (11.2)
 
     @mute_logger('odoo.models.unlink')
     def test_assign_populated(self):
         """ Test assignment on a more high volume oriented test set in order to
         test more real life use cases. """
+        # fix the seed and avoid randomness (funny: try 1870)
+        random.seed(1871)
+
         # create leads enough to assign one month of work
         _lead_count, _email_dup_count, _partner_count = 600, 50, 150
         leads = self._create_leads_batch(

--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -8,7 +8,7 @@ from odoo.tests.common import tagged
 from odoo.tools import mute_logger
 
 
-@tagged('lead_assign', 'crm_performance', '-standard')
+@tagged('lead_assign', 'crm_performance')
 class TestLeadAssignPerf(TestLeadAssignCommon):
     """ Test performances of lead assignment feature added in saas-14.2
 
@@ -21,15 +21,13 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
     of random in tests.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        super(TestLeadAssignPerf, cls).setUpClass()
-        random.seed('crm_assign')
-
     @mute_logger('odoo.models.unlink', 'odoo.addons.crm.models.crm_team', 'odoo.addons.crm.models.crm_team_member')
     def test_assign_perf_duplicates(self):
         """ Test assign process with duplicates on partner. Allow to ensure notably
         that de duplication is effectively performed. """
+        # fix the seed and avoid randomness
+        random.seed(1940)
+
         leads = self._create_leads_batch(
             lead_type='lead',
             user_ids=[False],
@@ -50,7 +48,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         leads.flush()
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=1336):  # crm only: ??
+            with self.assertQueryCount(user_sales_manager=1363):  # 1354 ??
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
@@ -71,6 +69,9 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
 
     @mute_logger('odoo.models.unlink', 'odoo.addons.crm.models.crm_team', 'odoo.addons.crm.models.crm_team_member')
     def test_assign_perf_no_duplicates(self):
+        # fix the seed and avoid randomness
+        random.seed(1945)
+
         leads = self._create_leads_batch(
             lead_type='lead',
             user_ids=[False],
@@ -91,7 +92,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         leads.flush()
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=586):  # crm only: ?? (583 often)
+            with self.assertQueryCount(user_sales_manager=674):
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
@@ -112,6 +113,9 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
     def test_assign_perf_populated(self):
         """ Test assignment on a more high volume oriented test set in order to
         have more insights on query counts. """
+        # fix the seed and avoid randomness
+        random.seed(1871)
+
         # create leads enough to have interesting counters
         _lead_count, _email_dup_count, _partner_count = 600, 50, 150
         leads = self._create_leads_batch(
@@ -170,7 +174,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         leads.flush()
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=5861):  # crm only: ??
+            with self.assertQueryCount(user_sales_manager=6579):
                 self.env['crm.team'].browse(sales_teams.ids)._action_assign_leads(work_days=30)
 
         # teams assign


### PR DESCRIPTION
Seed is now fixed at beginning of each test to ensure random state is set
once for all and avoid random issues.

Task-2643740
