### PR TITLE
[FIX] stock: auto assign backorder

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1089,6 +1089,8 @@ class Picking(models.Model):
                 moves_to_backorder.mapped('package_level_id').write({'picking_id':backorder_picking.id})
                 moves_to_backorder.mapped('move_line_ids').write({'picking_id': backorder_picking.id})
                 backorders |= backorder_picking
+        if backorders:
+            backorders.action_assign()
         return backorders
 
     def _log_activity_get_documents(self, orig_obj_changes, stream_field, stream, sorted_method=False, groupby_method=False):

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -122,7 +122,7 @@ class TestPickShip(TestStockCommon):
         picking_client._action_done()  # no new in order to create backorder
 
         backorder = self.env['stock.picking'].search([('backorder_id', '=', picking_client.id)])
-        self.assertEqual(backorder.state, 'waiting', 'Backorder should be waiting for reservation')
+        self.assertEqual(backorder.state, 'assigned', 'Backorder should be started')
 
     def test_mto_moves_transfer(self):
         """
@@ -293,7 +293,7 @@ class TestPickShip(TestStockCommon):
         # create a backorder
         picking_pick._action_done()
         picking_pick_backorder = self.env['stock.picking'].search([('backorder_id', '=', picking_pick.id)])
-        self.assertEqual(picking_pick_backorder.state, 'confirmed')
+        self.assertEqual(picking_pick_backorder.state, 'assigned')
         self.assertEqual(picking_pick_backorder.move_lines.product_qty, 5.0)
 
         self.assertEqual(picking_client.state, 'assigned')
@@ -773,11 +773,8 @@ class TestSinglePicking(TestStockCommon):
         delivery_order.move_lines[0].move_line_ids[0].qty_done = 1
         delivery_order._action_done()
         self.assertNotEqual(delivery_order.date_done, False)
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 1.0)
 
         backorder = self.env['stock.picking'].search([('backorder_id', '=', delivery_order.id)])
-        self.assertEqual(backorder.state, 'confirmed')
-        backorder.action_assign()
         self.assertEqual(backorder.state, 'assigned')
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, pack_location), 0.0)
 


### PR DESCRIPTION
When a backorder is created, the quantities are not reserved. This is an
issue: the module should try to directly assign these quantities.

(Revert of 6b15eab7e103b7bb09e885efa6c3ddc09dc739a9)

OPW-2658469