### PR TITLE
[FIX] sale_project: fix sales order stat button traceback

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -100,7 +100,7 @@ class Project(models.Model):
                 'icon': 'dollar',
                 'text': _('Sales Order'),
                 'action_type': 'object',
-                'action': 'action_view_so',
+                'action': 'action_view_sos',
                 'show': bool(self.sale_order_id),
                 'sequence': 1,
             })


### PR DESCRIPTION
Currently, when we click on 'sales order' stat button of 'project.update'
it shows traceback because action name is incorrect.

In this commit, action is renamed-[odoo@3d10c7c](https://github.com/odoo/odoo/commit/3d10c7c70884993f1290a4fd430a1c52247a8420#
)

closes #79739
task-2689432