### PR TITLE
[FIX] product: change the link to the doc

### DIFF
--- a/addons/product/views/res_config_settings_views.xml
+++ b/addons/product/views/res_config_settings_views.xml
@@ -45,7 +45,7 @@
                         </div>
                         <div class="o_setting_right_pane">
                             <label for="module_product_images" string="Google Images"/>
-                            <a href="https://www.odoo.com/documentation/15.0/applications/general/product_images.html"
+                            <a href="https://www.odoo.com/documentation/15.0/applications/sales/sales/products_prices/products/product_images.html"
                                title="Documentation" class="o_doc_link" target="_blank"/>
                             <div class="text-muted">
                                 Get product pictures using Barcode


### PR DESCRIPTION
The documentation link for the product_images module was already
hard-coded in the settings view but has changed since then.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
