### PR TITLE
[IMP] sale: improve string of partner_shipping_id for Bill

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -22,7 +22,7 @@ class AccountMove(models.Model):
         readonly=True,
         states={'draft': [('readonly', False)]},
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
-        help="Delivery address for current invoice.\nOR\nDispatch address for current bill.")
+        help="Delivery address for customer invoice.  Dispatch address for vendor bill.")
 
     @api.onchange('partner_shipping_id', 'company_id')
     def _onchange_partner_shipping_id(self):

--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -22,7 +22,7 @@ class AccountMove(models.Model):
         readonly=True,
         states={'draft': [('readonly', False)]},
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
-        help="Delivery address for current invoice.")
+        help="Delivery address for current invoice.\nOR\nDispatch address for current bill.")
 
     @api.onchange('partner_shipping_id', 'company_id')
     def _onchange_partner_shipping_id(self):

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -1228,7 +1228,13 @@
             <field name="arch" type="xml">
                 <data>
                     <xpath expr="//field[@name='partner_id']" position="after">
-                       <field name="partner_shipping_id"
+                        <div class="o_td_label" groups="sale.group_delivery_invoice_address">
+                            <label for="partner_shipping_id" string="Delivery Address" style="font-weight:bold;"
+                                   attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund'))]}"/>
+                            <label for="partner_shipping_id" string="Dispatch Address" style="font-weight:bold;"
+                                   attrs="{'invisible': [('move_type', 'not in', ('in_invoice', 'in_refund'))]}"/>
+                        </div>
+                        <field name="partner_shipping_id" nolabel="1"
                               groups="sale.group_delivery_invoice_address"
                               attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund'))]}"/>
                    </xpath>


### PR DESCRIPTION
Before this commit:
===================
In Bill partner_shipping_id field string is Delivery Address but this is not true functionally

After this commit:
==================
In Bill partner_shipping_id field string is Dispatch Address so functionally it's true

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
