### PR TITLE
[FIX] l10n_de: adding check in template

### DIFF
--- a/addons/l10n_de/models/__init__.py
+++ b/addons/l10n_de/models/__init__.py
@@ -6,3 +6,4 @@ from . import base_document_layout
 from . import chart_template
 from . import ir_actions_report
 from . import account_move
+from . import hr_timesheet

--- a/addons/l10n_de/models/hr_timesheet.py
+++ b/addons/l10n_de/models/hr_timesheet.py
@@ -1,0 +1,16 @@
+from odoo import models, fields, api, _
+
+class AccountAnalyticLine(models.Model):
+    _inherit = 'account.analytic.line'
+
+    l10n_de_template_data = fields.Binary(compute='_compute_l10n_de_template_data')
+    l10n_de_document_title = fields.Char(compute='_compute_l10n_de_document_title')
+
+    def _compute_l10n_de_template_data(self):
+        for record in self:
+            record.l10n_de_template_data = []
+
+    def _compute_l10n_de_document_title(self):
+        for record in self:
+            record.l10n_de_document_title = ''
+

--- a/addons/l10n_de/report/din5008_report.xml
+++ b/addons/l10n_de/report/din5008_report.xml
@@ -106,9 +106,12 @@
                         </tr>
                     </table>
                     <h2>
-                        <span t-if="not o"><t t-esc="company.l10n_de_document_title"/></span>
-                        <span t-elif="'l10n_de_document_title' in o"><t t-esc="o.l10n_de_document_title"/></span>
-                        <span t-else="" t-field="o.name"/>
+                        <span t-if="not o and not docs"><t t-esc="company.l10n_de_document_title"/></span>
+                        <span t-else="">
+                            <t t-set="o" t-value="docs[0]" t-if="not o" />
+                            <span t-if="'l10n_de_document_title' in o"><t t-esc="o.l10n_de_document_title"/></span>
+                            <span t-else="" t-field="o.name"/>
+                        </span>
                     </h2>
                     <t t-raw="0"/>
                 </div>


### PR DESCRIPTION
Some conditions are added to make sure that fields are
available in the object. That was not the case previously
and it raised errors while printing.

Signed-off-by: Adrien Minet <admi@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
