### PR TITLE
[IMP] digest: show pictures stored on Odoo

### DIFF
--- a/addons/account/data/digest_data.xml
+++ b/addons/account/data/digest_data.xml
@@ -15,7 +15,7 @@
 <div>
     <p class="tip_title">Tip: No need to print, put in an envelop and post your invoices</p>
     <p class="tip_content">Use the “<i>Send by Post</i>” option to post invoices automatically. For the cost of a local stamp, we do all the manual work: your invoice will be printed in the right country, put in an envelop and sent by snail mail. Use this feature from the list view to post hundreds of invoices in bulk.</p>
-    <img src="/account/static/src/img/invoice-stamps.png" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/account/static/src/img/invoice-stamps.png" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/crm/data/digest_data.xml
+++ b/addons/crm/data/digest_data.xml
@@ -34,7 +34,7 @@
 <div>
     <p class="tip_title">Tip: Did you know Odoo has built-in lead mining?</p>
     <p class="tip_content">For a sales team, there is nothing worse than being dry on leads. Fortunately, in just a few clicks, you can generate leads specifically targeted to your needs: company size, industry, etc. To help you test the feature, we offer you 200 credits for free.</p>
-    <img src="/crm/static/src/img/generate-leads.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/crm/static/src/img/generate-leads.gif" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -46,7 +46,7 @@
 <div>
     <p class="tip_title">Tip: Opportunity win rate is predicted with AI</p>
     <p class="tip_content">Odoo's artificial intelligence engine predicts the success rate of each opportunity based on your history. You can always update the success rate manually, but if you let Odoo do the job the score is updated while the opportunity moves forward in your sales cycle.</p>
-    <img src="/crm/static/src/img/probability-rate.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/crm/static/src/img/probability-rate.gif" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -58,7 +58,7 @@
 <div>
     <p class="tip_title">Tip: Manage your pipeline</p>
     <p class="tip_content">A great tip to boost sales efficiency is to always define a next step on each opportunity. To manage ongoing activities, click on any status of the progress bar to filter opportunities based on their next activities' status. Click on the grey area of the progress bar to see all opportunities that have no next activity.</p>
-    <img src="/crm/static/src/img/pipeline-progress.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/crm/static/src/img/pipeline-progress.gif" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -70,7 +70,7 @@
 <div>
     <p class="tip_title">Tip: Do not waste time recording customers' data</p>
     <p class="tip_content">Did you know you can search a company by name or VAT number to instantly fill in all its data? Odoo autocompletes everything for you: logo, address, company size, business information, social media accounts, etc.</p>
-    <img src="/crm/static/src/img/autofill.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/crm/static/src/img/autofill.gif" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -82,7 +82,7 @@
 <div>
     <p class="tip_title">Tip: Turn a selection of opportunities into a map</p>
     <p class="tip_content">Did you know you can turn a list of opportunities into a map view, using the top-right map icon? A lot of screens in Odoo can be turned into a map: tasks, contacts, delivery orders, etc.</p>
-    <img src="/crm/static/src/img/mapview-toggle.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/crm/static/src/img/mapview-toggle.gif" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/digest/data/digest_data.xml
+++ b/addons/digest/data/digest_data.xml
@@ -444,10 +444,10 @@
     <div style="width: 50%; float: left;">
         <p class="run_business">Run your business from anywhere with <b>Odoo Mobile</b>.</p>
         <div>
-            <a href="https://play.google.com/store/apps/details?id=com.odoo.mobile" target="_blank"><img class="download_app" src="https://www.odoo.com/digest/static/src/img/google_play.png" /></a>
+            <a href="https://play.google.com/store/apps/details?id=com.odoo.mobile" target="_blank"><img class="download_app" src="https://download.odoocdn.com/digests/digest/static/src/img/google_play.png" /></a>
         </div>
         <div>
-            <a href="https://itunes.apple.com/us/app/odoo/id1272543640" target="_blank"><img class="download_app" src="https://www.odoo.com/digest/static/src/img/app_store.png" /></a>
+            <a href="https://itunes.apple.com/us/app/odoo/id1272543640" target="_blank"><img class="download_app" src="https://download.odoocdn.com/digests/digest/static/src/img/app_store.png" /></a>
         </div>
     </div>
 </div>

--- a/addons/digest/data/digest_tips_data.xml
+++ b/addons/digest/data/digest_tips_data.xml
@@ -18,7 +18,7 @@
 <div>
     <p class="tip_title">Tip: Speed up your workflow with shortcuts</p>
     <p class="tip_content">Press ALT in any screen to highlight shortcuts for every button in the screen. It is useful to process multiple documents in batch.</p>
-    <img src="/digest/static/src/img/alt-shortcuts.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/digest/static/src/img/alt-shortcuts.gif" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -30,7 +30,7 @@
 <div>
     <p class="tip_title">Tip: Click on an avatar to chat with a user</p>
     <p class="tip_content">Have a question about a document? Click on the responsible user's picture to start a conversation. If his avatar has a green dot, he is online.</p>
-    <img src="/digest/static/src/img/avatar.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/digest/static/src/img/avatar.gif" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -42,7 +42,7 @@
 <div>
     <p class="tip_title">Tip: A calculator in Odoo</p>
     <p class="tip_content">When editing a number, you can use formulae by typing the `=` character. This is useful when computing a margin or a discount on a quotation, sale order or invoice.</p>
-    <img src="/digest/static/src/img/calculator.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/digest/static/src/img/calculator.gif" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -54,7 +54,7 @@
 <div>
     <p class="tip_title">Tip: How to ping users in internal notes?</p>
     <p class="tip_content">Type "@" to notify someone in a message, or "#" to link to a channel. Try to notify @OdooBot to test the feature.</p>
-    <img src="/digest/static/src/img/notifications.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/digest/static/src/img/notifications.gif" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -67,7 +67,7 @@
     <p class="tip_title">Tip: Knowledge is power</p>
     <p class="tip_content">When following documents, use the pencil icon to fine-tune the information you want to receive.
 Follow a project / sales team to keep track of this project's tasks / this team's opportunities.</p>
-    <img src="/digest/static/src/img/following.png" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/digest/static/src/img/following.png" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/hr_expense/data/digest_data.xml
+++ b/addons/hr_expense/data/digest_data.xml
@@ -9,7 +9,7 @@
 <div>
     <p class="tip_title">Tip: Snap pictures of your receipts with the remote app</p>
     <p class="tip_content">Do not keep your expense tickets in your pockets any longer. Just snap a picture of your receipt and let Odoo digitalizes it for you. The OCR and Artificial Intelligence will fill the data automatically.</p>
-    <img src="/hr_expense/static/src/img/expense.png" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/hr_expense/static/src/img/expense.png" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/hr_timesheet/data/digest_data.xml
+++ b/addons/hr_timesheet/data/digest_data.xml
@@ -9,7 +9,7 @@
 <div>
     <b class="tip_title">Tip: Record your Timesheets faster</b>
     <p class="tip_content">Record your timesheets in an instant by pressing Shift + the corresponding hotkey to add 15min to your projects.</p>
-    <img src="/hr_timesheet/static/img/digest_tip_timesheets_hotkeys.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/hr_timesheet/static/img/digest_tip_timesheets_hotkeys.gif" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/im_livechat/data/digest_data.xml
+++ b/addons/im_livechat/data/digest_data.xml
@@ -17,7 +17,7 @@
 <div>
     <p class="tip_title">Tip: Use canned responses to chat faster</p>
     <p class="tip_content">Use canned responses to define templates of messages in the livechat app. To load a canned response, start your sentence with ':' and select the template.</p>
-    <img src="/im_livechat/static/src/img/canned-responses.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/im_livechat/static/src/img/canned-responses.gif" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/mrp/data/digest_data.xml
+++ b/addons/mrp/data/digest_data.xml
@@ -9,7 +9,7 @@
 <div>
     <p class="tip_title">Tip: Use tablets in the shop to control manufacturing</p>
     <p class="tip_content">With the Odoo work center control panel, your worker can start work orders in the shop and follow instructions of the worksheet. Quality tests are perfectly integrated into the process. Workers can trigger feedback loops, maintenance alerts, scrap products, etc.</p>
-    <img src="/mrp/static/src/img/mrp-tablet.png" style="margin-top: 20px; max-width: 580px" width="100%" />
+    <img src="https://download.odoocdn.com/digests/mrp/static/src/img/mrp-tablet.png" style="margin-top: 20px; max-width: 580px" width="100%" />
 </div>
             </field>
         </record>

--- a/addons/project/data/digest_data.xml
+++ b/addons/project/data/digest_data.xml
@@ -15,7 +15,7 @@
 <div>
     <p class="tip_title">Tip: Customize tasks and stages according to the project</p>
     <p class="tip_content">Customize how tasks are named according to the project and create tailor made status messages for each step of the workflow. It helps to document your workflow: what should be done at which step.</p>
-    <img src="/project/static/src/img/project-custom-tasks.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/project/static/src/img/project-custom-tasks.gif" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/purchase/data/digest_data.xml
+++ b/addons/purchase/data/digest_data.xml
@@ -9,7 +9,7 @@
 <div>
     <p class="tip_title">Tip: How to keep late receipts under control?</p>
     <p class="tip_content">When creating a purchase order, have a look at the vendor's <i>On Time Delivery</i> rate: the percentage of products shipped on time. If it is too low, activate the <i>automated reminders</i>. A few days before the due shipment, Odoo will send the vendor an email to ask confirmation of shipment dates and keep you informed in case of any delays. To get the vendor's performance statistics, click on the OTD rate.</p>
-    <img src="/purchase/static/src/img/OTDPurchase.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/purchase/static/src/img/OTDPurchase.gif" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/sale_management/data/digest_data.xml
+++ b/addons/sale_management/data/digest_data.xml
@@ -13,7 +13,7 @@
 <div>
     <p class="tip_title">Tip: Odoo supports configurable products</p>
     <p class="tip_content">Struggling with a complex product catalog? Try out the Product Configurator to help sales configure a product with different options: colors, size, capacity, etc. Make sale orders encoding easier and error-proof.</p>
-    <img src="/sale_management/static/src/img/Sales-configure-products.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/sale_management/static/src/img/Sales-configure-products.gif" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -25,7 +25,7 @@
 <div>
     <p class="tip_title">Tip: Sell or buy products in bulk with matrixes</p>
     <p class="tip_content">Selling the same product in different sizes or colors? Try the product grid and populate your orders with multiple quantities of each variant. This feature also exists in the Purchase application.</p>
-    <img src="/sale_management/static/src/img/t-shirts.png" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/sale_management/static/src/img/t-shirts.png" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/stock/data/digest_data.xml
+++ b/addons/stock/data/digest_data.xml
@@ -10,7 +10,7 @@
     <p class="tip_title">Tip: Speed up inventory operations with barcodes</p>
     <div class="tip_twocol">
         <div class="tip_twocol_left" style="float: left; width: 45%;">
-            <img src="/stock/static/src/img/barcode.gif" class="tip_twocol_img" />
+            <img src="https://download.odoocdn.com/digests/stock/static/src/img/barcode.gif" class="tip_twocol_img" />
         </div>
         <div style="float: left; width: 55%;">
             <p class="tip_content" style="margin: 0;">Enjoy a quick-paced experience with the Odoo barcode app. It is blazing fast and works even without a stable internet connection. It supports all flows: inventory adjustments, batch picking, moving lots or pallets, low inventory checks, etc. Go to the "Apps" menu to activate the barcode interface.</p>

--- a/addons/website/data/digest_data.xml
+++ b/addons/website/data/digest_data.xml
@@ -9,7 +9,7 @@
 <div>
     <p class="tip_title">Tip: Engage with visitors to convert them into leads</p>
     <p class="tip_content">Monitor your visitors while they are browsing your website with the Odoo Social app. Engage with them in just a click using a live chat request or a push notification. If they have completed one of your forms, you can send them an SMS, or call them right away while they are browsing your website.</p>
-    <img src="/website/static/src/img/website-visitors.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/website/static/src/img/website-visitors.gif" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -21,7 +21,7 @@
 <div>
     <p class="tip_title">Tip: Use royalty-free photos</p>
     <p class="tip_content">Search in the media dialogue when you need photos to illustrate your website. Odoo's integration with Unsplash, featuring millions of royalty free and high quality photos, makes it possible for you to get the perfect picture, in just a few clicks.</p>
-    <img src="/website/static/src/img/image-search.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/website/static/src/img/image-search.gif" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -33,7 +33,7 @@
 <div>
     <p class="tip_title">Tip: Search Engine Optimization (SEO)</p>
     <p class="tip_content">To get more visitors, you should target keywords that are often searched in Google. With the built-in SEO tool, once you define a few keywords, Odoo will recommend you the best keywords to target. Then adapt your title and description accordingly to boost your traffic.</p>
-    <img src="/website/static/src/img/SEO-keywords.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/website/static/src/img/SEO-keywords.gif" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -45,7 +45,7 @@
 <div>
     <p class="tip_title">Tip: Use illustrations to spice up your website</p>
     <p class="tip_content">Not only can you search for royalty-free illustrations, their colors are also converted so that they always fit your Theme.</p>
-    <img src="/website/static/src/img/digest_tip_website_illustrations.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/website/static/src/img/digest_tip_website_illustrations.gif" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -57,7 +57,7 @@
 <div>
     <p class="tip_title">Tip: Add shapes to energize your Website</p>
     <p class="tip_content">More than 90 shapes exist and their colors are picked to match your Theme.</p>
-    <img src="/website/static/src/img/digest_tip_website_shapes.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/website/static/src/img/digest_tip_website_shapes.gif" class="illustration_border" />
 </div>
             </field>
         </record>


### PR DESCRIPTION
Purpose
=======
Pictures from the digest emails are currently stored on the database
itself, meaning that if the database expires (e.g. after trial expires) all
pictures from previously sent emails won't be visible.
This is an issue since digest tips are meant as a marketing tool to bring
people to Odoo after trying a database.

Pictures are now stored on Odoo's server
(https://download.odoocdn.com/digests) so that the pictures will still
be visible after the database has expired.

Task-2372195
