### PR TITLE
[FIX] account : Average price fix invoice report

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -100,7 +100,7 @@ class AccountInvoiceReport(models.Model):
                 -line.balance * currency_table.rate                         AS price_subtotal,
                 -COALESCE(
                    -- Average line price
-                   (line.balance / NULLIF(line.quantity, 0.0))
+                   (line.balance / NULLIF(line.quantity, 0.0)) * (CASE WHEN move.move_type IN ('in_invoice','out_refund','in_receipt') THEN -1 ELSE 1 END)
                    -- convert to template uom
                    * (NULLIF(COALESCE(uom_line.factor, 1), 0.0) / NULLIF(COALESCE(uom_template.factor, 1), 0.0)),
                    0.0) * currency_table.rate                               AS price_average,

--- a/addons/account/tests/test_account_invoice_report.py
+++ b/addons/account/tests/test_account_invoice_report.py
@@ -103,6 +103,7 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
             'price_subtotal': vals[1],
             'quantity': vals[2],
         } for vals in expected_values_list]
+
         self.assertRecordValues(reports, expected_values_dict)
 
     def test_invoice_report_multiple_types(self):
@@ -112,7 +113,7 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
             [1000,           1000,           1],
             [250,            750,            3],
             [6,              6,              1],
-            [-20,            -20,           -1],
-            [-20,            -20,           -1],
-            [-600,           -600,          -1],
+            [20,             -20,           -1],
+            [20,             -20,           -1],
+            [600,            -600,          -1],
         ])


### PR DESCRIPTION
Current behavior:
Invoices report had a wrong average price when invoice had credit note

Steps to reproduce:
Create a db with accounting
Create a customer C and a Product P
Create an Invoice for C for 10 pieces of P
Create a Credit note for C for 1 P
Go to Reporting > Invoice Analysis
Open the pivot view, in the Measures, display the Average Price, the Product quantity and the Untaxed Total
The Total multiplied by the quantity is not equals to the average.

opw-2557420
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
