### PR TITLE
[FIX] website: add test for onFocus/onBlur flow

### DIFF
--- a/addons/website/static/tests/tours/focus_blur_snippets.js
+++ b/addons/website/static/tests/tours/focus_blur_snippets.js
@@ -1,0 +1,80 @@
+odoo.define('website.tour.focus_blur_snippets', function (require) {
+'use strict';
+
+const ajax = require('web.ajax');
+const tour = require('web_tour.tour');
+
+const blockIDToData = {
+    parent: {
+        selector: '.s_focusblur',
+        name: 'section',
+        number: 0,
+    },
+    child1: {
+        selector: '.s_focusblur_child1',
+        name: 'first child',
+        number: 1,
+    },
+    child2: {
+        selector: '.s_focusblur_child2',
+        name: 'second child',
+        number: 2,
+    },
+};
+
+function clickAndCheck(blockID, expected) {
+    const blockData = blockIDToData[blockID] || {};
+
+    return [{
+        content: blockID ? `Enable the ${blockData.name}` : 'Disable all blocks',
+        trigger: blockData.selector || '#wrapwrap',
+    }, {
+        content: 'Once the related overlays are enabled/disabled, check that the focus/blur calls have been correct.',
+        trigger: blockID
+            ? `.oe_overlay.ui-draggable:eq(${blockData.number}).oe_active`
+            : `#oe_manipulators:not(:has(.oe_active))`,
+        run: function (actions) {
+            const result = window.focusBlurSnippetsResult;
+            window.focusBlurSnippetsResult = [];
+
+            if (expected.length !== result.length
+                    || !expected.every((item, i) => item === result[i])) {
+                console.error(`
+                    Expected: ${expected.toString()}
+                    Result: ${result.toString()}
+                `);
+            }
+        },
+    }];
+}
+
+window.focusBlurSnippetsResult = [];
+
+tour.register('focus_blur_snippets', {
+    url: '/?enable_editor=1',
+}, [
+    {
+        content: 'First load our custom JS options',
+        trigger: 'body',
+        run: function () {
+            ajax.loadJS('/website/static/tests/tours/tour_utils/focus_blur_snippets_options.js').then(function () {
+                $('body').addClass('focus_blur_snippets_options_loaded');
+            });
+        },
+    },
+    {
+        content: 'Drag the custom block into the page',
+        trigger: '#snippet_structure .oe_snippet:has(.oe_snippet_body.s_focusblur) .oe_snippet_thumbnail',
+        extra_trigger: 'body.focus_blur_snippets_options_loaded',
+        run: 'drag_and_drop #wrap',
+    },
+    ...clickAndCheck('parent', ['focus parent']),
+    ...clickAndCheck(null, ['blur parent']),
+    ...clickAndCheck('child1', ['focus parent', 'focus child1']),
+    ...clickAndCheck(null, ['blur parent', 'blur child1']),
+    ...clickAndCheck('parent', ['focus parent']),
+    ...clickAndCheck('child1', ['blur parent', 'focus parent', 'focus child1']),
+    ...clickAndCheck('child2', ['blur parent', 'blur child1', 'focus parent', 'focus child2']),
+    ...clickAndCheck('parent', ['blur parent', 'blur child2', 'focus parent']),
+]);
+});

--- a/addons/website/static/tests/tours/tour_utils/focus_blur_snippets_options.js
+++ b/addons/website/static/tests/tours/tour_utils/focus_blur_snippets_options.js
@@ -1,0 +1,19 @@
+odoo.define('website.tour_focus_blur_snippets_options', function (require) {
+'use strict';
+
+const options = require('web_editor.snippets.options');
+
+const FocusBlur = options.Class.extend({
+    onFocus() {
+        window.focusBlurSnippetsResult.push(`focus ${this.focusBlurName}`);
+    },
+    onBlur() {
+        window.focusBlurSnippetsResult.push(`blur ${this.focusBlurName}`);
+    },
+});
+
+options.registry.FocusBlurParent = FocusBlur.extend({focusBlurName: 'parent'});
+options.registry.FocusBlurChild1 = FocusBlur.extend({focusBlurName: 'child1'});
+options.registry.FocusBlurChild2 = FocusBlur.extend({focusBlurName: 'child2'});
+
+});

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -155,3 +155,54 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_07_carousel_snippet_content_removal(self):
         self.start_tour("/", "carousel_content_removal", login='admin')
+
+    def test_08_editor_focus_blur_unit_test(self):
+        # TODO this should definitely not be a website python tour test but
+        # while waiting for a proper web_editor qunit JS test suite for the
+        # editor, it is better than no test at all as this was broken multiple
+        # times already.
+        self.env["ir.ui.view"].create([{
+            'name': 's_focusblur',
+            'key': 'website.s_focusblur',
+            'type': 'qweb',
+            'arch': """
+                <section class="s_focusblur bg-success py-5">
+                    <div class="container">
+                        <div class="row">
+                            <div class="col-lg-6 s_focusblur_child1 bg-warning py-5"></div>
+                            <div class="col-lg-6 s_focusblur_child2 bg-danger py-5"></div>
+                        </div>
+                    </div>
+                </section>
+            """,
+        }, {
+            'name': 's_focusblur_snippets',
+            'mode': 'extension',
+            'inherit_id': self.env.ref('website.snippets').id,
+            'key': 'website.s_focusblur_snippets',
+            'type': 'qweb',
+            'arch': """
+                <data>
+                    <xpath expr="//*[@id='snippet_structure']//t[@t-snippet]" position="before">
+                        <t t-snippet="website.s_focusblur"/>
+                    </xpath>
+                </data>
+            """,
+        }, {
+            'name': 's_focusblur_options',
+            'mode': 'extension',
+            'inherit_id': self.env.ref('web_editor.snippet_options').id,
+            'key': 'website.s_focusblur_options',
+            'type': 'qweb',
+            'arch': """
+                <data>
+                    <xpath expr=".">
+                        <div data-js="FocusBlurParent" data-selector=".s_focusblur"/>
+                        <div data-js="FocusBlurChild1" data-selector=".s_focusblur_child1"/>
+                        <div data-js="FocusBlurChild2" data-selector=".s_focusblur_child2"/>
+                    </xpath>
+                </data>
+            """,
+        }])
+
+        self.start_tour("/?enable_editor=1", "focus_blur_snippets", login="admin")

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -22,6 +22,7 @@
         <script type="text/javascript" src="/website/static/tests/tours/carousel_content_removal.js"/>
         <script type="text/javascript" src="/website/static/tests/tours/reset_password.js"></script>
         <script type="text/javascript" src="/website/static/tests/tours/rte.js"/>
+        <script type="text/javascript" src="/website/static/tests/tours/focus_blur_snippets.js"/>
         <script type="text/javascript" src="/website/static/tests/tours/html_editor.js"/>
         <script type="text/javascript" src="/website/static/tests/tours/restricted_editor.js"/>
         <script type="text/javascript" src="/website/static/tests/tours/dashboard_tour.js"/>


### PR DESCRIPTION
The flow has been broken multiple times across the years. Let's add a
test in all stable versions. In 14.0 and 15.0, bugs in that flow have
been reintroduced in multiple ways, those will be fixed during the
forward-port of this test.
