### PR TITLE
[FIX] mrp: sync operation's work center and bom

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _, tools
+from odoo.exceptions import ValidationError
 
 
 class MrpRoutingWorkcenter(models.Model):
@@ -18,7 +19,7 @@ class MrpRoutingWorkcenter(models.Model):
         help="Gives the sequence order when displaying a list of routing Work Centers.")
     bom_id = fields.Many2one(
         'mrp.bom', 'Bill of Material',
-        index=True, ondelete='cascade', required=True,
+        index=True, ondelete='cascade', required=True, check_company=True,
         help="The Bill of Material this operation is linked to")
     company_id = fields.Many2one('res.company', 'Company', related='bom_id.company_id')
     worksheet_type = fields.Selection([

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -62,9 +62,9 @@
                         <group>
                             <group name="description">
                                 <field name="name"/>
-                                <field name="workcenter_id" context="{'default_company_id': company_id}"/>
                                 <field name="sequence" groups="base.group_no_one"/>
-                                <field name="bom_id" invisible="context.get('bom_id_invisible', False)"/>
+                                <field name="bom_id" invisible="context.get('bom_id_invisible', False)" domain="[]"/>
+                                <field name="workcenter_id" context="{'default_company_id': company_id}"/>
                             </group><group name="workorder">
                                 <field name="workorder_count" invisible="1"/>
                                 <field name="time_mode" widget="radio"/>


### PR DESCRIPTION
Fixes 2 issues:
1 - odoo/odoo#61027 made mrp.routing.workcenter.company_id =
  self.bom_id.company_id. This made it so the work center selection is
  empty until a BoM is selected, which is confusing to users. To make it
  less confusing, we switch the order since we expect users to fill in
  the fields from top to bottom.

2 - odoo/odoo#65628 made it so the BoM can be changed. This made it so
  it's possible to save the record and have the company of the BoM and
  the work center not match. This can lead to a usererror when users try
  to start the WO associated with the operation. Steps to reproduce:

  - create a new operation from Configuration > Operations
  - select a BoM from company 1 and a Work Center from company 1 + save
  - edit and change BoM to a BoM from company 2 and DO NOT change the
    Work Center

  Expected result: save error
  Actual result: Save will be allowed, but WO will throw an usererror
                 when you try to start it.

  To fix this, we prevent the user from changing the 2 values in the
  list view (no better way to avoid it) and add an onchange to prevent
  this mismatch from occuring.

Task: 2682365

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
