### PR TITLE
[FIX] web_editor: make a step on paste

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2025,6 +2025,7 @@ export class OdooEditor extends EventTarget {
             const splitAroundUrl = text.split(URL_REGEX);
             const linkAttributes = this.options.defaultLinkAttributes || {};
 
+            this.historyPauseSteps();
             for (let i = 0; i < splitAroundUrl.length; i++) {
                 // Even indexes will always be plain text, and odd indexes will always be URL.
                 if (i % 2) {
@@ -2054,6 +2055,8 @@ export class OdooEditor extends EventTarget {
                     }
                 }
             }
+            this.historyUnpauseSteps();
+            this.historyStep();
         }
     }
     /**


### PR DESCRIPTION
Before this commit, because a final step was not made on paste,
the following historyRevert would undo the changes of the paste.

Example enter just after an url paste.

Task-2668262




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
