### PR TITLE
[IMP] website_sale: remove internal ref from product snippet

### DIFF
--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -15,7 +15,7 @@
                     <i t-if="data.get('_latest_viewed')" class="fa fa-trash o_carousel_product_remove js_remove"></i>
                     <div class="o_carousel_product_card_body card-body border-top">
                         <a t-att-href="record.website_url" class="text-decoration-none">
-                            <div class="h6 card-title mb-0" t-field="record.display_name"/>
+                            <div class="h6 card-title mb-0" t-field="record.name"/>
                         </a>
                         <div class="mt-2">
                             <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
@@ -45,7 +45,7 @@
                         <img class="card-img-top p-3" loading="lazy" t-att-src="data['image_512']" t-att-alt="record.display_name"/>
                     </a>
                     <div class="o_carousel_product_card_body card-body d-flex flex-column justify-content-between">
-                        <div class="card-title h5" t-field="record.display_name"/>
+                        <div class="card-title h5" t-field="record.name"/>
                         <div class="card-text" t-field="record.description_sale"/>
                         <div class="mt-2">
                             <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
@@ -109,7 +109,7 @@
                     <a class="o_carousel_product_img_link stretched-link" t-att-href="record.website_url">
                         <img class="card-img-top p-3" loading="lazy" t-att-src="data['image_512']" t-att-alt="record.display_name"/>
                     </a>
-                    <div class="h6 text-center mt-2 p-2" t-field="record.display_name"/>
+                    <div class="h6 text-center mt-2 p-2" t-field="record.name"/>
                 </div>
             </t>
         </template>
@@ -124,7 +124,7 @@
                         <img class="card-img-top" loading="lazy" t-att-src="data['image_512']" t-att-alt="record.display_name"/>
                     </a>
                     <div class="o_carousel_product_card_body card-body d-flex flex-column justify-content-between">
-                        <div class="card-title h5 text-center" t-field="record.display_name"/>
+                        <div class="card-title h5 text-center" t-field="record.name"/>
                         <div class="text-center">
                             <div class="h5">
                                 <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
@@ -160,7 +160,7 @@
                     </a>
                     <div class="o_carousel_product_card_body d-flex flex-wrap flex-column justify-content-between h-100">
                         <a t-att-href="record.website_url" class="o_carousel_product_img_link text-decoration-none">
-                            <div class="h6 card-title mt-4" t-field="record.display_name"/>
+                            <div class="h6 card-title mt-4" t-field="record.name"/>
                         </a>
                         <div>
                             <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
@@ -196,7 +196,7 @@
                                     <t t-set="rating_count" t-value="record.rating_count"/>
                                 </t>
                             </t>
-                            <div class="card-title h6 w-100 mt-2" t-field="record.display_name"/>
+                            <div class="card-title h6 w-100 mt-2" t-field="record.name"/>
                         </div>
                         <div class="text-right o_dynamic_snippet_btn_wrapper">
                             <button type="button" role="button" class="btn btn-primary js_add_cart" title="Add to Cart">
@@ -220,7 +220,7 @@
                         </div>
                         <div class="col-lg-6">
                             <div class="o_carousel_product_card_body p-5">
-                                <div class="card-title h1" t-field="record.display_name"/>
+                                <div class="card-title h1" t-field="record.name"/>
                                 <div class="d-flex align-items-center my-4">
                                     <div class="text-primary h4 mb-0 mr-3">
                                         <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
@@ -260,7 +260,7 @@
                         </div>
                         <div class="o_carousel_product_card_body col-lg-8 pl-3 d-flex flex-column justify-content-between">
                             <div>
-                                <div class="card-title h6" t-field="record.display_name"/>
+                                <div class="card-title h6" t-field="record.name"/>
                                 <div class="mb-2">
                                     <t t-if="is_view_active('website_sale.product_comment')" t-call="portal_rating.rating_widget_stars_static">
                                         <t t-set="rating_avg" t-value="record.rating_avg"/>

--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -22,26 +22,32 @@ class WebsiteSnippetFilter(models.Model):
         if model._name == 'product.product':
             data = [{
                 'image_512': b'/product/static/img/product_chair.png',
+                'name': _('Chair'),
                 'display_name': _('Chair'),
                 'description_sale': _('Sit comfortably'),
             }, {
                 'image_512': b'/product/static/img/product_lamp.png',
+                'name': _('Lamp'),
                 'display_name': _('Lamp'),
                 'description_sale': _('Lightbulb sold separately'),
             }, {
                 'image_512': b'/product/static/img/product_product_20-image.png',
+                'name': _('Whiteboard'),
                 'display_name': _('Whiteboard'),
                 'description_sale': _('With three feet'),
             }, {
                 'image_512': b'/product/static/img/product_product_27-image.png',
+                'name': _('Drawer'),
                 'display_name': _('Drawer'),
                 'description_sale': _('On wheels'),
             }, {
                 'image_512': b'/product/static/img/product_product_7-image.png',
+                'name': _('Box'),
                 'display_name': _('Box'),
                 'description_sale': _('Reinforced for heavy loads'),
             }, {
                 'image_512': b'/product/static/img/product_product_9-image.png',
+                'name': _('Bin'),
                 'display_name': _('Bin'),
                 'description_sale': _('Pedal-based opening system'),
             }]


### PR DESCRIPTION
Dynamic snippets that display products display product names, photos, descriptions. Since Odoo 14.0, the name is prefixed by the "internal reference" field if it exists. This should not be the case (maybe an option later but not by default). With this commit, the name is no more prefixed by the internal reference on snippets that display products.

This also requires a small modification of the sample product

Task-2691541
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr