### PR TITLE
[FIX] product: show the discount amount in pricelist before the save

### DIFF
--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -93,6 +93,7 @@
             <field name="arch" type="xml">
                 <form string="Pricelist Rule">
                     <sheet>
+                        <h1><field name="name"/></h1>
                         <group name="pricelist_rule_computation" groups="product.group_sale_pricelist" string="Price Computation">
                             <group name="pricelist_rule_method">
                                 <field name="compute_price" string="Computation" widget="radio"/>


### PR DESCRIPTION
Bug introduced by this commit: https://github.com/odoo/odoo/commit/52b87b694833dcfffb75b736f5d75c445e26880c#diff-6b23a03ba86caa77cb7a88cc7678cdba6bd4a0d27f2dadc0b8e49a07002bea6fL96

When you create a new pricelist (Advanced price rules (discounts, formulas)), it will not show the amount of the discount, the percentage either. You have to save it to be able to see it, since it shows 0

In the view, the "name" field is important for values to be updated, please see: https://github.com/odoo/odoo/blob/4a360603783bbfb0fac4bd757c356a59bd99041f/odoo/models.py#L6124-L6130

The first condition will be false and the second condition will check if at least one dependency of the field is present in `others_fields` and one of these fields is the “name".
So if we add this field, the condition will be true and an `"on_change ="1"` will be added to the view and therefore the view will be updated

opw-2685373


https://user-images.githubusercontent.com/78867936/140944921-53477d71-a7de-4206-be6a-d7ad4c5d570f.mp4






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
