### PR TITLE
[REM] project: remove unused data

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -674,35 +674,9 @@ class Project(models.Model):
         }
 
     def _get_tasks_analysis(self):
-        self.ensure_one()
-        counts = self._get_tasks_analysis_counts(updated=True)
-        data = [{
-            'name': _("Open Tasks"),
-            'action': {
-                'action': "project.action_project_task_user_tree",
-                'additional_context': json.dumps({
-                    'search_default_project_id': self.id,
-                    'active_id': self.id,
-                    'search_default_open_tasks': True,
-                    'search_default_Stage': True,
-                }),
-            },
-            'value': counts['open_tasks_count']
-        }, {
-            'name': _("Updated (Last 30 Days)"),
-            'action': {
-                'action': "project.action_project_task_burndown_chart_report",
-                'additional_context': json.dumps({
-                    'search_default_project_id': self.id,
-                    'active_id': self.id,
-                    'search_default_last_month': 1,
-                    'graph_mode': 'bar'
-                }),
-            },
-            'value': counts['updated_tasks_count']
-        }]
+        # Deprecated
         return {
-            'data': data,
+            'data': [],
         }
 
     def _get_milestones(self):
@@ -772,23 +746,8 @@ class Project(models.Model):
         return buttons
 
     def _get_tasks_analysis_counts(self, created=False, updated=False):
-        tasks = self.env['project.task'].search([('display_project_id', '=', self.id)])
-        open_tasks_count = created_tasks_count = updated_tasks_count = 0
-        tasks_count = len(tasks)
-        thirty_days_ago = datetime.combine(fields.Date.context_today(self) + timedelta(days=-30), datetime.min.time())
-        for t in tasks:
-            if not t.stage_id.fold and not t.stage_id.is_closed:
-                open_tasks_count += 1
-            if created and t.create_date > thirty_days_ago:
-                created_tasks_count += 1
-            if updated and t.write_date > thirty_days_ago:
-                updated_tasks_count += 1
-        return dict(
-            open_tasks_count=open_tasks_count,
-            created_tasks_count=created_tasks_count,
-            updated_tasks_count=updated_tasks_count,
-            tasks_count=tasks_count
-        )
+        # Deprecated
+        return {}
 
     # ---------------------------------------------------
     #  Business Methods


### PR DESCRIPTION
Prior to this commit, the `tasks_analysis` information was added to the
panel data dict but never used clientside.

This commit removes this useless call to avoid a Traceback on large
projects, with lots of tasks (MemoryError).

task-2694765

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
