### PR TITLE
[FIX] {pos,sale}_gift_card: compute the gift card balance correctly

### DIFF
--- a/addons/pos_gift_card/models/gift_card.py
+++ b/addons/pos_gift_card/models/gift_card.py
@@ -22,7 +22,7 @@ class GiftCard(models.Model):
         super()._compute_balance()
         for record in self:
             confirmed_line = record.redeem_pos_order_line_ids.filtered(
-                lambda l: l.order_id.state == "paid"
+                lambda l: l.order_id.state in ('paid', 'done', 'invoiced')
             )
             balance = record.balance
             if confirmed_line:

--- a/addons/sale_gift_card/models/gift_card.py
+++ b/addons/sale_gift_card/models/gift_card.py
@@ -15,7 +15,7 @@ class GiftCard(models.Model):
     def _compute_balance(self):
         super()._compute_balance()
         for record in self:
-            confirmed_line = record.redeem_line_ids.filtered(lambda l: l.state == 'sale')
+            confirmed_line = record.redeem_line_ids.filtered(lambda l: l.state in ('sale', 'done'))
             balance = record.balance
             if confirmed_line:
                 balance -= sum(confirmed_line.mapped(


### PR DESCRIPTION
Steps to reproduce the bug:
- Install POS
- Go to the POS settings and enable “Gift Card” option
- Create a new Gift card with initial amount of $50
- Open a new POS session > create an order of $50 and apply the gift card
- Confirm the order > the order state becomes “paid” and the gift card balance is computed correctly: $0

Problem:
Close the POS session, the order state becomes “done” and the balance is computed wrongly: $50

opw-2683523




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
