### PR TITLE
[FIX] web: indent navbar menu group entry

### DIFF
--- a/addons/web/static/src/legacy/scss/navbar.scss
+++ b/addons/web/static/src/legacy/scss/navbar.scss
@@ -104,10 +104,8 @@
       @include border-top-radius(0);
     }
 
-    .o_dropdown_menu_group_entry {
-      > .dropdown-item {
-        padding-left: $o-dropdown-hpadding * 1.5;
-      }
+    .o_dropdown_menu_group_entry.dropdown-item {
+      padding-left: $o-dropdown-hpadding * 1.5;
 
       + .dropdown-item:not(.o_dropdown_menu_group_entry) {
         margin-top: .8em;


### PR DESCRIPTION
Before this commit:
Some navbar app sections items were
not properly indented in dropdowns.

After this commit:
The indentation is restored, leading to
a clearer usage of the navbar menus.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
