### PR TITLE
[FIX] pos_hr: allow non-admin user to close session and do cash in/out

### DIFF
--- a/addons/pos_hr/static/src/js/Chrome.js
+++ b/addons/pos_hr/static/src/js/Chrome.js
@@ -12,10 +12,10 @@ odoo.define('pos_hr.chrome', function (require) {
                 if (this.env.pos.config.module_pos_hr) this.showTempScreen('LoginScreen');
             }
             get headerButtonIsShown() {
-                return !this.env.pos.config.module_pos_hr || this.env.pos.get('cashier').role == 'manager';
+                return !this.env.pos.config.module_pos_hr || this.env.pos.get('cashier').role != 'cashier';
             }
             showCashMoveButton() {
-                return super.showCashMoveButton() && this.env.pos.get('cashier').role == 'manager';
+                return super.showCashMoveButton() && this.env.pos.get('cashier').role != 'cashier';
             }
         };
 

--- a/addons/pos_hr/static/src/js/models.js
+++ b/addons/pos_hr/static/src/js/models.js
@@ -57,6 +57,15 @@ models.PosModel = models.PosModel.extend({
                         employee.pin = data.pin;
                     }
                 });
+            }).then(async () => {
+                const employee_roles = await self.rpc({
+                    model: 'hr.employee',
+                    method: 'get_employee_roles',
+                    args: [self.employees.map(employee => employee.id)],
+                });
+                for (const employee of self.employees) {
+                    employee.role = employee_roles[employee.id]
+                }
             });
         });
     },


### PR DESCRIPTION
Prior to v15, non-admin user can close the session and/or perform
cash in/out from the backend. Now that those features were moved to
frontend, non-admin users are not capable of doing them. This fix
introduces a new method that determines the role of the employee
such that when the employee has no proper POS access writes,
he is given 'cashier' role, while users who belong to `group_pos_user`
are given 'user' role, lastly, users belonging to `group_pos_manager`
are given 'manager' role.

The close and cash in/out buttons are shown to employees with 'user'
or 'manager' role.

TASK-ID: 2691155

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
