### PR TITLE
[FIX] web: Provide context to executeAction

### DIFF
--- a/addons/web/static/src/legacy/js/components/action_menus.js
+++ b/addons/web/static/src/legacy/js/components/action_menus.js
@@ -120,6 +120,7 @@ odoo.define('web.ActionMenus', function (require) {
                     args: [this.props.domain],
                     kwargs: {
                         limit: this.env.session.active_ids_limit,
+                        context: this.props.context,
                     },
                 });
             }

--- a/addons/web/static/tests/legacy/components/action_menus_tests.js
+++ b/addons/web/static/tests/legacy/components/action_menus_tests.js
@@ -246,5 +246,33 @@ odoo.define('web.action_menus_tests', function (require) {
 
             actionMenus.destroy();
         });
+
+        QUnit.test('execute action with context', async function (assert) {
+            assert.expect(1);
+            const actionMenus = await createComponent(ActionMenus, {
+                env: {
+                    action: this.action,
+                    view: this.view,
+                },
+                props: {
+                    ...this.props,
+                    isDomainSelected:  true,
+                    context: {
+                        allowed_company_ids: [112],
+                    },
+                },
+                async mockRPC(route, args) {
+                    if (route === "/web/dataset/call_kw/hobbit/search"){
+                        assert.deepEqual(args.kwargs.context, { allowed_company_ids: [112] }, "The kwargs should contains the right context");
+                    }
+                    return this._super(...arguments);
+                },
+            });
+
+            await testUtils.controlPanel.toggleActionMenu(actionMenus, "Action");
+            await testUtils.controlPanel.toggleMenuItem(actionMenus, "What's taters, precious ?");
+
+            actionMenus.destroy();
+        });
     });
 });


### PR DESCRIPTION
When fetching the active_ids from the server,
the context does not appear in the rpc call,
which can lead to obtaining records linked to
another company and therefore to an access error

opw-2669292