### PR TITLE
[FIX] base: The symbol ANG must be before the amount

### DIFF
--- a/odoo/addons/base/data/res_currency_data.xml
+++ b/odoo/addons/base/data/res_currency_data.xml
@@ -652,6 +652,7 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Guilder</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="position">before</field>
         </record>
 
         <record id="CYP" model="res.currency">


### PR DESCRIPTION
REF:https://www.xe.com/currency/ang-dutch-guilder/

opw:2690166-