### PR TITLE
[WIP][IMP] survey: improve convenience of question creation

### DIFF
--- a/addons/survey/__manifest__.py
+++ b/addons/survey/__manifest__.py
@@ -92,6 +92,8 @@ sent mails with personal token for the invitation of the survey.
             'survey/static/src/css/survey_templates_result.css',
             'survey/static/src/js/fields_section_one2many.js',
             'survey/static/src/js/fields_form_page_description.js',
+            'survey/static/src/js/survey_survey_controller.js',
+            'survey/static/src/js/survey_survey_view.js',
             'survey/static/src/scss/survey_survey_views.scss',
         ],
         'web.assets_tests': [

--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -704,3 +704,11 @@ class Survey(http.Controller):
         user_input_lines = request.env['survey.user_input'].sudo().search(user_input_domain).mapped('user_input_line_ids')
 
         return user_input_lines, search_filters
+
+    # ------------------------------------------------------------
+    # SURVEY "VALIDATE ENTRY" CHECKS
+    # ------------------------------------------------------------
+
+    @http.route('/survey/form_validation', type='json', auth='user', website=False)
+    def get_check_validate_entry_js(self):
+        return json.dumps(request.env['survey.question'].get_form_validation_js())

--- a/addons/survey/static/src/js/survey_survey_controller.js
+++ b/addons/survey/static/src/js/survey_survey_controller.js
@@ -1,0 +1,33 @@
+odoo.define('survey.SurveyFormController', function (require) {
+'use strict';
+
+const FormController = require('web.FormController');
+const core = require('web.core');
+
+const _t = core._t;
+
+
+return FormController.extend({
+    custom_events: _.extend({}, FormController.prototype.custom_events, {
+        save_form_before_new_question: '_saveFormBeforeNewQuestion',
+    }),
+
+    _saveFormBeforeNewQuestion: async function (ev) {
+        if (ev) {
+            ev.stopPropagation();
+        }
+        // Run this pipeline synchronously before opening editor form to update/create
+        return await this.saveRecord(null, {
+            stayInEdit: true,
+            reload: true,
+        }).then(function () {
+            if (ev && ev.data.callback)
+                ev.data.callback();
+            return Promise.resolve("Survey saved")
+        }).catch(reason => {
+            return Promise.reject(reason);
+        })
+    }
+});
+
+});

--- a/addons/survey/static/src/js/survey_survey_view.js
+++ b/addons/survey/static/src/js/survey_survey_view.js
@@ -1,0 +1,20 @@
+odoo.define('survey.SurveyFormView', function (require) {
+'use strict';
+
+const SurveyFormController = require('survey.SurveyFormController');
+const FormRenderer = require('web.FormRenderer');
+const FormView = require('web.FormView');
+const viewRegistry = require('web.view_registry');
+
+const SurveyFormView = FormView.extend({
+    config: _.extend({}, FormView.prototype.config, {
+        Controller: SurveyFormController,
+        Renderer: FormRenderer,
+    }),
+});
+
+viewRegistry.add('survey_survey_form', SurveyFormView);
+
+return SurveyFormView;
+
+});

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -181,7 +181,9 @@
                                 </group>
                                 <group string="Conditional Display" attrs="{'invisible': [('questions_selection', '=', 'random')]}">
                                     <field name="is_conditional"/>
-                                    <field name="triggering_question_id"  options="{'no_open': True, 'no_create': True}"
+                                    <field name="allowed_triggering_question_ids" invisible="1"/>
+                                    <field name="triggering_question_id"  options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"
+                                           domain="[('id', 'in', allowed_triggering_question_ids)]"
                                            attrs="{'invisible': [('is_conditional','=', False)], 'required': [('is_conditional','=', True)]}"/>
                                     <field name="triggering_answer_id" options="{'no_open': True, 'no_create': True}"
                                            attrs="{'invisible': ['|', ('is_conditional','=', False), ('triggering_question_id','=', False)],

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -5,7 +5,7 @@
         <field name="name">survey.survey.view.form</field>
         <field name="model">survey.survey</field>
         <field name="arch" type="xml">
-            <form string="Survey" class="o_survey_form">
+            <form js_class="survey_survey_form" string="Survey" class="o_survey_form">
                 <field name="id" invisible="1"/>
                 <field name="session_state" invisible="1"/>
                 <header>


### PR DESCRIPTION
PURPOSE
This commit addresses two pain points of creating questions in Survey.
1. The 'Validate Entry' fields were not verified before the survey was saved,
although database constraints are set. This forces the user to go back to
question forms after they are closed if errors were made.
2. When creating a scored survey, the survey has to be saved for the option to
score a question to appear on the "Add/modify question" forms.

SPECIFICATIONS
1. For the survey question model, SQL constraints are now defined in parallel
with a JavaScript counterpart. When loading a survey, the client will fetch an
additional JavaScript function to perform client-side validation of form fields.

2. The parent survey will be saved synchronously before opening a question form,
allowing the latter to access survey fields such as the option to score
questions without the user having to click save and go back to edit mode
(similarly to [#6675](https://github.com/odoo/enterprise/pull/6675)).

Task-2623482