### PR TITLE
[FIX] web_editor: avoid onbeforeunload pop-up issue

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -211,16 +211,17 @@ const Wysiwyg = Widget.extend({
                 selectorEditableArea: '.o_editable',
             }, options));
             await this._insertSnippetMenu();
+
+            window.addEventListener('beforeunload', (event) => {
+                if (this.isDirty()) {
+                    event.returnValue = _t('This document is not saved!');
+                }
+            });
         }
         if (this.options.getContentEditableAreas) {
             $(this.options.getContentEditableAreas()).find('*').off('mousedown mouseup click');
         }
 
-        window.onbeforeunload = (event) => {
-            if (this.isDirty()) {
-                return _t('This document is not saved!');
-            }
-        };
         // The toolbar must be configured after the snippetMenu is loaded
         // because if snippetMenu is loaded in an iframe, binding of the color
         // buttons must use the jquery loaded in that iframe. See


### PR DESCRIPTION
Remove onbeforeunload pop-up if editor has no snippet.
This fix pop-ups wrongly showing outside website editing.

see: #79731

task-2666177

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
