### PR TITLE
[FIX] hr_holidays : Only request both approval for employee request

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -300,7 +300,7 @@ class HolidaysAllocation(models.Model):
     def _compute_can_approve(self):
         for allocation in self:
             try:
-                if allocation.state == 'confirm' and allocation.validation_type == 'both':
+                if allocation.state == 'confirm' and allocation.holiday_status_id.allocation_type == "fixed_allocation" and allocation.validation_type == 'both':
                     allocation._check_approval_update('validate1')
                 else:
                     allocation._check_approval_update('validate')


### PR DESCRIPTION
Current behaviour :
When creating a leave type with both approval required for allocation and then setting allocation to 'Set by time off officer', we still require 2 approvals.

Behaviour after PR :
Leave type with allocation set to 'Set by time off officer' will only require one approval as expected.

opw-2671540

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
