### PR TITLE
[FIX] website_crm: fixes the issue of not creating crm.lead when install website_crm

### DIFF
--- a/addons/website_crm/views/website_templates_contactus.xml
+++ b/addons/website_crm/views/website_templates_contactus.xml
@@ -12,6 +12,9 @@
                     'description': request.params.get('description', ''),
                 })"/>
             </xpath>
+            <xpath expr="//form[@id='contactus_form']" position="attributes">
+                <attribute name="data-model_name">crm.lead</attribute>
+            </xpath>
 		</template>
     </data>
 </odoo>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**
When install website_crm module /contactus page did not create a new crm.lead. This was working in v14 and stopped working in v15.

**Current behavior before PR**
After website_crm module is installed, when a user submits the contactus page it sent an email rather than creating a new crm.lead record. The Form Action of the snippet didn't change to "Create an Oppurtunity".

**Desired behavior after PR is merged**
After installing the website_crm module, the contactus page form action is automatically set to "Create an Oppurtunity" and upon submitting contactus form the crm.lead record is created successfully.

Fixes #78841

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
