### PR TITLE
[FIX] base_import: fix the import speed with many batches

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1424,7 +1424,8 @@ class Import(models.TransientModel):
                 for field in split_fields:
                     if field != target_field:  # if not on the last hierarchy level, retarget the model
                         target_model = self.env[target_model][field]._name
-                field_type = self.env[target_model].fields_get().get(target_field, {}).get('type', '')
+                field = self.env[target_model]._fields.get(target_field)
+                field_type = field.type if field else ''
 
                 # merge data if necessary
                 if field_type == 'char':


### PR DESCRIPTION
Purpose
=======
Since v15, the time to import records in Odoo is much slower than in
v14. With a profiling, we know that the cause is `fields_get`. Indeed,
this method is heavy and call many times (#rows * #columns * ~#batches).

So the import time (in seconds) is;

```
Batch size | v14 | v15 | v15 fix
--------------------------------
2000       |   7 |  20 |      14
 200       |  11 |  48 |      15
  20       |  17 | 423 |      23
```

We can see that just by calling `._fields.get` instead of `fields_get`
we gain a lot of time. The reason for that is `fields_get` just read in
a python dictionary (which is really really fast), while `fields_get`
checks the access right, get the description of each fields (which
might make SQL queries to retrieve translation, etc).

Task-2687407
