### PR TITLE
[FIX] hr_holidays: allow Officers to create allocation again

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -91,7 +91,7 @@
                     <group>
                         <group>
                             <field name="type_request_unit" invisible="1"/>
-                            <field name="holiday_status_id" context="{'employee_id':employee_id, 'default_date_from':current_date}" domain="[('employee_requests', '=', 'yes')]"/>
+                            <field name="holiday_status_id" context="{'employee_id':employee_id, 'default_date_from':current_date}"/>
 
                             <field name="allocation_type" invisible="1" widget="radio"
                                 attrs="{'readonly': ['|', ('is_officer', '=', False), ('state', 'not in', ('draft', 'confirm'))]}"/>


### PR DESCRIPTION
The domain on the allocation leave type was too restrictive for Time Off
Officer and they couldn't create allocations when the "Employee
Requests" of the Time Off Type was set to "no".

This commit allows the Time Off Officer to request those allocations
again.

TaskID: 2694163

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
