### PR TITLE
[FIX] mail : Starred message count doesn't updated when delete starred message

### DIFF
--- a/addons/mail/views/mail_message_views.xml
+++ b/addons/mail/views/mail_message_views.xml
@@ -49,6 +49,7 @@
                         </group>
                         <notebook>
                             <page string="Body" name="body">
+                                <field name="is_empty" invisible="1"/>
                                 <field name="body" options="{'style-inline': true}"/>
                             </page>
                             <page string="Gateway" name="gateway">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When install discuss module , click on history and Star some of the messages then go to starred message menu and delete some of the starred message then the count of the starred message doesn't decreased properly.

Current behavior before PR:
In the code onClickConfirmDelete method doesn't call the toggleStar method which counts the starred message.

Desired behavior after PR is merged:
This commit resolves the issue of not counting starred message when delete some starred message.

Fixes #79932

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
