### PR TITLE
[14.0][FIX] pos_cache: wrong data in odoo cache in a multicompany context

### DIFF
--- a/addons/pos_cache/models/pos_cache.py
+++ b/addons/pos_cache/models/pos_cache.py
@@ -25,8 +25,9 @@ class pos_cache(models.Model):
 
     def refresh_cache(self):
         for cache in self:
-            Product = self.env['product.product'].with_user(cache.compute_user_id.id)
+            Product = self.env['product.product'].with_company(cache.config_id.company_id).with_user(cache.compute_user_id.id)
             products = Product.search(cache.get_product_domain())
+            products.invalidate_cache()
             prod_ctx = products.with_context(pricelist=cache.config_id.pricelist_id.id,
                 display_default_code=False, lang=cache.compute_user_id.lang)
             res = prod_ctx.read(cache.get_product_fields())


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

We faced problems where the product tax in the point of sale was not consistent with the pos company.
We have several pos_caches on different companies and they all content the taxes of the company of the first one.

Current behavior before PR:

Taxes is wrong if you have several cache on several company

Desired behavior after PR is merged:

Taxes should be consistent with the company


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
