### PR TITLE
[FIX] mrp_subcontracting_dropshipping: changing an incorrect function call

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/models/purchase.py
+++ b/addons/mrp_subcontracting_dropshipping/models/purchase.py
@@ -13,10 +13,9 @@ class PurchaseOrder(models.Model):
         if not self.dest_address_id:
             return super()._get_destination_location()
 
-        if self.mrp_production_count:
-            mrp_production_ids = self._get_mrp_productions()
-            if self.dest_address_id in mrp_production_ids.bom_id.subcontractor_ids:
-                return self.dest_address_id.property_stock_subcontractor.id
+        mrp_production_ids = (self.order_line.move_dest_ids.group_id.mrp_production_ids | self.order_line.move_ids.move_dest_ids.group_id.mrp_production_ids)
+        if mrp_production_ids and self.dest_address_id in mrp_production_ids.bom_id.subcontractor_ids:
+            return self.dest_address_id.property_stock_subcontractor.id
         elif self.sale_order_count:
             return super()._get_destination_location()
 


### PR DESCRIPTION
steps to reproduce the bug:
- install `”purchase_mrp”` and `”mrp_subcontracting_dropshipping”`
- Enable `”subcontracting”` option in the manufacturing settings
- Create a storable product “P1”:
    - in the inventory tab > enable the "Dropship Subcontractor on Order" route
    - in the purchase tab > add “azure interior” as vendor
- Create a storable product “P2”:
    - Create a BOM:
	- BOM type: Subcontracting
	- Add “azure interior” as Subcontractors
	- Add “P1” as Component
    - in the purchase tab > add “azure interior” as vendor
- Create a PO:
    - Select “azure interior” as vendor
    - Add “P2”
    - Confirm to trigger an automatic PO for the component
- Go to the automatic PO:
    - set the “Dropship Address”
    - Confirm the PO

Problem:
Traceback is triggered because a function that does not exist is used

opw-2686309




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
