### PR TITLE
[FIX] account: use specific account on product

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1834,7 +1834,7 @@ class AccountMove(models.Model):
         self.ensure_one()
 
         for line in self.line_ids:
-            analytic_account = line.analytic_account_id
+            analytic_account = line._cache.get('analytic_account_id')
 
             # Do something only on invoice lines.
             if line.exclude_from_invoice_tab:

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -2961,3 +2961,22 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertRecordValues(copy_invoice.line_ids.filtered('date_maturity'), [
             {'date_maturity': fields.Date.from_string('2018-01-01')},
         ])
+
+    def test_select_specific_product_account(self):
+        """ When a product has a specific income account, the latter should be used on the related account move
+        lines.
+        """
+        sale_journal = self.company_data['default_journal_sale']
+        other_income_account = sale_journal.default_account_id.copy()
+        self.product_a.property_account_income_id = other_income_account
+
+        invoice = self.env['account.move'].create({
+            'journal_id': sale_journal.id,
+            'move_type': 'out_invoice',
+            'invoice_line_ids': [(0, 0, {
+                'product_id': self.product_a.id,
+                'quantity': 1.0,
+                'price_unit': 16,
+            })],
+        })
+        self.assertRecordValues(invoice.invoice_line_ids, [{'account_id': other_income_account.id}])


### PR DESCRIPTION
When selling a product that has a specific income account, the
associated account move line will still have the default income account
of the journal

To reproduce the issue:
(Need account_accountant,point_of_sale. Use demo data)
1. Open the Chart Of Accounts
2. Let A01 be the account "400000 - Product Sales"
3. Duplicate A01 (let A02 be the duplicate)
4. In Products, edit "Conference Chair (CONFIG)":
    - Income Account: A02
5. Start a POS session
6. Add a Conference Chair to the cart
7. Process the payment:
    - Set a customer
    - Activate the invoice
8. Close POS session & Post Entries
9. Open the associated Journal Items

Error: The account used for the credit line related to the sale is A01
instead of A02

When creating the invoice, we temporarily create an account move:
https://github.com/odoo/odoo/blob/e35dc4c87821bbb668657eed99bb51c1f853c208/addons/account/models/account_move.py#L1921
We then use this temporary record to perform several operations. In
`_move_autocomplete_invoice_lines_values`, we save
`line.analytic_account_id` in case the user gave a specific analytic
account:
https://github.com/odoo/odoo/blob/e35dc4c87821bbb668657eed99bb51c1f853c208/addons/account/models/account_move.py#L1840
But, in the above case, the user didn't manually specified any
`analytic_account_id`. As a result, the compute method of the field is
triggered:
https://github.com/odoo/odoo/blob/e35dc4c87821bbb668657eed99bb51c1f853c208/addons/account/models/account_move.py#L3445-L3457
As said before, the current record is a new one. Therefore, in the
compute method: reading `account_id` on `record` will lead to
https://github.com/odoo/odoo/blob/d10073d49608ca79e60cc0cb04076253facd046a/odoo/fields.py#L1049-L1060
i.e., `record.account_id` is defined with its default value (A01 in the
above case) and the latter is stored in the cache. Thus, back to
`_move_autocomplete_invoice_lines_values`:
https://github.com/odoo/odoo/blob/e35dc4c87821bbb668657eed99bb51c1f853c208/addons/account/models/account_move.py#L1849-L1850
`account_id` is already defined and stored in the cache, so
`_get_computed_account` won't be called and `account_id` won't be
overridden with its correct value.

We should rather try to save `analytic_account_id` without triggering
its compute method.

OPW-2662511