### PR TITLE
[FIX] pos_resturant: distinguish all order lines

### DIFF
--- a/addons/pos_restaurant/static/src/js/multiprint.js
+++ b/addons/pos_restaurant/static/src/js/multiprint.js
@@ -175,22 +175,16 @@ models.Order = models.Order.extend({
             if (line.mp_skip) {
                 return;
             }
-            var line_hash = line.get_line_diff_hash();
             var qty  = Number(line.get_quantity());
             var note = line.get_note();
             var product_id = line.get_product().id;
-
-            if (typeof resume[line_hash] === 'undefined') {
-                resume[line_hash] = {
-                    qty: qty,
-                    note: note,
-                    product_id: product_id,
-                    product_name_wrapped: line.generate_wrapped_product_name(),
-                };
-            } else {
-                resume[line_hash].qty += qty;
-            }
-
+            var product_resume = product_id in resume ? resume[product_id] : {
+                product_name_wrapped: line.generate_wrapped_product_name(),
+                qties: {},
+            };
+            if (note in product_resume['qties']) product_resume['qties'][note] += qty;
+            else product_resume['qties'][note] = qty;
+            resume[product_id] = product_resume;
         });
         return resume;
     },
@@ -207,62 +201,55 @@ models.Order = models.Order.extend({
         var json        = this.export_as_JSON();
         var add = [];
         var rem = [];
-        var line_hash;
+        var pid, note;
 
-        for ( line_hash in current_res) {
-            var curr = current_res[line_hash];
-            var old  = {};
-            var found = false;
-            for(var id in old_res) {
-                if(old_res[id].product_id === curr.product_id){
-                    found = true;
-                    old = old_res[id];
-                    break;
+        for (pid in current_res) {
+            for (note in current_res[pid]['qties']) {
+                var curr = current_res[pid];
+                var old  = old_res[pid] || {};
+                var found = pid in old_res && note in old_res[pid]['qties'];
+
+                if (!found) {
+                    add.push({
+                        'id':       pid,
+                        'name':     this.pos.db.get_product_by_id(pid).display_name,
+                        'name_wrapped': curr.product_name_wrapped,
+                        'note':     note,
+                        'qty':      curr['qties'][note],
+                    });
+                } else if (old['qties'][note] < curr['qties'][note]) {
+                    add.push({
+                        'id':       pid,
+                        'name':     this.pos.db.get_product_by_id(pid).display_name,
+                        'name_wrapped': curr.product_name_wrapped,
+                        'note':     note,
+                        'qty':      curr['qties'][note] - old['qties'][note],
+                    });
+                } else if (old['qties'][note] > curr['qties'][note]) {
+                    rem.push({
+                        'id':       pid,
+                        'name':     this.pos.db.get_product_by_id(pid).display_name,
+                        'name_wrapped': curr.product_name_wrapped,
+                        'note':     note,
+                        'qty':      old['qties'][note] - curr['qties'][note],
+                    });
                 }
-            }
-
-            if (!found) {
-                add.push({
-                    'id':       curr.product_id,
-                    'name':     this.pos.db.get_product_by_id(curr.product_id).display_name,
-                    'name_wrapped': curr.product_name_wrapped,
-                    'note':     curr.note,
-                    'qty':      curr.qty,
-                });
-            } else if (old.qty < curr.qty) {
-                add.push({
-                    'id':       curr.product_id,
-                    'name':     this.pos.db.get_product_by_id(curr.product_id).display_name,
-                    'name_wrapped': curr.product_name_wrapped,
-                    'note':     curr.note,
-                    'qty':      curr.qty - old.qty,
-                });
-            } else if (old.qty > curr.qty) {
-                rem.push({
-                    'id':       curr.product_id,
-                    'name':     this.pos.db.get_product_by_id(curr.product_id).display_name,
-                    'name_wrapped': curr.product_name_wrapped,
-                    'note':     curr.note,
-                    'qty':      old.qty - curr.qty,
-                });
             }
         }
 
-        for (line_hash in old_res) {
-            var found = false;
-            for(var id in current_res) {
-                if(current_res[id].product_id === old_res[line_hash].product_id)
-                    found = true;
-            }
-            if (!found) {
-                var old = old_res[line_hash];
-                rem.push({
-                    'id':       old.product_id,
-                    'name':     this.pos.db.get_product_by_id(old.product_id).display_name,
-                    'name_wrapped': old.product_name_wrapped,
-                    'note':     old.note,
-                    'qty':      old.qty,
-                });
+        for (pid in old_res) {
+            for (note in old_res[pid]['qties']) {
+                var found = pid in current_res && note in current_res[pid]['qties'];
+                if (!found) {
+                    var old = old_res[pid];
+                    rem.push({
+                        'id':       pid,
+                        'name':     this.pos.db.get_product_by_id(pid).display_name,
+                        'name_wrapped': old.product_name_wrapped,
+                        'note':     note,
+                        'qty':      old['qties'][note],
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
In some cases, it is not possible to print the order changes

To reproduce the issue:
(Use demo data)
1. Point of Sale > Configuration > Order Printers, edit Kitchen Printer:
    - Printed Product Categories: Food
2. Edit the POS Bar:
    - Enable Order Printer
3. Start a session of POS Bar
4. Open table T1
5. Select a Food product and add a note
6. Submit the order to the kitchen
7. Select again the same product without any note

Error: The order button isn't green, it is not possible to sent the
second order line to the kitchen

The issue comes from the logic used in `computeChanges`:
https://github.com/odoo/odoo/blob/75fb0aa6e9c314b61b30d49b5c463fa126dfc835/addons/pos_restaurant/static/src/js/multiprint.js#L215-L222
`old_res` contains the products already sent to the kitchen
As a result, since the line from step 5 and the one from step 7 have the
same product, we consider that the new line (step 7) was already
present. Then, when comparing the quantities, both lines have their
quantity equal to 1, so we consider there isn't any information that
should be sent to the kitchen

OPW-2557518