### PR TITLE
[IMP] point_of_sale: inform the PoS User when he is encoding the wrong SN/LN

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -34,6 +34,7 @@
         'views/pos_bill_view.xml',
         'views/pos_session_view.xml',
         'views/point_of_sale_sequence.xml',
+        'views/point_of_sale_template.xml',
         'data/point_of_sale_data.xml',
         'views/pos_order_report_view.xml',
         'views/account_statement_view.xml',

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -688,8 +688,7 @@ class PosOrder(models.Model):
                 else:
                     destination_id = picking_type.default_location_dest_id.id
 
-                pickings = self.env['stock.picking']._create_picking_from_pos_order_lines(destination_id, self.lines, picking_type, self.partner_id)
-                pickings.write({'pos_session_id': self.session_id.id, 'pos_order_id': self.id, 'origin': self.name})
+                self.env['stock.picking']._create_picking_from_pos_order_lines(destination_id, self.lines, picking_type, self.partner_id, pos_session=self.session_id, pos_order=self)
 
     def add_payment(self, data):
         """Create a new payment for the order"""

--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -2634,6 +2634,10 @@ td {
     color: white;
     background: rgba(255, 76, 76, 0.5);
 }
+.pos .popup-lot-error {
+    margin-top: 10px;
+    color: rgb(197, 52, 0);
+}
 .pos .popup.popup-selection .selection {
     overflow-y: auto;
     max-height: 273px;

--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -234,6 +234,21 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
                 }
             }
 
+            var order_lines = this.currentOrder.get_orderlines();
+            order_lines.forEach(function(order_line) {
+                if (order_line.has_product_lot) {
+                    order_line.pack_lot_lines.models.forEach(function(model) {
+                        order_line.product.stock_production_lot.forEach(function(stock_production_lot) {
+                            if (stock_production_lot.name === model.attributes.lot_name) {
+                                stock_production_lot.product_qty -= model.order_line.quantity;
+                            }
+                        });
+                    });
+                } else {
+                    order_line.product.qty_available -= order_line.quantity;
+                }
+            });
+
             this.showScreen(this.nextScreen);
 
             // If we succeeded in syncing the current order, and

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/OrderWidget.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/OrderWidget.js
@@ -33,6 +33,13 @@ odoo.define('point_of_sale.OrderWidget', function(require) {
         get orderlinesArray() {
             return this.order ? this.order.get_orderlines() : [];
         }
+        get_lot_error(packLotLinesToEdit, product) {
+            if (!packLotLinesToEdit.length) {
+                return false;
+            }
+            var lot_error = this.env.pos.db.load('lot_error', {});
+            return lot_error[product.id];
+        }
         _selectLine(event) {
             this.order.select_orderline(event.detail.orderline);
         }
@@ -47,10 +54,12 @@ odoo.define('point_of_sale.OrderWidget', function(require) {
             const orderline = event.detail.orderline;
             const isAllowOnlyOneLot = orderline.product.isAllowOnlyOneLot();
             const packLotLinesToEdit = orderline.getPackLotLinesToEdit(isAllowOnlyOneLot);
+            const lot_error = this.get_lot_error(packLotLinesToEdit, orderline.product);
             const { confirmed, payload } = await this.showPopup('EditListPopup', {
                 title: this.env._t('Lot/Serial Number(s) Required'),
                 isSingleItem: isAllowOnlyOneLot,
                 array: packLotLinesToEdit,
+                lot_error: lot_error,
             });
             if (confirmed) {
                 // Segregate the old and new packlot lines

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -67,6 +67,13 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
         get currentOrder() {
             return this.env.pos.get_order();
         }
+        get_lot_error(packLotLinesToEdit, product) {
+            if (!packLotLinesToEdit.length) {
+                return false;
+            }
+            var lot_error = this.env.pos.db.load('lot_error', {});
+            return lot_error[product.id];
+        }
         async _getAddProductOptions(product, base_code) {
             let price_extra = 0.0;
             let draftPackLotLines, weight, description, packLotLinesToEdit;
@@ -103,10 +110,12 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
                         packLotLinesToEdit = [];
                     }
                 }
+                const lot_error = this.get_lot_error(packLotLinesToEdit, product);
                 const { confirmed, payload } = await this.showPopup('EditListPopup', {
                     title: this.env._t('Lot/Serial Number(s) Required'),
                     isSingleItem: isAllowOnlyOneLot,
                     array: packLotLinesToEdit,
+                    lot_error: lot_error,
                 });
                 if (confirmed) {
                     // Segregate the old and new packlot lines

--- a/addons/point_of_sale/static/src/xml/Popups/EditListPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/EditListPopup.xml
@@ -12,6 +12,9 @@
                     <t t-foreach="state.array" t-as="item" t-key="item._id">
                         <EditListInput item="item" />
                     </t>
+                    <div t-if="props.lot_error" class="popup-lot-error">
+                        <span t-esc="props.lot_error"/>
+                    </div>
                 </main>
                 <footer class="footer">
                     <div class="button confirm" t-on-click="confirm">

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/Orderline.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/Orderline.xml
@@ -24,6 +24,22 @@
                         />
                     </t>
                 </t>
+                <t t-if="props.line.get_product().tracking==='none'">
+                    <t t-if="props.line.has_available_quantity()">
+                        <i  class="fa fa-check oe_icon oe_green"
+                            aria-label="Quantity is available"
+                            role="img"
+                            title="Quantity is available"
+                        />
+                    </t>
+                    <t t-else="">
+                        <i  class="fa fa-check oe_icon oe_red"
+                            aria-label="Quantity is not available"
+                            role="img"
+                            title="Quantity is not available"
+                        />
+                    </t>
+                </t>
             </span>
             <span class="price">
                 <t t-esc="env.pos.format_currency(props.line.get_display_price())"/>

--- a/addons/point_of_sale/views/point_of_sale_template.xml
+++ b/addons/point_of_sale/views/point_of_sale_template.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="exception_stock_pickings">
+        <div>
+            <p t-if="message"><t t-esc="message"/></p>
+            <div class="mt16">
+                <ul t-foreach="stock_pickings" t-as="stock_picking">
+                    <li>
+                        <a href="#" data-oe-model="stock.picking" t-att-data-oe-id="stock_picking.id"><t t-esc="stock_picking.name"/></a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </template>
+</odoo>

--- a/addons/pos_gift_card/static/src/js/models.js
+++ b/addons/pos_gift_card/static/src/js/models.js
@@ -4,7 +4,6 @@ odoo.define("pos_gift_card.gift_card", function (require) {
   const models = require("point_of_sale.models");
 
   models.load_fields("pos.order.line", "generated_gift_card_ids");
-  models.load_fields("pos.order.line", "redeem_pos_order_line_ids");
 
     // Load the products used for creating program reward lines.
     var existing_models = models.PosModel.prototype.models;


### PR DESCRIPTION
We need to inform the PoS User when the encoded SN/LN is valid or not

1. ONLINE
Display a warning when encoding the SN/LN,
    - " 'SN/LN' - This lot/serial number has already been delivered and is not
      available anymore."
    - " 'SN/LN' - This lot/serial number could not be found."
    - " 'SN/LN' - Serial Number(s) use 'count' times."

2. GENERAL
- Log the next activity of type exception the PoS Session if some delivery orders
  could not be confirmed + with link to the pickings.
- Exception,
    1) "Some operations could not be confirmed due to exceptions:"
        - WH/OUT/XXXX (clickable link)
        - WH/OUT/YYYY (clickable link)
    2) "Some operations processed with more than available quantity:"
        - WH/OUT/XXXX (clickable link)
        - WH/OUT/YYYY (clickable link)

Task - 1906359