### PR TITLE
[FIX] stock: fix printing picking operation

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -111,7 +111,7 @@
                                                 </div>
                                             </td>
                                             <td class=" text-center h6" t-if="has_serial_number">
-                                                <div t-if="has_serial_number and (ml.lot_id or ml.lot_name)" t-field="ml.lot_id.name or ml.lot_name" t-options="{'widget': 'barcode', 'humanreadable': 1, 'width': 400, 'height': 100, 'img_style': 'width:100%;height:35px;'}"/>
+                                                <div t-if="has_serial_number and (ml.lot_id or ml.lot_name)" t-esc="ml.lot_id.name or ml.lot_name" t-options="{'widget': 'barcode', 'humanreadable': 1, 'width': 400, 'height': 100, 'img_style': 'width:100%;height:35px;'}"/>
                                             </td>
                                             <td class="text-center" t-if="has_barcode">
                                                 <t t-if="product_barcode != ml.product_id.barcode">


### PR DESCRIPTION
Steps to reproduce the problem:
- Create a storable product tracked by a unique serial number.
- use the product in a delivery
- try to print the "Picking Operations" document

Problem:
Traceback is triggered because we cannot use two fields in a "t-field"

opw-2692226




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
