### PR TITLE
[FIX] web: run server actions with the correct context

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1050,7 +1050,7 @@ function makeActionManager(env) {
     async function _executeServerAction(action, options) {
         const runProm = env.services.rpc("/web/action/run", {
             action_id: action.id,
-            context: action.context || {},
+            context: Object.assign(env.services.user.context, action.context || {}),
         });
         let nextAction = await keepLast.add(runProm);
         nextAction = nextAction || { type: "ir.actions.act_window_close" };

--- a/addons/web/static/tests/webclient/actions/server_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/server_action_tests.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { createWebClient, doAction, getActionManagerServerData } from "./../helpers";
+import { session } from "@web/session";
 
 let serverData;
 
@@ -12,10 +13,13 @@ QUnit.module("ActionManager", (hooks) => {
     QUnit.module("Server actions");
 
     QUnit.test("can execute server actions from db ID", async function (assert) {
-        assert.expect(10);
+        assert.expect(13);
         const mockRPC = async (route, args) => {
             assert.step((args && args.method) || route);
             if (route === "/web/action/run") {
+                assert.strictEqual(args.context.lang, session.user_context.lang);
+                assert.strictEqual(args.context.tz, session.user_context.tz);
+                assert.strictEqual(args.context.uid, session.uid);
                 assert.strictEqual(args.action_id, 2, "should call the correct server action");
                 return Promise.resolve(1); // execute action 1
             }


### PR DESCRIPTION
Currently, actions are run only with their own specified context (aka ctxt in the context field).
But this context should be considered as an additional context and not a full context,
to avoid losing critical information like the current company(ies).

The fact that the multi-company management is done through the context is frequently (and globally)
forgotten for rpc contexts coming from the client side.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
