### PR TITLE
[IMP] account: implementation of storno accounting

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -93,6 +93,7 @@ class AccountChartTemplate(models.Model):
             "templates, this is useful when you want to generate accounts of this template only when loading its child template.")
     currency_id = fields.Many2one('res.currency', string='Currency', required=True)
     use_anglo_saxon = fields.Boolean(string="Use Anglo-Saxon accounting", default=False)
+    use_storno_accounting = fields.Boolean(string="Use Storno accounting", default=False)
     complete_tax_set = fields.Boolean(string='Complete Set of Taxes', default=True,
         help="This boolean helps you to choose if you want to propose to the user to encode the sale and purchase rates or choose from list "
             "of taxes. This last choice assumes that the set of tax defined on this template is complete")
@@ -259,6 +260,7 @@ class AccountChartTemplate(models.Model):
 
         company.write({'currency_id': self.currency_id.id,
                        'anglo_saxon_accounting': self.use_anglo_saxon,
+                       'account_storno': self.use_storno_accounting,
                        'bank_account_code_prefix': self.bank_account_code_prefix,
                        'cash_account_code_prefix': self.cash_account_code_prefix,
                        'transfer_account_code_prefix': self.transfer_account_code_prefix,

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -167,6 +167,9 @@ class ResCompany(models.Model):
         help="Account that will be set on lines created in cash basis journal entry and used to keep track of the "
              "tax base amount.")
 
+    # Storno Accounting
+    account_storno = fields.Boolean(string="Storno accounting", readonly=False)
+
     @api.constrains('account_opening_move_id', 'fiscalyear_last_day', 'fiscalyear_last_month')
     def _check_fiscalyear_last_day(self):
         # if the user explicitly chooses the 29th of February we allow it:

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -145,6 +145,9 @@ class ResConfigSettings(models.TransientModel):
     # Technical field to hide country specific fields from accounting configuration
     country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
 
+    # Storno Accounting
+    account_storno = fields.Boolean(string="Storno accounting", readonly=False, related='company_id.account_storno')
+
     # Allows for the use of a different delivery address
     group_sale_delivery_address = fields.Boolean("Customer Addresses", implied_group='account.group_delivery_invoice_address')
 

--- a/addons/account/tests/test_account_move_in_refund.py
+++ b/addons/account/tests/test_account_move_in_refund.py
@@ -1010,3 +1010,66 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             **self.move_vals,
             'currency_id': self.currency_data['currency'].id,
         })
+
+    def test_in_refund_create_storno(self):
+        # Test creating an account_move refund (credit note)
+        # with multiple lines while in Storno accounting
+        self.env.company.account_storno = True
+
+        move = self.env['account.move'].create({
+            'move_type': 'in_refund',
+            'partner_id': self.partner_a.id,
+            'invoice_date': fields.Date.from_string('2019-01-01'),
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_payment_term_id': self.pay_terms_a.id,
+            'invoice_line_ids': [
+                (0, None, self.product_line_vals_1),
+                (0, None, self.product_line_vals_2),
+            ]
+        })
+
+        self.assertInvoiceValues(move, [
+            {
+                **self.product_line_vals_1,
+                'currency_id': self.currency_data['currency'].id,
+                'amount_currency': -800.0,
+                'balance': -400.0,
+                'debit': -400.0,
+                'credit': 0.0,
+            },
+            {
+                **self.product_line_vals_2,
+                'currency_id': self.currency_data['currency'].id,
+                'amount_currency': -160.0,
+                'balance': -80.0,
+                'debit': -80.0,
+                'credit': 0.0,
+            },
+            {
+                **self.tax_line_vals_1,
+                'currency_id': self.currency_data['currency'].id,
+                'amount_currency': -144.0,
+                'balance': -72.0,
+                'debit': -72.0,
+                'credit': 0.0,
+            },
+            {
+                **self.tax_line_vals_2,
+                'currency_id': self.currency_data['currency'].id,
+                'amount_currency': -24.0,
+                'balance': -12.0,
+                'debit': -12.0,
+                'credit': 0.0,
+            },
+            {
+                **self.term_line_vals_1,
+                'currency_id': self.currency_data['currency'].id,
+                'amount_currency': 1128.0,
+                'balance': 564.0,
+                'debit': 0.0,
+                'credit': -564.0,
+            },
+        ], {
+             **self.move_vals,
+             'currency_id': self.currency_data['currency'].id,
+        })

--- a/addons/account/tests/test_account_move_out_refund.py
+++ b/addons/account/tests/test_account_move_out_refund.py
@@ -993,3 +993,66 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             **self.move_vals,
             'currency_id': self.currency_data['currency'].id,
         })
+
+    def test_out_refund_create_storno(self):
+        # Test creating an account_move refund (credit note)
+        # with multiple lines while in Storno accounting
+        self.env.company.account_storno = True
+
+        move = self.env['account.move'].create({
+            'move_type': 'out_refund',
+            'partner_id': self.partner_a.id,
+            'invoice_date': fields.Date.from_string('2019-01-01'),
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_payment_term_id': self.pay_terms_a.id,
+            'invoice_line_ids': [
+                (0, None, self.product_line_vals_1),
+                (0, None, self.product_line_vals_2),
+            ]
+        })
+
+        self.assertInvoiceValues(move, [
+            {
+                **self.product_line_vals_1,
+                'currency_id': self.currency_data['currency'].id,
+                'amount_currency': 1000.0,
+                'balance': 500.0,
+                'debit': 0.0,
+                'credit': -500.0,
+            },
+            {
+                **self.product_line_vals_2,
+                'currency_id': self.currency_data['currency'].id,
+                'amount_currency': 200.0,
+                'balance': 100.0,
+                'debit': 0.0,
+                'credit': -100.0,
+            },
+            {
+                **self.tax_line_vals_1,
+                'currency_id': self.currency_data['currency'].id,
+                'amount_currency': 180.0,
+                'balance': 90.0,
+                'debit': 0.0,
+                'credit': -90.0,
+            },
+            {
+                **self.tax_line_vals_2,
+                'currency_id': self.currency_data['currency'].id,
+                'amount_currency': 30.0,
+                'balance': 15.0,
+                'debit': 0.0,
+                'credit': -15.0,
+            },
+            {
+                **self.term_line_vals_1,
+                'currency_id': self.currency_data['currency'].id,
+                'amount_currency': -1410.0,
+                'balance': -705.0,
+                'debit': -705.0,
+                'credit': 0.0,
+            },
+        ], {
+             **self.move_vals,
+             'currency_id': self.currency_data['currency'].id,
+         })

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -639,6 +639,23 @@
                                 </div>
                             </div>
                         </div>
+                        <h2>Storno Accounting</h2>
+                        <div class="row mt16 o_settings_container" id="storno">
+                            <div class="col-12 col-lg-6 o_setting_box"
+                                id="enable_storno_accounting"
+                                title="Allows you to use Storno accounting.">
+                                <div class="o_setting_left_pane">
+                                    <field name="account_storno"/>
+                                </div>
+                                <div class="o_setting_right_pane">
+                                    <label for="account_storno"/>
+                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
+                                    <div class="text-muted">
+                                        Use Storno accounting
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </xpath>
             </field>

--- a/addons/l10n_cn/data/l10n_cn_chart_data.xml
+++ b/addons/l10n_cn/data/l10n_cn_chart_data.xml
@@ -22,6 +22,7 @@ http://kjs.mof.gov.cn/zhengwuxinxi/zhengcefabu/201111/t20111107_605525.html
             <field name="transfer_account_code_prefix">1012</field>
             <field name="spoken_languages" eval="'en_US'"/>
             <field name="country_id" ref="base.cn"/>
+            <field name="use_storno_accounting" eval="True"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_cz/data/l10n_cz_coa_data.xml
+++ b/addons/l10n_cz/data/l10n_cz_coa_data.xml
@@ -10,6 +10,7 @@
             <field name="transfer_account_code_prefix">261</field>
             <field name="currency_id" ref="base.CZK"/>
             <field name="country_id" ref="base.cz"/>
+            <field name="use_storno_accounting" eval="True"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_hr/data/l10n_hr_chart_data.xml
+++ b/addons/l10n_hr/data/l10n_hr_chart_data.xml
@@ -13,6 +13,7 @@
             <field name="currency_id" ref="base.HRK"/>
             <field name="code_digits">0</field>
             <field name="country_id" ref="base.hr"/>
+            <field name="use_storno_accounting" eval="True"/>
         </record>
 
     </data>

--- a/addons/l10n_pl/data/l10n_pl_chart_data.xml
+++ b/addons/l10n_pl/data/l10n_pl_chart_data.xml
@@ -21,6 +21,7 @@
             <field name="cash_account_code_prefix">12-000-000</field>
             <field name="transfer_account_code_prefix">11-090-000</field>
             <field name="country_id" ref="base.pl"/>
+            <field name="use_storno_accounting" eval="True"/>
         </record>
 
 </data>

--- a/addons/l10n_ro/data/l10n_ro_chart_data.xml
+++ b/addons/l10n_ro/data/l10n_ro_chart_data.xml
@@ -11,5 +11,6 @@
         <field name="code_digits">6</field>
         <field name="currency_id" ref="base.RON"/>
         <field name="country_id" ref="base.ro"/>
+        <field name="use_storno_accounting" eval="True"/>
     </record>
 </odoo>

--- a/addons/l10n_si/data/l10n_si_chart_data.xml
+++ b/addons/l10n_si/data/l10n_si_chart_data.xml
@@ -10,5 +10,6 @@
         <field name="code_digits">6</field>
         <field name="currency_id" ref="base.EUR"/>
         <field name="country_id" ref="base.si"/>
+        <field name="use_storno_accounting" eval="True"/>
     </record>
 </odoo>

--- a/addons/l10n_sk/data/l10n_sk_coa_data.xml
+++ b/addons/l10n_sk/data/l10n_sk_coa_data.xml
@@ -10,6 +10,7 @@
             <field name="transfer_account_code_prefix">261</field>
             <field name="currency_id" ref="base.EUR"/>
             <field name="country_id" ref="base.sk"/>
+            <field name="use_storno_accounting" eval="True"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_ua/data/account_chart_template.xml
+++ b/addons/l10n_ua/data/account_chart_template.xml
@@ -9,6 +9,7 @@
         <field name="code_digits">6</field>
         <field name="currency_id" ref="base.UAH"/>
         <field name="country_id" ref="base.ua"/>
+        <field name="use_storno_accounting" eval="True"/>
     </record>
 
     <record id="l10n_ua_ias_chart_template" model="account.chart.template">
@@ -19,5 +20,6 @@
         <field name="code_digits">6</field>
         <field name="currency_id" ref="base.UAH"/>
         <field name="country_id" ref="base.ua"/>
+        <field name="use_storno_accounting" eval="True"/>
     </record>
 </odoo>


### PR DESCRIPTION
Storno accounting is the term used to described the process of recording a reverse action as a negative amount on the same site instead of a positive amount on the opposite site of the credit/debit.

For instance, when one creates a credit note for an invoice, the values of debit and credit will be kept in the same column with negative signs instead of swapping columns like in non-Storno accounting.

The following invoice
![image](https://user-images.githubusercontent.com/91618364/140953716-3dea6135-eba9-42ff-b4f2-8435bab5db69.png)
will generate the following credit note
![image](https://user-images.githubusercontent.com/91618364/140953851-93e3494f-e09a-4cdb-b49c-af2473a92b6c.png)
instead of
![image](https://user-images.githubusercontent.com/91618364/140953998-7c125acb-c258-4d94-b1f8-2612a26d9448.png)


Storno accounting is available as an option in the settings and is automatically activated for some countries which use this type of accounting such as Croatia or Slovenia. 

Related upgrade script: https://github.com/odoo/upgrade/pull/3212

task-2064899