### PR TITLE
[FIX] hr_holidays, *_calendar: disable sync on new leave

### DIFF
--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -31,6 +31,9 @@ def after_commit(func):
         context = self.env.context
         uid = self.env.uid
 
+        if self.env.context.get('no_calendar_sync'):
+            return
+
         @self.env.cr.postcommit.add
         def called_after():
             db_registry = registry(dbname)

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1189,6 +1189,7 @@ class HolidaysRequest(models.Model):
                     tracking_disable=True,
                     mail_activity_automation_skip=True,
                     leave_fast_create=True,
+                    no_calendar_sync=True,
                     leave_skip_state_check=True,
                 ).create(values)
 

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -33,6 +33,9 @@ def after_commit(func):
         context = self.env.context
         uid = self.env.uid
 
+        if self.env.context.get('no_calendar_sync'):
+            return
+
         @self.env.cr.postcommit.add
         def called_after():
             db_registry = registry(dbname)


### PR DESCRIPTION
On large databases, the `postcommit` hook for Google|Microsoft Calendar
was taking up to 10% of a leave validation even if the user has the sync
disabled.

This commit disables the postcommit hook for new leaves, as the event will
be synced through the cron eventually.

TaskID: 2693265

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
