### PR TITLE
[FIX] hr_work_entry_holidays: Refuse leave before unlink

### DIFF
--- a/addons/hr_work_entry_holidays/models/hr_leave.py
+++ b/addons/hr_work_entry_holidays/models/hr_leave.py
@@ -186,6 +186,10 @@ class HrLeave(models.Model):
         self.env['hr.work.entry'].create(vals_list)
         return res
 
+    def unlink(self):
+        self.action_refuse()
+        return super().unlink()
+
     def _get_number_of_days(self, date_from, date_to, employee_id):
         """ If an employee is currently working full time but asks for time off next month
             where he has a new contract working only 3 days/week. This should be taken into


### PR DESCRIPTION
Purpose
=======

If the time off is directly unlinked, the work entries are not
re-generated over this period, and the payslips won't be updated
accordingly.

Unlinking a time off is not a good idea, but we don't want to
prevent users doing this.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
