### PR TITLE
[FIX] hr_contract: fix wrong view definition

### DIFF
--- a/addons/hr_contract/views/hr_employee_public_views.xml
+++ b/addons/hr_contract/views/hr_employee_public_views.xml
@@ -5,9 +5,9 @@
         <field name="model">hr.employee.public</field>
         <field name="inherit_id" ref="hr.hr_employee_public_view_form"/>
         <field name="arch" type="xml">
+            <field name="employee_type" position="replace"/>
+            <field name="user_id" position="replace"/>
             <group name="location" position="after">
-                <field name="employee_type" position="replace"/>
-                <field name="user_id" position="replace"/>
                 <group string="Status" name="status">
                     <field name="employee_type"/>
                     <field name="first_contract_date"/>


### PR DESCRIPTION
The fields `employee_type` and `user_id` were not properly replaced in
the view.

TaskID: 2694143

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
