### PR TITLE
[FIX] web_editor: fix translate button position

### DIFF
--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -527,8 +527,8 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
         $button.css({
             'font-size': '15px',
             position: 'absolute',
-            right: '+5px',
-            top: '+5px',
+            right: odoo.debug && this.nodeOptions.codeview ? '40px' : '5px',
+            top: '5px',
         });
         this.$el.append($button);
         if (odoo.debug && this.nodeOptions.codeview) {


### PR DESCRIPTION
The translate button was overlapping the codeview button
in the mail template view.

task-2683847

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
