### PR TITLE
[IMP] stock: Run the scheduler as the company passed in parameter

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -542,6 +542,9 @@ class ProcurementGroup(models.Model):
             if use_new_cursor:
                 cr = registry(self._cr.dbname).cursor()
                 self = self.with_env(self.env(cr=cr))  # TDE FIXME
+            
+            if company_id:
+                self = self.with_company(company_id)
 
             self._run_scheduler_tasks(use_new_cursor=use_new_cursor, company_id=company_id)
         finally:


### PR DESCRIPTION
To avoid wrong company dependent properties values, when passing
company_id as parameter, switch to the target company.

Description of the issue/feature this PR addresses:

This avoid wrong properties evaluation if passing company_id as parameter

Current behavior before PR:

Wrong values

Desired behavior after PR is merged:

Correct values


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
