### PR TITLE
[FIX] mrp: improve mrp BOM report

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -15,7 +15,7 @@ class ReportBomStructure(models.AbstractModel):
         for bom_id in docids:
             bom = self.env['mrp.bom'].browse(bom_id)
             candidates = bom.product_id or bom.product_tmpl_id.product_variant_ids
-            quantity = float(data.get('quantity', 1))
+            quantity = float(data.get('quantity', bom.product_qty))
             for product_variant_id in candidates.ids:
                 if data and data.get('childs'):
                     doc = self._get_pdf_line(bom_id, product_id=product_variant_id, qty=quantity, child_bom_ids=json.loads(data.get('childs')))


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a BOM:
    - set the quantity of the finished product and component as more than 1
    - save > print > BOM Structure

Problem:
The report generated shows the qty and cost for production of 1 unit of product, regardless of the BOM quantity

opw-2691632



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
