### PR TITLE
[MERGE] payment{,_stripe},{,website_}sale: improve stripe onboarding 

### DIFF
--- a/addons/payment/data/payment_acquirer_data.xml
+++ b/addons/payment/data/payment_acquirer_data.xml
@@ -308,12 +308,12 @@
 
     <record id="payment_acquirer_stripe" model="payment.acquirer">
         <field name="name">Stripe</field>
-        <field name="display_as">Credit Card (powered by Stripe)</field>
+        <field name="display_as">Credit &amp; Debit Card</field>
         <field name="image_128" type="base64" file="payment_stripe/static/src/img/stripe_icon.png"/>
         <field name="module_id" ref="base.module_payment_stripe"/>
         <field name="description" type="html">
             <p>
-                A payment gateway to accept online payments via credit cards.
+                A payment gateway to accept online payments via credit and debit cards.
             </p>
             <ul class="list-inline">
                 <li class="list-inline-item"><i class="fa fa-check"/>Online Payment</li>

--- a/addons/payment/data/payment_icon_data.xml
+++ b/addons/payment/data/payment_icon_data.xml
@@ -1,106 +1,127 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="payment_icon_cc_visa" model="payment.icon">
+        <field name="sequence">10</field>
         <field name="name">VISA</field>
         <field name="image" type="base64" file="payment/static/img/visa.png"/>
     </record>
 
-    <record id="payment_icon_cc_american_express" model="payment.icon">
-        <field name="name">American Express</field>
-        <field name="image" type="base64" file="payment/static/img/american_express.png"/>
-    </record>
-
-    <record id="payment_icon_cc_cirrus" model="payment.icon">
-        <field name="name">Cirrus</field>
-        <field name="image" type="base64" file="payment/static/img/cirrus.png"/>
-    </record>
-
-    <record id="payment_icon_cc_diners_club_intl" model="payment.icon">
-        <field name="name">Diners Club International</field>
-        <field name="image" type="base64" file="payment/static/img/diners_club_intl.png"/>
-    </record>
-
-    <record id="payment_icon_cc_discover" model="payment.icon">
-        <field name="name">Discover</field>
-        <field name="image" type="base64" file="payment/static/img/discover.png"/>
-    </record>
-
-    <record id="payment_icon_cc_jcb" model="payment.icon">
-        <field name="name">JCB</field>
-        <field name="image" type="base64" file="payment/static/img/jcb.png"/>
-    </record>
-
-    <record id="payment_icon_cc_maestro" model="payment.icon">
-        <field name="name">Maestro</field>
-        <field name="image" type="base64" file="payment/static/img/maestro.png"/>
-    </record>
-
     <record id="payment_icon_cc_mastercard" model="payment.icon">
+        <field name="sequence">20</field>
         <field name="name">MasterCard</field>
         <field name="image" type="base64" file="payment/static/img/mastercard.png"/>
     </record>
 
-    <record id="payment_icon_cc_unionpay" model="payment.icon">
-        <field name="name">UnionPay</field>
-        <field name="image" type="base64" file="payment/static/img/unionpay.png"/>
+    <record id="payment_icon_cc_american_express" model="payment.icon">
+        <field name="sequence">30</field>
+        <field name="name">American Express</field>
+        <field name="image" type="base64" file="payment/static/img/american_express.png"/>
     </record>
 
-    <record id="payment_icon_cc_bancontact" model="payment.icon">
-        <field name="name">Bancontact</field>
-        <field name="image" type="base64" file="payment/static/img/bancontact.png"/>
+    <record id="payment_icon_cc_discover" model="payment.icon">
+        <field name="sequence">40</field>
+        <field name="name">Discover</field>
+        <field name="image" type="base64" file="payment/static/img/discover.png"/>
     </record>
 
-    <record id="payment_icon_cc_eps" model="payment.icon">
-        <field name="name">EPS</field>
-        <field name="image" type="base64" file="payment/static/img/eps.png"/>
-    </record>
-
-    <record id="payment_icon_cc_giropay" model="payment.icon">
-        <field name="name">Giropay</field>
-        <field name="image" type="base64" file="payment/static/img/giropay.png"/>
-    </record>
-
-    <record id="payment_icon_cc_p24" model="payment.icon">
-        <field name="name">P24</field>
-        <field name="image" type="base64" file="payment/static/img/p24.png"/>
-    </record>
-
-    <record id="payment_icon_cc_codensa_easy_credit" model="payment.icon">
-        <field name="name">Codensa Easy Credit</field>
-        <field name="image" type="base64" file="payment/static/img/codensa_easy_credit.png"/>
-    </record>
-
-    <record id="payment_icon_cc_western_union" model="payment.icon">
-        <field name="name">Western Union</field>
-        <field name="image" type="base64" file="payment/static/img/western_union.png"/>
-    </record>
-
-    <record id="payment_icon_cc_ideal" model="payment.icon">
-        <field name="name">iDEAL</field>
-        <field name="image" type="base64" file="payment/static/img/ideal.png"/>
-    </record>
-
-    <record id="payment_icon_cc_webmoney" model="payment.icon">
-        <field name="name">WebMoney</field>
-        <field name="image" type="base64" file="payment/static/img/webmoney.png"/>
+    <record id="payment_icon_cc_diners_club_intl" model="payment.icon">
+        <field name="sequence">50</field>
+        <field name="name">Diners Club International</field>
+        <field name="image" type="base64" file="payment/static/img/diners_club_intl.png"/>
     </record>
 
     <record id="payment_icon_paypal" model="payment.icon">
+        <field name="sequence">60</field>
         <field name="name">Paypal</field>
         <field name="image" type="base64" file="payment/static/img/paypal.png"/>
     </record>
 
     <record id="payment_icon_apple_pay" model="payment.icon">
+        <field name="sequence">70</field>
         <field name="name">Apple Pay</field>
         <field name="image" type="base64" file="payment/static/img/applepay.png"/>
     </record>
 
+    <record id="payment_icon_cc_jcb" model="payment.icon">
+        <field name="sequence">80</field>
+        <field name="name">JCB</field>
+        <field name="image" type="base64" file="payment/static/img/jcb.png"/>
+    </record>
+
+    <record id="payment_icon_cc_maestro" model="payment.icon">
+        <field name="sequence">90</field>
+        <field name="name">Maestro</field>
+        <field name="image" type="base64" file="payment/static/img/maestro.png"/>
+    </record>
+
+    <record id="payment_icon_cc_cirrus" model="payment.icon">
+        <field name="sequence">100</field>
+        <field name="name">Cirrus</field>
+        <field name="image" type="base64" file="payment/static/img/cirrus.png"/>
+    </record>
+
+    <record id="payment_icon_cc_unionpay" model="payment.icon">
+        <field name="sequence">110</field>
+        <field name="name">UnionPay</field>
+        <field name="image" type="base64" file="payment/static/img/unionpay.png"/>
+    </record>
+
+    <record id="payment_icon_cc_bancontact" model="payment.icon">
+        <field name="sequence">120</field>
+        <field name="name">Bancontact</field>
+        <field name="image" type="base64" file="payment/static/img/bancontact.png"/>
+    </record>
+
+    <record id="payment_icon_cc_western_union" model="payment.icon">
+        <field name="sequence">130</field>
+        <field name="name">Western Union</field>
+        <field name="image" type="base64" file="payment/static/img/western_union.png"/>
+    </record>
+
     <record id="payment_icon_sepa" model="payment.icon">
+        <field name="sequence">140</field>
         <field name="name">SEPA Direct Debit</field>
         <field name="image" type="base64" file="payment/static/img/sepa.png"/>
     </record>
 
+    <record id="payment_icon_cc_ideal" model="payment.icon">
+        <field name="sequence">150</field>
+        <field name="name">iDEAL</field>
+        <field name="image" type="base64" file="payment/static/img/ideal.png"/>
+    </record>
+
+    <record id="payment_icon_cc_webmoney" model="payment.icon">
+        <field name="sequence">160</field>
+        <field name="name">WebMoney</field>
+        <field name="image" type="base64" file="payment/static/img/webmoney.png"/>
+    </record>
+
+    <record id="payment_icon_cc_giropay" model="payment.icon">
+        <field name="sequence">170</field>
+        <field name="name">Giropay</field>
+        <field name="image" type="base64" file="payment/static/img/giropay.png"/>
+    </record>
+
+    <record id="payment_icon_cc_eps" model="payment.icon">
+        <field name="sequence">180</field>
+        <field name="name">EPS</field>
+        <field name="image" type="base64" file="payment/static/img/eps.png"/>
+    </record>
+
+    <record id="payment_icon_cc_p24" model="payment.icon">
+        <field name="sequence">190</field>
+        <field name="name">P24</field>
+        <field name="image" type="base64" file="payment/static/img/p24.png"/>
+    </record>
+
+    <record id="payment_icon_cc_codensa_easy_credit" model="payment.icon">
+        <field name="sequence">200</field>
+        <field name="name">Codensa Easy Credit</field>
+        <field name="image" type="base64" file="payment/static/img/codensa_easy_credit.png"/>
+    </record>
+
     <record id="payment_icon_kbc" model="payment.icon">
+        <field name="sequence">210</field>
         <field name="name">KBC</field>
         <field name="image" type="base64" file="payment/static/img/kbc.png"/>
     </record>

--- a/addons/payment/i18n/payment.pot
+++ b/addons/payment/i18n/payment.pot
@@ -217,6 +217,11 @@ msgid "Activate"
 msgstr ""
 
 #. module: payment
+#: model_terms:ir.ui.view,arch_db:payment.onboarding_payment_acquirer_step
+msgid "Activate Stripe"
+msgstr ""
+
+#. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_token__active
 msgid "Active"
 msgstr ""
@@ -432,11 +437,6 @@ msgid "Choose a payment method"
 msgstr ""
 
 #. module: payment
-#: model_terms:ir.ui.view,arch_db:payment.onboarding_payment_acquirer_step
-msgid "Choose your default customer payment method."
-msgstr ""
-
-#. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_transaction__partner_city
 #: model_terms:ir.ui.view,arch_db:payment.payment_transaction_form
 msgid "City"
@@ -577,6 +577,11 @@ msgid "Credentials"
 msgstr ""
 
 #. module: payment
+#: model:payment.acquirer,display_as:payment.payment_acquirer_stripe
+msgid "Credit & Debit Card"
+msgstr ""
+
+#. module: payment
 #: model:payment.acquirer,display_as:payment.payment_acquirer_adyen
 msgid "Credit Card (powered by Adyen)"
 msgstr ""
@@ -614,11 +619,6 @@ msgstr ""
 #. module: payment
 #: model:payment.acquirer,display_as:payment.payment_acquirer_sips
 msgid "Credit Card (powered by Sips)"
-msgstr ""
-
-#. module: payment
-#: model:payment.acquirer,display_as:payment.payment_acquirer_stripe
-msgid "Credit Card (powered by Stripe)"
 msgstr ""
 
 #. module: payment
@@ -706,6 +706,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:payment.field_payment_transaction__partner_email
 #: model_terms:ir.ui.view,arch_db:payment.payment_acquirer_onboarding_wizard_form
 msgid "Email"
+msgstr ""
+
+#. module: payment
+#: model_terms:ir.ui.view,arch_db:payment.onboarding_payment_acquirer_step
+msgid "Enable credit &amp; debit card payments supported by Stripe"
 msgstr ""
 
 #. module: payment
@@ -1133,6 +1138,11 @@ msgid "Ok"
 msgstr ""
 
 #. module: payment
+#: model_terms:ir.ui.view,arch_db:payment.onboarding_payment_acquirer_step
+msgid "Online Payments"
+msgstr ""
+
+#. module: payment
 #: model:ir.model.fields.selection,name:payment.selection__payment_transaction__operation__online_direct
 msgid "Online direct payment"
 msgstr ""
@@ -1145,6 +1155,11 @@ msgstr ""
 #. module: payment
 #: model:ir.model.fields.selection,name:payment.selection__payment_transaction__operation__online_redirect
 msgid "Online payment with redirection"
+msgstr ""
+
+#. module: payment
+#: model_terms:ir.ui.view,arch_db:payment.onboarding_payment_acquirer_step
+msgid "Online payments enabled"
 msgstr ""
 
 #. module: payment
@@ -1300,7 +1315,6 @@ msgstr ""
 
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_acquirer_onboarding_wizard__payment_method
-#: model_terms:ir.ui.view,arch_db:payment.onboarding_payment_acquirer_step
 msgid "Payment Method"
 msgstr ""
 
@@ -1372,11 +1386,6 @@ msgstr ""
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_link_wizard__payment_acquirer_selection
 msgid "Payment acquirer selected"
-msgstr ""
-
-#. module: payment
-#: model_terms:ir.ui.view,arch_db:payment.onboarding_payment_acquirer_step
-msgid "Payment method set!"
 msgstr ""
 
 #. module: payment
@@ -1607,11 +1616,6 @@ msgstr ""
 #: code:addons/payment/static/src/xml/payment_post_processing.xml:0
 #, python-format
 msgid "Server error:"
-msgstr ""
-
-#. module: payment
-#: model_terms:ir.ui.view,arch_db:payment.onboarding_payment_acquirer_step
-msgid "Set payments"
 msgstr ""
 
 #. module: payment

--- a/addons/payment/models/res_company.py
+++ b/addons/payment/models/res_company.py
@@ -22,6 +22,9 @@ class ResCompany(models.Model):
     @api.model
     def action_open_payment_onboarding_payment_acquirer(self):
         """ Called by onboarding panel above the customer invoice list. """
+        # TODO remove me in master.
+        #  This action is never used anywhere because the onboarding step's method is overridden in
+        #  website_sale to call action_open_website_sale_onboarding_payment_acquirer instead.
         # Fail if there are no existing accounts
         self.env.company.get_chart_of_accounts_or_fail()
 
@@ -29,6 +32,53 @@ class ResCompany(models.Model):
             'payment.action_open_payment_onboarding_payment_acquirer_wizard'
         )
         return action
+
+    def _run_payment_onboarding_step(self, menu_id):
+        """ Install the suggested payment modules and configure the acquirers.
+
+        It's checked that the current company has a Chart of Account.
+
+        :param int menu_id: The menu from which the user started the onboarding step, as an
+                            `ir.ui.menu` id
+        :return: The action returned by `action_stripe_connect_account`
+        :rtype: dict
+        """
+        self.env.company.get_chart_of_accounts_or_fail()
+
+        self._install_modules(['payment_paypal', 'payment_stripe', 'account_payment'])
+
+        # Create a new env including the freshly installed module(s)
+        new_env = api.Environment(self.env.cr, self.env.uid, self.env.context)
+
+        default_journal = new_env['account.journal'].search(
+            [('type', '=', 'bank'), ('company_id', '=', new_env.company.id)], limit=1
+        )
+
+        # Configure Stripe
+        stripe_acquirer = new_env.ref('payment.payment_acquirer_stripe')
+        stripe_acquirer.journal_id = stripe_acquirer.journal_id or default_journal
+        if stripe_acquirer.state == 'disabled':  # The onboarding step has never been run
+            # Configure PayPal
+            paypal_acquirer = new_env.ref('payment.payment_acquirer_paypal')
+            if not paypal_acquirer.paypal_email_account:
+                paypal_acquirer.paypal_email_account = new_env.user.email or new_env.company.email
+            if paypal_acquirer.state == 'disabled' and paypal_acquirer.paypal_email_account:
+                paypal_acquirer.state = 'enabled'
+            paypal_acquirer.journal_id = paypal_acquirer.journal_id or default_journal
+
+        return stripe_acquirer.action_stripe_connect_account(menu_id=menu_id)
+
+    def _install_modules(self, module_names):
+        modules_sudo = self.env['ir.module.module'].sudo().search([('name', 'in', module_names)])
+        STATES = ['installed', 'to install', 'to upgrade']
+        modules_sudo.filtered(lambda m: m.state not in STATES).button_immediate_install()
+
+    def _mark_payment_onboarding_step_as_done(self):
+        """ Mark the payment onboarding step as done.
+
+        :return: None
+        """
+        self.set_onboarding_step_done('payment_acquirer_onboarding_state')
 
     def get_account_invoice_onboarding_steps_states_names(self):
         """ Override of account. """

--- a/addons/payment/wizards/payment_acquirer_onboarding_templates.xml
+++ b/addons/payment/wizards/payment_acquirer_onboarding_templates.xml
@@ -3,10 +3,10 @@
     <!-- onboarding step -->
     <template id="onboarding_payment_acquirer_step">
         <t t-call="base.onboarding_step">
-            <t t-set="title">Payment Method</t>
-            <t t-set="description">Choose your default customer payment method.</t>
-            <t t-set="btn_text">Set payments</t>
-            <t t-set="done_text">Payment method set!</t>
+            <t t-set="title">Online Payments</t>
+            <t t-set="description">Enable credit &amp; debit card payments supported by Stripe</t>
+            <t t-set="btn_text">Activate Stripe</t>
+            <t t-set="done_text">Online payments enabled</t>
             <t t-set="method" t-value="'action_open_payment_onboarding_payment_acquirer'" />
             <t t-set="model" t-value="'res.company'" />
             <t t-set="state" t-value="state.get('payment_acquirer_onboarding_state')" />
@@ -42,12 +42,10 @@
                                     </a>
                                 </p>
                             </div>
-                            <div attrs="{'invisible': [('payment_method', '!=', 'stripe')]}">
+                            <div invisible="1">
                                 <group>
-                                    <field name="stripe_secret_key" password="True"
-                                       attrs="{'required': [('payment_method', '=', 'stripe')]}" />
-                                    <field name="stripe_publishable_key" password="True"
-                                       attrs="{'required': [('payment_method', '=', 'stripe')]}" />
+                                    <field name="stripe_secret_key" password="True"/>
+                                    <field name="stripe_publishable_key" password="True"/>
                                 </group>
                                 <p>
                                     <a href="https://dashboard.stripe.com/account/apikeys" target="_blank">

--- a/addons/payment_stripe/const.py
+++ b/addons/payment_stripe/const.py
@@ -2,6 +2,10 @@
 
 from collections import namedtuple
 
+API_VERSION = '2019-05-16'  # The API version of Stripe implemented in this module
+
+# Stripe proxy URL
+PROXY_URL = 'https://stripe.api.odoo.com/api/stripe/'
 
 # Support payment method types
 PMT = namedtuple('PaymentMethodType', ['name', 'countries', 'currencies', 'recurrence'])
@@ -22,3 +26,8 @@ INTENT_STATUS_MAPPING = {
     'done': ('succeeded',),
     'cancel': ('canceled',),
 }
+
+# Events which are handled by the webhook
+WEBHOOK_HANDLED_EVENTS = [
+    'checkout.session.completed',
+]

--- a/addons/payment_stripe/controllers/__init__.py
+++ b/addons/payment_stripe/controllers/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import main
+from . import onboarding

--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -7,8 +7,6 @@ import logging
 import pprint
 from datetime import datetime
 
-import werkzeug
-
 from odoo import http
 from odoo.exceptions import ValidationError
 from odoo.http import request
@@ -20,6 +18,7 @@ _logger = logging.getLogger(__name__)
 class StripeController(http.Controller):
     _checkout_return_url = '/payment/stripe/checkout_return'
     _validation_return_url = '/payment/stripe/validation_return'
+    _webhook_url = '/payment/stripe/webhook'
     WEBHOOK_AGE_TOLERANCE = 10*60  # seconds
 
     @http.route(_checkout_return_url, type='http', auth='public', csrf=False)
@@ -73,7 +72,7 @@ class StripeController(http.Controller):
         # Redirect the user to the status page
         return request.redirect('/payment/status')
 
-    @http.route('/payment/stripe/webhook', type='json', auth='public')
+    @http.route(_webhook_url, type='json', auth='public')
     def stripe_webhook(self):
         """ Process the `checkout.session.completed` event sent by Stripe to the webhook.
 
@@ -91,7 +90,7 @@ class StripeController(http.Controller):
                 tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
                     'stripe', data
                 )
-                if self._verify_webhook_signature(tx_sudo.acquirer_id.stripe_webhook_secret):
+                if self._verify_webhook_signature(tx_sudo.acquirer_id._get_stripe_webhook_secret()):
                     # Fetch the PaymentIntent, Charge and PaymentMethod objects from Stripe
                     if checkout_session.get('payment_intent'):  # Can be None
                         payment_intent = tx_sudo.acquirer_id._stripe_make_request(

--- a/addons/payment_stripe/controllers/onboarding.py
+++ b/addons/payment_stripe/controllers/onboarding.py
@@ -1,0 +1,47 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from werkzeug.urls import url_encode
+
+from odoo import http
+from odoo.http import request
+
+
+class OnboardingController(http.Controller):
+    _onboarding_return_url = '/payment/stripe/onboarding/return'
+    _onboarding_refresh_url = '/payment/stripe/onboarding/refresh'
+
+    @http.route(_onboarding_return_url, type='http', methods=['GET'], auth='user')
+    def stripe_return_from_onboarding(self, acquirer_id, menu_id):
+        """ Redirect the user to the acquirer form of the onboarded Stripe account.
+
+        The user is redirected to this route by Stripe after or during (if the user clicks on a
+        dedicated button) the onboarding.
+
+        :param str acquirer_id: The acquirer linked to the Stripe account being onboarded, as a
+                                `payment.acquirer` id
+        :param str menu_id: The menu from which the user started the onboarding step, as an
+                            `ir.ui.menu` id
+        """
+        stripe_acquirer = request.env['payment.acquirer'].browse(int(acquirer_id))
+        stripe_acquirer.company_id._mark_payment_onboarding_step_as_done()
+        action = request.env.ref(
+            'payment_stripe.action_payment_acquirer_onboarding', raise_if_not_found=False
+        ) or request.env.ref('payment.action_payment_acquirer')
+        get_params_string = url_encode({'action': action.id, 'id': acquirer_id, 'menu_id': menu_id})
+        return request.redirect(f'/web?#{get_params_string}')
+
+    @http.route(_onboarding_refresh_url, type='http', methods=['GET'], auth='user')
+    def stripe_refresh_onboarding(self, acquirer_id, account_id, menu_id):
+        """ Redirect the user to a new Stripe Connect onboarding link.
+
+        The user is redirected to this route by Stripe if the onboarding link they used was expired.
+
+        :param str acquirer_id: The acquirer linked to the Stripe account being onboarded, as a
+                                `payment.acquirer` id
+        :param str account_id: The id of the connected account
+        :param str menu_id: The menu from which the user started the onboarding step, as an
+                            `ir.ui.menu` id
+        """
+        stripe_acquirer = request.env['payment.acquirer'].browse(int(acquirer_id))
+        account_link = stripe_acquirer._stripe_create_account_link(account_id, int(menu_id))
+        return request.redirect(account_link, local=False)

--- a/addons/payment_stripe/i18n/payment_stripe.pot
+++ b/addons/payment_stripe/i18n/payment_stripe.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server saas~14.4\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-12 07:49+0000\n"
-"PO-Revision-Date: 2021-07-12 07:49+0000\n"
+"POT-Creation-Date: 2022-01-11 09:46+0000\n"
+"PO-Revision-Date: 2022-01-11 09:46+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,24 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: payment_stripe
+#: model_terms:ir.ui.view,arch_db:payment_stripe.payment_acquirer_form
+msgid "Connect Stripe"
+msgstr ""
+
+#. module: payment_stripe
 #: code:addons/payment_stripe/models/payment_acquirer.py:0
 #, python-format
 msgid "Could not establish the connection to the API."
+msgstr ""
+
+#. module: payment_stripe
+#: model_terms:ir.ui.view,arch_db:payment_stripe.payment_acquirer_form
+msgid "Generate your webhook"
+msgstr ""
+
+#. module: payment_stripe
+#: model_terms:ir.ui.view,arch_db:payment_stripe.payment_acquirer_form
+msgid "Get your Secret and Publishable keys"
 msgstr ""
 
 #. module: payment_stripe
@@ -37,6 +52,11 @@ msgstr ""
 #. module: payment_stripe
 #: model:ir.model,name:payment_stripe.model_payment_acquirer
 msgid "Payment Acquirer"
+msgstr ""
+
+#. module: payment_stripe
+#: model:ir.actions.act_window,name:payment_stripe.action_payment_acquirer_onboarding
+msgid "Payment Acquirers"
 msgstr ""
 
 #. module: payment_stripe
@@ -104,6 +124,24 @@ msgid "Stripe Payment Method ID"
 msgstr ""
 
 #. module: payment_stripe
+#: code:addons/payment_stripe/models/payment_acquirer.py:0
+#, python-format
+msgid "Stripe Proxy error: %(error)s"
+msgstr ""
+
+#. module: payment_stripe
+#: code:addons/payment_stripe/models/payment_acquirer.py:0
+#, python-format
+msgid "Stripe Proxy: An error occurred when communicating with the proxy."
+msgstr ""
+
+#. module: payment_stripe
+#: code:addons/payment_stripe/models/payment_acquirer.py:0
+#, python-format
+msgid "Stripe Proxy: Could not establish the connection."
+msgstr ""
+
+#. module: payment_stripe
 #: model:ir.model.fields,help:payment_stripe.field_payment_acquirer__provider
 msgid "The Payment Service Provider to use with this acquirer"
 msgstr ""
@@ -138,4 +176,23 @@ msgstr ""
 #. module: payment_stripe
 #: model:ir.model.fields,field_description:payment_stripe.field_payment_acquirer__stripe_webhook_secret
 msgid "Webhook Signing Secret"
+msgstr ""
+
+#. module: payment_stripe
+#: code:addons/payment_stripe/models/payment_acquirer.py:0
+#, python-format
+msgid "You Stripe Webhook was successfully set up!"
+msgstr ""
+
+#. module: payment_stripe
+#: code:addons/payment_stripe/models/payment_acquirer.py:0
+#, python-format
+msgid ""
+"You cannot create a Stripe Webhook if your Stripe Secret Key is not set."
+msgstr ""
+
+#. module: payment_stripe
+#: code:addons/payment_stripe/models/payment_acquirer.py:0
+#, python-format
+msgid "Your Stripe Webhook is already set up."
 msgstr ""

--- a/addons/payment_stripe/models/payment_acquirer.py
+++ b/addons/payment_stripe/models/payment_acquirer.py
@@ -1,12 +1,17 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
+import uuid
 
 import requests
-from werkzeug import urls
+from werkzeug.urls import url_join, url_encode
 
 from odoo import _, fields, models
 from odoo.exceptions import ValidationError
+
+from odoo.addons.payment_stripe.const import API_VERSION, PROXY_URL, WEBHOOK_HANDLED_EVENTS
+from odoo.addons.payment_stripe.controllers.onboarding import OnboardingController
+from odoo.addons.payment_stripe.controllers.main import StripeController
 
 _logger = logging.getLogger(__name__)
 
@@ -27,6 +32,96 @@ class PaymentAcquirer(models.Model):
              "authenticate the messages sent from Stripe to Odoo.",
         groups='base.group_system')
 
+    # === ACTION METHODS === #
+
+    def action_stripe_connect_account(self, menu_id=None):
+        """ Create a Stripe Connect account and redirect the user to the next onboarding step.
+
+        If the acquirer is already enabled, close the current window. Otherwise, generate a Stripe
+        Connect onboarding link and redirect the user to it. If provided, the menu id is included in
+        the URL the user is redirected to when coming back on Odoo after the onboarding. If the link
+        generation failed, redirect the user to the acquirer form.
+
+        Note: This method is overridden by the internal module responsible for Stripe Connect.
+        Note: self.ensure_one()
+
+        :param int menu_id: The menu from which the user started the onboarding step, as an
+                            `ir.ui.menu` id.
+        :return: The next step action
+        :rtype: dict
+        """
+        self.ensure_one()
+
+        if self.state == 'enabled':
+            self.company_id._mark_payment_onboarding_step_as_done()
+            action = {'type': 'ir.actions.act_window_close'}
+        else:
+            # Account creation
+            connected_account = self._stripe_fetch_or_create_connected_account()
+
+            # Link generation
+            menu_id = menu_id or self.env.ref('payment.payment_acquirer_menu').id
+            account_link_url = self._stripe_create_account_link(connected_account['id'], menu_id)
+            if account_link_url:
+                action = {
+                    'type': 'ir.actions.act_url',
+                    'url': account_link_url,
+                    'target': 'self',
+                }
+            else:
+                action = {
+                    'type': 'ir.actions.act_window',
+                    'model': 'payment.acquirer',
+                    'views': [[False, 'form']],
+                    'res_id': self.id,
+                }
+
+        return action
+
+    def action_stripe_create_webhook(self):
+        """ Create a webhook and return a feedback notification.
+
+        Note: This action only works for instances using a public URL
+
+        :return: The feedback notification
+        :rtype: dict
+        """
+        self.ensure_one()
+
+        if self.stripe_webhook_secret:
+            message = _("Your Stripe Webhook is already set up.")
+            notification_type = 'warning'
+        elif not self.stripe_secret_key:
+            message = _("You cannot create a Stripe Webhook if your Stripe Secret Key is not set.")
+            notification_type = 'danger'
+        else:
+            webhook = self._stripe_make_request(
+                'webhook_endpoints', payload={
+                    'url': self._get_stripe_webhook_url(),
+                    'enabled_events[]': WEBHOOK_HANDLED_EVENTS,
+                    'api_version': API_VERSION,
+                }
+            )
+            self.stripe_webhook_secret = webhook.get('secret')
+            message = _("You Stripe Webhook was successfully set up!")
+            notification_type = 'info'
+
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'message': message,
+                'sticky': False,
+                'type': notification_type,
+                'next': {'type': 'ir.actions.act_window_close'},  # Refresh the form to show the key
+            }
+        }
+
+    def _get_stripe_webhook_url(self):
+        return self.company_id.get_base_url() + StripeController._webhook_url
+
+    # === BUSINESS METHODS - PAYMENT FLOW === #
+
     def _stripe_make_request(self, endpoint, payload=None, method='POST', offline=False):
         """ Make a request to Stripe API at the specified endpoint.
 
@@ -42,11 +137,8 @@ class PaymentAcquirer(models.Model):
         """
         self.ensure_one()
 
-        url = urls.url_join('https://api.stripe.com/v1/', endpoint)
-        headers = {
-            'AUTHORIZATION': f'Bearer {self.stripe_secret_key}',
-            'Stripe-Version': '2019-05-16',  # SetupIntent needs a specific version
-        }
+        url = url_join('https://api.stripe.com/v1/', endpoint)
+        headers = self._get_stripe_request_headers(endpoint)
         try:
             response = requests.request(method, url, data=payload, headers=headers, timeout=60)
             # Stripe can send 4XX errors for payment failures (not only for badly-formed requests).
@@ -73,8 +165,171 @@ class PaymentAcquirer(models.Model):
             raise ValidationError("Stripe: " + _("Could not establish the connection to the API."))
         return response.json()
 
+    def _get_stripe_request_headers(self, endpoint):
+        """ Return the headers for the Stripe API request.
+
+        Note: This method is overridden by the internal module responsible for Stripe Connect.
+
+        :param str endpoint: The Stripe endpoint that will be called
+        :returns: The request headers
+        :rtype: dict
+        """
+        return {
+            'AUTHORIZATION': f'Bearer {self._get_stripe_secret_key()}',
+            'Stripe-Version': API_VERSION,  # SetupIntent needs a specific version
+        }
+
     def _get_default_payment_method_id(self):
         self.ensure_one()
         if self.provider != 'stripe':
             return super()._get_default_payment_method_id()
         return self.env.ref('payment_stripe.payment_method_stripe').id
+
+    # === BUSINESS METHODS - STRIPE CONNECT CREDENTIALS === #
+
+    def _get_stripe_publishable_key(self):
+        """ Return the publishable key for Stripe.
+
+        Note: This method is overridden by the internal module responsible for Stripe Connect.
+
+        :return: The publishable key
+        :rtype: str
+        """
+        return self.stripe_publishable_key
+
+    def _get_stripe_secret_key(self):
+        """ Return the secret key for Stripe.
+
+        Note: This method is overridden by the internal module responsible for Stripe Connect.
+
+        :return: The secret key
+        :rtype: str
+        """
+        return self.stripe_secret_key
+
+    def _get_stripe_webhook_secret(self):
+        """ Return the webhook secret for Stripe.
+
+        Note: This method is overridden by the internal module responsible for Stripe Connect.
+
+        :returns: The webhook secret
+        :rtype: str
+        """
+        return self.stripe_webhook_secret
+
+    # === BUSINESS METHODS - STRIPE CONNECT ONBOARDING === #
+
+    def _stripe_fetch_or_create_connected_account(self):
+        """ Fetch the connected Stripe account and create one if not already done.
+
+        Note: This method is overridden by the internal module responsible for Stripe Connect.
+
+        :return: The connected account
+        :rtype: dict
+        """
+        return self._stripe_make_proxy_request(
+            'accounts', payload=self._stripe_prepare_connect_account_payload()
+        )
+
+    def _stripe_prepare_connect_account_payload(self):
+        """ Prepare the payload for the creation of a connected account in Stripe format.
+
+        Note: This method is overridden by the internal module responsible for Stripe Connect.
+        Note: self.ensure_one()
+
+        :return: The Stripe-formatted payload for the creation request
+        :rtype: dict
+        """
+        self.ensure_one()
+
+        return {
+            'type': 'standard',
+            'country': self.company_id.country_id.code,
+            'email': self.company_id.email,
+            'business_type': 'individual',
+            'company[address][city]': self.company_id.city or '',
+            'company[address][country]': self.company_id.country_id.code or '',
+            'company[address][line1]': self.company_id.street or '',
+            'company[address][line2]': self.company_id.street2 or '',
+            'company[address][postal_code]': self.company_id.zip or '',
+            'company[address][state]': self.company_id.state_id.name or '',
+            'company[name]': self.company_id.name,
+            'individual[address][city]': self.company_id.city or '',
+            'individual[address][country]': self.company_id.country_id.code or '',
+            'individual[address][line1]': self.company_id.street or '',
+            'individual[address][line2]': self.company_id.street2 or '',
+            'individual[address][postal_code]': self.company_id.zip or '',
+            'individual[address][state]': self.company_id.state_id.name or '',
+            'individual[email]': self.company_id.email or '',
+            'business_profile[name]': self.company_id.name,
+        }
+
+    def _stripe_create_account_link(self, connected_account_id, menu_id):
+        """ Create an account link and return its URL.
+
+        An account link url is the beginning URL of Stripe Onboarding.
+        This URL is only valid once, and can only be used once.
+
+        Note: self.ensure_one()
+
+        :param str connected_account_id: The id of the connected account.
+        :param int menu_id: The menu from which the user started the onboarding step, as an
+                            `ir.ui.menu` id
+        :return: The account link URL
+        :rtype: str
+        """
+        self.ensure_one()
+
+        base_url = self.company_id.get_base_url()
+        return_url = OnboardingController._onboarding_return_url
+        refresh_url = OnboardingController._onboarding_refresh_url
+        return_params = dict(acquirer_id=self.id, menu_id=menu_id)
+        refresh_params = dict(**return_params, account_id=connected_account_id)
+
+        account_link = self._stripe_make_proxy_request('account_links', payload={
+            'account': connected_account_id,
+            'return_url': f'{url_join(base_url, return_url)}?{url_encode(return_params)}',
+            'refresh_url': f'{url_join(base_url, refresh_url)}?{url_encode(refresh_params)}',
+            'type': 'account_onboarding',
+        })
+        return account_link['url']
+
+    def _stripe_make_proxy_request(self, endpoint, payload=None, version=1):
+        """ Make a request to the Stripe proxy at the specified endpoint.
+
+        :param str endpoint: The proxy endpoint to be reached by the request
+        :param dict payload: The payload of the request
+        :param int version: The proxy version used
+        :return The JSON-formatted content of the response
+        :rtype: dict
+        :raise: ValidationError if an HTTP error occurs
+        """
+        proxy_payload = {
+            'jsonrpc': '2.0',
+            'id': uuid.uuid4().hex,
+            'method': 'call',
+            'params': {'payload': payload},
+        }
+        url = url_join(PROXY_URL, f'{version}/{endpoint}')
+        try:
+            response = requests.post(url=url, json=proxy_payload, timeout=60)
+            response.raise_for_status()
+        except requests.exceptions.ConnectionError:
+            raise ValidationError(
+                _("Stripe Proxy: Could not establish the connection.")
+            )
+        except requests.exceptions.HTTPError:
+            raise ValidationError(
+                _("Stripe Proxy: An error occurred when communicating with the proxy.")
+            )
+        response_content = response.json()
+        if response_content.get('error'):
+            _logger.exception(
+                "Stripe proxy error: %s, traceback:\n%s",
+                response_content['error']['data']['message'],
+                response_content['error']['data']['debug']
+            )
+            raise ValidationError(_(
+                "Stripe Proxy error: %(error)s", error=response_content['error']['data']['message']
+            ))
+        return response_content.get('result', {})

--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -35,7 +35,7 @@ class PaymentTransaction(models.Model):
 
         checkout_session = self._stripe_create_checkout_session()
         return {
-            'publishable_key': self.acquirer_id.stripe_publishable_key,
+            'publishable_key': self.acquirer_id._get_stripe_publishable_key(),
             'session_id': checkout_session['id'],
         }
 
@@ -79,15 +79,7 @@ class PaymentTransaction(models.Model):
 
         # Create the session according to the operation and return it
         customer = self._stripe_create_customer()
-        common_session_values = {
-            **pmt_values,
-            'client_reference_id': self.reference,
-            # Assign a customer to the session so that Stripe automatically attaches the payment
-            # method to it in a validation flow. In checkout flow, a customer is automatically
-            # created if not provided but we still do it here to avoid requiring the customer to
-            # enter his email on the checkout page.
-            'customer': customer['id'],
-        }
+        common_session_values = self._get_common_stripe_session_values(pmt_values, customer)
         base_url = self.acquirer_id.get_base_url()
         if self.operation == 'online_redirect':
             return_url = f'{urls.url_join(base_url, StripeController._checkout_return_url)}' \
@@ -149,6 +141,26 @@ class PaymentTransaction(models.Model):
         )
         return customer
 
+    def _get_common_stripe_session_values(self, pmt_values, customer):
+        """ Return the Stripe Session values that are common to redirection and validation.
+
+        Note: This method is overridden by the internal module responsible for Stripe Connect.
+
+        :param dict pmt_values: The payment method types values
+        :param dict customer: The Stripe customer to assign to the session
+        :return: The common Stripe Session values
+        :rtype: dict
+        """
+        return {
+            **pmt_values,
+            'client_reference_id': self.reference,
+            # Assign a customer to the session so that Stripe automatically attaches the payment
+            # method to it in a validation flow. In checkout flow, a customer is automatically
+            # created if not provided but we still do it here to avoid requiring the customer to
+            # enter his email on the checkout page.
+            'customer': customer['id'],
+        }
+
     def _send_payment_request(self):
         """ Override of payment to send a payment request to Stripe with a confirmed PaymentIntent.
 
@@ -184,15 +196,7 @@ class PaymentTransaction(models.Model):
 
         response = self.acquirer_id._stripe_make_request(
             'payment_intents',
-            payload={
-                'amount': payment_utils.to_minor_currency_units(self.amount, self.currency_id),
-                'currency': self.currency_id.name.lower(),
-                'confirm': True,
-                'customer': self.token_id.acquirer_ref,
-                'off_session': True,
-                'payment_method': self.token_id.stripe_payment_method,
-                'description': self.reference,
-            },
+            payload=self._stripe_prepare_payment_intent_payload(),
             offline=self.operation == 'offline',
         )
         if 'error' not in response:
@@ -206,6 +210,25 @@ class PaymentTransaction(models.Model):
             payment_intent = response['error'].get('payment_intent')  # Get the PI from the error
 
         return payment_intent
+
+    def _stripe_prepare_payment_intent_payload(self):
+        """ Prepare the payload for the creation of a payment intent in Stripe format.
+
+        Note: This method is overridden by the internal module responsible for Stripe Connect.
+        Note: self.ensure_one()
+
+        :return: The Stripe-formatted payload for the payment intent request
+        :rtype: dict
+        """
+        return {
+            'amount': payment_utils.to_minor_currency_units(self.amount, self.currency_id),
+            'currency': self.currency_id.name.lower(),
+            'confirm': True,
+            'customer': self.token_id.acquirer_ref,
+            'off_session': True,
+            'payment_method': self.token_id.stripe_payment_method,
+            'description': self.reference,
+        }
 
     @api.model
     def _get_tx_from_feedback_data(self, provider, data):

--- a/addons/payment_stripe/static/src/js/payment_form.js
+++ b/addons/payment_stripe/static/src/js/payment_form.js
@@ -22,12 +22,24 @@ odoo.define('payment_stripe.payment_form', require => {
                 return this._super(...arguments);
             }
 
-            const stripeJS = Stripe(processingValues['publishable_key']);
+            const stripeJS = Stripe(processingValues['publishable_key'],
+                this._prepareStripeOptions(processingValues));
             stripeJS.redirectToCheckout({
                 sessionId: processingValues['session_id']
             });
         },
 
+        /**
+         * Prepare the options to init the Stripe JS Object
+         *
+         * Function overriden in internal module
+         *
+         * @param {object} processingValues
+         * @return {object}
+         */
+        _prepareStripeOptions: function (processingValues) {
+            return {};
+        },
     };
 
     checkoutForm.include(stripeMixin);

--- a/addons/payment_stripe/views/payment_views.xml
+++ b/addons/payment_stripe/views/payment_views.xml
@@ -6,14 +6,47 @@
         <field name="model">payment.acquirer</field>
         <field name="inherit_id" ref="payment.payment_acquirer_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='acquirer']" position="inside">
-                <group attrs="{'invisible': [('provider', '!=', 'stripe')]}">
-                    <field name="stripe_publishable_key" attrs="{'required':[('provider', '=', 'stripe'), ('state', '!=', 'disabled')]}" password="True"/>
-                    <field name="stripe_secret_key" attrs="{'required':[('provider', '=', 'stripe'), ('state', '!=', 'disabled')]}" password="True"/>
-                    <field name="stripe_webhook_secret" password="True"/>
+            <xpath expr="//group[@name='acquirer']" position="before">
+                <group invisible="context.get('stripe_onboarding', False)"
+                       name="stripe_onboarding_group"
+                       attrs="{'invisible': ['|', ('provider', '!=', 'stripe'), '&amp;', ('stripe_secret_key', '!=', False), ('stripe_publishable_key', '!=', False)]}">
+                    <button string="Connect Stripe"
+                            type="object"
+                            name="action_stripe_connect_account"
+                            class="btn-primary"
+                            attrs="{'invisible': [('state', '=', 'enabled')]}"/>
                 </group>
             </xpath>
+            <xpath expr="//group[@name='acquirer']" position="inside">
+                <group attrs="{'invisible': [('provider', '!=', 'stripe')]}" name="stripe_credentials">
+                    <field name="stripe_publishable_key" attrs="{'required':[('provider', '=', 'stripe'), ('state', '!=', 'disabled')]}" password="True"/>
+                    <field name="stripe_secret_key" attrs="{'required':[('provider', '=', 'stripe'), ('state', '!=', 'disabled')]}" password="True"/>
+                    <label for="stripe_webhook_secret"/>
+                    <div class="o_row" col="2">
+                        <field name="stripe_webhook_secret" password="True"/>
+                        <button string="Generate your webhook"
+                                type="object"
+                                name="action_stripe_create_webhook"
+                                class="btn-primary"
+                                attrs="{'invisible': ['|', ('stripe_webhook_secret', '!=', False), ('stripe_secret_key', '=', False)]}"/>
+                    </div>
+                </group>
+                <div name="stripe_keys_link"
+                     invisible="not context.get('stripe_onboarding', False)"
+                     attrs="{'invisible': ['|', ('provider', '!=', 'stripe'), '&amp;', ('stripe_secret_key', '!=', False), ('stripe_publishable_key', '!=', False)]}">
+                    <a class="btn btn-link" role="button" href="https://dashboard.stripe.com/account/apikeys" target="_blank">
+                        Get your Secret and Publishable keys
+                    </a>
+                </div>
+            </xpath>
         </field>
+    </record>
+
+    <record id="action_payment_acquirer_onboarding" model="ir.actions.act_window">
+        <field name="name">Payment Acquirers</field>
+        <field name="res_model">payment.acquirer</field>
+        <field name="view_mode">form</field>
+        <field name="context">{'stripe_onboarding': True, 'form_view_initial_mode': 'edit'}</field>
     </record>
 
 </odoo>

--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -1101,7 +1101,7 @@ msgstr ""
 
 #. module: sale
 #: model:ir.model.fields.selection,name:sale.selection__sale_payment_acquirer_onboarding_wizard__payment_method__stripe
-msgid "Credit card (via Stripe)"
+msgid "Credit & Debit card (via Stripe)"
 msgstr ""
 
 #. module: sale

--- a/addons/sale/models/res_company.py
+++ b/addons/sale/models/res_company.py
@@ -38,6 +38,19 @@ class ResCompany(models.Model):
         action = self.env["ir.actions.actions"]._for_xml_id("sale.action_open_sale_onboarding_payment_acquirer_wizard")
         return action
 
+    def _mark_payment_onboarding_step_as_done(self):
+        """ Override of payment to mark the sale onboarding step as done.
+
+        The payment onboarding step of Sales is only marked as done if it was started from Sales.
+        This prevents incorrectly marking the step as done if another module's payment onboarding
+        step was marked as done.
+
+        :return: None
+        """
+        super()._mark_payment_onboarding_step_as_done()
+        if self.sale_onboarding_payment_method:  # The onboarding step was started from Sales
+            self.set_onboarding_step_done('sale_onboarding_order_confirmation_state')
+
     def _get_sample_sales_order(self):
         """ Get a sample quotation or create one if it does not exist. """
         # use current user as partner

--- a/addons/sale/wizard/payment_acquirer_onboarding_wizard.py
+++ b/addons/sale/wizard/payment_acquirer_onboarding_wizard.py
@@ -16,8 +16,8 @@ class PaymentWizard(models.TransientModel):
 
     payment_method = fields.Selection(selection_add=[
         ('digital_signature', "Electronic signature"),
+        ('stripe', "Credit & Debit card (via Stripe)"),
         ('paypal', "PayPal"),
-        ('stripe', "Credit card (via Stripe)"),
         ('other', "Other payment acquirer"),
         ('manual', "Custom payment instructions"),
     ], default=_get_default_payment_method)
@@ -35,3 +35,8 @@ class PaymentWizard(models.TransientModel):
             self.env.company.portal_confirmation_pay = True
 
         return super(PaymentWizard, self).add_payment_methods(*args, **kwargs)
+
+    def _start_stripe_onboarding(self):
+        """ Override of payment to set the sale menu as start menu of the payment onboarding. """
+        menu_id = self.env.ref('sale.sale_menu_root').id
+        return self.env.company._run_payment_onboarding_step(menu_id)

--- a/addons/website_sale/models/res_company.py
+++ b/addons/website_sale/models/res_company.py
@@ -12,6 +12,6 @@ class ResCompany(models.Model):
     @api.model
     def action_open_website_sale_onboarding_payment_acquirer(self):
         """ Called by onboarding panel above the quotation list."""
-        self.env.company.get_chart_of_accounts_or_fail()
-        action = self.env["ir.actions.actions"]._for_xml_id("website_sale.action_open_website_sale_onboarding_payment_acquirer_wizard")
-        return action
+        self.env.company.payment_onboarding_payment_method = 'stripe'
+        menu_id = self.env.ref('website.menu_website_dashboard').id
+        return self._run_payment_onboarding_step(menu_id)

--- a/addons/website_sale/views/onboarding_views.xml
+++ b/addons/website_sale/views/onboarding_views.xml
@@ -5,9 +5,6 @@
         <xpath expr="//t[@t-set='method']" position="replace">
             <t t-set="method" t-value="'action_open_website_sale_onboarding_payment_acquirer'" />
         </xpath>
-        <xpath expr="//t[@t-set='state']" position="replace">
-            <t t-set="state" t-value="state.get('website_sale_onboarding_payment_acquirer_state')" />
-        </xpath>
     </template>
 
     <record id="action_open_website_sale_onboarding_payment_acquirer_wizard" model="ir.actions.act_window">

--- a/addons/website_sale/wizard/payment_acquirer_onboarding_wizard.py
+++ b/addons/website_sale/wizard/payment_acquirer_onboarding_wizard.py
@@ -11,4 +11,9 @@ class PaymentWizard(models.TransientModel):
 
     def _set_payment_acquirer_onboarding_step_done(self):
         """ Override. """
-        self.env.company.sudo().set_onboarding_step_done('website_sale_onboarding_payment_acquirer_state')
+        self.env.company.sudo().set_onboarding_step_done('payment_acquirer_onboarding_state')
+
+    def _start_stripe_onboarding(self):
+        """ Override of payment to set the dashboard as start menu of the payment onboarding. """
+        menu_id = self.env.ref('website.menu_website_dashboard').id
+        return self.env.company._run_payment_onboarding_step(menu_id)


### PR DESCRIPTION
Purpose
=======
Help users easily onboard with Stripe by using the Stripe Connect API.

Specifications
==============
During the payment onboarding, if the user selects Stripe, they will
start the Stripe Onboarding. (NB: The process uses a proxy that handles
the Stripe Onboarding calls and signs them with the Stripe Connect key)
1) A call is made through the proxy to get the Stripe account token;
2) A call is made through the proxy to get the Stripe account link which
   contains the URL of the Onboarding;
3) The user is redirected to the Stripe Onboarding;
4) The user completes the Stripe Onboarding;
5) The user comes back to the acquirer form of Stripe and is able to get
   their keys.
6) The user can directly create their webhook after having copied/pasted
   their API keys.

Note that the Onboarding status isn't stored in the database so there is
no call to Stripe API to validate the account status.

API Documentation :
- Connect Onboarding: https://stripe.com/docs/connect/standard-accounts
- Webhook creation: https://stripe.com/docs/api/webhook_endpoints/create

task-2685160
task-2691213

See also:
- Enterprise: https://github.com/odoo/enterprise/pull/23060
- IAP: https://github.com/odoo/iap-apps/pull/450
- Internal: https://github.com/odoo/internal/pull/1493