### PR TITLE
[IMP] l10n_ar: document types settings

### DIFF
--- a/addons/l10n_ar/data/l10n_latam.document.type.csv
+++ b/addons/l10n_ar/data/l10n_latam.document.type.csv
@@ -19,35 +19,35 @@ dc_e_f,170,19,FACTURAS DE EXPORTACION,E,FACTURA,invoice,FA-E,base.ar,not_zero
 dc_e_nd,180,20,NOTAS DE DEBITO POR OPERACIONES CON EL EXTERIOR,E,NOTA DE DEBITO,debit_note,ND-E,base.ar,not_zero
 dc_e_nc,190,21,NOTAS DE CREDITO POR OPERACIONES CON EL EXTERIOR,E,NOTA DE CREDITO,credit_note,NC-E,base.ar,not_zero
 dc_e_fs,200,22,FACTURAS - PERMISO EXPORTACION SIMPLIFICADO - DTO. 855/97,E,,,,base.ar,not_zero
-dc_usados,210,30,COMPROBANTES DE COMPRA DE BIENES USADOS,,,,,base.ar,
+dc_usados,210,30,COMPROBANTES DE COMPRA DE BIENES USADOS,,,invoice,CBU,base.ar,not_zero
 dc_mandato,220,31,MANDATO - CONSIGNACION,,,,,base.ar,
-dc_reciclado,230,32,COMPROBANTES PARA RECICLAR MATERIALES,,,,,base.ar,
-dc_a_rg1415,240,34,"COMPROBANTES A DEL APARTADO A, INC. F), R.G. Nº 1415",A,,invoice,,base.ar,not_zero
-dc_b_rg1415,250,35,"COMPROBANTES B DEL ANEXO I, APARTADO A, INC. F), R.G. Nº 1415",B,,invoice,,base.ar,zero
-dc_c_rg1415,260,36,"COMPROBANTES C DEL ANEXO I, APARTADO A, INC. F), R.G. Nº 1415",C,,invoice,,base.ar,zero
-dc_nd_rg1415,270,37,NOTAS DE DEBITO O DOCUMENTO EQUIVALENTE QUE CUMPLAN CON LA R.G. Nº 1415,,,debit_note,,base.ar,not_zero
-dc_nc_rg1415,280,38,NOTAS DE CREDITO O DOCUMENTO EQUIVALENTE QUE CUMPLAN CON LA R.G. Nº 1415,,,credit_note,,base.ar,not_zero
+dc_reciclado,230,32,COMPROBANTES PARA RECICLAR MATERIALES,,,invoice,CRM,base.ar,not_zero
+dc_a_rg1415,240,34,"COMPROBANTES A DEL APARTADO A, INC. F), R.G. Nº 1415",A,,invoice,CA-A,base.ar,not_zero
+dc_b_rg1415,250,35,"COMPROBANTES B DEL ANEXO I, APARTADO A, INC. F), R.G. Nº 1415",B,,invoice,CA-B,base.ar,zero
+dc_c_rg1415,260,36,"COMPROBANTES C DEL ANEXO I, APARTADO A, INC. F), R.G. Nº 1415",C,,invoice,CA-C,base.ar,zero
+dc_nd_rg1415,270,37,NOTAS DE DEBITO O DOCUMENTO EQUIVALENTE QUE CUMPLAN CON LA R.G. Nº 1415,,,debit_note,ND1415,base.ar,not_zero
+dc_nc_rg1415,280,38,NOTAS DE CREDITO O DOCUMENTO EQUIVALENTE QUE CUMPLAN CON LA R.G. Nº 1415,,,credit_note,NC1415,base.ar,not_zero
 dc_a_o_rg1415,290,39,OTROS COMPROBANTES A QUE CUMPLEN CON LA R.G. Nº 1415,A,,invoice,OC-A,base.ar,not_zero
 dc_b_o_rg1415,300,40,OTROS COMPROBANTES B QUE CUMPLAN CON LA R.G. Nº 1415,B,,invoice,OC-B,base.ar,zero
 dc_c_o_rg1415,310,41,OTROS COMPROBANTES C QUE CUMPLAN CON LA R.G. Nº 1415,C,,invoice,OC-C,base.ar,zero
 dc_a_rf,320,50,RECIBO FACTURA A REGIMEN DE FACTURA DE CREDITO,A,,,,base.ar,not_zero
 dc_m_f,330,51,FACTURAS M,M,FACTURA,invoice,FA-M,base.ar,not_zero
-dc_m_nd,340,52,NOTAS DE DEBITO M,M,NOTA DE DEBITO,debit_note,ND-C,base.ar,not_zero
-dc_m_nc,350,53,NOTAS DE CREDITO M,M,NOTA DE CREDITO,credit_note,NC-C,base.ar,not_zero
+dc_m_nd,340,52,NOTAS DE DEBITO M,M,NOTA DE DEBITO,debit_note,ND-M,base.ar,not_zero
+dc_m_nc,350,53,NOTAS DE CREDITO M,M,NOTA DE CREDITO,credit_note,NC-M,base.ar,not_zero
 dc_m_r,360,54,RECIBOS M,M,RECIBO,invoice,RE-M,base.ar,not_zero
 dc_m_nvc,370,55,NOTAS DE VENTA AL CONTADO M,M,,invoice,NVC-M,base.ar,not_zero
-dc_m_rg1415,380,56,"COMPROBANTES M DEL ANEXO I, APARTADO A, INC. F), R.G. Nº 1415",M,,invoice,,base.ar,not_zero
-dc_m_o_rg1415,390,57,OTROS COMPROBANTES M QUE CUMPLAN CON LA R.G. Nº 1415,M,,invoice,,base.ar,not_zero
-dc_m_cvl,400,58,CUENTAS DE VENTA Y LIQUIDO PRODUCTO M,M,,invoice,,base.ar,not_zero
+dc_m_rg1415,380,56,"COMPROBANTES M DEL ANEXO I, APARTADO A, INC. F), R.G. Nº 1415",M,,invoice,CA-M,base.ar,not_zero
+dc_m_o_rg1415,390,57,OTROS COMPROBANTES M QUE CUMPLAN CON LA R.G. Nº 1415,M,,invoice,OC-M,base.ar,not_zero
+dc_m_cvl,400,58,CUENTAS DE VENTA Y LIQUIDO PRODUCTO M,M,,invoice,LP-M,base.ar,not_zero
 dc_m_l,410,59,LIQUIDACIONES M,M,LIQUIDACION,invoice,LI-M,base.ar,not_zero
 dc_a_cvl,420,60,CUENTAS DE VENTA Y LIQUIDO PRODUCTO A,A,CTA VTA LIQUIDO PRODUCTO,invoice,LP-A,base.ar,not_zero
 dc_b_cvl,430,61,CUENTAS DE VENTA Y LIQUIDO PRODUCTO B,B,CTA VTA LIQUIDO PRODUCTO,invoice,LP-B,base.ar,zero
 dc_a_l,440,63,LIQUIDACIONES A,A,LIQUIDACION,invoice,LI-A,base.ar,not_zero
 dc_b_l,450,64,LIQUIDACIONES B,B,LIQUIDACION,invoice,LI-B,base.ar,zero
-dc_nc,460,65,"NOTAS DE CREDITO DE COMPROBANTES CON COD. 34, 39, 58, 59, 60, 63, 96, 97,",,,credit_note,,base.ar,
+dc_nc,460,65,"NOTAS DE CREDITO DE COMPROBANTES CON COD. 34, 39, 58, 59, 60, 63, 96, 97,",,,,,base.ar,
 dc_desp_imp,470,66,DESPACHO DE IMPORTACION,,,invoice,DI,base.ar,not_zero
-dc_imp_serv,480,67,IMPORTACION DE SERVICIOS,,,invoice,IS,base.ar,
-dc_c_l,490,68,LIQUIDACION C,C,LIQUIDACION,invoice,,base.ar,not_zero
+dc_imp_serv,480,67,IMPORTACION DE SERVICIOS,,,,,base.ar,
+dc_c_l,490,68,LIQUIDACION C,C,LIQUIDACION,invoice,LI-C,base.ar,not_zero
 dc_rfc,500,70,RECIBOS FACTURA DE CREDITO,,,,,base.ar,not_zero
 dc_cfcp,510,71,CREDITO FISCAL POR CONTRIBUCIONES PATRONALES,,,,,base.ar,
 dc_f1116,520,73,FORMULARIO 1116 RT,,,,,base.ar,
@@ -57,13 +57,13 @@ dc_zeta,550,80,INFORME DIARIO DE CIERRE (ZETA) - CONTROLADORES FISCALES,,,,,base
 dc_a_t,560,81,TIQUE FACTURA A,A,TIQUE FACTURA,invoice,TF-A,base.ar,not_zero
 dc_b_t,570,82,TIQUE - FACTURA B,B,TIQUE FACTURA,invoice,TF-B,base.ar,zero
 dc_t,580,83,TIQUE,,TIQUE,invoice,TI-X,base.ar,zero
-dc_sp_c,590,84,COMPROBANTE FACTURA DE SERVICIOS PUBLICOS INTERESES FINANCIEROS,,,invoice,,base.ar,
-dc_sp_nc,600,85,NOTA DE CREDITO SERVICIOS PUBLICOS NOTA DE CREDITO CONTROLADORES FISCALES,,,credit_note,,base.ar,
-dc_sp_nd,610,86,NOTA DE DEBITO SERVICIOS PUBLICOS,,,debit_note,,base.ar,
-dc_oc_se,620,87,OTROS COMPROBANTES - SERVICIOS DEL EXTERIOR,,,invoice,,base.ar,
+dc_sp_c,590,84,COMPROBANTE FACTURA DE SERVICIOS PUBLICOS INTERESES FINANCIEROS,,,,,base.ar,
+dc_sp_nc,600,85,NOTA DE CREDITO SERVICIOS PUBLICOS NOTA DE CREDITO CONTROLADORES FISCALES,,,,,base.ar,
+dc_sp_nd,610,86,NOTA DE DEBITO SERVICIOS PUBLICOS,,,,,base.ar,
+dc_oc_se,620,87,OTROS COMPROBANTES - SERVICIOS DEL EXTERIOR,,,,,base.ar,
 dc_oc_c,630,88,REMITO ELECTRONICO,,,,,base.ar,
-dc_oc_nd,640,89,RESUMEN DE DATOS,,,debit_note,,base.ar,
-dc_oc_nc,650,90,OTROS COMPROBANTES - DOCUMENTOS EXCEPTUADOS - NOTAS DE CREDITO,,,credit_note,,base.ar,not_zero
+dc_oc_nd,640,89,RESUMEN DE DATOS,,,,,base.ar,
+dc_oc_nc,650,90,OTROS COMPROBANTES - DOCUMENTOS EXCEPTUADOS - NOTAS DE CREDITO,,,credit_note,OC,base.ar,not_zero
 dc_r_r,660,91,REMITOS R,R,,,,base.ar,
 dc_ac_inc_df,670,92,AJUSTES CONTABLES QUE INCREMENTAN EL DEBITO FISCAL,,,,,base.ar,
 dc_ac_dis_df,680,93,AJUSTES CONTABLES QUE DISMINUYEN EL DEBITO FISCAL,,,,,base.ar,
@@ -74,8 +74,8 @@ dc_f1116c,720,97,FORMULARIO 1116 C,,,,,base.ar,
 dc_oc_ncrg3419,730,99,OTROS COMPROBANTES QUE NO CUMPLEN O ESTAN EXCEPTUADOS DE LA R.G. Nº 1415 Y SUS MODIF,,,invoice,OC-X,base.ar,not_zero
 dc_aa_dj_pos,740,101,AJUSTE ANUAL PROVENIENTE DE LA D J DEL IVA POSITIVO,,,,,base.ar,
 dc_aa_dj_neg,750,102,AJUSTE ANUAL PROVENIENTE DE LA D J DEL IVA NEGATIVO,,,,,base.ar,
-dc_na,760,103,NOTA DE ASIGNACION,,,invoice,,base.ar,
-dc_nca,770,104,NOTA DE CREDITO DE ASIGNACION,,,credit_note,,base.ar,
+dc_na,760,103,NOTA DE ASIGNACION,,,,,base.ar,
+dc_nca,770,104,NOTA DE CREDITO DE ASIGNACION,,,,,base.ar,
 dc_remito_x,790,94,REMITOS X,X,REMITO,,RM-X,base.ar,
 dc_liq_s_a,800,17,LIQUIDACION DE SERVICIOS PUBLICOS CLASE A,A,,invoice,LS-A,base.ar,not_zero
 dc_liq_s_b,810,18,LIQUIDACION DE SERVICIOS PUBLICOS CLASE B,B,,invoice,LS-B,base.ar,zero
@@ -86,14 +86,14 @@ dc_con_b_m,850,26,"COMPROBANTES ""B"" DE CONSIGNACION PRIMARIA PARA EL SECTOR PE
 dc_liq_uci_a,860,27,LIQUIDACION UNICA COMERCIAL IMPOSITIVA CLASE A,A,,invoice,LU-A,base.ar,not_zero
 dc_liq_uci_b,870,28,LIQUIDACION UNICA COMERCIAL IMPOSITIVA CLASE B,B,,invoice,LU-B,base.ar,zero
 dc_liq_uci_c,880,29,LIQUIDACION UNICA COMERCIAL IMPOSITIVA CLASE C,C,,invoice,LU-C,base.ar,zero
-dc_liq_prim_gr,890,33,LIQUIDACION PRIMARIA DE GRANOS,,,,,base.ar,
+dc_liq_prim_gr,890,33,LIQUIDACION PRIMARIA DE GRANOS,,,invoice,LPG,base.ar,not_zero
 dc_nc_liq_uci_a,900,43,NOTA DE CREDITO LIQUIDACION UNICA COMERCIAL IMPOSITIVA CLASE B,B,,credit_note,NCLU-B,base.ar,zero
 dc_nc_liq_uci_b,910,44,NOTA DE CREDITO LIQUIDACION UNICA COMERCIAL IMPOSITIVA CLASE C,C,,credit_note,NCLU-C,base.ar,zero
 dc_nd_liq_uci_a,920,45,NOTA DE DEBITO LIQUIDACION UNICA COMERCIAL IMPOSITIVA CLASE A,A,,debit_note,NDLU-A,base.ar,not_zero
 dc_nd_liq_uci_b,930,46,NOTA DE DEBITO LIQUIDACION UNICA COMERCIAL IMPOSITIVA CLASE B,B,,debit_note,NDLU-B,base.ar,zero
 dc_nd_liq_uci_c,940,47,NOTA DE DEBITO LIQUIDACION UNICA COMERCIAL IMPOSITIVA CLASE C,C,,debit_note,NDLU-C,base.ar,zero
 dc_nc_liq_uci_c,950,48,NOTA DE CREDITO LIQUIDACION UNICA COMERCIAL IMPOSITIVA CLASE A,A,,credit_note,NCLU-A,base.ar,not_zero
-dc_bs_no_reg,960,49,COMPROBANTES DE COMPRA DE BIENES NO REGISTRABLES A CONSUMIDORES FINALES,,,,BNR,base.ar,not_zero
+dc_bs_no_reg,960,49,COMPROBANTES DE COMPRA DE BIENES NO REGISTRABLES A CONSUMIDORES FINALES,,,invoice,BNR,base.ar,not_zero
 dc_t_nc,970,110,TIQUE NOTA DE CREDITO,,TIQUE NOTA DE CREDITO,credit_note,TC-X,base.ar,not_zero
 dc_t_c,980,111,TIQUE FACTURA C,C,TIQUE FACTURA,invoice,TF-C,base.ar,zero
 dc_t_nc_a,990,112,TIQUE NOTA DE CREDITO A,A,TIQUE NOTA DE CREDITO,credit_note,TN-A,base.ar,not_zero
@@ -105,7 +105,7 @@ dc_t_nd_c,1040,117,TIQUE NOTA DE DEBITO C,C,TIQUE NOTA DE DEBITO,debit_note,TD-C
 dc_t_m,1050,118,TIQUE FACTURA M,M,FACTURA,invoice,TF-M,base.ar,not_zero
 dc_t_nc_m,1060,119,TIQUE NOTA DE CREDITO M,M,NOTA DE CREDITO,credit_note,TC-M,base.ar,not_zero
 dc_t_nd_m,1070,120,TIQUE NOTA DE DEBITO M,M,NOTA DE DEBITO,debit_note,TD-M,base.ar,not_zero
-dc_liq_sec_gr,1080,331,LIQUIDACION SECUNDARIA DE GRANOS,,,,,base.ar,
+dc_liq_sec_gr,1080,331,LIQUIDACION SECUNDARIA DE GRANOS,,,invoice,LSG,base.ar,not_zero
 dc_cert_ele_gr,1090,332,CERTIFICACION ELECTRONICA (GRANOS),,,,,base.ar,
 dc_fce_a_f,1100,201,FACTURA DE CREDITO ELECTRONICA MiPyMEs (FCE) A,A,FACTURA DE CREDITO ELECTRONICA,invoice,FCE-A,base.ar,not_zero
 dc_fce_a_nd,1110,202,NOTA DE DEBITO ELECTRONICA MiPyMEs (FCE) A,A,NOTA DE DEBITO ELECTRONICA,debit_note,NDE-A,base.ar,not_zero


### PR DESCRIPTION
1. disable document types that are not available https://www.afip.gob.ar/libro-iva-digital/documentos/Libro-IVA-Digital-Tablas-del-Sistema.pdf (remove "internal_type" value)
2. Add prefix and purchase_aliquots for every document type that usable (has an internal_type value)
3. Enable liquidacion primaria/secundaria de granos

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
