### PR TITLE
[FIX] pos_{hr,restaurant}: show opening cash control popup at the right time

### DIFF
--- a/addons/point_of_sale/static/src/js/Chrome.js
+++ b/addons/point_of_sale/static/src/js/Chrome.js
@@ -12,9 +12,10 @@ odoo.define('point_of_sale.Chrome', function(require) {
     const Registries = require('point_of_sale.Registries');
     const IndependentToOrderScreen = require('point_of_sale.IndependentToOrderScreen');
     const contexts = require('point_of_sale.PosContext');
-    const { identifyError } = require('point_of_sale.utils');
+    const { identifyError, posbus } = require('point_of_sale.utils');
     const { odooExceptionTitleMap } = require("@web/core/errors/error_dialogs");
     const { ConnectionLostError, ConnectionAbortedError, RPCError } = require('@web/core/network/rpc_service');
+    const { useBus } = require("@web/core/utils/hooks");
 
     // This is kind of a trick.
     // We get a reference to the whole exports so that
@@ -40,6 +41,7 @@ odoo.define('point_of_sale.Chrome', function(require) {
             useListener('set-sync-status', this._onSetSyncStatus);
             useListener('show-notification', this._onShowNotification);
             useListener('close-notification', this._onCloseNotification);
+            useBus(posbus, 'start-cash-control', this.openCashControl);
             NumberBuffer.activate();
 
             this.chromeContext = useContext(contexts.chrome);
@@ -203,6 +205,16 @@ odoo.define('point_of_sale.Chrome', function(require) {
                     exitButtonIsShown: true,
                 });
             }
+        }
+
+        openCashControl() {
+            if (this.shouldShowCashControl()) {
+                this.showPopup('CashOpeningPopup', { notEscapable: true });
+            }
+        }
+
+        shouldShowCashControl() {
+            return this.env.pos.config.cash_control && this.env.pos.pos_session.state == 'opening_control';
         }
 
         // EVENT HANDLERS //

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -7,8 +7,7 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
     const { useListener } = require('web.custom_hooks');
     const Registries = require('point_of_sale.Registries');
     const { onChangeOrder, useBarcodeReader } = require('point_of_sale.custom_hooks');
-    const { Gui } = require('point_of_sale.Gui');
-    const { isConnectionError } = require('point_of_sale.utils');
+    const { isConnectionError, posbus } = require('point_of_sale.utils');
     const { useState, onMounted } = owl.hooks;
     const { parse } = require('web.field_utils');
 
@@ -45,9 +44,7 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
             });
         }
         mounted() {
-            if(this.env.pos.config.cash_control && this.env.pos.pos_session.state == 'opening_control') {
-                Gui.showPopup('CashOpeningPopup', {notEscapable: true});
-            }
+            posbus.trigger('start-cash-control');
             this.env.pos.on('change:selectedClient', this.render, this);
         }
         willUnmount() {

--- a/addons/pos_hr/static/src/js/Chrome.js
+++ b/addons/pos_hr/static/src/js/Chrome.js
@@ -17,6 +17,9 @@ odoo.define('pos_hr.chrome', function (require) {
             showCashMoveButton() {
                 return super.showCashMoveButton() && this.env.pos.get('cashier').role == 'manager';
             }
+            shouldShowCashControl() {
+                return super.shouldShowCashControl() && this.env.pos.hasLoggedIn;
+            }
         };
 
     Registries.Component.extend(Chrome, PosHrChrome);

--- a/addons/pos_hr/static/src/js/LoginScreen.js
+++ b/addons/pos_hr/static/src/js/LoginScreen.js
@@ -6,6 +6,7 @@ odoo.define('pos_hr.LoginScreen', function (require) {
     const Registries = require('point_of_sale.Registries');
     const useSelectEmployee = require('pos_hr.useSelectEmployee');
     const { useBarcodeReader } = require('point_of_sale.custom_hooks');
+    const { posbus } = require('point_of_sale.utils');
 
     class LoginScreen extends PosComponent {
         constructor() {
@@ -45,6 +46,8 @@ odoo.define('pos_hr.LoginScreen', function (require) {
             if (employee) {
                 this.env.pos.set_cashier(employee);
                 this.back();
+                this.env.pos.hasLoggedIn = true;
+                posbus.trigger('start-cash-control');
             }
         }
         async _barcodeCashierAction(code) {

--- a/addons/pos_hr/static/src/js/models.js
+++ b/addons/pos_hr/static/src/js/models.js
@@ -40,6 +40,12 @@ models.load_models([{
 
 var posmodel_super = models.PosModel.prototype;
 models.PosModel = models.PosModel.extend({
+    after_load_server_data: function() {
+        return posmodel_super.after_load_server_data.apply(this, arguments).then(() => {
+            // Value starts at false when module_pos_hr is true.
+            this.hasLoggedIn = !this.config.module_pos_hr;
+        });
+    },
     load_server_data: function () {
         var self = this;
         return posmodel_super.load_server_data.apply(this, arguments).then(function () {

--- a/addons/pos_hr/static/tests/tours/PosHrTour.js
+++ b/addons/pos_hr/static/tests/tours/PosHrTour.js
@@ -13,7 +13,6 @@ odoo.define('point_of_sale.tour.PosHr', function (require) {
 
     startSteps();
 
-    ProductScreen.do.confirmOpeningPopup();
     PosHr.check.loginScreenIsShown();
     PosHr.do.clickLoginButton();
     SelectionPopup.check.isShown();
@@ -38,6 +37,7 @@ odoo.define('point_of_sale.tour.PosHr', function (require) {
     NumberPopup.check.inputShownIs('••••');
     NumberPopup.do.clickConfirm();
     ProductScreen.check.isShown();
+    ProductScreen.do.confirmOpeningPopup();
     PosHr.check.cashierNameIs('Pos Employee1');
     PosHr.do.clickCashierName();
     SelectionPopup.do.clickItem('Mitchell Admin');

--- a/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
@@ -6,6 +6,7 @@ odoo.define('pos_restaurant.FloorScreen', function (require) {
     const { useState, useRef } = owl.hooks;
     const { useListener } = require('web.custom_hooks');
     const Registries = require('point_of_sale.Registries');
+    const { posbus } = require('point_of_sale.utils');
 
     class FloorScreen extends PosComponent {
         /**
@@ -45,6 +46,7 @@ odoo.define('pos_restaurant.FloorScreen', function (require) {
             if (this.env.pos.table) {
                 this.env.pos.set_table(null);
             }
+            posbus.trigger('start-cash-control');
             this.floorMapRef.el.style.background = this.state.floorBackground;
             this.state.floorMapScrollTop = this.floorMapRef.el.getBoundingClientRect().top;
             // call _tableLongpolling once then set interval of 5sec.


### PR DESCRIPTION
1. pos_hr: Show the popup when an employee is logged in.
2. pos_restaurant: Show the popup already in the FloorScreen, no need
to click a table to see the popup.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
