### PR TITLE
[IMP] sales: add _create_invoices hook in sale.advance.payment.inv

### DIFF
--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -183,6 +183,16 @@ class Project(models.Model):
                     project._create_analytic_account()
         return super(Project, self).write(values)
 
+    def name_get(self):
+        res = super().name_get()
+        if len(self.env.context.get('allowed_company_ids', [])) <= 1:
+            return res
+        name_mapping = dict(res)
+        for project in self:
+            if project.is_internal_project:
+                name_mapping[project.id] = f'{name_mapping[project.id]} - {project.company_id.name}'
+        return list(name_mapping.items())
+
     @api.model
     def _init_data_analytic_account(self):
         self.search([('analytic_account_id', '=', False), ('allow_timesheets', '=', True)])._create_analytic_account()

--- a/addons/hr_timesheet/models/res_company.py
+++ b/addons/hr_timesheet/models/res_company.py
@@ -61,7 +61,7 @@ class ResCompany(models.Model):
         for company in self:
             company = company.with_company(company)
             results += [{
-                'name': _('Internal - %s', company.name),
+                'name': _('Internal'),
                 'allow_timesheets': True,
                 'company_id': company.id,
                 'type_ids': type_ids,

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -551,7 +551,7 @@
                     <field name="sequence" optional="show" widget="handle"/>
                     <field name="message_needaction" invisible="1"/>
                     <field name="active" invisible="1"/>
-                    <field name="name" string="Name" class="font-weight-bold"/>
+                    <field name="display_name" string="Name" class="font-weight-bold"/>
                     <field name="partner_id" optional="show" string="Customer"/>
                     <field name="privacy_visibility" optional="hide"/>
                     <field name="company_id" optional="show"  groups="base.group_multi_company" options="{'no_create': True, 'no_create_edit': True}"/>
@@ -648,7 +648,7 @@
             <field name="model">project.project</field>
             <field name="arch" type="xml">
                 <kanban class="oe_background_grey o_kanban_dashboard o_project_kanban o_emphasize_colors" on_create="project.open_create_project" js_class="project_project_kanban" sample="1">
-                    <field name="name"/>
+                    <field name="display_name"/>
                     <field name="partner_id"/>
                     <field name="commercial_partner_id"/>
                     <field name="color"/>
@@ -677,7 +677,7 @@
                                     <div class="o_kanban_card_content mw-100">
                                         <div class="o_kanban_primary_left">
                                             <div class="o_primary">
-                                                <span class="o_text_overflow"><t t-esc="record.name.value"/></span>
+                                                <span class="o_text_overflow"><t t-esc="record.display_name.value"/></span>
                                                 <span class="o_text_overflow text-muted" t-if="record.partner_id.value">
                                                     <span class="fa fa-user mr-2" aria-label="Partner" title="Partner"></span><t t-esc="record.partner_id.value"/>
                                                 </span>


### PR DESCRIPTION
Prior to this commit it was not possible to get a hook from
sale.advance.payment.inv in order to get the created invoices.

The create_invoices def returns either an action or an ir.actions.act_window_close

The introduction of the _create_invoices def will allow to get the created invoices
from the wizzard.

task-2608812

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
