### PR TITLE
[FIX] delivery: allow validating a SO with several "stock.move"

### DIFF
--- a/addons/delivery/models/stock_move.py
+++ b/addons/delivery/models/stock_move.py
@@ -20,7 +20,7 @@ class StockMove(models.Model):
     def _get_new_picking_values(self):
         vals = super(StockMove, self)._get_new_picking_values()
         carrier_id = self.group_id.sale_id.carrier_id.id
-        vals['carrier_id'] = self.rule_id.propagate_carrier and carrier_id
+        vals['carrier_id'] = any(propagate_carrier for propagate_carrier in self.rule_id) and carrier_id
         return vals
 
     def _key_assign_picking(self):


### PR DESCRIPTION
Steps to reproduce the bug:
- install delivery and sale_management
- Create a product with route "Buy + MTO" and a product with route "Buy"
- Create a SO with both products
- Confirm the SO

Problem:
A traceback is triggered, because in this case, we have two `stock.move`, so two` stock.rule`
therefore, when accessing the `propagate_carrier` field an error will be thrown

opw-2681427




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
