### PR TITLE
[FIX] web_editor: prevent editor observing technical modification

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2885,7 +2885,7 @@ export class OdooEditor extends EventTarget {
         }
     }
     _pluginAdd(Plugin) {
-        this._plugins.push(new Plugin(this));
+        this._plugins.push(new Plugin({ editor: this }));
     }
     _pluginCall(method, args) {
         for (const plugin of this._plugins) {

--- a/addons/web_editor/static/src/js/backend/QWebPlugin.js
+++ b/addons/web_editor/static/src/js/backend/QWebPlugin.js
@@ -5,6 +5,15 @@ import { ancestors } from '@web_editor/js/common/wysiwyg_utils';
 export class QWebPlugin {
     constructor(options = {}) {
         this._options = options;
+        if (this._options.editor) {
+            this._editable = this._options.editor.editable;
+            this._document = this._options.editor.document;
+        } else {
+            this._editable = this._options.editable;
+            this._document = this._options.document || window.document;
+        }
+        this._editable = this._options.editable || (this._options.editor && this._options.editor.editable);
+        this._document = this._options.document || (this._options.editor && this._options.editor.document) || window.document;
         this._tGroupCount = 0;
         this._hideBranchingSelection = this._hideBranchingSelection.bind(this);
         this._makeBranchingSelection();
@@ -27,8 +36,8 @@ export class QWebPlugin {
         if (subRoot.nodeType !== Node.ELEMENT_NODE) {
             return;
         }
-        if (this._editor) {
-            this._editor.observerUnactive('qweb-plugin-sanitize');
+        if (this._options.editor) {
+            this._options.editor.observerUnactive('qweb-plugin-sanitize');
         }
 
         this._fixInlines(subRoot);
@@ -39,8 +48,8 @@ export class QWebPlugin {
         }
 
         this._groupQwebBranching(subRoot);
-        if (this._editor) {
-            this._editor.observerActive('qweb-plugin-sanitize');
+        if (this._options.editor) {
+            this._options.editor.observerActive('qweb-plugin-sanitize');
         }
     }
     _groupQwebBranching(subRoot) {
@@ -107,16 +116,16 @@ export class QWebPlugin {
         // todo: remove the setTimeout when the editor will provide a signal
         // that the editable is on the dom.
         setTimeout(() => {
-            if (this._editor) {
-                this._editor.observerUnactive('qweb-plugin-checkAllInline');
+            if (this._options.editor) {
+                this._options.editor.observerUnactive('qweb-plugin-checkAllInline');
             }
             for (const tElement of tElements) {
                 if (checkAllInline(tElement)) {
                     tElement.setAttribute('data-oe-t-inline', 'true');
                 }
             }
-            if (this._editor) {
-                this._editor.observerActive('qweb-plugin-checkAllInline');
+            if (this._options.editor) {
+                this._options.editor.observerActive('qweb-plugin-checkAllInline');
             }
         });
     }
@@ -131,7 +140,7 @@ export class QWebPlugin {
     _showBranchingSelection(target) {
         this._hideBranchingSelection();
 
-        const branchingHierarchyElements = [target, ...ancestors(target, this._options.editable)]
+        const branchingHierarchyElements = [target, ...ancestors(target, this._editable)]
             .filter(element => element.getAttribute('data-oe-t-group-active') === 'true')
             .filter(element => {
                 const itemGroupId = element.getAttribute('data-oe-t-group');


### PR DESCRIPTION
Whenever the qweb plugin modified the dom for rendering purposes,
the mutations were observed but shouldn't. The reason was that the
reference to the editor was missing in the plugin and therfore it did
not call `observerUnactive` and `observerActive`.

Task-2695658



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
