### PR TITLE
[FIX] web_editor: avoid editor history on image cropper

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5036,7 +5036,7 @@ registry.ImageTools = ImageHandlerOption.extend({
     async crop() {
         this.trigger_up('hide_overlay');
         this.trigger_up('disable_loading_effect');
-        new weWidgets.ImageCropWidget(this, this.$target[0]).appendTo(this.options.wysiwyg.$editable);
+        new weWidgets.ImageCropWidget(this, this.$target[0]).appendTo(this.options.wysiwyg.odooEditor.document.body);
 
         await new Promise(resolve => {
             this.$target.one('image_cropper_destroyed', async () => {
@@ -5077,7 +5077,7 @@ registry.ImageTools = ImageHandlerOption.extend({
      */
     async resetCrop() {
         const cropper = new weWidgets.ImageCropWidget(this, this.$target[0]);
-        await cropper.appendTo(this.options.wysiwyg.$editable);
+        await cropper.appendTo(this.options.wysiwyg.odooEditor.document.body);
         await cropper.reset();
         await this._reapplyCurrentShape();
     },


### PR DESCRIPTION
In some circumstance, the image cropper is being reverted by the
Odoo editor unbreakable mechanics. The reason was that the cropper tool
was appended inside the editable rather than outside the editable.

Task-2693553



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
