### PR TITLE
[FIX] account: Keep changed invoice line's description

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1845,7 +1845,7 @@ class AccountMove(models.Model):
             # A section / note must not have an account_id set.
             if not line._cache.get('account_id') and not line.display_type and not line._origin:
                 line.account_id = line._get_computed_account() or self.journal_id.default_account_id
-            if line.product_id and not line._cache.get('name'):
+            if line.product_id and not line.name:
                 line.name = line._get_computed_name()
 
             # Compute the account before the partner_id


### PR DESCRIPTION
**Description of the issue this PR addresses**
The line's name may not be in the cache yet.
The issue happens when there is a button in the invoice that adds an invoice line, for instance https://github.com/OCA/l10n-italy/issues/2498

**Current behavior before PR**
The line's name is reset to the product's description

**Desired behavior after PR is merged**
The existing line's name is preserved

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
