### PR TITLE
[FIX] mail: duplicate attachement using sudo

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -258,7 +258,7 @@ class MailComposer(models.TransientModel):
                 new_attachment_ids = []
                 for attachment in wizard.attachment_ids:
                     if attachment in wizard.template_id.attachment_ids:
-                        new_attachment_ids.append(attachment.copy({'res_model': 'mail.compose.message', 'res_id': wizard.id}).id)
+                        new_attachment_ids.append(attachment.sudo().copy({'res_model': 'mail.compose.message', 'res_id': wizard.id}).id)
                     else:
                         new_attachment_ids.append(attachment.id)
                 new_attachment_ids.reverse()


### PR DESCRIPTION
To be able to copy an attachement, we need to be have write access on
the linked record.
In this wizard, write access on mail.template is then required which
is no longer the case since cc012a086464e88f7ede1e5
Read access on the template is already checked when reading the values
of the tempate.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
