### PR TITLE
[FIX] tools.mail: ignore original email during encapsulation

### DIFF
--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -469,12 +469,14 @@ class EmailConfigCase(SavepointCase):
         set_param('mail.dynamic.smtp.from', False)
         set_param('mail.catchall.domain', 'odoo.example.com')
 
-        email_from, return_path = get_email_from('admin@test.example.com')
-        self.assertEqual(email_from, '"admin@test.example.com" <email_force@domain.com>')
+        # name + email -> encapsulated with name only
+        email_from, return_path = get_email_from('"Admin" <admin@test.example.com>')
+        self.assertEqual(email_from, '"Admin" <email_force@domain.com>')
         self.assertEqual(return_path, 'email_force@domain.com')
 
-        email_from, return_path = get_email_from('"Admin" <admin@test.example.com>')
-        self.assertEqual(email_from, '"Admin (admin@test.example.com)" <email_force@domain.com>')
+        # no-name + email -> encapsulated with local part of email only
+        email_from, return_path = get_email_from('admin@test.example.com')
+        self.assertEqual(email_from, '"admin" <email_force@domain.com>')
         self.assertEqual(return_path, 'email_force@domain.com')
 
         # We always force the email FROM (notification email contains a name part)
@@ -483,7 +485,7 @@ class EmailConfigCase(SavepointCase):
         set_param('mail.catchall.domain', 'odoo.example.com')
 
         email_from, return_path = get_email_from('"Admin" <admin@test.example.com>')
-        self.assertEqual(email_from, '"Admin (admin@test.example.com)" <email_force@domain.com>',
+        self.assertEqual(email_from, '"Admin" <email_force@domain.com>',
                          msg='Should drop the name part of the forced email')
         self.assertEqual(return_path, 'email_force@domain.com')
 
@@ -493,7 +495,7 @@ class EmailConfigCase(SavepointCase):
         set_param('mail.catchall.domain', 'odoo.example.com')
 
         email_from, return_path = get_email_from('"Admin" <admin@test.example.com>')
-        self.assertEqual(email_from, '"Admin (admin@test.example.com)" <notification@odoo.example.com>',
+        self.assertEqual(email_from, '"Admin" <notification@odoo.example.com>',
                          msg='Domain is not the same as the catchall domain, we should force the email FROM')
         self.assertEqual(return_path, 'notification@odoo.example.com')
 
@@ -508,7 +510,7 @@ class EmailConfigCase(SavepointCase):
         set_param('mail.catchall.domain', 'odoo.example.com')
 
         email_from, return_path = get_email_from('"Admin" <admin@test.example.com>')
-        self.assertEqual(email_from, '"Admin (admin@test.example.com)" <notification@odoo.example.com>',
+        self.assertEqual(email_from, '"Admin" <notification@odoo.example.com>',
                          msg='Domain is not the same as the catchall domain, we should force the email FROM')
         self.assertEqual(return_path, 'notification@odoo.example.com')
 

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -621,7 +621,7 @@ def encapsulate_email(old_email, new_email):
     e.g.
     * Old From: "Admin" <admin@gmail.com>
     * New From: notifications@odoo.com
-    * Output:   "Admin (admin@gmail.com)" <notifications@odoo.com>
+    * Output: "Admin" <notifications@odoo.com>
     """
     old_email_split = getaddresses([old_email])
     if not old_email_split or not old_email_split[0]:
@@ -631,10 +631,11 @@ def encapsulate_email(old_email, new_email):
     if not new_email_split or not new_email_split[0]:
         return
 
-    if old_email_split[0][0]:
-        name_part = '%s (%s)' % old_email_split[0]
+    old_name, old_email = old_email_split[0]
+    if old_name:
+        name_part = old_name
     else:
-        name_part = old_email_split[0][1]
+        name_part = old_email.split("@")[0]
 
     return formataddr((
         name_part,


### PR DESCRIPTION
When the system broadcasts an email response to document followers, if the config parameters `mail.force.smtp.from` or `mail.dynamic.smtp.from` are defined, it will rewrite the `From` address to avoid spoofing the sender's domain.

For example, if the `mail.catchall.domain` is set to `example.com` and an email response comes from:

   `"John D" <john@doe.com>`

it will rewrite it to:

   `"John D (john@doe.com)" <notifications@example.com>`

This will make sure the system never sends outgoing email for an external domain, as it has no authority for doing so, and that could break mail filtering/authentication rules (SPF, DMARC, etc.)

During this "encapsulation rewrite step", both the original Sender name and their email are preserved, and put into the quoted "name" field of the rewritten address. It seems sensible to preserve as much information as possible about the original sender.

Unfortunately, the inclusion of the Sender email in the final name makes it appear to some inbox providers as if the message is trying to deceptively impersonate another person (as many phishing schemes would).
As of November 2021 GMail at least does this, and will hide the name in the UI when it happens. It will keep only the rewritten email, which is not very useful in the case of a notification (even though it's more technically correct, of course).

This patch removes the original email from the rewritten notification, keeping only the name, considering that the email is not the most important part, and it's better to have one of the two than none.

So after the patch, the rewritten address is now:
    
  `"John D" <notifications@example.com>`
    
When there is no name in the original address, we keep only the local part of the email, to avoid the same display issue. The recipient will have to identify the sender based on the context / past messages.
