### PR TITLE
[FIX] web_editor: use text url by default in link dialog

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -89,6 +89,13 @@ const Link = Widget.extend({
             this.data.content = this.data.content ? this.data.content.replace(/[ \t\r\n]+/g, ' ') : '';
         }
 
+        if (!this.data.url) {
+            const urls = this.data.content.match(OdooEditorLib.URL_REGEX_WITH_INFOS);
+            if (urls) {
+                this.data.url = urls[0];
+            }
+        }
+
         if (this.linkEl) {
             this.data.isNewWindow = this.data.isNewWindow || this.linkEl.target === '_blank';
         }


### PR DESCRIPTION
On an html field whenever selecting only text that contain an url
and opening the link dialog, the url was not reused.

Task-2580485




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
