### PR TITLE
[FIX] website_sale: incorrect view called in borderless product view

### DIFF
--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -191,7 +191,7 @@
                                 <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
                             </div>
                             <t t-if="is_view_active('website_sale.product_comment')">
-                                <t t-call="portal_rating.rating_widget_stars_static_compressed">
+                                <t t-call="portal_rating.rating_widget_stars_static">
                                     <t t-set="rating_avg" t-value="record.rating_avg"/>
                                     <t t-set="rating_count" t-value="record.rating_count"/>
                                 </t>


### PR DESCRIPTION
We should call view portal_rating.rating_widget_stars_static instead of
portal_rating.rating_widget_stars_static_compressed.

Description of the issue/feature this PR addresses:
opw-2687483

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
