### PR TITLE
[IMP] website_slides: Improve frontend UI

### DIFF
--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -295,7 +295,7 @@ class WebsiteBlog(http.Controller):
         response = request.render("website_blog.blog_post_complete", values)
 
         if blog_post.id not in request.session.get('posts_viewed', []):
-            if sql.increment_field_skiplock(blog_post, 'visits'):
+            if sql.increment_fields_skiplock(blog_post, 'visits'):
                 if not request.session.get('posts_viewed'):
                     request.session['posts_viewed'] = []
                 request.session['posts_viewed'].append(blog_post.id)

--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -904,7 +904,7 @@ class Post(models.Model):
 
     def _set_viewed(self):
         self.ensure_one()
-        return sql.increment_field_skiplock(self, 'views')
+        return sql.increment_fields_skiplock(self, 'views')
 
     def _get_access_action(self, access_uid=None, force_website=False):
         """ Instead of the classic form view, redirect to the post on the website directly """

--- a/addons/website_sale_slides/models/sale_order.py
+++ b/addons/website_sale_slides/models/sale_order.py
@@ -34,7 +34,7 @@ class SaleOrder(models.Model):
         return result
 
     def _verify_updated_quantity(self, order_line, product_id, new_qty, **kwargs):
-        """Forbid quantity updates on event booth lines."""
+        """Forbid quantity updates on courses lines."""
         product = self.env['product.product'].browse(product_id)
         if product.detailed_type == 'course' and new_qty > 1:
             return 1, _('You can only add a course once in your cart.')

--- a/addons/website_sale_slides/static/src/xml/slide_course_join.xml
+++ b/addons/website_sale_slides/static/src/xml/slide_course_join.xml
@@ -7,7 +7,7 @@
                     Sign in
                 </t>
                 <t t-else="">
-                    Buy course
+                    Buy this Course
                 </t>
             </t>
         </t>

--- a/addons/website_sale_slides/views/website_slides_templates.xml
+++ b/addons/website_sale_slides/views/website_slides_templates.xml
@@ -18,15 +18,23 @@
         <li t-elif="aside_slide.channel_id.enroll == 'payment'" class="text-decoration-none small">
             <i class="fa fa-download me-1"/>
             <t t-call="website_sale_slides.course_buy_course_link">
+                <t t-set="for_resources" t-value="1"/>
                 <t t-set="slide" t-value="aside_slide"/>
             </t>
         </li>
     </xpath>
 </template>
 
-<template name="Buy Course To Download Resource Slide Detail" id="slide_content_detailed_buy_course" inherit_id="website_slides.slide_content_detailed">
+<template name="Buy Course To Access Resources or Interact Slide Detail" id="slide_content_detailed_buy_course" inherit_id="website_slides.slide_content_detailed">
     <xpath expr="//div[hasclass('o_wslides_js_course_join') and hasclass('o_wslides_no_access')]" position="inside">
         <span t-elif="slide.channel_id.enroll == 'payment'" class="text-muted me-auto border-start ps-3">
+            <t t-call="website_sale_slides.course_buy_course_link">
+                <t t-set="for_resources" t-value="1"/>
+            </t>
+        </span>
+    </xpath>
+    <xpath expr="//div[hasclass('o_wslides_js_course_join') and hasclass('o_wslides_no_access_comments')]" position="inside">
+        <span t-elif="slide.channel_id.enroll == 'payment'">
             <t t-call="website_sale_slides.course_buy_course_link"/>
         </span>
     </xpath>
@@ -62,7 +70,9 @@
     <xpath expr="//div[hasclass('o_wslides_js_course_join') and hasclass('o_wslides_no_access')]" position="inside">
         <li t-elif="slide.channel_id.enroll == 'payment'" class="o_wslides_fs_slide_link mb-1">
             <i class="fa fa-download me-1"/>
-            <t t-call="website_sale_slides.course_buy_course_link"/>
+            <t t-call="website_sale_slides.course_buy_course_link">
+                <t t-set="for_resources" t-value="1"/>
+            </t>
         </li>
     </xpath>
 </template>
@@ -92,7 +102,7 @@
 <!-- TOOLS -->
 <template name="Buy Course Link" id="course_buy_course_link">
     <a class="post_link" t-att-href="'/shop/cart/update?product_id=%s' % slide.channel_id.product_id.id">
-        Buy Course</a> to access resources
+        Join this Course</a><t t-if="for_resources"> to access resources</t>
 </template>
 
 <template name="Buy Course Button" id="course_buy_course_button">
@@ -140,8 +150,7 @@
 <template name="Display 'Buy Now'" id="course_option_buy_course_now" inherit_id="website_sale_slides.course_buy_course_button" active="False">
     <xpath expr="//div[hasclass('add_to_cart_button')]" position="before">
         <div class="mb-1">
-          <!-- FIXME TDE seems strange to redirect to /cart/update with get params when it only supports POST requests -->
-            <a role="button" class="btn btn-primary btn-block post_link" t-attf-href="/shop/cart/update?product_id={{channel.product_id.id}}&amp;express=1">
+            <a role="button" class="post_link btn btn-primary btn-block" t-attf-href="/shop/cart/update?product_id={{channel.product_id.id}}&amp;express=1">
                 <i class="fa fa-bolt"></i> Buy Now
             </a>
         </div>

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -67,9 +67,7 @@ class WebsiteSlides(WebsiteProfile):
         if not slide.channel_id.is_member:
             viewed_slides = request.session.setdefault('viewed_slides', set())
             if slide.id not in viewed_slides:
-                if tools.sql.increment_field_skiplock(slide, 'public_views'):
-                    # Increment total views immediately as compute is not triggered
-                    tools.sql.increment_field_skiplock(slide, 'total_views')
+                if tools.sql.increment_fields_skiplock(slide, 'public_views', 'total_views'):
                     viewed_slides.add(slide.id)
                     request.session.touch()
         else:

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -64,10 +64,12 @@ class WebsiteSlides(WebsiteProfile):
         return {'slide': slide}
 
     def _set_viewed_slide(self, slide, quiz_attempts_inc=False):
-        if request.env.user._is_public() or not slide.website_published or not slide.channel_id.is_member:
+        if not slide.channel_id.is_member:
             viewed_slides = request.session.setdefault('viewed_slides', set())
             if slide.id not in viewed_slides:
                 if tools.sql.increment_field_skiplock(slide, 'public_views'):
+                    # Increment total views immediately as compute is not triggered
+                    tools.sql.increment_field_skiplock(slide, 'total_views')
                     viewed_slides.add(slide.id)
                     request.session.touch()
         else:

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -882,7 +882,7 @@ class Slide(models.Model):
             ('partner_id', '=', target_partner.id)
         ])
         if quiz_attempts_inc and existing_sudo:
-            sql.increment_field_skiplock(existing_sudo, 'quiz_attempts_count')
+            sql.increment_fields_skiplock(existing_sudo, 'quiz_attempts_count')
             existing_sudo.invalidate_recordset(['quiz_attempts_count'])
 
         new_slides = self_sudo - existing_sudo.mapped('slide_id')

--- a/addons/website_slides/static/src/js/slides_course_join.js
+++ b/addons/website_slides/static/src/js/slides_course_join.js
@@ -1,9 +1,8 @@
 /** @odoo-module **/
 
-import core from 'web.core';
+import { sprintf } from '@web/core/utils/strings';
+import { _t } from 'web.core';
 import publicWidget from 'web.public.widget';
-
-var _t = core._t;
 
 var CourseJoinWidget = publicWidget.Widget.extend({
     template: 'slide.course.join',
@@ -22,7 +21,7 @@ var CourseJoinWidget = publicWidget.Widget.extend({
      * @param {boolean} options.isMember whether current user is member or not
      * @param {boolean} options.publicUser whether current user is public or not
      * @param {string} [options.joinMessage] the message to use for the simple join case
-     *   when the course if free and the user is logged in, defaults to "Join Course".
+     *   when the course is free and the user is logged in, defaults to "Join this Course".
      * @param {Promise} [options.beforeJoin] a promise to execute before we redirect to
      *   another url within the join process (login / buy course / ...)
      * @param {function} [options.afterJoin] a callback function called after the user has
@@ -33,7 +32,7 @@ var CourseJoinWidget = publicWidget.Widget.extend({
         this.channel = options.channel;
         this.isMember = options.isMember;
         this.publicUser = options.publicUser;
-        this.joinMessage = options.joinMessage || _t('Join Course');
+        this.joinMessage = options.joinMessage || _t('Join this Course');
         this.beforeJoin = options.beforeJoin || function () {return Promise.resolve();};
         this.afterJoin = options.afterJoin || function () {document.location.reload();};
     },
@@ -78,7 +77,7 @@ var CourseJoinWidget = publicWidget.Widget.extend({
         } else {
             url = `/slides/${this.channel.channelId}`;
         }
-        document.location = _.str.sprintf('/web/login?redirect=%s', encodeURIComponent(url));
+        document.location = sprintf('/web/login?redirect=%s', encodeURIComponent(url));
     },
 
     /**
@@ -89,6 +88,7 @@ var CourseJoinWidget = publicWidget.Widget.extend({
     _popoverAlert: function ($el, message) {
         $el.popover({
             trigger: 'focus',
+            delay: {'hide': 300},
             placement: 'bottom',
             container: 'body',
             html: true,
@@ -117,12 +117,10 @@ var CourseJoinWidget = publicWidget.Widget.extend({
                 self.afterJoin();
             } else {
                 if (data.error === 'public_user') {
-                    var message = _t('Please <a href="/web/login?redirect=%s">login</a> to join this course');
-                    var signupAllowed = data.error_signup_allowed || false;
-                    if (signupAllowed) {
-                        message = _t('Please <a href="/web/signup?redirect=%s">create an account</a> to join this course');
-                    }
-                    self._popoverAlert(self.$el, _.str.sprintf(message, (document.URL)));
+                    const message = data.error_signup_allowed ?
+                        _t('Please <a href="/web/login?redirect=%s">login</a> or <a href="/web/signup?redirect=%s">create an account</a> to join this course') :
+                        _t('Please <a href="/web/login?redirect=%s">login</a> to join this course');
+                    self._popoverAlert(self.$el, sprintf(message, document.URL, document.URL));
                 } else if (data.error === 'join_done') {
                     self._popoverAlert(self.$el, _t('You have already joined this channel'));
                 } else {

--- a/addons/website_slides/static/src/js/slides_slide_like.js
+++ b/addons/website_slides/static/src/js/slides_slide_like.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { sprintf } from '@web/core/utils/strings';
 import { _t } from 'web.core';
 import publicWidget from 'web.public.widget';
 import '@website_slides/js/slides';
@@ -22,6 +23,7 @@ var SlideLikeWidget = publicWidget.Widget.extend({
     _popoverAlert: function ($el, message) {
         $el.popover({
             trigger: 'focus',
+            delay: {'hide': 300},
             placement: 'bottom',
             container: 'body',
             html: true,
@@ -65,12 +67,10 @@ var SlideLikeWidget = publicWidget.Widget.extend({
                 $dislikesIcon.toggleClass("fa-thumbs-o-down", data.user_vote !== -1);
             } else {
                 if (data.error === 'public_user') {
-                    var message = _t('Please <a href="/web/login?redirect=%s">login</a> to vote this lesson');
-                    var signupAllowed = data.error_signup_allowed || false;
-                    if (signupAllowed) {
-                        message = _t('Please <a href="/web/signup?redirect=%s">create an account</a> to vote this lesson');
-                    }
-                    self._popoverAlert(self.$el, _.str.sprintf(message, (document.URL)));
+                    const message = data.error_signup_allowed ?
+                        _t('Please <a href="/web/login?redirect=%s">login</a> or <a href="/web/signup?redirect=%s">create an account</a> to vote for this lesson') :
+                        _t('Please <a href="/web/login?redirect=%s">login</a> to vote for this lesson');
+                    self._popoverAlert(self.$el, sprintf(message, document.URL, document.URL));
                 } else if (data.error === 'slide_access') {
                     self._popoverAlert(self.$el, _t('You don\'t have access to this lesson'));
                 } else if (data.error === 'channel_membership_required') {

--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -16,18 +16,22 @@ $o-wslides-fs-side-width: 300px;
 // If '-webkit-line-clamp' is not supported, a less effective
 // 'line-height' fallback will be used instead.
 $truncate-limits: 2, 3, 10;
+$line-height-truncate: 1.25em;
 
 @each $limit in $truncate-limits {
     .o_wslides_desc_truncate_#{$limit} {
-        $line-height: 1.3;
-        max-height: $limit * $line-height * 1.2em;
+        max-height: $limit * $line-height-truncate;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: normal;
-        line-height: $line-height;
+        line-height: $line-height-truncate;
         display: -webkit-box;
         -webkit-box-orient: vertical;
         -webkit-line-clamp: $limit;
+    }
+    .o_wslides_desc_truncate_#{$limit}_badges {
+        @extend .o_wslides_desc_truncate_#{$limit};
+        max-height: $limit * $line-height-truncate * 1.2;
     }
 }
 
@@ -220,10 +224,6 @@ $truncate-limits: 2, 3, 10;
 
 }
 
-.o_wslides_card_default_background {
-    background-color: $o-wslides-color-bg;  // same as body
-}
-
 .o_wslides_channel_completion_completed {
     font-size: 1rem;
 }
@@ -237,7 +237,11 @@ $truncate-limits: 2, 3, 10;
             border: none;
         }
     }
-
+    .o_wslides_background_image img {
+        height: 100%;
+        width: 100%;
+        object-fit: cover;
+    }
     .o_wprofile_progress_circle {
         margin-left: auto;
         margin-right: auto;
@@ -489,6 +493,21 @@ $truncate-limits: 2, 3, 10;
             }
         }
     }
+
+    .o_wslides_promoted_slide {
+        .o_wslides_background_image {
+            background-size: cover;
+            background-position: center;
+            padding-bottom: 35%;
+        }
+    }
+    .o_wslides_lesson_card {
+        .o_wslides_background_image img {
+            height: 100%;
+            width: 100%;
+            object-fit: cover;
+        }
+    }
 }
 
 
@@ -496,6 +515,13 @@ $truncate-limits: 2, 3, 10;
 // **************************************************
 .o_wslides_lesson_main {
     .o_wslides_lesson_aside {
+        .o_wslides_background_image_aside_card {
+            min-width: 20%;
+            padding-top: 20%;
+            background-size: cover;
+            background-position: center;
+        }
+
         .o_wslides_lesson_aside_collapse.collapsed {
             transform: rotate(90deg);
         }

--- a/addons/website_slides/static/src/scss/website_slides_profile.scss
+++ b/addons/website_slides/static/src/scss/website_slides_profile.scss
@@ -1,4 +1,9 @@
 // Quest - Course Card
 .o_wprofile_slides_course_card_body {
     cursor: pointer;
+
+    .o_wslides_background_image {
+        background-size: cover;
+        background-position: center;
+    }
 }

--- a/addons/website_slides/static/tests/tours/slides_course_member.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member.js
@@ -19,7 +19,7 @@ tour.register('course_member', {
 {
     trigger: 'a:contains("Basics of Gardening - Test")'
 }, {
-    trigger: 'a:contains("Join Course")'
+    trigger: 'a:contains("Join this Course")'
 }, {
     trigger: '.o_wslides_js_course_join:contains("You\'re enrolled")',
     run: function () {} // check membership

--- a/addons/website_slides/static/tests/tours/slides_course_member_yt.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member_yt.js
@@ -38,7 +38,7 @@ tour.register('course_member_youtube', {
 }, {
     trigger: 'a:contains("Choose your wood")'
 }, {
-    trigger: 'a:contains("Join Course")'
+    trigger: 'a:contains("Join this Course")'
 }, {
     trigger: '.o_wslides_js_course_join:contains("You\'re enrolled")',
     run: function () {} // check membership

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -96,7 +96,7 @@
                             <page name="options" string="Options">
                                 <group>
                                     <group name="course" string="Course">
-                                        <field name="user_id" domain="[('share', '=', False)]"/>
+                                        <field name="user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
                                         <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>
                                     </group>
                                     <group name="access_rights" string="Access Rights">

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -122,7 +122,7 @@
                             <!-- ==== Header Left ==== -->
                             <div class="col-12 col-md-4 col-lg-3 position-relative">
                                 <div class="d-flex align-items-end justify-content-around h-100">
-                                    <div t-if="channel.image_1920" t-field="channel.image_1920" t-options='{"widget": "image", "class": "o_wslides_course_pict d-inline-block mb-2 mt-3 my-md-0"}' class="h-100"/>
+                                    <div t-if="channel.image_1920" t-field="channel.image_1920" t-options='{"widget": "image", "class": "o_wslides_course_pict d-inline-block mb-2 mt-3 my-md-0", "preview_image": "image_1024"}' class="h-100"/>
                                     <div t-else="" class="h-100">
                                         <img t-att-src="'/website_slides/static/src/img/channel-%s-default.jpg' % ('training' if channel.channel_type == 'training' else 'documentation')"
                                             class="o_wslides_course_pict d-inline-block mb-2 mt-3 my-md-0"/>
@@ -295,12 +295,11 @@
     <div class="o_wslides_js_course_join flex-grow-1 d-grid">
         <a t-if="not channel.is_member and channel.enroll == 'public'" role="button"
             class="btn btn-primary o_wslides_js_course_join_link"
-            title="Start Course" aria-label="Start Course Channel"
-            t-att-href="'#'"
+            title="Start Course" aria-label="Start Course Channel" href="#"
             t-att-data-channel-id="channel.id"
             t-att-data-channel-enroll="channel.enroll">
             <span class="cta-title text_small_caps">
-                Join Course
+                Join this Course
             </span>
         </a>
 
@@ -557,28 +556,31 @@
     <div class="o_wslides_promoted_slide">
         <div t-if="not search and not search_slide_category and slide_promoted" class="container py-1 mb-2">
             <div class="card flex-column flex-lg-row">
-                <t t-set="image_url" t-value="website.image_url(slide_promoted, 'image_1024')"/>
+                <t t-set="image_url" t-value="website.image_url(slide_promoted, 'image_512')"/>
 
                 <a t-if="slide_promoted.is_preview or channel.is_member or is_slides_publisher"
-                t-attf-href="/slides/slide/#{slug(slide_promoted)}#{query_string}" class="w-100 w-lg-50 flex-shrink-0 rounded">
-                    <div t-attf-style="background-image:url(#{image_url}); background-size: cover; background-position:center; padding-bottom: 35%;" class="h-lg-100"/>
+                   t-attf-href="/slides/slide/#{slug(slide_promoted)}#{query_string}" class="w-100 w-lg-50 flex-shrink-0 rounded">
+                    <div t-if="slide_promoted.image_1920" t-field="slide_promoted.image_1920"
+                         t-options="{'widget': 'image', 'style': 'height:100%', 'preview_image': 'image_512'}" class="h-100"/>
+                    <div t-else="" t-attf-style="background-image:url(#{image_url});" class="o_wslides_background_image h-lg-100"/>
                 </a>
                 <div t-else="" class="w-100 w-lg-50 flex-shrink-0 rounded">
-                    <div t-attf-style="background-image:url(#{image_url}); background-size: cover; background-position:center; padding-bottom: 35%;" class="h-lg-100"/>
+                    <div t-if="slide_promoted.image_1920" t-field="slide_promoted.image_1920"
+                         t-options="{'widget': 'image', 'style': 'height:100%', 'preview_image': 'image_512'}" class="h-100"/>
+                    <div t-else="" t-attf-style="background-image:url(#{image_url});" class="o_wslides_background_image h-lg-100"/>
                 </div>
 
                 <div class="card-body">
                     <a t-if="slide_promoted.is_preview or channel.is_member or is_slides_publisher"
                     t-attf-href="/slides/slide/#{slug(slide_promoted)}#{query_string}"
-                    class="h4 d-block" t-att-title="slide_promoted.name" t-field="slide_promoted.name"/>
-                    <h4 t-else="" class="text-muted" t-field="slide_promoted.name"/>
-
-                    <div t-if="slide_promoted.tag_ids" class="border-top mt-2 pt-1">
+                    class="h4 d-block pb-2 border-bottom" t-att-title="slide_promoted.name" t-field="slide_promoted.name"/>
+                    <h4 t-else="" class="text-muted pb-2 border-bottom" t-field="slide_promoted.name"/>
+                    <div class="o_wslides_desc_truncate_10 mt-3" t-field="slide_promoted.description"/>
+                    <div t-if="slide_promoted.tag_ids" class="mt-2 pt-1">
                         <t t-foreach="slide_promoted.tag_ids" t-as="tag">
                             <a t-att-href="'/slides/%s/tag/%s' % (slug(slide_promoted.channel_id), slug(tag))" class="badge text-bg-light" t-esc="tag.name"/>
                         </t>
                     </div>
-                    <div class="o_wslides_desc_truncate_10 mt-3" t-field="slide_promoted.description"/>
                 </div>
             </div>
         </div>
@@ -760,48 +762,36 @@
 
 <template id='lesson_card' name="Lesson Card">
     <div class="card w-100 o_wslides_lesson_card mb-4">
-            <t t-if="slide.is_new_slide and not channel_progress[slide.id].get('completed')" t-call="website_slides.course_card_information"/>
+        <t t-if="slide.is_new_slide and not channel_progress[slide.id].get('completed')" t-call="website_slides.course_card_information"/>
         <t t-set="can_access" t-value="slide.is_preview or channel.is_member or channel.can_publish"/>
-
-        <t t-if="slide.image_1024">
-            <t t-set="lesson_image" t-value="website.image_url(slide, 'image_1024')"/>
-            <a t-if="can_access" t-attf-href="/slides/slide/#{slug(slide)}#{query_string}" t-title="slide.name">
-                <div class="card-img-top border-bottom" t-attf-style="padding-top: 50%; background-image: url(#{lesson_image}); background-size: cover; background-position:center"/>
-            </a>
-            <div t-else="" class="card-img-top border-bottom" t-attf-style="padding-top: 50%; background-image: url(#{lesson_image}); background-size: cover; background-position:center"/>
-        </t>
-        <t t-else="">
-            <a t-if="can_access" t-attf-href="/slides/slide/#{slug(slide)}#{query_string}" t-title="slide.name">
-                <div class="o_wslides_card_default_background card-img-top border-bottom" t-attf-style="padding-top: 50%;"/>
-            </a>
-            <div t-else="" class="o_wslides_card_default_background card-img-top border-bottom" t-attf-style="padding-top: 50%;"/>
-        </t>
+        <a t-if="can_access" t-attf-href="/slides/slide/#{slug(slide)}#{query_string}" t-title="slide.name" style="height:150px">
+            <div t-if="slide.image_1920" t-field="slide.image_1920" t-options="{'widget': 'image', 'preview_image': 'image_512'}"
+                 class="o_wslides_background_image h-100"/>
+            <div t-else="" class="o_wslides_background_image">
+                <img t-att-src="channel.website_background_image_url" class="img img-fluid"/>
+            </div>
+        </a>
+        <div t-else="" class="o_wslides_background_image" style="height:150px">
+            <img t-att-src="channel.website_background_image_url" class="img img-fluid"/>
+        </div>
         <i t-if="channel_progress[slide.id].get('completed')" class="position-absolute py-1 px-2 h5 fa fa-check-circle text-primary" style="right:0; top:0;"/>
 
-        <div class="card-body d-flex flex-column p-3">
-            <a t-if="can_access" class="card-title h5 mb-2o_wslides_desc_truncate_2" t-attf-href="/slides/slide/#{slug(slide)}#{query_string}" t-esc="slide.name"/>
-            <span t-else="" class="card-title h5 mb-2 o_wslides_desc_truncate_2 text-muted" t-esc="slide.name"/>
-            <div class="card-subtitle mb-2 text-muted" t-if="slide.is_preview or (not slide.is_published and user.has_group('website_slides.group_website_slides_officer'))">
-                <t t-if="slide.is_preview">
-                    <span class="badge text-bg-info">Preview</span>
-                </t>
-                <t t-if="not slide.is_published and channel.can_publish">
-                    <span class="badge text-bg-danger">Unpublished</span>
-                </t>
+        <div class="card-body d-flex flex-column px-3">
+            <a t-if="can_access" class="card-title h5 o_wslides_desc_truncate_2" t-attf-href="/slides/slide/#{slug(slide)}#{query_string}" t-esc="slide.name"/>
+            <span t-else="" class="card-title h5 o_wslides_desc_truncate_2 text-muted" t-esc="slide.name"/>
+            <div class="text-muted o_wslides_desc_truncate_2 mb-2" t-if="slide.is_preview or (not slide.is_published and user.has_group('website_slides.group_website_slides_officer'))">
+                <span t-if="slide.is_preview" class="badge text-bg-info">Preview</span>
+                <span t-if="not slide.is_published and channel.can_publish" class="badge text-bg-danger">Unpublished</span>
             </div>
-            <div class="card-text pt-2">
+            <div class="card-text mb-auto">
                 <div class="o_wslides_desc_truncate_3 fw-light oe_no_empty" t-field="slide.description"/>
             </div>
-            <div class="mt-auto">
-                <div t-if="slide.tag_ids" class="o_wslides_desc_truncate_2 my-2">
-                    <t t-foreach="slide.tag_ids" t-as="tag">
-                        <a t-att-href="'/slides/%s/tag/%s' % (slug(slide.channel_id), slug(tag))" class="badge text-bg-light" t-esc="tag.name"/>
-                    </t>
-                </div>
-                <t t-if="channel.is_member and channel_progress[slide.id].get('completed')">
-                    <span class="badge rounded-pill text-bg-success"><i class="fa fa-check"/> Completed</span>
+            <div class="text-muted o_wslides_desc_truncate_2 my-2">
+                <t t-foreach="slide.tag_ids" t-as="tag">
+                    <a t-att-href="'/slides/%s/tag/%s' % (slug(slide.channel_id), slug(tag))" class="badge text-bg-light" t-esc="tag.name"/>
                 </t>
             </div>
+            <span t-if="channel.is_member and channel_progress[slide.id].get('completed')" class="badge rounded-pill text-bg-success align-self-start"><i class="fa fa-check me-1"/>Completed</span>
         </div>
         <div class="card-footer bg-white text-600">
             <div class="d-flex align-items-center small">

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -330,21 +330,21 @@
 
 <template id='course_card' name="Course Card">
     <div t-attf-class="card w-100 o_wslides_course_card mb-4 #{'o_wslides_course_unpublished' if not channel.is_published else ''}" t-cache="channel if is_public_user else None">
-        <t t-set="course_image" t-value="website.image_url(channel, 'image_1024')"/>
         <t t-set="channel_frontend_tags" t-value="channel.tag_ids.filtered(lambda tag: tag.color)"/>
-        <a t-attf-href="/slides/#{slug(channel)}" t-title="channel.name">
-            <t t-if="channel.partner_has_new_content" t-call="website_slides.course_card_information"/> 
-            <div t-if="channel.image_1024" class="card-img-top" t-attf-style="padding-top: 50%; background-image: url(#{course_image}); background-size: cover; background-position:center"/>
-            <div t-else="" class="o_wslides_card_default_background card-img-top position-relative" style="padding-top: 50%; opacity: 0.8">
-                <i class="fa fa-graduation-cap fa-2x me-3 mb-3 position-absolute text-white-75" style="right:0; bottom: 0"/>
+        <a t-attf-href="/slides/#{slug(channel)}" t-title="channel.name" style="height:120px">
+            <div t-if="channel.image_1920" t-field="channel.image_1920" t-options="{'widget': 'image', 'preview_image': 'image_512'}" class="o_wslides_background_image h-100 ">
+                <t t-if="channel.partner_has_new_content" t-call="website_slides.course_card_information"/>
+            </div>
+            <div t-else="" class="o_wslides_background_image">
+                <img t-att-src="channel.website_background_image_url" class=" img img-fluid"/>
             </div>
         </a>
-        <div class="card-body p-3">
+        <div class="card-body d-flex flex-column p-3">
             <a class="card-title h5 mb-2 o_wslides_desc_truncate_2" t-attf-href="/slides/#{slug(channel)}" t-esc="channel.name"/>
             <span t-if="not channel.is_published" class="badge text-bg-danger p-1">Unpublished</span>
-            <div class="card-text mt-1">
+            <div class="card-text d-flex flex-column flex-grow-1 mt-1">
                 <div class="fw-light o_wslides_desc_truncate_3" t-field="channel.description_short"/>
-                <div t-if="channel_frontend_tags" class="mt-2 pt-1 o_wslides_desc_truncate_2">
+                <div t-if="channel_frontend_tags" class="mt-auto pt-1 o_wslides_desc_truncate_2_badges">
                     <t t-foreach="channel_frontend_tags" t-as="tag">
                         <t t-if="search_tags">
                             <a t-att-href="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category)" t-attf-class="badge post_link #{'text-bg-primary' if tag in search_tags else 'o_wslides_channel_tag o_tag_color_0'}" t-att-rel="search_tags and 'nofollow'" t-esc="tag.name"/>

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -48,6 +48,7 @@
             </t>
             <div class="container o_wslides_lesson_main">
                 <div class="row">
+                    <t t-set="can_access_channel" t-value="slide.channel_id.is_member or slide.channel_id.can_publish"/>
                     <div t-attf-class="o_wslides_lesson_aside col-lg-3 #{'order-2' if slide.channel_id.channel_type == 'documentation' else ''}">
                         <t t-if="slide.channel_id.channel_type == 'training'" t-call="website_slides.slide_aside_training"/>
                         <t t-if="slide.channel_id.channel_type == 'documentation'" t-call="website_slides.slide_aside_documentation"/>
@@ -98,10 +99,8 @@
 <!-- Slide sub-template: display an item in a list of related slides (Related, Most Viewed, ...) -->
 <template id="slide_aside_card" name="Related Slide">
     <a class="list-group-item list-group-item-action d-flex align-items-start px-2" t-att-href="'/slides/slide/%s' % (slug(aside_slide))">
-        <t t-set="slide_image" t-value="website.image_url(aside_slide, 'image_1024')"/>
-
-        <div t-if="aside_slide.image_1024" class="flex-shrink-0 me-1 border" t-attf-style="width: 20%; padding-top: 20%; background-image: url(#{slide_image}); background-size: cover; background-position:center"/>
-        <div t-else="" class="o_wslides_card_default_background flex-shrink-0 me-1" t-attf-style="width: 20%; padding-top: 20%;"/>
+        <t t-set="slide_image" t-value="website.image_url(aside_slide, 'image_256') if can_access_channel or aside_slide.is_preview else slide.channel_id.website_background_image_url"/>
+        <div class="me-1 border o_wslides_background_image_aside_card" t-attf-style="background-image: url(#{slide_image});"/>
         <div class="overflow-hidden d-flex flex-column justify-content-start">
             <h6 t-esc="aside_slide.name" class="o_wslides_desc_truncate_2 mb-1" style="line-height: 1.15"/>
             <small class="text-600">
@@ -159,7 +158,7 @@
                             <t t-set="slide_completed" t-value="channel_progress[aside_slide.id].get('completed')"/>
                         </t>
                         <a t-att-href="'/slides/slide/%s' % (slug(aside_slide)) if can_access else '#'"
-                            t-attf-class="d-flex align-items-center text-decoration-none mw-100 overflow-hidden ms-2">
+                            t-attf-class="d-flex align-items-center text-decoration-none mw-100 overflow-hidden ms-2 #{'text-muted' if not can_access else ''}">
                             <t t-call="website_slides.slide_icon">
                                 <t t-set="slide" t-value="aside_slide"/>
                             </t>
@@ -193,7 +192,9 @@
                         <div t-else="" class="o_wslides_js_course_join o_wslides_no_access">
                             <li t-if="aside_slide.channel_id.enroll == 'public'" class="text-decoration-none small">
                                 <i class="fa fa-download me-1"/>
-                                <t t-call="website_slides.join_course_link"/>
+                                <t t-call="website_slides.join_course_link">
+                                    <t t-set="for_resources" t-value="1"/>
+                                </t>
                             </li>
                         </div>
                         <li t-if="aside_slide.question_ids and aside_slide.slide_category != 'quiz'" class="ps-4">
@@ -289,9 +290,9 @@
             <a t-att-href="'/slides/%s/tag/%s' % (slug(slide.channel_id), slug(tag))" class="badge text-bg-info py-1 px-2" t-esc="tag.name"/>
         </t>
     </div>
-    <div class="o_wslides_lesson_content_type">
-        <img t-if="slide.slide_category == 'infographic'"
-            t-att-src="website.image_url(slide, 'image_1024')" class="img-fluid" style="width:100%" t-att-alt="slide.name"/>
+    <div class="oe_structure oe_empty"/>
+    <div t-if="slide.slide_category == 'infographic'" class="o_wslides_lesson_content_type" t-field='slide.image_1920' t-options="{'widget': 'image', 'style': 'width: 100%;'}"/>
+    <div t-else="" class="o_wslides_lesson_content_type">
         <div t-if="slide.slide_category == 'document'" class="ratio ratio-4x3 embed-responsive-item mb8" style="height: 600px;">
             <t t-out="slide.embed_code"/>
         </div>
@@ -311,16 +312,16 @@
     <div class="mb-5">
         <ul class="nav nav-tabs o_wslides_lesson_nav" role="tablist">
             <li class="nav-item">
-                <a href="#about" aria-controls="about" class="nav-link active" role="tab" data-bs-toggle="tab">
+                <a href="#about" aria-controls="about" t-att-class="'nav-link active' if not comments else 'nav-link'" role="tab" data-bs-toggle="tab">
                     <i class="fa fa-home"></i> About
                 </a>
             </li>
-            <li t-if="slide.channel_id.allow_comment" class="nav-item">
-                <a href="#discuss" aria-controls="discuss" class="nav-link" role="tab" data-bs-toggle="tab">
+            <li class="nav-item">
+                <a href="#discuss" aria-controls="discuss" t-att-class="'nav-link active' if comments else 'nav-link'" role="tab" data-bs-toggle="tab">
                     <i class="fa fa-comments"></i> Comments (<span t-esc="slide.comments_count"/>)
                 </a>
             </li>
-            <li class="nav-item">
+            <li class="nav-item" groups="base.group_user">
                 <a href="#statistic" aria-controls="statistic" class="nav-link" role="tab" data-bs-toggle="tab">
                     <i class="fa fa-bar-chart"></i> Statistics
                 </a>
@@ -351,13 +352,36 @@
                 </div>
             </div>
             <div role="tabpanel" t-att-class="comments and 'tab-pane fade in show active' or 'tab-pane fade'" id="discuss">
-                <t t-call="portal.message_thread">
+                <t t-set="enable_slide_comments" t-value="0"/>
+                <p t-if="not (slide.channel_id.allow_comment and slide.channel_id.channel_type == 'training')">
+                    Commenting is not enabled on this course.
+                </p>
+                <t t-elif="not slide.comments_count">
+                    <p t-if="not can_access_channel">
+                        There are no comments for now.
+                        <t t-if="slide.channel_id.enroll != 'invite'">
+                            <div class="o_wslides_js_course_join o_wslides_no_access_comments d-inline">
+                                <t t-if="slide.channel_id.enroll == 'public'" t-call="website_slides.join_course_link"/>
+                            </div>
+                            to be the first to leave a comment.
+                        </t>
+                    </p>
+                    <p t-elif="not slide.channel_id.can_comment">
+                        There are no comments for now. Earn more Karma to be the first to leave a comment.
+                    </p>
+                    <t t-else="" t-set="enable_slide_comments" t-value="1"/>
+                </t>
+                <t t-else="">
+                    <t t-set="enable_slide_comments" t-value="1"/>
+                    <t t-if="not slide.channel_id.can_comment and slide.channel_id.can_access_channel"><p>Earn more Karma to leave a comment.</p></t>
+                </t>
+                <t t-if="enable_slide_comments" t-call="portal.message_thread">
                     <t t-set="object" t-value="slide"/>
                     <t t-set="disable_composer" t-value="not (slide.channel_id.can_comment and slide.channel_id.allow_comment)"/>
                     <t t-set="display_rating" t-value="False"/>
                 </t>
             </div>
-            <div role="tabpanel" class="tab-pane fade" id="statistic" t-att-slide-url="slide.website_url">
+            <div role="tabpanel" class="tab-pane fade" groups="base.group_user" id="statistic" t-att-slide-url="slide.website_url">
                 <div class="row">
                     <div class="col-md-6">
                         <table class="table table-sm">
@@ -456,12 +480,17 @@
                 </group>
             </t>
             <t t-else="">
-                <span t-if="slide.is_preview or slide.channel_id.enroll in ['private', 'payment']" class="text-muted fw-bold me-3">
+                <span t-if="slide.is_preview" class="text-muted fw-bold me-3">
                     Additional Resources
                 </span>
                 <div class="o_wslides_js_course_join o_wslides_no_access">
+                    <div t-if="slide.channel_id.enroll == 'invite'">
+                        <span>Content only accessible to course members.</span>
+                    </div>
                     <div t-if="slide.channel_id.enroll == 'public'" class="text-muted me-auto border-start ps-3">
-                        <t t-call="website_slides.join_course_link"/>
+                        <t t-call="website_slides.join_course_link">
+                            <t t-set="for_resources" t-value="1"/>
+                        </t>
                     </div>
                 </div>
             </t>

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -309,7 +309,7 @@
         </div>
     </div>
 
-    <div class="mb-5">
+    <div class="mb-5 position-relative">
         <ul class="nav nav-tabs o_wslides_lesson_nav" role="tablist">
             <li class="nav-item">
                 <a href="#about" aria-controls="about" t-att-class="'nav-link active' if not comments else 'nav-link'" role="tab" data-bs-toggle="tab">

--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -158,7 +158,9 @@
                             <div t-else="" class="o_wslides_js_course_join o_wslides_no_access ps-0">
                                 <li t-if="slide.channel_id.enroll == 'public'" class="o_wslides_fs_slide_link mb-1">
                                     <i class="fa fa-download me-1"/>
-                                    <t t-call="website_slides.join_course_link"/>
+                                    <t t-call="website_slides.join_course_link">
+                                        <t t-set="for_resources" t-value="1"/>
+                                    </t>
                                 </li>
                             </div>
                             <li class="o_wslides_fs_sidebar_list_item ps-0 mb-1" t-if="slide.question_ids and not slide.slide_category == 'quiz'"

--- a/addons/website_slides/views/website_slides_templates_profile.xml
+++ b/addons/website_slides/views/website_slides_templates_profile.xml
@@ -39,12 +39,7 @@
                 <div class="card mb-2">
                     <div class="card-body o_wprofile_slides_course_card_body p-0 d-flex"
                         t-attf-onclick="location.href='/slides/#{slug(course.channel_id)}';">
-
-                        <div t-if="course.channel_id.image_1024" class="ps-5 pe-4 rounded-start" t-attf-style="background-image: url(#{website.image_url(course.channel_id, 'image_1024')}); background-size: cover; background-position: center"/>
-                        <div t-else="" class="o_wslides_card_default_background ps-5 pe-4 rounded-start position-relative" style="opacity: 0.8">
-                            <i class="fa fa-graduation-cap fa-fw me-2 mt-3 position-absolute text-white-75" style="right:0; top: 0"/>
-                        </div>
-
+                        <div class="o_wslides_background_image ps-5 pe-4 rounded-start" t-attf-style="background-image: url(#{course.channel_id.website_background_image_url});"/>
                         <div class="p-2 w-100">
                             <h5 class="mt-0 mb-1" t-field="course.channel_id.name"/>
 

--- a/addons/website_slides/views/website_slides_templates_utils.xml
+++ b/addons/website_slides/views/website_slides_templates_utils.xml
@@ -70,8 +70,7 @@
 
 <template id="join_course_link" name="Join Course Link">
     <a class="o_wslides_js_course_join_link" href="#" t-att-data-channel-enroll="slide.channel_id.enroll"
-       t-att-data-channel-id="slide.channel_id.id">
-        Join Course</a> to access resources
+       t-att-data-channel-id="slide.channel_id.id">Join this Course</a><t t-if="for_resources"> to access resources</t>
 </template>
 
 <!-- Python equivalent of the JS template "website.slides.sidebar.done.button" -->

--- a/addons/website_slides_survey/tests/test_course_certification_failure.py
+++ b/addons/website_slides_survey/tests/test_course_certification_failure.py
@@ -55,12 +55,12 @@ class TestCourseCertificationFailureFlow(TestSurveyCommon):
             'survey_id': certification.id,
             'is_published': True,
         })
-        # Step 3: add public user as member of the channel
-        self.channel._action_add_members(self.user_public.partner_id)
+        # Step 3: add portal user as member of the channel
+        self.channel._action_add_members(self.user_portal.partner_id)
         # forces recompute of partner_ids as we create directly in relation
         self.channel.invalidate_model()
-        slide_partner = self.slide_certification._action_set_viewed(self.user_public.partner_id)
-        self.slide_certification.with_user(self.user_public)._generate_certification_url()
+        slide_partner = self.slide_certification._action_set_viewed(self.user_portal.partner_id)
+        self.slide_certification.with_user(self.user_portal)._generate_certification_url()
 
         self.assertEqual(1, len(slide_partner.user_input_ids), 'A user input should have been automatically created upon slide view')
 
@@ -70,11 +70,11 @@ class TestCourseCertificationFailureFlow(TestSurveyCommon):
         self.assertFalse(slide_partner.survey_scoring_success, 'Quizz should not be marked as passed with wrong answers')
         # forces recompute of partner_ids as we delete directly in relation
         self.channel.invalidate_model()
-        self.assertIn(self.user_public.partner_id, self.channel.partner_ids, 'Public user should still be a member of the course because they still have attempts left')
+        self.assertIn(self.user_portal.partner_id, self.channel.partner_ids, 'Portal user should still be a member of the course because they still have attempts left')
 
         # Step 5: simulate a 'retry'
         retry_user_input = self.slide_certification.survey_id.sudo()._create_answer(
-            partner=self.user_public.partner_id,
+            partner=self.user_portal.partner_id,
             **{
                 'slide_id': self.slide_certification.id,
                 'slide_partner_id': slide_partner.id
@@ -85,16 +85,16 @@ class TestCourseCertificationFailureFlow(TestSurveyCommon):
         self.fill_in_answer(retry_user_input, certification.question_ids)
         # forces recompute of partner_ids as we delete directly in relation
         self.channel.invalidate_model()
-        self.assertNotIn(self.user_public.partner_id, self.channel.partner_ids, 'Public user should have been kicked out of the course because they failed their last attempt')
+        self.assertNotIn(self.user_portal.partner_id, self.channel.partner_ids, 'Portal user should have been kicked out of the course because they failed their last attempt')
 
-        # Step 7: add public user as member of the channel once again
-        self.channel._action_add_members(self.user_public.partner_id)
+        # Step 7: add portal user as member of the channel once again
+        self.channel._action_add_members(self.user_portal.partner_id)
         # forces recompute of partner_ids as we create directly in relation
         self.channel.invalidate_model()
 
-        self.assertIn(self.user_public.partner_id, self.channel.partner_ids, 'Public user should be a member of the course once again')
-        new_slide_partner = self.slide_certification._action_set_viewed(self.user_public.partner_id)
-        self.slide_certification.with_user(self.user_public)._generate_certification_url()
+        self.assertIn(self.user_portal.partner_id, self.channel.partner_ids, 'Portal user should be a member of the course once again')
+        new_slide_partner = self.slide_certification._action_set_viewed(self.user_portal.partner_id)
+        self.slide_certification.with_user(self.user_portal)._generate_certification_url()
         self.assertEqual(1, len(new_slide_partner.user_input_ids.filtered(lambda user_input: user_input.state != 'done')), 'A new user input should have been automatically created upon slide view')
 
         # Step 8: fill in the created user_input with correct answers this time
@@ -102,7 +102,7 @@ class TestCourseCertificationFailureFlow(TestSurveyCommon):
         self.assertTrue(new_slide_partner.survey_scoring_success, 'Quizz should be marked as passed with correct answers')
         # forces recompute of partner_ids as we delete directly in relation
         self.channel.invalidate_model()
-        self.assertIn(self.user_public.partner_id, self.channel.partner_ids, 'Public user should still be a member of the course')
+        self.assertIn(self.user_portal.partner_id, self.channel.partner_ids, 'Portal user should still be a member of the course')
 
     def fill_in_answer(self, answer, questions, good_answers=False):
         """ Fills in the user_input with answers for all given questions.

--- a/odoo/addons/test_performance/models/models.py
+++ b/odoo/addons/test_performance/models/models.py
@@ -67,3 +67,16 @@ class Eggs(models.Model):
     _description = 'Test Performance Eggs'
 
     name = fields.Char()
+
+
+class Mozzarella(models.Model):
+    _name = 'test_performance.mozzarella'
+    _description = 'Test Performance Mozzarella'
+
+    value = fields.Integer(default=0, required=True)
+    value_plus_one = fields.Integer(compute="_value_plus_one", required=True, store=True)
+
+    @api.depends('value')
+    def _value_plus_one(self):
+        for record in self:
+            record.value_plus_one = record.value + 1

--- a/odoo/addons/test_performance/security/ir.model.access.csv
+++ b/odoo/addons/test_performance/security/ir.model.access.csv
@@ -4,3 +4,4 @@ access_test_performance_line,access_test_performance_line,model_test_performance
 access_test_performance_tag,access_test_performance_tag,model_test_performance_tag,,1,1,1,1
 access_test_performance_bacon,access_test_performance_bacon,model_test_performance_bacon,,1,1,1,1
 access_test_performance_eggs,access_test_performance_eggs,model_test_performance_eggs,,1,1,1,1
+access_test_performance_mozzarella,access_test_performance_mozzarella,model_test_performance_mozzarella,,1,1,1,1


### PR DESCRIPTION
The layout of slides needs a little freshening-up, with a more technical change 
described at the end of this description.

### Comments and slides

* The ratings are only showed once, and only for "documentation" contents
* Indications of why the user cannot post a comment are added (signing up,
  Karma, commenting not allowed), and the portal template is not called if
  there is no comment and commenting is not allowed (for user or course).
  In addition, the "Comment" tab is never hidden anymore, to not hide
  the available/activate-able features.
* Detailed view statistics are now shown only to internal users.
* Slide public views represent views by the public and all users that
  are not members of the course.
* When channel/slide images are not set or inaccessible, a default image
  is used (instead of plain background or unauthorized requests).
* These images are now editable on frontend.
* The 'Additional Resources' subtitle is hidden from the detailed slide view
  for invite-only courses as nothing else was shown with it.

### Misc.

*  This PR also fixes the "unresponsive" `total_views` count after public
views, by manually incrementing it too. This is required because `public_views`
is updated via SQL query does not trigger model _computes.

We therefore update the method `sql_increment_skiplock` to accept multiple 
fields to be updated for the same records.

Task-2663320