### PR TITLE
[FIX] web_editor: prevent link dialog to close upon error

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
@@ -198,7 +198,9 @@ const LinkDialog = Dialog.extend({
     save: function () {
         this.linkWidget.save();
         this.final_data = this.linkWidget.final_data;
-        return this._super(...arguments);
+        if (this.final_data) {
+            return this._super(...arguments);
+        }
     },
 });
 


### PR DESCRIPTION
Before this commit, if the link dialog had unvalid form data, and the
user clicked on the "save" button, the link dialog tried to close
and save with no data.

Now, it is not possible to close the dialog if the form data is invalid.

Task-2583696

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
