### PR TITLE
[FIX] stock: package level not moved on backorder

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1022,6 +1022,7 @@ class Picking(models.Model):
                 moves_to_backorder.write({'picking_id': backorder_picking.id})
                 moves_to_backorder.move_line_ids.package_level_id.write({'picking_id':backorder_picking.id})
                 moves_to_backorder.mapped('move_line_ids').write({'picking_id': backorder_picking.id})
+                moves_to_backorder.mapped('move_line_ids.package_level_id').write({'picking_id': backorder_picking.id})
                 backorder_picking.action_assign()
                 backorders |= backorder_picking
         return backorders


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Correctly moves package levels at backorder creation

Current behavior before PR:
in some cases, there's package_levels attached to the
move lines that references the original picking, and aren't set
to reference the new picking.

In such case, a new package_level is created in the backorder picking.
When the backorder is validated, it is the package level attached to
the previous picking that is validated, instead of the new one, which is wrong.

Desired behavior after PR is merged:
When a backorder is created, the moves to put in the backorder
are linked to the new picking, as well as the related move lines
and the related package levels.

Steps to reproduce:
On a fresh database, install "Sales" and "Inventory"
In inventory settings, enable "Multistep routing" and "delivery packages"
On the warehouse, enable the "3 steps route" for "Outgoing Shipments"
On the "Delivery Orders" picking type, enable "Move entire packages"
Add some stock and enable the "3 steps route" on two products (I've used "E-COM06" and "E-COM07" for my tests)
Create a SO with two lines (one for each one of the previous products) and confirm
On the pick picking, confirm
On the pack picking, create a "destination package" for each one of the lines
On the "ship" picking, set one package as done, confirm and create a backorder
Here, we still have two "stock.package_level" attached to the original picking (expected the "done" one only)
On the backorder, we have a "stock.package_level" for the same package.
Confirm the backorder, the new "stock.package_level" is still draft, while the one attached to the original picking is set to done.

Odoo OPW: 2694658
internal ref: 3021

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
