### PR TITLE
[REV] hr_timesheet: revert use of timesheet_ids in project kanban

### DIFF
--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -239,14 +239,13 @@
             <field name="arch" type="xml">
                 <field name="partner_id" position="after">
                     <field name="allow_timesheets" invisible="1"/>
-                    <field name="timesheet_ids" invisible="1"/>
                     <field name="total_timesheet_time" invisible="1"/>
                     <field name="remaining_hours" invisible="1"/>
                     <field name="has_planned_hours_tasks" invisible="1"/>
                     <field name="encode_uom_in_days" invisible="1"/>
                 </field>
                 <xpath expr="//div[hasclass('o_kanban_manage_view')]" position="inside">
-                    <div role="menuitem" t-if="record.allow_timesheets.raw_value and record.timesheet_ids.raw_value.length" groups="hr_timesheet.group_hr_timesheet_user">
+                    <div role="menuitem" t-if="record.allow_timesheets.raw_value and record.total_timesheet_time.raw_value" groups="hr_timesheet.group_hr_timesheet_user">
                         <a name="%(act_hr_timesheet_line_by_project)d" type="action">Timesheets</a>
                     </div>
                 </xpath>


### PR DESCRIPTION
This commit reverts 0fff5b03270a88ab0f994bfa1ee780628607ce77 as it
fetches all the records which is a bad idea.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
