### PR TITLE
[FIX] mail: prevent traceback when granting video permissions

### DIFF
--- a/addons/mail/static/src/models/rtc/rtc.js
+++ b/addons/mail/static/src/models/rtc/rtc.js
@@ -912,6 +912,9 @@ function factory(dependencies) {
             for (const [token, peerConnection] of Object.entries(this._peerConnections)) {
                 await this._updateRemoteTrack(peerConnection, 'video', { token });
             }
+            if (!this.currentRtcSession) {
+                return;
+            }
             this.currentRtcSession.updateAndBroadcast({
                 isScreenSharingOn: !!this.sendDisplay,
                 isCameraOn: !!this.sendUserVideo,


### PR DESCRIPTION
Before this commit, granting the video permission when the call had
already ended would generate a traceback.

This commit fixes this issue.

