### PR TITLE
[FIX] base: fix acl error on wizard merge contact

### DIFF
--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -208,8 +208,8 @@ class MergePartnerAutomatic(models.TransientModel):
             update_records('mail.message', src=partner)
             update_records('ir.model.data', src=partner)
 
-        records = self.env['ir.model.fields'].search([('ttype', '=', 'reference')])
-        for record in records.sudo():
+        records = self.env['ir.model.fields'].sudo().search([('ttype', '=', 'reference')])
+        for record in records:
             try:
                 Model = self.env[record.model]
                 field = Model._fields[record.name]


### PR DESCRIPTION
Since 5dc4cff60a557e, we removed the access read on ir.model.*

Before this commit, an employee without admin rights cannot merge partners
because he doesn't have the right to read the model ir.model.fields.

Now with use a sudo to find the reference fields and avoid the traceback.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
