### PR TITLE
[FIX] project: fix not checking for user_ids presence + dependency tracking query count

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1879,6 +1879,8 @@ class Task(models.Model):
                 )
 
     def _message_auto_subscribe_followers(self, updated_values, default_subtype_ids):
+        if 'user_ids' not in updated_values:
+            return []
         # Since the changes to user_ids becoming a m2m, the default implementation of this function
         #  could not work anymore, override the function to keep the functionality.
         new_followers = []


### PR DESCRIPTION
Fixes an issue where new followers would always be checked upon updating
a task. Which could result in a lot more queries than necessary when
changes are cascading.

Use cache more in dependency tracking.

TaskId-2693899
