### PR TITLE
[FIX] pos_coupon: free product is not properly added in the order

### DIFF
--- a/addons/pos_coupon/static/src/js/coupon.js
+++ b/addons/pos_coupon/static/src/js/coupon.js
@@ -565,7 +565,7 @@ odoo.define('pos_coupon.pos', function (require) {
                 return this._getOnOrderDiscountRewards(program, coupon_id, freeProducts);
             };
             globalDiscounts.push(...collectRewards(onOrderPrograms, onOrderDiscountGetter));
-            globalDiscounts.push(...collectRewards(onCheapestPrograms, this._getOnCheapestProductDiscount.bind(this)));
+            globalDiscounts.push(...collectRewards(onCheapestPrograms, (program, coupon_id) => this._getOnCheapestProductDiscount(program, coupon_id, freeProducts)));
 
             // - Group the discounts by program id.
             const groupedGlobalDiscounts = {};
@@ -862,21 +862,75 @@ odoo.define('pos_coupon.pos', function (require) {
          * @returns {[Reward[], string | null]}
          */
         _getProductRewards: function (program, coupon_id) {
-            const totalQuantity = this._getRegularOrderlines()
-                .filter((line) => {
-                    return program.valid_product_ids.has(line.product.id);
-                })
-                .reduce((quantity, line) => quantity + line.quantity, 0);
-
-            const freeQuantity = computeFreeQuantity(
-                totalQuantity,
-                program.rule_min_quantity,
-                program.reward_product_quantity
+            const rewardProduct = this.pos.db.get_product_by_id(program.reward_product_id[0]);
+            const countedOrderlines = this._getRegularOrderlines().filter((line) =>
+                program.valid_product_ids.has(line.product.id)
             );
+            const totalQuantity = countedOrderlines.reduce((quantity, line) => quantity + line.quantity, 0);
+            const totalAmount = countedOrderlines.reduce((amount, line) => {
+                const { priceWithTax, priceWithoutTax } = line.get_all_prices();
+                if (program.rule_minimum_amount_tax_inclusion == 'tax_included') {
+                    amount += priceWithTax;
+                } else {
+                    amount += priceWithoutTax;
+                }
+                return amount;
+            }, 0);
+
+            // Compute the free quantities based on rule_min_amount and rule_min_quantity.
+            let freeQuantityFromMinAmount = Math.Infinity;
+            let freeQuantityFromMinQuantity;
+            const existingRewardQty = this._getRegularOrderlines()
+                .filter((line) => line.product.id == rewardProduct.id)
+                .reduce((total, line) => total + line.quantity, 0);
+            if (program.valid_product_ids.has(rewardProduct.id)) {
+                if (existingRewardQty) {
+                    freeQuantityFromMinQuantity = Math.min(
+                        computeFreeQuantity(totalQuantity, program.rule_min_quantity, program.reward_product_quantity),
+                        existingRewardQty
+                    );
+                    if (program.rule_minimum_amount !== 0) {
+                        // Normalize the values based on amount to be able to utilize computeFreeQuantity.
+                        const rewardProductAmount = program.reward_product_quantity * rewardProduct.lst_price;
+                        const freeAmount = computeFreeQuantity(
+                            totalAmount,
+                            program.rule_minimum_amount,
+                            rewardProductAmount
+                        );
+                        freeQuantityFromMinAmount = Math.min(
+                            Math.trunc(freeAmount / rewardProduct.lst_price),
+                            existingRewardQty
+                        );
+                    }
+                } else {
+                    // No free quantity if the reward product is not among the orderlines.
+                    freeQuantityFromMinQuantity = 0;
+                    freeQuantityFromMinAmount = 0;
+                }
+            } else {
+                freeQuantityFromMinQuantity = Math.min(
+                    Math.trunc((totalQuantity * program.reward_product_quantity) / program.rule_min_quantity),
+                    existingRewardQty
+                );
+                if (program.rule_minimum_amount !== 0) {
+                    freeQuantityFromMinAmount = Math.min(
+                        Math.trunc((totalAmount * program.reward_product_quantity) / program.rule_minimum_amount),
+                        existingRewardQty
+                    );
+                }
+            }
+
+            // Based on freeQuantityFromMinAmount and freeQuantityFromMinQuantity, compute the actual free quantity.
+            let freeQuantity = 0;
+            if (freeQuantityFromMinAmount < freeQuantityFromMinQuantity) {
+                freeQuantity = freeQuantityFromMinAmount;
+            } else {
+                freeQuantity = freeQuantityFromMinQuantity;
+            }
+
             if (freeQuantity === 0) {
                 return [[], 'Zero free product quantity.'];
             } else {
-                const rewardProduct = this.pos.db.get_product_by_id(program.reward_product_id[0]);
                 const discountLineProduct = this.pos.db.get_product_by_id(program.discount_line_product_id[0]);
                 return [
                     [
@@ -953,21 +1007,60 @@ odoo.define('pos_coupon.pos', function (require) {
          * @param {number} coupon_id
          * @returns {[Reward[], string | null]}
          */
-        _getOnCheapestProductDiscount: function (program, coupon_id) {
+        _getOnCheapestProductDiscount: function (program, coupon_id, productRewards) {
             const amountsToDiscount = {};
             const orderlines = this._getRegularOrderlines();
             if (orderlines.length > 0) {
-                const cheapestLine = orderlines.reduce((min_line, line) => {
-                    if (line.price < min_line.price) {
-                        return line;
-                    } else {
-                        return min_line;
-                    }
-                }, orderlines[0]);
-                const key = this._getGroupKey(cheapestLine);
-                amountsToDiscount[key] = cheapestLine.price;
+                const cheapestLine = this._findCheapestLine(orderlines, productRewards);
+                if (cheapestLine) {
+                    const key = this._getGroupKey(cheapestLine);
+                    amountsToDiscount[key] = cheapestLine.price;
+                }
             }
             return this._createDiscountRewards(program, coupon_id, amountsToDiscount);
+        },
+        /**
+         * Returns the cheapest line from the given orderlines considering the rewarded products.
+         * @param {models.Orderline[]} orderlines
+         * @param {Reward[]} productRewards
+         * @returns {models.Orderline}
+         */
+        _findCheapestLine: function (orderlines, productRewards) {
+            // Compute free quantity per product.
+            const freeQuantityPerProduct = {};
+            for (const productReward of productRewards) {
+                const productId = productReward.rewardedProductId;
+                if (!(productId in freeQuantityPerProduct)) {
+                    freeQuantityPerProduct[productId] = 0;
+                }
+                freeQuantityPerProduct[productId] += productReward.quantity;
+            }
+            // Map each line to its remaining free quantity.
+            // Important to loop over the lines in decreasing price.
+            const remainingQtyOfLine = new Map();
+            for (const line of [...orderlines].sort((a, b) => b.price - a.price)) {
+                const productId = line.product.id;
+                let freeQuantity = freeQuantityPerProduct[productId] || 0;
+                remainingQtyOfLine.set(line, line.get_quantity());
+                if (float_is_zero(freeQuantity, this.pos.dp['Product Unit of Measure'])) {
+                    continue;
+                }
+                const lineQty = remainingQtyOfLine.get(line);
+                if (lineQty < freeQuantity) {
+                    remainingQtyOfLine.set(line, 0);
+                    freeQuantity -= lineQty;
+                } else {
+                    remainingQtyOfLine.set(line, lineQty - freeQuantity);
+                    freeQuantity = 0;
+                }
+                freeQuantityPerProduct[productId] = freeQuantity;
+            }
+            // Among the lines with remaining quantity, return the one with the lowest price.
+            const linesWithoutRewards = [...remainingQtyOfLine.entries()]
+                .filter(([_, remainingQty]) => !float_is_zero(remainingQty, this.pos.currency.decimals))
+                .map(([line, _]) => line)
+                .sort((a, b) => a.price - b.price);
+            return linesWithoutRewards[0];
         },
         /**
          * This method is called via `collectRewards` inside `_calculateRewards`.

--- a/addons/pos_coupon/static/src/js/tours/PosCoupon1.tour.js
+++ b/addons/pos_coupon/static/src/js/tours/PosCoupon1.tour.js
@@ -73,5 +73,21 @@ odoo.define('pos_coupon.tour.pos_coupon1', function (require) {
     PosCoupon.check.orderTotalIs('36.89')
     PosCoupon.exec.finalizeOrder('Cash', '50')
 
+    // code_promo_program_free_product
+    // applied programs:
+    //   - on cheapest product
+    //   - free product different from criterion product
+    //      (Buy 3 Whiteboard Pen, Take 1 Magnetic Board)
+    PosCoupon.do.enterCode('board')
+    ProductScreen.exec.addOrderline('Whiteboard Pen', '5') // 3.20 each
+    // User should manually add the free product to get the reward.
+    ProductScreen.exec.addOrderline('Magnetic Board', '1') // 1.98
+    PosCoupon.check.hasRewardLine('Free Product - Magnetic Board', '-1.98') // meaning 1 item
+    // cheapest product should point to Whiteboard Pen and not the added Magnetic Board
+    // even though Whiteboard Pen ($3.20) costs more than Magnetic Board ($1.98).
+    PosCoupon.check.hasRewardLine('90.0% discount on cheapest product', '-2.88')
+    PosCoupon.check.orderTotalIs('13.12')
+    PosCoupon.exec.finalizeOrder('Cash', '20')
+
     Tour.register('PosCouponTour1', { test: true, url: '/pos/web' }, getSteps());
 });

--- a/addons/pos_coupon/tests/test_frontend.py
+++ b/addons/pos_coupon/tests/test_frontend.py
@@ -55,12 +55,27 @@ class TestUi(TestPointOfSaleHttpCommon):
         )
         self.promo_programs |= self.auto_promo_program_next
 
+        self.code_promo_program_free_product = self.env["coupon.program"].create(
+            {
+                "name": "Promo Program - Buy 3 Whiteboard Pen, Get 1 Magnetic Board",
+                "program_type": "promotion_program",
+                "rule_products_domain": "[('name', '=', 'Whiteboard Pen')]",
+                "promo_code_usage": "code_needed",
+                "promo_code": "board",
+                "reward_type": "product",
+                "rule_min_quantity": 3,
+                "reward_product_id": self.magnetic_board.id,
+                "reward_product_quantity": 1,
+            }
+        )
+        self.promo_programs |= self.code_promo_program_free_product
+
         # coupon program -> free product
         self.coupon_program = self.env["coupon.program"].create(
             {
                 "name": "Coupon Program - Buy 3 Take 2 Free Product",
                 "program_type": "coupon_program",
-                "rule_products_domain": "[('name', 'ilike', 'Desk Organizer')]",
+                "rule_products_domain": "[('name', '=', 'Desk Organizer')]",
                 "reward_type": "product",
                 "rule_min_quantity": 3,
                 "reward_product_id": self.desk_organizer.id,
@@ -124,16 +139,17 @@ class TestUi(TestPointOfSaleHttpCommon):
             msg="`5678` coupon code is used but was eventually freed.",
         )
         # check pos_order_count in each program
-        self.assertEqual(self.auto_promo_program_current.pos_order_count, 3)
+        self.assertEqual(self.auto_promo_program_current.pos_order_count, 4)
         self.assertEqual(self.auto_promo_program_next.pos_order_count, 0)
         self.assertEqual(self.code_promo_program.pos_order_count, 1)
+        self.assertEqual(self.code_promo_program_free_product.pos_order_count, 1)
         self.assertEqual(self.coupon_program.pos_order_count, 1)
         # check number of generated coupons
-        self.assertEqual(len(self.auto_promo_program_next.coupon_ids), 5)
+        self.assertEqual(len(self.auto_promo_program_next.coupon_ids), 6)
         # check number of orders in the session
         pos_session = self.main_pos_config.current_session_id
         self.assertEqual(
-            len(pos_session.order_ids), 5, msg="5 orders were made in tour part1."
+            len(pos_session.order_ids), 6, msg="6 orders were made in tour part1."
         )
 
         ##
@@ -164,7 +180,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertEqual(self.coupon4.state, "new")
         self.assertEqual(promo_coupon4.state, "new")
         # check pos_order_count in each program
-        self.assertEqual(self.auto_promo_program_current.pos_order_count, 5)
+        self.assertEqual(self.auto_promo_program_current.pos_order_count, 6)
         self.assertEqual(self.auto_promo_program_next.pos_order_count, 2)
         self.assertEqual(self.code_promo_program.pos_order_count, 2)
         self.assertEqual(self.coupon_program.pos_order_count, 3)


### PR DESCRIPTION
For free product promo (or coupon) program, there are 2 scenarios:
1. reward product = criterion product
2. reward product != criterion product

**Scenario 1**

For 1, there is no problem and it behaves like this:

Promo: Buy 3 Beers, Get 1 Beer

After adding 3 beers, no reward is automatically added yet. The order looks
like this:
```
 3 Beer
```
To get the free beer, the user has to add another beer in the order. So,
after clicking again the Beer product, the order becomes:
```
 4 Beer
-1 Free Product - Beer
```
Let's call the -1 line as virtual reward line. Its role is to negate the
effect of the 4th beer.

**Scenario 2**

The bug is in this scenario.

Example Promo: Buy 4 Notebooks, Get 1 Pen

Bug: After adding 4 Notebooks, there is no reward line, but when the order
became 5 Notebooks, -1 Free Product - Pen is added. Here's how it looks like:
```
 5 Notebook
-1 Free Product - Pen
```
Fix: When there are 4 notebooks in the order, the order is now ready to accept
a free pen. Thus, manual addition of a pen in the order will come with a line
that negates it.
```
 3 Notebook
 1 Fancy Notebook <- the 4th Notebook
 1 Pen
-1 Free Product - Pen
```

**Miscellaneous**

These changes also take into account:
* When selecting cheapest item, the reward line should not be considered.
* Free product reward where it is part of the valid_product_ids should work properly.

TASK-ID: 2692252

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
