### PR TITLE
[FIX] project: don't check access if in sudo

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1635,6 +1635,7 @@ class Task(models.Model):
         # The sudo is required for a portal user as the record creation
         # requires the read access on other models, as mail.template
         # in order to compute the field tracking
+        was_in_sudo = self.env.su
         if is_portal_user:
             ctx = {
                 key: value for key, value in self.env.context.items()
@@ -1646,7 +1647,9 @@ class Task(models.Model):
         tasks = super(Task, self).create(vals_list)
         tasks._populate_missing_personal_stages()
         self._task_message_auto_subscribe_notify({task: task.user_ids - self.env.user for task in tasks})
-        if is_portal_user:
+
+        # in case we were already in sudo, we don't check the rights.
+        if is_portal_user and not was_in_sudo:
             # since we use sudo to create tasks, we need to check
             # if the portal user could really create the tasks based on the ir rule.
             tasks.with_user(self.env.user).check_access_rule('create')


### PR DESCRIPTION
Before this commit, since the code make a sudo -> unsudo to check the rights,
whatever the previous env, it is no more possible to create a task from an
alias.

This commit check that we are not already in sudo before, or in this case it
doesn't check the access right with an unsudo.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
