### PR TITLE
[12.0] FIX website_sale_delivery, _compute_amount_delivery as "compute" method is usually run by superadmin and self.env.user could have different groups from the user of the order

### DIFF
--- a/addons/website_sale_delivery/models/sale_order.py
+++ b/addons/website_sale_delivery/models/sale_order.py
@@ -26,7 +26,8 @@ class SaleOrder(models.Model):
     @api.depends('order_line.price_unit', 'order_line.tax_id', 'order_line.discount', 'order_line.product_uom_qty')
     def _compute_amount_delivery(self):
         for order in self:
-            if self.env.user.has_group('account.group_show_line_subtotals_tax_excluded'):
+            current_user = order.partner_id.user_ids[0] if order.partner_id.user_ids else self.env.user
+            if current_user.has_group('account.group_show_line_subtotals_tax_excluded'):
                 order.amount_delivery = sum(order.order_line.filtered('is_delivery').mapped('price_subtotal'))
             else:
                 order.amount_delivery = sum(order.order_line.filtered('is_delivery').mapped('price_total'))


### PR DESCRIPTION




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
