### PR TITLE
[FIX] stock: add correctly a product in storage categories

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -78,7 +78,7 @@ class Location(models.Model):
     next_inventory_date = fields.Date("Next Expected Inventory", compute="_compute_next_inventory_date", store=True, help="Date for next planned inventory based on cyclic schedule.")
     warehouse_view_ids = fields.One2many('stock.warehouse', 'view_location_id', readonly=True)
     warehouse_id = fields.Many2one('stock.warehouse', compute='_compute_warehouse_id')
-    storage_category_id = fields.Many2one('stock.storage.category', string='Storage Category')
+    storage_category_id = fields.Many2one('stock.storage.category', string='Storage Category', check_company=True)
     outgoing_move_line_ids = fields.One2many('stock.move.line', 'location_id', help='Technical: used to compute weight.')
     incoming_move_line_ids = fields.One2many('stock.move.line', 'location_dest_id', help='Technical: used to compute weight.')
     net_weight = fields.Float('Net Weight', compute="_compute_weight")

--- a/addons/stock/security/stock_security.xml
+++ b/addons/stock/security/stock_security.xml
@@ -179,5 +179,11 @@
         <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
     </record>
 
+    <record model="ir.rule" id="stock_storage_category_rule">
+        <field name="name">stock_storage_category multi-company</field>
+        <field name="model_id" ref="model_stock_storage_category"/>
+        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+    </record>
+
 </data>
 </odoo>

--- a/addons/stock/views/stock_storage_category_views.xml
+++ b/addons/stock/views/stock_storage_category_views.xml
@@ -25,7 +25,7 @@
                     </group>
                     <notebook>
                         <page string="Capacity by Package" name="package_capacity" groups="stock.group_tracking_lot">
-                            <field name="package_capacity_ids" context="{'default_storage_category_id': id}">
+                            <field name="package_capacity_ids" context="{'default_storage_category_id': id, 'default_company_id': company_id}">
                                 <tree editable="bottom">
                                     <field name="package_type_id" required="1"/>
                                     <field name="quantity"/>
@@ -34,9 +34,9 @@
                             </field>
                         </page>
                         <page string="Capacity by Product" name="product_capacity">
-                            <field name="product_capacity_ids" context="{'default_storage_category_id': id}">
+                            <field name="product_capacity_ids" context="{'default_storage_category_id': id, 'default_company_id': company_id}">
                                 <tree editable="bottom">
-                                    <field name="product_id" required="1"/>
+                                    <field name="product_id" required="1" context="{'default_detailed_type': 'product'}"/>
                                     <field name="quantity"/>
                                     <field name="product_uom_id" options="{'no_create': True, 'no_open': True}"/>
                                     <field name="company_id" invisible="1"/>


### PR DESCRIPTION
Steps to reproduce the bug:
- Connect as Admin and select “My Company (San Francisco)”
- Create a storable product “P1” and select “My Company (San Francisco)” in the `”company”` field
- Go to inventory settings and enable the “Storage Categories” option
- Create a new “Storage Categorie” > select “My Company (San Francisco)” in the `”company”` field > save

**BUG1:**  BUG1:  Edit and try to add the product “P1” > Edit and try to add the product “P1”
"P1" is not filtered correctly with domain, because the `”company”` field of the `"stock.storage.category.capacity"` model is not set.
As it's a related field, the “default_company_id” should be in the context so that the “company_id” field will be correctly set with this value

In the case that the "storage categorie" is not yet saved in the DB, the company should be added in the context

**BUG2:** Add a new line > create and edit a new product > the product type is “consumable” instead of storable, so we should add the type in the context

**BUG3:** Add multi-company security rule

opw-2689426




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
