### PR TITLE
[FIX] hr_holidays: hide validated leaves with multiple holidays

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -56,7 +56,7 @@
                 <filter name="filter_date_from" date="date_from"/>
                 <separator/>
                 <filter name="active_time_off" string="Active Time Off"
-                    domain="[('holiday_status_id.active', '=', True)]" help="Active Time Off"/>
+                    domain="[('holiday_status_id.active', '=', True), '|', ('employee_id', '!=', False), '&amp;', ('employee_id', '=', False), ('state', '!=', 'validate')]" help="Active Time Off"/>
                 <filter name="archive" string="Archived Time Off"
                     domain="[('holiday_status_id.active', '=', False)]" help="Archived Time Off"/>
                 <filter invisible="1" string="Late Activities" name="activities_overdue"


### PR DESCRIPTION
Do not show the validated leaves with multiple holidays.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
