### PR TITLE
[FIX] point_of_sale: localeCompare is not a function when name is false

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -74,7 +74,7 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
             } else {
                 res = this.env.pos.db.get_partners_sorted(1000);
             }
-            return res.sort(function (a, b) { return a.name.localeCompare(b.name) });
+            return res.sort(function (a, b) { return (a.name || '').localeCompare(b.name || '') });
         }
         get isNextButtonVisible() {
             return this.state.selectedClient ? true : false;


### PR DESCRIPTION
When the loaded res.partner has `name` = false, the call to localeCompare
fails because boolean doesn't have the method. Note that `name` field
of res.partner can be false because no default is specified in its
declaration in the base module.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
