### PR TITLE
[FIX] web: load_filters in search dialogs

### DIFF
--- a/addons/web/static/src/js/views/view_dialogs.js
+++ b/addons/web/static/src/js/views/view_dialogs.js
@@ -347,7 +347,7 @@ var SelectCreateDialog = ViewDialog.extend({
                 search_defaults[match[1]] = value_;
             }
         });
-        this.loadViews(this.dataset.model, this.dataset.get_context().eval(), [[false, 'list'], [false, 'search']], {})
+        this.loadViews(this.dataset.model, this.dataset.get_context().eval(), [[false, 'list'], [false, 'search']], {load_filters: true})
             .then(this.setup.bind(this, search_defaults))
             .then(function (fragment) {
                 self.opened().then(function () {


### PR DESCRIPTION
When opening a view in a dialog, the favorite filters were not loaded.
For example on the runbot:
1. In CRM, open any lead, edit it, and open the Customer dropdown
2. Create a custom filter, save it as favorite, and close the dialog
3. Open the dialog again: you don't see your new filter

With this commit, you will see your filter at step nr. 3