### PR TITLE
[FIX] sale_timesheet: fix traceback on uom onchange

### DIFF
--- a/addons/sale_timesheet/models/product.py
+++ b/addons/sale_timesheet/models/product.py
@@ -35,7 +35,7 @@ class ProductTemplate(models.Model):
     def _compute_service_upsell_threshold_ratio(self):
         product_uom_hour = self.env.ref('uom.product_uom_hour')
         for record in self:
-            record.service_upsell_threshold_ratio = f"1 {record.uom_id.name} = {product_uom_hour.factor / record.uom_id.factor:.2f} Hours"
+            record.service_upsell_threshold_ratio = f"1 {record.uom_id.name} = {product_uom_hour.factor / record.uom_id.factor:.2f} Hours" if record.uom_id else ""
 
     def _compute_visible_expense_policy(self):
         visibility = self.user_has_groups('project.group_project_user')


### PR DESCRIPTION
Before this commit:
===================
When we have sale_timesheet module installed,
-> Open product form
-> Change Unit of Measure to blank
It will raise a traceback

In this commit:
====================
Fixed the traceback

task: 2686339
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
