### PR TITLE
[FIX] website: manually cascade delete from page to menu

### DIFF
--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -196,6 +196,8 @@ class Page(models.Model):
             if not pages_linked_to_iruiview and not page.view_id.inherit_children_ids:
                 # If there is no other pages linked to that ir_ui_view, we can delete the ir_ui_view
                 page.view_id.unlink()
+        # Make sure website._get_menu_ids() will be recomputed
+        self.clear_caches()
         return super(Page, self).unlink()
 
     def write(self, vals):


### PR DESCRIPTION
Before this commit when a website page was deleted, its related website
menu was deleted inside the database only through the ondelete="cascade"
of the Many2one relationship. This however did not perform the menu
cleanup on the ORM side.
This caused problems when the related menu id was kept in cache by
website's _get_menu_ids(), because the record could not be fetched
anymore. E.g. deleting a website-specific version of the "Contact Us"
page caused the problem, making the menu bar non renderable on all
pages.

After this commit the cascade from page to menu is manually triggered
from the unlink() of the page to the unlink() of its menu.

task-2686221

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
