### PR TITLE
Master perf name get raob

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -447,6 +447,9 @@ class AccountAccount(models.Model):
             self.tax_ids = self.company_id.account_purchase_tax_id
 
     def name_get(self):
+        # Prefetch the fields used by the `name_get`, so `browse` doesn't fetch other fields
+        self._origin._read(['code', 'name'])
+
         result = []
         for account in self:
             name = account.code + ' ' + account.name

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -190,6 +190,9 @@ class PurchaseOrder(models.Model):
 
     @api.depends('name', 'partner_ref')
     def name_get(self):
+        # Prefetch the fields used by the `name_get`, so `browse` doesn't fetch other fields
+        self._origin._read(['name', 'partner_ref'])
+
         result = []
         for po in self:
             name = po.name

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -753,6 +753,9 @@ class Partner(models.Model):
         return name
 
     def name_get(self):
+        # Prefetch the fields used by the `name_get`, so `browse` doesn't fetch other fields
+        self._origin._read(['is_company', 'name', 'parent_id', 'type', 'company_name', 'commercial_company_name'])
+
         res = []
         for partner in self:
             name = partner._get_name()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

`name_get` is called everywhere and causes Odoo to prefetch a lot of fields
that won't be used for the computation of `display_name`.
By fetching only the required fields for `name_get`, we avoid prefetching
unnecessary fields and see a small performance improvement.
While small, the improvement will make m2o fields and views that show many
records' `display_name` faster.
    
The Google Sheet link in the chatter of [https://www.odoo.com/web#id=2482847&action=4043&model=project.task&view_type=form&cids=1&menu_id=4720] shows the gain for many models
    
task-2482847

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
