### PR TITLE
[FIX] website: fix ripple effect on buttons

### DIFF
--- a/addons/website/models/theme_models.py
+++ b/addons/website/models/theme_models.py
@@ -221,8 +221,8 @@ class Theme(models.AbstractModel):
         )
 
         # Reinitialize effets
-        self.disable_asset('website.ripple_effect_scss')
-        self.disable_asset('website.ripple_effect_js')
+        self.disable_asset('Ripple effect SCSS')
+        self.disable_asset('Ripple effect JS')
 
         # Reinitialize header templates
         self.disable_view('website.template_header_hamburger')
@@ -250,6 +250,7 @@ class Theme(models.AbstractModel):
         # Reinitialize footer scrolltop template
         self.disable_view('website.option_footer_scrolltop')
 
+    # TODO Rename name in key and search with the key in master
     @api.model
     def _toggle_asset(self, name, active):
         ThemeAsset = self.env['theme.ir.asset'].sudo().with_context(active_test=False)
@@ -259,7 +260,7 @@ class Theme(models.AbstractModel):
             obj = obj.copy_ids.filtered(lambda x: x.website_id == website)
         else:
             Asset = self.env['ir.asset'].sudo().with_context(active_test=False)
-            obj = Asset.search([('name', '=', name)])
+            obj = Asset.search([('name', '=', name)], limit=1)
             has_specific = obj.key and Asset.search_count([
                 ('key', '=', obj.key),
                 ('website_id', '=', website.id)

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1350,7 +1350,7 @@
             <we-input string="⌙ Large" data-customize-website-variable="" data-variable="btn-border-radius-lg" data-unit="px" data-save-unit="rem"/>
         </we-collapse>
         <we-checkbox string="Ripple Effect"
-                     data-customize-website-views="website.option_ripple_effect"
+                     data-customize-website-assets="website.ripple_effect_scss, website.ripple_effect_js"
                      data-customize-website-variable="false|true"
                      data-variable="btn-ripple"/>
         <we-select string="Link Style" data-variable="link-underline">

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2042,6 +2042,7 @@
 
 <!-- Effect options -->
 <record id="website.ripple_effect_scss" model="ir.asset">
+    <field name="key">website.ripple_effect_scss</field>
     <field name="name">Ripple effect SCSS</field>
     <field name="bundle">web.assets_frontend</field>
     <field name="path">/website/static/src/scss/options/ripple_effect.scss</field>
@@ -2049,6 +2050,7 @@
 </record>
 
 <record id="website.ripple_effect_js" model="ir.asset">
+    <field name="key">website.ripple_effect_js</field>
     <field name="name">Ripple effect JS</field>
     <field name="bundle">web.assets_frontend</field>
     <field name="path">/website/static/src/js/content/ripple_effect.js</field>


### PR DESCRIPTION
Before this commit, the "ripple effect" no longer worked because the
assets were never activated for the following 2 reasons:

- To activate the ripple effect assets via the editor options, we
activated a template that no longer exists (with
data-customize-website-views). Instead of activating the assets with the
new system of assets using records.

- To activate the ripple effect when installing themes, we looked for
assets with the "name" field instead of the "key" field.

After this commit, a new "data-customize-website-assets" xml attribute
was created so that the assets can enable/disable in the same way as the
views. The "write" method for ir.asset has also been overridden in
website so that each website has its specific assets (via COW).

task-2686370