### PR TITLE
[FIX] project: fix access error when project user goes to project form

### DIFF
--- a/addons/project/security/ir.model.access.csv
+++ b/addons/project/security/ir.model.access.csv
@@ -37,6 +37,7 @@ access_project_milestone_portal,project.milestone.portal,model_project_milestone
 access_project_milestone_project_user,project.milestone.project.user,model_project_milestone,project.group_project_user,1,0,0,0
 access_project_milestone_project_manager,project.milestone.project.manager,model_project_milestone,project.group_project_manager,1,1,1,1
 access_project_collaborator_manager,project.collaborator.manager,model_project_collaborator,project.group_project_manager,1,1,1,1
+access_project_collaborator_user,project.collaborator.user,model_project_collaborator,project.group_project_user,1,0,0,0
 access_project_collaborator_portal,project.collaborator.portal,model_project_collaborator,base.group_portal,1,0,0,0
 access_project_share_manager,project.share.wizard.manager,model_project_share_wizard,project.group_project_manager,1,1,1,0
 access_project_personal_stage,project.personal.stage.user,model_project_task_stage_personal,base.group_user,1,1,1,1


### PR DESCRIPTION
Before this commit, when a project user wants to see the project form
view, he has an access error because he does not have any access to
`project.collaborators`.

This commit adds `ir.model.access` to give read access to the project
user to `project.collaborators` model.

task-2692587

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
