### PR TITLE
[FIX] mail, activity view: filter out unrelevant activity types

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -604,8 +604,13 @@ class MailActivity(models.Model):
         activity_type_infos = []
         activity_type_ids = self.env['mail.activity.type'].search(
             ['|', ('res_model', '=', res_model), ('res_model', '=', False)])
+        displayed_activities = activity_type_ids.ids
+        if self._context.get('activity_hide_empty_group'):
+            displayed_activities = set([a['activity_type_id'][0] for a in grouped_activities])
         for elem in sorted(activity_type_ids, key=lambda item: item.sequence):
             mail_template_info = []
+            if elem.id not in displayed_activities:
+                continue
             for mail_template_id in elem.mail_template_ids:
                 mail_template_info.append({"id": mail_template_id.id, "name": mail_template_id.name})
             activity_type_infos.append([elem.id, elem.name, mail_template_info])

--- a/addons/mail/static/src/js/systray/systray_activity_menu.js
+++ b/addons/mail/static/src/js/systray/systray_activity_menu.js
@@ -69,7 +69,7 @@ var ActivityMenu = Widget.extend({
      * @returns {Array[]} output the list of views to display.
      */
     _getViewsList(model) {
-        return [[false, 'kanban'], [false, 'list'], [false, 'form']];
+        return [[false, 'kanban'], [false, 'list'], [false, 'form'], [false, 'activity']];
     },
     /**
      * Update(render) activity system tray view on activity updation.

--- a/addons/mail/static/src/js/views/activity/activity_model.js
+++ b/addons/mail/static/src/js/views/activity/activity_model.js
@@ -67,6 +67,7 @@ const ActivityModel = BasicModel.extend({
         params.domain.push(['activity_ids', '!=', false]);
         this.domain = params.domain;
         this.modelName = params.modelName;
+        this.context = params.context;
         params.groupedBy = [];
         var def = this._super.apply(this, arguments);
         return Promise.all([def, this._fetchData()]).then(function (result) {
@@ -110,7 +111,7 @@ const ActivityModel = BasicModel.extend({
             kwargs: {
                 res_model: this.modelName,
                 domain: this.domain,
-                context: session.user_context,
+                context: this.context,
             }
         }).then(function (result) {
             self.additionalData = result;


### PR DESCRIPTION
There're chances that the activity types are not relevant for the displayed objects, filtering out those never used avoid displaying empty columns in the activity view.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
