### PR TITLE
[FIX] point_of_sale : Closing popup buttons

### DIFF
--- a/addons/point_of_sale/static/src/css/popups/closing_pos_popup.css
+++ b/addons/point_of_sale/static/src/css/popups/closing_pos_popup.css
@@ -46,7 +46,7 @@
 }
 
 .pos .close-pos-popup .payment-methods-overview {
-    max-height: 370px;
+    max-height: 320px;
     overflow: auto;
 }
 


### PR DESCRIPTION
Current behavior:
When you try to close the PoS session when there are more than 6 payement methods the footer buttons dissapear

Steps to reproduce:
Add atleast 6 payement methods to any PoS. When you try to close a session of this PoS the footer buttons are out of the popup

opw-2667725




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
