### PR TITLE
[IMP] payment(_*): normalize logs across all acquirers

### DIFF
--- a/addons/payment_alipay/controllers/main.py
+++ b/addons/payment_alipay/controllers/main.py
@@ -19,14 +19,14 @@ class AlipayController(http.Controller):
     @http.route(_return_url, type='http', auth="public", methods=['GET'])
     def alipay_return_from_redirect(self, **data):
         """ Alipay return """
-        _logger.info("received Alipay return data:\n%s", pprint.pformat(data))
+        _logger.info("handling redirection from Alipay with data:\n%s", pprint.pformat(data))
         request.env['payment.transaction'].sudo()._handle_feedback_data('alipay', data)
         return request.redirect('/payment/status')
 
     @http.route(_notify_url, type='http', auth='public', methods=['POST'], csrf=False)
     def alipay_notify(self, **post):
         """ Alipay Notify """
-        _logger.info("received Alipay notification data:\n%s", pprint.pformat(post))
+        _logger.info("notification received from Alipay with data:\n%s", pprint.pformat(post))
         self._alipay_validate_notification(**post)
         request.env['payment.transaction'].sudo()._handle_feedback_data('alipay', post)
         return 'success'  # Return 'success' to stop receiving notifications for this tx

--- a/addons/payment_authorize/controllers/main.py
+++ b/addons/payment_authorize/controllers/main.py
@@ -52,7 +52,10 @@ class AuthorizeController(http.Controller):
         response_content = tx_sudo._authorize_create_transaction_request(opaque_data)
 
         # Handle the payment request response
-        _logger.info("make payment response:\n%s", pprint.pformat(response_content))
+        _logger.info(
+            "payment request response for transaction with reference %s:\n%s",
+            reference, pprint.pformat(response_content)
+        )
         # As the API has no redirection flow, we always know the reference of the transaction.
         # Still, we prefer to simulate the matching of the transaction by crafting dummy feedback
         # data in order to go through the centralized `_handle_feedback_data` method.

--- a/addons/payment_authorize/models/authorize_request.py
+++ b/addons/payment_authorize/models/authorize_request.py
@@ -109,8 +109,12 @@ class AuthorizeAPI:
 
         if not response.get('customerProfileId'):
             _logger.warning(
-                'Unable to create customer payment profile, data missing from transaction. Transaction_id: %s - Partner_id: %s',
-                transaction_id, partner,
+                "unable to create customer payment profile, data missing from transaction with "
+                "id %(tx_id)s, partner id: %(partner_id)s",
+                {
+                    'tx_id': transaction_id,
+                    'partner_id': partner,
+                },
             )
             return False
 

--- a/addons/payment_buckaroo/controllers/main.py
+++ b/addons/payment_buckaroo/controllers/main.py
@@ -18,6 +18,6 @@ class BuckarooController(http.Controller):
 
         :param dict data: The feedback data
         """
-        _logger.info("received notification data:\n%s", pprint.pformat(data))
+        _logger.info("handling redirection from Buckaroo with data:\n%s", pprint.pformat(data))
         request.env['payment.transaction'].sudo()._handle_feedback_data('buckaroo', data)
         return request.redirect('/payment/status')

--- a/addons/payment_buckaroo/models/payment_transaction.py
+++ b/addons/payment_buckaroo/models/payment_transaction.py
@@ -140,5 +140,8 @@ class PaymentTransaction(models.Model):
         elif status_code in STATUS_CODES_MAPPING['error']:
             self._set_error(_("An error occurred during processing of your payment (code %s). Please try again.", status_code))
         else:
-            _logger.warning("Buckaroo: received unknown status code: %s", status_code)
+            _logger.warning(
+                "received data with invalid payment status (%s) for transaction with reference %s",
+                status_code, self.reference
+            )
             self._set_error("Buckaroo: " + _("Unknown status code: %s", status_code))

--- a/addons/payment_mollie/controllers/main.py
+++ b/addons/payment_mollie/controllers/main.py
@@ -33,7 +33,7 @@ class MollieController(http.Controller):
         :param dict data: The feedback data (only `id`) and the transaction reference (`ref`)
                           embedded in the return URL
         """
-        _logger.info("Received Mollie return data:\n%s", pprint.pformat(data))
+        _logger.info("handling redirection from Mollie with data:\n%s", pprint.pformat(data))
         request.env['payment.transaction'].sudo()._handle_feedback_data('mollie', data)
         return request.redirect('/payment/status')
 
@@ -46,9 +46,9 @@ class MollieController(http.Controller):
         :return: An empty string to acknowledge the notification
         :rtype: str
         """
-        _logger.info("Received Mollie notify data:\n%s", pprint.pformat(data))
+        _logger.info("notification received from Mollie with data:\n%s", pprint.pformat(data))
         try:
             request.env['payment.transaction'].sudo()._handle_feedback_data('mollie', data)
         except ValidationError:  # Acknowledge the notification to avoid getting spammed
-            _logger.exception("unable to handle the notification data; skipping to acknowledge")
+            _logger.exception("unable to handle the data; skipping to acknowledge the notification")
         return ''  # Acknowledge the notification with an HTTP 200 response

--- a/addons/payment_mollie/models/payment_acquirer.py
+++ b/addons/payment_mollie/models/payment_acquirer.py
@@ -75,6 +75,6 @@ class PaymentAcquirer(models.Model):
             response = requests.request(method, url, json=data, headers=headers, timeout=60)
             response.raise_for_status()
         except requests.exceptions.RequestException:
-            _logger.exception("Unable to communicate with Mollie: %s", url)
+            _logger.exception("unable to communicate with Mollie: %s", url)
             raise ValidationError("Mollie: " + _("Could not establish the connection to the API."))
         return response.json()

--- a/addons/payment_mollie/models/payment_transaction.py
+++ b/addons/payment_mollie/models/payment_transaction.py
@@ -112,7 +112,10 @@ class PaymentTransaction(models.Model):
         elif payment_status in ['expired', 'canceled', 'failed']:
             self._set_canceled("Mollie: " + _("Canceled payment with status: %s", payment_status))
         else:
-            _logger.info("Received data with invalid payment status: %s", payment_status)
+            _logger.info(
+                "received data with invalid payment status (%s) for transaction with reference %s",
+                payment_status, self.reference
+            )
             self._set_error(
                 "Mollie: " + _("Received data with invalid payment status: %s", payment_status)
             )

--- a/addons/payment_ogone/controllers/main.py
+++ b/addons/payment_ogone/controllers/main.py
@@ -42,7 +42,7 @@ class OgoneController(http.Controller):
         self._verify_signature(feedback_data, data)
 
         # Handle the feedback data
-        _logger.info("entering _handle_feedback_data with data:\n%s", pprint.pformat(data))
+        _logger.info("handling redirection from Ogone with data:\n%s", pprint.pformat(data))
         request.env['payment.transaction'].sudo()._handle_feedback_data('ogone', data)
         return request.redirect('/payment/status')
 

--- a/addons/payment_paypal/controllers/main.py
+++ b/addons/payment_paypal/controllers/main.py
@@ -23,7 +23,7 @@ class PaypalController(http.Controller):
         The "PDT notification" is actually POST data sent along the user redirection.
         The route also allows the GET method in case the user clicks on "go back to merchant site".
         """
-        _logger.info("beginning DPN with post data:\n%s", pprint.pformat(data))
+        _logger.info("handling redirection from Ogone with data:\n%s", pprint.pformat(data))
         try:
             self._validate_data_authenticity(**data)
         except ValidationError:
@@ -38,12 +38,12 @@ class PaypalController(http.Controller):
     @http.route(_notify_url, type='http', auth='public', methods=['GET', 'POST'], csrf=False)
     def paypal_ipn(self, **data):
         """ Route used by the IPN. """
-        _logger.info("beginning IPN with post data:\n%s", pprint.pformat(data))
+        _logger.info("notification received from Ogone with data:\n%s", pprint.pformat(data))
         try:
             self._validate_data_authenticity(**data)
             request.env['payment.transaction'].sudo()._handle_feedback_data('paypal', data)
         except ValidationError:  # Acknowledge the notification to avoid getting spammed
-            _logger.exception("unable to handle the IPN data; skipping to acknowledge the notif")
+            _logger.exception("unable to handle the data; skipping to acknowledge the notification")
         return ''
 
     def _validate_data_authenticity(self, **data):

--- a/addons/payment_paypal/models/payment_transaction.py
+++ b/addons/payment_paypal/models/payment_transaction.py
@@ -120,7 +120,10 @@ class PaymentTransaction(models.Model):
         elif payment_status in PAYMENT_STATUS_MAPPING['cancel']:
             self._set_canceled()
         else:
-            _logger.info("received data with invalid payment status: %s", payment_status)
+            _logger.info(
+                "received data with invalid payment status (%s) for transaction with reference %s",
+                payment_status, self.reference
+            )
             self._set_error(
                 "PayPal: " + _("Received data with invalid payment status: %s", payment_status)
             )

--- a/addons/payment_payulatam/controllers/main.py
+++ b/addons/payment_payulatam/controllers/main.py
@@ -14,6 +14,6 @@ class PayuLatamController(http.Controller):
 
     @http.route(_return_url, type='http', auth='public', methods=['GET'])
     def payulatam_return(self, **data):
-        _logger.info("entering _handle_feedback_data with data:\n%s", pprint.pformat(data))
+        _logger.info("handling redirection from PayU Latam with data:\n%s", pprint.pformat(data))
         request.env['payment.transaction'].sudo()._handle_feedback_data('payulatam', data)
         return request.redirect('/payment/status')

--- a/addons/payment_payulatam/models/payment_transaction.py
+++ b/addons/payment_payulatam/models/payment_transaction.py
@@ -151,7 +151,7 @@ class PaymentTransaction(models.Model):
             self._set_canceled(state_message=state_message)
         else:
             _logger.warning(
-                "received unrecognized payment state %s for transaction with reference %s",
+                "received data with invalid payment status (%s) for transaction with reference %s",
                 status, self.reference
             )
             self._set_error("PayU Latam: " + _("Invalid payment status."))

--- a/addons/payment_payumoney/controllers/main.py
+++ b/addons/payment_payumoney/controllers/main.py
@@ -29,6 +29,6 @@ class PayUMoneyController(http.Controller):
 
         :param dict data: The feedback data to process
         """
-        _logger.info("entering handle_feedback_data with data:\n%s", pprint.pformat(data))
+        _logger.info("handling redirection from PayU money with data:\n%s", pprint.pformat(data))
         request.env['payment.transaction'].sudo()._handle_feedback_data('payumoney', data)
         return request.redirect('/payment/status')

--- a/addons/payment_sips/models/payment_transaction.py
+++ b/addons/payment_sips/models/payment_transaction.py
@@ -157,7 +157,13 @@ class PaymentTransaction(models.Model):
             status = "error"
             self._set_error(_("Unrecognized response received from the payment provider."))
         _logger.info(
-            "ref: %s, got response [%s], set as '%s'.", self.reference, response_code, status
+            "received data with response %(response)s for transaction with reference %(ref)s, set "
+            "status as '%(status)s'",
+            {
+                'response': response_code,
+                'ref': self.reference,
+                'status': status,
+            },
         )
 
     def _sips_data_to_object(self, data):

--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -115,7 +115,7 @@ class StripeController(http.Controller):
                     # Handle the feedback data crafted with Stripe API objects as a regular feedback
                     request.env['payment.transaction'].sudo()._handle_feedback_data('stripe', data)
         except ValidationError:  # Acknowledge the notification to avoid getting spammed
-            _logger.exception("unable to handle the event data; skipping to acknowledge")
+            _logger.exception("unable to handle the data; skipping to acknowledge the notification")
         return ''
 
     @staticmethod

--- a/addons/payment_transfer/controllers/main.py
+++ b/addons/payment_transfer/controllers/main.py
@@ -14,6 +14,6 @@ class TransferController(http.Controller):
 
     @http.route(_accept_url, type='http', auth='public', methods=['POST'], csrf=False)
     def transfer_form_feedback(self, **post):
-        _logger.info("beginning _handle_feedback_data with post data %s", pprint.pformat(post))
+        _logger.info("handling redirection from Transfer with data:\n%s", pprint.pformat(post))
         request.env['payment.transaction'].sudo()._handle_feedback_data('transfer', post)
         return request.redirect('/payment/status')

--- a/addons/payment_transfer/models/payment_transaction.py
+++ b/addons/payment_transfer/models/payment_transaction.py
@@ -66,7 +66,8 @@ class PaymentTransaction(models.Model):
             return
 
         _logger.info(
-            "validated transfer payment for tx with reference %s: set as pending", self.reference
+            "validated transfer payment for transaction with reference %s: set as pending",
+            self.reference
         )
         self._set_pending()
 


### PR DESCRIPTION
The logs for payments contain the transaction reference whenever possible.
Before logs for transactions contained the reference or the id of the
transaction in an inconsistent way. Now transactions are identified by
reference whenever possible.

The logs for payments for the same function on different acquirers should
have the same format. Same flow steps for different acquirers had
information passed in different formats. Now at each step of a transaction
flow log messages have the same format regardless of the acquirer.

Overall the payment logs should have an uniform format. Hopefully
understanding log messages related to transactions should be easier, as
now log format is independent of the acquirer and transaction are easily
identified by reference.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
