### PR TITLE
[FIX] account: fix misc reverse tags

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3379,7 +3379,7 @@ class AccountMoveLine(models.Model):
                     # Cash basis entries are always treated as misc operations, applying the tag sign directly to the balance
                     type_multiplicator = 1
                 else:
-                    type_multiplicator = (record.journal_id.type == 'sale' and -1 or 1) * (self._get_refund_tax_audit_condition(record) and -1 or 1)
+                    type_multiplicator = (record.journal_id.type == 'sale' and self._get_not_entry_condition(record) and -1 or 1) * (self._get_refund_tax_audit_condition(record) and -1 or 1)
 
                 tag_amount = type_multiplicator * (tag.tax_negate and -1 or 1) * record.balance
 
@@ -3394,6 +3394,14 @@ class AccountMoveLine(models.Model):
                     audit_str += tag.name + ': ' + formatLang(self.env, tag_amount, currency_obj=currency)
 
             record.tax_audit = audit_str
+
+    def _get_not_entry_condition(self, aml):
+        """
+        Returns the condition to exclude entry move types to avoid their tax_audit value
+        to be revesed if they are from type entry.
+        This function is overridden in pos.
+        """
+        return aml.move_id.type != 'entry'
 
     def _get_refund_tax_audit_condition(self, aml):
         """ Returns the condition to be used for the provided move line to tell

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2059,10 +2059,6 @@ class AccountMove(models.Model):
             # invoice_repartition_line => refund_repartition_line
             mapping = {}
 
-            # Do nothing if the move is not a credit note.
-            if move_vals['type'] not in ('out_refund', 'in_refund'):
-                return mapping
-
             for line_command in move_vals.get('line_ids', []):
                 line_vals = line_command[2]  # (0, 0, {...})
 
@@ -2080,9 +2076,33 @@ class AccountMove(models.Model):
                         mapping[inv_rep_line] = ref_rep_line
             return mapping
 
+        def invert_tags_if_needed(repartition_line, tags):
+            tax_type = repartition_line.tax_id.type_tax_use
+            tags_need_inversion = self._tax_tags_need_inversion(
+                self,
+                (
+                    (tax_type == 'purchase' and line_vals['credit'] > 0) or
+                    (tax_type == 'sale' and line_vals['debit'] > 0)
+                ),
+                tax_type)
+            if tags_need_inversion:
+                return self.env['account.move.line']._revert_signed_tags(tags)
+            return tags
+
         move_vals = self.with_context(include_business_fields=True).copy_data(default=default_values)[0]
 
-        tax_repartition_lines_mapping = compute_tax_repartition_lines_mapping(move_vals)
+        is_refund = False
+        if move_vals['type'] in ('out_refund', 'in_refund'):
+            is_refund = True
+        elif move_vals['type'] == 'entry':
+            base_lines = self.line_ids.filtered(lambda line: line.tax_ids)
+            tax_type = set(base_lines.tax_ids.mapped('type_tax_use'))
+            if tax_type == {'sale'} and sum(base_lines.mapped('debit')) == 0:
+                is_refund = True
+            elif tax_type == {'purchase'} and sum(base_lines.mapped('credit')) == 0:
+                is_refund = True
+
+        tax_repartition_lines_mapping = compute_tax_repartition_lines_mapping(move_vals) if is_refund else {}
 
         for line_command in move_vals.get('line_ids', []):
             line_vals = line_command[2]  # (0, 0, {...})
@@ -2097,7 +2117,7 @@ class AccountMove(models.Model):
                 'credit': balance < 0.0 and -balance or 0.0,
             })
 
-            if move_vals['type'] not in ('out_refund', 'in_refund'):
+            if not is_refund:
                 continue
 
             # ==== Map tax repartition lines ====
@@ -2124,6 +2144,7 @@ class AccountMove(models.Model):
                     subsequent_taxes = self.env['account.tax'].browse(line_vals['tax_ids'][0][2])
                     tags += subsequent_taxes.refund_repartition_line_ids.filtered(lambda x: x.repartition_type == 'base').tag_ids
 
+                tags = invert_tags_if_needed(refund_repartition_line, tags)
                 line_vals.update({
                     'tax_repartition_line_id': refund_repartition_line.id,
                     'account_id': account_id,
@@ -2138,7 +2159,11 @@ class AccountMove(models.Model):
                 refund_repartition_lines = invoice_repartition_lines\
                     .mapped(lambda line: tax_repartition_lines_mapping[line])
 
-                line_vals['tag_ids'] = [(6, 0, refund_repartition_lines.mapped('tag_ids').ids)]
+                tag_ids = []
+                for refund_repartition_line in refund_repartition_lines:
+                    tag_ids += invert_tags_if_needed(refund_repartition_line, refund_repartition_line.tag_ids).ids
+
+                line_vals['tag_ids'] = [(6, 0, tag_ids)]
         return move_vals
 
     def _reverse_moves(self, default_values_list=None, cancel=False):

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3350,9 +3350,6 @@ class AccountMoveLine(models.Model):
             audit_str = ''
             for tag in record.tag_ids:
 
-                caba_origin_inv_type = record.move_id.type
-                caba_origin_inv_journal_type = record.journal_id.type
-
                 if record.move_id.tax_cash_basis_rec_id:
                     # Cash basis entries are always treated as misc operations, applying the tag sign directly to the balance
                     type_multiplicator = 1

--- a/addons/account/tests/test_reconciliation.py
+++ b/addons/account/tests/test_reconciliation.py
@@ -1913,12 +1913,15 @@ class TestReconciliationExec(TestReconciliation):
     def test_reconciliation_cash_basis_revert(self):
         company = self.env.ref('base.main_company')
         company.tax_cash_basis_journal_id = self.cash_basis_journal
-        tax_cash_basis10percent = self.tax_cash_basis.copy({'amount': 10})
-        self.tax_waiting_account.reconcile = True
         tax_waiting_account10 = self.tax_waiting_account.copy({
             'name': 'TAX WAIT 10',
             'code': 'TWAIT1',
         })
+        tax_cash_basis10percent = self.tax_cash_basis.copy({
+            'amount': 10,
+            'cash_basis_transition_account_id': tax_waiting_account10.id,
+        })
+        self.tax_waiting_account.reconcile = True
 
         # Purchase
         purchase_move = self.env['account.move'].create({

--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -46,6 +46,16 @@ class AccountMoveLine(models.Model):
             price_unit = - order._get_pos_anglo_saxon_price_unit(self.product_id, self.move_id.partner_id.id, self.quantity)
         return price_unit
 
+    def _get_not_entry_condition(self, aml):
+        # Overridden so that sale entry moves created par POS still have their amount inverted
+        # in _compute_tax_audit()
+        rslt = super()._get_not_entry_condition(aml)
+
+        sessions_count = self.env['pos.session'].search_count([('move_id', '=', aml.move_id.id)])
+        pos_orders_count = self.env['pos.order'].search_count([('account_move', '=', aml.move_id.id)])
+
+        return rslt or (sessions_count + pos_orders_count)
+
     def _get_refund_tax_audit_condition(self, aml):
         # Overridden so that the returns can be detected as credit notes by the tax audit computation
         rslt = super()._get_refund_tax_audit_condition(aml)


### PR DESCRIPTION


Before this fix, all moves of type “entry“ were considered as misc operations in regard to repartition tags and the tax report. And only moves of type “out_refund” and “in_refund” were considered refunds.
Now reverse entries with sale/purchase taxes get their tags set accordingly to repartition lines.

```
Account                                    D      C      Tax   Tax Grids
700000 Ventes en Belgique (marchandises)   0      1000   21%   -03
451000 T.V.A. à payer                      0      210          -54
400000 Clients                             1210   0
```

Was reversed to:
```
Account                                    D      C      Tax   Tax Grids
700000 Ventes en Belgique (marchandises)   1000   0      21%   -03
451000 T.V.A. à payer                      210    0            -54
400000 Clients                             0      1210
```

Is now reversed to:
```
Account                                    D      C      Tax   Tax Grids
700000 Ventes en Belgique (marchandises)   1000   0      21%   +49
451000 T.V.A. à payer                      210    0            +64
400000 Clients                             0      1210

```
Task: 2687215