### PR TITLE
[FIX] http_routing: don't remove trailing / during redirect

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -167,11 +167,7 @@ def url_lang(path_or_uri, lang_code=None):
             elif lang_url_code != default_lg.url_code or force_lang:
                 ps.insert(1, lang_url_code)
 
-            # remove trailing /
-            # ['', fr', ''] => /fr/ instead of /fr
-            if ps[-1] == '':
-                ps.pop(-1)
-            location = (u'/'.join(ps) or u'/') + sep + qs
+            location = u'/'.join(ps) + sep + qs
     return location
 
 

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -22,7 +22,7 @@ class TestLangUrl(HttpCase):
 
     def test_01_url_lang(self):
         with MockRequest(self.env, website=self.website):
-            self.assertEqual(url_lang('', '[lang]'), '/[lang]/hello', "`[lang]` is used to be replaced in the url_return after installing a language, it should not be replaced or removed.")
+            self.assertEqual(url_lang('', '[lang]'), '/[lang]/hello/', "`[lang]` is used to be replaced in the url_return after installing a language, it should not be replaced or removed.")
 
     def test_02_url_redirect(self):
         url = '/fr_WHATEVER/contactus'

--- a/addons/website/tests/test_qweb.py
+++ b/addons/website/tests/test_qweb.py
@@ -140,14 +140,14 @@ class TestQwebProcessAtt(TransactionCase):
         with MockRequest(self.env, website=self.website):
             self._test_att('/', {'href': '/'})
             self._test_att('/en/', {'href': '/'})
-            self._test_att('/fr/', {'href': '/fr'})
+            self._test_att('/fr/', {'href': '/fr/'})
             self._test_att('/fr', {'href': '/fr'})
 
     def test_process_att_with_request_lang(self):
         with MockRequest(self.env, website=self.website, context={'lang': 'fr_FR'}):
-            self._test_att('/', {'href': '/fr'})
+            self._test_att('/', {'href': '/fr/'})
             self._test_att('/en/', {'href': '/'})
-            self._test_att('/fr/', {'href': '/fr'})
+            self._test_att('/fr/', {'href': '/fr/'})
             self._test_att('/fr', {'href': '/fr'})
 
     def test_process_att_matching_cdn_and_lang(self):


### PR DESCRIPTION
Before this commit, since we promote the use of route without trailing / for
best SEO (fee0113), we remove the trailing / during a redirect to avoid an
extra request.

Unfortunately, it will break some route with trailing / in case of multi lang.

So we remove this optimization, it will increase potentially number of http
request before to get the final url, but it will allow to continue to support
trailing slash in v15.

This commit partially revert the commit ae35117

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
