### PR TITLE
[FIX] mass_mailing: correctly hide editor button

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -360,7 +360,8 @@ var MassMailingFieldHtml = FieldHtml.extend({
         var $themes = $snippetsSideBar.find("#email_designer_themes").children();
         var $snippets = $snippetsSideBar.find(".oe_snippet");
         var selectorToKeep = '.o_we_external_history_buttons, .email_designer_top_actions';
-        $snippetsSideBar.find(`.o_we_website_top_actions>*:not(${selectorToKeep})`).hide();
+        // Overide `d-flex` class which style is `!important`
+        $snippetsSideBar.find(`.o_we_website_top_actions > *:not(${selectorToKeep})`).attr('style', 'display: none!important');
         var $snippets_menu = $snippetsSideBar.find("#snippets_menu");
         var $selectTemplateBtn = $snippets_menu.find('.o_we_select_template');
 


### PR DESCRIPTION
Since this [commit], the layout style was improved to not break when the save
and discard button are translated.
But it was breaking the mass mailing editor, as those button were not hidden
anymore.

[commit]: https://github.com/odoo/odoo/commit/120c88a6fffc111afba734c60eb06cf0543c1760
