### PR TITLE
[FIX] stock_account: fix multi-company stock.quant value

### DIFF
--- a/addons/stock_account/models/stock_quant.py
+++ b/addons/stock_account/models/stock_quant.py
@@ -32,7 +32,7 @@ class StockQuant(models.Model):
                 quant.value = 0
                 continue
             if quant.product_id.cost_method == 'fifo':
-                quantity = quant.product_id.quantity_svl
+                quantity = quant.product_id.with_company(quant.company_id).quantity_svl
                 if float_is_zero(quantity, precision_rounding=quant.product_id.uom_id.rounding):
                     quant.value = 0.0
                     continue


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On multi company environment, the Inventory Report had incorrect 'value' when quantities on the companies differed. The stock.quants belonging to the company you were currently on was correct, however the others ones were wrong.
![before_fix](https://user-images.githubusercontent.com/29302288/141745561-b9bdd829-f042-45d3-a09d-9be612d7d9da.png)


Current behavior before PR:
On Fifo costing method, the 'value' field of a stock quant was computed using quantity_svl and value_svl of the product_id.
However the method 'with_company()' wasn't used for quantity_svl, resulting in an incorrect 'value' field of stock.quant


Desired behavior after PR is merged:
Both value_svl and quantity_svl are get using 'with_company()' method. 
![after_fix](https://user-images.githubusercontent.com/29302288/141745625-137103ea-a082-403d-acf9-5f15deff8ef5.png)


OPW-2652211
https://www.odoo.com/web#id=2652211&action=3531&model=project.task&view_type=form&cids=1&menu_id=4720

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
