### PR TITLE
[FIX] mrp: set component's lot as readonly in MO

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -271,7 +271,9 @@
                                     <field name="show_details_visible" invisible="1"/>
                                     <field name="lot_ids" widget="many2many_tags"
                                         groups="stock.group_production_lot" optional="hide"
-                                        attrs="{'invisible': ['|', '|', ('show_details_visible', '=', False), ('has_tracking', '!=', 'serial'), ('parent.state', '=', 'draft')], 'column_invisible': [('parent.show_lot_ids', '=',  False)]}"
+                                        attrs="{'invisible': ['|', '|', ('show_details_visible', '=', False), ('has_tracking', '!=', 'serial'), ('parent.state', '=', 'draft')],
+                                                'readonly': ['|', '|', ('show_details_visible', '=', False), ('has_tracking', '!=', 'serial'), ('parent.state', '=', 'draft')],
+                                                'column_invisible': [('parent.show_lot_ids', '=',  False)]}"
                                         options="{'create': [('parent.use_create_components_lots', '!=', False)]}"
                                         context="{'default_company_id': company_id, 'default_product_id': product_id}"
                                         domain="[('product_id','=',product_id)]"


### PR DESCRIPTION
Updating the producing quantity may wrongly change the consumed quantity
of tracked products

To reproduce the issue:
1. Create two storable products P1, P2:
    - P2 is tracked by lots
2. Update P2's quantity >= 10
3. Create a BoM:
    - Product: P1
    - Components: 1 x P2
4. Create and confirm a MO for 10 x P1
5. Check availability
6. Edit the MO and set the consumed quantity of P2 to 10
7. Edit the MO and set the producing quantity to 8

Error: The consumed quantity of P2 becomes 1

When saving the MO, it also writes the `lot_ids` on `move_raw_ids` while
it shouldn't. As a result, it triggers method `_set_lot_ids` for no
reason and lead to an undesirable behavior.

OPW-2667412