### PR TITLE
[FIX] project: remove gantt and map views from project.task actions

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2079,7 +2079,7 @@ class Task(models.Model):
             action['res_id'] = self.dependent_ids.id
         else:
             action['name'] = _('Dependent Tasks')
-            action['view_mode'] = 'tree,form,kanban,calendar,pivot,graph,gantt,activity,map'
+            action['view_mode'] = 'tree,form,kanban,calendar,pivot,graph,activity'
             action['domain'] = [('depend_on_ids', '=', self.id)]
         return action
 
@@ -2088,7 +2088,7 @@ class Task(models.Model):
             'name': 'Tasks in Recurrence',
             'type': 'ir.actions.act_window',
             'res_model': 'project.task',
-            'view_mode': 'tree,form,kanban,calendar,pivot,graph,gantt,activity,map',
+            'view_mode': 'tree,form,kanban,calendar,pivot,graph,activity',
             'domain': [('recurrence_id', 'in', self.recurrence_id.ids)],
         }
 

--- a/addons/project_mrp/models/project.py
+++ b/addons/project_mrp/models/project.py
@@ -29,7 +29,7 @@ class Project(models.Model):
         self.ensure_one()
         action = self.analytic_account_id.action_view_workorder()
         if self.workorder_count > 1:
-            action['view_mode'] = 'tree,form,kanban,calendar,pivot,graph,gantt'
+            action['view_mode'] = 'tree,form,kanban,calendar,pivot,graph'
         return action
 
     # ----------------------------


### PR DESCRIPTION
Prior to this commit:

    * The `action_dependent_tasks` and `action_recurring_tasks` were wrongly
      returning a view_mode containing the gantt and map views, which are part
      of enterprise.

After this commit:

    * The `action_dependent_tasks` and `action_recurring_tasks` will return a
      community valid view_mode.

Related to issue https://github.com/odoo/odoo/issues/79555

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
