### PR TITLE
[IMP] hr_holidays: add default filters to smart buttons

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -11,7 +11,6 @@
                 <field name="allocation_type"/>
                 <filter domain="[('state', '=', 'confirm')]" string="To Approve" name="second_approval"/>
                 <filter string="Approved Allocations" domain="[('state', '=', 'validate')]" name="validated"/>
-                <filter string="Accrual Allocations" domain="[('allocation_type', '=', 'accrual')]" name="accrual_allocation"/>
                 <separator/>
                 <filter name="active_types" string="Active Types" domain="[('holiday_status_id.active', '=', True)]" help="Filters only on allocations that belong to an time off type that is 'active' (active field is True)"/>
                 <separator/>
@@ -25,10 +24,8 @@
                 <separator/>
                 <filter name="year" string="Current Year"
                     domain="[
+                        ('date_from', '&gt;=', context_today().strftime('%Y-1-1')),
                         ('date_from', '&lt;=', context_today().strftime('%Y-12-31')),
-                    '|',
-                        ('date_to', '=', False),
-                        ('date_to', '&gt;=', context_today().strftime('%Y-1-1'))
                     ]"
                      help="Active Allocations"/>
                 <separator/>
@@ -44,6 +41,10 @@
                 <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                         domain="[('my_activity_date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))
                         ]"/>
+                <separator/>
+                <filter name="approved_state" string="To Approve or Approved Allocations" invisible="1"
+                    domain="[('state', 'in', ('confirm', 'validate'))]"/>
+                <separator/>
                 <group expand="0" string="Group By">
                     <filter name="group_employee" string="Employee" context="{'group_by':'employee_id'}"/>
                     <filter name="group_type" string="Time Off Type" context="{'group_by':'holiday_status_id'}"/>

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -21,19 +21,34 @@
             <form string="Time Off Type">
                 <sheet>
                     <div class="oe_button_box" name="button_box">
-                        <button class="oe_stat_button" type="object" name="action_see_days_allocated" icon="fa-calendar" attrs="{'invisible': ['|', ('requires_allocation', '=', 'no'), ('id', '=', False)]}">
+                        <button class="oe_stat_button"
+                                type="object"
+                                name="action_see_days_allocated"
+                                icon="fa-calendar"
+                                attrs="{'invisible': ['|', ('requires_allocation', '=', 'no'), ('id', '=', False)]}"
+                                help="Count of allocations for this time off type (approved or waiting for approbation) with a validity period starting this year.">
                             <div class="o_stat_info">
                                 <field name="allocation_count"/>
                                 <span class="o_stat_text">Allocations</span>
                             </div>
                         </button>
-                        <button class="oe_stat_button" type="object" name="action_see_group_leaves" icon="fa-calendar" attrs="{'invisible': [('id', '=', False)]}">
+                        <button class="oe_stat_button"
+                                type="object"
+                                name="action_see_group_leaves"
+                                icon="fa-calendar"
+                                attrs="{'invisible': [('id', '=', False)]}"
+                                help="Count of time off requests for this time off type (approved or waiting for approbation) with a start date in the current year.">
                             <div class="o_stat_info">
                                 <field name="group_days_leave"/>
                                 <span class="o_stat_text">Time Off</span>
                             </div>
                         </button>
-                        <button class="oe_stat_button" type="object" name="action_see_accrual_plans" icon="fa-calendar" attrs="{'invisible': ['|', ('id', '=', False), ('accrual_count', '=', 0)]}">
+                        <button class="oe_stat_button"
+                                type="object"
+                                name="action_see_accrual_plans"
+                                icon="fa-calendar"
+                                attrs="{'invisible': ['|', ('id', '=', False), ('accrual_count', '=', 0)]}"
+                                help="Count of plans linked to this time off type.">
                             <div class="o_stat_info">
                                 <field name="accrual_count"/>
                                 <span class="o_stat_text">Accruals</span>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -47,12 +47,17 @@
                 <filter domain="[('state','in',('confirm','validate1'))]" string="To Approve" name="approve"/>
                 <filter domain="[('state', '=', 'validate1')]" string="Need Second Approval" name="second_approval"/>
                 <filter string="Approved Time Off" domain="[('state', '=', 'validate')]" name="validated"/>
+                <filter string="To Approve or Need Second Approval or Approved Time Off" domain="[('state', 'in', ('validate', 'validate1', 'confirm'))]" name="need_approval_approved"/>
                 <separator/>
                 <filter string="My Time Off" name="my_leaves" domain="[('employee_id.user_id', '=', uid)]"/>
                 <filter string="My Team" name="my_team" domain="['|', ('employee_id.leave_manager_id', '=', uid), ('employee_id.user_id', '=', uid)]" help="Time off of people you are manager of"/>
                 <filter string="My Department" name="department" domain="['|', ('department_id.member_ids.user_id', '=', uid), ('employee_id.user_id', '=', uid)]" help="My Department"/>
                 <separator/>
                 <filter string="Active Employee" name="active_employee" domain="[('active_employee','=',True)]"/>
+                <separator/>
+                <filter name="this_year" string="Current Year"
+                    domain="['&amp;', ('date_from', '&gt;=', context_today().strftime('%Y-1-1')),
+                                      ('date_from', '&lt;=', context_today().strftime('%Y-12-31'))]"/>
                 <filter name="filter_date_from" date="date_from"/>
                 <separator/>
                 <filter name="active_time_off" string="Active Time Off"


### PR DESCRIPTION
Add default filters to the Allocations and Time Off smartbuttons on the time off type form.
This is done to avoid having numerous records with time and only show the relevant to approved and approved allocations as well as the time off for the current year.

task-2688122

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
