### PR TITLE
[FIX] stock: Don't try to load reports from unselected companies

### DIFF
--- a/addons/stock/static/src/js/report_stock_forecasted.js
+++ b/addons/stock/static/src/js/report_stock_forecasted.js
@@ -35,6 +35,7 @@ const ReplenishReport = clientAction.extend({
         var loadWarehouses = this._rpc({
             model: 'report.stock.report_product_product_replenishment',
             method: 'get_warehouses',
+            context: this.context,
         }).then((res) => {
             this.warehouses = res;
             if (this.context.warehouse) {


### PR DESCRIPTION
If we have two companies A and B with B selected and we try to access the Forecast Report via a product, company A's warehouse is automatically selected, which of course creates a security error.

This fix modifies the ´get_warehouses´ method in order to return only the warehouses whose company is selected.

opw-2688135