### PR TITLE
[FIX] web: list_view: pager in grouped list display

### DIFF
--- a/addons/web/static/src/legacy/scss/list_view.scss
+++ b/addons/web/static/src/legacy/scss/list_view.scss
@@ -165,12 +165,16 @@
                 margin-top: -2px;
                 margin-bottom: -2px;
 
+                input.o_pager_value {
+                    display: inline-block;
+                }
+
                 .o_pager_previous, .o_pager_next {
                     max-height: 30px;
                     padding: 0 5px;
-                    background-color: $o-list-group-header-color;
+                    background-color: lighten($o-brand-lightsecondary, 10%);
                     &:hover {
-                        background-color: darken($o-list-group-header-color, 10%);
+                        background-color: $o-brand-lightsecondary;
                     }
                 }
             }


### PR DESCRIPTION
Before this commit, the style of the pager in a grouped list was a little off.
- The colors of the previous/next buttons were too dark in enterprise (because of: odoo/enterprise@f26203eb2472bef48cc0fd57dff766ada5a598d2)
- The pager's input lost its alignment.

After this commit, the situation is much better, colors are okay and the pager's
input doesn't jump randomly somewhere else.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
