### PR TITLE
Clean up models.py

### DIFF
--- a/addons/portal/wizard/portal_wizard.py
+++ b/addons/portal/wizard/portal_wizard.py
@@ -61,7 +61,6 @@ class PortalWizard(models.TransientModel):
 
     def _action_open_modal(self):
         """Allow to keep the wizard modal open after executing the action."""
-        self.refresh()
         return {
             'name': _('Portal Access Management'),
             'type': 'ir.actions.act_window',

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -21,10 +21,6 @@ class IrUiMenu(models.Model):
     _order = "sequence,id"
     _parent_store = True
 
-    def __init__(self, *args, **kwargs):
-        super(IrUiMenu, self).__init__(*args, **kwargs)
-        self.pool['ir.model.access'].register_cache_clearing_method(self._name, 'clear_caches')
-
     name = fields.Char(string='Menu', required=True, translate=True)
     active = fields.Boolean(default=True)
     sequence = fields.Integer(default=10)

--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -7,6 +7,7 @@ from . import test_api
 from . import test_base
 from . import test_basecase
 from . import test_cache
+from . import test_deprecation
 from . import test_db_cursor
 from . import test_expression
 from . import test_float

--- a/odoo/addons/base/tests/test_deprecation.py
+++ b/odoo/addons/base/tests/test_deprecation.py
@@ -1,0 +1,26 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import inspect
+
+from odoo.tests.common import TransactionCase, tagged
+
+DEPRECATED_MODEL_ATTRIBUTES = [
+    'view_init',
+]
+
+
+@tagged('-at_install', 'post_install', 'deprecation')
+class TestModelDeprecations(TransactionCase):
+
+    def test_model_attributes(self):
+        for model_name, Model in self.registry.items():
+            for attr in DEPRECATED_MODEL_ATTRIBUTES:
+                with self.subTest(model=model_name, attr=attr):
+                    value = getattr(Model, attr, None)
+                    if value is None:
+                        continue
+                    msg = f"Deprecated method/attribute {model_name}.{attr}"
+                    module = inspect.getmodule(value)
+                    if module:
+                        msg += f" in {module}"
+                    self.fail(msg)

--- a/odoo/addons/base/tests/test_deprecation.py
+++ b/odoo/addons/base/tests/test_deprecation.py
@@ -6,6 +6,7 @@ from odoo.tests.common import TransactionCase, tagged
 
 DEPRECATED_MODEL_ATTRIBUTES = [
     'view_init',
+    '_needaction',
 ]
 
 

--- a/odoo/addons/base/tests/test_deprecation.py
+++ b/odoo/addons/base/tests/test_deprecation.py
@@ -7,6 +7,8 @@ from odoo.tests.common import TransactionCase, tagged
 DEPRECATED_MODEL_ATTRIBUTES = [
     'view_init',
     '_needaction',
+    '_sql',
+    '_execute_sql',
 ]
 
 

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -74,10 +74,6 @@ class Meta(type):
             if not key.startswith('__') and callable(value):
                 # make the method inherit from decorators
                 value = propagate(getattr(parent, key, None), value)
-
-                if (getattr(value, '_api', None) or '').startswith('cr'):
-                    _logger.warning("Deprecated method %s.%s in module %s", name, key, attrs.get('__module__'))
-
                 attrs[key] = value
 
         return type.__new__(meta, name, bases, attrs)

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -534,7 +534,7 @@ class Environment(Mapping):
 
     def __getitem__(self, model_name):
         """ Return an empty recordset from the given model. """
-        return self.registry[model_name]._browse(self, (), ())
+        return self.registry[model_name](self, (), ())
 
     def __iter__(self):
         """ Return an iterator on model names. """

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -34,6 +34,7 @@ import operator
 import pytz
 import re
 import uuid
+import warnings
 from collections import defaultdict, OrderedDict
 from collections.abc import MutableMapping
 from contextlib import closing
@@ -6008,6 +6009,8 @@ Fields:
             .. deprecated:: 8.0
                 The record cache is automatically invalidated.
         """
+        warnings.warn('refresh() is deprecated method, use invalidate_cache() instead',
+                      DeprecationWarning)
         self.invalidate_cache()
 
     @api.model

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -538,13 +538,6 @@ class BaseModel(metaclass=MetaModel):
 
     CONCURRENCY_CHECK_FIELD = '__last_update'
 
-    @api.model
-    def view_init(self, fields_list):
-        """ Override this method to do specific things when a form view is
-        opened. This method is invoked by :meth:`~default_get`.
-        """
-        pass
-
     def _valid_field_parameter(self, field, name):
         """ Return whether the given parameter name is valid for the field. """
         return name == 'related_sudo'
@@ -1389,9 +1382,6 @@ class BaseModel(metaclass=MetaModel):
             Unrequested defaults won't be considered, there is no need to return a
             value for fields whose names are not in `fields_list`.
         """
-        # trigger view init hook
-        self.view_init(fields_list)
-
         defaults = {}
         parent_fields = defaultdict(list)
         ir_defaults = self.env['ir.default'].get_model_defaults(self._name)

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2844,9 +2844,6 @@ class BaseModel(metaclass=MetaModel):
         if self._auto:
             self._add_sql_constraints()
 
-        if must_create_table:
-            self._execute_sql()
-
         if parent_path_compute:
             self._parent_store_compute()
 
@@ -2887,11 +2884,6 @@ class BaseModel(metaclass=MetaModel):
                 self.pool.post_init(tools.add_constraint, cr, self._table, conname, definition)
             else:
                 self.pool.post_constraint(tools.add_constraint, cr, self._table, conname, definition)
-
-    def _execute_sql(self):
-        """ Execute the SQL code from the _sql attribute (if any)."""
-        if hasattr(self, "_sql"):
-            self._cr.execute(self._sql)
 
     #
     # Update objects that use this one to update their _inherits fields

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5693,9 +5693,8 @@ Fields:
 
     def update(self, values):
         """ Update the records in ``self`` with ``values``. """
-        for record in self:
-            for name, value in values.items():
-                record[name] = value
+        for name, value in values.items():
+            self[name] = value
 
     @api.model
     def flush(self, fnames=None, records=None):
@@ -6160,7 +6159,7 @@ Fields:
                     real_records = self - new_records
                     records = model.browse()
                     if real_records:
-                        records |= model.search([(key.name, 'in', real_records.ids)], order='id')
+                        records = model.search([(key.name, 'in', real_records.ids)], order='id')
                     if new_records:
                         cache_records = self.env.cache.get_records(model, key)
                         records |= cache_records.filtered(lambda r: set(r[key.name]._ids) & set(self._ids))


### PR DESCRIPTION

[REF] base: replace `_browse` by `__init__`

The creation of recordset object was done by `_browse` instead
of a normal python class with the `__init__`.
We remove the old usage of `__init__`, we can now reuse it
with a normal usage.
After this commit, we can create recordset by the Class without call a
classmethod: `self.env['model_name'](env, ids, prefetch_ids)`

[REM] base: depreciate _execute_sql

It wasn't unused then depreciate to be removed in the next version.

[REM] base: remove deadcode from models.py

- Remove unused imports `AsIs` and `Collector`
- Remove _schema variable (unused)
- Remove same_name function (unused)
- Remove attribute `_needaction` which is useless
- Remove backward compatibility `__new__` and `__init__` which isn't
used anymore.
- Remove backward compatibility `__export_rows`

[FIX] base: two small optimisation

- The `update` method of BaseModel wasn't batch for no
reason. This method is used in `_onchange_eval` and in few
onchange in Odoo.
- In `_modified_triggers` avoid a useless record union.

[REM] base: depreciated refresh method

The `refresh` method of models.py is a duplicate of
`invalidate_cache` and deprecated since 8.0 but without any
warning. Add this warning to be able to completely remove it
in the next version.

[REM] base: remove useless view_init

view_init is a useless hook call from default_get.
We can get the same result by overriding default_get
directly.
