### PR TITLE
[FIX] web: set _super with Object.defineProperty

### DIFF
--- a/addons/web/static/src/core/utils/patch.js
+++ b/addons/web/static/src/core/utils/patch.js
@@ -80,11 +80,17 @@ export function patch(obj, patchName, patchValue, options = {}) {
                     let prevSuper;
                     if (this) {
                         prevSuper = this._super;
-                        this._super = _superFn.bind(this);
+                        Object.defineProperty(this, "_super", {
+                            value: _superFn.bind(this),
+                            configurable: true,
+                        });
                     }
                     const result = patchFn.call(this, ...args);
                     if (this) {
-                        this._super = prevSuper;
+                        Object.defineProperty(this, "_super", {
+                            value: prevSuper,
+                            configurable: true,
+                        });
                     }
                     return result;
                 },


### PR DESCRIPTION
Before this commit, `_super` was set like this
`this._super = patchFn.bind(this);`
this triggered an update in owl reactivity.

To prevent the update, we use Object.defineProperty
`Object.defineProperty(this, "_super", { value: patchFn.bind(this) })`