### PR TITLE
[FIX] google_calendar: empty event name in google calendar

### DIFF
--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -69,7 +69,7 @@ class GoogleCalendarService():
     def patch(self, event_id, values, token=None, timeout=TIMEOUT):
         url = "/calendar/v3/calendars/primary/events/%s?sendUpdates=all" % event_id
         headers = {'Content-type': 'application/json', 'Authorization': 'Bearer %s' % token}
-        self.google_service._do_request(url, json.dumps(values), headers, method='PUT', timeout=timeout)
+        self.google_service._do_request(url, json.dumps(values), headers, method='PATCH', timeout=timeout)
 
     @requires_auth_token
     def delete(self, event_id, token=None, timeout=TIMEOUT):


### PR DESCRIPTION
As explained at below, when there is no Odoo user who is the owner of the updated event, modification are limited to some fields only.
https://github.com/odoo/odoo/blob/171e42e380a46463b4359166955dc4c5f6ccf42e/addons/google_calendar/models/calendar.py#L206-L212

In this case, that means we must use the `PATCH` method instead of the `PUT` one to avoid erasing all not modified fields such the event name.

opw-2694739

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
