### PR TITLE
[FIX] core, base - Fixed the issue of date widget in Qweb report which did not consider timezone.

### DIFF
--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -1178,7 +1178,7 @@ class TestQWebStaticXml(TransactionCase):
 
             result = doc.find('result[@id="{}"]'.format(template)).text
             self.assertEqual(
-                qweb._render(template, values=params, load=loader).strip(),
+                qweb.with_context(tz=self.env.user.tz)._render(template, values=params, load=loader).strip(),
                 (result or u'').strip().replace('&quot;', '&#34;'),
                 template
             )

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1301,7 +1301,11 @@ def format_date(env, value, lang_code=False, date_format=False):
     if not date_format:
         date_format = posix_to_ldml(lang.date_format, locale=locale)
 
-    return babel.dates.format_date(value, format=date_format, locale=locale)
+    tzinfo = None
+    if env.context.get("tz"):
+        tzinfo = babel.dates.get_timezone(env.context["tz"])
+
+    return babel.dates.format_datetime(value, format=date_format, tzinfo=tzinfo, locale=locale)
 
 def parse_date(env, value, lang_code=False):
     '''


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When in t-options widget "date" was used the date was not converted to correct timezone of the user.

**Current behavior before PR:**
1. The format_date() function of misc tools didn't considered the user timezone.
2. format_date() function of babel library does not have an parameter which accepts timezone.

**Desired behavior after PR is merged:**
Taking reference from "format_datetime" funtion of babels library,
1. Used babel.dates.format_datetime() method to convert the date to the correct timezone.
2. Timezone "tz" is taken from context else None.
3. Now when widget "date" is used in Qweb report, the date is shown correctly as per user's timezone

Fixes #79890
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
