### PR TITLE
[FIX] stock: consider inactive warehouses for locations

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -133,7 +133,7 @@ class Location(models.Model):
 
     @api.depends('warehouse_view_ids')
     def _compute_warehouse_id(self):
-        warehouses = self.env['stock.warehouse'].search([('view_location_id', 'parent_of', self.ids)])
+        warehouses = self.env['stock.warehouse'].with_context(active_test=False).search([('view_location_id', 'parent_of', self.ids)])
         view_by_wh = OrderedDict((wh.view_location_id.id, wh.id) for wh in warehouses)
         self.warehouse_id = False
         for loc in self:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The archived warehouses are not considered when computing the warehouse_id of stock locations, and they should be considered.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr