### PR TITLE
[FIX][14.0] auth_totp: add missing model decorator on change_password method override

### DIFF
--- a/addons/auth_totp/models/res_users.py
+++ b/addons/auth_totp/models/res_users.py
@@ -144,6 +144,7 @@ class Users(models.Model):
     def _revoke_all_devices(self):
         self.totp_trusted_device_ids._remove()
 
+    @api.model
     def change_password(self, old_passwd, new_passwd):
         self.env.user._revoke_all_devices()
         return super().change_password(old_passwd, new_passwd)


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
**api.model** decorator is missing on change_password method override.
This implies the call of method _call_kw_multi_ instead of _call_kw_model_
Current behavior before PR:
**api.model** decorator is missing

Desired behavior after PR is merged:
**api.model** decorator restored



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
