### PR TITLE
[FIX] purchase_stock: delete a wrong field on setup class test

### DIFF
--- a/addons/purchase_stock/tests/test_purchase_stock_accrued_entries.py
+++ b/addons/purchase_stock/tests/test_purchase_stock_accrued_entries.py
@@ -19,7 +19,6 @@ class TestAccruedPurchaseStock(AccountTestInvoicingCommon):
             'type': 'consu',
             'uom_id': uom_unit.id,
             'uom_po_id': uom_unit.id,
-            'invoice_policy': 'delivery',
         })
 
         cls.purchase_order = cls.env['purchase.order'].with_context(tracking_disable=True).create({


### PR DESCRIPTION
The field `invoice_policy` on the product model is defined in the module `sale`.
So if you run the tests with only “purchase_stock” installed on the DB, an error will be thrown.

Bug introduced by this commit: https://github.com/odoo/odoo/pull/75886/commits/72955411964440747125e7c9d00ef952bc69a80e#diff-f3237d6d25dc46b109ec461ad910dd4cf6f5c6572e29e1b7eedbd9cfa63cb5c2R22

opw-2685389




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
