### PR TITLE
[FIX] mail: mail_followers: add selected column in SQL query GROUP BY

### DIFF
--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -235,7 +235,7 @@ FROM mail_followers fol
 LEFT JOIN mail_followers_mail_message_subtype_rel fol_rel ON fol_rel.mail_followers_id = fol.id
 LEFT JOIN mail_message_subtype subtype ON subtype.id = fol_rel.mail_message_subtype_id
 WHERE %s
-GROUP BY fol.id%s""" % (
+GROUP BY fol.id, fol.res_id, fol.partner_id, fol.channel_id%s""" % (
             ', partner.partner_share' if include_pshare else '',
             'LEFT JOIN res_partner partner ON partner.id = fol.partner_id' if include_pshare else '',
             where_clause,

--- a/addons/pos_restaurant/static/src/js/multiprint.js
+++ b/addons/pos_restaurant/static/src/js/multiprint.js
@@ -175,22 +175,16 @@ models.Order = models.Order.extend({
             if (line.mp_skip) {
                 return;
             }
-            var line_hash = line.get_line_diff_hash();
             var qty  = Number(line.get_quantity());
             var note = line.get_note();
             var product_id = line.get_product().id;
-
-            if (typeof resume[line_hash] === 'undefined') {
-                resume[line_hash] = {
-                    qty: qty,
-                    note: note,
-                    product_id: product_id,
-                    product_name_wrapped: line.generate_wrapped_product_name(),
-                };
-            } else {
-                resume[line_hash].qty += qty;
-            }
-
+            var product_resume = product_id in resume ? resume[product_id] : {
+                product_name_wrapped: line.generate_wrapped_product_name(),
+                qties: {},
+            };
+            if (note in product_resume['qties']) product_resume['qties'][note] += qty;
+            else product_resume['qties'][note] = qty;
+            resume[product_id] = product_resume;
         });
         return resume;
     },
@@ -207,62 +201,55 @@ models.Order = models.Order.extend({
         var json        = this.export_as_JSON();
         var add = [];
         var rem = [];
-        var line_hash;
+        var pid, note;
 
-        for ( line_hash in current_res) {
-            var curr = current_res[line_hash];
-            var old  = {};
-            var found = false;
-            for(var id in old_res) {
-                if(old_res[id].product_id === curr.product_id){
-                    found = true;
-                    old = old_res[id];
-                    break;
+        for (pid in current_res) {
+            for (note in current_res[pid]['qties']) {
+                var curr = current_res[pid];
+                var old  = old_res[pid] || {};
+                var found = pid in old_res && note in old_res[pid]['qties'];
+
+                if (!found) {
+                    add.push({
+                        'id':       pid,
+                        'name':     this.pos.db.get_product_by_id(pid).display_name,
+                        'name_wrapped': curr.product_name_wrapped,
+                        'note':     note,
+                        'qty':      curr['qties'][note],
+                    });
+                } else if (old['qties'][note] < curr['qties'][note]) {
+                    add.push({
+                        'id':       pid,
+                        'name':     this.pos.db.get_product_by_id(pid).display_name,
+                        'name_wrapped': curr.product_name_wrapped,
+                        'note':     note,
+                        'qty':      curr['qties'][note] - old['qties'][note],
+                    });
+                } else if (old['qties'][note] > curr['qties'][note]) {
+                    rem.push({
+                        'id':       pid,
+                        'name':     this.pos.db.get_product_by_id(pid).display_name,
+                        'name_wrapped': curr.product_name_wrapped,
+                        'note':     note,
+                        'qty':      old['qties'][note] - curr['qties'][note],
+                    });
                 }
-            }
-
-            if (!found) {
-                add.push({
-                    'id':       curr.product_id,
-                    'name':     this.pos.db.get_product_by_id(curr.product_id).display_name,
-                    'name_wrapped': curr.product_name_wrapped,
-                    'note':     curr.note,
-                    'qty':      curr.qty,
-                });
-            } else if (old.qty < curr.qty) {
-                add.push({
-                    'id':       curr.product_id,
-                    'name':     this.pos.db.get_product_by_id(curr.product_id).display_name,
-                    'name_wrapped': curr.product_name_wrapped,
-                    'note':     curr.note,
-                    'qty':      curr.qty - old.qty,
-                });
-            } else if (old.qty > curr.qty) {
-                rem.push({
-                    'id':       curr.product_id,
-                    'name':     this.pos.db.get_product_by_id(curr.product_id).display_name,
-                    'name_wrapped': curr.product_name_wrapped,
-                    'note':     curr.note,
-                    'qty':      old.qty - curr.qty,
-                });
             }
         }
 
-        for (line_hash in old_res) {
-            var found = false;
-            for(var id in current_res) {
-                if(current_res[id].product_id === old_res[line_hash].product_id)
-                    found = true;
-            }
-            if (!found) {
-                var old = old_res[line_hash];
-                rem.push({
-                    'id':       old.product_id,
-                    'name':     this.pos.db.get_product_by_id(old.product_id).display_name,
-                    'name_wrapped': old.product_name_wrapped,
-                    'note':     old.note,
-                    'qty':      old.qty,
-                });
+        for (pid in old_res) {
+            for (note in old_res[pid]['qties']) {
+                var found = pid in current_res && note in current_res[pid]['qties'];
+                if (!found) {
+                    var old = old_res[pid];
+                    rem.push({
+                        'id':       pid,
+                        'name':     this.pos.db.get_product_by_id(pid).display_name,
+                        'name_wrapped': old.product_name_wrapped,
+                        'note':     note,
+                        'qty':      old['qties'][note],
+                    });
+                }
             }
         }
 

--- a/doc/cla/individual/partho222.md
+++ b/doc/cla/individual/partho222.md
@@ -1,0 +1,11 @@
+Bangladesh, 2021-11-18
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Tariq Ahmed Khan partho222@gmail.com https://github.com/partho222


### PR DESCRIPTION
### ISSUE:
When executing the SQL query 

        SELECT fol.id, fol.res_id, fol.partner_id, fol.channel_id, array_agg(subtype.id)%s
        FROM mail_followers fol
        %s
        LEFT JOIN mail_followers_mail_message_subtype_rel fol_rel ON fol_rel.mail_followers_id = fol.id
        LEFT JOIN mail_message_subtype subtype ON subtype.id = fol_rel.mail_message_subtype_id
        WHERE %s
        GROUP BY fol.id%s ...

in `_get_subscription_data` method of the `mail.followers` model

**Found:**
`psycopg2.ProgrammingError: column "fol.res_id" must appear in the GROUP BY clause or be used in an aggregate function`

_Tested with: postgres (PostgreSQL) 11.14 on Ubuntu 18.04 LTS_


### CAUSE:
If we look at the logic of the query, we can see why this error occurs:

`SELECT fol.id, fol.res_id, fol.partner_id, fol.channel_id ...`
This says that for each row, we want the `id, res_id, partner_id, channel_id` from `mail_followers` table

but in
`GROUP BY fol.id ...`
This says we want one row for each unique `id` of `mail_followers`, no matter what else is different.

So, if there is more than `res_id, partner_id or channel_id` for the same `id` from `mail_followers` table (which won't happen as each row id is unique) BUT database would have no way of knowing which of those values to give us. So Postgres tells us to change the query.


### SOLUTION:
In this case, we know that every `id` corresponds to a single value of `res_id, partner_id & channel_id`, so we can just add them all to the GROUP BY clause

--------------------------------------------------------------------------------------------
Closes previous one
Re-created PR after merging of my CLA