### PR TITLE
[FIX] website: Display correctly top buttons of the editor sidebar

### DIFF
--- a/addons/website/static/src/xml/website.editor.xml
+++ b/addons/website/static/src/xml/website.editor.xml
@@ -12,11 +12,11 @@
     <!-- Editor top bar which contains the summernote tools and save/discard buttons -->
     <t t-name="website.editorbar">
         <div class="o_we_website_top_actions">
-            <div class="o_we_external_history_buttons">
+            <div class="o_we_external_history_buttons d-flex">
                 <button type="button" data-action="undo" class="btn btn-secondary fa fa-undo"/>
                 <button type="button" data-action="redo" class="btn btn-secondary fa fa-repeat"/>
             </div>
-            <form class="ml-auto">
+            <form class="ml-auto d-flex">
                 <button type="button" class="btn btn-secondary" data-action="cancel" accesskey="j">Discard</button>
                 <button type="button" class="btn btn-primary" data-action="save" accesskey="s">Save</button>
             </form>


### PR DESCRIPTION
Steps to reproduce :

  - Install website module
  - Activate (and translate website) French language
  - Go to translated terms and fetch for "Discard" in website module
  - Replace the translated value by "Ne pas sauvegarder"
  - Go to Website -> Configuration -> Websites
  - Select main website and change language to french then save
  - Go to Website and edit homepage
  - Add any block

Issues :

  On top of editor sidebar, buttons are not displayed correctly.

Solutions :

  Add css class `d-flex` to the div around the buttons.

opw-2683602