### PR TITLE
[FIX] remove company_id from dropshiping route

### DIFF
--- a/addons/stock_dropshipping/models/res_company.py
+++ b/addons/stock_dropshipping/models/res_company.py
@@ -106,6 +106,7 @@ class ResCompany(models.Model):
     @api.model
     def create_missing_dropship_rule(self):
         dropship_route = self.env.ref('stock_dropshipping.route_drop_shipping')
+        dropship_route.write({'company_id': None})
 
         company_ids = self.env['res.company'].search([])
         company_has_dropship_rule = self.env['stock.rule'].search([('route_id', '=', dropship_route.id)]).mapped('company_id')


### PR DESCRIPTION
If a company has been set for the default dropshiping
route, an inconsistency will occur between the
company of the newly created rule and
the company of the route. i.e. the rule and
corresponding route won't have the same company.

It can cause some confusion, this line:
https://github.com/odoo/odoo/blob/890a212e0ed5292b58196f73c8533fcb88a7b68c/addons/stock_dropshipping/models/stock.py#L13

will break all dropshiping rule that have no company.
It shouldn't be a problem since a new rule is
created for every company. However, if the newly
created rules have the inconsistency they cannot be used,
leaving no valid dropshipping rule.

This happened for upg-43553

Removing the company from the default
dropshiping route will make sure that all newly created
rules can be accessed by their respective company.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
