### PR TITLE
[FIX] web_editor: prevent traceback when droping undroppable snippet

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2507,7 +2507,9 @@ var SnippetsMenu = Widget.extend({
                         });
                     } else {
                         $toInsert.remove();
-                        dragAndDropResolve();
+                        if (dragAndDropResolve) {
+                            dragAndDropResolve();
+                        }
                         self.$el.find('.oe_snippet_thumbnail').removeClass('o_we_already_dragging');
                     }
                 },


### PR DESCRIPTION
When trying to drop a snippet that could not be possibly dropped,
a traceback is shown but shouldn't.

Task-2692492




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
