### PR TITLE
[FIX] web: row groupby overwrite

### DIFF
--- a/addons/web/static/src/js/views/pivot/pivot_model.js
+++ b/addons/web/static/src/js/views/pivot/pivot_model.js
@@ -749,6 +749,9 @@ var PivotModel = AbstractModel.extend({
         values.slice(0, values.length - 1).forEach(function (value) {
             tree = tree.directSubTrees.get(value);
         });
+        if (tree.directSubTrees.get(values[values.length - 1]) !== undefined){
+            return;
+        }
         tree.directSubTrees.set(values[values.length - 1], {
             root: {
                 labels: labels,


### PR DESCRIPTION
1. Post invoice in current year (ex:2021) with just product A
2. Post invoice in previous year (ex:2020) with just product B
3. Post invoice in current and previous year with other product C
4. Go to invoice analysis report in pivot view
5. Fold everything then unfold "partner" > "product", you will see ABC
6. Select "Time Ranges" button and use the range "This year" compare to
"Previous year"

Product A disappears but should not because it is in the time range
If you fold the products then unfold again, the product A will appear.

opw-2635113

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
