### PR TITLE
[FIX] l10n_it_stock_ddt: separate xpaths might need the invisible fie…

### DIFF
--- a/addons/l10n_it_stock_ddt/views/stock_picking_views.xml
+++ b/addons/l10n_it_stock_ddt/views/stock_picking_views.xml
@@ -16,6 +16,7 @@
             </xpath>
             <group name='carrier_data' position="after">
                 <group string="DDT Information" attrs="{'invisible': ['|', ('country_code', '!=', 'IT'), ('picking_type_code', '!=', 'outgoing')]}">
+                    <field name="country_code" invisible="1"/>
                     <field name="l10n_it_ddt_number"/>
                     <field name="l10n_it_transport_reason"/>
                     <field name="l10n_it_transport_method"/>


### PR DESCRIPTION
…lds for inheritance purposes

Before, when installing stock_picking_batch after l10n_it_stock_ddt,
it would give a traceback because the header was replaced in a view
in stock_picking_batch and that removed the invisible field that was
used in an attrs in another place.

So we add the field again in that other place.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
