### PR TITLE
'HttpRequest' object has no attribute 'website'

### DIFF
--- a/addons/website_form/controllers/main.py
+++ b/addons/website_form/controllers/main.py
@@ -178,7 +178,7 @@ class WebsiteForm(http.Controller):
 
         # Add metadata if enabled
         environ = request.httprequest.headers.environ
-        if(request.website.website_form_enable_metadata):
+        if(hasattr(request, 'website') and request.website.website_form_enable_metadata):
             data['meta'] += "%s : %s\n%s : %s\n%s : %s\n%s : %s\n" % (
                 "IP"                , environ.get("REMOTE_ADDR"),
                 "USER_AGENT"        , environ.get("HTTP_USER_AGENT"),

--- a/doc/cla/individual/odoobiz.md
+++ b/doc/cla/individual/odoobiz.md
@@ -1,0 +1,9 @@
+India, 11/11/2021
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Shiv Shankar dirtyhandsphp@gmail.com https://github.com/odoobiz


### PR DESCRIPTION
The issue appears when we try to create API for website_form

Description of the issue/feature this PR addresses: Fixes 'HttpRequest' object has no attribute 'website' issue for website_form

Current behavior before PR: APIs developed over website_form doesn't work

Desired behavior after PR is merged: APIs developed over website_form should work




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
