### PR TITLE
[FIX] project: Subtask not linked to Project

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -863,7 +863,7 @@
                             <field name="description" type="html" options="{'collaborative': true}"/>
                         </page>
                         <page name="sub_tasks_page" string="Sub-tasks" attrs="{'invisible': [('allow_subtasks', '=', False)]}">
-                            <field name="child_ids" context="{'default_project_id': project_id if not parent_id or not display_project_id else display_project_id, 'default_user_ids': user_ids, 'default_parent_id': id, 'default_partner_id': partner_id}">
+                            <field name="child_ids" context="{'default_display_project_id': project_id, 'default_project_id': project_id if not parent_id or not display_project_id else display_project_id, 'default_user_ids': user_ids, 'default_parent_id': id, 'default_partner_id': partner_id}">
                                 <tree editable="bottom">
                                     <field name="project_id" invisible="1"/>
                                     <field name="is_closed" invisible="1"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Subtask are not linked to project or Project is not fetched automatically from parent task.

Current behavior before PR:
subtask are not linked directly to the project.

Desired behavior after PR is merged:
subtask are linked directly to the project.

Fixes #79558



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
