### PR TITLE
[FIX] account: invoice date == tax lock date for sales documents

### DIFF
--- a/addons/account/models/account_full_reconcile.py
+++ b/addons/account/models/account_full_reconcile.py
@@ -27,9 +27,7 @@ class AccountFullReconcile(models.Model):
         res = super().unlink()
 
         # Reverse all exchange moves at once.
-        today = fields.Date.context_today(self)
         default_values_list = [{
-            'date': today,
             'ref': _('Reversal of: %s') % move.name,
         } for move in moves_to_reverse]
         moves_to_reverse._reverse_moves(default_values_list, cancel=True)

--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -117,9 +117,7 @@ class AccountPartialReconcile(models.Model):
         res = super().unlink()
 
         # Reverse CABA entries.
-        today = fields.Date.context_today(self)
         default_values_list = [{
-            'date': move.date if move.date > (move.company_id.period_lock_date or date.min) else today,
             'ref': _('Reversal of: %s') % move.name,
         } for move in moves_to_reverse]
         moves_to_reverse._reverse_moves(default_values_list, cancel=True)

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -142,15 +142,13 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         ], self.move_vals)
 
     def test_out_invoice_onchange_invoice_date(self):
-        for tax_date, invoice_date, accounting_date in [
-            ('2019-03-31', '2019-05-12', '2019-05-12'),
-            ('2019-03-31', '2019-02-10', '2019-04-1'),
-            ('2019-05-31', '2019-06-15', '2019-06-15'),
-        ]:
-            self.invoice.company_id.tax_lock_date = tax_date
+        self.invoice.company_id.tax_lock_date = '2019-03-31'
+        with Form(self.invoice) as move_form:
+            move_form.invoice_date = '2019-05-12'
+        self.assertEqual(self.invoice.date, fields.Date.to_date('2019-05-12'))
+        with self.assertRaises(UserError):
             with Form(self.invoice) as move_form:
-                move_form.invoice_date = invoice_date
-            self.assertEqual(self.invoice.date, fields.Date.to_date(accounting_date))
+                move_form.invoice_date = '2019-02-10'
 
     def test_out_invoice_line_onchange_product_1(self):
         move_form = Form(self.invoice)
@@ -2250,111 +2248,6 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 'amount_tax': 230.0,
                 'amount_total': 1430.0,
             })
-
-    def test_out_invoice_post_2(self):
-        ''' Check the date will be set automatically at the next available post date due to the tax lock date. '''
-        # Create an invoice with rate 1/3.
-        move = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_date': fields.Date.from_string('2016-01-01'),
-            'date': fields.Date.from_string('2015-01-01'),
-            'currency_id': self.currency_data['currency'].id,
-            'invoice_payment_term_id': self.pay_terms_a.id,
-            'invoice_line_ids': [
-                (0, None, {
-                    'name': self.product_line_vals_1['name'],
-                    'product_id': self.product_line_vals_1['product_id'],
-                    'product_uom_id': self.product_line_vals_1['product_uom_id'],
-                    'quantity': self.product_line_vals_1['quantity'],
-                    'price_unit': self.product_line_vals_1['price_unit'],
-                    'tax_ids': self.product_line_vals_1['tax_ids'],
-                }),
-                (0, None, {
-                    'name': self.product_line_vals_2['name'],
-                    'product_id': self.product_line_vals_2['product_id'],
-                    'product_uom_id': self.product_line_vals_2['product_uom_id'],
-                    'quantity': self.product_line_vals_2['quantity'],
-                    'price_unit': self.product_line_vals_2['price_unit'],
-                    'tax_ids': self.product_line_vals_2['tax_ids'],
-                }),
-            ],
-        })
-
-        # Add a manual edition of a tax line:
-        # - The modification must be preserved in the business fields.
-        # - The journal entry must be balanced before / after the post.
-        move.write({
-            'line_ids': [
-                (1, move.line_ids.filtered(lambda line: line.tax_line_id.id == self.tax_line_vals_1['tax_line_id']).id, {
-                    'amount_currency': -200.0,
-                }),
-                (1, move.line_ids.filtered(lambda line: line.date_maturity).id, {
-                    'amount_currency': 1430.0,
-                }),
-            ],
-        })
-
-        # Set the tax lock date:
-        # - The date must be set automatically at the date after the tax_lock_date.
-        # - As the date changed, the currency rate has changed (1/3 => 1/2).
-        move.company_id.tax_lock_date = fields.Date.from_string('2016-12-31')
-
-        move.action_post()
-
-        self.assertInvoiceValues(move, [
-            {
-                **self.product_line_vals_1,
-                'currency_id': self.currency_data['currency'].id,
-                'amount_currency': -1000.0,
-                'debit': 0.0,
-                'credit': 500.0,
-            },
-            {
-                **self.product_line_vals_2,
-                'currency_id': self.currency_data['currency'].id,
-                'amount_currency': -200.0,
-                'debit': 0.0,
-                'credit': 100.0,
-            },
-            {
-                **self.tax_line_vals_1,
-                'currency_id': self.currency_data['currency'].id,
-                'price_unit': 200.0,
-                'price_subtotal': 200.0,
-                'price_total': 200.0,
-                'amount_currency': -200.0,
-                'debit': 0.0,
-                'credit': 100.0,
-            },
-            {
-                **self.tax_line_vals_2,
-                'currency_id': self.currency_data['currency'].id,
-                'amount_currency': -30.0,
-                'debit': 0.0,
-                'credit': 15.0,
-            },
-            {
-                **self.term_line_vals_1,
-                'name': move.name,
-                'currency_id': self.currency_data['currency'].id,
-                'price_unit': -1430.0,
-                'price_subtotal': -1430.0,
-                'price_total': -1430.0,
-                'amount_currency': 1430.0,
-                'debit': 715.0,
-                'credit': 0.0,
-                'date_maturity': fields.Date.from_string('2016-01-01'),
-            },
-        ], {
-            **self.move_vals,
-            'payment_reference': move.name,
-            'currency_id': self.currency_data['currency'].id,
-            'date': fields.Date.from_string('2017-01-01'),
-            'amount_untaxed': 1200.0,
-            'amount_tax': 230.0,
-            'amount_total': 1430.0,
-        })
 
     def test_out_invoice_switch_out_refund_1(self):
         # Test creating an account_move with an out_invoice_type and switch it in an out_refund.


### PR DESCRIPTION
This is the expected behavior, and it was the case until version 12.0
but it was changed in [1]
The accounting date is not displayed on customer invoices and changing
the date automatically could therefore make strange behaviors. You are
supposed to take the invoice into account as soon as you create it.
The behavior is kept in vendor bills, where the accounting date is
displayed. You might receive the bill after you set your lock dates, so
you might have to take it into account later.

[1] https://github.com/odoo/odoo/commit/6b8acd025758b042cca39508bc8994a1307d1ccd

[task-2689073](https://www.odoo.com/web#active_id=2689073&cids=1&id=2689073&model=project.task&menu_id=)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
