### PR TITLE
[15.0] point_of_sale: Fixed issue of customer screen not loading when Contact Name is not set for invoice type customer

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -74,7 +74,7 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
             } else {
                 res = this.env.pos.db.get_partners_sorted(1000);
             }
-            return res.sort(function (a, b) { return a.name.localeCompare(b.name) });
+            return res.sort(function (a, b) { return (a.name || '').localeCompare(b.name) });
         }
         get isNextButtonVisible() {
             return this.state.selectedClient ? true : false;


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
If there is invoice customer which no "Contact Name" and try to open customer screen in POS then it gives blank screen

**Current behaviour before PR:**
The POS customer selection screen displays blank and no option to go back

**Desired behaviour after PR is merged:**
When referred to v14 it showed "false" in the contact name. Handled the `get clients()` method which will load the screen successfully and the contact name will be shown "false".

Fixes #80147 
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
