### PR TITLE
[REF] event: reduce code redundancy & unstore a field

### DIFF
--- a/addons/event/models/event_ticket.py
+++ b/addons/event/models/event_ticket.py
@@ -55,7 +55,7 @@ class EventTicket(models.Model):
         return res
 
     # description
-    event_type_id = fields.Many2one(ondelete='set null', required=False)
+    event_type_id = fields.Many2one('event.type', related='event_id.event_type_id')
     event_id = fields.Many2one(
         'event.event', string="Event",
         ondelete='cascade', required=True)

--- a/addons/event_booth/models/event_booth.py
+++ b/addons/event_booth/models/event_booth.py
@@ -15,7 +15,7 @@ class EventBooth(models.Model):
     ]
 
     # owner
-    event_type_id = fields.Many2one(ondelete='set null', required=False)
+    event_type_id = fields.Many2one('event.type', related='event_id.event_type_id')
     event_id = fields.Many2one('event.event', string='Event', ondelete='cascade', required=True)
     # customer
     partner_id = fields.Many2one('res.partner', string='Renter', tracking=True, copy=False)


### PR DESCRIPTION
The 'event.mail' model and the 'event.type.mail' have common fields and functions. To reduce the code redundancy, we will use the inheritance mechanism: The 'event.mail' model will now inherit from the 'event.type.mail' model.

On the 'event.event.ticket' model, the field 'event_type_id' will become a related field. By doing so, the field will no longer be stored in the database which slightly reduces the disk usage.

task-2602540

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
