### PR TITLE
[FIX] stock_account:make cogs multi_company safe

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -194,7 +194,7 @@ class PosOrder(models.Model):
             .mapped('picking_id.move_lines')\
             .filtered(lambda m: m.product_id.id == product.id)\
             .sorted(lambda x: x.date)
-        price_unit = product._compute_average_price(0, quantity, moves)
+        price_unit = product.with_context(force_company=self.company_id.id)._compute_average_price(0, quantity, moves)
         return - price_unit
 
     name = fields.Char(string='Order Ref', required=True, readonly=True, copy=False, default='/')

--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -26,7 +26,7 @@ class AccountMoveLine(models.Model):
                     prod_moves = moves.filtered(lambda m: m.product_id == product)
                     prod_qty_invoiced = factor * qty_invoiced
                     prod_qty_to_invoice = factor * qty_to_invoice
-                    average_price_unit += factor * product._compute_average_price(prod_qty_invoiced, prod_qty_to_invoice, prod_moves)
+                    average_price_unit += factor * product.with_context(force_company=self.company_id.id)._compute_average_price(prod_qty_invoiced, prod_qty_to_invoice, prod_moves)
                 price_unit = average_price_unit / bom.product_qty or price_unit
                 price_unit = self.product_id.uom_id._compute_price(price_unit, self.product_uom_id)
         return price_unit

--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -117,9 +117,8 @@ class AccountMoveLine(models.Model):
         if so_line:
             qty_to_invoice = self.product_uom_id._compute_quantity(self.quantity, self.product_id.uom_id)
             qty_invoiced = sum([x.product_uom_id._compute_quantity(x.quantity, x.product_id.uom_id) for x in so_line.invoice_lines if x.move_id.state == 'posted'])
-            average_price_unit = self.product_id._compute_average_price(qty_invoiced, qty_to_invoice, so_line.move_ids)
+            average_price_unit = self.product_id.with_context(force_company=self.company_id.id)._compute_average_price(qty_invoiced, qty_to_invoice, so_line.move_ids)
 
             price_unit = average_price_unit or price_unit
-            price_unit = self.product_id.uom_id._compute_price(price_unit, self.product_uom_id)
+            price_unit = self.product_id.uom_id.with_context(force_company=self.company_id.id)._compute_price(price_unit, self.product_uom_id)
         return price_unit
-

--- a/addons/sale_stock/tests/__init__.py
+++ b/addons/sale_stock/tests/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import test_anglo_saxon_valuation
 from . import test_anglo_saxon_valuation_reconciliation
+from . import test_anglosaxon_account
 from . import test_sale_stock
 from . import test_sale_stock_lead_time
 from . import test_sale_order_dates

--- a/addons/sale_stock/tests/test_anglosaxon_account.py
+++ b/addons/sale_stock/tests/test_anglosaxon_account.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+from odoo.addons.account.tests.account_test_savepoint import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+@tagged('post_install', '-at_install')
+class TestAngloSaxonAccounting(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        (cls.company_data['company'] + cls.company_data_2['company']).write({'anglo_saxon_accounting': True})
+        product_category = cls.env['product.category'].create({
+            'name': 'a random storable product category',
+            'property_cost_method': 'fifo',
+            'property_valuation': 'real_time',
+        })
+        cls.storable_product = cls.env['product.product'].create({
+            'name': 'storable product a',
+            'type': 'product',
+            'categ_id': product_category.id,
+        })
+        # Those values are company dependent and need to be explicitly set for both companies
+        product_category.with_context(force_company=cls.company_data_2['company'].id).write({
+            'property_cost_method': 'fifo',
+            'property_valuation': 'real_time',
+        })
+
+    def test_cogs_should_use_price_from_the_right_company(self):
+        """
+        Reproduce the flow of creating an invoice from a sale order with company A
+        and posting the invoice with both companies selected and company B as the main.
+        """
+        company_a_data = self.company_data
+        company_b_data = self.company_data_2
+        product = self.storable_product
+
+        # set different cost price for the same product in the 2 companies
+        company_a_standard_price = 20.0
+        product.with_context(force_company=company_a_data['company'].id).standard_price = company_a_standard_price
+        company_b_standard_price = 10.0
+        product.with_context(force_company=company_b_data['company'].id).standard_price = company_b_standard_price
+
+        # create sale order with company A in draft (by default, self.env.user.company_id is company A)
+        company_a_order = self.env['sale.order'].create({
+            'name': 'testing sale order',
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                (0, 0, {
+                    'name': 'product storable product a',
+                    'product_id': product.id,
+                    'product_uom_qty': 1,
+                    'product_uom': product.uom_id.id,
+                    'price_unit': 40.0,
+                })
+            ],
+        })
+        company_a_order.action_confirm()
+
+        # Create an invoice from the sale order using the sale wizard
+        self.env['sale.advance.payment.inv'].with_context({
+            'active_model': 'sale.order',
+            'active_ids': [company_a_order.id],
+            'active_id': company_a_order.id,
+            'default_journal_id': company_a_data['default_journal_sale'].id
+        }).create({
+            'advance_payment_method': 'delivered'
+        }).create_invoices()
+        company_a_invoice = company_a_order.invoice_ids
+
+        # Post the invoice from company A with company B
+        company_a_invoice.with_context(force_company=company_b_data['company'].id).action_post()
+
+        # check cost used for anglo_saxon_line is from company A
+        anglo_saxon_lines = company_a_invoice.line_ids.filtered('is_anglo_saxon_line')
+        self.assertRecordValues(anglo_saxon_lines, [
+            {'debit': 0.0, 'credit': company_a_standard_price},
+            {'debit': company_a_standard_price, 'credit': 0.0},
+        ])

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -239,4 +239,4 @@ class AccountMoveLine(models.Model):
         self.ensure_one()
         if not self.product_id:
             return self.price_unit
-        return self.product_id._stock_account_get_anglo_saxon_price_unit(uom=self.product_uom_id)
+        return self.product_id.with_context(force_company=self.company_id.id)._stock_account_get_anglo_saxon_price_unit(uom=self.product_uom_id)

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -2364,7 +2364,7 @@ class TestStockValuation(SavepointCase):
 
         self.assertAlmostEqual(self.product1.standard_price, 10.0)
 
-    def test_average_perpetual_8(self):
+    def test_average_perpetual_9(self):
         """ When a product has an available quantity of -5, edit an incoming shipment and increase
         the received quantity by 5 units.
         """


### PR DESCRIPTION
## Goal:
The aim of this commit is to make the cogs generation multi-company
safe.

## Before this commit:
When posting an invoice from company A with both company A and B
selected and B being selected as "main", the cost from company B could
be selected instead of cost from company A to create the anglosaxon
lines.

## After this commit:
Whatever the selected companies, the cost selected will always be from
the company that created the invoice.

### task: #2686104