### PR TITLE
[FIX] account: Call onchange methods if tax_line has been created previously.

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -676,9 +676,9 @@ class AccountMove(models.Model):
                     **taxes_map_entry['grouping_dict'],
                 })
 
-            if tax_line and in_draft_mode:
-                tax_line._onchange_amount_currency()
-                tax_line._onchange_balance()
+            if in_draft_mode:
+                taxes_map_entry['tax_line']._onchange_amount_currency()
+                taxes_map_entry['tax_line']._onchange_balance()
 
     def _tax_tags_need_inversion(self, move, is_refund, tax_type):
         """ Tells whether the tax tags need to be inverted for a given move.


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**:
From this commit https://github.com/odoo/odoo/commit/8d9788247c1b2373110caab878300426a96f4737 when creating an invoice from a purchase order with defined taxes the invoice is created without taxes.

**Impacted versions**:
- 13.0

cc @Tecnativa TT32920


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
