### PR TITLE
[FIX] stock: auto assign backorder

### DIFF
--- a/addons/stock/tests/test_stock_flow.py
+++ b/addons/stock/tests/test_stock_flow.py
@@ -2067,3 +2067,36 @@ class TestStockFlow(TestStockCommon):
         validate_picking(in02)
         self.assertEqual(out02.state, 'confirmed')
         self.assertEqual(out03.state, 'assigned')
+
+    def test_auto_assign_backorder(self):
+        """ When a backorder is created, the quantities should be assigned if the reservation method
+         is set on 'At Confirmation' """
+        stock_location = self.env['stock.location'].browse(self.stock_location)
+        picking_type_out = self.env['stock.picking.type'].browse(self.picking_type_out)
+
+        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 10)
+        picking_type_out.reservation_method = 'at_confirm'
+
+        picking_out = self.PickingObj.create({
+            'picking_type_id': picking_type_out.id,
+            'location_id': stock_location.id,
+            'location_dest_id': self.customer_location,
+        })
+        move_out = self.MoveObj.create({
+            'name': self.productA.name,
+            'product_id': self.productA.id,
+            'product_uom_qty': 10,
+            'product_uom': self.productA.uom_id.id,
+            'picking_id': picking_out.id,
+            'location_id': stock_location.id,
+            'location_dest_id': self.customer_location
+        })
+
+        move_out.quantity_done = 7
+
+        action_dict = picking_out.button_validate()
+        backorder_wizard = Form(self.env[action_dict['res_model']].with_context(action_dict['context'])).save()
+        backorder_wizard.process()
+
+        bo = self.env['stock.picking'].search([('backorder_id', '=', picking_out.id)])
+        self.assertEqual(bo.state, 'assigned')


### PR DESCRIPTION
When a backorder is created, the quantities are not reserved. This is an
issue: the module should try to directly assign these quantities if the
reservation method of the associated operation type is "At Confirmation"

(Forward port of 723d4b35f9fa9c49249c1b4e9b8dc93e51c5d359)

OPW-2658469