### PR TITLE
[FIX] hr_holidays: let 'new time off' button open dialog

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1240,6 +1240,11 @@ class HolidaysRequest(models.Model):
             'domain': domain
         }
 
+    def get_new_time_off_view_ids(self):
+        return self.env['ir.ui.view'].sudo().search([
+            ['name', '=', 'hr.leave.view.form.dashboard.new.time.off'],
+            ['model', '=', 'hr.leave'],
+        ]).ids
 
     def _check_approval_update(self, state):
         """ Check if target state is achievable. """

--- a/addons/hr_holidays/static/src/js/time_off_calendar.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar.js
@@ -85,16 +85,11 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
         _onNewTimeOff: function () {
             let self = this;
 
-            let domain = [
-                ['name', '=', 'hr.leave.view.form.dashboard.new.time.off'],
-                ['model', '=', 'hr.leave']
-            ];
-
             self._rpc({
-                model: 'ir.ui.view',
-                method: 'search',
-                args: [domain],
-            }).then(function(ids) {
+                model: 'hr.leave',
+                method: 'get_new_time_off_view_ids',
+                args: [[]],
+            }).then(function (ids) {
                 self.timeOffDialog = new dialogs.FormViewDialog(self, {
                     res_model: "hr.leave",
                     view_id: ids,

--- a/addons/hr_holidays/static/src/js/time_off_calendar_employee.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar_employee.js
@@ -181,15 +181,11 @@ odoo.define('hr_holidays.employee.dashboard.views', function(require) {
         _onNewTimeOff: function () {
             let self = this;
 
-            let domain = [
-                ['name', '=', 'hr.leave.view.form.dashboard.new.time.off']
-            ];
-
             self._rpc({
-                model: 'ir.ui.view',
-                method: 'search',
-                args: [domain],
-            }).then(function(ids) {
+                model: 'hr.leave',
+                method: 'get_new_time_off_view_ids',
+                args: [[]],
+            }).then(function (ids) {
                 self.timeOffDialog = new dialogs.FormViewDialog(self, {
                     res_model: "hr.leave",
                     view_id: ids,


### PR DESCRIPTION
Before this commit, the user that doesn't have super power, will not be able
to launch the dialog to encode his time off, because a search on ir.ui.view is
done in rpc but it is only allowed for powered user.

Now we call a method that return the ids with a sudo to avoid to have the
traceback.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
