### PR TITLE
[MERGE][IMP] website_mass_mailing: improve newsletter snippets

### DIFF
--- a/addons/website_mass_mailing/__manifest__.py
+++ b/addons/website_mass_mailing/__manifest__.py
@@ -12,6 +12,7 @@ On a simple click, your visitors can subscribe to mailing lists managed in the E
     'category': 'Website/Website',
     'depends': ['website', 'mass_mailing', 'google_recaptcha'],
     'data': [
+        'data/ir_model_data.xml',
         'views/snippets/s_popup.xml',
         'views/snippets_templates.xml',
     ],
@@ -25,6 +26,9 @@ On a simple click, your visitors can subscribe to mailing lists managed in the E
             'website_mass_mailing/static/src/js/website_mass_mailing.editor.js',
             'website_mass_mailing/static/src/scss/website_mass_mailing_edit_mode.scss',
             'website_mass_mailing/static/src/snippets/s_popup/options.js',
+        ],
+        'website.assets_editor': [
+            'website_mass_mailing/static/src/js/mass_mailing_form_editor.js',
         ],
         'web.assets_tests': [
             'website_mass_mailing/static/tests/**/*',

--- a/addons/website_mass_mailing/__manifest__.py
+++ b/addons/website_mass_mailing/__manifest__.py
@@ -24,6 +24,7 @@ On a simple click, your visitors can subscribe to mailing lists managed in the E
         'website.assets_wysiwyg': [
             'website_mass_mailing/static/src/js/website_mass_mailing.editor.js',
             'website_mass_mailing/static/src/scss/website_mass_mailing_edit_mode.scss',
+            'website_mass_mailing/static/src/snippets/s_popup/options.js',
         ],
         'web.assets_tests': [
             'website_mass_mailing/static/tests/**/*',

--- a/addons/website_mass_mailing/controllers/__init__.py
+++ b/addons/website_mass_mailing/controllers/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import main
+from . import website_form

--- a/addons/website_mass_mailing/controllers/main.py
+++ b/addons/website_mass_mailing/controllers/main.py
@@ -8,43 +8,58 @@ from odoo.addons.mass_mailing.controllers import main
 
 class MassMailController(main.MassMailController):
 
-    @route('/website_mass_mailing/is_subscriber', type='json', website=True, auth="public")
-    def is_subscriber(self, list_id, **post):
-        email = None
-        if not request.env.user._is_public():
-            email = request.env.user.email
-        elif request.session.get('mass_mailing_email'):
-            email = request.session['mass_mailing_email']
-
+    @route('/website_mass_mailing/is_subscriber', type='json', website=True, auth='public')
+    def is_subscriber(self, list_id, subscription_type, **post):
+        value = self._get_value(subscription_type)
+        fname = self._get_fname(subscription_type)
         is_subscriber = False
-        if email:
-            contacts_count = request.env['mailing.contact.subscription'].sudo().search_count([('list_id', 'in', [int(list_id)]), ('contact_id.email', '=', email), ('opt_out', '=', False)])
+        if value and fname:
+            contacts_count = request.env['mailing.contact.subscription'].sudo().search_count(
+                [('list_id', 'in', [int(list_id)]), (f'contact_id.{fname}', '=', value), ('opt_out', '=', False)])
             is_subscriber = contacts_count > 0
 
-        return {'is_subscriber': is_subscriber, 'email': email}
+        return {'is_subscriber': is_subscriber, 'value': value}
 
-    @route('/website_mass_mailing/subscribe', type='json', website=True, auth="public")
-    def subscribe(self, list_id, email, **post):
+    def _get_value(self, subscription_type):
+        value = None
+        if subscription_type == 'email':
+            if not request.env.user._is_public():
+                value = request.env.user.email
+            elif request.session.get('mass_mailing_email'):
+                value = request.session['mass_mailing_email']
+        return value
+
+    def _get_fname(self, subscription_type):
+        return 'email' if subscription_type == 'email' else ''
+
+    @route('/website_mass_mailing/subscribe', type='json', website=True, auth='public')
+    def subscribe(self, list_id, value, subscription_type, **post):
         if not request.env['ir.http']._verify_request_recaptcha_token('website_mass_mailing_subscribe'):
             return {
                 'toast_type': 'danger',
                 'toast_content': _("Suspicious activity detected by Google reCaptcha."),
             }
+
         ContactSubscription = request.env['mailing.contact.subscription'].sudo()
         Contacts = request.env['mailing.contact'].sudo()
-        name, email = Contacts.get_name_email(email)
+        if subscription_type == 'email':
+            name, value = Contacts.get_name_email(value)
+        elif subscription_type == 'mobile':
+            name = value
 
-        subscription = ContactSubscription.search([('list_id', '=', int(list_id)), ('contact_id.email', '=', email)], limit=1)
+        fname = self._get_fname(subscription_type)
+        subscription = ContactSubscription.search(
+            [('list_id', '=', int(list_id)), (f'contact_id.{fname}', '=', value)], limit=1)
         if not subscription:
             # inline add_to_list as we've already called half of it
-            contact_id = Contacts.search([('email', '=', email)], limit=1)
+            contact_id = Contacts.search([(fname, '=', value)], limit=1)
             if not contact_id:
-                contact_id = Contacts.create({'name': name, 'email': email})
+                contact_id = Contacts.create({'name': name, fname: value})
             ContactSubscription.create({'contact_id': contact_id.id, 'list_id': int(list_id)})
         elif subscription.opt_out:
             subscription.opt_out = False
         # add email to session
-        request.session['mass_mailing_email'] = email
+        request.session[f'mass_mailing_{fname}'] = value
         return {
             'toast_type': 'success',
             'toast_content': _("Thanks for subscribing!"),

--- a/addons/website_mass_mailing/controllers/website_form.py
+++ b/addons/website_mass_mailing/controllers/website_form.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+
+from odoo import _
+from odoo.http import request
+from odoo.addons.website.controllers.form import WebsiteForm
+
+
+class WebsiteNewsletterForm(WebsiteForm):
+
+    def _handle_website_form(self, model_name, **kwargs):
+        if model_name == 'mailing.contact':
+            list_ids = [int(x) for x in kwargs['list_ids'].split(',')]
+            private_list_ids = request.env['mailing.list'].search([
+                ('id', 'in', list_ids), ('is_public', '=', False)])
+            if private_list_ids:
+                return json.dumps({
+                    'error': _('You cannot subscribe to the following list anymore : %s',
+                               ', '.join(private_list_ids.mapped('name')))
+                })
+        return super()._handle_website_form(model_name, **kwargs)

--- a/addons/website_mass_mailing/data/ir_model_data.xml
+++ b/addons/website_mass_mailing/data/ir_model_data.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="mass_mailing.model_mailing_contact" model="ir.model">
+            <field name="website_form_key">create_mailing_contact</field>
+            <field name="website_form_access">True</field>
+            <field name="website_form_label">Subscribe to Newsletter</field>
+        </record>
+
+        <function model="ir.model.fields" name="formbuilder_whitelist">
+            <value>mailing.contact</value>
+            <value eval="[
+                'name',
+                'company_name',
+                'title_id',
+                'email',
+                'list_ids',
+                'country_id',
+                'tag_ids',
+            ]"/>
+        </function>
+    </data>
+</odoo>

--- a/addons/website_mass_mailing/static/src/js/mass_mailing_form_editor.js
+++ b/addons/website_mass_mailing/static/src/js/mass_mailing_form_editor.js
@@ -1,0 +1,26 @@
+/** @odoo-module **/
+
+import core from "web.core";
+import FormEditorRegistry from "website.form_editor_registry";
+
+const _t = core._t;
+
+FormEditorRegistry.add('create_mailing_contact', {
+    formFields: [{
+        name: 'name',
+        required: true,
+        string: _t('Your Name'),
+        type: 'char',
+    }, {
+        name: 'email',
+        required: true,
+        string: _t('Your Email'),
+        type: 'email',
+    }, {
+        name: 'list_ids',
+        relation: 'mailing.list',
+        required: true,
+        string: _t('Subscribe to'),
+        type: 'many2many',
+    }],
+});

--- a/addons/website_mass_mailing/static/src/js/website_mass_mailing.editor.js
+++ b/addons/website_mass_mailing/static/src/js/website_mass_mailing.editor.js
@@ -40,8 +40,10 @@ options.registry.mailing_list_subscribe = options.Class.extend({
      */
     cleanForSave() {
         const previewClasses = ['o_disable_preview', 'o_enable_preview'];
-        this.$target[0].querySelector('.js_subscribe_btn').classList.remove(...previewClasses);
-        this.$target[0].querySelector('.js_subscribed_btn').classList.remove(...previewClasses);
+        const subscribeBtn = this.$target[0].querySelector('.js_subscribe_btn');
+        subscribeBtn && subscribeBtn.classList.remove(...previewClasses);
+        const subscribedBtn = this.$target[0].querySelector('.js_subscribed_btn');
+        subscribedBtn && subscribedBtn.classList.remove(...previewClasses);
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website_mass_mailing/static/src/snippets/s_popup/000.js
+++ b/addons/website_mass_mailing/static/src/snippets/s_popup/000.js
@@ -16,7 +16,7 @@ PopupWidget.include({
     _canShowPopup() {
         if (
             this.$el.is('.o_newsletter_popup') &&
-            this.$el.find('input.js_subscribe_email').prop('disabled')
+            this.$el.find('input.js_subscribe_value').prop('disabled')
         ) {
             return false;
         }

--- a/addons/website_mass_mailing/static/src/snippets/s_popup/options.js
+++ b/addons/website_mass_mailing/static/src/snippets/s_popup/options.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import options from 'web_editor.snippets.options';
+
+options.registry.NewsletterLayout = options.registry.SelectTemplate.extend({
+    /**
+     * @constructor
+     */
+    init() {
+        this._super(...arguments);
+        this.containerSelector = '> .container, > .container-fluid, > .o_container_small';
+        this.selectTemplateWidgetName = 'newsletter_template_opt';
+    },
+});

--- a/addons/website_mass_mailing/static/tests/tours/newsletter_block.js
+++ b/addons/website_mass_mailing/static/tests/tours/newsletter_block.js
@@ -14,7 +14,7 @@ wTourUtils.registerEditionTour('newsletter_block_edition', {
     }),
     {
         content: 'Wait for the list id to be set.',
-        trigger: 'iframe .s_newsletter_subscribe_form[data-list-id]:not([data-list-id="0"])',
+        trigger: 'iframe .s_newsletter_block[data-list-id]:not([data-list-id="0"]) .s_newsletter_subscribe_form',
         run: () => null, // it's a check
     },
     ...wTourUtils.clickOnSave(),

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -80,19 +80,34 @@
 </template>
 
 <template id="newsletter_subscribe_options" name="Newsletter Subscribe Options" inherit_id="website.snippet_options">
-    <xpath expr="//div" position="after">
-        <t t-set="selector" t-value="'.js_subscribe'"/>
-        <div data-js="mailing_list_subscribe"
-            t-att-data-selector="selector">
-            <we-select string="Newsletter" data-attribute-name="listId"></we-select>
-        </div>
-        <div data-js="recaptchaSubscribe"
-            t-att-data-selector="selector">
-            <t t-set="recaptcha_public_key" t-value="request.env['ir.config_parameter'].sudo().get_param('recaptcha_public_key')"/>
-            <we-checkbox t-if="recaptcha_public_key" string="Show reCaptcha Policy" data-toggle-recaptcha-legal="" data-no-preview="true"/>
-        </div>
-        <div t-att-data-selector="selector" data-drop-near="p, h1, h2, h3, blockquote, .card"/>
+    <xpath expr="//*[@t-set='so_snippet_addition_selector']" position="inside">, .o_newsletter_popup</xpath>
+    <xpath expr="//div[last()]" position="after">
+        <t t-call="website_mass_mailing.newsletter_subscribe_options_common">
+            <t t-set="_selector">.o_newsletter_popup</t>
+            <t t-set="_target">.s_newsletter_list</t>
+        </t>
+        <t t-call="website_mass_mailing.newsletter_subscribe_options_common">
+            <t t-set="_selector">.s_newsletter_list</t>
+            <t t-set="_exclude">.s_newsletter_block .s_newsletter_list, .o_newsletter_popup .s_newsletter_list</t>
+        </t>
+        <div data-selector=".js_subscribe" data-drop-near="p, h1, h2, h3, blockquote, .card"/>
     </xpath>
+</template>
+
+<template id="newsletter_subscribe_options_common">
+    <div data-js="mailing_list_subscribe"
+         t-att-data-selector="_selector"
+         t-att-data-exclude="_exclude"
+         t-att-data-target="_target">
+        <we-select string="Newsletter" data-attribute-name="listId"></we-select>
+    </div>
+    <div data-js="recaptchaSubscribe"
+         t-att-data-selector="_selector"
+         t-att-data-exclude="_exclude"
+         t-att-data-target="_target">
+        <t t-set="recaptcha_public_key" t-value="request.env['ir.config_parameter'].sudo().get_param('recaptcha_public_key')"/>
+        <we-checkbox t-if="recaptcha_public_key" string="Show reCaptcha Policy" data-toggle-recaptcha-legal="" data-no-preview="true"/>
+    </div>
 </template>
 
 <!-- Extend default mass_mailing snippets with website feature -->

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -25,9 +25,9 @@
 </template>
 
 <template id="s_newsletter_subscribe_form" name="Newsletter">
-    <div class="s_newsletter_subscribe_form js_subscribe" data-vxml="001" data-list-id="0" data-name="Newsletter Form">
+    <div class="s_newsletter_subscribe_form s_newsletter_list js_subscribe" data-vxml="001" data-list-id="0" data-name="Newsletter Form">
         <div class="input-group">
-            <input type="email" name="email" class="js_subscribe_email form-control" placeholder="your email..."/>
+            <input type="email" name="email" class="js_subscribe_value form-control" placeholder="your email..."/>
             <a role="button" href="#" class="btn btn-primary js_subscribe_btn o_submit">Subscribe</a>
             <a role="button" href="#" class="btn btn-success js_subscribed_btn d-none o_submit" disabled="disabled">Thanks</a>
         </div>
@@ -35,13 +35,110 @@
 </template>
 
 <template id="s_newsletter_block" name="Newsletter block">
-    <section class="s_newsletter_block bg-200 pt32 pb32">
+    <section class="s_newsletter_block s_newsletter_list pt32 pb32" data-list-id="0">
         <div class="container">
-            <div class="row">
-                <div class="col-lg-8 offset-lg-2 pt24 pb24">
-                    <h2>Always First.</h2>
-                    <p>Be the first to find out all the latest news, products, and trends.</p>
-                    <t t-snippet-call="website_mass_mailing.s_newsletter_subscribe_form"/>
+            <t t-call="website_mass_mailing.s_newsletter_block_default_template"/>
+        </div>
+    </section>
+</template>
+
+<template id="s_newsletter_block_default_template" groups="base.group_user">
+    <div class="row">
+        <div class="col-lg-8 offset-lg-2 pt24 pb24">
+            <h2>Always First.</h2>
+            <p>Be the first to find out all the latest news, products, and trends.</p>
+            <t t-snippet-call="website_mass_mailing.s_newsletter_subscribe_form"/>
+        </div>
+    </div>
+</template>
+
+<template id="s_newsletter_block_form_template" groups="base.group_user">
+    <section class="s_website_form" data-vcss="001" data-snippet="s_website_form" data-name="Form">
+        <div class="container">
+            <form id="newsletter_form" action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required"
+                  data-mark="*" data-model_name="mailing.contact" data-success-mode="message" hide-change-model="true">
+                <div class="s_website_form_rows row s_col_no_bgcolor">
+                    <div class="mb-3 col-12 s_website_form_field s_website_form_model_required" data-type="char" data-name="Field">
+                        <div class="row s_col_no_resize s_col_no_bgcolor">
+                            <label class="col-form-label col-sm-auto s_website_form_label" style="width: 250px" for="mailing_sub1">
+                                <span class="s_website_form_label_content">Your Name</span>
+                                <span class="s_website_form_mark"> *</span>
+                            </label>
+                            <div class="col-sm">
+                                <input id="mailing_sub1" type="text" class="form-control s_website_form_input" name="name" required="1"/>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="mb-3 col-12 s_website_form_field s_website_form_model_required" data-type="email" data-name="Field">
+                        <div class="row s_col_no_resize s_col_no_bgcolor">
+                            <label class="col-form-label col-sm-auto s_website_form_label" style="width: 250px" for="mailing_sub2">
+                                <span class="s_website_form_label_content">Your Email</span>
+                                <span class="s_website_form_mark"> *</span>
+                            </label>
+                            <div class="col-sm">
+                                <input id="mailing_sub2" type='email' class='form-control s_website_form_input' name="email"/>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="mb-3 col-12 s_website_form_field s_website_form_model_required" data-type="many2many" data-name="Field">
+                        <div class="row s_col_no_resize s_col_no_bgcolor">
+                            <label class="col-sm-auto s_website_form_label" style="width: 250px" for="mailing_list_">
+                                <span class="s_website_form_label_content">Subscribe to</span>
+                                <span class="s_website_form_mark"> *</span>
+                            </label>
+                            <div class="col-sm">
+                                <div class="row s_col_no_resize s_col_no_bgcolor s_website_form_multiple" data-name="list_ids" data-display="horizontal">
+                                    <t t-foreach="request.env['mailing.list'].search([('is_public', '=', True)])" t-as="record">
+                                        <div class="checkbox col-12 col-lg-4 col-md-6">
+                                            <div class="form-check">
+                                                <input type="checkbox" class="s_website_form_input form-check-input" name="list_ids"
+                                                    t-attf-id="mailing_list_#{record.id}" t-att-value="record.id" required="1"/>
+                                                <label class="form-check-label s_website_form_check_label" t-attf-for="mailing_list_#{record.id}">
+                                                    <t t-esc="record.display_name"/>
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </t>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="mb-3 col-12 s_website_form_field s_website_form_custom s_website_form_required" data-type="boolean" data-name="Field">
+                        <div class="row s_col_no_resize s_col_no_bgcolor">
+                            <label class="col-sm-auto s_website_form_label" style="width: 250px;" for="mailing_sub3">
+                                <span class="s_website_form_label_content">I agree to receive updates</span>
+                                <span class="s_website_form_mark"> *</span>
+                            </label>
+                            <div class="col-sm">
+                                <div class="form-check">
+                                    <input type="checkbox" value="Yes" class="s_website_form_input" name="I want to be kept updated"
+                                           id="mailing_sub3" required="1"/>
+                                </div>
+                                <div class="s_website_form_field_description small form-text text-muted">
+                                    We send one weekly newsletter per list and always try to keep it interesting. You can unsubscribe at any time.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="mb-3 col-12 s_website_form_submit" data-name="Submit Button">
+                        <div style="width: 250px;" class="s_website_form_label"/>
+                        <a href="#" role="button" class="btn btn-primary btn-lg s_website_form_send">Subscribe</a>
+                        <span id="s_website_form_result"></span>
+                    </div>
+                </div>
+            </form>
+            <div class="s_website_form_end_message d-none">
+                <div class="oe_structure">
+                    <section class="s_text_block pt64 pb64 o_colored_level o_cc o_cc2" data-snippet="s_text_block">
+                        <div class="container">
+                            <h2 class="text-center"><span class="fa fa-check-circle"></span>
+                                Thank you for subscribing !
+                            </h2>
+                            <p class="text-center">
+                                You will now be informed about the latest news.<br/>
+                            </p>
+                        </div>
+                    </section>
                 </div>
             </div>
         </div>
@@ -81,7 +178,20 @@
 
 <template id="newsletter_subscribe_options" name="Newsletter Subscribe Options" inherit_id="website.snippet_options">
     <xpath expr="//*[@t-set='so_snippet_addition_selector']" position="inside">, .o_newsletter_popup</xpath>
-    <xpath expr="//div[last()]" position="after">
+    <xpath expr="//div[1]" position="before">
+        <div data-js="NewsletterLayout" data-selector=".s_newsletter_block">
+            <we-select string="Template"
+                       data-name="newsletter_template_opt"
+                       data-attribute-name="newsletterTemplate"
+                       data-attribute-default-value="email">
+                <we-button title="Email Subscription" string="Email Subscription"
+                           data-select-template="website_mass_mailing.s_newsletter_block_default_template"
+                           data-select-data-attribute="email" data-name="email_opt"/>
+                <we-button title="Form Subscription" string="Form Subscription"
+                           data-select-template="website_mass_mailing.s_newsletter_block_form_template"
+                           data-select-data-attribute="form" data-name="form_opt"/>
+            </we-select>
+        </div>
         <t t-call="website_mass_mailing.newsletter_subscribe_options_common">
             <t t-set="_selector">.o_newsletter_popup</t>
             <t t-set="_target">.s_newsletter_list</t>
@@ -99,7 +209,7 @@
          t-att-data-selector="_selector"
          t-att-data-exclude="_exclude"
          t-att-data-target="_target">
-        <we-select string="Newsletter" data-attribute-name="listId"></we-select>
+        <we-select string="Newsletter" data-attribute-name="listId" data-dependencies="!form_opt"></we-select>
     </div>
     <div data-js="recaptchaSubscribe"
          t-att-data-selector="_selector"

--- a/addons/website_mass_mailing_sms/__init__.py
+++ b/addons/website_mass_mailing_sms/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import controllers

--- a/addons/website_mass_mailing_sms/__manifest__.py
+++ b/addons/website_mass_mailing_sms/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Newsletter Subscribe SMS Template',
+    'summary': 'Attract visitors to subscribe to mailing lists',
+    'description': """
+This module adds a new template to the Newsletter Block to allow 
+your visitors to subscribe with their phone number.
+    """,
+    'version': '1.0',
+    'category': 'Website/Website',
+    'depends': ['website_mass_mailing', 'mass_mailing_sms'],
+    'data': [
+        'views/snippets/snippets_templates.xml',
+        'data/ir_model_data.xml',
+    ],
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/website_mass_mailing_sms/controllers/__init__.py
+++ b/addons/website_mass_mailing_sms/controllers/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import main

--- a/addons/website_mass_mailing_sms/controllers/main.py
+++ b/addons/website_mass_mailing_sms/controllers/main.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.http import request
+from odoo.addons.mass_mailing.controllers import main
+
+
+class MassMailController(main.MassMailController):
+
+    def _get_value(self, subscription_type):
+        value = super(MassMailController, self)._get_value(subscription_type)
+        if not value and subscription_type == 'mobile':
+            if not request.env.user._is_public():
+                value = request.env.user.partner_id.mobile
+            elif request.session.get('mass_mailing_mobile'):
+                value = request.session['mass_mailing_mobile']
+        return value
+
+    def _get_fname(self, subscription_type):
+        value_field = super(MassMailController, self)._get_fname(subscription_type)
+        if not value_field and subscription_type == 'mobile':
+            value_field = 'mobile'
+        return value_field

--- a/addons/website_mass_mailing_sms/data/ir_model_data.xml
+++ b/addons/website_mass_mailing_sms/data/ir_model_data.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <function model="ir.model.fields" name="formbuilder_whitelist">
+            <value>mailing.contact</value>
+            <value eval="[
+                'mobile',
+            ]"/>
+        </function>
+    </data>
+</odoo>

--- a/addons/website_mass_mailing_sms/views/snippets/snippets_templates.xml
+++ b/addons/website_mass_mailing_sms/views/snippets/snippets_templates.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_newsletter_block_sms_template" groups="base.group_user">
+    <div class="row">
+        <div class="col-lg-8 offset-lg-2 pt24 pb24">
+            <h2>Always First.</h2>
+            <p>Be the first to find out all the latest news, products, and trends.</p>
+            <div class="s_newsletter_subscribe_form s_subscription_list js_subscribe" data-vxml="001" data-list-id="0" data-name="Newsletter Form">
+                <div class="input-group">
+                    <!-- input name must be an existing 'mailing.contact' field -->
+                    <input type="tel" name="mobile" class="js_subscribe_value form-control" placeholder="e.g. +1 555-555-1234"/>
+                    <a role="button" href="#" class="btn btn-primary js_subscribe_btn o_submit">Subscribe</a>
+                    <a role="button" href="#" class="btn btn-success js_subscribed_btn d-none o_submit" disabled="disabled">Thanks</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<template id="newsletter_subscribe_options" name="Newsletter Subscribe Options" inherit_id="website.snippet_options">
+    <xpath expr="//div[@data-js='NewsletterLayout']/we-select/we-button[@data-select-data-attribute='email']" position="after">
+        <we-button title="SMS Newsletter" string="SMS Subscription"
+                   data-select-template="website_mass_mailing_sms.s_newsletter_block_sms_template"
+                   data-select-data-attribute="sms" data-name="sms_opt"/>
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
These commits improve the newsletter snippet by adding a template selection to it.
One can now choose between email / sms / form templates. 
The first two are composed by a unique input to allow the user subscribing with its email or mobile phone. 
The last allows the user to fill up a form more thoroughly and to select more than one mailing list to subscribe to.

it's also possible for one to create a subscription form by using the form snippet directly.

Task-2672194