### PR TITLE
[FIX] account: tax line  in invoice report

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -3,6 +3,9 @@
 from odoo import models, api, _
 from odoo.exceptions import UserError
 
+from odoo.tools import float_compare
+
+
 class IrActionsReport(models.Model):
     _inherit = 'ir.actions.report'
 
@@ -45,3 +48,8 @@ class IrActionsReport(models.Model):
                     raise UserError(_("Only invoices could be printed."))
 
         return super().render_qweb_pdf(res_ids=res_ids, data=data)
+
+    def _get_rendering_context(self, docids, data):
+        data = data and dict(data) or {}
+        data.update({'float_compare': float_compare})
+        return super()._get_rendering_context(docids=docids, data=data)

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -138,7 +138,7 @@
                                     </tr>
                                     <t t-foreach="o.amount_by_group" t-as="amount_by_group">
                                         <tr style="">
-                                            <t t-if="len(o.line_ids.filtered(lambda line: line.tax_line_id)) in [0, 1] and o.amount_untaxed == amount_by_group[2]">
+                                            <t t-if="len(o.line_ids.filtered(lambda line: line.tax_line_id)) in [0, 1] and float_compare(o.amount_untaxed, amount_by_group[2], precision_rounding=o.currency_id.rounding) == 0">
                                                 <td><span class="text-nowrap" t-esc="amount_by_group[0]"/></td>
                                                 <td class="text-right o_price_total">
                                                     <span class="text-nowrap" t-esc="amount_by_group[3]" />


### PR DESCRIPTION
Steps to reproduce:

- Install Argentinian Accounting
- Enable multi-currency
- Create a customer invoice in USD
- Product X, quantity 10, price 17.82, VAT 21%
- Save and click on preview

Issue:

On tax line, "VAT 21% on $178.20" is displaid instead of just "VAT 21%"

Cause

This is the result of a rounding issue inherent to python, when passing in Currency.round method, 178.20 became 178.20xxx001.

Solution

Overwritte the _get_rendering_context method in order to be able to use the float_compare method instead of a strict comparison in xml report.

opw-2677160

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
