### PR TITLE
[FIX] l10n_in: copying gst treatment from client

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -8,11 +8,6 @@ from odoo.exceptions import ValidationError
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    @api.depends('amount_total')
-    def _compute_amount_total_words(self):
-        for invoice in self:
-            invoice.amount_total_words = invoice.currency_id.amount_to_text(invoice.amount_total)
-
     amount_total_words = fields.Char("Total (In Words)", compute="_compute_amount_total_words")
     l10n_in_gst_treatment = fields.Selection([
             ('regular', 'Registered Business - Regular'),
@@ -22,7 +17,7 @@ class AccountMove(models.Model):
             ('overseas', 'Overseas'),
             ('special_economic_zone', 'Special Economic Zone'),
             ('deemed_export', 'Deemed Export')
-        ], string="GST Treatment", readonly=True, states={'draft': [('readonly', False)]})
+        ], string="GST Treatment", compute="_compute_l10n_in_gst_treatment", store=True, readonly=False)
     l10n_in_state_id = fields.Many2one('res.country.state', string="Location of supply")
     l10n_in_company_country_code = fields.Char(related='company_id.country_id.code', string="Country code")
     l10n_in_gstin = fields.Char(string="GSTIN")
@@ -32,12 +27,15 @@ class AccountMove(models.Model):
     l10n_in_shipping_port_code_id = fields.Many2one('l10n_in.port.code', 'Port code', states={'draft': [('readonly', False)]})
     l10n_in_reseller_partner_id = fields.Many2one('res.partner', 'Reseller', domain=[('vat', '!=', False)], help="Only Registered Reseller", readonly=True, states={'draft': [('readonly', False)]})
 
-    @api.onchange('partner_id')
-    def _onchange_partner_id(self):
-        """Use journal type to define document type because not miss state in any entry including POS entry"""
-        if self.l10n_in_company_country_code == 'IN':
-            self.l10n_in_gst_treatment = self.partner_id.l10n_in_gst_treatment
-        return super()._onchange_partner_id()
+    @api.depends('amount_total')
+    def _compute_amount_total_words(self):
+        for invoice in self:
+            invoice.amount_total_words = invoice.currency_id.amount_to_text(invoice.amount_total)
+
+    @api.depends('partner_id')
+    def _compute_l10n_in_gst_treatment(self):
+        for record in self:
+            record.l10n_in_gst_treatment = record.partner_id.l10n_in_gst_treatment
 
     @api.model
     def _l10n_in_get_indian_state(self, partner):

--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -8,7 +8,7 @@
             <xpath expr="//field[@name='ref']" position="after">
                 <field name="l10n_in_company_country_code" invisible="1"/>
                 <field name="l10n_in_gst_treatment"
-                    attrs="{'invisible': ['|', ('l10n_in_company_country_code', '!=', 'IN'), ('move_type', '=', 'entry')], 'required': [('l10n_in_company_country_code', '=', 'IN'), ('move_type', '!=', 'entry')]}"/>
+                    attrs="{'invisible': ['|', ('l10n_in_company_country_code', '!=', 'IN'), ('move_type', '=', 'entry')], 'required': [('l10n_in_company_country_code', '=', 'IN'), ('move_type', '!=', 'entry')], 'readonly': [('state', '!=', 'draft')]}"/>
             </xpath>
             <xpath expr="//page[@id='other_tab']/group[@id='other_tab_group']" position="after">
                 <group string="Export India" attrs="{'invisible': ['|', ('l10n_in_gst_treatment', 'not in', ['overseas', 'deemed_export']), ('move_type', 'not in', ['out_invoice', 'out_refund'])]}">


### PR DESCRIPTION
When creating a new account.move object, the gst treatment is not copied.
This commit fixes that by fetching the gst treatment from the partner and
by copying it in the field of the account.move object.

Signed-off-by: Adrien Minet <admi@odoo.com>




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
