### PR TITLE
[FIX] accouting: fix 'unpaid invoice' filter on main dashboard

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -517,7 +517,7 @@ class ResPartner(models.Model):
             ('move_type', 'in', ('out_invoice', 'out_refund')),
             ('partner_id', 'child_of', self.id),
         ]
-        action['context'] = {'default_move_type':'out_invoice', 'move_type':'out_invoice', 'journal_type': 'sale', 'search_default_unpaid': 1}
+        action['context'] = {'default_move_type':'out_invoice', 'move_type':'out_invoice', 'journal_type': 'sale', 'search_default_open': 1}
         return action
 
     def can_edit_vat(self):

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -327,12 +327,12 @@
                             <div class="row" t-if="dashboard.number_waiting">
                                 <div class="col overflow-hidden text-left">
                                     <a type="object" t-if="journal_type == 'sale'" name="open_action"
-                                    context="{'search_default_unpaid':1, 'search_default_posted':1, 'search_default_partial': 1}" id="account_dashboard_sale_pay_link">
+                                    context="{'search_default_open':1, 'search_default_posted':1, 'search_default_partial': 1}" id="account_dashboard_sale_pay_link">
                                         <t t-esc="dashboard.number_waiting"/> Unpaid Invoices
                                     </a>
 
                                     <a type="object" t-if="journal_type == 'purchase'" name="open_action"
-                                    context="{'search_default_unpaid':1, 'search_default_posted':1, 'search_default_partial': 1}" id="account_dashboard_purchase_pay_link">
+                                    context="{'search_default_open':1, 'search_default_posted':1, 'search_default_partial': 1}" id="account_dashboard_purchase_pay_link">
                                         <t t-esc="dashboard.number_waiting"/> Bills to Pay
                                     </a>
                                 </div>


### PR DESCRIPTION
### Expected Behaviour
When clicking on the "XX Unpaid Invoices" link on the main dashboard of the accounting app, we should get to a list view with only unpaid (and partially paid) invoices

### Observed Behaviour
When cliking on the link, we get all the invoices, even the paid ones.

### Reproducibility
This bug can be reproduced following these steps :
1. Create some invoices
2. Make sure some of them are paid and some are not
3. Go to the main dashboard
4. Click on the "XX Unpaid Invoices" link in the "Customer Invoices" app

### Problem Root Cause
The problem comes from a change in the filter name from V14 to V15 ("unpaid" category has been replaced by "open").

### Related issues
- opw-2681099


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
