### PR TITLE
[FIX]: point_of_sale: load missing products from Ticket Screen

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -549,6 +549,8 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
                     args: [idsNotInCache],
                     context: this.env.session.user_context,
                 });
+                // Check for missing products and load them in the PoS
+                await this.env.pos._loadMissingProducts(fetchedOrders);
                 // Cache these fetched orders so that next time, no need to fetch
                 // them again, unless invalidated. See `_onInvoiceOrder`.
                 fetchedOrders.forEach((order) => {


### PR DESCRIPTION
Old behavior: whenever an order had at least one product not loaded in the PoS, the orders could not be initialized in the Ticket Screen.

Current behavior: the Ticket Screen will load all missing products from the fetched orders.