### PR TITLE
[FIX] payment_authorize: don't error on long account names

### DIFF
--- a/addons/payment_authorize/static/src/js/payment_form.js
+++ b/addons/payment_authorize/static/src/js/payment_form.js
@@ -60,7 +60,7 @@ odoo.define('payment_authorize.payment_form', require => {
             } else {
                 return {
                     bankData: {
-                        nameOnAccount: inputs.accountName.value,
+                        nameOnAccount: inputs.accountName.value.substring(0, 22), // Max allowed by acceptjs
                         accountNumber: inputs.accountNumber.value,
                         routingNumber: inputs.abaNumber.value,
                         accountType: inputs.accountType.value,


### PR DESCRIPTION
The maximum length for nameOnAccount is 22 characters [1]. Entering a
longer name results in an unclear error message:

  Server Error
  We are not able to process your payment.
  E_WC_26: Please provide valid account holder name.

A maxlength="22" on the input was considered as well, but it would be
confusing for users and bank transactions with the first 22 characters
should be accepted.

opw-2688384

[1] https://developer.authorize.net/api/reference/features/acceptjs.html