### PR TITLE
[FIX] mail: fix traceback on emoji

### DIFF
--- a/addons/mail/static/src/components/chatter/tests/chatter_tests.js
+++ b/addons/mail/static/src/components/chatter/tests/chatter_tests.js
@@ -91,7 +91,7 @@ QUnit.test('base rendering when chatter has no attachment', async function (asse
 });
 
 QUnit.test('base rendering when chatter has no record', async function (assert) {
-    assert.expect(8);
+    assert.expect(10);
 
     await this.start();
     const chatter = this.messaging.models['mail.chatter'].create({
@@ -137,6 +137,20 @@ QUnit.test('base rendering when chatter has no record', async function (assert) 
         document.body,
         '.o_MessageList_loadMore',
         "should not have the 'load more' button"
+    );
+
+    await afterNextRender(() =>
+        document.querySelector('.o_Message').click()
+    );
+    assert.strictEqual(
+        document.querySelectorAll(`.o_MessageActionList`).length,
+        1,
+        "should action list in message"
+    );
+    assert.containsNone(
+        document.body,
+        '.o_MessageActionList_action',
+        "should not have any action in action list of message"
     );
 });
 

--- a/addons/mail/static/src/components/message_action_list/message_action_list.xml
+++ b/addons/mail/static/src/components/message_action_list/message_action_list.xml
@@ -3,7 +3,7 @@
     <t t-name="mail.MessageActionList" owl="1">
         <div class="o_MessageActionList d-flex" t-on-click="messageActionList and messageActionList.onClick">
             <t t-if="messageActionList">
-                <Popover class="o_MessageActionList_action o_MessageActionList_actionReaction p-2 fa fa-lg fa-smile-o" position="'top'" titleAttribute="ADD_A_REACTION" t-on-o-emoji-selection="messageActionList.onEmojiSelection" t-on-o-popover-closed="messageActionList.onReactionPopoverClosed" t-on-o-popover-opened="messageActionList.onReactionPopoverOpened" t-ref="reactionPopover">
+                <Popover t-if="messageActionList.message.hasReactionIcon" class="o_MessageActionList_action o_MessageActionList_actionReaction p-2 fa fa-lg fa-smile-o" position="'top'" titleAttribute="ADD_A_REACTION" t-on-o-emoji-selection="messageActionList.onEmojiSelection" t-on-o-popover-closed="messageActionList.onReactionPopoverClosed" t-on-o-popover-opened="messageActionList.onReactionPopoverOpened" t-ref="reactionPopover">
                     <t t-set="opened">
                         <EmojisPopover/>
                     </t>

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -395,6 +395,13 @@ function factory(dependencies) {
         }
 
         /**
+         * @returns {boolean}
+         */
+        _computeHasReactionIcon() {
+            return !this.isTemporary && !this.isTransient;
+        }
+
+        /**
          * @private
          * @returns {boolean}
          */
@@ -617,6 +624,12 @@ function factory(dependencies) {
         }),
         guestAuthor: many2one('mail.guest', {
             inverse: 'authoredMessages',
+        }),
+        /**
+         * Determines whether the message has a reaction icon.
+         */
+        hasReactionIcon: attr({
+            compute: '_computeHasReactionIcon',
         }),
         id: attr({
             readonly: true,


### PR DESCRIPTION
Current behavior before PR:

When trying to select emoji on log note before record creation,
it shows traceback.

Desired behavior after PR is merged:

Hiding the emoji button when the record is under creation.

Task-2664700
