### PR TITLE
[FIX] calendar: Popup notifications 'Details' button lead to a existing event.

### DIFF
--- a/addons/calendar/static/src/js/services/calendar_notification_service.js
+++ b/addons/calendar/static/src/js/services/calendar_notification_service.js
@@ -61,12 +61,13 @@ export const calendarNotificationService = {
                             {
                                 name: env._t("Details"),
                                 onClick: async () => {
-                                    await action.doAction(
-                                        "calendar.action_calendar_event_notify",
-                                        {
-                                            resId: notif.event_id,
-                                        }
-                                    );
+                                    await action.doAction({
+                                        res_model: 'calendar.event',
+                                        res_id: notif.event_id,
+                                        type: "ir.actions.act_window",
+                                        views: [[false, "form"]],
+                                        view_mode: "form",
+                                    });
                                     notificationRemove();
                                 },
                             },


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**
Popup notifications 'Details' button lead to a new form instead of opening an existing calendar event.

**Current behavior before PR**
Popup notifications 'Details' button lead to a new form instead of opening an existing calendar event.

resId was returned in doAction in js where it was not handled and correct record was not opening.

**Desired behavior after PR is merged**
Handled the doAction method via "ir.actions.act_window" and passed the res_id which now opens the correct record.

After this commit when user clicks on "Details" button on the popup notification it now opens the related calendar event.

Fixes #78002

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
