### PR TITLE
[FIX] rating: kanban view of rating update

### DIFF
--- a/addons/rating/i18n/rating.pot
+++ b/addons/rating/i18n/rating.pot
@@ -377,6 +377,12 @@ msgid "Thank you, we appreciate your feedback!"
 msgstr ""
 
 #. module: rating
+#: model:ir.model.fields,help:rating.field_rating_rating__create_date
+msgid "The date at which the rating is submitted to the client."
+msgstr ""
+
+
+#. module: rating
 #: model:ir.model.fields,help:rating.field_rating_rating__res_name
 msgid "The name of the rated resource."
 msgstr ""

--- a/addons/rating/models/rating.py
+++ b/addons/rating/models/rating.py
@@ -35,7 +35,7 @@ class Rating(models.Model):
     def _selection_target_model(self):
         return [(model.model, model.name) for model in self.env['ir.model'].search([])]
 
-    create_date = fields.Datetime(string="Submitted on")
+    create_date = fields.Datetime(string="Submitted on", help="The date at which the rating is submitted to the client.")
     res_name = fields.Char(string='Resource name', compute='_compute_res_name', store=True, help="The name of the rated resource.")
     res_model_id = fields.Many2one('ir.model', 'Related Document Model', index=True, ondelete='cascade', help='Model of the followed resource')
     res_model = fields.Char(string='Document Model', related='res_model_id.model', store=True, index=True, readonly=True)

--- a/addons/rating/views/rating_rating_views.xml
+++ b/addons/rating/views/rating_rating_views.xml
@@ -87,7 +87,7 @@
                                             </span>
                                         </li>
                                         <li>
-                                            on <field name="create_date" />
+                                            on <field name="write_date" />
                                         </li>
                                     </ul>
                                     <i t-if="record.feedback.raw_value" class="fa fa-comment float-right mt4" t-att-title="record.feedback.raw_value"  t-att-aria-label="record.feedback.raw_value" role="img"/>


### PR DESCRIPTION
Current behaviour :
The date on the kanban view of rating.rating show the creation date which can be confusing as it doesn't update when the client rate the task.

Behaviour after PR :
The date shown on the kanban view of rating.rating is the last update date which now correctly show when client updated the his rating of the task or when it was created if it hasn't been updated yet.

Also added tool-tip on the submitted on field to show it represent the creation date

opw-2633831

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
