### PR TITLE
autosave form view before navigating to next/previous  page

### DIFF
--- a/addons/web/static/src/js/chrome/keyboard_navigation_mixin.js
+++ b/addons/web/static/src/js/chrome/keyboard_navigation_mixin.js
@@ -198,8 +198,15 @@ odoo.define('web.KeyboardNavigationMixin', function (require) {
                     if (elementWithAccessKey.length) {
                         if (this.BrowserDetection.isOsMac() ||
                             !this.BrowserDetection.isBrowserChrome()) { // on windows and linux, chrome does not prevent the default of the accesskeys
+                            // we want to trigger onchange before click is trigerred as otherwise click handler is called
+                            // before onchange is trigerred and form gets dirty
+                            // scenario: Go to form view and edit and any input field and then go to next page using ALT + N
+                            // form is not get saved because click handler to go to next page is called before onchange is called.
+                            // add setTimeout before click is called so that focus triggers onchange event first and then click event trigerred
                             elementWithAccessKey[0].focus();
-                            elementWithAccessKey[0].click();
+                            setTimeout(() => {
+                                elementWithAccessKey[0].click();
+                            }, 0);
                             if (keyDownEvent.preventDefault) keyDownEvent.preventDefault(); else keyDownEvent.returnValue = false;
                             if (keyDownEvent.stopPropagation) keyDownEvent.stopPropagation();
                             if (keyDownEvent.cancelBubble) keyDownEvent.cancelBubble = true;


### PR DESCRIPTION
PURPOSE

Fix Issue:
    In firefox, using the formview pager with the keyboard navigation does not save the record.
    Steps:
        1. Edit the formview
        2. Set a value in a char field, do not click out
        3. Go to the next record with ALT+N
        4. Going back to the first record, you can see it hasn't been saved

It is because when user press ALT+N or ALT + P then next/previous pager button element is focused and then it is clicked, here focus will later call onchange of Input element but here click handler is called before onchange is trigerred and hence form is not getting dirty and it is not saved by autosave feature.

SPEC
When user changed Input element and press ALT+N or ALT + P then first onchange should be trigerred and then click should be trigerred so autosave feature works properly with keyboard navigation.

TASK 2516219

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
