### PR TITLE
[FIX] stock: enable all "Show Detailed Operations" only once

### DIFF
--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, SUPERUSER_ID
 
 
 class ResConfigSettings(models.TransientModel):
@@ -65,6 +65,7 @@ class ResConfigSettings(models.TransientModel):
 
     def set_values(self):
         previous_group = self.default_get(['group_stock_multi_locations', 'group_stock_production_lot', 'group_stock_tracking_lot'])
+        was_operations_showed = self.env['stock.picking.type'].with_user(SUPERUSER_ID)._default_show_operations()
         res = super(ResConfigSettings, self).set_values()
 
         if not self.user_has_groups('stock.group_stock_manager'):
@@ -84,7 +85,7 @@ class ResConfigSettings(models.TransientModel):
                 ('delivery_steps', '=', 'ship_only')]
             ).mapped('int_type_id').write({'active': False})
 
-        if any(self[group] and not prev_value for group, prev_value in previous_group.items()):
+        if not was_operations_showed and self.env['stock.picking.type'].with_user(SUPERUSER_ID)._default_show_operations():
             picking_types = self.env['stock.picking.type'].with_context(active_test=False).search([
                 ('code', '!=', 'incoming'),
                 ('show_operations', '=', False)


### PR DESCRIPTION
When changing any option in Settings, the option "Show Detailed
Operations" of almost all operations types will be enabled

To reproduce the issue:
(Use demo data)
1. Open the Operation Type "YourCompany: Delivery Orders" and ensure
"Show Detailed Operations" is unchecked
2. In Settings, enable an option (e.g., "Default Access Rights")
3. Go back to the form of "YourCompany: Delivery Orders"

Error: "Show Detailed Operations" is checked for no reason

With this commit, "Show Detailed Operations" of almost all operations
types will be directly enabled only if one of the three options (Lots &
Serial Numbers, Storage Locations or Packages) is enabled and none of
these options was enabled before.

OPW-2514993