### PR TITLE
[IMP] stock: improve stock_inventory action_start perfs

### DIFF
--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -6,6 +6,7 @@ from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import float_compare, float_is_zero
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
+from odoo.tools.misc import OrderedSet
 
 
 class Inventory(models.Model):
@@ -218,8 +219,6 @@ class Inventory(models.Model):
 
         vals = []
         Product = self.env['product.product']
-        # Empty recordset of products available in stock_quants
-        quant_products = self.env['product.product']
 
         # If inventory by company
         if self.company_id:
@@ -238,6 +237,8 @@ class Inventory(models.Model):
             WHERE %s
             GROUP BY sq.product_id, sq.location_id, sq.lot_id, sq.package_id, sq.owner_id """ % domain, args)
 
+        product_ids = OrderedSet()
+
         for product_data in self.env.cr.dictfetchall():
             product_data['company_id'] = self.company_id.id
             product_data['inventory_id'] = self.id
@@ -248,9 +249,12 @@ class Inventory(models.Model):
             if self.prefill_counted_quantity == 'zero':
                 product_data['product_qty'] = 0
             if product_data['product_id']:
-                product_data['product_uom_id'] = Product.browse(product_data['product_id']).uom_id.id
-                quant_products |= Product.browse(product_data['product_id'])
+                product_ids.add(product_data['product_id'])
             vals.append(product_data)
+        product_id_to_product = dict(zip(product_ids, self.env['product.product'].browse(product_ids)))
+        for val in vals:
+            if val.get('product_id'):
+                val['product_uom_id'] = product_id_to_product[val['product_id']].product_tmpl_id.uom_id.id
         return vals
 
 
@@ -398,7 +402,8 @@ class InventoryLine(models.Model):
         set in an onchange of `product_id`.
         Finally, this override checks we don't try to create a duplicated line.
         """
-        for values in vals_list:
+        products = self.env['product.product'].browse([vals.get('product_id') for vals in vals_list])
+        for product, values in zip(products, vals_list):
             if 'theoretical_qty' not in values:
                 theoretical_qty = self.env['product.product'].get_theoretical_quantity(
                     values['product_id'],
@@ -410,7 +415,7 @@ class InventoryLine(models.Model):
                 )
                 values['theoretical_qty'] = theoretical_qty
             if 'product_id' in values and 'product_uom_id' not in values:
-                values['product_uom_id'] = self.env['product.product'].browse(values['product_id']).uom_id.id
+                values['product_uom_id'] = product.product_tmpl_id.uom_id.id
         res = super(InventoryLine, self).create(vals_list)
         res._check_no_duplicate_line()
         return res
@@ -421,17 +426,16 @@ class InventoryLine(models.Model):
         return res
 
     def _check_no_duplicate_line(self):
+        # Performance: restrict domain on 'not null' fields of stock_inventory_line.
+        domain = [('product_id', 'in', self.product_id.ids), ('location_id', 'in', self.location_id.ids)]
+        groupby_fields = ['product_id', 'location_id', 'partner_id', 'package_id', 'prod_lot_id', 'inventory_id']
+        lines_count = {}
+        for group in self.read_group(domain, ['product_id'], groupby_fields, lazy=False):
+            key = tuple([group[field] and group[field][0] for field in groupby_fields])
+            lines_count[key] = group['__count']
         for line in self:
-            domain = [
-                ('id', '!=', line.id),
-                ('product_id', '=', line.product_id.id),
-                ('location_id', '=', line.location_id.id),
-                ('partner_id', '=', line.partner_id.id),
-                ('package_id', '=', line.package_id.id),
-                ('prod_lot_id', '=', line.prod_lot_id.id),
-                ('inventory_id', '=', line.inventory_id.id)]
-            existings = self.search_count(domain)
-            if existings:
+            key = (line.product_id.id, line.location_id.id, line.partner_id.id, line.package_id.id, line.prod_lot_id.id, line.inventory_id.id)
+            if lines_count[key] > 1:
                 raise UserError(_("There is already one inventory adjustment line for this product,"
                                   " you should rather modify this one instead of creating a new one."))
 


### PR DESCRIPTION
Backport branch odoo/odoo#79587 to v13.

In `_get_inventory_lines_values`, remove quants recordset
as it has been unused since commit cc9324f74084.

Browse product.product in `_get_inventory_lines_values`
outside of for loop to speedup getting the uom_id.


#### speedup

Time reported = calling `inventory.action_start` on an inventory with 10.000 products.

| Before PR | Backport only | After PR |
|:----------:|:--------------:|:---------:|
|  2min | 1min24s | 9.30s |


_NB : This branch should be ignored by fw-bot._

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
