### PR TITLE
[FIX] base_vat: only use VIES service for company VAT numbers and not individuals

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -182,7 +182,8 @@ class ResPartner(models.Model):
         for partner in self:
             if not partner.vat:
                 continue
-            if company.vat_check_vies and partner.commercial_partner_id.country_id in eu_countries:
+            is_eu_country = partner.commercial_partner_id.country_id in eu_countries
+            if company.vat_check_vies and is_eu_country and partner.is_company:
                 # force full VIES online check
                 check_func = self.vies_vat_check
             else:

--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -178,15 +178,16 @@ class ResPartner(models.Model):
             company = self.env['res.company'].browse(self.env.context['company_id'])
         else:
             company = self.env.company
-        if company.vat_check_vies:
-            # force full VIES online check
-            check_func = self.vies_vat_check
-        else:
-            # quick and partial off-line checksum validation
-            check_func = self.simple_vat_check
+        eu_countries = self.env.ref('base.europe').country_ids
         for partner in self:
             if not partner.vat:
                 continue
+            if company.vat_check_vies and partner.commercial_partner_id.country_id in eu_countries:
+                # force full VIES online check
+                check_func = self.vies_vat_check
+            else:
+                # quick and partial off-line checksum validation
+                check_func = self.simple_vat_check
             #check with country code as prefix of the TIN
             failed_check = False
             vat_country_code, vat_number = self._split_vat(partner.vat)

--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -50,11 +50,6 @@ class TestStructure(common.TransactionCase):
             "vat": "ATU12345675",
             "company_type": "company",
         })
-        contact = self.env["res.partner"].create({
-            "name": "Sylvestre",
-            "parent_id": company.id,
-            "company_type": "person",
-        })
 
         def mock_check_vies(vat_number):
             """ Fake vatnumber method that will only allow one number """


### PR DESCRIPTION
Partial backport of 9a46cc7ad89544a5669b4e5a7ae8b6c31d52eab3 to do the VIES check only for companies in the EU

And

Some countries, such as Portugal, persons also have VAT-like tax numbers, that can be used in invoices, just like company VAT numbers can.

Originally by @dreispt in #76856

**Current behavior before PR:**
We check the VAT of individuals with VIES which results in a failure.

**Desired behavior after PR is merged:**
We should only check the VAT with VIES for companies.