### PR TITLE
[FIX] pos_adyen: Extend interval to poll for response

### DIFF
--- a/addons/pos_adyen/controllers/main.py
+++ b/addons/pos_adyen/controllers/main.py
@@ -27,6 +27,10 @@ class PosAdyenController(http.Controller):
             if data['SaleToPOIResponse'].get('DiagnosisResponse'):
                 payment_method.adyen_latest_diagnosis = data['SaleToPOIResponse']['MessageHeader']['ServiceID']
             else:
-                payment_method.adyen_latest_response = json.dumps(data)
+                TransactionID = json.dumps(data)['SaleToPOIResponse']['PaymentResponse']['SaleData']['SaleTransactionID'].get('TransactionID')
+                payment_identifier = TransactionID[:-4] + terminal_identifier
+                if type(payment_method.adyen_latest_response) is not dict:
+                    payment_method.adyen_latest_response = {}
+                payment_method.adyen_latest_response[payment_identifier] = json.dumps(data)
         else:
             _logger.error('received a message for a terminal not registered in Odoo: %s', terminal_identifier)

--- a/addons/pos_adyen/static/src/js/payment_adyen.js
+++ b/addons/pos_adyen/static/src/js/payment_adyen.js
@@ -28,7 +28,7 @@ var PaymentAdyen = PaymentInterface.extend({
     _reset_state: function () {
         this.was_cancelled = false;
         this.last_diagnosis_service_id = false;
-        this.remaining_polls = 9; // Give 21 * 5,5 secondes for the customer to pay
+        this.remaining_polls = 9;
         clearTimeout(this.polling);
     },
 
@@ -211,6 +211,7 @@ var PaymentAdyen = PaymentInterface.extend({
                 self.remaining_polls--;
             }
 
+            // Need check if payment_identifier match
             if (notification && notification.SaleToPOIResponse.MessageHeader.ServiceID == self.most_recent_service_id) {
                 var response = notification.SaleToPOIResponse.PaymentResponse.Response;
                 var additional_response = new URLSearchParams(response.AdditionalResponse);

--- a/addons/pos_adyen/static/src/js/payment_adyen.js
+++ b/addons/pos_adyen/static/src/js/payment_adyen.js
@@ -28,7 +28,7 @@ var PaymentAdyen = PaymentInterface.extend({
     _reset_state: function () {
         this.was_cancelled = false;
         this.last_diagnosis_service_id = false;
-        this.remaining_polls = 4;
+        this.remaining_polls = 21; // Give 21 * 5,5 secondes for the customer to pay
         clearTimeout(this.polling);
     },
 
@@ -302,7 +302,7 @@ var PaymentAdyen = PaymentInterface.extend({
 
                 self.polling = setInterval(function () {
                     self._poll_for_response(resolve, reject);
-                }, 3000);
+                }, 5500);
             });
 
             // make sure to stop polling when we're done

--- a/addons/pos_adyen/static/src/js/payment_adyen.js
+++ b/addons/pos_adyen/static/src/js/payment_adyen.js
@@ -28,7 +28,7 @@ var PaymentAdyen = PaymentInterface.extend({
     _reset_state: function () {
         this.was_cancelled = false;
         this.last_diagnosis_service_id = false;
-        this.remaining_polls = 21; // Give 21 * 5,5 secondes for the customer to pay
+        this.remaining_polls = 9; // Give 21 * 5,5 secondes for the customer to pay
         clearTimeout(this.polling);
     },
 


### PR DESCRIPTION
Actually to interval to poll for response is lower than the timeout of the request
So if the response come in this difference odoo can't record payment

With this commit we extend this delay to cover the timeout of the request

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
