### PR TITLE
[FIX] website_sale: check combination before add to cart

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -465,8 +465,16 @@ publicWidget.registry.WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
      */
     _onClickAdd: function (ev) {
         ev.preventDefault();
-        this.isBuyNow = $(ev.currentTarget).attr('id') === 'buy_now';
-        return this._handleAdd($(ev.currentTarget).closest('form'));
+        var def = () => {
+            this.isBuyNow = $(ev.currentTarget).attr('id') === 'buy_now';
+            return this._handleAdd($(ev.currentTarget).closest('form'));
+        };
+        if ($('.js_add_cart_variants').children().length) {
+            return this._getCombinationInfo(ev).then(() => {
+                return !$(ev.target).closest('.js_product').hasClass("css_not_available") ? def() : Promise.resolve();
+            });
+        }
+        return def();
     },
     /**
      * Initializes the optional products modal


### PR DESCRIPTION
Steps to reproduce the issue:

- Install "eCommerce" module
- Create 2 attributes with 'Variants Creation Mode' is Never and
  one of them should have at least 2 values.
- Create a product and add the two attributes as variants and
  one of them should have at least one value
- Go to configure variant and select the first attribute and
  exclude one or more values from the second variant
- Go to the website and change the variant to a value from the one
  you excluded and add to the cart directly (you should be fast).

Issue:

    Product with a not possible combination is added to cart.

Cause:

    Not checking if the combination is possible before adding to cart.

Solution:

    When adding product to cart, trigger _getCombinationInfo to retrieve
    last combination info, then add it only if the combination is
    possible.

opw-2569109