### PR TITLE
[FIX] point_of_sale: Default value for the tips popup in paymentScreen (German)

### DIFF
--- a/addons/point_of_sale/static/src/js/Popups/NumberPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/NumberPopup.js
@@ -26,7 +26,7 @@ odoo.define('point_of_sale.NumberPopup', function(require) {
             useListener('close-this-popup', this.cancel);
             let startingBuffer = '';
             if (typeof this.props.startingValue === 'number' && this.props.startingValue > 0) {
-                startingBuffer = this.props.startingValue.toString();
+                startingBuffer = this.props.startingValue.toString().replace('.', this.decimalSeparator);
             }
             this.state = useState({ buffer: startingBuffer });
             NumberBuffer.use({


### PR DESCRIPTION
For German language and for the languages that use the same arithmetic system
(use of comma "," to separate decimal digits and use of point "." to indicate
thousands, millions etc.) the tips pop up in payment screen was displaying an
erroneous initial value: ex. '0.84' was displayed instead of '0,84'. This was
causing a miscalculation of the intended tipping amount. Thus, the tipping
amount had to be inserted manually in every occasion.

task-2695104
opw-2677249


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
