### PR TITLE
[FIX] hr_holidays: fix time off with allocation of one day

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -356,9 +356,9 @@ class HolidaysRequest(models.Model):
                 date_to = leave.date_to.replace(tzinfo=UTC).astimezone(timezone(leave.tz)).date()
                 date_from = leave.date_from.replace(tzinfo=UTC).astimezone(timezone(leave.tz)).date()
                 for allocation in allocations_dict[(leave.holiday_status_id.id, leave.employee_id.id)]:
-                    date_to_check = allocation['date_to'] > date_to if allocation['date_to'] else False
-                    date_from_check = allocation['date_to'] is False and allocation['date_from'] <= date_from
-                    if (date_to_check or date_from_check):
+                    date_to_check = allocation['date_to'] >= date_to if allocation['date_to'] else True
+                    date_from_check = allocation['date_from'] <= date_from
+                    if (date_to_check and date_from_check):
                         found_allocation = allocation['id']
                         break
                 leave.holiday_allocation_id = self.env['hr.leave.allocation'].browse(found_allocation) if found_allocation else False


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
As an HR officer, when you create an allocation of one day for a user,
you need to be able to put a time off on that person, following the allocation.
But for the moment, we got an error saying there is no valid allocation on that day.

Current behavior before PR:
There is no allocation found on that day when a time off is taken on the day of the allocation

Desired behavior after PR is merged:
If you create an allocation of 1 day, you need to be able to put a time off on
that specific day without any error message.

task-2696771


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
