### PR TITLE
[FIX] core: revert check on new models before setup

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -193,19 +193,18 @@ def load_module_graph(cr, graph, status=None, perform_checks=True,
             mode = 'init'
 
         loaded_modules.append(package.name)
-        if model_names:
-            if needs_update:
-                models_updated |= set(model_names)
-                models_to_check -= set(model_names)
-                registry.setup_models(cr)
-                registry.init_models(cr, model_names, {'module': package.name}, new_install)
-            elif package.state != 'to remove':
-                # The current module has simply been loaded. The models extended by this module
-                # and for which we updated the schema, must have their schema checked again.
-                # This is because the extension may have changed the model,
-                # e.g. adding required=True to an existing field, but the schema has not been
-                # updated by this module because it's not marked as 'to upgrade/to install'.
-                models_to_check |= set(model_names) & models_updated
+        if needs_update:
+            models_updated |= set(model_names)
+            models_to_check -= set(model_names)
+            registry.setup_models(cr)
+            registry.init_models(cr, model_names, {'module': package.name}, new_install)
+        elif package.state != 'to remove':
+            # The current module has simply been loaded. The models extended by this module
+            # and for which we updated the schema, must have their schema checked again.
+            # This is because the extension may have changed the model,
+            # e.g. adding required=True to an existing field, but the schema has not been
+            # updated by this module because it's not marked as 'to upgrade/to install'.
+            models_to_check |= set(model_names) & models_updated
 
         idref = {}
 


### PR DESCRIPTION
This reverts commit 9cc4d6956b71291958114196107b1889109e92a1.

How to reproduce the issue:
- Starts from a database with some modules installed (account).
- Install a module with data only (l10n_generic_coa)

The models are not setup and the data fails to install.

A proper fix would be to mark the registry as dirty when new models are
added and only setup models when needed.

Since the faulty commit was part of a bunch of optimization and the
impact of this particular one is quite small, reverting it is a quick
and easy fix waiting for a better one (maybe, one day).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
