### PR TITLE
[FIX] stock: only display source document in report when any

### DIFF
--- a/addons/stock/report/report_stock_reception.xml
+++ b/addons/stock/report/report_stock_reception.xml
@@ -13,7 +13,7 @@
                     <t t-foreach="range(qty)" t-as="j">
                         <div class="o_label_page o_label_dymo">
                             <div t-out="move.product_id.display_name"/>
-                            <div t-out="move._get_source_document().name"/>
+                            <div t-if="move._get_source_document()" t-out="move._get_source_document().name"/>
                             <div class="address"
                                 t-if="move.picking_id and move.picking_id.partner_id"
                                 t-field="move.picking_id.partner_id"


### PR DESCRIPTION
Since `_get_source_document` can return `False`, we need to be defensive
and check for that before trying to read the name.

For instance: https://runbot.odoo.com/runbot/build/10949016



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
