### PR TITLE
[FIX] point_of_sale: correct receipt reference

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -690,23 +690,13 @@ exports.PosModel = Backbone.Model.extend({
 
         for (var i = 0; i < jsons.length; i++) {
             var json = jsons[i];
-            if (json.pos_session_id === this.pos_session.id) {
+            if (json.lines.length > 0) {
                 orders.push(new exports.Order({},{
                     pos:  this,
                     json: json,
                 }));
             }
-        }
-        for (var i = 0; i < jsons.length; i++) {
-            var json = jsons[i];
-            if (json.pos_session_id !== this.pos_session.id && json.lines.length > 0) {
-                orders.push(new exports.Order({},{
-                    pos:  this,
-                    json: json,
-                }));
-            } else if (json.pos_session_id !== this.pos_session.id) {
-                this.db.remove_unpaid_order(jsons[i]);
-            }
+            this.db.remove_unpaid_order(jsons[i]);
         }
 
         orders = orders.sort(function(a,b){
@@ -2366,14 +2356,9 @@ exports.Order = Backbone.Model.extend({
      */
     init_from_JSON: function(json) {
         var client;
-        if (json.pos_session_id !== this.pos.pos_session.id) {
-            this.sequence_number = this.pos.pos_session.sequence_number++;
-        } else {
-            this.sequence_number = json.sequence_number;
-            this.pos.pos_session.sequence_number = Math.max(this.sequence_number+1,this.pos.pos_session.sequence_number);
-        }
+        this.sequence_number = this.pos.pos_session.sequence_number++;
         this.session_id = this.pos.pos_session.id;
-        this.uid = json.uid;
+        this.uid = this.generate_unique_id();
         this.name = _.str.sprintf(_t("Order %s"), this.uid);
         this.validation_date = json.creation_date;
         this.server_id = json.server_id ? json.server_id : false;


### PR DESCRIPTION
When you are re-opening a pos config, the reference on the receipt can
have a reference that does not match the current sequence of the
session.

To avoid that, each time an order is initiated, we are giving it a new
reference number, which is not an issue as it has not been finalized
yet.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
