### PR TITLE
[FIX] website: translate configurator's features page

### DIFF
--- a/addons/test_website_modules/tests/test_configurator.py
+++ b/addons/test_website_modules/tests/test_configurator.py
@@ -1,46 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from unittest.mock import patch
-
 import odoo.tests
-from odoo.addons.iap.tools.iap_tools import iap_jsonrpc_mocked
-
+from odoo.addons.website.tests.test_configurator import TestConfiguratorCommon
 
 @odoo.tests.common.tagged('post_install', '-at_install')
-class TestConfigurator(odoo.tests.HttpCase):
-
-    def _theme_upgrade_upstream(self):
-        # patch to prevent module install/upgrade during tests
-        pass
-
-    def setUp(self):
-        super().setUp()
-
-        def iap_jsonrpc_mocked_configurator(*args, **kwargs):
-            endpoint = args[0]
-            if endpoint.endswith('/api/website/1/configurator/industries'):
-                return {"industries": [
-                    {"id": 1, "label": "abbey"},
-                    {"id": 2, "label": "aboriginal and torres strait islander organisation"},
-                    {"id": 3, "label": "aboriginal art gallery"},
-                    {"id": 4, "label": "abortion clinic"},
-                    {"id": 5, "label": "abrasives supplier"},
-                    {"id": 6, "label": "abundant life church"}]}
-            elif '/api/website/2/configurator/recommended_themes' in endpoint:
-                return []
-            elif '/api/website/2/configurator/custom_resources/' in endpoint:
-                return {'images': {}}
-
-            iap_jsonrpc_mocked()
-
-        iap_patch = patch('odoo.addons.iap.tools.iap_tools.iap_jsonrpc', iap_jsonrpc_mocked_configurator)
-        iap_patch.start()
-        self.addCleanup(iap_patch.stop)
-
-        patcher = patch('odoo.addons.website.models.ir_module_module.IrModuleModule._theme_upgrade_upstream', wraps=self._theme_upgrade_upstream)
-        patcher.start()
-        self.addCleanup(patcher.stop)
+class TestConfigurator(TestConfiguratorCommon):
 
     def test_01_configurator_flow(self):
         self.start_tour('/web#action=website.action_website_configuration', 'configurator_flow', login="admin")

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -254,10 +254,11 @@ class Website(Home):
         if not request.env.user.has_group('website.group_website_designer'):
             raise werkzeug.exceptions.NotFound()
         website_id = request.env['website'].get_current_website()
-        if website_id.configurator_done is False:
-            return request.render('website.website_configurator', {'lang': request.env.user.lang})
-        else:
+        if website_id.configurator_done:
             return request.redirect('/')
+        if request.env.lang != website_id.default_lang_id.code:
+            return request.redirect('/%s%s' % (website_id.default_lang_id.url_code, request.httprequest.path))
+        return request.render('website.website_configurator')
 
     @http.route(['/website/social/<string:social>'], type='http', auth="public", website=True, sitemap=False)
     def social(self, social, **kwargs):

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -315,7 +315,7 @@ class Website(models.Model):
     def configurator_init(self):
         r = dict()
         company = self.get_current_website().company_id
-        configurator_features = self.env['website.configurator.feature'].search([])
+        configurator_features = self.env['website.configurator.feature'].with_context(lang=self.get_current_website().default_lang_id.code).search([])
         r['features'] = [{
             'id': feature.id,
             'name': feature.name,
@@ -329,7 +329,7 @@ class Website(models.Model):
         if company.logo and company.logo != company._get_logo():
             r['logo'] = company.logo.decode('utf-8')
         try:
-            result = self._website_api_rpc('/api/website/1/configurator/industries', {'lang': self.env.user.lang})
+            result = self._website_api_rpc('/api/website/1/configurator/industries', {'lang': self.get_current_website().default_lang_id.code})
             r['industries'] = result['industries']
         except AccessError as e:
             logger.warning(e.args[0])
@@ -424,7 +424,7 @@ class Website(models.Model):
             nb_snippets = len(snippet_list)
             for i, snippet in enumerate(snippet_list, start=1):
                 try:
-                    view_id = self.env['website'].with_context(website_id=website.id).viewref('website.' + snippet)
+                    view_id = self.env['website'].with_context(website_id=website.id, lang=website.default_lang_id.code).viewref('website.' + snippet)
                     if view_id:
                         el = html.fromstring(view_id._render(values=cta_data))
 

--- a/addons/website/static/src/components/configurator/configurator.js
+++ b/addons/website/static/src/components/configurator/configurator.js
@@ -65,7 +65,7 @@ const SESSION_STORAGE_ITEM_NAME = 'websiteConfigurator' + session.website_id;
 
 class SkipButton extends Component {
     async skip() {
-        await skipConfigurator();
+        await skipConfigurator(Component.env.services);
     }
 }
 
@@ -318,7 +318,7 @@ class PaletteSelectionScreen extends Component {
             img = await svgToPNG(img);
         }
         img = img.split(',')[1];
-        const [color1, color2] = await rpc.query({
+        const [color1, color2] = await this.rpc({
             model: 'base.document.layout',
             method: 'extract_image_primary_secondary_colors',
             args: [img],
@@ -356,7 +356,7 @@ class FeaturesSelectionScreen extends Component {
             industry_id: industryId,
             palette: this.state.selectedPalette
         };
-        const themes = await rpc.query({
+        const themes = await this.rpc({
             model: 'website',
             method: 'configurator_recommended_themes',
             kwargs: params,
@@ -522,10 +522,10 @@ const actions = {
     }
 };
 
-async function getInitialState() {
+async function getInitialState(services) {
 
     // Load values from python and iap
-    var results = await rpc.query({
+    var results = await services.rpc({
         model: 'website',
         method: 'configurator_init',
     });
@@ -559,7 +559,7 @@ async function getInitialState() {
                 industry_id: localState.selectedIndustry.id,
                 palette: localState.selectedPalette
             };
-            themes = await rpc.query({
+            themes = await services.rpc({
                 model: 'website',
                 method: 'configurator_recommended_themes',
                 kwargs: params,
@@ -599,8 +599,8 @@ async function getInitialState() {
     });
 }
 
-async function skipConfigurator() {
-    await rpc.query({
+async function skipConfigurator(services) {
+    await services.rpc({
         model: 'website',
         method: 'configurator_skip',
     });
@@ -639,7 +639,7 @@ async function applyConfigurator(self, themeName) {
             website_type: WEBSITE_TYPES[self.state.selectedType].name,
             logo_attachment_id: self.state.logoAttachmentId,
         };
-        const resp = await rpc.query({
+        const resp = await self.rpc({
             model: 'website',
             method: 'configurator_apply',
             kwargs: {...data},
@@ -653,7 +653,8 @@ async function makeEnvironment() {
     const env = {};
     const router = new Router(env, ROUTES);
     await router.start();
-    const state = await getInitialState();
+    const services = Component.env.services;
+    const state = await getInitialState(services);
     const store = new Store({state, actions, getters});
     store.on("update", null, () => {
         const newState = {
@@ -679,14 +680,13 @@ async function makeEnvironment() {
     env.loader = qweb.renderToString('website.ThemePreview.Loader', {
         showTips: true
     });
-    const services = Component.env.services;
     return Object.assign(env, {router, store, qweb, services});
 }
 
 async function setup() {
     const env = await makeEnvironment();
     if (!env.store.state.industries) {
-        await skipConfigurator();
+        await skipConfigurator(env.services);
     } else {
         mount(App, {target: document.body, env});
     }

--- a/addons/website/static/tests/tours/configurator_translation.js
+++ b/addons/website/static/tests/tours/configurator_translation.js
@@ -1,0 +1,62 @@
+/** @odoo-module */
+
+import tour from 'web_tour.tour';
+
+tour.register('configurator_translation', {
+    test: true,
+    url: '/website/configurator',
+},
+[
+    // Configurator first screen
+    {
+        content: "click next",
+        trigger: 'button.o_configurator_show',
+    },
+    // Description screen
+    {
+        content: "select a website type",
+        trigger: 'a.o_change_website_type',
+    }, {
+        content: "insert a website industry",
+        trigger: '.o_configurator_industry input',
+        run: 'text ab',
+    }, {
+        content: "select a website industry from the autocomplete",
+        trigger: '.o_configurator_industry ul li a:contains(in fr)',
+        extra_trigger: 'html[lang*=fr]',
+    }, {
+        content: "select an objective",
+        trigger: '.o_configurator_purpose_dd a',
+    }, {
+        content: "choose from the objective list",
+        trigger: 'a.o_change_website_purpose',
+    },
+    // Palette screen
+    {
+        content: "chose a palette card",
+        trigger: '.palette_card',
+    },
+    // Features screen
+    {
+        content: "select confidentialité",
+        trigger: '.card:contains(confidentialité)',
+    }, {
+        content: "Click on build my website",
+        trigger: 'button.btn-primary',
+    }, {
+        content: "Loader should be shown",
+        trigger: '.o_theme_install_loader_container',
+        run: function () {}, // it's a check
+    }, {
+        content: "Wait untill the configurator is finished",
+        trigger: 'body.editor_started',
+        timeout: 30000,
+    }, {
+        content: "exit edit mode",
+        trigger: '.o_we_website_top_actions button.btn-primary:contains("Sauver")',
+    }, {
+         content: "wait for editor to be closed",
+         trigger: 'body:not(.editor_enable)',
+         run: function () {}, // It's a check.
+    }
+]);

--- a/addons/website/tests/__init__.py
+++ b/addons/website/tests/__init__.py
@@ -3,6 +3,7 @@
 from . import test_attachment
 from . import test_auth_signup_uninvited
 from . import test_base_url
+from . import test_configurator
 from . import test_controllers
 from . import test_converter
 from . import test_crawl

--- a/addons/website/tests/test_configurator.py
+++ b/addons/website/tests/test_configurator.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from unittest.mock import patch
+
+import odoo.tests
+from odoo.addons.iap.tools.iap_tools import iap_jsonrpc_mocked
+from odoo.tools import mute_logger
+
+class TestConfiguratorCommon(odoo.tests.HttpCase):
+
+    def _theme_upgrade_upstream(self):
+        # patch to prevent module install/upgrade during tests
+        pass
+
+    def setUp(self):
+        super().setUp()
+
+        def iap_jsonrpc_mocked_configurator(*args, **kwargs):
+            endpoint = args[0]
+            params = kwargs.get('params', {})
+            language = params.get('lang', 'en_US')
+            if endpoint.endswith('/api/website/1/configurator/industries'):
+                if language == 'fr_FR':
+                    return {"industries": [
+                        {"id": 1, "label": "abbey in fr"},
+                        {"id": 2, "label": "aboriginal and torres strait islander organisation in fr"},
+                        {"id": 3, "label": "aboriginal art gallery in fr"},
+                        {"id": 4, "label": "abortion clinic in fr"},
+                        {"id": 5, "label": "abrasives supplier in fr"},
+                        {"id": 6, "label": "abundant life church in fr"}]}
+                else:
+                    return {"industries": [
+                        {"id": 1, "label": "abbey"},
+                        {"id": 2, "label": "aboriginal and torres strait islander organisation"},
+                        {"id": 3, "label": "aboriginal art gallery"},
+                        {"id": 4, "label": "abortion clinic"},
+                        {"id": 5, "label": "abrasives supplier"},
+                        {"id": 6, "label": "abundant life church"}]}
+            elif '/api/website/2/configurator/recommended_themes' in endpoint:
+                return []
+            elif '/api/website/2/configurator/custom_resources/' in endpoint:
+                return {'images': {}}
+
+            iap_jsonrpc_mocked()
+
+        iap_patch = patch('odoo.addons.iap.tools.iap_tools.iap_jsonrpc', iap_jsonrpc_mocked_configurator)
+        iap_patch.start()
+        self.addCleanup(iap_patch.stop)
+
+        patcher = patch('odoo.addons.website.models.ir_module_module.IrModuleModule._theme_upgrade_upstream', wraps=self._theme_upgrade_upstream)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+@odoo.tests.common.tagged('post_install', '-at_install')
+class TestConfiguratorTranslation(TestConfiguratorCommon):
+
+    def test_01_configurator_translation(self):
+        with mute_logger('odoo.addons.base.models.ir_translation'):
+            self.env["base.language.install"].create({'lang': 'fr_FR', 'overwrite': True}).lang_install()
+        website_fr = self.env['website'].create({
+            'name': "Website Fr",
+            'default_lang_id': self.env.ref('base.lang_fr').id
+        })
+        # disable configurator todo to ensure this test goes through
+        active_todo = self.env['ir.actions.todo'].search([('state', '=', 'open')], limit=1)
+        active_todo.update({'state': 'done'})
+        self.start_tour('/website/force/%s?path=%%2Fwebsite%%2Fconfigurator' % website_fr.id, 'configurator_translation', login='admin')


### PR DESCRIPTION
Prior to this commit the configurator's features and pages were
not translated.

This commit fixes that by using the right env to make call to the
website.configurator.features model

task-2687416

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
