### PR TITLE
[FIX] base: return all the attachments in the is_css_preprocessed function

### DIFF
--- a/doc/cla/individual/zwgshr.md
+++ b/doc/cla/individual/zwgshr.md
@@ -1,0 +1,11 @@
+china, 2021-11-08
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Zhang WenGuang zwgmlr3@outlook.com https://github.com/zwgshr

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -408,7 +408,7 @@ class AssetsBundle(object):
 
     def is_css_preprocessed(self):
         preprocessed = True
-        attachments = None
+        old_attachments = self.env['ir.attachment']
         asset_types = [SassStylesheetAsset, ScssStylesheetAsset, LessStylesheetAsset]
         if self.user_direction == 'rtl':
             asset_types.append(StylesheetAsset)
@@ -419,6 +419,7 @@ class AssetsBundle(object):
             if assets:
                 assets_domain = self._get_assets_domain_for_already_processed_css(assets)
                 attachments = self.env['ir.attachment'].sudo().search(assets_domain)
+                old_attachments += attachments
                 for attachment in attachments:
                     asset = assets[attachment.url]
                     if asset.last_modified > attachment['__last_update']:
@@ -435,7 +436,7 @@ class AssetsBundle(object):
                 if outdated:
                     preprocessed = False
 
-        return preprocessed, attachments
+        return preprocessed, old_attachments
 
     def preprocess_css(self, debug=False, old_attachments=None):
         """


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Make the is_css_preprocessed function return all attachments that meet the conditions.

Current behavior before PR:

When there are both .less and .scss files, The is_css_preprocessed function only returns the attachments of the last type (.less)，cause .scss attachment to never be deleted.

Desired behavior after PR is merged:

return all the attachments in the for loop

#74952 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
