### PR TITLE
[FIX]account:reverse move condtnly hide btn and radio button

### DIFF
--- a/addons/account/wizard/account_move_reversal_view.xml
+++ b/addons/account/wizard/account_move_reversal_view.xml
@@ -12,10 +12,10 @@
                     <field name="move_type" invisible="1"/>
                     <field name="available_journal_ids" invisible="1"/>
                     <group>
-                         <group attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'in_invoice'))]}">
+                         <group attrs="{'invisible': ['|',('move_type', 'not in', ('out_invoice', 'in_invoice')),('residual', '=', 0)]}">
                             <field name="refund_method" widget="radio" attrs="{'readonly': [('residual', '=', 0)]}"/>
                          </group>
-                         <group attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'in_invoice', 'some_invoice'))]}">
+                         <group attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice', 'in_invoice', 'some_invoice')), ('residual', '=', 0)]}">
                             <div attrs="{'invisible':[('refund_method', '!=', 'refund')]}" class="oe_grey" colspan="4">
                                The credit note is created in draft and can be edited before being issued.
                             </div>


### PR DESCRIPTION
## Aim of this commit:
- Prevent user to create credit note for 0 value based invoice.
- Hide the disabled radio button on reversal wizard.

## before this commit:
- The button add a credit note is present on invoice and bill even when
the amount_total is 0.
- The radio buttons in the reversal wizard are visible even when it's
disabled.

## after this commit:
- The button add a credit note is hidden when the amount_total is 0.
- Radio buttons are hidden when it can't be used.

task/ticket:#2603144