### PR TITLE
[FIX] project: fix following on assignation

### DIFF
--- a/addons/project/data/mail_template_data.xml
+++ b/addons/project/data/mail_template_data.xml
@@ -97,5 +97,18 @@
             <field name="lang">{{ object.rating_get_partner_id().lang }}</field>
             <field name="auto_delete" eval="True"/>
         </record>
+
+        <!-- You have been assigned email -->
+        <template id="project_message_user_assigned">
+<p style="margin: 0px;">
+    <span>Dear <t t-esc="assignee_name"/>,</span><br />
+    <span style="margin-top: 8px;">You have been assigned to the <t t-esc="model_description or 'document'"/> <t t-esc="object.display_name"/>.</span>
+</p>
+<p style="padding-top: 24px; padding-bottom: 16px;">
+    <a t-att-href="access_link" t-att-data-oe-model="object._name" t-att-data-oe-id="object.id" style="background-color:#875A7B; padding: 10px; text-decoration: none; color: #fff; border-radius: 5px;">
+            View <t t-esc="model_description or 'document'"/>
+    </a>
+</p>
+        </template>
     </data>
 </odoo>

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1686,6 +1686,7 @@ class Task(models.Model):
             self = self.with_context(ctx).sudo()
         tasks = super(Task, self).create(vals_list)
         tasks._populate_missing_personal_stages()
+        self._task_message_auto_subscribe_notify({task: task.user_ids - self.env.user for task in tasks})
         if is_portal_user:
             # since we use sudo to create tasks, we need to check
             # if the portal user could really create the tasks based on the ir rule.
@@ -1753,6 +1754,9 @@ class Task(models.Model):
         if portal_can_write:
             tasks = tasks.sudo()
 
+        # Track user_ids to send assignment notifications
+        old_user_ids = {t: t.user_ids for t in self}
+
         # X2Many Field Tracking
         # Extract to a separate function if necessary
         x2m_tracked_fields = {'user_ids', 'depend_on_ids'}
@@ -1788,6 +1792,8 @@ class Task(models.Model):
                             old_value, new_value, field, {'type': 'char', 'string': field_desc}, 100, self._name)))
                 if tracking_value_ids:
                     task._message_log(tracking_value_ids=tracking_value_ids)
+
+        self._task_message_auto_subscribe_notify({task: task.user_ids - old_user_ids[task] - self.env.user for task in self})
 
         if 'user_ids' in vals:
             tasks._populate_missing_personal_stages()
@@ -1842,6 +1848,51 @@ class Task(models.Model):
     # ---------------------------------------------------
     # Mail gateway
     # ---------------------------------------------------
+
+    @api.model
+    def _task_message_auto_subscribe_notify(self, users_per_task):
+        # Utility method to send assignation notification upon writing/creation.
+        template_id = self.env['ir.model.data']._xmlid_to_res_id('project.project_message_user_assigned', raise_if_not_found=False)
+        if not template_id:
+            return
+        view = self.env['ir.ui.view'].browse(template_id)
+        task_model_description = self.env['ir.model']._get(self._name).display_name
+        for task, users in users_per_task.items():
+            if not users:
+                continue
+            values = {
+                'object': task,
+                'model_description': task_model_description,
+                'access_link': task._notify_get_action_link('view'),
+            }
+            for user in users:
+                values.update(assignee_name=user.sudo().name)
+                assignation_msg = view._render(values, engine='ir.qweb', minimal_qcontext=True)
+                assignation_msg = self.env['mail.render.mixin']._replace_local_links(assignation_msg)
+                task.message_notify(
+                    subject=_('You have been assigned to %s', task.display_name),
+                    body=assignation_msg,
+                    partner_ids=user.partner_id.ids,
+                    record_name=task.display_name,
+                    email_layout_xmlid='mail.mail_notification_light',
+                    model_description=task_model_description,
+                )
+
+    def _message_auto_subscribe_followers(self, updated_values, default_subtype_ids):
+        # Since the changes to user_ids becoming a m2m, the default implementation of this function
+        #  could not work anymore, override the function to keep the functionality.
+        new_followers = []
+        # Normalize input to tuple of ids
+        value = self._fields['user_ids'].convert_to_cache(updated_values.get('user_ids', []), self.env['project.task'], validate=False)
+        users = self.env['res.users'].browse(value)
+        for user in users:
+            try:
+                if user.partner_id:
+                    # The you have been assigned notification is handled separately
+                    new_followers.append((user.partner_id.id, default_subtype_ids, False))
+            except:
+                pass
+        return new_followers
 
     def _mail_track(self, tracked_fields, initial_values):
         result = super()._mail_track(tracked_fields, initial_values)

--- a/addons/project/tests/__init__.py
+++ b/addons/project/tests/__init__.py
@@ -18,3 +18,4 @@ from . import test_portal
 from . import test_multicompany
 from . import test_personal_stages
 from . import test_task_dependencies
+from . import test_task_follow

--- a/addons/project/tests/test_task_follow.py
+++ b/addons/project/tests/test_task_follow.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from .test_project_base import TestProjectCommon
+
+from odoo.tests import tagged, TransactionCase
+
+class TestTaskFollow(TestProjectCommon):
+
+    def test_follow_on_create(self):
+        # Tests that the user is follower of the task upon creation
+        self.assertTrue(self.user_projectuser.partner_id in self.task_1.message_partner_ids)
+
+    def test_follow_on_write(self):
+        # Tests that the user is follower of the task upon writing new assignees
+        self.task_2.user_ids += self.user_projectmanager
+        self.assertTrue(self.user_projectmanager.partner_id in self.task_2.message_partner_ids)


### PR DESCRIPTION
This commit fixes an issue since user_id was changed to user_ids.

The default behaviour of `_message_auto_subscribe_followers` could not
work with the user_ids field as it is only meant to work with user_id.

This also fixes a related issue due to the same problem where the
assignation emails were not sent.

TaskId-2691486