### PR TITLE
[FIX] base: duplicate mandatory field while creating contact

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -168,8 +168,8 @@
                         <field name="country_code" invisible="1"/>
                         <field name="company_type" widget="radio" options="{'horizontal': true}"/>
                         <h1>
-                            <field id="company" class="o_text_overflow" name="name" default_focus="1" placeholder="e.g. Lumber Inc" attrs="{'required' : [('type', '=', 'contact')], 'invisible': [('is_company','=', False)]}"/>
-                            <field id="individual" class="o_text_overflow" name="name" default_focus="1" placeholder="e.g. Brandom Freeman" attrs="{'required' : [('type', '=', 'contact')], 'invisible': [('is_company','=', True)]}"/>
+                            <field id="company" class="o_text_overflow" name="name" default_focus="1" placeholder="e.g. Lumber Inc" attrs="{'required' : [('type', '=', 'contact'),('is_company', '=', True)], 'invisible': [('is_company','=', False)]}"/>
+                            <field id="individual" class="o_text_overflow" name="name" default_focus="1" placeholder="e.g. Brandom Freeman" attrs="{'required' : [('type', '=', 'contact'), ('is_company', '=', False)], 'invisible': [('is_company','=', True)]}"/>
                         </h1>
                         <div class="o_row">
                             <field name="parent_id"


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
"Name" mandatory field in popup is still appearing two times when user tries to save the contact record.

**Current behaviour before PR:**
Already PR: https://github.com/odoo/odoo/pull/78802 is merged which added changes into "view_partner_simple_form" form view but still the name is showing  twice in popup when saving the contact record.

**Desired behaviour after PR is merged:**
In this commit the same changes are added into "view_partner_form" form view and now the name is only visible once in the popup.

Fixes #79753


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
