### PR TITLE
[FIX] web_editor: remove warning on save

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -212,11 +212,12 @@ const Wysiwyg = Widget.extend({
             }, options));
             await this._insertSnippetMenu();
 
-            window.addEventListener('beforeunload', (event) => {
+            this._onBeforeUnload = (event) => {
                 if (this.isDirty()) {
                     event.returnValue = _t('This document is not saved!');
                 }
-            });
+            };
+            window.addEventListener('beforeunload', this._onBeforeUnload);
         }
         if (this.options.getContentEditableAreas) {
             $(this.options.getContentEditableAreas()).find('*').off('mousedown mouseup click');
@@ -676,7 +677,7 @@ const Wysiwyg = Widget.extend({
         await this._saveViewBlocks();
 
         this.trigger_up('edition_was_stopped');
-        window.onbeforeunload = null;
+        window.removeEventListener('beforeunload', this._onBeforeUnload);
         if (reload) {
             window.location.reload();
         }


### PR DESCRIPTION
Pop-up warning was appearing when saving website pages.

task-2666177

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
