### PR TITLE
[FIX] account: incorrect currency in line created from bank statement

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -703,7 +703,7 @@ class AccountBankStatementLine(models.Model):
         if foreign_currency != company_currency and self.foreign_currency_id:
             amount_currency = amounts[foreign_currency.id]
             currency_id = foreign_currency.id
-        elif journal_currency != company_currency and not self.foreign_currency_id:
+        elif journal_currency != company_currency and (not self.foreign_currency_id or self.foreign_currency_id == company_currency):
             amount_currency = amounts[journal_currency.id]
             currency_id = journal_currency.id
         else:

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -31,6 +31,7 @@ class TestAccountBankStatementCommon(AccountTestInvoicingCommon):
         cls.bank_journal_1 = cls.company_data['default_journal_bank']
         cls.bank_journal_2 = cls.bank_journal_1.copy()
         cls.bank_journal_3 = cls.bank_journal_2.copy()
+        cls.bank_journal_4 = cls.bank_journal_3.copy()
         cls.currency_1 = cls.company_data['currency']
         cls.currency_2 = cls.currency_data['currency']
         cls.currency_3 = cls.currency_data_2['currency']
@@ -1592,3 +1593,24 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
         self.assertRecordValues(statement_line.line_ids.analytic_line_ids, [
             {'amount': 100.0, 'account_id': analytic_account.id},
         ])
+
+    def test_currency_suspense_account(self):
+        self.bank_journal_4.currency_id = self.currency_2
+        self.bank_journal_4.default_account_id.currency_id = self.currency_2
+        self.bank_journal_4.suspense_account_id.currency_id = self.currency_2
+
+        statement = self.env['account.bank.statement'].with_context(skip_check_amounts_currencies=True).create({
+            'name': 'test_statement',
+            'date': '2021-09-01',
+            'journal_id': self.bank_journal_4.id,
+            'line_ids': [
+                (0, 0, {
+                    'date': '2021-09-01',
+                    'payment_ref': 'line',
+                    'partner_id': False,
+                    'foreign_currency_id': self.company_data['currency'].id,
+                    'amount': 125.0,
+                    'amount_currency': 250.0,
+                }),
+            ],
+        })


### PR DESCRIPTION
In case a currency is set on the suspense account of the journal, and if we
create a bank statement line having this one as foreign currency, we are
wrongly setting the currency amount to the company account. This prevents to
create the statement as there is a consistency check between the account
currency and the statement line currency.

Description of the issue/feature this PR addresses:
opw-2619755

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
