### PR TITLE
[FIX] web_editor: close link popover of removed links

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -82,6 +82,7 @@ const LinkPopoverWidget = Widget.extend({
         .data('bs.popover').tip.classList.add('o_edit_menu_popover');
 
 
+        this.popover = this.$target.data('bs.popover');
         this.$target.on('mousedown.link_popover', (e) => {
             if (!popoverShown) {
                 this.$target.popover('show');
@@ -97,7 +98,7 @@ const LinkPopoverWidget = Widget.extend({
                             !hierarchy.some(x => x.tagName && x.tagName === 'A'))
                     )
                 ) {
-                    this.$target.popover('hide');
+                    this.popover.hide();
                 }
             }
         }


### PR DESCRIPTION
Before this commit, the link could be removed from the DOM
before hiding the query popover. After being removed, the
reference of the popover from the jquery element was lost.

We now keep the reference to the popover to always be able
to hide it.

Task-2684819



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
