### PR TITLE
no longer used libsass~0.17.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,8 @@ idna==2.6
 Jinja2==2.10.1; python_version < '3.8'
 # bullseye version, focal patched 2.10
 Jinja2==2.11.2; python_version >= '3.8'
-libsass==0.17.0
+# no longer used libsass~0.17.0
+libsass==0.21.0
 lxml==3.7.1 ; sys_platform != 'win32' and python_version < '3.7'
 lxml==4.3.2 ; sys_platform != 'win32' and python_version == '3.7'
 lxml==4.6.1 ; sys_platform != 'win32' and python_version > '3.7'


### PR DESCRIPTION
no longer used libsass~0.17.0, so we need to used libsass~0.21.0,
I used to install python dependencies by below command 
sudo pip3 install -r /opt/odoo/requirements.txt,
but it stuck at libsass dependency, it tried to remove libsass from requirements.txt file, run again above command, it worked fine,
after this,  I installed that dependency separately by running below command,
sudo pip3 install libsass, 
this library contains styles/css for layout design, it will update latest version of libsass

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
