### PR TITLE
[12.0->14.0][FIX] purchase: bad context display wrong lst price in product pop-up

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -186,7 +186,7 @@
                                     <field name="product_type" invisible="1"/>
                                     <field name="invoice_lines" invisible="1"/>
                                     <field name="sequence" widget="handle"/>
-                                    <field name="product_id" attrs="{'readonly': [('state', 'in', ('purchase', 'to approve','done', 'cancel'))]}" context="{'partner_id':parent.partner_id, 'quantity':product_qty,'uom':product_uom, 'company_id': parent.company_id}" force_save="1"/>
+                                    <field name="product_id" attrs="{'readonly': [('state', 'in', ('purchase', 'to approve','done', 'cancel'))]}" context="{'partner_id':parent.partner_id, 'quantity':product_qty, 'company_id': parent.company_id}" force_save="1"/>
                                     <field name="name"/>
                                     <field name="date_planned"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**

Step to reproduce : 
- on a fresh database with purchase module installed.
- add user to the group "Manage Multiple Units of Measure"
- create a product like Purchase UoM != Main UoM.

![image](https://user-images.githubusercontent.com/3407482/140741313-1e79a728-d1ce-4980-9f17-1ca1e829d077.png)

- Create a new purchase order and add the product
- Open the product by clicking on the button : 

![image](https://user-images.githubusercontent.com/3407482/140741802-b440add9-7c94-4fcd-9553-88284d9d6c06.png)

**Current behavior before PR**

The list price (``lst_price``) displayed in the popup is not the good one.

![image](https://user-images.githubusercontent.com/3407482/140741696-193a63cb-d5ff-465f-9ff8-3e7cdcff84d4.png)

The sale price has been multiplated by the radio of the Purchase uom due to this code : 
https://github.com/odoo/odoo/blob/12.0/addons/product/models/product.py#L217

**Desired behavior after PR is merged**

The sale price is correct.

![image](https://user-images.githubusercontent.com/3407482/140742123-c1453b42-2c75-4d0e-b0a0-88721622d33c.png)

**Version**
- reproduced on 12.0 // 13.0 // 14.0
- bug not present on V15.0. because the ``lst_price`` is not displayed in the popup. (but the ``list_price``)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
