### PR TITLE
[FIX] cloc: re introduce exclusion of design theme

### DIFF
--- a/odoo/tools/cloc.py
+++ b/odoo/tools/cloc.py
@@ -20,7 +20,7 @@ DEFAULT_EXCLUDE = [
     "upgrades/**/*",
 ]
 
-STANDARD_MODULES = ['web', 'web_enterprise', 'base']
+STANDARD_MODULES = ['web', 'web_enterprise', 'theme_common', 'base']
 MAX_FILE_SIZE = 25 * 2**20 # 25 MB
 
 class Cloc(object):


### PR DESCRIPTION
Since
https://github.com/odoo/odoo/commit/ebf8d67485f7f71f6eb51762298cf50c5835ee08
design-themes repo is not excluded from the cloc count.
The module website_animate that was used as beacon to identify
the folder that contains the design-themes as been merged into website.

We need a new one, theme_common seems a reasonable candidate


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
