### PR TITLE
[FIX] web

### DIFF
--- a/addons/web/static/src/core/errors/error_dialogs.js
+++ b/addons/web/static/src/core/errors/error_dialogs.js
@@ -175,6 +175,7 @@ registry
     .add("odoo.exceptions.MissingError", WarningDialog)
     .add("odoo.exceptions.UserError", WarningDialog)
     .add("odoo.exceptions.ValidationError", WarningDialog)
+    .add("odoo.exceptions.Warning", WarningDialog)
     .add("odoo.exceptions.RedirectWarning", RedirectWarningDialog)
     .add("odoo.http.SessionExpiredException", SessionExpiredDialog)
     .add("werkzeug.exceptions.Forbidden", SessionExpiredDialog)


### PR DESCRIPTION
- Add back missing exceptions name to the registry

Description of the issue/feature this PR addresses:
Exception dialog is missing "odoo.exceptions.Warning" when user do raise Warning('").
We defined the title for this exception in: https://github.com/odoo/odoo/blob/15.0/addons/web/static/src/core/errors/error_dialogs.js#L13
However, the registry doesn't have the exceptions: https://github.com/odoo/odoo/blob/15.0/addons/web/static/src/core/errors/error_dialogs.js#L177

Current behavior before PR:
For automated action, it will raise the base_automation error dialog.

Desired behavior after PR is merged:
It should show WarningDialog like odoo 14.0



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
