### PR TITLE
[FIX] mrp: configure in and out moves of draft MO

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -128,6 +128,9 @@ class StockMove(models.Model):
                 defaults['state'] = 'done'
                 defaults['product_uom_qty'] = 0.0
                 defaults['additional'] = True
+            elif production_id.state == 'draft':
+                defaults['group_id'] = production_id.procurement_group_id.id
+                defaults['reference'] = production_id.name
         return defaults
 
     def _action_assign(self):

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -469,3 +469,32 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         self.assertEqual(finished_product_SML.product_uom_qty, 2)
         self.assertEqual(secondary_product_SML.product_uom.id, four_units_uom.id)
         self.assertEqual(secondary_product_SML.product_uom_qty, 1)
+
+    def test_2_steps_and_additional_moves(self):
+        """ Suppose a 2-steps configuration. If a user adds a product to an existing draft MO and then
+        confirms it, the associated picking should includes this new product"""
+        self.warehouse.manufacture_steps = 'pbm'
+
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = self.bom.product_id
+        mo_form.picking_type_id = self.warehouse.manu_type_id
+        mo = mo_form.save()
+
+        component_move = mo.move_raw_ids[0]
+        mo.with_context(default_raw_material_production_id=mo.id).move_raw_ids = [
+            [0, 0, {
+                'location_id': component_move.location_id.id,
+                'location_dest_id': component_move.location_dest_id.id,
+                'picking_type_id': component_move.picking_type_id.id,
+                'product_id': self.product_2.id,
+                'name': self.product_2.display_name,
+                'product_uom_qty': 1,
+                'product_uom': self.product_2.uom_id.id,
+                'warehouse_id': component_move.warehouse_id.id,
+                'raw_material_production_id': mo.id,
+            }]
+        ]
+
+        mo.action_confirm()
+
+        self.assertEqual(self.bom.bom_line_ids.product_id + self.product_2, mo.picking_ids.move_lines.product_id)


### PR DESCRIPTION
In multi steps configurations, the additional products of a MO could be
missing in the associated picking

To reproduce the issue:
(Use demo data)
1. In Settings, enable "Multi-Step Routes"
2. Update the current warehouse:
    - Manufacture: 2 steps
3. Create a MO for product "Table Top"
4. Edit the MO:
    - Add 1 x Screw in the components
5. Confirm the MO
6. Open the generated Picking

Error: The operations only contains one line for "Wood Panel". There
should be a second line for the "Screw"

When adding the new component, a new stock move is created but the
latter does not have any `group_id` defined. This is the reason why the
generated picking does not include this stock move.

OPW-2671995