### PR TITLE
[13.0][FIX] orm: incorrect group by count result

### DIFF
--- a/doc/cla/individual/d3stozaur.md
+++ b/doc/cla/individual/d3stozaur.md
@@ -1,0 +1,11 @@
+Poland, 18.11.2021
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mateusz Sołtys mateusz@soltys.co https://github.com/d3stozaur

--- a/doc/cla/individual/d3stozaur.md
+++ b/doc/cla/individual/d3stozaur.md
@@ -8,4 +8,4 @@ declaration.
 
 Signed,
 
-Mateusz Sołtys mateusz@soltys.co https://github.com/d3stozaur
+Mateusz Sołtys 32417963+d3stozaur@users.noreply.github.com https://github.com/d3stozaur

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2276,7 +2276,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
             aggregated_fields.append(name)
 
             expr = self._inherits_join_calc(self._table, fname, query)
-            if func.lower() == 'count_distinct':
+            if func.lower() in ('count_distinct', 'avg', 'sum'):
                 term = 'COUNT(DISTINCT %s) AS "%s"' % (expr, name)
             else:
                 term = '%s(%s) AS "%s"' % (func, expr, name)

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2299,7 +2299,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         prefix_term = lambda prefix, term: ('%s %s' % (prefix, term)) if term else ''
 
         query = """
-            SELECT min("%(table)s".id) AS id, count("%(table)s".id) AS "%(count_field)s" %(extra_fields)s
+            SELECT min("%(table)s".id) AS id, count(DISTINCT "%(table)s".id) AS "%(count_field)s" %(extra_fields)s
             FROM %(from)s
             %(where)s
             %(groupby)s


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When we use group by filter and some other filter especially filter which requires table join we receive incorrect record count.

Current behavior before PR:
Example:
Create 2 sale_order objects, in one add two order lines, one with product  [FURN_7800] Desk Combination and  [FURN_0001] Desk Organizer, in second sale_order add only one line with product  [FURN_0001] Desk Organizer. Now in list view use group by Order Date -> Day filter, and add filter for "Search Product for: desk".

In return we get group by list with 3 elements, when expanded the row count changes to 2.  This is because _read_group_raw method gets all 3 sale_order_lines with product Desk but on expanding search_read method is called which calls for _search method which returns only unique records using _uniquify_list subfunction.

[Runbot enterpise proof](https://webmshare.com/O99bP)

Desired behavior after PR is merged:
Group by count should return only count of unique records

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
