### PR TITLE
[FIX] web_editor: remove button tooltip of link tooltip

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -56,6 +56,10 @@ const LinkPopoverWidget = Widget.extend({
             placement: 'bottom',
             container: this.options.wysiwyg.odooEditor.document.body,
         });
+        const tooltips = [];
+        for (const el of this.$('[data-toggle="tooltip"]').toArray()) {
+            tooltips.push($(el).data('bs.tooltip'));
+        }
         let popoverShown = true;
         this.$target.popover({
             html: true,
@@ -77,6 +81,11 @@ const LinkPopoverWidget = Widget.extend({
         })
         .on('hide.bs.popover.link_popover', () => {
             popoverShown = false;
+        })
+        .on('hidden.bs.popover.link_popover', () => {
+            for (const tooltip of tooltips) {
+                tooltip.hide();
+            }
         })
         .popover('show')
         .data('bs.popover').tip.classList.add('o_edit_menu_popover');


### PR DESCRIPTION
Whenever the link tooltip hide, the tooltip of the buttons
could remain in the page but shouldn't.

Task-2692301



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
