### PR TITLE
[FIX] hr_holidays: fix date range picker

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -256,7 +256,7 @@
                                         'invisible': ['|', ('request_unit_half', '=', True), ('request_unit_hours', '=', True)],
                                         'required': ['|', ('date_from', '=', False), ('date_to', '=', False)]
                                             }"
-                                    widget="daterange" options="{'related_end_date': 'request_date_from'}"/>
+                                    widget="daterange" options="{'related_start_date': 'request_date_from'}"/>
                                 <field name="request_date_from_period" class="oe_inline"
                                     string="In"
                                     options="{'horizontal': True}"


### PR DESCRIPTION
Before this commit, picking a range of dates by clicking on
the end date field set the wrong date on the start date field.
This was because the option "related_end_date" was used
on the end date field instead of "related_start_date"

Replacing the "related_end_date" by "related_start_date"
on the end date field fixes the issue.