### PR TITLE
[FIX] l10n_nl_edi, l10_no_edi: traceback when posting invoice as a Dutch company

### DIFF
--- a/addons/l10n_nl_edi/data/nlcius_template.xml
+++ b/addons/l10n_nl_edi/data/nlcius_template.xml
@@ -27,5 +27,30 @@
             </xpath>
         </template>
 
+        <template id="export_nlcius_ubl_invoice_partner"
+                  inherit_id="account_edi_ubl.export_ubl_invoice_partner"
+                  primary="True">
+            <xpath expr="//*[local-name()='CountrySubentity']" position="replace"/>
+        </template>
+
+        <template id="export_nlcius_ubl_invoice"
+                  inherit_id="account_edi_ubl.export_ubl_invoice"
+                  primary="True">
+            <xpath expr="//*[local-name()='AccountingSupplierParty']" position="replace">
+                <cac:AccountingSupplierParty t-call="l10n_nl_edi.export_nlcius_ubl_invoice_partner"
+                xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+                xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                    <t t-set="partner_vals" t-value="supplier_vals"/>
+                </cac:AccountingSupplierParty>
+            </xpath>
+            <xpath expr="//*[local-name()='AccountingCustomerParty']" position="replace">
+                <cac:AccountingCustomerParty t-call="l10n_nl_edi.export_nlcius_ubl_invoice_partner"
+                xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                    <t t-set="partner_vals" t-value="customer_vals"/>
+                </cac:AccountingCustomerParty>
+            </xpath>
+        </template>
+
     </data>
 </odoo>

--- a/addons/l10n_nl_edi/i18n/l10n_nl_edi.pot
+++ b/addons/l10n_nl_edi/i18n/l10n_nl_edi.pot
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_nl_edi
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 15.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-11-15 15:40+0000\n"
+"PO-Revision-Date: 2021-11-15 15:40+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_nl_edi
+#: code:addons/l10n_nl_edi/models/account_edi_format.py:0
+#, python-format
+msgid "The l10n_nl_edi.%s template is missing."
+msgstr ""


### PR DESCRIPTION
Steps to reproduce the error:
 - Create a new company, set Netherlands as country and fill in required info (street, zip, city, vat, kvk-number).
 - Set a bank account on the company contact
 - Install NL chart of account on this company (Netherlands Accounting package)
 - Create a test customer, and don't set any address or set a country not listed in EAS (https://docs.peppol.eu/poacc/billing/3.0/codelist/eas/)
 - Create an invoice for this test customer and try to post it.

Before this commit, if a Dutch company had tried to create an invoice for a customer from a country not listed in the Electronic Address Scheme (EAS) codes, Odoo would have given them a traceback error.

Now the code checks if the customer is from an EAS country: if they are, the code renders the bis3 invoice template, if not the code renders the ubl invoice template.
While fixing the issue explained above, I found out that the l10n_no_edi, if installed alongside the l10n_nl_edi, could interfere with the expected NL invoice posting flow.
For this specific reason I modified the l10n_no_edi pkg to prevent any kind of interference in the case both packages are installed in the same db.

opw-2676802

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
