### PR TITLE
[IMP] calendar: add discuss video url in calendar

### DIFF
--- a/addons/calendar/controllers/main.py
+++ b/addons/calendar/controllers/main.py
@@ -101,3 +101,15 @@ class CalendarController(http.Controller):
     @http.route('/calendar/notify_ack', type='json', auth="user")
     def notify_ack(self):
         return request.env['res.partner'].sudo()._set_calendar_last_notif_ack()
+
+    @http.route('/calendar/join_videocall/<string:access_token>', type='http', auth='public')
+    def calendar_join_videocall(self, access_token):
+        event = request.env['calendar.event'].sudo().search([('access_token', '=', access_token)])
+        if not event:
+            return request.not_found()
+
+        # if channel doesn't exist
+        if not event.videocall_channel_id:
+            event._create_videocall_channel()
+
+        return request.redirect(event.videocall_channel_id.invitation_url)

--- a/addons/calendar/static/src/js/calendar_view.js
+++ b/addons/calendar/static/src/js/calendar_view.js
@@ -6,6 +6,11 @@ import AttendeeCalendarRenderer from '@calendar/js/calendar_renderer';
 import CalendarView from 'web.CalendarView';
 import viewRegistry from 'web.view_registry';
 
+
+import rpc from 'web.rpc';
+import FormView from 'web.FormView';
+import FormController from 'web.FormController';
+
 const CalendarRenderer = AttendeeCalendarRenderer.AttendeeCalendarRenderer;
 
 var AttendeeCalendarView = CalendarView.extend({
@@ -17,5 +22,49 @@ var AttendeeCalendarView = CalendarView.extend({
 });
 
 viewRegistry.add('attendee_calendar', AttendeeCalendarView);
+
+const CalendarFormController = FormController.extend({
+    start: async function () {
+        rpc.query({
+            model: 'calendar.event',
+            method: 'get_discuss_videocall_location'
+        }).then((discussVideocallLocation) => {
+            this.discussVideocallLocation = discussVideocallLocation
+        });
+        return this._super.apply(this, arguments);
+    },
+    _onButtonClicked: function (ev) {
+        const action = ev.data.attrs.name;
+        if (action == 'clear_videocall_location' || action === 'set_discuss_videocall_location') {
+            let newVal = false;
+            let videoCallSource = 'custom'
+            let changes = {};
+            if (action === 'set_discuss_videocall_location') {
+                newVal = this.discussVideocallLocation;
+                videoCallSource = 'discuss';
+                changes.access_token = this.discussVideocallLocation.split('/').pop();
+            }
+            changes = Object.assign(changes, {
+                videocall_location: newVal,
+                videocall_source: videoCallSource,
+            });
+
+            this.trigger_up('field_changed', {
+                dataPointID: ev.data.record.id,
+                changes
+            });
+            return;
+        }
+        return this._super.apply(this, arguments);
+    },
+});
+
+export const CalendarFormView = FormView.extend({
+    config: _.extend({}, FormView.prototype.config, {
+        Controller: CalendarFormController,
+    }),
+});
+
+viewRegistry.add('calendar_form', CalendarFormView);
 
 export default AttendeeCalendarView;

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -160,6 +160,7 @@ class TestEventNotifications(TransactionCase, MailCase, CronMixinCase):
                 'partner_ids': [fields.Command.link(self.partner.id)],
                 'alarm_ids': [fields.Command.link(alarm.id)],
             })
+            self.event.flush()  # flush is required to make partner_ids be present in the event
 
         capt.records.ensure_one()
         self.assertLessEqual(capt.records.call_at, now)

--- a/addons/calendar/tests/test_event_recurrence.py
+++ b/addons/calendar/tests/test_event_recurrence.py
@@ -288,6 +288,24 @@ class TestCreateRecurrentEvents(TestRecurrentEvents):
             (datetime(2020, 3, 30, 0, 0), datetime(2020, 3, 30, 23, 59)),
         ])
 
+    def test_videocall_recurrency(self):
+        self.event._set_discuss_videocall_location()
+        self.event._apply_recurrence_values({
+            'interval': 1,
+            'rrule_type': 'weekly',
+            'mon': True,
+            'count': 2,
+        })
+
+        recurrent_events = self.event.recurrence_id.calendar_event_ids
+        detached_events = self.event.recurrence_id.calendar_event_ids - self.event
+        rec_events_videocall_locations = recurrent_events.mapped('videocall_location')
+        self.assertEqual(len(rec_events_videocall_locations), len(set(rec_events_videocall_locations)), 'Recurrent events should have different videocall locations')
+        self.assertEqual(not any(recurrent_events.videocall_channel_id), True, 'No channel should be set before the route is accessed')
+        # create the first channel
+        detached_events[0]._create_videocall_channel()
+        # after channel is created, all other events should have the same channel
+        self.assertEqual(detached_events[0].videocall_channel_id.id, self.event.videocall_channel_id.id)
 
 class TestUpdateRecurrentEvents(TestRecurrentEvents):
 

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -104,7 +104,7 @@
         <field name="model">calendar.event</field>
         <field name="priority" eval="1"/>
         <field name="arch" type="xml">
-            <form string="Meetings">
+            <form string="Meetings" js_class="calendar_form">
                 <div attrs="{'invisible': [('recurrence_id','=',False)]}" class="alert alert-info oe_edit_only" role="status">
                     <p>Edit recurring event</p>
                     <field name="recurrence_update" widget="radio"/>
@@ -135,6 +135,7 @@
                         <div name="send_buttons" class="sm-2">
                             <button name="action_open_composer" help="Send Email to attendees" type="object" string=" EMAIL" icon="fa-envelope"/>
                         </div>
+                        <button name="action_join_video_call" class="btn-primary" help="Join Video Call" type="object" string="Join Video Call" attrs="{'invisible': [('videocall_location', '=', False)]}"/>
                     </div>
                     <div class="alert alert-warning o_form_header mt-2" attrs="{'invisible': [('invalid_email_partner_ids', '=', [])]}" role="status">
                         <p><strong>The following attendees have invalid email addresses and won't receive any email notifications:</strong></p>
@@ -162,7 +163,19 @@
                                 <group>
                                     <field name="alarm_ids" widget="many2many_tags" options="{'no_quick_create': True}"/>
                                     <field name="location" />
-                                    <field name="videocall_location"/>
+                                    <field name="videocall_location" class="oe_inline" string="Videocall URL" widget="CopyClipboardChar" force_save="1" attrs="{'readonly':[('videocall_source','=', 'discuss')]}"/>
+                                    <div colspan="12" class="d-flex justify-content-center">
+                                    <button name="clear_videocall_location" type="object" class="btn btn-link"
+                                        attrs="{'invisible': [('videocall_location', '=', False)]}" context="{'recurrence_update': recurrence_update}">
+                                         <span class="fa fa-times"></span><span> Clear meeting</span>
+                                    </button>
+                                    <button name="set_discuss_videocall_location" type="object" class="btn btn-link"
+                                        attrs="{'invisible':  [('videocall_location', '!=', False)]}" context="{'recurrence_update': recurrence_update}">
+                                         <span class="fa fa-plus"></span><span> Add Odoo meeting</span>
+                                    </button>
+                                    </div>
+                                    <field name="videocall_source" invisible="1"/>
+                                    <field name="access_token" invisible="1" force_save="1"/>
                                     <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                                 </group>
                             </group>
@@ -278,6 +291,7 @@
                        filters="1" widget="many2manyattendee" write_model="calendar.filters"
                        write_field="partner_id" filter_field="partner_checked" avatar_field="avatar_128"
                 />
+                <field name="videocall_location" widget="url" text="Join Video Call" options="{'icon': 'fa fa-lg fa-video-camera'}" attrs="{'invisible': [('videocall_location', '=', False)]}"/>
                 <field name="is_highlighted" invisible="1"/>
                 <field name="is_organizer_alone" invisible="1"/>
                 <field name="display_description" invisible="1"/>

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -70,7 +70,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
         })
         partner_model = self.env.ref('base.model_res_partner')
         partner = self.env['res.partner'].search([], limit=1)
-        with self.assertQueryCount(__system__=617):
+        with self.assertQueryCount(__system__=618):
             events = self.env['calendar.event'].create([{
                 'name': "Event %s" % (i),
                 'start': datetime(2020, 1, 15, 8, 0),
@@ -102,7 +102,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
         })
         partner_model = self.env.ref('base.model_res_partner')
         partner = self.env['res.partner'].search([], limit=1)
-        with self.assertQueryCount(__system__=72):
+        with self.assertQueryCount(__system__=73):
             event = self.env['calendar.event'].create({
                 'name': "Event",
                 'start': datetime(2020, 1, 15, 8, 0),

--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -323,7 +323,7 @@ class TestCompanyLeave(TransactionCase):
         })
         company_leave._compute_date_from_to()
 
-        with self.assertQueryCount(__system__=249, admin=865):  # 247 community
+        with self.assertQueryCount(__system__=250, admin=865):  # 247 community
             # Original query count: 1987
             # Without tracking/activity context keys: 5154
             company_leave.action_validate()

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -31,7 +31,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
         self.richard_emp.generate_work_entries(date(2018, 1, 1), date(2018, 1, 2))
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=91, admin=92):
+        with self.assertQueryCount(__system__=92, admin=93):
             leave.action_validate()
         leave.action_refuse()
 

--- a/addons/web/static/src/legacy/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/legacy/js/views/calendar/calendar_renderer.js
@@ -524,7 +524,10 @@ return AbstractRenderer.extend({
 
                 // On double click, edit the event
                 element.on('dblclick', function () {
-                    self.trigger_up('edit_event', {id: event.id});
+                    self.trigger_up('edit_event', {
+                        id: event.id,
+                        title: event.extendedProps.record.display_name
+                    });
                 });
                 }
             },

--- a/addons/web/static/src/legacy/js/views/view_dialogs.js
+++ b/addons/web/static/src/legacy/js/views/view_dialogs.js
@@ -191,7 +191,6 @@ var FormViewDialog = ViewDialog.extend({
     open: function () {
         var self = this;
         var _super = this._super.bind(this);
-        var FormView = view_registry.get('form');
         var fields_view_def;
         if (this.options.fields_view) {
             fields_view_def = Promise.resolve(this.options.fields_view);
@@ -203,6 +202,9 @@ var FormViewDialog = ViewDialog.extend({
             var refinedContext = _.pick(self.context, function (value, key) {
                 return key.indexOf('_view_ref') === -1;
             });
+            var xml = new DOMParser().parseFromString(viewInfo.arch, "text/xml")
+            var key = xml.documentElement.getAttribute("js_class");
+            var FormView = view_registry.get(key || 'form');
             var formview = new FormView(viewInfo, {
                 modelName: self.res_model,
                 context: refinedContext,


### PR DESCRIPTION
This commit aims to integrate the calendar module with discuss video calls.
Now it is possible to choose the videocall source as either discuss or custom.
Custom source allows the user to enter any URL, while discuss source generates
an URL that will be used to create the discuss channel.
For recurring events, the same discuss channel is used for all events.
For single events, each event will create a discuss channel.
The discuss channel is only created when someone tries to enter the videocall
URL.

[FIX] calendar: title undefined when double clicking event

Currently in calendar if you double click an event in the calendar view, it
opens a dialog with the event title as undefined. This occurs, because the
title is not correctly passed in the context. This commit adds the correct
title to it, therefore fixing the error.

task-2685472

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
