### PR TITLE
[FIX] hr_holidays: fix allocation to time off link

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -338,6 +338,7 @@ class HolidaysRequest(models.Model):
             [
                 ('holiday_status_id', 'in', self.holiday_status_id.ids),
                 ('employee_id', 'in', self.employee_id.ids),
+                ('state', '=', 'validate'),
                 '|',
                 ('date_to', '>=', min(self.mapped('date_to'))),
                 '&',


### PR DESCRIPTION
The link between time off and allocation didn't check for allocation
state.

TaskId-2695066
