### PR TITLE
[IMP] web, mail, *: use Yes/No instead of True/False for boolean fields

### DIFF
--- a/addons/crm/static/tests/tours/crm_forecast_tour.js
+++ b/addons/crm/static/tests/tours/crm_forecast_tour.js
@@ -57,7 +57,7 @@ tour.register('crm_forecast', {
         trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Opportunity 1')",
         content: "move to the next month",
         run: function (actions) {
-            const undefined_groups = $('.o_column_title:contains("Undefined")').length;
+            const undefined_groups = $('.o_column_title:contains("None")').length;
             actions.drag_and_drop(` .o_opportunity_kanban .o_kanban_group:eq(${1 + undefined_groups})`, this.$anchor);
         }
     }, {

--- a/addons/mail/static/src/components/message/message.js
+++ b/addons/mail/static/src/components/message/message.js
@@ -282,8 +282,8 @@ export class Message extends Component {
              */
             switch (value.field_type) {
                 case 'boolean':
-                    value.old_value = format.boolean(value.old_value, undefined, { forceString: true });
-                    value.new_value = format.boolean(value.new_value, undefined, { forceString: true });
+                    value.old_value = value.old_value ? _lt('Yes') : _lt('No');
+                    value.new_value = value.new_value ? _lt('Yes') : _lt('No');
                     break;
                 /**
                  * many2one formatter exists but is expecting id/name_get or data

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -151,10 +151,12 @@
                                                 <t t-if="value.old_value">
                                                     <div class="o_Message_trackingValueOldValue o_Message_trackingValueItem" t-esc="value.old_value"/>
                                                 </t>
+                                                <i t-else="" class="mr-2">None</i>
                                                 <div class="o_Message_trackingValueSeparator o_Message_trackingValueItem fa fa-long-arrow-right" title="Changed" role="img"/>
                                                 <t t-if="value.new_value">
                                                     <div class="o_Message_trackingValueNewValue o_Message_trackingValueItem" t-esc="value.new_value"/>
                                                 </t>
+                                                <i t-else="">None</i>
                                             </div>
                                         </li>
                                     </t>

--- a/addons/mail/static/src/components/message/tests/message_tests.js
+++ b/addons/mail/static/src/components/message/tests/message_tests.js
@@ -1153,7 +1153,7 @@ QUnit.test('rendering of tracked field of type boolean: from true to false', asy
     await createMessageComponent(message);
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
-        "Is Ready:TrueFalse",
+        "Is Ready:YesNo",
         "should display the correct content of tracked field of type boolean: from true to false (Is Ready: True -> False)"
     );
 });
@@ -1175,7 +1175,7 @@ QUnit.test('rendering of tracked field of type boolean: from false to true', asy
     await createMessageComponent(message);
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
-        "Is Ready:FalseTrue",
+        "Is Ready:NoYes",
         "should display the correct content of tracked field of type boolean: from false to true (Is Ready: False -> True)"
     );
 });
@@ -1197,8 +1197,8 @@ QUnit.test('rendering of tracked field of type char: from a string to empty stri
     await createMessageComponent(message);
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
-        "Name:Marc",
-        "should display the correct content of tracked field of type char: from a string to empty string (Name: Marc ->)"
+        "Name:MarcNone",
+        "should display the correct content of tracked field of type char: from a string to empty string (Name: Marc -> None)"
     );
 });
 
@@ -1219,8 +1219,8 @@ QUnit.test('rendering of tracked field of type char: from empty string to a stri
     await createMessageComponent(message);
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
-        "Name:Marc",
-        "should display the correct content of tracked field of type char: from empty string to a string (Name: -> Marc)"
+        "Name:NoneMarc",
+        "should display the correct content of tracked field of type char: from empty string to a string (Name: None -> Marc)"
     );
 });
 
@@ -1241,8 +1241,8 @@ QUnit.test('rendering of tracked field of type date: from no date to a set date'
     await createMessageComponent(message);
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
-        "Deadline:12/14/2018",
-        "should display the correct content of tracked field of type date: from no date to a set date (Deadline: -> 12/14/2018)"
+        "Deadline:None12/14/2018",
+        "should display the correct content of tracked field of type date: from no date to a set date (Deadline: None -> 12/14/2018)"
     );
 });
 
@@ -1263,8 +1263,8 @@ QUnit.test('rendering of tracked field of type date: from a set date to no date'
     await createMessageComponent(message);
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
-        "Deadline:12/14/2018",
-        "should display the correct content of tracked field of type date: from a set date to no date (Deadline: 12/14/2018 ->)"
+        "Deadline:12/14/2018None",
+        "should display the correct content of tracked field of type date: from a set date to no date (Deadline: 12/14/2018 -> None)"
     );
 });
 
@@ -1285,8 +1285,8 @@ QUnit.test('rendering of tracked field of type datetime: from no date and time t
     await createMessageComponent(message);
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
-        "Deadline:12/14/2018 13:42:28",
-        "should display the correct content of tracked field of type datetime: from no date and time to a set date and time (Deadline: -> 12/14/2018 13:42:28)"
+        "Deadline:None12/14/2018 13:42:28",
+        "should display the correct content of tracked field of type datetime: from no date and time to a set date and time (Deadline: None -> 12/14/2018 13:42:28)"
     );
 });
 
@@ -1307,8 +1307,8 @@ QUnit.test('rendering of tracked field of type datetime: from a set date and tim
     await createMessageComponent(message);
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
-        "Deadline:12/14/2018 13:42:28",
-        "should display the correct content of tracked field of type datetime: from a set date and time to no date and time (Deadline: 12/14/2018 13:42:28 ->)"
+        "Deadline:12/14/2018 13:42:28None",
+        "should display the correct content of tracked field of type datetime: from a set date and time to no date and time (Deadline: 12/14/2018 13:42:28 -> None)"
     );
 });
 
@@ -1329,8 +1329,8 @@ QUnit.test('rendering of tracked field of type text: from some text to empty', a
     await createMessageComponent(message);
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
-        "Name:Marc",
-        "should display the correct content of tracked field of type text: from some text to empty (Name: Marc ->)"
+        "Name:MarcNone",
+        "should display the correct content of tracked field of type text: from some text to empty (Name: Marc -> None)"
     );
 });
 
@@ -1351,8 +1351,8 @@ QUnit.test('rendering of tracked field of type text: from empty to some text', a
     await createMessageComponent(message);
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
-        "Name:Marc",
-        "should display the correct content of tracked field of type text: from empty to some text (Name: -> Marc)"
+        "Name:NoneMarc",
+        "should display the correct content of tracked field of type text: from empty to some text (Name: None -> Marc)"
     );
 });
 
@@ -1373,8 +1373,8 @@ QUnit.test('rendering of tracked field of type selection: from a selection to no
     await createMessageComponent(message);
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
-        "State:ok",
-        "should display the correct content of tracked field of type selection: from a selection to no selection (State: ok ->)"
+        "State:okNone",
+        "should display the correct content of tracked field of type selection: from a selection to no selection (State: ok -> None)"
     );
 });
 
@@ -1395,8 +1395,8 @@ QUnit.test('rendering of tracked field of type selection: from no selection to a
     await createMessageComponent(message);
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
-        "State:ok",
-        "should display the correct content of tracked field of type selection: from no selection to a selection (State: -> ok)"
+        "State:Noneok",
+        "should display the correct content of tracked field of type selection: from no selection to a selection (State: None -> ok)"
     );
 });
 
@@ -1417,8 +1417,8 @@ QUnit.test('rendering of tracked field of type many2one: from having a related r
     await createMessageComponent(message);
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
-        "Author:Marc",
-        "should display the correct content of tracked field of type many2one: from having a related record to no related record (Author: Marc ->)"
+        "Author:MarcNone",
+        "should display the correct content of tracked field of type many2one: from having a related record to no related record (Author: Marc -> None)"
     );
 });
 
@@ -1439,8 +1439,8 @@ QUnit.test('rendering of tracked field of type many2one: from no related record 
     await createMessageComponent(message);
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
-        "Author:Marc",
-        "should display the correct content of tracked field of type many2one: from no related record to having a related record (Author: -> Marc)"
+        "Author:NoneMarc",
+        "should display the correct content of tracked field of type many2one: from no related record to having a related record (Author: None -> Marc)"
     );
 });
 

--- a/addons/web/static/src/legacy/js/control_panel/search_utils.js
+++ b/addons/web/static/src/legacy/js/control_panel/search_utils.js
@@ -16,8 +16,8 @@ odoo.define('web.searchUtils', function (require) {
             { symbol: "=", description: _lt("is not set"), value: false },
         ],
         boolean: [
-            { symbol: "=", description: _lt("is true"), value: true },
-            { symbol: "!=", description: _lt("is false"), value: true },
+            { symbol: "=", description: _lt("is Yes"), value: true },
+            { symbol: "!=", description: _lt("is No"), value: true },
         ],
         char: [
             { symbol: "ilike", description: _lt("contains") },

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_column.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_column.js
@@ -80,10 +80,12 @@ var KanbanColumn = Widget.extend({
 
         if (options.grouped_by_m2o || options.grouped_by_date || options.grouped_by_m2m) {
             // For many2x and datetime, a false value means that the field is not set.
-            this.title = value ? value : _t('Undefined');
+            this.title = value ? value : _t('None');
+        } else if (this.groupedBy && this.fields[this.groupedBy].type === 'boolean') {
+            this.title = value === undefined ? _t('None') : (value ? _t('Yes') : _t('No'));
         } else {
             // False and 0 might be valid values for these fields.
-            this.title = value === undefined ? _t('Undefined') : value;
+            this.title = value === undefined ? _t('None') : value;
         }
 
         if (options.group_by_tooltip) {

--- a/addons/web/static/src/legacy/js/views/list/list_renderer.js
+++ b/addons/web/static/src/legacy/js/views/list/list_renderer.js
@@ -718,8 +718,8 @@ var ListRenderer = BasicRenderer.extend({
         const groupByFieldName = groupBy.split(':')[0];
         const groupByField = group.fields[groupByFieldName];
         const name = groupByField.type === "boolean"
-            ? (group.value === undefined ? _t('Undefined') : group.value)
-            : (group.value === undefined || group.value === false ? _t('Undefined') : group.value);
+            ? (group.value === undefined ? _t('None') : (group.value ? _t('Yes') : _t('No')))
+            : (group.value === undefined || group.value === false ? _t('None') : group.value);
         var $th = $('<th>')
             .addClass('o_group_name')
             .attr('tabindex', -1)

--- a/addons/web/static/src/search/filter_menu/custom_filter_item.js
+++ b/addons/web/static/src/search/filter_menu/custom_filter_item.js
@@ -33,8 +33,8 @@ const FIELD_TYPES = {
 // FilterMenu parameters
 const FIELD_OPERATORS = {
     boolean: [
-        { symbol: "=", description: _lt("is true"), value: true },
-        { symbol: "!=", description: _lt("is false"), value: true },
+        { symbol: "=", description: _lt("is Yes"), value: true },
+        { symbol: "!=", description: _lt("is No"), value: true },
     ],
     char: [
         { symbol: "ilike", description: _lt("contains") },

--- a/addons/web/static/src/views/pivot/pivot_model.js
+++ b/addons/web/static/src/views/pivot/pivot_model.js
@@ -1516,8 +1516,17 @@ export class PivotModel extends Model {
     _sanitizeLabel(value, groupBy, config) {
         const { metaData } = config;
         const fieldName = groupBy.split(":")[0];
+        if (
+            fieldName &&
+            metaData.fields[fieldName] &&
+            metaData.fields[fieldName].type === "boolean"
+        ) {
+            return value === undefined ?
+                this.env._t('None')
+                : (value ? this.env._t('Yes') : this.env._t('No'));
+        }
         if (value === false) {
-            return this.env._t("Undefined");
+            return this.env._t("None");
         }
         if (value instanceof Array) {
             return this._getNumberedLabel(value, fieldName, config);

--- a/addons/web/static/tests/legacy/control_panel/custom_filter_item_tests.js
+++ b/addons/web/static/tests/legacy/control_panel/custom_filter_item_tests.js
@@ -211,7 +211,7 @@ odoo.define('web.filter_menu_generator_tests', function (require) {
                     const preFilters = args[0];
                     const preFilter = preFilters[0];
                     assert.strictEqual(preFilter.type, 'filter');
-                    assert.strictEqual(preFilter.description, 'Boolean Field is true');
+                    assert.strictEqual(preFilter.description, 'Boolean Field is Yes');
                     assert.strictEqual(preFilter.domain, '[["boolean_field","=",True]]');
                 }
             }
@@ -557,7 +557,7 @@ odoo.define('web.filter_menu_generator_tests', function (require) {
                             type: "filter",
                         },
                         {
-                            description: 'Boolean Field is false',
+                            description: 'Boolean Field is No',
                             domain: '[["boolean_field","!=",True]]',
                             type: "filter",
                         },

--- a/addons/web/static/tests/legacy/views/kanban_tests.js
+++ b/addons/web/static/tests/legacy/views/kanban_tests.js
@@ -357,7 +357,7 @@ QUnit.module('Views', {
 
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_kanban_group")].map(el => el.innerText.replace(/\s/g, " ")),
-            ["Undefined blork", "gold yopblip", "silver yopgnap"],
+            ["None blork", "gold yopblip", "silver yopgnap"],
         );
 
         // check archive/restore all actions in kanban header's config dropdown
@@ -5996,7 +5996,7 @@ QUnit.module('Views', {
                         "column should contain 2 record(s)");
         assert.strictEqual(kanban.$('.o_kanban_group:nth-child(3) .o_kanban_record').length, 1,
                         "column should contain 1 record(s)");
-        assert.ok(kanban.$('.o_kanban_group:first span.o_column_title:contains(Undefined)').length,
+        assert.ok(kanban.$('.o_kanban_group:first span.o_column_title:contains(None)').length,
             "first column should have a default title for when no value is provided");
         assert.ok(!kanban.$('.o_kanban_group:first .o_kanban_header_title').data('original-title'),
             "tooltip of first column should not defined, since group_by_tooltip title and the many2one field has no value");
@@ -8068,7 +8068,7 @@ QUnit.module('Views', {
         assert.containsNone(kanban.el, ".o_kanban_group.o_kanban_group_show");
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_column_title")].map(el => el.innerText),
-            ["false", "true"],
+            ["No", "Yes"],
         );
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_kanban_group:nth-child(1) .o_kanban_counter .progress-bar")].map(el => el.dataset.originalTitle),
@@ -8082,7 +8082,7 @@ QUnit.module('Views', {
         // Apply an active filter
         await testUtils.dom.click(kanban.el.querySelector(".o_kanban_group:nth-child(2) .progress-bar[data-filter=yop]"));
         assert.containsOnce(kanban.el, ".o_kanban_group.o_kanban_group_show");
-        assert.strictEqual(kanban.el.querySelector(".o_kanban_group.o_kanban_group_show .o_column_title").innerText, "true");
+        assert.strictEqual(kanban.el.querySelector(".o_kanban_group.o_kanban_group_show .o_column_title").innerText, "Yes");
 
         // Add searchdomain to something restricting progressbars' values (records still in filtered group)
         await kanban.update({ domain: [["foo", "=", "yop"]] });
@@ -8090,7 +8090,7 @@ QUnit.module('Views', {
         // Check that we have now 1 column only and check its progressbar's state
         assert.containsOnce(kanban.el, ".o_kanban_group");
         assert.containsOnce(kanban.el, ".o_kanban_group.o_kanban_group_show");
-        assert.strictEqual(kanban.el.querySelector(".o_column_title").innerText, "true");
+        assert.strictEqual(kanban.el.querySelector(".o_column_title").innerText, "Yes");
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_kanban_group .o_kanban_counter .progress-bar")].map(el => el.dataset.originalTitle),
             ["1 yop", "0 blip", "0 __false"],
@@ -8104,7 +8104,7 @@ QUnit.module('Views', {
         assert.containsOnce(kanban.el, ".o_kanban_group.o_kanban_group_show");
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_column_title")].map(el => el.innerText),
-            ["false", "true"],
+            ["No", "Yes"],
         );
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_kanban_group:nth-child(1) .o_kanban_counter .progress-bar")].map(el => el.dataset.originalTitle),
@@ -8147,7 +8147,7 @@ QUnit.module('Views', {
         assert.containsNone(kanban.el, ".o_kanban_group.o_kanban_group_show");
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_column_title")].map(el => el.innerText),
-            ["false", "true"],
+            ["No", "Yes"],
         );
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_kanban_group:nth-child(1) .o_kanban_counter .progress-bar")].map(el => el.dataset.originalTitle),
@@ -8169,7 +8169,7 @@ QUnit.module('Views', {
         // Apply an active filter
         await testUtils.dom.click(kanban.el.querySelector(".o_kanban_group:nth-child(2) .progress-bar[data-filter=yop]"));
         assert.containsOnce(kanban.el, ".o_kanban_group.o_kanban_group_show");
-        assert.strictEqual(kanban.el.querySelector(".o_kanban_group.o_kanban_group_show .o_column_title").innerText, "true");
+        assert.strictEqual(kanban.el.querySelector(".o_kanban_group.o_kanban_group_show .o_column_title").innerText, "Yes");
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_kanban_group.o_kanban_group_show .o_kanban_counter .progress-bar")].map(el => el.dataset.originalTitle),
             ["1 yop", "1 blip", "1 __false"],
@@ -8187,7 +8187,7 @@ QUnit.module('Views', {
         assert.containsNone(kanban.el, ".o_kanban_group.o_kanban_group_show");
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_column_title")].map(el => el.innerText),
-            ["false", "true"],
+            ["No", "Yes"],
         );
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_kanban_group:nth-child(1) .o_kanban_counter .progress-bar")].map(el => el.dataset.originalTitle),
@@ -8214,7 +8214,7 @@ QUnit.module('Views', {
         assert.containsNone(kanban.el, ".o_kanban_group.o_kanban_group_show");
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_column_title")].map(el => el.innerText),
-            ["false", "true"],
+            ["No", "Yes"],
         );
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_kanban_group:nth-child(1) .o_kanban_counter .progress-bar")].map(el => el.dataset.originalTitle),
@@ -8265,7 +8265,7 @@ QUnit.module('Views', {
         assert.containsNone(kanban.el, ".o_kanban_group.o_kanban_group_show");
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_column_title")].map(el => el.innerText),
-            ["false", "true"],
+            ["No", "Yes"],
         );
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_kanban_group:nth-child(1) .o_kanban_counter .progress-bar")].map(el => el.dataset.originalTitle),
@@ -8288,7 +8288,7 @@ QUnit.module('Views', {
         await testUtils.dom.click(kanban.el.querySelector(".o_kanban_group:nth-child(2) .progress-bar[data-filter=yop]"));
         assert.hasClass(kanban.el.querySelector(".o_kanban_group:nth-child(2)"), "o_kanban_group_show");
         assert.containsOnce(kanban.el, ".o_kanban_group.o_kanban_group_show");
-        assert.strictEqual(kanban.el.querySelector(".o_kanban_group.o_kanban_group_show .o_column_title").innerText, "true");
+        assert.strictEqual(kanban.el.querySelector(".o_kanban_group.o_kanban_group_show .o_column_title").innerText, "Yes");
         assert.containsOnce(kanban.el, ".o_kanban_group.o_kanban_group_show .o_kanban_record");
         assert.strictEqual(kanban.el.querySelector(".o_kanban_group.o_kanban_group_show .o_kanban_record").innerText, "1 yop");
 
@@ -8303,7 +8303,7 @@ QUnit.module('Views', {
         assert.containsOnce(kanban.el, ".o_kanban_group.o_kanban_group_show");
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_column_title")].map(el => el.innerText),
-            ["false", "true"],
+            ["No", "Yes"],
         );
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_kanban_group:nth-child(1) .o_kanban_counter .progress-bar")].map(el => el.dataset.originalTitle),
@@ -8358,7 +8358,7 @@ QUnit.module('Views', {
         assert.containsNone(kanban.el, ".o_kanban_group.o_kanban_group_show");
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_column_title")].map(el => el.innerText),
-            ["false", "true"],
+            ["No", "Yes"],
         );
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_kanban_group:nth-child(1) .o_kanban_counter .progress-bar")].map(el => el.dataset.originalTitle),
@@ -8387,7 +8387,7 @@ QUnit.module('Views', {
         await testUtils.dom.click(kanban.el.querySelector(".o_kanban_group:nth-child(2) .progress-bar[data-filter=yop]"));
         assert.hasClass(kanban.el.querySelector(".o_kanban_group:nth-child(2)"), "o_kanban_group_show");
         assert.containsOnce(kanban.el, ".o_kanban_group.o_kanban_group_show");
-        assert.strictEqual(kanban.el.querySelector(".o_kanban_group.o_kanban_group_show .o_column_title").innerText, "true");
+        assert.strictEqual(kanban.el.querySelector(".o_kanban_group.o_kanban_group_show .o_column_title").innerText, "Yes");
         assert.containsOnce(kanban.el, ".o_kanban_group.o_kanban_group_show .o_kanban_record");
         assert.strictEqual(kanban.el.querySelector(".o_kanban_group.o_kanban_group_show .o_kanban_record").innerText, "1 yop");
         assert.verifySteps(["/web/dataset/search_read"]);
@@ -8403,7 +8403,7 @@ QUnit.module('Views', {
         assert.containsNone(kanban.el, ".o_kanban_group.o_kanban_group_show");
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_column_title")].map(el => el.innerText),
-            ["false", "true"],
+            ["No", "Yes"],
         );
         assert.deepEqual(
             [...kanban.el.querySelectorAll(".o_kanban_group:nth-child(1) .o_kanban_counter .progress-bar")].map(el => el.dataset.originalTitle),

--- a/addons/web/static/tests/legacy/views/list_tests.js
+++ b/addons/web/static/tests/legacy/views/list_tests.js
@@ -1316,7 +1316,7 @@ QUnit.module('Views', {
         assert.containsNone(list, ".o_group_open", "no group is open");
         assert.deepEqual(
             [...list.el.querySelectorAll(".o_group_header .o_group_name")].map((el) => el.innerText),
-            ["Value 1 (3)", "Value 2 (2)", "Value 3 (1)", "Undefined (1)"],
+            ["Value 1 (3)", "Value 2 (2)", "Value 3 (1)", "None (1)"],
             "should have those group headers",
         );
 
@@ -1340,7 +1340,7 @@ QUnit.module('Views', {
                 "​blipValue1Value2Value3",
                 "Value3(1)",
                 "​blipValue1Value2Value3",
-                "Undefined(1)",
+                "None(1)",
                 "​gnap"
             ],
             "should have these row contents"
@@ -9188,7 +9188,7 @@ QUnit.module('Views', {
             groupBy: ['date:month'],
         });
 
-        assert.strictEqual(list.$('tbody').text(), "January 2017 (1)Undefined (3)",
+        assert.strictEqual(list.$('tbody').text(), "January 2017 (1)None (3)",
             "the group names should be correct");
 
         list.destroy();
@@ -10981,14 +10981,14 @@ QUnit.module('Views', {
             'should focus the "Add a line" button');
         await testUtils.fields.triggerKeydown($(document.activeElement), 'down');
 
-        assert.strictEqual(document.activeElement.textContent, 'false (1)',
+        assert.strictEqual(document.activeElement.textContent, 'No (1)',
             'focus should be on second group header');
         assert.strictEqual(list.$('tr.o_data_row').length, 3,
             'should have 3 rows displayed');
         await testUtils.fields.triggerKeydown($(document.activeElement), 'enter');
         assert.strictEqual(list.$('tr.o_data_row').length, 4,
             'should have 4 rows displayed');
-        assert.strictEqual(document.activeElement.textContent, 'false (1)',
+        assert.strictEqual(document.activeElement.textContent, 'No (1)',
             'focus should still be on second group header');
 
         await testUtils.fields.triggerKeydown($(document.activeElement), 'down');
@@ -11037,12 +11037,12 @@ QUnit.module('Views', {
             'second field of first record should be focused');
 
         await testUtils.fields.triggerKeydown($(document.activeElement), 'up');
-        assert.strictEqual(document.activeElement.textContent, 'true (3)',
+        assert.strictEqual(document.activeElement.textContent, 'Yes (3)',
             'focus should be on first group header');
         await testUtils.fields.triggerKeydown($(document.activeElement), 'enter');
         assert.strictEqual(list.$('tr.o_data_row').length, 2,
             'should have 2 rows displayed (first group should be closed)');
-        assert.strictEqual(document.activeElement.textContent, 'true (3)',
+        assert.strictEqual(document.activeElement.textContent, 'Yes (3)',
             'focus should still be on first group header');
 
         assert.strictEqual(list.$('tr.o_data_row').length, 2,
@@ -11050,27 +11050,27 @@ QUnit.module('Views', {
         await testUtils.fields.triggerKeydown($(document.activeElement), 'right');
         assert.strictEqual(list.$('tr.o_data_row').length, 5,
             'should have 5 rows displayed');
-        assert.strictEqual(document.activeElement.textContent, 'true (3)',
+        assert.strictEqual(document.activeElement.textContent, 'Yes (3)',
             'focus is still in header');
         await testUtils.fields.triggerKeydown($(document.activeElement), 'right');
         assert.strictEqual(list.$('tr.o_data_row').length, 5,
             'should have 5 rows displayed');
-        assert.strictEqual(document.activeElement.textContent, 'true (3)',
+        assert.strictEqual(document.activeElement.textContent, 'Yes (3)',
             'focus is still in header');
 
         await testUtils.fields.triggerKeydown($(document.activeElement), 'left');
         assert.strictEqual(list.$('tr.o_data_row').length, 2,
             'should have 2 rows displayed');
-        assert.strictEqual(document.activeElement.textContent, 'true (3)',
+        assert.strictEqual(document.activeElement.textContent, 'Yes (3)',
             'focus is still in header');
         await testUtils.fields.triggerKeydown($(document.activeElement), 'left');
         assert.strictEqual(list.$('tr.o_data_row').length, 2,
             'should have 2 rows displayed');
-        assert.strictEqual(document.activeElement.textContent, 'true (3)',
+        assert.strictEqual(document.activeElement.textContent, 'Yes (3)',
             'focus is still in header');
 
         await testUtils.fields.triggerKeydown($(document.activeElement), 'down');
-        assert.strictEqual(document.activeElement.textContent, 'false (2)',
+        assert.strictEqual(document.activeElement.textContent, 'No (2)',
             'focus should now be on second group header');
         await testUtils.fields.triggerKeydown($(document.activeElement), 'down');
         assert.strictEqual(document.activeElement.tagName, 'TD',
@@ -11188,7 +11188,7 @@ QUnit.module('Views', {
         assert.containsOnce(list, 'tbody:nth(3) .o_data_row');
 
         await testUtils.dom.click(list.$('.o_group_field_row_add a:eq(1)')); // create row in second group
-        assert.strictEqual(list.$('.o_group_name:eq(1)').text(), 'false (2)',
+        assert.strictEqual(list.$('.o_group_name:eq(1)').text(), 'No (2)',
             "group should have correct name and count");
         assert.containsN(list, 'tbody:nth(3) .o_data_row', 2);
         assert.hasClass(list.$('.o_data_row:nth(3)'), 'o_selected_row');

--- a/addons/web/static/tests/search/custom_filter_item_tests.js
+++ b/addons/web/static/tests/search/custom_filter_item_tests.js
@@ -320,7 +320,7 @@ QUnit.module("Search", (hooks) => {
 
         await applyFilter(controlPanel);
 
-        assert.deepEqual(getFacetTexts(controlPanel), ["Boolean Field is true"]);
+        assert.deepEqual(getFacetTexts(controlPanel), ["Boolean Field is Yes"]);
         assert.deepEqual(getDomain(controlPanel), [["boolean_field", "=", true]]);
 
         assert.containsOnce(controlPanel, ".o_menu_item");
@@ -672,7 +672,7 @@ QUnit.module("Search", (hooks) => {
         assert.deepEqual(getFacetTexts(controlPanel), [
             [
                 'A date is equal to "01/09/1997"',
-                "Boolean Field is false",
+                "Boolean Field is No",
                 'Floaty McFloatface is equal to "7.2"',
                 'ID is "9"',
             ].join("or"),

--- a/addons/web/static/tests/views/pivot_view_tests.js
+++ b/addons/web/static/tests/views/pivot_view_tests.js
@@ -2102,7 +2102,7 @@ QUnit.module("Views", (hooks) => {
         await toggleMenuItem(webClient, "Bar");
         assert.strictEqual(
             webClient.el.querySelector("tbody .o_pivot_header_cell_closed").textContent,
-            "true"
+            "Yes"
         );
 
         // remove filter
@@ -2110,7 +2110,7 @@ QUnit.module("Views", (hooks) => {
 
         assert.strictEqual(
             webClient.el.querySelector("tbody .o_pivot_header_cell_closed").textContent,
-            "true"
+            "Yes"
         );
     });
 
@@ -2155,7 +2155,7 @@ QUnit.module("Views", (hooks) => {
         await toggleMenuItem(webClient, "Bar");
         assert.strictEqual(
             webClient.el.querySelector("tbody .o_pivot_header_cell_closed").textContent,
-            "true"
+            "Yes"
         );
 
         // remove groupBy
@@ -2280,7 +2280,7 @@ QUnit.module("Views", (hooks) => {
 
             assert.strictEqual(
                 webClient.el.querySelector("thead .o_pivot_header_cell_closed").textContent,
-                "true"
+                "Yes"
             );
 
             // desactivate the unique existing favorite
@@ -2293,7 +2293,7 @@ QUnit.module("Views", (hooks) => {
 
             assert.strictEqual(
                 webClient.el.querySelector("thead .o_pivot_header_cell_closed").textContent,
-                "true"
+                "Yes"
             );
 
             // Let's get rid of the rows and columns groupBy
@@ -2321,7 +2321,7 @@ QUnit.module("Views", (hooks) => {
 
             assert.strictEqual(
                 webClient.el.querySelector("thead .o_pivot_header_cell_closed").textContent,
-                "true"
+                "Yes"
             );
         }
     );
@@ -4448,7 +4448,7 @@ QUnit.module("Views", (hooks) => {
             };
             serverData.models.partner.records[0].favorite_animal = "Dog";
             serverData.models.partner.records[1].favorite_animal = "false";
-            serverData.models.partner.records[2].favorite_animal = "Undefined";
+            serverData.models.partner.records[2].favorite_animal = "None";
 
             patchDate(2016, 11, 20, 1, 0, 0);
             const pivot = await makeView({
@@ -4468,7 +4468,7 @@ QUnit.module("Views", (hooks) => {
             );
             assert.deepEqual(
                 [...pivot.el.querySelectorAll("tbody th")].map((th) => th.innerText),
-                ["Total", "Dog", "false", "Undefined", "Undefined"],
+                ["Total", "Dog", "false", "None", "None"],
                 "The row headers should be as expected"
             );
         }
@@ -4545,7 +4545,7 @@ QUnit.module("Views", (hooks) => {
             );
             assert.deepEqual(
                 [...pivot.el.querySelectorAll("tbody th")].map((th) => th.innerText),
-                ["Total", "Company", "true", "individual", "true", "Undefined"],
+                ["Total", "Company", "Yes", "individual", "Yes", "No"],
                 "The row headers should be as expected"
             );
         }


### PR DESCRIPTION
Purpose
=======
"True" and "False" are not very user-friendly, especially for
non-technical people. Instead, we want to have "Yes" or "No" which have
more sens for non-technical people.

This change is done for the the custom filter and the tracking messages.

Task-2648390