### PR TITLE
[FIX] account: wrong invoice date

### DIFF
--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -64,7 +64,7 @@ class AccountMoveReversal(models.TransientModel):
                    if self.reason
                    else _('Reversal of: %s', move.name),
             'date': reverse_date,
-            'invoice_date': move.is_invoice(include_receipts=True) and (self.date or move.date) or False,
+            'invoice_date': move.is_invoice(include_receipts=True) and reverse_date or False,
             'journal_id': self.journal_id and self.journal_id.id or move.journal_id.id,
             'invoice_payment_term_id': None,
             'invoice_user_id': move.invoice_user_id.id,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Create an customer invoice with date and invoice_date : 31/10/2021
- The 17/11/2021 you create a reverse with refund_method = cancel and date_mode = entry
--> Issue the invoice_date of refund is the date of today, it should be the date of the original invoice


@oco-odoo 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
