### PR TITLE
[FIX] website: change the asset disabling from GC to CRON

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -27,6 +27,7 @@
         'security/website_security.xml',
         'security/ir.model.access.csv',
         'data/ir_asset.xml',
+        'data/ir_cron_data.xml',
         'data/mail_mail_data.xml',
         'data/website_data.xml',
         'data/website_visitor_cron.xml',

--- a/addons/website/data/ir_cron_data.xml
+++ b/addons/website/data/ir_cron_data.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="website_disable_unused_snippets_assets" model="ir.cron">
+        <field name="name">Disable unused snippets assets</field>
+        <field name="model_id" ref="model_website"/>
+        <field name="state">code</field>
+        <field name="code">model._disable_unused_snippets_assets()</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">weeks</field>
+        <field name="numbercall">-1</field>
+    </record>
+</odoo>

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1436,7 +1436,6 @@ class Website(models.Model):
                     return True
         return False
 
-    @api.autovacuum
     def _disable_unused_snippets_assets(self):
         snippets_assets = self._get_snippets_assets()
         html_fields = self._get_html_fields()


### PR DESCRIPTION
Before this commit, the behavior disabling the unsed snippet assets was put
directly in the autovaccum CRON instead of its own CRON.

That behavior is leading to some perf-issue running the autovaccum cron since
it would take too much time.
Indeed, the code will loop inside as many snippet as it exists, and every time
then perform an SQL Query to get the HTML fields using the snippet.

An improvement will come later to not loop on every snippet anymore.

task-2694120
