### PR TITLE
[FIX] l10n_fr: tax data for tva 10%

### DIFF
--- a/addons/l10n_fr/data/account_tax_data.xml
+++ b/addons/l10n_fr/data/account_tax_data.xml
@@ -53,7 +53,7 @@
         <field name="amount" eval="10.0"/>
         <field name="amount_type">percent</field>
         <field name="tax_exigibility">on_payment</field>
-        <field name="cash_basis_transition_account_id" ref="pcg_44571" />
+        <field name="cash_basis_transition_account_id" ref="pcg_445800" />
         <field name="sequence" eval="10"/>
         <field name="type_tax_use">sale</field>
         <field name="tax_group_id" ref="tax_group_tva_10"/>
@@ -68,7 +68,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'plus_report_line_ids': [ref('l10n_fr.tax_report_tva_coll_10')],
-                'account_id': ref('pcg_445800'),
+                'account_id': ref('pcg_44571'),
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -416,7 +416,7 @@
         <field name="amount" eval="10"/>
         <field name="amount_type">percent</field>
         <field name="tax_exigibility">on_payment</field>
-        <field name="cash_basis_transition_account_id" ref="pcg_44571" />
+        <field name="cash_basis_transition_account_id" ref="pcg_445800" />
         <field name="sequence" eval="10"/>
         <field name="type_tax_use">sale</field>
         <field name="tax_group_id" ref="tax_group_tva_10"/>
@@ -431,7 +431,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'plus_report_line_ids': [ref('l10n_fr.tax_report_tva_coll_10')],
-                'account_id': ref('pcg_445800'),
+                'account_id': ref('pcg_44571'),
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),


### PR DESCRIPTION
Steps to reproduce:

-In a database with french accounting,
- The fields cash_basis_transition_account_id and invoice_repartition_line_ids are not well configured

opw-2669061

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
