### PR TITLE
[FIX] hr_attendance: use correct company in Kiosk mode

### DIFF
--- a/addons/hr_attendance/static/src/js/kiosk_mode.js
+++ b/addons/hr_attendance/static/src/js/kiosk_mode.js
@@ -22,14 +22,15 @@ var KioskMode = AbstractAction.extend({
         var self = this;
         core.bus.on('barcode_scanned', this, this._onBarcodeScanned);
         self.session = Session;
+        const company_id = this.session.user_context.allowed_company_ids[0];
         var def = this._rpc({
                 model: 'res.company',
                 method: 'search_read',
-                args: [[['id', '=', this.session.company_id]], ['name']],
+                args: [[['id', '=', company_id]], ['name']],
             })
             .then(function (companies){
                 self.company_name = companies[0].name;
-                self.company_image_url = self.session.url('/web/image', {model: 'res.company', id: self.session.company_id, field: 'logo',});
+                self.company_image_url = self.session.url('/web/image', {model: 'res.company', id: company_id, field: 'logo',});
                 self.$el.html(QWeb.render("HrAttendanceKioskMode", {widget: self}));
                 self.start_clock();
             });

--- a/addons/hr_attendance/static/tests/hr_attendance_tests.js
+++ b/addons/hr_attendance/static/tests/hr_attendance_tests.js
@@ -84,7 +84,9 @@ QUnit.module('HR Attendance', {
             data: this.data,
             session: {
                 uid: 1,
-                company_id: 1,
+                user_context: {
+                    allowed_company_ids: [1],
+                }
             },
             mockRPC: function(route, args) {
                 if (args.method === 'attendance_scan' && args.model === 'hr.employee') {


### PR DESCRIPTION
A wrong company was used in the Kiosk mode, preventing users to check in
/ out.

TaskID: 2691031

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
