### PR TITLE
[IMP] sale_project: add a new field in product template

### DIFF
--- a/addons/sale_project/models/product.py
+++ b/addons/sale_project/models/product.py
@@ -28,6 +28,8 @@ class ProductTemplate(models.Model):
         'project.project', 'Project Template', company_dependent=True, copy=True,
         domain="[('company_id', '=', current_company_id)]",
         help='Select a billable project to be the skeleton of the new created project when selling the current product. Its stages and tasks will be duplicated.')
+    task_template_ids = fields.Many2many('project.task', 'project_task_template_rel', string="Task Template", copy=True,
+        domain="[('company_id', '=', current_company_id)]")
 
     @api.depends('service_tracking', 'type')
     def _compute_product_tooltip(self):

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -218,6 +218,10 @@ class SaleOrderLine(models.Model):
         if self.product_id.project_template_id:
             values['name'] = "%s - %s" % (values['name'], self.product_id.project_template_id.name)
             project = self.product_id.project_template_id.copy(values)
+            vals_list = []
+            for task in self.product_id.task_template_ids:
+                vals_list.append({**task.copy_data()[0], 'stage_id': task.stage_id.id})
+            project.tasks = self.env['project.task'].create(vals_list)
             project.tasks.write({
                 'sale_line_id': self.id,
                 'partner_id': self.order_id.partner_id.id,

--- a/addons/sale_project/views/product_views.xml
+++ b/addons/sale_project/views/product_views.xml
@@ -12,6 +12,7 @@
             <field name="product_tooltip" position="after">
                 <field name="project_id" context="{'default_allow_billable': True}" attrs="{'invisible':[('service_tracking','!=','task_global_project')], 'required':[('service_tracking','==','task_global_project')]}"/>
                 <field name="project_template_id" context="{'active_test': False, 'default_allow_billable': True}" attrs="{'invisible':[('service_tracking','not in',['task_in_project', 'project_only'])]}"/>
+                <field name="task_template_ids" widget="many2many_tags" context="{'default_project_id': project_template_id}" attrs="{'invisible':['|', ('service_tracking','not in',['task_in_project']), ('project_template_id', '=', False)]}" domain="[('project_id', '=', project_template_id)]"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
In this commit, we add a 'Tasks Templates' m2m field below the
'project template' field. The field is only visible if 'project & task'
is selected for 'create on order' and if the 'project template' field
is set on a product. Also, if  'Task Template' is false then it copies
all of the tasks from the selected project template on the SO
confirmation else, only copy the selected tasks.

task-2672783
PR: #79822

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
