### PR TITLE
[FIX] web: correctly render nbsp in title tooltip

### DIFF
--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -555,7 +555,9 @@ var ListRenderer = BasicRenderer.extend({
         };
         var formattedValue = formatter(value, field, formatOptions);
         var title = '';
-        if (field.type !== 'boolean') {
+        if(field.type === 'monetary') {
+            title = formatter(value, field, _.extend(formatOptions, {escape: false, forceString: true}));
+        }else if (field.type !== 'boolean') {
             title = formatter(value, field, _.extend(formatOptions, {escape: false}));
         }
         return $td.html(formattedValue).attr('title', title);


### PR DESCRIPTION
### Expected behavior  
The content of a Monetary field's tooltip should be rendered correctly (e.g. `$ 23.00`)

### Current behavior
Tooltip content is not rendered correctly has `&nbsp;` isn't rendered as expected (e.g. `$&nbsp;23.00`)

### Steps to reproduce the error
- Go on any Accounting view list with Monetary column
- Stay above the cell content to display the tooltip

| Expected result  | Current result |
| ------------- | ------------- |
| `$ 23.00`  | `$&nbsp;23.00`  |

### Reason
HTML Escape (`&nbsp;`) isn't rendered in title attribute so we should need the `forceString` option and set it to true in formatter options for monetary type. 

OPW-2667867