### PR TITLE
[FIX] web: report client action can keep context on reload.

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -971,10 +971,21 @@ function makeActionManager(env) {
             report_url: _getReportUrl(action, "html"),
             context: Object.assign({}, action.context),
         });
-        const clientActionOptions = Object.assign({}, options, {
-            props,
+
+        const controller = {
+            jsId: `controller_${++id}`,
+            // for historical reasons, the report Component is a client action,
+            // but there's no need to keep this when it will be converted to owl.
+            Component: actionRegistry.get("report.client_action"),
+            action,
+            ..._getActionInfo(action, props),
+        };
+
+        return _updateUI(controller, {
+            clearBreadcrumbs: options.clearBreadcrumbs,
+            stackPosition: options.stackPosition,
+            onClose: options.onClose,
         });
-        return doAction("report.client_action", clientActionOptions);
     }
 
     /**

--- a/addons/web/static/tests/webclient/actions/report_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/report_action_tests.js
@@ -354,4 +354,24 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps(["/report/check_wkhtmltopdf", "/report/download"]);
         testUtils.mock.unpatch(ReportClientAction);
     });
+
+    QUnit.test("url is valid", async (assert) => {
+        assert.expect(2);
+
+        patchWithCleanup(ReportClientAction.prototype, {
+            init() {
+                this._super(...arguments);
+                this.report_url = "about:blank";
+            },
+        });
+
+        const webClient = await createWebClient({ serverData });
+
+        await doAction(webClient, 12); // 12 is a html report action in serverData
+
+        const hash = webClient.router.current.hash;
+        // used to put report.client_action in the url
+        assert.strictEqual(hash.action === "report.client_action", false);
+        assert.strictEqual(hash.action === 12, true);
+    });
 });


### PR DESCRIPTION
Report client action can need context data to be properly be
displayed. But because all the required data is not put in the url,
reloading didn't work.
However, there is the current action data kept in the session storage
which is a solution to avoid the described problem. But it didn't
work because of the implementation of the report client action execution.
It was in reality executing two actions: one for the report, gathering
the data and fallbacking to a client action. By doing this, the
session storage would not have the necessary data kept for reloading the
page.

The fix is simply to duplicate the code of the client action execution
instead of calling doAction again.


