### PR TITLE
[IMP] l10n uk: Brexiting tax overhaul and tax report update

### DIFF
--- a/addons/l10n_uk/__manifest__.py
+++ b/addons/l10n_uk/__manifest__.py
@@ -28,8 +28,8 @@ This is the latest UK Odoo localisation necessary to run Odoo accounting for UK 
         'data/account.tax.group.csv',
         'data/account_tax_report_data.xml',
         'data/account_tax_data.xml',
-        'data/account_chart_template_data.xml',
         'data/account_fiscal_position_template_data.xml',
+        'data/account_chart_template_data.xml',
     ],
     'demo': [
         'demo/l10n_uk_demo.xml',

--- a/addons/l10n_uk/__manifest__.py
+++ b/addons/l10n_uk/__manifest__.py
@@ -29,6 +29,7 @@ This is the latest UK Odoo localisation necessary to run Odoo accounting for UK 
         'data/account_tax_report_data.xml',
         'data/account_tax_data.xml',
         'data/account_chart_template_data.xml',
+        'data/account_fiscal_position_template_data.xml',
     ],
     'demo': [
         'demo/l10n_uk_demo.xml',

--- a/addons/l10n_uk/data/account.chart.template.csv
+++ b/addons/l10n_uk/data/account.chart.template.csv
@@ -1,2 +1,2 @@
 "id","name","property_account_receivable_id:id","property_account_payable_id:id","property_account_expense_categ_id:id","property_account_income_categ_id:id","income_currency_exchange_account_id:id","expense_currency_exchange_account_id:id","default_pos_receivable_account_id:id","use_anglo_saxon"
-"l10n_uk","UK Tax and Account Chart Template","1100","2100","5000","4000","7700","7700","1104","True"
+"l10n_uk","Great Britain Tax and Account Chart Template","1100","2100","5000","4000","7700","7700","1104","True"

--- a/addons/l10n_uk/data/account.chart.template.csv
+++ b/addons/l10n_uk/data/account.chart.template.csv
@@ -1,2 +1,2 @@
 "id","name","property_account_receivable_id:id","property_account_payable_id:id","property_account_expense_categ_id:id","property_account_income_categ_id:id","income_currency_exchange_account_id:id","expense_currency_exchange_account_id:id","default_pos_receivable_account_id:id","use_anglo_saxon"
-"l10n_uk","UK Tax and Account Chart Template (by SmartMode)","1100","2100","5000","4000","7700","7700","1104","True"
+"l10n_uk","UK Tax and Account Chart Template","1100","2100","5000","4000","7700","7700","1104","True"

--- a/addons/l10n_uk/data/account.tax.group.csv
+++ b/addons/l10n_uk/data/account.tax.group.csv
@@ -1,5 +1,6 @@
 id,name,country_id/id
 tax_group_0,TAX 0%,base.uk
 tax_group_5,TAX 5%,base.uk
+tax_group_125,TAX 12.5%,base.uk
 tax_group_175,TAX 17.5%,base.uk
 tax_group_20,TAX 20%,base.uk

--- a/addons/l10n_uk/data/account_fiscal_position_template_data.xml
+++ b/addons/l10n_uk/data/account_fiscal_position_template_data.xml
@@ -1,48 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <!-- = = = = = = = = = = = = = = = -->
-    <!-- Fiscal Position Templates     -->
-    <!-- = = = = = = = = = = = = = = = -->
+    <!-- = = = = = = = = = = = = = -->
+    <!-- Fiscal Position Templates -->
+    <!-- = = = = = = = = = = = = = -->
 
-    <!-- Brexit Great Britain to Northern Ireland Fiscal Position -->
-    <record id="fiscal_position_template_gb_ni" model="account.fiscal.position.template">
-        <field name="sequence">1</field>
-        <field name="name">Great Britain to Northern Ireland</field>
-        <field name="chart_template_id" ref="l10n_uk_gb"/>
-        <field name="auto_apply" eval="True"/>
-        <field name="vat_required" eval="False" />
-        <field name="country_id" ref="base.uk"></field>
-    </record>
+    <!-- United Kingdom Domestic Fiscal Positions -->
+    <!--
+        These fiscal postions will contain no mappings,
+        they are just here to distinguish domestic trade
+        from trade with the "rest of the world"
+    -->
+    <!-- <record id="fiscal_position_template_domestic" model="account.fiscal.position.template"> -->
+    <!--     <field name="sequence">1</field> -->
+    <!--     <field name="name">UK Domestic</field> -->
+    <!--     <field name="chart_template_id" ref="l10n_uk"/> -->
+    <!--     <field name="auto_apply" eval="True"/> -->
+    <!--     <field name="vat_required" eval="False" /> -->
+    <!--     <field name="country_id" ref="base.uk"></field> -->
+    <!-- </record> -->
 
-    <!-- Brexit Northern Ireland to Great Britain Fiscal Position -->
-    <record id="fiscal_position_template_ni_gb" model="account.fiscal.position.template">
+    <record id="fiscal_position_template_domestic" model="account.fiscal.position.template">
         <field name="sequence">1</field>
-        <field name="name">Northern Ireland to Great Britain</field>
-        <field name="chart_template_id" ref="l10n_uk_ni"/>
+        <field name="name">UK Domestic B2B</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
         <field name="auto_apply" eval="True"/>
         <field name="vat_required" eval="False" />
         <field name="country_id" ref="base.uk"></field>
     </record>
 
     <!-- Northern Ireland to EU Fiscal Position -->
-    <record id="fiscal_position_template_b2b_goods_ni_eu" model="account.fiscal.position.template">
-        <field name="sequence">1</field>
-        <field name="name">Goods from Northern Ireland to European Union member states</field>
+    <record id="fiscal_position_template_b2b_ni_eu" model="account.fiscal.position.template">
+        <field name="sequence">2</field>
+        <field name="name">Northern Ireland to European Union member states B2B</field>
         <field name="chart_template_id" ref="l10n_uk_ni"/>
         <field name="auto_apply" eval="True"/>
         <field name="vat_required" eval="True"/>
         <field name="country_group_id" ref="base.europe"/>
     </record>
 
-    <!-- Great Britain to ROW Fiscal Position -->
-    <record id="fiscal_position_template_gb_eu" model="account.fiscal.position.template">
-        <field name="sequence">1</field>
+    <!-- United Kingdom to "Rest of World" Fiscal Position -->
+    <record id="fiscal_position_template_b2b_row" model="account.fiscal.position.template">
+        <field name="sequence">3</field>
         <field name="name">Great Britain to the rest of the world</field>
-        <field name="chart_template_id" ref="l10n_uk_gb"/>
+        <field name="chart_template_id" ref="l10n_uk"/>
         <field name="auto_apply" eval="True"/>
-        <field name="vat_required" eval="False" />
-        <field name="country_id" ref="base.uk"></field>
+        <field name="vat_required" eval="False"/>
     </record>
 
     <!-- = = = = = = = = = = = = = = = -->
@@ -63,28 +66,28 @@
 
     <!-- Standard rate sales (20%) to Sales to customers in EC -->
     <record id="fp_tax_template_b2b_ni_eu_ST11G_ST4" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
         <field name="tax_src_id" ref="ST11G"/>
         <field name="tax_dest_id" ref="ST4"/>
     </record>
 
     <record id="fp_tax_template_b2b_ni_eu_ST5G_ST4" model="account.fiscal.position.tax.template">
     <!-- Reduced rate sales (5%) to Sales to customers in EC -->
-        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
         <field name="tax_src_id" ref="ST5G"/>
         <field name="tax_dest_id" ref="ST4"/>
     </record>
 
     <!-- Zero Rated to Sales to customers in EC -->
     <record id="fp_tax_template_b2b_ni_eu_ST0G_ST4" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
         <field name="tax_src_id" ref="ST0G"/>
         <field name="tax_dest_id" ref="ST4"/>
     </record>
 
     <!-- Tax Exempt to customers in EC -->
     <record id="fp_tax_template_b2b_ni_eu_ST2_ST4" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
         <field name="tax_src_id" ref="ST2"/>
         <field name="tax_dest_id" ref="ST4"/>
 
@@ -94,28 +97,28 @@
 
     <!-- Standard rated purchases (20%) to Standard rated purchases from EC -->
     <record id="fp_tax_template_b2b_ni_eu_PT11G_PT8" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
         <field name="tax_src_id" ref="PT11G"/>
         <field name="tax_dest_id" ref="PT8"/>
     </record>
 
     <!-- Reduced rated purchases (5%) to Standard rated purchases from EC -->
     <record id="fp_tax_template_b2b_ni_eu_PT5G_PT8" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
         <field name="tax_src_id" ref="PT5G"/>
         <field name="tax_dest_id" ref="PT8"/>
     </record>
 
     <!-- Zero rated purchases to Zero rated purchases from EC -->
     <record id="fp_tax_template_b2b_ni_eu_PT0G_PT7" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
         <field name="tax_src_id" ref="PT0G"/>
         <field name="tax_dest_id" ref="PT7"/>
     </record>
 
     <!-- Exempt purchases to Zero rated purchases from EC -->
     <record id="fp_tax_template_b2b_ni_eu_PT2_PT7" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
         <field name="tax_src_id" ref="PT2"/>
         <field name="tax_dest_id" ref="PT7"/>
     </record>
@@ -130,7 +133,7 @@
 
     <!-- Standard rated sales to Zero rated sales reverse charge (0%) -->
     <record id="fp_tax_template_b2b_ni_eu_ST11S_ST0RC" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
         <field name="tax_src_id" ref="ST11S"/>
         <field name="tax_dest_id" ref="ST0RC"/>
     </record>
@@ -139,21 +142,135 @@
 
     <!-- Standard rated purchases to Standard rated purchases reverse charge deemed supply (20%) -->
     <record id="fp_tax_template_b2b_ni_eu_PT11S_PT11RCDS" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
         <field name="tax_src_id" ref="PT11S"/>
         <field name="tax_dest_id" ref="PT11RCDS"/>
     </record>
 
     <!-- Reduced rated purchases to Reduced rated purchases reverse charge deemed supply (5%) -->
     <record id="fp_tax_template_b2b_ni_eu_PT5S_PT5RCDS" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
         <field name="tax_src_id" ref="PT5S"/>
         <field name="tax_dest_id" ref="PT5RCDS"/>
     </record>
 
     <!-- Zero rated purchases to Zero rated purchases reverse charge deemed supply (0%) -->
     <record id="fp_tax_template_b2b_ni_eu_PT0S_PT0RCDS" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
+        <field name="tax_src_id" ref="PT0S"/>
+        <field name="tax_dest_id" ref="PT0RCDS"/>
+    </record>
+
+    <!-- = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = -->
+    <!-- United Kingdom to the rest of the world b2b fiscal position taxes -->
+    <!-- = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = -->
+
+        <!--
+            MAPPINGS FOR TAXES ON GOODS
+        -->
+
+    <!-- Sales Taxes -->
+    <!-- Standard rated sales (20%) to Exports (0%) -->
+    <record id="fp_tax_template_b2b_row_ST11G_ST0E" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_row"/>
+        <field name="tax_src_id" ref="ST11G"/>
+        <field name="tax_dest_id" ref="ST0E"/>
+    </record>
+
+    <!-- Reduced rated sales (5%) to Exports (0%) -->
+    <record id="fp_tax_template_b2b_row_ST5G_ST0E" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_row"/>
+        <field name="tax_src_id" ref="ST5G"/>
+        <field name="tax_dest_id" ref="ST0E"/>
+    </record>
+
+    <!-- Zero rated sales (0%) to Exports (0%) -->
+    <record id="fp_tax_template_b2b_row_ST0G_ST0E" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_row"/>
+        <field name="tax_src_id" ref="ST0G"/>
+        <field name="tax_dest_id" ref="ST0E"/>
+    </record>
+
+    <!-- Exempt sales to Exports (0%) -->
+    <record id="fp_tax_template_b2b_row_ST2_ST0E" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_row"/>
+        <field name="tax_src_id" ref="ST2"/>
+        <field name="tax_dest_id" ref="ST0E"/>
+    </record>
+
+    <!-- Purchase Taxes -->
+    <!-- Standard rated purchases (20%) to Standard rated imports postponed (20%) -->
+    <record id="fp_tax_template_b2b_row_PT11G_PT11IP" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_row"/>
+        <field name="tax_src_id" ref="PT11G"/>
+        <field name="tax_dest_id" ref="PT11IP"/>
+    </record>
+
+    <!-- Reduced rated purchases (5%) to Reduced rated imports postponed (5%) -->
+    <record id="fp_tax_template_b2b_row_PT5G_PT5IP" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_row"/>
+        <field name="tax_src_id" ref="PT5G"/>
+        <field name="tax_dest_id" ref="PT5IP"/>
+    </record>
+
+    <!-- Zero rated purchases (0%) to Zero rated imports (0%) -->
+    <record id="fp_tax_template_b2b_row_PT0G_PT0I" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_row"/>
+        <field name="tax_src_id" ref="PT0G"/>
+        <field name="tax_dest_id" ref="PT0I"/>
+    </record>
+
+    <!-- Exempt purchases to Exempt imports -->
+    <record id="fp_tax_template_b2b_row_PT2_PT0I" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_row"/>
+        <field name="tax_src_id" ref="PT2"/>
+        <field name="tax_dest_id" ref="PT0I"/>
+    </record>
+
+        <!--
+            MAPPINGS FOR TAXES ON SERVICES
+        -->
+
+    <!-- Sales Taxes -->
+    <!-- Standard rated sales (20%) to Exports (0%) -->
+    <record id="fp_tax_template_b2b_row_ST11S_ST0E" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_row"/>
+        <field name="tax_src_id" ref="ST11S"/>
+        <field name="tax_dest_id" ref="ST0E"/>
+    </record>
+
+    <!-- Reduced rated sales (5%) to Exports (0%) -->
+    <record id="fp_tax_template_b2b_row_ST5S_ST0E" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_row"/>
+        <field name="tax_src_id" ref="ST5S"/>
+        <field name="tax_dest_id" ref="ST0E"/>
+    </record>
+
+    <!-- Zero rated sales (0%) to Exports (0%) -->
+    <record id="fp_tax_template_b2b_row_ST0S_ST0E" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_row"/>
+        <field name="tax_src_id" ref="ST0S"/>
+        <field name="tax_dest_id" ref="ST0E"/>
+    </record>
+
+    <!-- Purchase Taxes -->
+    <!-- Standard rated purchases (20%) to Standard rated purchases reverse charge deemed supply (20%) -->
+    <record id="fp_tax_template_b2b_row_PT11S_PT11RCDS" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_row"/>
+        <field name="tax_src_id" ref="PT11S"/>
+        <field name="tax_dest_id" ref="PT11RCDS"/>
+    </record>
+
+    <!-- Reduced rated purchases (5%) to Reduced rated purchases reverse charge deemed supply (5%) -->
+    <record id="fp_tax_template_b2b_row_PT5S_PT5RCDS" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_row"/>
+        <field name="tax_src_id" ref="PT5S"/>
+        <field name="tax_dest_id" ref="PT5RCDS"/>
+    </record>
+
+    <!-- Zero rated purchases (0%) to Zero rated purchases reverse charge deemed supply (0%) -->
+    <record id="fp_tax_template_b2b_row_PT0S_PT0RCDS" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_row"/>
         <field name="tax_src_id" ref="PT0S"/>
         <field name="tax_dest_id" ref="PT0RCDS"/>
     </record>

--- a/addons/l10n_uk/data/account_fiscal_position_template_data.xml
+++ b/addons/l10n_uk/data/account_fiscal_position_template_data.xml
@@ -9,7 +9,7 @@
     <record id="fiscal_position_template_gb_ni" model="account.fiscal.position.template">
         <field name="sequence">1</field>
         <field name="name">Great Britain to Northern Ireland</field>
-        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="chart_template_id" ref="l10n_uk_gb"/>
         <field name="auto_apply" eval="True"/>
         <field name="vat_required" eval="False" />
         <field name="country_id" ref="base.uk"></field>
@@ -19,7 +19,7 @@
     <record id="fiscal_position_template_ni_gb" model="account.fiscal.position.template">
         <field name="sequence">1</field>
         <field name="name">Northern Ireland to Great Britain</field>
-        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="chart_template_id" ref="l10n_uk_ni"/>
         <field name="auto_apply" eval="True"/>
         <field name="vat_required" eval="False" />
         <field name="country_id" ref="base.uk"></field>
@@ -28,18 +28,18 @@
     <!-- Northern Ireland to EU Fiscal Position -->
     <record id="fiscal_position_template_b2b_goods_ni_eu" model="account.fiscal.position.template">
         <field name="sequence">1</field>
-        <field name="name">Northern Ireland to European Union Member States</field>
-        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="name">Goods from Northern Ireland to European Union member states</field>
+        <field name="chart_template_id" ref="l10n_uk_ni"/>
         <field name="auto_apply" eval="True"/>
         <field name="vat_required" eval="True"/>
-        <field name="country_id" ref="base.uk"></field>
+        <field name="country_group_id" ref="base.europe"/>
     </record>
 
-    <!-- Great Britain to EU Fiscal Position -->
+    <!-- Great Britain to ROW Fiscal Position -->
     <record id="fiscal_position_template_gb_eu" model="account.fiscal.position.template">
         <field name="sequence">1</field>
-        <field name="name">Great Britain to European Union Member States</field>
-        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="name">Great Britain to the rest of the world</field>
+        <field name="chart_template_id" ref="l10n_uk_gb"/>
         <field name="auto_apply" eval="True"/>
         <field name="vat_required" eval="False" />
         <field name="country_id" ref="base.uk"></field>
@@ -49,48 +49,67 @@
     <!-- Fiscal Position Tax Templates -->
     <!-- = = = = = = = = = = = = = = = -->
 
-    <!-- <!-\- Northern Ireland to EU Fiscal Position Taxes -\-> -->
-    <!-- <!-\- Sales Taxes -\-> -->
-    <!-- <!-\- Zero Rated to Sales to customers in EC -\-> -->
-    <record id="fp_tax_template_b2b_ni_eu_ST0_ST4" model="account.fiscal.position.tax.template">
+    <!-- = = = = = = = = = = = = = = = = = = = = = = = -->
+    <!-- Northern Ireland to EU Fiscal Position Taxes  -->
+    <!-- = = = = = = = = = = = = = = = = = = = = = = = -->
+
+        <!--
+            MAPPINGS FOR TAXES ON GOODS
+            EU Rules on taxes only apply to the sale and purchase of goods between
+            Northern Ireland and the EU.
+        -->
+
+    <!-- Sales Taxes -->
+
+    <!-- Standard rate sales (20%) to Sales to customers in EC -->
+    <record id="fp_tax_template_b2b_ni_eu_ST11G_ST4" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
-        <field name="tax_src_id" ref="ST0"/>
+        <field name="tax_src_id" ref="ST11G"/>
         <field name="tax_dest_id" ref="ST4"/>
     </record>
 
-    <!-- <!-\- Exempt Sales to Sales to customers in EC -\-> -->
+    <record id="fp_tax_template_b2b_ni_eu_ST5G_ST4" model="account.fiscal.position.tax.template">
+    <!-- Reduced rate sales (5%) to Sales to customers in EC -->
+        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="tax_src_id" ref="ST5G"/>
+        <field name="tax_dest_id" ref="ST4"/>
+    </record>
+
+    <!-- Zero Rated to Sales to customers in EC -->
+    <record id="fp_tax_template_b2b_ni_eu_ST0G_ST4" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="tax_src_id" ref="ST0G"/>
+        <field name="tax_dest_id" ref="ST4"/>
+    </record>
+
+    <!-- Tax Exempt to customers in EC -->
     <record id="fp_tax_template_b2b_ni_eu_ST2_ST4" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
         <field name="tax_src_id" ref="ST2"/>
         <field name="tax_dest_id" ref="ST4"/>
-    </record>
 
-    <!-- Zero rated sales to Sales to customers in EC -->
-    <record id="fp_tax_template_b2b_ni_eu_ST0_ST4" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
-        <field name="tax_src_id" ref="ST0"/>
-        <field name="tax_dest_id" ref="ST4"/>
-    </record>
-
-    <!-- Reduced rate sales (5%) to Sales to customers in EC -->
-    <record id="fp_tax_template_b2b_ni_eu_ST5_ST4" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
-        <field name="tax_src_id" ref="ST5"/>
-        <field name="tax_dest_id" ref="ST4"/>
-    </record>
-
-    <!-- Standard rate sales (20%) to Sales to customers in EC -->
-    <record id="fp_tax_template_b2b_ni_eu_ST11_ST4" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
-        <field name="tax_src_id" ref="ST11"/>
-        <field name="tax_dest_id" ref="ST4"/>
     </record>
 
     <!-- Purchase Taxes -->
-    <!-- Zero rated purchases to Zero rated purchases from EC -->
-    <record id="fp_tax_template_b2b_ni_eu_PT0_PT7" model="account.fiscal.position.tax.template">
+
+    <!-- Standard rated purchases (20%) to Standard rated purchases from EC -->
+    <record id="fp_tax_template_b2b_ni_eu_PT11G_PT8" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
-        <field name="tax_src_id" ref="PT0"/>
+        <field name="tax_src_id" ref="PT11G"/>
+        <field name="tax_dest_id" ref="PT8"/>
+    </record>
+
+    <!-- Reduced rated purchases (5%) to Standard rated purchases from EC -->
+    <record id="fp_tax_template_b2b_ni_eu_PT5G_PT8" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="tax_src_id" ref="PT5G"/>
+        <field name="tax_dest_id" ref="PT8"/>
+    </record>
+
+    <!-- Zero rated purchases to Zero rated purchases from EC -->
+    <record id="fp_tax_template_b2b_ni_eu_PT0G_PT7" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="tax_src_id" ref="PT0G"/>
         <field name="tax_dest_id" ref="PT7"/>
     </record>
 
@@ -101,18 +120,42 @@
         <field name="tax_dest_id" ref="PT7"/>
     </record>
 
-    <!-- Lower rate purchases (5%) to Standard rated purchases from EC -->
-    <record id="fp_tax_template_b2b_ni_eu_PT5_PT8" model="account.fiscal.position.tax.template">
+        <!--
+            MAPPINGS FOR TAXES ON SERVICES
+            Sales and purchases of services do not follow EU tax rules. Therefore the EU
+            should be treated as the rest of the world for services.
+        -->
+
+    <!-- Sales Taxes -->
+
+    <!-- Standard rated sales to Zero rated sales reverse charge (0%) -->
+    <record id="fp_tax_template_b2b_ni_eu_ST11S_ST0RC" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
-        <field name="tax_src_id" ref="PT5"/>
-        <field name="tax_dest_id" ref="PT8"/>
+        <field name="tax_src_id" ref="ST11S"/>
+        <field name="tax_dest_id" ref="ST0RC"/>
     </record>
 
-    <!-- Standard rate purchases (20%) to Standard rated purchases from EC -->
-    <record id="fp_tax_template_b2b_ni_eu_PT11_PT8" model="account.fiscal.position.tax.template">
+    <!-- Purchase Taxes -->
+
+    <!-- Standard rated purchases to Standard rated purchases reverse charge deemed supply (20%) -->
+    <record id="fp_tax_template_b2b_ni_eu_PT11S_PT11RCDS" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
-        <field name="tax_src_id" ref="PT11"/>
-        <field name="tax_dest_id" ref="PT8"/>
+        <field name="tax_src_id" ref="PT11S"/>
+        <field name="tax_dest_id" ref="PT11RCDS"/>
+    </record>
+
+    <!-- Reduced rated purchases to Reduced rated purchases reverse charge deemed supply (5%) -->
+    <record id="fp_tax_template_b2b_ni_eu_PT5S_PT5RCDS" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="tax_src_id" ref="PT5S"/>
+        <field name="tax_dest_id" ref="PT5RCDS"/>
+    </record>
+
+    <!-- Zero rated purchases to Zero rated purchases reverse charge deemed supply (0%) -->
+    <record id="fp_tax_template_b2b_ni_eu_PT0S_PT0RCDS" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="tax_src_id" ref="PT0S"/>
+        <field name="tax_dest_id" ref="PT0RCDS"/>
     </record>
 
 </odoo>

--- a/addons/l10n_uk/data/account_fiscal_position_template_data.xml
+++ b/addons/l10n_uk/data/account_fiscal_position_template_data.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- = = = = = = = = = = = = = = = -->
+    <!-- Fiscal Position Templates     -->
+    <!-- = = = = = = = = = = = = = = = -->
+
+    <!-- Brexit Great Britain to Northern Ireland Fiscal Position -->
+    <record id="fiscal_position_template_gb_ni" model="account.fiscal.position.template">
+        <field name="sequence">1</field>
+        <field name="name">Great Britain to Northern Ireland</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="auto_apply" eval="True"/>
+        <field name="vat_required" eval="False" />
+        <field name="country_id" ref="base.uk"></field>
+    </record>
+
+    <!-- Brexit Northern Ireland to Great Britain Fiscal Position -->
+    <record id="fiscal_position_template_ni_gb" model="account.fiscal.position.template">
+        <field name="sequence">1</field>
+        <field name="name">Northern Ireland to Great Britain</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="auto_apply" eval="True"/>
+        <field name="vat_required" eval="False" />
+        <field name="country_id" ref="base.uk"></field>
+    </record>
+
+    <!-- Northern Ireland to EU Fiscal Position -->
+    <record id="fiscal_position_template_b2b_goods_ni_eu" model="account.fiscal.position.template">
+        <field name="sequence">1</field>
+        <field name="name">Northern Ireland to European Union Member States</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="auto_apply" eval="True"/>
+        <field name="vat_required" eval="True"/>
+        <field name="country_id" ref="base.uk"></field>
+    </record>
+
+    <!-- Great Britain to EU Fiscal Position -->
+    <record id="fiscal_position_template_gb_eu" model="account.fiscal.position.template">
+        <field name="sequence">1</field>
+        <field name="name">Great Britain to European Union Member States</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="auto_apply" eval="True"/>
+        <field name="vat_required" eval="False" />
+        <field name="country_id" ref="base.uk"></field>
+    </record>
+
+    <!-- = = = = = = = = = = = = = = = -->
+    <!-- Fiscal Position Tax Templates -->
+    <!-- = = = = = = = = = = = = = = = -->
+
+    <!-- <!-\- Northern Ireland to EU Fiscal Position Taxes -\-> -->
+    <!-- <!-\- Sales Taxes -\-> -->
+    <!-- <!-\- Zero Rated to Sales to customers in EC -\-> -->
+    <record id="fp_tax_template_b2b_ni_eu_ST0_ST4" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="tax_src_id" ref="ST0"/>
+        <field name="tax_dest_id" ref="ST4"/>
+    </record>
+
+    <!-- <!-\- Exempt Sales to Sales to customers in EC -\-> -->
+    <record id="fp_tax_template_b2b_ni_eu_ST2_ST4" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="tax_src_id" ref="ST2"/>
+        <field name="tax_dest_id" ref="ST4"/>
+    </record>
+
+    <!-- Zero rated sales to Sales to customers in EC -->
+    <record id="fp_tax_template_b2b_ni_eu_ST0_ST4" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="tax_src_id" ref="ST0"/>
+        <field name="tax_dest_id" ref="ST4"/>
+    </record>
+
+    <!-- Reduced rate sales (5%) to Sales to customers in EC -->
+    <record id="fp_tax_template_b2b_ni_eu_ST5_ST4" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="tax_src_id" ref="ST5"/>
+        <field name="tax_dest_id" ref="ST4"/>
+    </record>
+
+    <!-- Standard rate sales (20%) to Sales to customers in EC -->
+    <record id="fp_tax_template_b2b_ni_eu_ST11_ST4" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="tax_src_id" ref="ST11"/>
+        <field name="tax_dest_id" ref="ST4"/>
+    </record>
+
+    <!-- Purchase Taxes -->
+    <!-- Zero rated purchases to Zero rated purchases from EC -->
+    <record id="fp_tax_template_b2b_ni_eu_PT0_PT7" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="tax_src_id" ref="PT0"/>
+        <field name="tax_dest_id" ref="PT7"/>
+    </record>
+
+    <!-- Exempt purchases to Zero rated purchases from EC -->
+    <record id="fp_tax_template_b2b_ni_eu_PT2_PT7" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="tax_src_id" ref="PT2"/>
+        <field name="tax_dest_id" ref="PT7"/>
+    </record>
+
+    <!-- Lower rate purchases (5%) to Standard rated purchases from EC -->
+    <record id="fp_tax_template_b2b_ni_eu_PT5_PT8" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="tax_src_id" ref="PT5"/>
+        <field name="tax_dest_id" ref="PT8"/>
+    </record>
+
+    <!-- Standard rate purchases (20%) to Standard rated purchases from EC -->
+    <record id="fp_tax_template_b2b_ni_eu_PT11_PT8" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_goods_ni_eu"/>
+        <field name="tax_src_id" ref="PT11"/>
+        <field name="tax_dest_id" ref="PT8"/>
+    </record>
+
+</odoo>

--- a/addons/l10n_uk/data/account_fiscal_position_template_data.xml
+++ b/addons/l10n_uk/data/account_fiscal_position_template_data.xml
@@ -11,21 +11,21 @@
         they are just here to distinguish domestic trade
         from trade with the "rest of the world"
     -->
-    <!-- <record id="fiscal_position_template_domestic" model="account.fiscal.position.template"> -->
-    <!--     <field name="sequence">1</field> -->
-    <!--     <field name="name">UK Domestic</field> -->
-    <!--     <field name="chart_template_id" ref="l10n_uk"/> -->
-    <!--     <field name="auto_apply" eval="True"/> -->
-    <!--     <field name="vat_required" eval="False" /> -->
-    <!--     <field name="country_id" ref="base.uk"></field> -->
-    <!-- </record> -->
-
-    <record id="fiscal_position_template_domestic" model="account.fiscal.position.template">
+    <record id="fiscal_position_template_domestic_b2c" model="account.fiscal.position.template">
         <field name="sequence">1</field>
-        <field name="name">UK Domestic B2B</field>
+        <field name="name">UK domestic B2C</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="auto_apply" eval="True"/>
         <field name="vat_required" eval="False" />
+        <field name="country_id" ref="base.uk"></field>
+    </record>
+
+    <record id="fiscal_position_template_domestic_b2b" model="account.fiscal.position.template">
+        <field name="sequence">1</field>
+        <field name="name">UK domestic B2B</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="auto_apply" eval="True"/>
+        <field name="vat_required" eval="True" />
         <field name="country_id" ref="base.uk"></field>
     </record>
 
@@ -42,7 +42,7 @@
     <!-- United Kingdom to "Rest of World" Fiscal Position -->
     <record id="fiscal_position_template_b2b_row" model="account.fiscal.position.template">
         <field name="sequence">3</field>
-        <field name="name">Great Britain to the rest of the world</field>
+        <field name="name">United Kingdom to the rest of the world B2B</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="auto_apply" eval="True"/>
         <field name="vat_required" eval="False"/>
@@ -71,8 +71,15 @@
         <field name="tax_dest_id" ref="ST4"/>
     </record>
 
-    <record id="fp_tax_template_b2b_ni_eu_ST5G_ST4" model="account.fiscal.position.tax.template">
+    <!-- Reduced rate sales (12.5%) to Sales to customers in EC -->
+    <record id="fp_tax_template_b2b_ni_eu_ST125G_ST4" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
+        <field name="tax_src_id" ref="ST125G"/>
+        <field name="tax_dest_id" ref="ST4"/>
+    </record>
+
     <!-- Reduced rate sales (5%) to Sales to customers in EC -->
+    <record id="fp_tax_template_b2b_ni_eu_ST5G_ST4" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
         <field name="tax_src_id" ref="ST5G"/>
         <field name="tax_dest_id" ref="ST4"/>
@@ -102,11 +109,18 @@
         <field name="tax_dest_id" ref="PT8"/>
     </record>
 
-    <!-- Reduced rated purchases (5%) to Standard rated purchases from EC -->
-    <record id="fp_tax_template_b2b_ni_eu_PT5G_PT8" model="account.fiscal.position.tax.template">
+    <!-- Reduced rated purchases (12.5%) to Reduced rated purchases from EC -->
+    <record id="fp_tax_template_b2b_ni_eu_PT125G_PT125E" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
+        <field name="tax_src_id" ref="PT125G"/>
+        <field name="tax_dest_id" ref="PT125E"/>
+    </record>
+
+    <!-- Reduced rated purchases (5%) to Reduced rated purchases from EC -->
+    <record id="fp_tax_template_b2b_ni_eu_PT5G_PT5E" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
         <field name="tax_src_id" ref="PT5G"/>
-        <field name="tax_dest_id" ref="PT8"/>
+        <field name="tax_dest_id" ref="PT5E"/>
     </record>
 
     <!-- Zero rated purchases to Zero rated purchases from EC -->
@@ -147,11 +161,18 @@
         <field name="tax_dest_id" ref="PT11RCDS"/>
     </record>
 
-    <!-- Reduced rated purchases to Reduced rated purchases reverse charge deemed supply (5%) -->
+    <!-- Reduced rated purchases (5%) to Reduced rated purchases reverse charge deemed supply (5%) -->
     <record id="fp_tax_template_b2b_ni_eu_PT5S_PT5RCDS" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
         <field name="tax_src_id" ref="PT5S"/>
         <field name="tax_dest_id" ref="PT5RCDS"/>
+    </record>
+
+    <!-- Reduced rated purchases (5%) to Reduced rated purchases reverse charge deemed supply (5%) -->
+    <record id="fp_tax_template_b2b_ni_eu_PT125S_PT125RCDS" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_b2b_ni_eu"/>
+        <field name="tax_src_id" ref="PT125S"/>
+        <field name="tax_dest_id" ref="PT125RCDS"/>
     </record>
 
     <!-- Zero rated purchases to Zero rated purchases reverse charge deemed supply (0%) -->

--- a/addons/l10n_uk/data/account_tax_data.xml
+++ b/addons/l10n_uk/data/account_tax_data.xml
@@ -133,7 +133,7 @@
         <field name="description">PT8</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">purchase</field>
-        <field name="name">(Northern Ireland) Standard rated purchases from EU member states</field>
+        <field name="name">Standard rated purchases from EC</field>
         <field name="amount_type">percent</field>
         <field name="amount">20</field>
         <field name="tax_group_id" ref="tax_group_0"/>
@@ -253,7 +253,7 @@
         <field name="description">ST4</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">sale</field>
-        <field name="name">(Northern Ireland) Sales to customers in European member states</field>
+        <field name="name">Sales to customers in EC</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
         <field name="tax_group_id" ref="tax_group_0"/>
@@ -285,7 +285,7 @@
         <field name="description">PT7</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">purchase</field>
-        <field name="name">(Northern Ireland) Zero rated purchases from European member states</field>
+        <field name="name">Zero rated purchases from EC</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
         <field name="tax_group_id" ref="tax_group_0"/>

--- a/addons/l10n_uk/data/account_tax_data.xml
+++ b/addons/l10n_uk/data/account_tax_data.xml
@@ -1,11 +1,205 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
 
-    <record id="ST0" model="account.tax.template">
-        <field name="description">ST0</field>
+    <!-- = = = = = = = -->
+    <!-- Domestic VAT  -->
+    <!-- = = = = = = = -->
+
+    <!-- = = = = = = -->
+    <!-- Normal VAT  -->
+    <!-- = = = = = = -->
+
+    <!-- = = = -->
+    <!-- Sales -->
+    <!-- = = = -->
+
+    <record id="ST11G" model="account.tax.template">
+        <field name="description">VAT 20%</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">sale</field>
-        <field name="name">Zero rated sales</field>
+        <field name="name">Standard rated sales (20%)</field>
+        <field name="tax_scope">consu</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">20</field>
+        <field name="tax_group_id" ref="tax_group_20"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2200'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2200'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+        ]"/>
+    </record>
+
+	<record id="ST5G" model="account.tax.template">
+        <field name="description">VAT 5%</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">sale</field>
+        <field name="name">Reduced rated sales (5%)</field>
+        <field name="tax_scope">consu</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">5</field>
+        <field name="tax_group_id" ref="tax_group_0"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2200'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2200'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+        ]"/>
+    </record>
+
+    <record id="ST0G" model="account.tax.template">
+        <field name="description">VAT 0%</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">sale</field>
+        <field name="name">Zero rated sales (0%)</field>
+        <field name="tax_scope">consu</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">0</field>
+        <field name="tax_group_id" ref="tax_group_0"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+    </record>
+
+    <record id="ST11S" model="account.tax.template">
+        <field name="description">VAT 20%</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">sale</field>
+        <field name="name">Standard rated sales (20%)</field>
+        <field name="tax_scope">service</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">20</field>
+        <field name="tax_group_id" ref="tax_group_20"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2200'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2200'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+        ]"/>
+    </record>
+
+	<record id="ST5S" model="account.tax.template">
+        <field name="description">VAT 5%</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">sale</field>
+        <field name="name">Reduced rated sales (5%)</field>
+        <field name="tax_scope">service</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">5</field>
+        <field name="tax_group_id" ref="tax_group_0"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2200'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2200'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+        ]"/>
+    </record>
+
+    <record id="ST0S" model="account.tax.template">
+        <field name="description">VAT 0%</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">sale</field>
+        <field name="name">Zero rated sales (0%)</field>
+        <field name="tax_scope">service</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
         <field name="tax_group_id" ref="tax_group_0"/>
@@ -34,7 +228,7 @@
     </record>
 
     <record id="ST2" model="account.tax.template">
-        <field name="description">ST2</field>
+        <field name="description">VAT exempt</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Exempt sales</field>
@@ -65,11 +259,197 @@
         ]"/>
     </record>
 
-    <record id="PT0" model="account.tax.template">
-        <field name="description">PT0</field>
+    <!-- = = = = = -->
+    <!-- Purchases -->
+    <!-- = = = = = -->
+
+    <record id="PT11G" model="account.tax.template">
+        <field name="description">VAT 20%</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">purchase</field>
-        <field name="name">Zero rated purchases</field>
+        <field name="name">Standard rated purchases (20%)</field>
+        <field name="tax_scope">consu</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">20</field>
+        <field name="tax_group_id" ref="tax_group_20"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+    </record>
+
+    <record id="PT5G" model="account.tax.template">
+        <field name="description">VAT 5%</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Reduced rated purchases (5%)</field>
+        <field name="tax_scope">consu</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">5</field>
+        <field name="tax_group_id" ref="tax_group_5"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+    </record>
+
+    <record id="PT0G" model="account.tax.template">
+        <field name="description">VAT 0%</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Zero rated purchases (0%)</field>
+        <field name="tax_scope">consu</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">0</field>
+        <field name="tax_group_id" ref="tax_group_0"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+    </record>
+
+    <record id="PT11S" model="account.tax.template">
+        <field name="description">VAT 20%</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Standard rated purchases (20%)</field>
+        <field name="tax_scope">service</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">20</field>
+        <field name="tax_group_id" ref="tax_group_20"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+    </record>
+
+    <record id="PT5S" model="account.tax.template">
+        <field name="description">VAT 5%</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Reduced rated purchases (5%)</field>
+        <field name="tax_scope">service</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">5</field>
+        <field name="tax_group_id" ref="tax_group_5"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+    </record>
+
+    <record id="PT0S" model="account.tax.template">
+        <field name="description">VAT 0%</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Zero rated purchases (0%)</field>
+        <field name="tax_scope">service</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
         <field name="tax_group_id" ref="tax_group_0"/>
@@ -98,7 +478,7 @@
     </record>
 
     <record id="PT2" model="account.tax.template">
-        <field name="description">PT2</field>
+        <field name="description">VAT exempt</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Exempt purchases</field>
@@ -129,14 +509,63 @@
         ]"/>
     </record>
 
+    <!-- = = = = = = = = = = = = = = = = = = = = -->
+    <!-- European Union VAT for Northern Ireland -->
+    <!-- = = = = = = = = = = = = = = = = = = = = -->
+
+    <!-- With respect to the Northern Ireland protocol, Northern Ireland is formally outside of the of the EU single market -->
+    <!-- but will, in effect, still follow EU rules regarding customs and VAT in the trade of goods -->
+
+    <!-- = = = -->
+    <!-- Sales -->
+    <!-- = = = -->
+
+    <record id="ST4" model="account.tax.template">
+        <field name="description">VAT 0% EU</field>
+        <field name="chart_template_id" ref="l10n_uk_ni"/>
+        <field name="type_tax_use">sale</field>
+        <field name="name">Sales to customers in EC (0%)</field>
+        <field name="tax_scope">consu</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">0</field>
+        <field name="tax_group_id" ref="tax_group_0"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box8'), ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box8'), ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+    </record>
+
+    <!-- = = = = = -->
+    <!-- Purchases -->
+    <!-- = = = = = -->
+
     <record id="PT8" model="account.tax.template">
-        <field name="description">PT8</field>
-        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="description">VAT 20% EU</field>
+        <field name="chart_template_id" ref="l10n_uk_ni"/>
         <field name="type_tax_use">purchase</field>
-        <field name="name">Standard rated purchases from EC</field>
+        <field name="name">Standard rated purchases from EC (20%)</field>
+        <field name="tax_scope">consu</field>
         <field name="amount_type">percent</field>
         <field name="amount">20</field>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_20"/>
 		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
             (0,0, {
                 'factor_percent': 100,
@@ -177,11 +606,12 @@
         ]"/>
     </record>
 
-    <record id="PT5" model="account.tax.template">
-        <field name="description">PT5</field>
-        <field name="chart_template_id" ref="l10n_uk"/>
+    <record id="PT5E" model="account.tax.template">
+        <field name="description">VAT 5% EU</field>
+        <field name="chart_template_id" ref="l10n_uk_ni"/>
         <field name="type_tax_use">purchase</field>
-        <field name="name">Lower rate purchases (5%)</field>
+        <field name="name">Reduced rated purchases from EC (5%)</field>
+        <field name="tax_scope">consu</field>
         <field name="amount_type">percent</field>
         <field name="amount">5</field>
         <field name="tax_group_id" ref="tax_group_5"/>
@@ -189,103 +619,48 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box9'), ref('account_tax_report_line_exd_vat_box7')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('2201'),
-                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5,0,0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box2')],
             }),
             (0,0, {
-                'factor_percent': 100,
+                'factor_percent': -100,
                 'repartition_type': 'tax',
                 'account_id': ref('2201'),
                 'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
             }),
         ]"/>
-    </record>
-
-	<record id="ST5" model="account.tax.template">
-        <field name="description">ST5</field>
-        <field name="chart_template_id" ref="l10n_uk"/>
-        <field name="type_tax_use">sale</field>
-        <field name="name">Lower rate sales (5%)</field>
-        <field name="amount_type">percent</field>
-        <field name="amount">5</field>
-        <field name="tax_group_id" ref="tax_group_0"/>
-		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('2200'),
-                'plus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
-            }),
-        ]"/>
         <field name="refund_repartition_line_ids" eval="[(5,0,0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box9'), ref('account_tax_report_line_exd_vat_box7')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('2200'),
-                'minus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
-            }),
-        ]"/>
-    </record>
-
-    <record id="ST4" model="account.tax.template">
-        <field name="description">ST4</field>
-        <field name="chart_template_id" ref="l10n_uk"/>
-        <field name="type_tax_use">sale</field>
-        <field name="name">Sales to customers in EC</field>
-        <field name="amount_type">percent</field>
-        <field name="amount">0</field>
-        <field name="tax_group_id" ref="tax_group_0"/>
-		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box8'), ref('account_tax_report_line_exd_vat_box6')],
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box2')],
             }),
             (0,0, {
-                'factor_percent': 100,
+                'factor_percent': -100,
                 'repartition_type': 'tax',
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5,0,0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box8'), ref('account_tax_report_line_exd_vat_box6')],
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
             }),
         ]"/>
     </record>
 
     <record id="PT7" model="account.tax.template">
-        <field name="description">PT7</field>
-        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="description">VAT 0% EU</field>
+        <field name="chart_template_id" ref="l10n_uk_ni"/>
         <field name="type_tax_use">purchase</field>
-        <field name="name">Zero rated purchases from EC</field>
+        <field name="name">Zero rated purchases from EC (0%)</field>
+        <field name="tax_scope">consu</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
         <field name="tax_group_id" ref="tax_group_0"/>
@@ -313,47 +688,20 @@
         ]"/>
     </record>
 
-    <record id="ST11" model="account.tax.template">
-        <field name="description">ST11</field>
-        <field name="chart_template_id" ref="l10n_uk"/>
-        <field name="type_tax_use">sale</field>
-        <field name="name">Standard rate sales (20%)</field>
-        <field name="amount_type">percent</field>
-        <field name="amount">20</field>
-        <field name="tax_group_id" ref="tax_group_20"/>
-		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('2200'),
-                'plus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5,0,0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('2200'),
-                'minus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
-            }),
-        ]"/>
-    </record>
+    <!-- = = = = = = = = = = = = = = = = = = -->
+    <!-- 'Rest of World' IMPORT/EXPORT taxes -->
+    <!-- = = = = = = = = = = = = = = = = = = -->
 
-    <record id="PT11" model="account.tax.template">
-        <field name="description">PT11</field>
+    <!-- = = = = = = = -->
+    <!-- Import taxes  -->
+    <!-- = = = = = = = -->
+
+    <record id="PT11IP" model="account.tax.template">
+        <field name="description">VAT 20% import postponed</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">purchase</field>
-        <field name="name">Standard rate purchases (20%)</field>
+        <field name="name">Standard rated imports postponed (20%)</field>
+        <field name="tax_scope">consu</field>
         <field name="amount_type">percent</field>
         <field name="amount">20</field>
         <field name="tax_group_id" ref="tax_group_20"/>
@@ -367,7 +715,62 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box9'), ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
                 'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+    </record>
+
+    <record id="PT5IP" model="account.tax.template">
+        <field name="description">VAT 5% import postponed</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Reduced rated imports postponed (5%)</field>
+        <field name="tax_scope">consu</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">5</field>
+        <field name="tax_group_id" ref="tax_group_5"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box2')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5,0,0),
@@ -380,7 +783,370 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box2')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+    </record>
+
+    <record id="PT0I" model="account.tax.template">
+        <field name="description">VAT 0% import</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Zero rated imports (0%)</field>
+        <field name="tax_scope">consu</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">0</field>
+        <field name="tax_group_id" ref="tax_group_0"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+    </record>
+    <!-- = = = = = = = -->
+    <!-- Export taxes  -->
+    <!-- = = = = = = = -->
+
+    <record id="ST0E" model="account.tax.template">
+        <field name="description">VAT 0% export</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">sale</field>
+        <field name="name">Zero rated exports (0%)</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">0</field>
+        <field name="tax_group_id" ref="tax_group_0"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+    </record>
+
+    <!-- = = = = = = = = = = = -->
+    <!-- Reverse charge Taxes  -->
+    <!-- = = = = = = = = = = = -->
+
+    <!--
+
+    Reverse charge taxes can apply to some domestic purchases, such as wholesale gas and mobile phones [1].
+    In this case, the seller is not required to collect any tax, and the buyer can add the tax to both
+    their inputs and outputs.
+
+    When buying services from from a supplier outside of the UK, when the place of supply is in the UK,
+    when you belong in the UK and are VAT registered, the reverse charge proceedure also applies.
+    The case of deemed supply applies to cases when receiving services from outside of the UK and some domestic
+    transactions. Deemed supply essentially suggests that you behave as though you are the
+    "both the supplier and recipient of the services" [2].
+
+    [1] https://www.gov.uk/guidance/the-vat-domestic-reverse-charge-procedure-notice-735#para3
+    [2] https://www.gov.uk/guidance/vat-place-of-supply-of-services-notice-741a#sec5
+
+    -->
+
+    <!-- = = = = = -->
+    <!-- Purchases -->
+    <!-- = = = = = -->
+
+    <record id="PT11RCDS" model="account.tax.template">
+        <field name="description">VAT 20% reverse charge</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Standard rated purchases reverse charge deemed supply (20%)</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">20</field>
+        <field name="tax_group_id" ref="tax_group_20"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6'), ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
                 'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6'), ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+    </record>
+
+    <record id="PT5RCDS" model="account.tax.template">
+        <field name="description">VAT 5% reverse charge</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Reduced rated purchases reverse charge deemed supply (5%)</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">5</field>
+        <field name="tax_group_id" ref="tax_group_5"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6'), ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6'), ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+    </record>
+
+    <!--
+    This tax has limited relevance, but it is applicable on foreign supply of services, see section 5.5 in [2].
+    -->
+
+    <record id="PT0RCDS" model="account.tax.template">
+        <field name="description">VAT 0% reverse charge</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Zero rated purchases reverse charge deemed supply (0%)</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">0</field>
+        <field name="tax_group_id" ref="tax_group_0"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6'), ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6'), ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+    </record>
+
+    <record id="PT11RC" model="account.tax.template">
+        <field name="description">VAT 20% reverse charge</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Standard rated purchases reverse charge (20%)</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">20</field>
+        <field name="tax_group_id" ref="tax_group_20"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+    </record>
+
+    <record id="PT5RC" model="account.tax.template">
+        <field name="description">VAT 5% reverse charge</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Reduced rated purchases reverse charge (5%)</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">5</field>
+        <field name="tax_group_id" ref="tax_group_5"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+    </record>
+
+    <!-- = = = -->
+    <!-- Sales -->
+    <!-- = = = -->
+
+    <record id="ST0RC" model="account.tax.template">
+        <field name="description">VAT to be accounted under reverse charge</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">sale</field>
+        <field name="name">Zero rated sales reverse charge (0%)</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">0</field>
+        <field name="tax_group_id" ref="tax_group_0"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
             }),
         ]"/>
     </record>

--- a/addons/l10n_uk/data/account_tax_data.xml
+++ b/addons/l10n_uk/data/account_tax_data.xml
@@ -826,6 +826,40 @@
             }),
         ]"/>
     </record>
+
+    <record id="PT2I" model="account.tax.template">
+        <field name="description">Exempt import</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Exempt imports (0%)</field>
+        <field name="tax_scope">consu</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">0</field>
+        <field name="tax_group_id" ref="tax_group_0"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+    </record>
+
     <!-- = = = = = = = -->
     <!-- Export taxes  -->
     <!-- = = = = = = = -->
@@ -834,7 +868,7 @@
         <field name="description">VAT 0% export</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">sale</field>
-        <field name="name">Zero rated exports (0%)</field>
+        <field name="name">Exports (0%)</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
         <field name="tax_group_id" ref="tax_group_0"/>
@@ -888,7 +922,7 @@
     <!-- = = = = = -->
 
     <record id="PT11RCDS" model="account.tax.template">
-        <field name="description">VAT 20% reverse charge</field>
+        <field name="description">VAT 20% reverse charge deemed supply</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Standard rated purchases reverse charge deemed supply (20%)</field>
@@ -936,7 +970,7 @@
     </record>
 
     <record id="PT5RCDS" model="account.tax.template">
-        <field name="description">VAT 5% reverse charge</field>
+        <field name="description">VAT 5% reverse charge deemed supply</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Reduced rated purchases reverse charge deemed supply (5%)</field>
@@ -988,7 +1022,7 @@
     -->
 
     <record id="PT0RCDS" model="account.tax.template">
-        <field name="description">VAT 0% reverse charge</field>
+        <field name="description">VAT 0% reverse charge deemed supply</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Zero rated purchases reverse charge deemed supply (0%)</field>

--- a/addons/l10n_uk/data/account_tax_data.xml
+++ b/addons/l10n_uk/data/account_tax_data.xml
@@ -133,7 +133,7 @@
         <field name="description">PT8</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">purchase</field>
-        <field name="name">Standard rated purchases from EC</field>
+        <field name="name">(Northern Ireland) Standard rated purchases from EU member states</field>
         <field name="amount_type">percent</field>
         <field name="amount">20</field>
         <field name="tax_group_id" ref="tax_group_0"/>
@@ -253,7 +253,7 @@
         <field name="description">ST4</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">sale</field>
-        <field name="name">Sales to customers in EC</field>
+        <field name="name">(Northern Ireland) Sales to customers in European member states</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
         <field name="tax_group_id" ref="tax_group_0"/>
@@ -285,7 +285,7 @@
         <field name="description">PT7</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">purchase</field>
-        <field name="name">Zero rated purchases from EC</field>
+        <field name="name">(Northern Ireland) Zero rated purchases from European member states</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
         <field name="tax_group_id" ref="tax_group_0"/>

--- a/addons/l10n_uk/data/account_tax_data.xml
+++ b/addons/l10n_uk/data/account_tax_data.xml
@@ -50,6 +50,43 @@
         ]"/>
     </record>
 
+	<record id="ST125G" model="account.tax.template">
+        <field name="description">VAT 12.5%</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">sale</field>
+        <field name="name">Reduced rated sales (12.5%)</field>
+        <field name="tax_scope">consu</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">12.5</field>
+        <field name="tax_group_id" ref="tax_group_125"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2200'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2200'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+        ]"/>
+    </record>
+
 	<record id="ST5G" model="account.tax.template">
         <field name="description">VAT 5%</field>
         <field name="chart_template_id" ref="l10n_uk"/>
@@ -58,7 +95,7 @@
         <field name="tax_scope">consu</field>
         <field name="amount_type">percent</field>
         <field name="amount">5</field>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_5"/>
 		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
             (0,0, {
                 'factor_percent': 100,
@@ -157,6 +194,42 @@
         ]"/>
     </record>
 
+	<record id="ST125S" model="account.tax.template">
+        <field name="description">VAT 12.5%</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">sale</field>
+        <field name="name">Reduced rated sales (12.5%)</field>
+        <field name="tax_scope">service</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">12.5</field>
+        <field name="tax_group_id" ref="tax_group_125"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2200'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2200'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+        ]"/>
+    </record>
 	<record id="ST5S" model="account.tax.template">
         <field name="description">VAT 5%</field>
         <field name="chart_template_id" ref="l10n_uk"/>
@@ -165,7 +238,7 @@
         <field name="tax_scope">service</field>
         <field name="amount_type">percent</field>
         <field name="amount">5</field>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_5"/>
 		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
             (0,0, {
                 'factor_percent': 100,
@@ -300,6 +373,43 @@
         ]"/>
     </record>
 
+    <record id="PT125G" model="account.tax.template">
+        <field name="description">VAT 12.5%</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Reduced rated purchases (12.5%)</field>
+        <field name="tax_scope">consu</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">12.5</field>
+        <field name="tax_group_id" ref="tax_group_125"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+    </record>
+
     <record id="PT5G" model="account.tax.template">
         <field name="description">VAT 5%</field>
         <field name="chart_template_id" ref="l10n_uk"/>
@@ -406,6 +516,44 @@
             }),
         ]"/>
     </record>
+
+    <record id="PT125S" model="account.tax.template">
+        <field name="description">VAT 12.5%</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Reduced rated purchases (12.5%)</field>
+        <field name="tax_scope">service</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">12.5</field>
+        <field name="tax_group_id" ref="tax_group_125"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+    </record>
+
 
     <record id="PT5S" model="account.tax.template">
         <field name="description">VAT 5%</field>
@@ -606,6 +754,55 @@
         ]"/>
     </record>
 
+    <record id="PT125E" model="account.tax.template">
+        <field name="description">VAT 12.5% EU</field>
+        <field name="chart_template_id" ref="l10n_uk_ni"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Reduced rated purchases from EC (12.5%)</field>
+        <field name="tax_scope">consu</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">12.5</field>
+        <field name="tax_group_id" ref="tax_group_125"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box9'), ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box2')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box9'), ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box2')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+    </record>
+
     <record id="PT5E" model="account.tax.template">
         <field name="description">VAT 5% EU</field>
         <field name="chart_template_id" ref="l10n_uk_ni"/>
@@ -735,6 +932,55 @@
                 'repartition_type': 'tax',
                 'account_id': ref('2201'),
                 'minus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+    </record>
+
+    <record id="PT125IP" model="account.tax.template">
+        <field name="description">VAT 12.5% import postponed</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Reduced rated imports postponed (12.5%)</field>
+        <field name="tax_scope">consu</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">12.5</field>
+        <field name="tax_group_id" ref="tax_group_125"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box2')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box2')],
             }),
             (0,0, {
                 'factor_percent': -100,
@@ -969,6 +1215,54 @@
         ]"/>
     </record>
 
+    <record id="PT125RCDS" model="account.tax.template">
+        <field name="description">VAT 12.5% reverse charge</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Reduced rated purchases reverse charge deemed supply (12.5%)</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">12.5</field>
+        <field name="tax_group_id" ref="tax_group_125"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6'), ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box6'), ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+    </record>
+
     <record id="PT5RCDS" model="account.tax.template">
         <field name="description">VAT 5% reverse charge deemed supply</field>
         <field name="chart_template_id" ref="l10n_uk"/>
@@ -1061,6 +1355,54 @@
         <field name="amount_type">percent</field>
         <field name="amount">20</field>
         <field name="tax_group_id" ref="tax_group_20"/>
+		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5,0,0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('account_tax_report_line_exd_vat_box7')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'minus_report_line_ids': [ref('account_tax_report_line_vat_box1')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('2201'),
+                'plus_report_line_ids': [ref('account_tax_report_line_vat_box4')],
+            }),
+        ]"/>
+    </record>
+
+    <record id="PT125RC" model="account.tax.template">
+        <field name="description">VAT 12.5% reverse charge</field>
+        <field name="chart_template_id" ref="l10n_uk"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">Reduced rated purchases reverse charge (12.5%)</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">12.5</field>
+        <field name="tax_group_id" ref="tax_group_125"/>
 		<field name="invoice_repartition_line_ids" eval="[(5,0,0),
             (0,0, {
                 'factor_percent': 100,

--- a/addons/l10n_uk/data/account_tax_report_data.xml
+++ b/addons/l10n_uk/data/account_tax_report_data.xml
@@ -22,7 +22,7 @@
     </record>
 
     <record id="account_tax_report_line_vat_box2" model="account.tax.report.line">
-        <field name="name">[BOX 2] VAT due on acquisitions from EC</field>
+        <field name="name">[BOX 2] VAT due on acquisitions of goods made in Northern Ireland from EU Member States</field>
         <field name="tag_name">2</field>
         <field name="code">UKTAX_2</field>
         <field name="report_id" ref="tax_report"/>
@@ -39,7 +39,7 @@
     </record>
 
     <record id="account_tax_report_line_vat_box4" model="account.tax.report.line">
-        <field name="name">[BOX 4] VAT reclaimed on purchases and other inputs (including acquisitions from EC)</field>
+        <field name="name">[BOX 4] VAT reclaimed on purchases and other inputs (including acquisitions in Northern Ireland from EU member states)</field>
         <field name="tag_name">4</field>
         <field name="code">UKTAX_4</field>
         <field name="report_id" ref="tax_report"/>
@@ -48,7 +48,7 @@
     </record>
 
     <record id="account_tax_report_line_vat_box5" model="account.tax.report.line">
-        <field name="name">[BOX 5] VAT to pay/reclaim</field>
+        <field name="name">[BOX 5] Net VAT to pay to HMRC or reclaim</field>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence" eval="5"/>
         <field name="formula">UKTAX_1 + UKTAX_2 - UKTAX_4</field>
@@ -62,29 +62,29 @@
     </record>
 
     <record id="account_tax_report_line_exd_vat_box6" model="account.tax.report.line">
-        <field name="name">[BOX 6] Total value of sales and other outputs excluding VAT (including EC supplies)</field>
+        <field name="name">[BOX 6] Total value of sales and other outputs excluding VAT</field>
         <field name="tag_name">6</field>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence" eval="1"/>
         <field name="parent_id" ref="account_tax_report_line_exd_vat"/>
     </record>
 
-    <record id="account_tax_report_line_ec_exd_vat" model="account.tax.report.line">
-        <field name="name">EC Sales and Purchases excluding VAT</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
     <record id="account_tax_report_line_exd_vat_box7" model="account.tax.report.line">
-        <field name="name">[BOX 7] Total value of purchases and inputs excluding VAT (including EC acquisitions)</field>
+        <field name="name">[BOX 7] Total value of purchases and other inputs excluding VAT</field>
         <field name="tag_name">7</field>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence" eval="2"/>
         <field name="parent_id" ref="account_tax_report_line_exd_vat"/>
     </record>
 
+    <record id="account_tax_report_line_ec_exd_vat" model="account.tax.report.line">
+        <field name="name">Northern Ireland Sales and Purchases Excluding VAT</field>
+        <field name="report_id" ref="tax_report"/>
+        <field name="sequence" eval="3"/>
+    </record>
+
     <record id="account_tax_report_line_exd_vat_box8" model="account.tax.report.line">
-        <field name="name">[BOX 8] Total value of EC sales excluding VAT</field>
+        <field name="name">[BOX 8] Total value of dispatches of goods and related costs (excluding VAT) from Northern Ireland to EU member states</field>
         <field name="tag_name">8</field>
         <field name="code">UKTAX_8</field>
         <field name="report_id" ref="tax_report"/>
@@ -93,7 +93,7 @@
     </record>
 
     <record id="account_tax_report_line_exd_vat_box9" model="account.tax.report.line">
-        <field name="name">[BOX 9] Total value of EC purchases excluding VAT</field>
+        <field name="name">[BOX 9] Total value of acquisitions of goods and related costs (excluding VAT) made in Northern Ireland from EU member states</field>
         <field name="tag_name">9</field>
         <field name="code">UKTAX_9</field>
         <field name="report_id" ref="tax_report"/>

--- a/addons/l10n_uk/data/l10n_uk_chart_data.xml
+++ b/addons/l10n_uk/data/l10n_uk_chart_data.xml
@@ -2,10 +2,9 @@
 <odoo>
     <menuitem id="account_reports_uk_statements_menu" name="United Kingdom" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
 
-        <!-- Parent chart template -->
+        <!-- Generalised Great Britain Chart template. Applies to England, Scotland and Wales. Loaded by default -->
         <record id="l10n_uk" model="account.chart.template">
-            <field name="name">Generalised UK Tax and Account Chart Template</field>
-            <field name="visible" eval="0"/>
+            <field name="name">Great Britain Tax and Account Chart Template</field>
             <field name="bank_account_code_prefix">1200</field>
             <field name="cash_account_code_prefix">1210</field>
             <field name="transfer_account_code_prefix">1220</field>
@@ -26,15 +25,4 @@
             <field name="country_id" ref="base.uk"/>
         </record>
 
-        <!-- Great Britain consists of England, Scotland and Wales and has differing fiscal positions to Northern Ireland -->
-        <record id="l10n_uk_gb" model="account.chart.template">
-            <field name="name">Great Britain Account Chart of Accounts and Taxes</field>
-            <field name="bank_account_code_prefix">1200</field>
-            <field name="cash_account_code_prefix">1210</field>
-            <field name="transfer_account_code_prefix">1220</field>
-            <field name="code_digits">6</field>
-            <field name="currency_id" ref="base.GBP"/>
-            <field name="parent_id" ref="l10n_uk"/>
-            <field name="country_id" ref="base.uk"/>
-        </record>
 </odoo>

--- a/addons/l10n_uk/data/l10n_uk_chart_data.xml
+++ b/addons/l10n_uk/data/l10n_uk_chart_data.xml
@@ -2,9 +2,9 @@
 <odoo>
     <menuitem id="account_reports_uk_statements_menu" name="United Kingdom" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
 
-        <!-- Chart template -->
+        <!-- Parent chart template -->
         <record id="l10n_uk" model="account.chart.template">
-            <field name="name">UK Tax and Account Chart Template</field>
+            <field name="name">Generalised UK Tax and Account Chart Template</field>
             <field name="visible" eval="0"/>
             <field name="bank_account_code_prefix">1200</field>
             <field name="cash_account_code_prefix">1210</field>
@@ -14,8 +14,21 @@
             <field name="country_id" ref="base.uk"/>
         </record>
 
+        <!-- Northern Ireland requires its own CoA for the differing taxes and fiscal positions it has as a result of the Northern Ireland protocol -->
         <record id="l10n_uk_ni" model="account.chart.template">
-            <field name="name">Northern Ireland Tax and Account Chart Template</field>
+            <field name="name">Northern Ireland Chart of Accounts and Taxes</field>
+            <field name="bank_account_code_prefix">1200</field>
+            <field name="cash_account_code_prefix">1210</field>
+            <field name="transfer_account_code_prefix">1220</field>
+            <field name="code_digits">6</field>
+            <field name="currency_id" ref="base.GBP"/>
+            <field name="parent_id" ref="l10n_uk"/>
+            <field name="country_id" ref="base.uk"/>
+        </record>
+
+        <!-- Great Britain consists of England, Scotland and Wales and has differing fiscal positions to Northern Ireland -->
+        <record id="l10n_uk_gb" model="account.chart.template">
+            <field name="name">Great Britain Account Chart of Accounts and Taxes</field>
             <field name="bank_account_code_prefix">1200</field>
             <field name="cash_account_code_prefix">1210</field>
             <field name="transfer_account_code_prefix">1220</field>

--- a/addons/l10n_uk/data/l10n_uk_chart_data.xml
+++ b/addons/l10n_uk/data/l10n_uk_chart_data.xml
@@ -4,12 +4,24 @@
 
         <!-- Chart template -->
         <record id="l10n_uk" model="account.chart.template">
-            <field name="name">UK Tax and Account Chart Template (by SmartMode)</field>
+            <field name="name">UK Tax and Account Chart Template</field>
+            <field name="visible" eval="0"/>
             <field name="bank_account_code_prefix">1200</field>
             <field name="cash_account_code_prefix">1210</field>
             <field name="transfer_account_code_prefix">1220</field>
             <field name="code_digits">6</field>
             <field name="currency_id" ref="base.GBP"/>
+            <field name="country_id" ref="base.uk"/>
+        </record>
+
+        <record id="l10n_uk_ni" model="account.chart.template">
+            <field name="name">Northern Ireland Tax and Account Chart Template</field>
+            <field name="bank_account_code_prefix">1200</field>
+            <field name="cash_account_code_prefix">1210</field>
+            <field name="transfer_account_code_prefix">1220</field>
+            <field name="code_digits">6</field>
+            <field name="currency_id" ref="base.GBP"/>
+            <field name="parent_id" ref="l10n_uk"/>
             <field name="country_id" ref="base.uk"/>
         </record>
 </odoo>


### PR DESCRIPTION
WIP

After the Brexit transition period ended, the UK is officially no longer part of the European single market. However, Northern Ireland still trades within the single market when selling/purchasing goods from EU member states. When selling/purchasing services from EU member states, businesses in Northern Ireland follow UK tax rules.

The current list of taxes in l10n_uk was not sufficient to represent both this kind of trade with the EU from Northern Ireland, and UK trade with the rest of the world. I've tried to add taxes that I think should cover most types of transactions.

Since Northern Ireland's trade situation differs from England, Scotland and Wales (Great Britain), I've constructed a chart of accounts specific to Northern Ireland, and a chart of accounts specific to Great Britain. This allows for Northern Ireland to have specific taxes and fiscal positions that relate to trade from Northern with European Union member states.

The lines of the UK vat report have been updated to match what is specified by HMRC for the report. The mechanism for uploading the tax report hasn't changed. 