### PR TITLE
base: efficient reversed method for BaseModel

### DIFF
--- a/odoo/addons/test_performance/tests/test_performance.py
+++ b/odoo/addons/test_performance/tests/test_performance.py
@@ -71,12 +71,12 @@ class TestPerformance(SavepointCaseWithUserDemo):
     def test_reversed_read_base(self):
         records = self.env['test_performance.base'].search([])
         self.assertEqual(len(records), 5)
-        with self.assertQueryCount(__system__=5, demo=5):
+        with self.assertQueryCount(__system__=1, demo=1):
             # without cache
             for record in reversed(records):
                 record.partner_id
 
-        with self.assertQueryCount(__system__=5, demo=5):
+        with self.assertQueryCount(__system__=1, demo=1):
             # without cache
             for record in reversed(records):
                 record.value_ctx

--- a/odoo/addons/test_performance/tests/test_performance.py
+++ b/odoo/addons/test_performance/tests/test_performance.py
@@ -66,6 +66,21 @@ class TestPerformance(SavepointCaseWithUserDemo):
             for record in records:
                 record.value_pc
 
+    @users('__system__', 'demo')
+    @warmup
+    def test_reversed_read_base(self):
+        records = self.env['test_performance.base'].search([])
+        self.assertEqual(len(records), 5)
+        with self.assertQueryCount(__system__=5, demo=5):
+            # without cache
+            for record in reversed(records):
+                record.partner_id
+
+        with self.assertQueryCount(__system__=5, demo=5):
+            # without cache
+            for record in reversed(records):
+                record.value_ctx
+
     @warmup
     def test_read_base_depends_context(self):
         """ Compute in batch even when in cache in another context. """

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -23,7 +23,6 @@ import time
 import traceback
 import types
 import unicodedata
-import zipfile
 from collections import OrderedDict
 from collections.abc import Iterable, Mapping, MutableMapping, MutableSet
 from contextlib import contextmanager
@@ -1175,18 +1174,18 @@ class Callbacks:
         self.data.clear()
 
 
-class IterableGenerator:
-    """ An iterable object based on a generator function, which is called each
-        time the object is iterated over.
-    """
-    __slots__ = ['func', 'args']
+class ReversedIterable:
+    """ An iterable implementing the reversal of another iterable. """
+    __slots__ = ['iterable']
 
-    def __init__(self, func, *args):
-        self.func = func
-        self.args = args
+    def __init__(self, iterable):
+        self.iterable = iterable
 
     def __iter__(self):
-        return self.func(*self.args)
+        return reversed(self.iterable)
+
+    def __reversed__(self):
+        return iter(self.iterable)
 
 
 def groupby(iterable, key=None):


### PR DESCRIPTION
[IMP] test_performance: add test of reversed BaseModel

[FIX] base: add `__reversed__` in BaseModel for efficiency
Before when we do `reserved(records)`, it iterates in a reverse
order of `records`. Unfortunately, the `__reserved__` method don't
exist explicitly in BaseModel then Python fallback on
its own implementation using `__getitem__` and `__len__` (coming from Sequence): https://github.com/python/cpython/blob/3.10/Lib/_collections_abc.py#L1047-L1049
Because it uses `__getitem__`, it breaks the prefetch of the recordset.

Example:
-------------
```
partners = self.env['res.partner'].browse(1, 2, 3, 4, 5)
for partner in reversed(partners):
    partner.name
```
will generate 5 SQL requests to fetch data (one by record)

Then create our own `__reversed__` and handle the prefetch correctly
(like `__iter__`). Now in the example, it will correctly generate only
1 SQL request because of the prefetch.

task-2687953
