### PR TITLE
[FIX] pos_adyen: Fix the last status deleted

### DIFF
--- a/addons/pos_adyen/models/pos_payment_method.py
+++ b/addons/pos_adyen/models/pos_payment_method.py
@@ -89,7 +89,6 @@ class PosPaymentMethod(models.Model):
 
         latest_response = self.sudo().adyen_latest_response
         latest_response = json.loads(latest_response) if latest_response else False
-        self.sudo().adyen_latest_response = ''  # avoid handling old responses multiple times
 
         return {
             'latest_response': latest_response,
@@ -98,6 +97,9 @@ class PosPaymentMethod(models.Model):
 
     def proxy_adyen_request(self, data, operation=False):
         ''' Necessary because Adyen's endpoints don't have CORS enabled '''
+        if data['SaleToPOIRequest']['MessageHeader']['MessageCategory'] == 'Payment': # Clear only if it is a payment request
+            self.sudo().adyen_latest_response = ''  # avoid handling old responses multiple times
+
         if not operation:
             operation = 'terminal_request'
 

--- a/addons/pos_adyen/static/src/js/payment_adyen.js
+++ b/addons/pos_adyen/static/src/js/payment_adyen.js
@@ -197,6 +197,9 @@ var PaymentAdyen = PaymentInterface.extend({
                 self.poll_error_order = self.pos.get_order();
                 return self._handle_odoo_connection_failure(data);
             }
+            // This is to make sure that if 'data' is not an instance of Error (i.e. timeout error),
+            // this promise don't resolve -- that is, it doesn't go to the 'then' clause.
+            return Promise.reject(data);
         }).then(function (status) {
             var notification = status.latest_response;
             var last_diagnosis_service_id = status.last_received_diagnosis_id;
@@ -302,7 +305,7 @@ var PaymentAdyen = PaymentInterface.extend({
 
                 self.polling = setInterval(function () {
                     self._poll_for_response(resolve, reject);
-                }, 3000);
+                }, 5500);
             });
 
             // make sure to stop polling when we're done


### PR DESCRIPTION
Actually the last status is deleted by the fist request who can reach it
So if a request is lost the answer too

With this fix we delete the last response only when we start a new one

## Manual testing made:

**Situation 1**
- Successful terminal
- Successful UI

**Situation 2**
- Successful terminal
- Failed UI
- Retry (at better internet connection)
  - Should be successful without asking the terminal again for the same payment

**Situation 3**
- Failed terminal (e.g. cancelled transaction thru the terminal)
- Successful UI check -> Should show "Retry" button in UI
- Retry
  - Should ask the terminal again

**Situation 4**
- Failed terminal
- Failed UI -> Should show "Retry" button
- Retry (at better internet connection)
  - Should show error that the transaction has failed (this is normal since the UI knows about the failed transaction for the first time).
  - Retry again
    - Should ask the terminal for new payment transaction
    


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
