### PR TITLE
[FIX] project - Fixed the issue of view not loading upon click of "Task in Recurrance" button

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2088,7 +2088,7 @@ class Task(models.Model):
             'name': 'Tasks in Recurrence',
             'type': 'ir.actions.act_window',
             'res_model': 'project.task',
-            'view_mode': 'tree,form,kanban,calendar,pivot,graph,gantt,activity,map',
+            'view_mode': 'tree,form,kanban,calendar,pivot,graph,activity',
             'domain': [('recurrence_id', 'in', self.recurrence_id.ids)],
         }
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When a user clicked on "Task in Recurrance" button it gave him following Warning.
No default view of type 'gantt' could be found !

**Current behavior before PR:**
In the code when the action was returned, there were gantt and map views returned. This views are not present in the XML and hence they do not exist.

**Desired behavior after PR is merged:**
This commit removes the map and gantt view from the action return and hence the view now loads successfully when user clicks on the smart button.

Fixes #79555




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
