### PR TITLE
[FIX] web: rpc error handling: use normal dialog if possible

### DIFF
--- a/addons/web/static/src/core/errors/error_handlers.js
+++ b/addons/web/static/src/core/errors/error_handlers.js
@@ -97,6 +97,12 @@ export function rpcErrorHandler(env, error, originalError) {
                 ErrorComponent = errorDialogRegistry.get(exceptionName);
             }
         }
+        if (!ErrorComponent && originalError.data.context) {
+            const exceptionClass = originalError.data.context.exception_class;
+            if (errorDialogRegistry.contains(exceptionClass)) {
+                ErrorComponent = errorDialogRegistry.get(exceptionClass);
+            }
+        }
 
         env.services.dialog.add(ErrorComponent || RPCErrorDialog, {
             traceback: error.traceback,

--- a/addons/web/static/src/core/network/rpc_service.js
+++ b/addons/web/static/src/core/network/rpc_service.js
@@ -29,11 +29,8 @@ export function makeErrorFromResponse(reponse) {
     // Odoo returns error like this, in a error field instead of properly
     // using http error codes...
     const { code, data: errorData, message, type: subType } = reponse;
-    const { context: data_context, name: data_name } = errorData || {};
-    const { exception_class } = data_context || {};
-    const exception_class_name = exception_class || data_name;
     const error = new RPCError();
-    error.exceptionName = exception_class_name;
+    error.exceptionName = errorData.name;
     error.subType = subType;
     error.data = errorData;
     error.message = message;


### PR DESCRIPTION
Before this commit, automated actions could not raise "normal"
errors anymore (e.g. UserError). Indeed, since the wowl refactoring,
it always shows the custom BaseAutomationErrorDialog when an error
is thrown in an automated action, even if it is a standard error
well-known by the framework. Before the wowl refactoring, those
errors were handled normally if possible, and when it wasn't the
case, the custom BaseAutomationErrorDialog was used.

This commit restores that behavior.

Complete steps to reproduce:
- Install base_automation module
- Install an app for the base_automation to trigger (e.g. Sales)
- Turn on debug mode
- Go to Automated Actions
- Create an action with Action To Do is Execute Python Code and the Trigger is On Creation & Update
- Set the model to your app (e.g. SalesOrder)
- Put `raise UserError('Test')` in Python Code section
- Go back to the app, try to create a new record in the model you set for the automated action to trigger
- Compare the result with 14.0

Current behavior before PR:
- It will show an error dialog which show a message with RPC error
![current](https://user-images.githubusercontent.com/85471608/140673916-c2f71d1c-048a-409b-8968-5d397eede2ad.png)

Desired behavior after PR is merged:
- It should show an User Warning like 14.0 version
![desire](https://user-images.githubusercontent.com/85471608/140673920-a723251f-86a3-482f-a7a9-80d180acec97.png)