### PR TITLE
[FIX] payment: issue Authorize.net manual capture

### DIFF
--- a/addons/payment/models/account_invoice.py
+++ b/addons/payment/models/account_invoice.py
@@ -90,7 +90,7 @@ class AccountMove(models.Model):
         return transaction
 
     def payment_action_capture(self):
-        self.authorized_transaction_ids.s2s_capture_transaction()
+        self.authorized_transaction_ids.action_capture()
 
     def payment_action_void(self):
-        self.authorized_transaction_ids.s2s_void_transaction()
+        self.authorized_transaction_ids.action_void()

--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1105,10 +1105,10 @@ Reason(s) of this behavior could be:
                 line.qty_to_invoice = 0
 
     def payment_action_capture(self):
-        self.authorized_transaction_ids.s2s_capture_transaction()
+        self.authorized_transaction_ids.action_capture()
 
     def payment_action_void(self):
-        self.authorized_transaction_ids.s2s_void_transaction()
+        self.authorized_transaction_ids.action_void()
 
     def get_portal_last_transaction(self):
         self.ensure_one()


### PR DESCRIPTION
When a 'manual capture' is set for Authorize.net and a client
make a payment in several partial payments the user can capture
all the authorized transactions without crashing now.

Task - 2676914



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
