### PR TITLE
[FIX] base: Fix records evaluation during printing

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -802,7 +802,7 @@ class IrActionsReport(models.Model):
             # bypassed
             raise UserError(_("Unable to find Wkhtmltopdf on this system. The PDF can not be created."))
 
-        html = self_sudo.with_context(context)._render_qweb_html(res_ids, data=data)[0]
+        html = self.with_context(context)._render_qweb_html(res_ids, data=data)[0]
 
         # Ensure the current document is utf-8 encoded.
         html = html.decode('utf-8')


### PR DESCRIPTION
If some fields are computed depending on fields with record rules,
the result value could be incorrect as records are evaluated with
su

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
