### PR TITLE
[FIX] l10n_at: do not delete all tags on update

### DIFF
--- a/addons/l10n_at/data/account_account_template.xml
+++ b/addons/l10n_at/data/account_account_template.xml
@@ -20,14 +20,13 @@
             <field name="chart_template_id" ref="l10n_at_chart_template"/>
         </record>
 
-
         <record id="chart_at_template_0010" model="account.account.template">
           <field name="name">Aufwendungen für das Ingangsetzen und Erweitern eines Betriebes</field>
           <field name="code">0010</field>
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAI1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAI1'))]" />
         </record>
         <record id="chart_at_template_0090" model="account.account.template">
           <field name="name">Kumulierte Abschreibungen</field>
@@ -42,7 +41,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAI1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAI1'))]" />
         </record>
         <record id="chart_at_template_0110" model="account.account.template">
           <field name="name">Patentrechte und Lizenzen</field>
@@ -50,7 +49,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAI1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAI1'))]" />
         </record>
         <record id="chart_at_template_0120" model="account.account.template">
           <field name="name">Datenverarbeitungsprogramme</field>
@@ -58,7 +57,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAI1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAI1'))]" />
         </record>
         <record id="chart_at_template_0121" model="account.account.template">
           <field name="name">Geringwertige Datenverarbeitungsprogramme</field>
@@ -66,7 +65,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAI1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAI1'))]" />
         </record>
         <record id="chart_at_template_0130" model="account.account.template">
           <field name="name">Marken, Warenzeichen und Musterschutzrechte, sonstige Urheberrechte</field>
@@ -74,7 +73,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAI1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAI1'))]" />
         </record>
         <record id="chart_at_template_0140" model="account.account.template">
           <field name="name">Pacht- und Mietrechte</field>
@@ -82,7 +81,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAI1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAI1'))]" />
         </record>
         <record id="chart_at_template_0150" model="account.account.template">
           <field name="name">Geschäfts(Firmen)wert</field>
@@ -90,7 +89,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAI2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAI2'))]" />
         </record>
         <record id="chart_at_template_0180" model="account.account.template">
           <field name="name">Geleistete Anzahlungen</field>
@@ -98,7 +97,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAI3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAI3'))]" />
         </record>
         <record id="chart_at_template_019" model="account.account.template">
           <field name="name">Kumulierte Abschreibungen</field>
@@ -113,7 +112,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII1'))]" />
         </record>
         <record id="chart_at_template_0210" model="account.account.template">
           <field name="name">Bebaute Grundstücke (Grundwert)</field>
@@ -121,7 +120,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII1'))]" />
         </record>
         <record id="chart_at_template_022" model="account.account.template">
           <field name="name">Grundstücksgleiche Rechte</field>
@@ -129,7 +128,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII1'))]" />
         </record>
         <record id="chart_at_template_0300" model="account.account.template">
           <field name="name">Betriebs- und Geschäftsgebäude auf eigenem Grund</field>
@@ -138,7 +137,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII1'))]" />
         </record>
         <record id="chart_at_template_0310" model="account.account.template">
           <field name="name">Wohn- und Sozialgebäude auf eigenem Grund</field>
@@ -147,7 +146,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII1'))]" />
         </record>
         <record id="chart_at_template_0320" model="account.account.template">
           <field name="name">Betriebs- und Geschäftsgebäude auf fremdem Grund</field>
@@ -155,7 +154,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII1'))]" />
         </record>
         <record id="chart_at_template_0330" model="account.account.template">
           <field name="name">Wohn- und Sozialgebäude auf fremdem Grund</field>
@@ -163,7 +162,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII1'))]" />
         </record>
         <record id="chart_at_template_0340" model="account.account.template">
           <field name="name">Grundstückseinrichtungen auf eigenem Grund</field>
@@ -171,7 +170,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII1'))]" />
         </record>
         <record id="chart_at_template_0350" model="account.account.template">
           <field name="name">Grundstückseinrichtungen auf fremdem Grund</field>
@@ -179,7 +178,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII1'))]" />
         </record>
         <record id="chart_at_template_0360" model="account.account.template">
           <field name="name">Bauliche Investitionen in fremden (gepachteten) Betriebs- und Geschäftsgebäuden</field>
@@ -187,7 +186,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII1'))]" />
         </record>
         <record id="chart_at_template_0370" model="account.account.template">
           <field name="name">Bauliche Investitionen in fremden (gepachteten) Wohn- und Sozialgebäuden</field>
@@ -195,7 +194,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII1'))]" />
         </record>
         <record id="chart_at_template_0390" model="account.account.template">
           <field name="name">Kumulierte Abschreibungen</field>
@@ -203,7 +202,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII1'))]" />
         </record>
         <record id="chart_at_template_0400" model="account.account.template">
           <field name="name">Fertigungsmaschinen</field>
@@ -211,7 +210,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII2'))]" />
         </record>
         <record id="chart_at_template_0410" model="account.account.template">
           <field name="name">Antriebsmaschinen</field>
@@ -219,7 +218,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII2'))]" />
         </record>
         <record id="chart_at_template_0420" model="account.account.template">
           <field name="name">Energieversorgungsanlagen</field>
@@ -227,7 +226,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII2'))]" />
         </record>
         <record id="chart_at_template_0430" model="account.account.template">
           <field name="name">Transportanlagen</field>
@@ -235,7 +234,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII2'))]" />
         </record>
         <record id="chart_at_template_0500" model="account.account.template">
           <field name="name">Maschinenwerkzeuge</field>
@@ -243,7 +242,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII2'))]" />
         </record>
         <record id="chart_at_template_0510" model="account.account.template">
           <field name="name">Allgemeine Werkzeuge und Handwerkzeuge</field>
@@ -251,7 +250,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII2'))]" />
         </record>
         <record id="chart_at_template_0520" model="account.account.template">
           <field name="name">Vorrichtungen, Formen und Modelle</field>
@@ -259,7 +258,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII2'))]" />
         </record>
         <record id="chart_at_template_0530" model="account.account.template">
           <field name="name">Andere Erzeugungshilfsmittel</field>
@@ -267,7 +266,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII2'))]" />
         </record>
         <record id="chart_at_template_0540" model="account.account.template">
           <field name="name">Hebezeuge und Montageanlagen</field>
@@ -275,7 +274,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII2'))]" />
         </record>
         <record id="chart_at_template_0550" model="account.account.template">
           <field name="name">Geringwertige Vermögensgegenstände, soweit im Erzeugungsprozeß verwendet</field>
@@ -283,7 +282,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII2'))]" />
         </record>
         <record id="chart_at_template_0600" model="account.account.template">
           <field name="name">Beheizungs- und Beleuchtungsanlagen</field>
@@ -291,7 +290,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII3'))]" />
         </record>
         <record id="chart_at_template_0610" model="account.account.template">
           <field name="name">Nachrichten- und Kontrollanlagen</field>
@@ -299,7 +298,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII3'))]" />
         </record>
         <record id="chart_at_template_0620" model="account.account.template">
           <field name="name">Büromaschinen, EDV-Anlagen</field>
@@ -307,7 +306,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII3'))]" />
         </record>
         <record id="chart_at_template_0630" model="account.account.template">
           <field name="name">PKW</field>
@@ -315,7 +314,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII3'))]" />
         </record>
         <record id="chart_at_template_0640" model="account.account.template">
           <field name="name">LKW</field>
@@ -323,7 +322,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII3'))]" />
         </record>
         <record id="chart_at_template_0650" model="account.account.template">
           <field name="name">Andere Beförderungsmittel</field>
@@ -331,7 +330,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII3'))]" />
         </record>
         <record id="chart_at_template_0660" model="account.account.template">
           <field name="name">Andere Betriebs- und Geschäftsausstattung</field>
@@ -339,7 +338,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII3'))]" />
         </record>
         <record id="chart_at_template_0670" model="account.account.template">
           <field name="name">Gebinde</field>
@@ -347,7 +346,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII3'))]" />
         </record>
         <record id="chart_at_template_0680" model="account.account.template">
           <field name="name">Geringwertige Büromaschinen, EDV-Anlagen</field>
@@ -355,7 +354,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII3'))]" />
         </record>
         <record id="chart_at_template_0681" model="account.account.template">
           <field name="name">Geringwertige Betriebs- und Geschäftsausstattung</field>
@@ -363,7 +362,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII3'))]" />
         </record>
         <record id="chart_at_template_0692" model="account.account.template">
           <field name="name">Kumulierte Abschreibungen zu Büromaschinen, EDV-Anlagen</field>
@@ -371,7 +370,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII3'))]" />
         </record>
         <record id="chart_at_template_0693" model="account.account.template">
           <field name="name">Kumulierte Abschreibungen zu PKW und Kombis</field>
@@ -379,7 +378,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII3'))]" />
         </record>
         <record id="chart_at_template_0694" model="account.account.template">
           <field name="name">Kumulierte Abschreibungen zu LKW</field>
@@ -387,7 +386,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII3'))]" />
         </record>
         <record id="chart_at_template_0696" model="account.account.template">
           <field name="name">Kumulierte Abschreibungen zur Betriebs- und Geschäftsausstattung</field>
@@ -395,7 +394,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII3'))]" />
         </record>
         <record id="chart_at_template_0700" model="account.account.template">
           <field name="name">Geleistete Anzahlungen</field>
@@ -403,7 +402,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_prepayments" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII4'))]" />
         </record>
         <record id="chart_at_template_0710" model="account.account.template">
           <field name="name">Anlagen in Bau</field>
@@ -411,7 +410,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII4'))]" />
         </record>
         <record id="chart_at_template_0790" model="account.account.template">
           <field name="name">Kumulierte Abschreibungen</field>
@@ -419,7 +418,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_fixed_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAII4'))]" />
         </record>
         <record id="chart_at_template_0800" model="account.account.template">
           <field name="name">Anteile an verbundenen Unternehmen</field>
@@ -427,7 +426,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAIII1'))]" />
         </record>
         <record id="chart_at_template_0810" model="account.account.template">
           <field name="name">Beteiligungen an Gemeinschaftsunternehmen</field>
@@ -435,7 +434,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAIII1'))]" />
         </record>
         <record id="chart_at_template_0820" model="account.account.template">
           <field name="name">Beteiligungen an angeschlossenen (assoziierten) Unternehmen</field>
@@ -443,7 +442,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAIII1'))]" />
         </record>
         <record id="chart_at_template_0830" model="account.account.template">
           <field name="name">Sonstige Beteiligungen</field>
@@ -451,7 +450,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAIII1'))]" />
         </record>
         <record id="chart_at_template_0840" model="account.account.template">
           <field name="name">Ausleihungen an verbundene Unternehmen</field>
@@ -459,7 +458,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAIII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAIII2'))]" />
         </record>
         <record id="chart_at_template_0850" model="account.account.template">
           <field name="name">Ausleihungen an Unternehmen, mit denen ein Beteiligungsverhältnis besteht</field>
@@ -467,7 +466,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAIII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAIII4'))]" />
         </record>
         <record id="chart_at_template_0860" model="account.account.template">
           <field name="name">Sonstige Ausleihungen</field>
@@ -475,7 +474,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAIII6')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAIII6'))]" />
         </record>
         <record id="chart_at_template_0870" model="account.account.template">
           <field name="name">Anteile an Kapitalgesellschaften ohne Beteiligungscharakter</field>
@@ -483,7 +482,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAIII5')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAIII5'))]" />
         </record>
         <record id="chart_at_template_0880" model="account.account.template">
           <field name="name">Anteile an Personengesellschaften ohne Beteiligungscharakter</field>
@@ -491,7 +490,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAIII5')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAIII5'))]" />
         </record>
         <record id="chart_at_template_0900" model="account.account.template">
           <field name="name">Genossenschaftsanteile ohne Beteiligungscharakter</field>
@@ -499,7 +498,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAIII5')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAIII5'))]" />
         </record>
         <record id="chart_at_template_0910" model="account.account.template">
           <field name="name">Anteile an Investmentfonds</field>
@@ -507,7 +506,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAIII5')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAIII5'))]" />
         </record>
         <record id="chart_at_template_0980" model="account.account.template">
           <field name="name">Geleistete Anzahlungen</field>
@@ -515,7 +514,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_prepayments" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAIII5')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAIII5'))]" />
         </record>
         <record id="chart_at_template_0990" model="account.account.template">
           <field name="name">Kumulierte Abschreibungen</field>
@@ -523,7 +522,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AAIII5')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AAIII5'))]" />
         </record>
         <record id="chart_at_template_1600" model="account.account.template">
           <field name="name">Handelswaren</field>
@@ -532,7 +531,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABI3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABI3'))]" />
         </record>
         <record id="chart_at_template_1800" model="account.account.template">
           <field name="name">Geleistete Anzahlungen</field>
@@ -541,7 +540,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_prepayments" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABI5')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABI5'))]" />
         </record>
         <record id="chart_at_template_2000" model="account.account.template">
           <field name="name">Forderungen von Partnern im Inland ohne eigenes Debitorenkonto</field>
@@ -549,7 +548,7 @@
           <field name="reconcile" eval="True"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_receivable" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII1'))]" />
         </record>
         <record id="chart_at_template_2099" model="account.account.template">
           <field name="name">Forderungen von Partnern (Point Of Sale)</field>
@@ -557,7 +556,7 @@
           <field name="reconcile" eval="True"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_receivable" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII1'))]" />
         </record>
         <record id="chart_at_template_2080" model="account.account.template">
           <field name="name">Einzelwertberichtigungen zu Forderungen aus Lieferungen und Leistungen Inland</field>
@@ -565,7 +564,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII1'))]" />
         </record>
         <record id="chart_at_template_2090" model="account.account.template">
           <field name="name">Pauschalwertberichtigungen zu Forderungen aus Lieferungen und Leistungen Inland</field>
@@ -573,7 +572,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII1'))]" />
         </record>
         <record id="chart_at_template_2100" model="account.account.template">
           <field name="name">Forderungen von Partnern im EU Raum ohne eigenes Debitorenkonto</field>
@@ -581,7 +580,7 @@
           <field name="reconcile" eval="True"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_receivable" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII1'))]" />
         </record>
         <record id="chart_at_template_2130" model="account.account.template">
           <field name="name">Einzelwertberichtigungen zu Forderungen aus Lieferungen und Leistungen Währungsunion</field>
@@ -589,7 +588,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII1'))]" />
         </record>
         <record id="chart_at_template_2140" model="account.account.template">
           <field name="name">Pauschalwertberichtigungen zu Forderungen aus Lieferungen und Leistungen Währungsunion</field>
@@ -597,7 +596,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII1'))]" />
         </record>
         <record id="chart_at_template_2150" model="account.account.template">
           <field name="name">Forderungen von Partnern in Drittstaaten ohne eigenes Debitorenkonto</field>
@@ -605,7 +604,7 @@
           <field name="reconcile" eval="True"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_receivable" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII1'))]" />
         </record>
         <record id="chart_at_template_2180" model="account.account.template">
           <field name="name">Einzelwertberichtigungen zu Forderungen aus Lieferungen und Leistungen sonstiges Ausland</field>
@@ -613,7 +612,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII1'))]" />
         </record>
         <record id="chart_at_template_2190" model="account.account.template">
           <field name="name">Pauschalwertberichtigungen zu Forderungen aus Lieferungen und Leistungen sonstiges Ausland</field>
@@ -621,7 +620,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII1'))]" />
         </record>
         <record id="chart_at_template_2230" model="account.account.template">
           <field name="name">Einzelwertberichtigungen zu Forderungen gegenüber verbundenen Unternehmen</field>
@@ -629,7 +628,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII2'))]" />
         </record>
         <record id="chart_at_template_2240" model="account.account.template">
           <field name="name">Pauschalwertberichtigungen zu Forderungen gegenüber verbundenen Unternehmen</field>
@@ -637,7 +636,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII2'))]" />
         </record>
         <record id="chart_at_template_2280" model="account.account.template">
           <field name="name">Einzelwertberichtigungen zu Forderungen gegenüber Unternehmen, mit denen ein Beteiligungsverhältnis besteht</field>
@@ -645,7 +644,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII3'))]" />
         </record>
         <record id="chart_at_template_2290" model="account.account.template">
           <field name="name">Pauschalwertberichtigungen zu Forderungen gegenüber Unternehmen, mit denen ein Beteiligungsverhältnis besteht</field>
@@ -653,7 +652,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII3'))]" />
         </record>
         <record id="chart_at_template_2470" model="account.account.template">
           <field name="name">Eingeforderte, aber noch nicht eingezahlte Einlagen</field>
@@ -661,7 +660,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII3')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII3'))]" />
         </record>
         <record id="chart_at_template_2480" model="account.account.template">
           <field name="name">Einzelwertberichtigungen zu sonstigen Forderungen und Vermögensgegenständen</field>
@@ -669,7 +668,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII4'))]" />
         </record>
         <record id="chart_at_template_2490" model="account.account.template">
           <field name="name">Pauschalwertberichtigungen zu sonstigen Forderungen und Vermögensgegenständen</field>
@@ -677,7 +676,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII4'))]" />
         </record>
         <record id="chart_at_template_2500" model="account.account.template">
           <field name="name">Vorsteuern 20%</field>
@@ -685,7 +684,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII4'))]" />
         </record>
         <record id="chart_at_template_2501" model="account.account.template">
           <field name="name">Vorsteuern 10%</field>
@@ -693,7 +692,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII4'))]" />
         </record>
         <record id="chart_at_template_2502" model="account.account.template">
           <field name="name">Vorsteuern 13%</field>
@@ -701,7 +700,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII4'))]" />
         </record>
         <record id="chart_at_template_2505" model="account.account.template">
           <field name="name">Sonstige Vorsteuern</field>
@@ -709,7 +708,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII4'))]" />
         </record>
         <record id="chart_at_template_2506" model="account.account.template">
           <field name="name">Vorsteuern RC 20%</field>
@@ -717,7 +716,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII4'))]" />
         </record>
         <record id="chart_at_template_2507" model="account.account.template">
           <field name="name">Vorsteuern RC 10%</field>
@@ -725,7 +724,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII4'))]" />
         </record>
         <record id="chart_at_template_2510" model="account.account.template">
           <field name="name">Vorsteuern RC EU 20%</field>
@@ -733,7 +732,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII4'))]" />
         </record>
         <record id="chart_at_template_2511" model="account.account.template">
           <field name="name">Vorsteuern IGE 20%</field>
@@ -741,7 +740,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII4'))]" />
         </record>
         <record id="chart_at_template_2512" model="account.account.template">
           <field name="name">Vorsteuern IGE 10%</field>
@@ -749,7 +748,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII4'))]" />
         </record>
         <record id="chart_at_template_2513" model="account.account.template">
           <field name="name">Vorsteuern IGE 13%</field>
@@ -757,7 +756,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII4'))]" />
         </record>
         <record id="chart_at_template_2515" model="account.account.template">
           <field name="name">Vorsteuern 20% (aus EUSt.)</field>
@@ -765,7 +764,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABII4')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABII4'))]" />
         </record>
         <record id="chart_at_template_2600" model="account.account.template">
           <field name="name">Eigene Anteile</field>
@@ -773,7 +772,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABIII')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABIII'))]" />
         </record>
         <record id="chart_at_template_2610" model="account.account.template">
           <field name="name">Anteile an verbundenen Unternehmen</field>
@@ -781,7 +780,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABIII1'))]" />
         </record>
         <record id="chart_at_template_2620" model="account.account.template">
           <field name="name">Sonstige Anteile</field>
@@ -789,7 +788,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABIII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABIII2'))]" />
         </record>
         <record id="chart_at_template_2680" model="account.account.template">
           <field name="name">Besitzwechsel, soweit dem Unternehmen nicht die der Ausstellung zugrundeliegenden Forderungen zustehen</field>
@@ -797,7 +796,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABIII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABIII2'))]" />
         </record>
         <record id="chart_at_template_2690" model="account.account.template">
           <field name="name">Wertberichtigungen</field>
@@ -805,7 +804,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABIII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABIII2'))]" />
         </record>
         <record id="chart_at_template_2730" model="account.account.template">
           <field name="name">Postwertzeichen</field>
@@ -813,7 +812,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABIV')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABIV'))]" />
         </record>
         <record id="chart_at_template_2740" model="account.account.template">
           <field name="name">Stempelmarken</field>
@@ -821,7 +820,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABIV')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABIV'))]" />
         </record>
         <record id="chart_at_template_2780" model="account.account.template">
           <field name="name">Schecks in Inlandswährung</field>
@@ -829,7 +828,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABIV')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABIV'))]" />
         </record>
         <record id="chart_at_template_transfer_288" model="account.account.template">
         </record>
@@ -839,7 +838,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_ABIV')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_ABIV'))]" />
         </record>
         <record id="chart_at_template_2900" model="account.account.template">
           <field name="name">Aktive Rechnungsabgrenzungsposten</field>
@@ -847,7 +846,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AC')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AC'))]" />
         </record>
         <record id="chart_at_template_2950" model="account.account.template">
           <field name="name">Disagio</field>
@@ -855,7 +854,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AC')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AC'))]" />
         </record>
         <record id="chart_at_template_2960" model="account.account.template">
           <field name="name">Unterschiedsbetrag zur gebotenen Pensionsrückstellung</field>
@@ -863,7 +862,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PBI')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PBI'))]" />
         </record>
         <record id="chart_at_template_2970" model="account.account.template">
           <field name="name">Unterschiedsbetrag gem. Abschnitt XII Pensionskassengesetz</field>
@@ -871,7 +870,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PBII')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PBII'))]" />
         </record>
         <record id="chart_at_template_2980" model="account.account.template">
           <field name="name">Steuerabgrenzung</field>
@@ -879,7 +878,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_AC')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_AC'))]" />
         </record>
         <record id="chart_at_template_3000" model="account.account.template">
           <field name="name">Rückstellungen für Abfertigungen</field>
@@ -887,7 +886,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PBI')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PBI'))]" />
         </record>
         <record id="chart_at_template_3010" model="account.account.template">
           <field name="name">Rückstellungen für Pensionen</field>
@@ -895,7 +894,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_non_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PBII')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PBII'))]" />
         </record>
         <record id="chart_at_template_3100" model="account.account.template">
           <field name="name">Anleihen (einschließlich konvertibler)</field>
@@ -903,7 +902,7 @@
           <field name="reconcile" eval="True"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCI')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCI'))]" />
         </record>
         <record id="chart_at_template_3200" model="account.account.template">
           <field name="name">Erhaltene Anzahlungen auf Bestellungen</field>
@@ -911,7 +910,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_assets" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCIII')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCIII'))]" />
         </record>
         <record id="chart_at_template_3210" model="account.account.template">
           <field name="name">Umsatzsteuer-Evidenzkonto für erhaltene Anzahlungen auf Bestellungen</field>
@@ -919,7 +918,7 @@
           <field name="reconcile" eval="True"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
         <record id="chart_at_template_3300" model="account.account.template">
           <field name="name">Verbindlichkeiten bei Partnern im Inland ohne eigenes Kreditorenkonto</field>
@@ -927,7 +926,7 @@
           <field name="reconcile" eval="True"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_payable" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCIV')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCIV'))]" />
         </record>
         <record id="chart_at_template_3360" model="account.account.template">
           <field name="name">Verbindlichkeiten bei Partnern im EU Raum ohne eigenes Kreditorenkonto</field>
@@ -935,7 +934,7 @@
           <field name="reconcile" eval="True"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_payable" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCIV')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCIV'))]" />
         </record>
         <record id="chart_at_template_3370" model="account.account.template">
           <field name="name">Verbindlichkeiten bei Partnern in Drittstaaten ohne eigenes Kreditorenkonto</field>
@@ -943,7 +942,7 @@
           <field name="reconcile" eval="True"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_payable" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCIV')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCIV'))]" />
         </record>
         <record id="chart_at_template_3480" model="account.account.template">
           <field name="name">Verbindlichkeiten gegenüber Gesellschaftern</field>
@@ -951,7 +950,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII'))]" />
         </record>
         <record id="chart_at_template_3500" model="account.account.template">
           <field name="name">Umsatzsteuer 20%</field>
@@ -959,7 +958,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
         <record id="chart_at_template_3501" model="account.account.template">
           <field name="name">Umsatzsteuer 10%</field>
@@ -967,7 +966,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
         <record id="chart_at_template_3502" model="account.account.template">
           <field name="name">Umsatzsteuer 13%</field>
@@ -975,7 +974,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
         <record id="chart_at_template_3505" model="account.account.template">
           <field name="name">Sonstige Umsatzsteuer</field>
@@ -983,7 +982,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
         <record id="chart_at_template_3510" model="account.account.template">
           <field name="name">Umsatzsteuer RC EU 20%</field>
@@ -991,7 +990,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
         <record id="chart_at_template_3511" model="account.account.template">
           <field name="name">Umsatzsteuer IGE 20%</field>
@@ -999,7 +998,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
         <record id="chart_at_template_3512" model="account.account.template">
           <field name="name">Umsatzsteuer IGE 10%</field>
@@ -1007,7 +1006,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
         <record id="chart_at_template_3513" model="account.account.template">
           <field name="name">Umsatzsteuer IGE 13%</field>
@@ -1015,7 +1014,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
         <record id="chart_at_template_3515" model="account.account.template">
           <field name="name">Einfuhrumsatzsteuer 20%</field>
@@ -1023,7 +1022,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
         <record id="chart_at_template_3520" model="account.account.template">
           <field name="name">Ust. Zahllast</field>
@@ -1031,27 +1030,25 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
-        
+
         <record id="chart_at_template_3530" model="account.account.template">
           <field name="name">Verrechnungskonto Finanzamt</field>
           <field name="code">3530</field>
           <field name="reconcile" eval="True"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_payable" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
-        
+
         <record id="chart_at_template_3540" model="account.account.template">
           <field name="name">Verrechnung Lohnsteuer</field>
           <field name="code">3540</field>
           <field name="reconcile" eval="True"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
         <record id="chart_at_template_3541" model="account.account.template">
           <field name="name">Verrechnung Dienstgeberbeitrag</field>
@@ -1059,35 +1056,31 @@
           <field name="reconcile" eval="True"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
         <record id="chart_at_template_3542" model="account.account.template">
           <field name="name">Verrechnung Dienstgeberzuschlag</field>
           <field name="code">3542</field>
           <field name="reconcile" eval="True"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
-          <field eval="[(6,0,[])]" name="tax_ids"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
         <record id="chart_at_template_3550" model="account.account.template">
           <field name="name">Verrechnung Kommunalsteuer</field>
           <field name="code">3550</field>
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
-          <field eval="[(6,0,[])]" name="tax_ids"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
         <record id="chart_at_template_3551" model="account.account.template">
           <field name="name">Verrechnung Wiener Dienstgeberabgabe</field>
           <field name="code">3551</field>
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
-          <field eval="[(6,0,[])]" name="tax_ids"/>
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII1'))]" />
         </record>
         <record id="chart_at_template_3600" model="account.account.template">
           <field name="name">Verrechungskonto Sozialversicherung</field>
@@ -1095,26 +1088,23 @@
           <field name="reconcile" eval="True"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_payable" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII2')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII2'))]" />
         </record>
         <record id="chart_at_template_3610" model="account.account.template">
           <field name="name">Verrechnungskonto Magistrat/Gemeinde (KoSt, U-Bahn, etc.)</field>
           <field name="code">3610</field>
           <field name="reconcile" eval="True"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
-          <field eval="[(6,0,[])]" name="tax_ids"/>
           <field name="user_type_id" ref="account.data_account_type_payable" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII2')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PCVIII2'))]" />
         </record>
         <record id="chart_at_template_3740" model="account.account.template">
           <field name="name">WERE Verrechnungskonto</field>
           <field name="code">3740</field>
           <field name="reconcile" eval="True"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
-          <field eval="[(6,0,[])]" name="tax_ids"/>
           <field name="user_type_id" ref="account.data_account_type_payable" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PD')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PD'))]" />
         </record>
         <record id="chart_at_template_4000" model="account.account.template">
           <field name="name">Brutto-Umsatzerlöse im Inland (20%)</field>
@@ -1122,8 +1112,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_revenue" />
-          <field name="tag_ids" eval="[(6, 0, [ref('account.account_tag_operating'), ref('l10n_at.account_tag_l10n_at_EBIT1')])]" />
-
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT1'))]" />
         </record>
         <record id="chart_at_template_4001" model="account.account.template">
           <field name="name">Brutto-Umsatzerlöse im Inland (10%)</field>
@@ -1131,7 +1120,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_revenue" />
-          <field name="tag_ids" eval="[(6, 0, [ref('account.account_tag_operating'), ref('l10n_at.account_tag_l10n_at_EBIT1')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT1'))]" />
         </record>
         <record id="chart_at_template_4100" model="account.account.template">
           <field name="name">Brutto-Umsatzerlöse im EU Raum (RC 20%)</field>
@@ -1139,7 +1128,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_revenue" />
-          <field name="tag_ids" eval="[(6, 0, [ref('account.account_tag_operating'), ref('l10n_at.account_tag_l10n_at_EBIT1')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT1'))]" />
         </record>
         <record id="chart_at_template_4110" model="account.account.template">
           <field name="name">Brutto-Umsatzerlöse im EU Raum (RC 10%)</field>
@@ -1147,7 +1136,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_revenue" />
-          <field name="tag_ids" eval="[(6, 0, [ref('account.account_tag_operating'), ref('l10n_at.account_tag_l10n_at_EBIT1')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT1'))]" />
         </record>
         <record id="chart_at_template_4200" model="account.account.template">
           <field name="name">Brutto-Umsatzerlöse in Drittstaaten (0%)</field>
@@ -1155,7 +1144,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_revenue" />
-          <field name="tag_ids" eval="[(6, 0, [ref('account.account_tag_operating'), ref('l10n_at.account_tag_l10n_at_EBIT1')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT1'))]" />
         </record>
         <record id="chart_at_template_4860" model="account.account.template">
           <field name="name">Kursgewinne aus Fremdwährungstransaktionen</field>
@@ -1163,7 +1152,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_other_income" />
-          <field name="tag_ids" eval="[(6, 0, [ref('account.account_tag_operating'), ref('l10n_at.account_tag_l10n_at_EBIT1')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT1'))]" />
         </record>
         <record id="chart_at_template_5000" model="account.account.template">
           <field name="name">Wareneinkauf</field>
@@ -1172,7 +1161,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('account.account_tag_operating'), ref('l10n_at.account_tag_l10n_at_EBIT5I')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT5I'))]" />
         </record>
         <record id="chart_at_template_5050" model="account.account.template">
           <field name="name">Wareneinkauf EU</field>
@@ -1181,7 +1170,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('account.account_tag_operating'), ref('l10n_at.account_tag_l10n_at_EBIT5I')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT5I'))]" />
         </record>
         <record id="chart_at_template_5090" model="account.account.template">
           <field name="name">Wareneinkauf 0%</field>
@@ -1190,7 +1179,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('account.account_tag_operating'), ref('l10n_at.account_tag_l10n_at_EBIT5I')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT5I'))]" />
         </record>
         <record id="chart_at_template_5800" model="account.account.template">
           <field name="name">Skontoerträge auf Materialaufwand</field>
@@ -1199,7 +1188,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('account.account_tag_operating'), ref('l10n_at.account_tag_l10n_at_EBIT5I')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT5I'))]" />
         </record>
         <record id="chart_at_template_5810" model="account.account.template">
           <field name="name">Skontoerträge auf sonstige bezogene Herstellungsleistungen</field>
@@ -1208,7 +1197,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('account.account_tag_operating'), ref('l10n_at.account_tag_l10n_at_EBIT5II')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT5II'))]" />
         </record>
         <record id="chart_at_template_5900" model="account.account.template">
           <field name="name">Aufwandsstellenrechnung</field>
@@ -1216,7 +1205,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('account.account_tag_operating')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating'))]" />
         </record>
         <record id="chart_at_template_6200" model="account.account.template">
           <field name="name">Gehälter (Angestellte)</field>
@@ -1224,8 +1213,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT6I')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT6I'))]" />
         </record>
         <record id="chart_at_template_6205" model="account.account.template">
           <field name="name">Geschäftsführerbezug</field>
@@ -1233,8 +1221,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT6I')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT6I'))]" />
         </record>
         <record id="chart_at_template_6242" model="account.account.template">
           <field name="name">Urlaubsabfindung (Angestellte)</field>
@@ -1242,8 +1229,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT6I')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT6I'))]" />
         </record>
         <record id="chart_at_template_6260" model="account.account.template">
           <field name="name">Sonstige Bezüge (Angestellte)</field>
@@ -1251,8 +1237,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT6I')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT6I'))]" />
         </record>
         <record id="chart_at_template_6270" model="account.account.template">
           <field name="name">Sachbezug (Angestellte)</field>
@@ -1260,8 +1245,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT6I')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT6I'))]" />
         </record>
         <record id="chart_at_template_6271" model="account.account.template">
           <field name="name">Sachbezug (Geschäftsführer)</field>
@@ -1269,8 +1253,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT6I')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT6I'))]" />
         </record>
         <record id="chart_at_template_6310" model="account.account.template">
           <field name="name">Grundgehälter (Überstunden)</field>
@@ -1278,8 +1261,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT6I')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT6I'))]" />
         </record>
         <record id="chart_at_template_6330" model="account.account.template">
           <field name="name">Gehälter (Überstundenzuschläge)</field>
@@ -1287,8 +1269,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT6I')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT6I'))]" />
         </record>
         <record id="chart_at_template_6340" model="account.account.template">
           <field name="name">Veränderung noch nicht konsumierter Urlaub</field>
@@ -1296,8 +1277,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT6I')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT6I'))]" />
         </record>
         <record id="chart_at_template_6400" model="account.account.template">
           <field name="name">Beiträge für betriebliche Mitarbeitervorsorgekasse</field>
@@ -1305,8 +1285,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT6II')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT6II'))]" />
         </record>
 
         <record id="chart_at_template_6560" model="account.account.template">
@@ -1315,8 +1294,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT6II')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT6II'))]" />
         </record>
 
         <record id="chart_at_template_6660" model="account.account.template">
@@ -1325,8 +1303,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT6II')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT6II'))]" />
         </record>
         <record id="chart_at_template_6661" model="account.account.template">
           <field name="name">Dienstgeberbeitrag zum Familienlastenausgleichsfonds (DB)</field>
@@ -1334,8 +1311,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT6II')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT6II'))]" />
         </record>
         <record id="chart_at_template_6662" model="account.account.template">
           <field name="name">Zuschlag zum Dienstnehmerbeitrag (DZ)</field>
@@ -1343,8 +1319,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT6II')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT6II'))]" />
         </record>
         <record id="chart_at_template_6640" model="account.account.template">
           <field name="name">Dienstgeberabgabe der Gemeinde Wien (U-Bahn Steuer)</field>
@@ -1352,8 +1327,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT6II')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT6II'))]" />
         </record>
 
         <record id="chart_at_template_6700" model="account.account.template">
@@ -1362,8 +1336,7 @@
           <field name="user_type_id" ref="account.data_account_type_expenses" />
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT6II')])]" />
-          <field eval="[(6,0,[])]" name="tax_ids"/>
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT6II'))]" />
         </record>
 
         <record id="chart_at_template_6900" model="account.account.template">
@@ -1380,7 +1353,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_depreciation" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT7I')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_EBIT7I'))]" />
         </record>
         <record id="chart_at_template_7090" model="account.account.template">
           <field name="name">Abschreibungen vom Umlaufvermögen, soweit diese die im Unternehmen üblichen Abschreibungen übersteigen</field>
@@ -1389,7 +1362,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_depreciation" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT7II')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_EBIT7II'))]" />
         </record>
         <record id="chart_at_template_7600" model="account.account.template">
           <field name="name">Büromaterial und Drucksorten</field>
@@ -1397,7 +1370,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT8')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT8'))]" />
         </record>
         <record id="chart_at_template_763" model="account.account.template">
           <field name="name">Fachliteratur und Zeitungen</field>
@@ -1405,7 +1378,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT8')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT8'))]" />
         </record>
         <record id="chart_at_template_7690" model="account.account.template">
           <field name="name">Spenden und Trinkgelder</field>
@@ -1414,7 +1387,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT8')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT8'))]" />
         </record>
         <record id="chart_at_template_7770" model="account.account.template">
           <field name="name">Aus- und Fortbildung</field>
@@ -1422,7 +1395,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT8')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT8'))]" />
         </record>
         <record id="chart_at_template_7780" model="account.account.template">
           <field name="name">Mitgliedsbeiträge</field>
@@ -1430,7 +1403,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT8')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT8'))]" />
         </record>
         <record id="chart_at_template_7790" model="account.account.template">
           <field name="name">Spesen des Geldverkehrs</field>
@@ -1438,7 +1411,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT8')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT8'))]" />
         </record>
         <record id="chart_at_template_7820" model="account.account.template">
           <field name="name">Buchwert abgegangener Anlagen, ausgenommen Finanzanlagen</field>
@@ -1447,7 +1420,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT8')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT8'))]" />
         </record>
         <record id="chart_at_template_7830" model="account.account.template">
           <field name="name">Verluste aus dem Abgang vom Anlagevermögen, ausgenommen Finanzanlagen</field>
@@ -1455,7 +1428,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT8')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT8'))]" />
         </record>
         <record id="chart_at_template_7860" model="account.account.template">
           <field name="name">Kursverluste aus Fremdwährungstransaktionen</field>
@@ -1463,7 +1436,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT8')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT8'))]" />
         </record>
         <record id="chart_at_template_7890" model="account.account.template">
           <field name="name">Skontoerträge auf sonstige betriebliche Aufwendungen</field>
@@ -1471,7 +1444,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_EBIT8')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT8'))]" />
         </record>
         <record id="chart_at_template_7900" model="account.account.template">
           <field name="name">Aufwandsstellenrechnung</field>
@@ -1507,7 +1480,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_expenses" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_FIN10')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_operating')), (4, ref('l10n_at.account_tag_l10n_at_EBIT8'))]" />
         </record>
         <record id="chart_at_template_8140" model="account.account.template">
           <field name="name">Erlöse aus dem Abgang von Beteiligungen</field>
@@ -1515,7 +1488,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_other_income" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_FIN10')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_financing')), (4, ref('l10n_at.account_tag_l10n_at_FIN10'))]" />
         </record>
         <record id="chart_at_template_8150" model="account.account.template">
           <field name="name">Erlöse aus dem Abgang von sonstigen Finanzanlagen</field>
@@ -1523,7 +1496,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_other_income" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_FIN10')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_financing')), (4, ref('l10n_at.account_tag_l10n_at_FIN10'))]" />
         </record>
         <record id="chart_at_template_8160" model="account.account.template">
           <field name="name">Erlöse aus dem Abgang von Wertpapieren des Umlaufvermögens</field>
@@ -1531,7 +1504,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_other_income" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_FIN10')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_financing')), (4, ref('l10n_at.account_tag_l10n_at_FIN10'))]" />
         </record>
         <record id="chart_at_template_8170" model="account.account.template">
           <field name="name">Buchwert abgegangener Beteiligungen</field>
@@ -1539,7 +1512,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_other_income" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_FIN10')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_financing')), (4, ref('l10n_at.account_tag_l10n_at_FIN10'))]" />
         </record>
         <record id="chart_at_template_8180" model="account.account.template">
           <field name="name">Buchwert abgegangener sonstiger Finanzanlagen</field>
@@ -1547,7 +1520,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_other_income" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_FIN11')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_financing')), (4, ref('l10n_at.account_tag_l10n_at_FIN11'))]" />
         </record>
         <record id="chart_at_template_8190" model="account.account.template">
           <field name="name">Buchwert abgegangener Wertpapiere des Umlaufvermögens</field>
@@ -1555,7 +1528,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_other_income" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_FIN11')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_financing')), (4, ref('l10n_at.account_tag_l10n_at_FIN11'))]" />
         </record>
         <record id="chart_at_template_8200" model="account.account.template">
           <field name="name">Erträge aus dem Abgang von und der Zuschreibung zu Finanzanlagen</field>
@@ -1563,7 +1536,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_other_income" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_FIN10')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_financing')), (4, ref('l10n_at.account_tag_l10n_at_FIN10'))]" />
         </record>
         <record id="chart_at_template_8210" model="account.account.template">
           <field name="name">Erträge aus dem Abgang von und der Zuschreibung zu Wertpapieren des Umlaufvermögens</field>
@@ -1571,7 +1544,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_other_income" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_FIN11')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_financing')), (4, ref('l10n_at.account_tag_l10n_at_FIN11'))]" />
         </record>
         <record id="chart_at_template_8350" model="account.account.template">
           <field name="name">Nicht ausgenützte Lieferantenskonti</field>
@@ -1579,7 +1552,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_other_income" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_FIN12')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_financing')), (4, ref('l10n_at.account_tag_l10n_at_FIN12'))]" />
         </record>
         <record id="chart_at_template_8990" model="account.account.template">
           <field name="name">Gewinnabfuhr bzw. Verlustüberrechnung aus Ergebnisabführungsverträgen</field>
@@ -1587,7 +1560,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_other_income" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_FIN12')])]" />
+          <field name="tag_ids" eval="[(4, ref('account.account_tag_financing')), (4, ref('l10n_at.account_tag_l10n_at_FIN12'))]" />
         </record>
         <record id="chart_at_template_9190" model="account.account.template">
           <field name="name">Nicht eingeforderte ausstehende Einlagen</field>
@@ -1595,7 +1568,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_equity" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PAI')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PAI'))]" />
         </record>
         <record id="chart_at_template_9390" model="account.account.template">
           <field name="name">Bilanzgewinn (-verlust)</field>
@@ -1603,7 +1576,7 @@
           <field name="reconcile" eval="False"/>
           <field name="chart_template_id" ref="l10n_at_chart_template"/>
           <field name="user_type_id" ref="account.data_account_type_equity" />
-          <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PAIV')])]" />
+          <field name="tag_ids" eval="[(4, ref('l10n_at.account_tag_l10n_at_PAIV'))]" />
         </record>
         <record id="chart_at_template_9800" model="account.account.template">
           <field name="name">Eröffnungsbilanz</field>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
As given by a test migration the template will somehow be applied
on related account.account which will remove all manually or from other
modules applied tags.

**Current behavior before PR:**
For unknown reasons (as it is closed source code of Odoo SA), the migration is deleting manually applied tags and also tags owned by another module which is not available during migration

**Desired behavior after PR is merged:**
Migration does not remove any tags which are not directly related to a template change.

Info: @wt-io-it



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
