### PR TITLE
[FIX] hr_holidays: let 'new time off' button open dialog

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar.js
@@ -85,15 +85,10 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
         _onNewTimeOff: function () {
             let self = this;
 
-            let domain = [
-                ['name', '=', 'hr.leave.view.form.dashboard.new.time.off'],
-                ['model', '=', 'hr.leave']
-            ];
-
             self._rpc({
                 model: 'ir.ui.view',
-                method: 'search',
-                args: [domain],
+                method: 'get_view_id',
+                args: ['hr_holidays.hr_leave_view_form_dashboard_new_time_off'],
             }).then(function(ids) {
                 self.timeOffDialog = new dialogs.FormViewDialog(self, {
                     res_model: "hr.leave",
@@ -120,15 +115,10 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
         _onNewAllocation: function () {
             let self = this;
 
-            let domain = [
-                ['name', '=', 'hr.leave.view.form.dashboard'],
-                ['model', '=', 'hr.leave.allocation']
-            ];
-
             self._rpc({
                 model: 'ir.ui.view',
-                method: 'search',
-                args: [domain],
+                method: 'get_view_id',
+                args: ['hr_holidays.hr_leave_allocation_view_form_dashboard'],
             }).then(function(ids) {
                 self.allocationDialog = new dialogs.FormViewDialog(self, {
                     res_model: "hr.leave.allocation",

--- a/addons/hr_holidays/static/src/js/time_off_calendar_employee.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar_employee.js
@@ -181,14 +181,10 @@ odoo.define('hr_holidays.employee.dashboard.views', function(require) {
         _onNewTimeOff: function () {
             let self = this;
 
-            let domain = [
-                ['name', '=', 'hr.leave.view.form.dashboard.new.time.off']
-            ];
-
             self._rpc({
                 model: 'ir.ui.view',
-                method: 'search',
-                args: [domain],
+                method: 'get_view_id',
+                args: ['hr_holidays.hr_leave_view_form_dashboard_new_time_off'],
             }).then(function(ids) {
                 self.timeOffDialog = new dialogs.FormViewDialog(self, {
                     res_model: "hr.leave",
@@ -216,14 +212,10 @@ odoo.define('hr_holidays.employee.dashboard.views', function(require) {
         _onNewAllocation: function () {
             let self = this;
 
-            let domain = [
-                ['name', '=', 'hr.leave.allocation.view.form.manager.dashboard']
-            ];
-
             self._rpc({
                 model: 'ir.ui.view',
-                method: 'search',
-                args: [domain],
+                method: 'get_view_id',
+                args: ['hr_holidays.hr_leave_allocation_view_form_manager_dashboard'],
             }).then(function(ids) {
                 self.allocationDialog = new dialogs.FormViewDialog(self, {
                     res_model: "hr.leave.allocation",


### PR DESCRIPTION
Before this commit, if the user doesn't have super power,
he will not be able to launch the dialog to encode his time off,
because a search on ir.ui.view is done in rpc
but it is only allowed for powered user.

Now we user the method get_view_id instead.

Only applicable to 15.0

task-2694180

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
