### PR TITLE
[IMP] *: improve report security

### DIFF
--- a/addons/hr_timesheet/report/hr_timesheet_report_view.xml
+++ b/addons/hr_timesheet/report/hr_timesheet_report_view.xml
@@ -154,18 +154,17 @@
         <menuitem id="menu_timesheets_reports"
             name="Reporting"
             parent="timesheet_menu_root"
-            groups="hr_timesheet.group_timesheet_manager"
             sequence="99"/>
 
         <menuitem id="menu_timesheets_reports_timesheet"
             name="Timesheets"
             parent="menu_timesheets_reports"
-            groups="hr_timesheet.group_timesheet_manager"
             sequence="10"/>
 
         <menuitem id="menu_hr_activity_analysis"
             parent="menu_timesheets_reports_timesheet"
             action="act_hr_timesheet_report"
+            groups="hr_timesheet.group_hr_timesheet_approver"
             name="By Employee"
             sequence="10"/>
 

--- a/addons/hr_timesheet_attendance/models/__init__.py
+++ b/addons/hr_timesheet_attendance/models/__init__.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding:utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
-from . import report
+from . import ir_ui_menu

--- a/addons/hr_timesheet_attendance/models/ir_ui_menu.py
+++ b/addons/hr_timesheet_attendance/models/ir_ui_menu.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrUiMenu(models.Model):
+    _inherit = 'ir.ui.menu'
+
+    def _load_menus_blacklist(self):
+        res = super()._load_menus_blacklist()
+        if not (self.env.user.has_group('hr_attendance.group_hr_attendance_user') and self.env.user.has_group('hr_timesheet.group_hr_timesheet_user')):
+            res.append(self.env.ref('hr_timesheet_attendance.menu_hr_timesheet_attendance_report').id)
+        return res

--- a/addons/hr_timesheet_attendance/security/hr_timesheet_attendance_report_security.xml
+++ b/addons/hr_timesheet_attendance/security/hr_timesheet_attendance_report_security.xml
@@ -5,4 +5,18 @@
         <field name="model_id" ref="model_hr_timesheet_attendance_report"/>
         <field name="domain_force"> ['|', ('company_id', 'in', company_ids), ('company_id', '=', False)]</field>
     </record>
+
+    <record id="hr_timesheet_attendance_report_rule_user" model="ir.rule">
+        <field name="name">Timesheet attendance Report: User</field>
+        <field name="model_id" ref="model_hr_timesheet_attendance_report"/>
+        <field name="domain_force">[('user_id', '=', user.id)]</field>
+        <field name="groups" eval="[(4, ref('hr_attendance.group_hr_attendance_user'))]"/>
+    </record>
+
+    <record id="hr_timesheet_attendance_report_rule_manager" model="ir.rule">
+        <field name="name">Timesheet attendance Report: Administrator</field>
+        <field name="model_id" ref="model_hr_timesheet_attendance_report"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('hr_attendance.group_hr_attendance_manager')), (4, ref('hr_timesheet.group_hr_timesheet_approver'))]"/>
+    </record>
 </odoo>

--- a/addons/project/models/ir_ui_menu.py
+++ b/addons/project/models/ir_ui_menu.py
@@ -11,4 +11,6 @@ class IrUiMenu(models.Model):
         res = super()._load_menus_blacklist()
         if self.env.user.has_group('project.group_project_stages'):
             res.append(self.env.ref('project.menu_projects').id)
+        if self.user_has_groups('project.group_project_user, !project.group_project_manager'):
+            res.append(self.env.ref('project.rating_rating_menu_project').id)
         return res

--- a/addons/project/security/ir.model.access.csv
+++ b/addons/project/security/ir.model.access.csv
@@ -9,6 +9,7 @@ access_project_task_type_manager,project.task.type manager,model_project_task_ty
 access_project_task_type_portal,task_type_portal,project.model_project_task_type,base.group_portal,1,0,0,0
 access_project_task,project.task,model_project_task,project.group_project_user,1,1,1,1
 access_report_project_task_user,report.project.task.user,model_report_project_task_user,project.group_project_manager,1,1,1,1
+access_report_project_task_user_project_user,report.project.task.user.project.user,model_report_project_task_user,project.group_project_user,1,0,0,0
 access_partner_task_user,base.res.partner user,base.model_res_partner,project.group_project_user,1,0,0,0
 access_task_on_partner,project.task on partners,model_project_task,base.group_user,1,0,0,0
 access_task_portal,task_portal,project.model_project_task,base.group_portal,1,0,0,0

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -231,6 +231,28 @@
         <field name="groups" eval="[(4,ref('base.group_user'))]"/>
     </record>
 
+    <record model="ir.rule" id="report_project_task_user_rule">
+        <field name="name">Tasks Analysis: project visibility User</field>
+        <field name="model_id" ref="model_report_project_task_user"/>
+        <field name="domain_force">[
+        '|',
+            ('project_id.privacy_visibility', '!=', 'followers'),
+            '|',
+                ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                '|',
+                    ('task_id.message_partner_ids', 'in', [user.partner_id.id]),
+                    ('user_ids', 'in', user.id)
+        ]</field>
+        <field name="groups" eval="[(4,ref('project.group_project_user'))]"/>
+    </record>
+
+    <record model="ir.rule" id="report_project_task_manager_rule">
+        <field name="name">Tasks Analysis: project visibility Manager</field>
+        <field name="model_id" ref="model_report_project_task_user"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
+    </record>
+
     <record id="update_visibility_project_admin" model="ir.rule">
         <field name="name">Project updates : Project user can see all project updates</field>
         <field name="model_id" ref="project.model_project_update"/>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -708,15 +708,20 @@
                                                     <a name="action_view_tasks" type="object">Tasks</a>
                                                 </div>
                                             </div>
-                                            <div class="col-6 o_kanban_card_manage_section o_kanban_manage_reporting" groups="project.group_project_manager">
-                                                <div role="menuitem" class="o_kanban_card_manage_title">
+                                            <div class="col-6 o_kanban_card_manage_section o_kanban_manage_reporting">
+                                                <div role="menuitem" class="o_kanban_card_manage_title" groups="project.group_project_manager,project.group_project_rating">
                                                     <span>Reporting</span>
                                                 </div>
-                                                <div role="menuitem">
+                                                <div role="menuitem" groups="project.group_project_manager">
                                                     <a name="action_view_tasks_analysis" type="object">Tasks Analysis</a>
                                                 </div>
-                                                <div role="menuitem" name="project_burndown_menu">
+                                                <div role="menuitem" name="project_burndown_menu" groups="project.group_project_manager">
                                                     <a name="%(action_project_task_burndown_chart_report)d" type="action">Burndown Chart</a>
+                                                </div>
+                                                <div role="menuitem" t-if="record.rating_active.raw_value">
+                                                   <a name="action_view_all_rating" type="object">
+                                                    Customer Ratings
+                                                    </a>
                                                 </div>
                                             </div>
                                         </div>
@@ -1469,7 +1474,6 @@
 
         <!-- Reporting menus -->
         <menuitem id="menu_project_report" name="Reporting"
-            groups="project.group_project_manager"
             parent="menu_main_pm" sequence="99"/>
 
         <menuitem id="menu_project_report_task_analysis"

--- a/addons/project/views/rating_views.xml
+++ b/addons/project/views/rating_views.xml
@@ -124,7 +124,7 @@
         <field name="name">Ratings</field>
         <field name="res_model">rating.rating</field>
         <field name="view_mode">kanban,tree,graph,pivot,form</field>
-        <field name="domain">[('consumed','=',True), ('parent_res_model','=','project.project')]</field>
+        <field name="domain">[('consumed','=',True), ('parent_res_model','=','project.project'), ('parent_res_id', '=', active_id)]</field>
         <field name="search_view_id" ref="rating_rating_view_search_project"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">

--- a/addons/rating/security/ir.model.access.csv
+++ b/addons/rating/security/ir.model.access.csv
@@ -1,5 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_rating_user,rating.rating.user,rating.model_rating_rating,base.group_user,1,1,1,0
+access_rating_user,rating.rating.user,rating.model_rating_rating,base.group_user,1,0,1,0
 access_rating_public,rating.rating.public,rating.model_rating_rating,base.group_public,0,0,0,0
 access_rating_portal,rating.rating.portal,rating.model_rating_rating,base.group_portal,0,0,0,0
 rating_rating_access_system,rating.rating.access.system,rating.model_rating_rating,base.group_system,1,1,1,1

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -105,13 +105,6 @@
                 <field name="sale_order_id" invisible="1"/>
                 <field name="pricing_type" invisible="1"/>
             </xpath>
-            <xpath expr="//div[hasclass('o_kanban_manage_reporting')]" position="inside">
-                <div role="menuitem" t-if="record.rating_active.raw_value" groups="project.group_project_manager">
-                   <a name="action_view_all_rating" type="object">
-                    Customer Ratings
-                    </a>
-                </div> 
-            </xpath>
             <xpath expr="//div[hasclass('o_kanban_manage_view')]" position="inside">
                 <div t-if="record.allow_billable.raw_value and record.sale_order_id.raw_value and record.pricing_type.raw_value != 'task_rate'"
                     role="menuitem"


### PR DESCRIPTION
* hr_timesheet_{attendance}, project, rating, sale_timesheet

- removed the 'admin' group on the reporting menu items so that 'users' can
  access these menus.
- 'timesheet / attendance' menu should only show if user has access for both
  the attendance and timesheet.
- Project/User should access 'Task Analysis' report And Added rule for user.
- customer ratings: only show ratings which has access of their project/task.
- ratings: user should not able to edit ratings.

LINKS:

Task-2467564
