### PR TITLE
[FIX] stock: add required fields to SML's kanban view

### DIFF
--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -95,6 +95,8 @@
         <field name="model">stock.move.line</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
+                <field name="location_id" invisible="1"/>
+                <field name="location_dest_id" invisible="1"/>
                 <templates>
                     <t t-name="kanban-box">
                         <div t-attf-class="oe_kanban_card oe_kanban_global_click">


### PR DESCRIPTION
When using a mobile, scanning a product to manage a delivery won't work

To reproduce the error:
(Need stock_barcode. Use demo data)
1. In Operations Types, edit "Delivery Orders":
    - Enable "Show Detailed Operations"
3. Create a planned delivery order DO:
    - 1 x [FURN_1118] Corner Desk Black
4. Mark a Todo
5. Switch to a mobile view
6. Edit DO and scan 601647855640 (i.e., the barcode of FURN_1118)
7. Save DO

Error: An error is displayed "The operation cannot be completed [...]
Model: Product Moves (Stock Move Line) (stock.move.line), Field: From
(location_id)"

The kanban view does not include both `location_id` and
`location_dest_id` although they are required

OPW-2688915