### PR TITLE
[FIX] hr_contract: Missing field added in the contract view

### DIFF
--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -172,6 +172,7 @@
                             <group name="top_info_right">
                                 <field name="department_id"/>
                                 <field name="job_id"/>
+                                <field name="contract_type_id"/>
                                 <field name="hr_responsible_id" required="1"/>
                             </group>
                         </group>


### PR DESCRIPTION
The field contract_type_id is added in hr_contract, but is not present
in the view.

Why not a custom module to add this field in the view?
The hr_contract is the base module, then, my custom module install it,
but it need to set the contract type and the field is not present.

The field cannot be added in the custom module, because some customers
that use my module also needs hr_contract_salary, that adds the field in
the view.

Then, this is related with another PR in enterprise that removes the
field from the view on that module.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
