### PR TITLE
[FIX] hr_expense: submited report is now read-only

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -500,7 +500,11 @@
                     </group>
                      <notebook>
                         <page name="expenses" string="Expense">
-                        <field name="expense_line_ids" nolabel="1" widget="many2many" domain="[('state', '=', 'draft'), ('employee_id', '=', employee_id), ('company_id', '=', company_id)]" options="{'reload_on_button': True}" context="{'form_view_ref' : 'hr_expense.hr_expense_view_form_without_header', 'default_company_id': company_id}">
+                        <field name="expense_line_ids" nolabel="1" widget="many2many"
+                          domain="[('state', '=', 'draft'), ('employee_id', '=', employee_id), ('company_id', '=', company_id)]"
+                          options="{'reload_on_button': True}"
+                          attrs="{'readonly': [('state', '!=', 'draft')]}"
+                          context="{'form_view_ref' : 'hr_expense.hr_expense_view_form_without_header', 'default_company_id': company_id}">
                             <tree decoration-danger="is_refused">
                                 <field name="date"/>
                                 <field name="name"/>


### PR DESCRIPTION
### Expected Behaviour

When creating a journal entry for an expense, the journal shouldn't be editable once it has been submitted for approval.

### Observed Behaviour

Even when the journal entry has been validated by the manager, the list of expenses is still editable, which can cause serious trouble.

### Reproducibility

This bug can be reproduced following these steps:
1. Create a new expense
2. Create the related journal entry (Create report)
3. Submit the report for approval
4. Validate the report
5. Try to edit the expenses list

### Problem Root Cause

As it can be seen in the PR, this issue came from the fact the expense list isn't in read-only mode

### Related Issue(s)
- opw-2659436

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
