### PR TITLE
[FIX] point_of_sale: solved 'false' is shown as name in the template

### DIFF
--- a/addons/point_of_sale/static/src/xml/Screens/ClientListScreen/ClientDetailsEdit.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ClientListScreen/ClientDetailsEdit.xml
@@ -13,7 +13,7 @@
                 </t>
                 <input type="file" class="image-uploader" t-on-change="uploadImage" />
             </div>
-            <input class="detail client-name" name="name" t-att-value="props.partner.name"
+            <input class="detail client-name" name="name" t-att-value="props.partner.name or ''"
                    placeholder="Name" t-on-change="captureChange" />
             <div class="client-details-box clearfix">
                 <div class="client-details-left">

--- a/addons/point_of_sale/static/src/xml/Screens/ClientListScreen/ClientLine.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ClientListScreen/ClientLine.xml
@@ -5,7 +5,7 @@
         <tr t-attf-class="client-line {{highlight}}" t-att-data-id="props.partner.id"
             t-on-click="trigger('click-client', {client: props.partner})">
             <td>
-                <t t-esc="props.partner.name" />
+                <t t-esc="props.partner.name or ''" />
                 <span t-if="highlight">
                     <br/><button class="edit-client-button" t-on-click.stop="trigger('click-edit')">EDIT</button>
                 </span>


### PR DESCRIPTION
Before this comment if a client had no name, false 
was displayed instead of an empty string in the 
user list.

Steps to reproduce:
1) Take a database with PoS.
2) Change a contact type to Delivery Address and then remove its name
3) Open PoS and click on the Customer.

Result:
- In the name column 'false' is shown instead of ''

If there's no name I'm showing an empty string

opw-2683482


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
