### PR TITLE
[IMP] auth_signup: redirect activated user to login on signup link

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import logging
 import werkzeug
+from werkzeug.urls import url_encode
 
 from odoo import http, tools, _
 from odoo.addons.auth_signup.models.res_users import SignupError
@@ -60,6 +61,11 @@ class AuthSignupHome(Home):
                     _logger.error("%s", e)
                     qcontext['error'] = _("Could not create a new account.")
 
+        elif 'signup_email' in qcontext:
+            user = request.env['res.users'].sudo().search([('email', '=', qcontext.get('signup_email')), ('state', '!=', 'new')], limit=1)
+            if user:
+                return request.redirect('/web/login?%s' % url_encode({'login': user.login, 'redirect': '/web'}))
+
         response = request.render('auth_signup.signup', qcontext)
         response.headers['X-Frame-Options'] = 'SAMEORIGIN'
         response.headers['Content-Security-Policy'] = "frame-ancestors 'self'"
@@ -92,6 +98,11 @@ class AuthSignupHome(Home):
                 _logger.exception('error when resetting password')
             except Exception as e:
                 qcontext['error'] = str(e)
+
+        elif 'signup_email' in qcontext:
+            user = request.env['res.users'].sudo().search([('email', '=', qcontext.get('signup_email')), ('state', '!=', 'new')], limit=1)
+            if user:
+                return request.redirect('/web/login?%s' % url_encode({'login': user.login, 'redirect': '/web'}))
 
         response = request.render('auth_signup.reset_password', qcontext)
         response.headers['X-Frame-Options'] = 'SAMEORIGIN'

--- a/addons/auth_signup/models/res_partner.py
+++ b/addons/auth_signup/models/res_partner.py
@@ -58,7 +58,7 @@ class ResPartner(models.Model):
 
             route = 'login'
             # the parameters to encode for the query
-            query = dict(db=self.env.cr.dbname)
+            query = {'db': self.env.cr.dbname, 'signup_email': partner.email}
             signup_type = self.env.context.get('signup_force_type_in_url', partner.sudo().signup_type or '')
             if signup_type:
                 route = 'reset_password' if signup_type == 'reset' else signup_type

--- a/addons/portal/data/mail_template_data.xml
+++ b/addons/portal/data/mail_template_data.xml
@@ -41,9 +41,6 @@
                             <a t-att-href="object.user_id.signup_url" style="display: inline-block; padding: 10px; text-decoration: none; font-size: 12px; background-color: #875A7B; color: #fff; border-radius: 5px;">
                                 <strong>Activate Account</strong>
                             </a>
-                            <a href="/web/login" style="display: inline-block; padding: 10px; text-decoration: none; font-size: 12px;">
-                                <strong>Log in</strong>
-                            </a>
                         </div>
                         <t t-out="object.wizard_id.welcome_message or ''">Welcome to our company's portal.</t>
                     </div>

--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -21,7 +21,7 @@ _logger = logging.getLogger(__name__)
 # Shared parameters for all login/signup flows
 SIGN_UP_REQUEST_PARAMS = {'db', 'login', 'debug', 'token', 'message', 'error', 'scope', 'mode',
                           'redirect', 'redirect_hostname', 'email', 'name', 'partner_id',
-                          'password', 'confirm_password', 'city', 'country_id', 'lang'}
+                          'password', 'confirm_password', 'city', 'country_id', 'lang', 'signup_email'}
 LOGIN_SUCCESSFUL_PARAMS = set()
 
 


### PR DESCRIPTION
Purpose
=======
When a user receives an email to activate their account, allow them to
click on the "Activate Account" button after the account has already
been activated instead of showing a "Invalid signup token" error.

Specifications
=============
Add a parameter p_id to the sign up url to check if the partner has
already activated their account (if their user_ids state is not new) and
redirect them to login otherwise.

Task-2680414
