### PR TITLE
[FIX] web_editor: keep table styling

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -115,6 +115,8 @@ const CLIPBOARD_WHITELISTS = {
         'img-thumbnail',
         'rounded',
         'rounded-circle',
+        'table',
+        'table-bordered',
         /^padding-/,
         /^shadow/,
         // Odoo colors


### PR DESCRIPTION
Before this commit, the styles of the table were not kept when
copy/pasting a table generated by the Odoo editor. Now it is.

Task-2657445



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
