### PR TITLE
[FIX] website_payment: fix traceback with specific input

### DIFF
--- a/addons/website_payment/models/payment_transaction.py
+++ b/addons/website_payment/models/payment_transaction.py
@@ -18,7 +18,7 @@ class PaymentTransaction(models.Model):
                 field_name = tx._fields[field].string
                 value = tx[field]
                 if value:
-                    if 'name' in value:
+                    if hasattr(value, 'name'):
                         value = value.name
                     msg.append('<br/>- %s: %s' % (field_name, value))
             tx.payment_id._message_log(body=''.join(msg))


### PR DESCRIPTION
When trying to donate on the website without being logged in, having
'name' in your name would trigger a traceback.

TaskId-2694024