### PR TITLE
[IMP] payment, *: hide tokenization checkbox when paying a subscription

### DIFF
--- a/addons/account_payment/controllers/portal.py
+++ b/addons/account_payment/controllers/portal.py
@@ -37,7 +37,9 @@ class PortalAccount(portal.PortalAccount):
             'acquirers': acquirers_sudo,
             'tokens': tokens,
             'fees_by_acquirer': fees_by_acquirer,
-            'show_tokenize_input': logged_in,  # Prevent public partner from saving payment methods
+            'show_tokenize_input': PaymentPortal._compute_show_tokenize_input_mapping(
+                acquirers_sudo, logged_in=logged_in
+            ),
             'amount': invoice.amount_residual,
             'currency': invoice.currency_id,
             'partner_id': partner.id,

--- a/addons/payment/tests/test_flows.py
+++ b/addons/payment/tests/test_flows.py
@@ -8,6 +8,7 @@ from freezegun import freeze_time
 from odoo.tests import tagged
 from odoo.tools import mute_logger
 
+from odoo.addons.payment.controllers.portal import PaymentPortal
 from odoo.addons.payment.tests.common import PaymentCommon
 from odoo.addons.payment.tests.http_common import PaymentHttpCommon
 
@@ -407,3 +408,17 @@ class TestFlows(PaymentCommon, PaymentHttpCommon):
                 **self._prepare_transaction_values(self.create_token().id, 'token')
             )
             self.assertEqual(patched.call_count, 1)
+
+    def test_tokenization_input_is_show_to_logged_in_users(self):
+        self.acquirer.allow_tokenization = True
+        show_tokenize_input = PaymentPortal._compute_show_tokenize_input_mapping(
+            self.acquirer, logged_in=True
+        )
+        self.assertDictEqual(show_tokenize_input, {self.acquirer.id: True})
+
+    def test_tokenization_input_is_hidden_for_logged_out_users(self):
+        self.acquirer.allow_tokenization = False
+        show_tokenize_input = PaymentPortal._compute_show_tokenize_input_mapping(
+            self.acquirer, logged_in=True
+        )
+        self.assertDictEqual(show_tokenize_input, {self.acquirer.id: False})

--- a/addons/payment/views/payment_templates.xml
+++ b/addons/payment/views/payment_templates.xml
@@ -97,10 +97,7 @@
                             </div>
                         </t>
                         <!-- === "Save my payment details" checkbox === -->
-                        <!-- Only included if partner is known and if the choice is given -->
-                        <t t-set="tokenization_required"
-                           t-value="acquirer._is_tokenization_required(provider=acquirer.provider)"/>
-                        <label t-if="show_tokenize_input and acquirer.allow_tokenization and not tokenization_required">
+                        <label t-if="show_tokenize_input[acquirer.id]">
                             <input name="o_payment_save_as_token" type="checkbox"/>
                             Save my payment details
                         </label>

--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -175,17 +175,13 @@ class CustomerPortal(portal.CustomerPortal):
                     order_sudo.partner_id.country_id,
                 ) for acquirer in acquirers_sudo.filtered('fees_active')
             }
-            # Prevent public partner from saving payment methods but force it for logged in partners
-            # buying subscription products
-            show_tokenize_input = logged_in \
-                and not request.env['payment.acquirer'].sudo()._is_tokenization_required(
-                    sale_order_id=order_sudo.id
-                )
             values.update({
                 'acquirers': acquirers_sudo,
                 'tokens': tokens,
                 'fees_by_acquirer': fees_by_acquirer,
-                'show_tokenize_input': show_tokenize_input,
+                'show_tokenize_input': PaymentPortal._compute_show_tokenize_input_mapping(
+                    acquirers_sudo, logged_in=logged_in, sale_order_id=order_sudo.id
+                ),
                 'amount': order_sudo.amount_total,
                 'currency': order_sudo.pricelist_id.currency_id,
                 'partner_id': order_sudo.partner_id.id,

--- a/addons/sale/tests/test_payment_flow.py
+++ b/addons/sale/tests/test_payment_flow.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from unittest.mock import ANY, patch
 
 from odoo.fields import Command
 from odoo.tests import tagged
@@ -45,7 +46,12 @@ class TestSalePayment(PaymentCommon, PaymentHttpCommon):
         route_values = self._prepare_pay_values()
         route_values['sale_order_id'] = self.order.id
 
-        tx_context = self.get_tx_checkout_context(**route_values)
+        with patch(
+            'odoo.addons.payment.controllers.portal.PaymentPortal'
+            '._compute_show_tokenize_input_mapping'
+        ) as patched:
+            tx_context = self.get_tx_checkout_context(**route_values)
+            patched.assert_called_once_with(ANY, logged_in=ANY, sale_order_id=ANY)
 
         self.assertEqual(tx_context['currency_id'], self.order.currency_id.id)
         self.assertEqual(tx_context['partner_id'], self.order.partner_id.id)

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -989,12 +989,6 @@ class WebsiteSale(http.Controller):
                 order.amount_total, order.currency_id, order.partner_id.country_id
             ) for acq_sudo in acquirers_sudo.filtered('fees_active')
         }
-        # Prevent public partner from saving payment methods but force it for logged in partners
-        # buying subscription products
-        show_tokenize_input = logged_in \
-            and not request.env['payment.acquirer'].sudo()._is_tokenization_required(
-                sale_order_id=order.id
-            )
         return {
             'website_sale_order': order,
             'errors': [],
@@ -1005,7 +999,9 @@ class WebsiteSale(http.Controller):
             'acquirers': acquirers_sudo,
             'tokens': tokens,
             'fees_by_acquirer': fees_by_acquirer,
-            'show_tokenize_input': show_tokenize_input,
+            'show_tokenize_input': PaymentPortal._compute_show_tokenize_input_mapping(
+                acquirers_sudo, logged_in=logged_in, sale_order_id=order.id
+            ),
             'amount': order.amount_total,
             'currency': order.currency_id,
             'partner_id': order.partner_id.id,


### PR DESCRIPTION
Users should not be able to disallow tokenization if they pay for a
subscription.

This commit introduces a new method to better predict when the
tokenization checkbox should be shown or hidden. This also ensures that
the behavior will be the same across all modules.

See also:
- https://github.com/odoo/enterprise/pull/25335

task-2695201