### PR TITLE
[FIX] web_editor: not override root on website

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -128,7 +128,7 @@ const Wysiwyg = Widget.extend({
         const $wrapwrap = $('#wrapwrap');
         if ($wrapwrap.length) {
             $wrapwrap[0].addEventListener('scroll', this.odooEditor.multiselectionRefresh, { passive: true });
-            this.$root = $wrapwrap;
+            this.$root = this.$root || $wrapwrap;
         }
 
         if (this._peerToPeerLoading) {


### PR DESCRIPTION
Before this commit, if the editor was initiated as a simple
editor rather than the website editor (eg. the editor in the forum or profile)
the $root of the wysiwyg was wrongly assigned to #wrapwrap rather
than the $editable.

Subsequent binding (eg. LinkPopover) was bound to too many elements
which generated incorrect behaviors (eg, link popover on triggered on every
links).

Task-2691117



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
