### PR TITLE
[FIX] stock: safely reference move source in reception report labels

### DIFF
--- a/addons/stock/report/report_stock_reception.xml
+++ b/addons/stock/report/report_stock_reception.xml
@@ -10,10 +10,11 @@
                 <t t-foreach="range(len(docs))" t-as="index">
                     <t t-set="move" t-value="docs[index]"/>
                     <t t-set="qty" t-value="qtys[index]"/>
+                    <t t-set="source" t-value="move._get_source_document()"/>
                     <t t-foreach="range(qty)" t-as="j">
                         <div class="o_label_page o_label_dymo">
                             <div t-out="move.product_id.display_name"/>
-                            <div t-out="move._get_source_document().name"/>
+                            <div t-if="source" t-out="source.name"/>
                             <div class="address"
                                 t-if="move.picking_id and move.picking_id.partner_id"
                                 t-field="move.picking_id.partner_id"


### PR DESCRIPTION
Commit d6abfbade9fb7f6dd6b3253551c559b1c7e6ece5 made it so we directly
reference a move's source origin via _get_source_document(). Normally
this is fine when the labels are created because labels would never be
created for a move without a source document, but this isn't safe when
the label is accessed via another way (e.g. test_reports). Therefore,
let's add in a check to prevent a error from trying to access
False.name.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
