### PR TITLE
[FIX] crm, sale: respect team set on partner in onchange

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -275,6 +275,8 @@ class Lead(models.Model):
                 'email_from': partner.email,
                 'phone': partner.phone,
                 'mobile': partner.mobile,
+                'user_id': partner.user_id.id or self.env.user.id,
+                'team_id': partner.team_id.id,
                 'zip': partner.zip,
                 'function': partner.function,
                 'website': partner.website,
@@ -301,7 +303,7 @@ class Lead(models.Model):
     @api.onchange('user_id')
     def _onchange_user_id(self):
         """ When changing the user, also set a team_id or restrict team id to the ones user_id is member of. """
-        if self.user_id.sale_team_id:
+        if self.user_id.sale_team_id and not self.partner_id.team_id:
             values = self._onchange_user_values(self.user_id.id)
             self.update(values)
 

--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -404,14 +404,15 @@ class SaleOrder(models.Model):
         if self.env['ir.config_parameter'].sudo().get_param('account.use_invoice_terms') and self.env.company.invoice_terms:
             values['note'] = self.with_context(lang=self.partner_id.lang).env.company.invoice_terms
         if not self.env.context.get('not_self_saleperson') or not self.team_id:
-            values['team_id'] = self.env['crm.team'].with_context(
-                default_team_id=self.partner_id.team_id.id
-            )._get_default_team_id(domain=['|', ('company_id', '=', self.company_id.id), ('company_id', '=', False)], user_id=user_id)
+            values['team_id'] = self.partner_id.team_id or self.env['crm.team']._get_default_team_id(
+                domain=['|', ('company_id', '=', self.company_id.id), ('company_id', '=', False)],
+                user_id=user_id
+            )
         self.update(values)
 
     @api.onchange('user_id')
     def onchange_user_id(self):
-        if self.user_id:
+        if self.user_id and not self.partner_id.team_id:
             self.team_id = self.env['crm.team'].with_context(
                 default_team_id=self.team_id.id
             )._get_default_team_id(user_id=self.user_id.id)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
If a team is set on the partner it will not be applied as the team is based on the user and the default method first does a team approximation based on the user and only if there is no team the team set on the partner is used based on the context injected.

Therefore we make sure that the team of the partner is initially taken and it won't be changed if set based on the user changed.

**Current behavior before PR:**
Team set on the partner was not respected by the on change logic

**Desired behavior after PR is merged:**
Working as expected and respected team on the partner which should win

Info: @wt-io-it



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
