### PR TITLE
[FIX] web_editor: fix ResizeObserver error in FF

### DIFF
--- a/addons/mass_mailing/static/src/js/mailing_mailing_view_form_full_width.js
+++ b/addons/mass_mailing/static/src/js/mailing_mailing_view_form_full_width.js
@@ -19,7 +19,16 @@ const MassMailingFullWidthFormController = FormController.extend({
         this._super(...arguments);
         this._boundOnDomUpdated = this._onDomUpdated.bind(this);
         bus.on('DOM_updated', this, this._onDomUpdated);
-        this._resizeObserver = new ResizeObserver(this._onResizeIframeContents.bind(this));
+        this._resizeObserver =  new ResizeObserver(entries => {
+            // We wrap this in requestAnimationFrame to greatly mitigate
+            // the "ResizeObserver loop limit exceeded" error.
+            window.requestAnimationFrame(() => {
+                if (!Array.isArray(entries) || !entries.length) {
+                    return;
+                }
+                this._onResizeIframeContents(entries);
+            });
+        });
     },
     /**
      * @override

--- a/addons/web/static/src/core/errors/error_service.js
+++ b/addons/web/static/src/core/errors/error_service.js
@@ -97,6 +97,15 @@ export const errorService = {
 
         browser.addEventListener("error", async (ev) => {
             const { colno, error: originalError, filename, lineno, message } = ev;
+            const errorsToIgnore = [
+                // Ignore some unnecessary "ResizeObserver loop limit exceeded" error in Firefox.
+                "ResizeObserver loop completed with undelivered notifications.",
+                // ignore Chrome video internal error: https://crbug.com/809574
+                "ResizeObserver loop limit exceeded"
+            ]
+            if (!originalError && errorsToIgnore.includes(message)) {
+                return;
+            }
             let uncaughtError;
             if (!filename && !lineno && !colno) {
                 uncaughtError = new UncaughtCorsError();
@@ -107,10 +116,6 @@ export const errorService = {
                         `(Opening your browser console might give you a hint on the error.)`
                 );
             } else {
-                // ignore Chrome video internal error: https://crbug.com/809574
-                if (!originalError && message === "ResizeObserver loop limit exceeded") {
-                    return;
-                }
                 uncaughtError = new UncaughtClientError();
                 await completeUncaughtError(env, uncaughtError, originalError);
             }


### PR DESCRIPTION
The error "ResizeObserver loop limit exceeded" was catch by the browser error
global listener. this error was wrongly flagged as a CORS error.
This error is well known to be useless and can safely be ignored.

We do so.

Task-2670745

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
