### PR TITLE
[FIX] hr: update accesss right for hr_employee

### DIFF
--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -29,7 +29,7 @@
     <record id="hr_employee_comp_rule" model="ir.rule">
         <field name="name">Employee multi company rule</field>
         <field name="model_id" ref="model_hr_employee"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">['|', '|',('company_id','=',False),('company_id', 'in', company_ids),('user_id', '=', user.id)]</field>
     </record>
 
     <record id="hr_dept_comp_rule" model="ir.rule">


### PR DESCRIPTION
In a multi-company environment, it is not possible to update information (language, email,...) from My Profile.
The security rule only allows to change information if the right company is selected or if the user has no company.
Since a user assigned to several companies will have several records in hr_employee referring the same user_id, the security rule is now updated to allow updating information from the My Profile page if the hr_employee.user_id refers to the current user_id.

task-2678411

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
