### PR TITLE
[FIX] l10n_fr_fec: correct translation of journal name in FEC export

### DIFF
--- a/addons/l10n_fr_fec/wizard/account_fr_fec.py
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec.py
@@ -9,6 +9,7 @@ import io
 from odoo import api, fields, models, _
 from odoo.exceptions import Warning
 from odoo.tools import float_is_zero, pycompat
+from odoo.tools.misc import get_lang
 
 
 class AccountFrFec(models.TransientModel):
@@ -294,7 +295,7 @@ class AccountFrFec(models.TransientModel):
         sql_query = '''
         SELECT
             replace(replace(aj.code, '|', '/'), '\t', '') AS JournalCode,
-            replace(replace(aj.name, '|', '/'), '\t', '') AS JournalLib,
+            replace(replace(COALESCE(aj__name.value, aj.name), '|', '/'), '\t', '') AS JournalLib,
             replace(replace(am.name, '|', '/'), '\t', '') AS EcritureNum,
             TO_CHAR(am.date, 'YYYYMMDD') AS EcritureDate,
             aa.code AS CompteNum,
@@ -336,6 +337,11 @@ class AccountFrFec(models.TransientModel):
             LEFT JOIN account_move am ON am.id=aml.move_id
             LEFT JOIN res_partner rp ON rp.id=aml.partner_id
             JOIN account_journal aj ON aj.id = am.journal_id
+            LEFT JOIN ir_translation aj__name ON aj__name.res_id = aj.id
+                                             AND aj__name.type = 'model'
+                                             AND aj__name.name = 'account.journal,name'
+                                             AND aj__name.lang = %s
+                                             AND aj__name.value != ''
             JOIN account_account aa ON aa.id = aml.account_id
             LEFT JOIN account_account_type aat ON aa.user_type_id = aat.id
             LEFT JOIN res_currency rc ON rc.id = aml.currency_id
@@ -359,8 +365,9 @@ class AccountFrFec(models.TransientModel):
             am.name,
             aml.id
         '''
+        lang = self.env.user.lang or get_lang(self.env).code
         self._cr.execute(
-            sql_query, (self.date_from, self.date_to, company.id))
+            sql_query, (lang, self.date_from, self.date_to, company.id))
 
         for row in self._cr.fetchall():
             rows_to_write.append(list(row))


### PR DESCRIPTION
Before this commit, when exporting the FEC report, we were using the account journal
name in the initial language set. As it could be confusing for the French administration
to see names in a foreign language, we should use the user language instead to allow the
export of FEC report in French even if another default language was used.

Description of the issue/feature this PR addresses:
opw-2649805

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
