### PR TITLE
[FIX] web: Display correct Favicon depending company

### DIFF
--- a/addons/web/static/src/start.js
+++ b/addons/web/static/src/start.js
@@ -42,4 +42,15 @@ export async function startWebClient(Webclient) {
     // delete odoo.debug; // FIXME: some legacy code rely on this
     odoo.__WOWL_DEBUG__ = { root };
     odoo.isReady = true;
+
+    // Update Favicons
+    const favicon = `/web/image/res.company/${env.services.company.currentCompany.id}/favicon`;
+    const icons = document.querySelectorAll("link[rel*='icon']");
+    const msIcon = document.querySelector("meta[name='msapplication-TileImage']");
+    for (const icon of icons) {
+        icon.href = favicon;
+    }
+    if (msIcon) {
+        msIcon.content = favicon;
+    }
 }


### PR DESCRIPTION
Steps to reproduce:

 - Install the module web_enterprise
 - Activate Debug mode
 - Go to Settings -> Companies
 - Create company A and B
 - Upload new **pictures** and use them as Favicon for each company
 - Refresh the page or switch company

Issue:

  The favicon is not the right one.

Cause:

  When starting the webclient, the main favicon in the header is updated
  (with the correct current company id from cookies) in JS.
  Since the current company favicon is a picture, the browser fallback
  on the next favicon available (not the first one since the favicon is
  a picture), who, if web_enterprise is installed, is the static mobile
  (android) icon.

Solution:

  Update all icons with JS so it will fallback on the first declared icon
  (even though it's a picture) and also fix the issue of having a static
  mobile icon in enterprise.

opw-2664525