### PR TITLE
[FIX] base_automation: recursive computed field cause too many calls to flush

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -176,8 +176,8 @@ class BaseAutomation(models.Model):
     def _filter_post_export_domain(self, records):
         """ Filter the records that satisfy the postcondition of action ``self``. """
         if self.filter_domain and records:
-            domain = [('id', 'in', records.ids)] + safe_eval(self.filter_domain, self._get_eval_context())
-            return records.sudo().search(domain).with_env(records.env), domain
+            domain = safe_eval(self.filter_domain, self._get_eval_context())
+            return records.sudo().filtered_domain(domain).with_env(records.env), domain
         else:
             return records, None
 


### PR DESCRIPTION
The use-case that motivated this fix is the deletion of a project task with many subtasks.  The field `project_id` on tasks is recursively computed, and some automated action must be executed when its value corresponds to a given project.

The issue occurs when the domain of automated actions is evaluated by method `search()`, because the latter flushes the fields to search on, which are also the ones being recomputed.  Combined with the fact that recursive fields are not computed in batch, this leads to a huge amount of recursive calls between the automated action and `flush()`.

The execution of `task.unlink()` looks like this:
- mark `project_id` to compute on subtasks
- delete task
- `flush()`
  - recompute `project_id` on subtask1
    - call compute on subtask1
    - in action, `search([('id', 'in', subtask1.ids), ('project_id', '=', pid)])`
      - `flush(['id', 'project_id'])`
        - recompute `project_id` on subtask2
          - call compute on subtask2
          - in action, `search([('id', 'in', subtask2.ids), ('project_id', '=', pid)])`
            - `flush(['id', 'project_id'])`
              - recompute `project_id` on subtask3
                - call compute on subtask3
                - in action, `search([('id', 'in', subtask3.ids), ('project_id', '=', pid)])`
                  - `flush(['id', 'project_id'])`
                    - recompute `project_id` on subtask4
                         ...

Backport of #80078 (the tests are present in the other pull request, but not this one).