### PR TITLE
[FIX] hr_leave: fix ambiguous column reference

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -50,8 +50,8 @@ class LeaveReportCalendar(models.Model):
                 WHEN hl.holiday_type = 'employee' THEN rr.tz
                 ELSE %s
             END AS tz,
-            state = 'refuse' as is_striked,
-            state not in ('validate', 'refuse') as is_hatched
+            hl.state = 'refuse' as is_striked,
+            hl.state not in ('validate', 'refuse') as is_hatched
         FROM hr_leave hl
             LEFT JOIN hr_employee em
                 ON em.id = hl.employee_id


### PR DESCRIPTION
Sometimes, when there are some custom module, we need to provide the
full column name from a table as `table_name/alias`.`column_name` to
avoid ambiguous column reference.

This error occured while upgrading a customer database.

upg-46000

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/15.0/odoo/service/server.py", line 1246, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/home/odoo/src/odoo/15.0/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/15.0/odoo/modules/loading.py", line 470, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/home/odoo/src/odoo/15.0/odoo/modules/loading.py", line 363, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/odoo/src/odoo/15.0/odoo/modules/loading.py", line 199, in load_module_graph
    registry.init_models(cr, model_names, {'module': package.name}, new_install)
  File "/home/odoo/src/odoo/15.0/odoo/modules/registry.py", line 425, in init_models
    model.init()
  File "/home/odoo/src/odoo/15.0/addons/hr_holidays/report/hr_leave_report_calendar.py", line 38, in init
    self._cr.execute("""CREATE OR REPLACE VIEW hr_leave_report_calendar AS
  File "<decorator-gen-3>", line 2, in execute
  File "/home/odoo/src/odoo/15.0/odoo/sql_db.py", line 89, in check
    return f(self, *args, **kwargs)
  File "/home/odoo/src/odoo/15.0/odoo/sql_db.py", line 310, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.AmbiguousColumn: column reference "state" is ambiguous
LINE 16:             state = 'refuse' as is_striked,
                     ^
```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
