### PR TITLE
[FIX] web_editor: prevent re-rendering of linktool

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -911,7 +911,9 @@ const Wysiwyg = Widget.extend({
                     }
                 };
                 this.odooEditor.document.addEventListener('mousedown', _onMousedown, true);
-                this.linkTools.appendTo(this.toolbar.$el);
+                if (!this.linkTools.$el) {
+                    this.linkTools.appendTo(this.toolbar.$el);
+                }
             } else {
                 this.linkTools.destroy();
                 this.linkTools = undefined;


### PR DESCRIPTION
Before this commit, the linktool was re-rendered clicking on
same link twice.
If between click, the some property of the link changed, they
were lost after the linktool being needlessly re-rendered.

Task-2691483



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
