### PR TITLE
[FIX] account: Allow custom bank account on register payment wizard

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -324,11 +324,16 @@ class AccountPayment(models.Model):
             payment.show_partner_bank_account = payment.payment_method_code in self._get_method_codes_using_bank_account()
             payment.require_partner_bank_account = payment.state == 'draft' and payment.payment_method_code in self._get_method_codes_needing_bank_account()
 
-    @api.depends('partner_id')
+    @api.depends('partner_id', 'company_id', 'payment_type')
     def _compute_partner_bank_id(self):
         ''' The default partner_bank_id will be the first available on the partner. '''
         for pay in self:
-            available_partner_bank_accounts = pay.partner_id.bank_ids.filtered(lambda x: x.company_id in (False, pay.company_id))
+            if pay.payment_type == 'inbound':
+                bank_partner = pay.company_id.partner_id
+            else:
+                bank_partner = pay.partner_id
+
+            available_partner_bank_accounts = bank_partner.bank_ids.filtered(lambda x: x.company_id in (False, pay.company_id))
             if available_partner_bank_accounts:
                 if pay.partner_bank_id not in available_partner_bank_accounts:
                     pay.partner_bank_id = available_partner_bank_accounts[0]._origin

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -14,9 +14,19 @@ class TestAccountPayment(AccountTestInvoicingCommon):
         cls.payment_debit_account_id = cls.copy_account(cls.company_data['default_journal_bank'].payment_debit_account_id)
         cls.payment_credit_account_id = cls.copy_account(cls.company_data['default_journal_bank'].payment_credit_account_id)
 
-        cls.partner_bank_account = cls.env['res.partner.bank'].create({
-            'acc_number': 'BE32707171912447',
+        cls.partner_bank_account1 = cls.env['res.partner.bank'].create({
+            'acc_number': "0123456789",
             'partner_id': cls.partner_a.id,
+            'acc_type': 'bank',
+        })
+        cls.partner_bank_account2 = cls.env['res.partner.bank'].create({
+            'acc_number': "9876543210",
+            'partner_id': cls.partner_a.id,
+            'acc_type': 'bank',
+        })
+        cls.comp_bank_account = cls.env['res.partner.bank'].create({
+            'acc_number': "985632147",
+            'partner_id': cls.env.company.partner_id.id,
             'acc_type': 'bank',
         })
 
@@ -25,10 +35,6 @@ class TestAccountPayment(AccountTestInvoicingCommon):
             'payment_credit_account_id': cls.payment_credit_account_id.id,
             'inbound_payment_method_ids': [(6, 0, cls.env.ref('account.account_payment_method_manual_in').ids)],
             'outbound_payment_method_ids': [(6, 0, cls.env.ref('account.account_payment_method_manual_out').ids)],
-        })
-
-        cls.partner_a.write({
-            'bank_ids': [(6, 0, cls.partner_bank_account.ids)],
         })
 
     def test_payment_move_sync_create_write(self):
@@ -51,12 +57,10 @@ class TestAccountPayment(AccountTestInvoicingCommon):
             'partner_id': False,
             'destination_account_id': copy_receivable.id,
             'payment_method_id': self.env.ref('account.account_payment_method_manual_in').id,
-            'partner_bank_id': False,
         }
         expected_move_values = {
             'currency_id': self.company_data['currency'].id,
             'partner_id': False,
-            'partner_bank_id': False,
         }
         expected_liquidity_line = {
             'debit': 50.0,
@@ -94,13 +98,11 @@ class TestAccountPayment(AccountTestInvoicingCommon):
             'destination_account_id': self.partner_a.property_account_payable_id.id,
             'currency_id': self.currency_data['currency'].id,
             'partner_id': self.partner_a.id,
-            'partner_bank_id': self.partner_bank_account.id,
         }])
         self.assertRecordValues(payment.move_id, [{
             **expected_move_values,
             'currency_id': self.currency_data['currency'].id,
             'partner_id': self.partner_a.id,
-            'partner_bank_id': self.partner_bank_account.id,
         }])
         self.assertRecordValues(payment.line_ids.sorted('balance'), [
             {
@@ -124,7 +126,6 @@ class TestAccountPayment(AccountTestInvoicingCommon):
 
         liquidity_lines, counterpart_lines, writeoff_lines = payment._seek_for_lines()
         payment.move_id.write({
-            'partner_bank_id': False,
             'line_ids': [
                 (1, counterpart_lines.id, {
                     'debit': 0.0,
@@ -764,3 +765,18 @@ class TestAccountPayment(AccountTestInvoicingCommon):
                 'account_id': self.company_data['default_journal_cash'].payment_debit_account_id.id,
             },
         ])
+
+    def test_payment_partner_bank_inbound(self):
+        """ Test the bank account is well recomputed for inbound payments. In that case, the recipient
+        bank account must be the one set on the company.
+        """
+        payment = self.env['account.payment'].create({
+            'amount': 50.0,
+            'payment_type': 'outbound',
+            'partner_type': 'supplier',
+            'partner_id': self.partner_a.id,
+        })
+        self.assertRecordValues(payment, [{'partner_bank_id': self.partner_bank_account1.id}])
+
+        payment.payment_type = 'inbound'
+        self.assertRecordValues(payment, [{'partner_bank_id': self.comp_bank_account.id}])

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.exceptions import UserError
-from odoo.tests import tagged
+from odoo.tests import tagged, Form
 
 
 @tagged('post_install', '-at_install')
@@ -47,6 +47,22 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
                 cls.custom_payment_method_out.id,
                 cls.manual_payment_method_out.id,
             ))],
+        })
+
+        cls.partner_bank_account = cls.env['res.partner.bank'].create({
+            'acc_number': "0123456789",
+            'partner_id': cls.partner_a.id,
+            'acc_type': 'bank',
+        })
+        cls.comp_bank_account1 = cls.env['res.partner.bank'].create({
+            'acc_number': "985632147",
+            'partner_id': cls.env.company.partner_id.id,
+            'acc_type': 'bank',
+        })
+        cls.comp_bank_account2 = cls.env['res.partner.bank'].create({
+            'acc_number': "741258963",
+            'partner_id': cls.env.company.partner_id.id,
+            'acc_type': 'bank',
         })
 
         # Customer invoices sharing the same batch.
@@ -533,6 +549,27 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
                 'reconciled': True,
             },
         ])
+
+    def test_register_payment_custom_bank_account(self):
+        """ Ensure the user is able to select a custom bank account when registering a payment and this bank account
+        lands correctly on the generated payment.
+        """
+        self.out_invoice_1.partner_bank_id = self.comp_bank_account1
+
+        ctx = {'active_model': 'account.move', 'active_ids': self.out_invoice_1.ids}
+        wizard_form = Form(self.env['account.payment.register'].with_context(**ctx))
+        wizard = wizard_form.save()
+
+        # The bank account set on the invoice must be the default suggested value.
+        self.assertRecordValues(wizard, [{'partner_bank_id': self.comp_bank_account1.id}])
+
+        wizard_form = Form(wizard)
+        wizard_form.partner_bank_id = self.comp_bank_account2
+        wizard = wizard_form.save()
+        payments = wizard._create_payments()
+
+        # The user should be able to set a custom bank account.
+        self.assertRecordValues(payments, [{'partner_bank_id': self.comp_bank_account2.id}])
 
     def test_register_payment_constraints(self):
         # Test to register a payment for a draft journal entry.

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -24,10 +24,18 @@ class AccountPaymentRegister(models.TransientModel):
     journal_id = fields.Many2one('account.journal', store=True, readonly=False,
         compute='_compute_journal_id',
         domain="[('company_id', '=', company_id), ('type', 'in', ('bank', 'cash'))]")
-    partner_bank_id = fields.Many2one('res.partner.bank', string="Recipient Bank Account",
-        readonly=False, store=True,
+    available_partner_bank_ids = fields.Many2many(
+        comodel_name='res.partner.bank',
+        compute='_compute_available_partner_bank_ids',
+    )
+    partner_bank_id = fields.Many2one(
+        comodel_name='res.partner.bank',
+        string="Recipient Bank Account",
+        readonly=False,
+        store=True,
         compute='_compute_partner_bank_id',
-        domain="['|', ('company_id', '=', False), ('company_id', '=', company_id), ('partner_id', '=', partner_id)]")
+        domain="[('id', 'in', available_partner_bank_ids)]",
+    )
     company_currency_id = fields.Many2one('res.currency', string="Company Currency",
         related='company_id.currency_id')
 
@@ -124,11 +132,17 @@ class AccountPaymentRegister(models.TransientModel):
         will be grouped together.
         :return: A python dictionary.
         '''
+        move = line.move_id
+        partner_bank_account = self.env['res.partner.bank']
+
+        if move.is_invoice(include_receipts=True):
+            partner_bank_account = move.partner_bank_id._origin
+
         return {
             'partner_id': line.partner_id.id,
             'account_id': line.account_id.id,
             'currency_id': (line.currency_id or line.company_currency_id).id,
-            'partner_bank_id': (line.move_id.partner_bank_id or line.partner_id.commercial_partner_id.bank_ids[:1]).id,
+            'partner_bank_id': partner_bank_account.id,
             'partner_type': 'customer' if line.account_internal_type == 'receivable' else 'supplier',
             'payment_type': 'inbound' if line.balance > 0.0 else 'outbound',
         }
@@ -212,6 +226,7 @@ class AccountPaymentRegister(models.TransientModel):
                     'partner_id': False,
                     'partner_type': False,
                     'payment_type': wizard_values_from_batch['payment_type'],
+                    'partner_bank_id': False,
                     'source_currency_id': False,
                     'source_amount': False,
                     'source_amount_currency': False,
@@ -254,20 +269,30 @@ class AccountPaymentRegister(models.TransientModel):
                 journal = self.env['account.journal'].search(domain, limit=1)
             wizard.journal_id = journal
 
+    @api.depends('company_id', 'can_edit_wizard')
+    def _compute_available_partner_bank_ids(self):
+        for wizard in self:
+            if wizard.can_edit_wizard:
+                batches = wizard._get_batches()
+                bank_partners = batches[0]['lines'].move_id.bank_partner_id
+                wizard.available_partner_bank_ids = bank_partners.bank_ids\
+                    .filtered(lambda x: x.company_id in (False, wizard.company_id))._origin
+            else:
+                wizard.available_partner_bank_ids = False
+
+    @api.depends('available_partner_bank_ids')
+    def _compute_partner_bank_id(self):
+        for wizard in self:
+            if wizard.can_edit_wizard:
+                batches = wizard._get_batches()
+                wizard.partner_bank_id = self.env['res.partner.bank'].browse(batches[0]['key_values']['partner_bank_id'])
+            else:
+                wizard.partner_bank_id = False
+
     @api.depends('journal_id')
     def _compute_currency_id(self):
         for wizard in self:
             wizard.currency_id = wizard.journal_id.currency_id or wizard.source_currency_id or wizard.company_id.currency_id
-
-    @api.depends('partner_id')
-    def _compute_partner_bank_id(self):
-        ''' The default partner_bank_id will be the first available on the partner. '''
-        for wizard in self:
-            available_partner_bank_accounts = wizard.partner_id.bank_ids.filtered(lambda x: x.company_id in (False, wizard.company_id))
-            if available_partner_bank_accounts:
-                wizard.partner_bank_id = available_partner_bank_accounts[0]._origin
-            else:
-                wizard.partner_bank_id = False
 
     @api.depends('payment_type',
                  'journal_id.inbound_payment_method_ids',
@@ -341,7 +366,7 @@ class AccountPaymentRegister(models.TransientModel):
     def default_get(self, fields_list):
         # OVERRIDE
         res = super().default_get(fields_list)
-        
+
         if 'line_ids' in fields_list and 'line_ids' not in res:
 
             # Retrieve moves to pay from the context.

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -24,6 +24,7 @@
                     <field name="require_partner_bank_account" invisible="1"/>
                     <field name="hide_payment_method" invisible="1"/>
                     <field name="available_payment_method_ids" invisible="1"/>
+                    <field name="available_partner_bank_ids" invisible="1"/>
                     <field name="company_currency_id" invisible="1"/>
 
                     <group>


### PR DESCRIPTION
- Create a partner with 2 bank accounts: BNK1 and BNK2
- Create an invoice => BNK1 is set by default
- Change BNK1 to BNK2
- Register a payment
=> BNK1 is proposed by default instead of BNK2

issue: 2683197

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
