### PR TITLE
[FIX] hr_expense: Make expense lines readonly on report

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -720,7 +720,7 @@
                     </group>
                      <notebook>
                         <page name="expenses" string="Expense">
-                        <field name="expense_line_ids" nolabel="1" widget="many2many" domain="[('state', '=', 'draft'), ('employee_id', '=', employee_id), ('company_id', '=', company_id)]" options="{'reload_on_button': True}" context="{'form_view_ref' : 'hr_expense.hr_expense_view_form_without_header', 'default_company_id': company_id, 'default_employee_id': employee_id}">
+                        <field name="expense_line_ids" nolabel="1" widget="many2many" domain="[('state', '=', 'draft'), ('employee_id', '=', employee_id), ('company_id', '=', company_id)]" options="{'reload_on_button': True}" context="{'form_view_ref' : 'hr_expense.hr_expense_view_form_without_header', 'default_company_id': company_id, 'default_employee_id': employee_id}" attrs="{'readonly': [('state', '!=', 'draft')]}">
                             <tree decoration-danger="is_refused" editable="bottom">
                                 <field name="date" optional="show"/>
                                 <field name="product_id"/>


### PR DESCRIPTION
Expected Behaviour

When creating a journal entry for an expense, the journal
shouldn't be editable once it has been submitted for approval.

Observed Behaviour

Even when the journal entry has been validated by the manager,
the list of expenses is still editable, which can cause serious
trouble.

Reproducibility

This bug can be reproduced following these steps:
- Create a new expense
- Create the related journal entry (Create report)
- Submit the report for approval
- Validate the report
- Try to edit the expenses list

Problem Root Cause

As it can be seen in the PR, this issue came from the fact the
expense list isn't in read-only mode

Related Issue(s)

opw-2659436

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
