### PR TITLE
[FIX] project_account: fix the analytic accounting setting

### DIFF
--- a/addons/project_account/views/project_project_templates.xml
+++ b/addons/project_account/views/project_project_templates.xml
@@ -3,9 +3,9 @@
         <record id="res_config_settings_view_form" model="ir.ui.view">
             <field name="name">res.config.settings.view.form.inherit.project</field>
             <field name="model">res.config.settings</field>
-            <field name="inherit_id" ref="project.res_config_settings_view_form" />
+            <field name="inherit_id" eval="False" />
             <field name="arch" type="xml">
-                <xpath expr="//div[@name='analytic']/div" position="replace"/>
+                <form/>
             </field>
         </record>
 </odoo>


### PR DESCRIPTION
Before this fix, the "Track costs & revenues by project" option is missing
from the project module if both project and invoicing are installed.

Now, this setting is shown on the project module until accounting is installed,
as expected. It is then shown in the settings of the account module.

task-2695812

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
