### PR TITLE
[FIX] website_crm_partner_assign: Coding error

### DIFF
--- a/addons/website_crm_partner_assign/report/crm_partner_report.py
+++ b/addons/website_crm_partner_assign/report/crm_partner_report.py
@@ -52,7 +52,7 @@ class CrmPartnerReportAssign(models.Model):
                 FROM
                     res_partner p
                     left join ({account_invoice_report}) i
-                        on (i.partner_id=p.id and i.move_type in ('out_invoice','out_refund') and i.state='open')
+                        on (i.partner_id=p.id and i.move_type in ('out_invoice','out_refund') and i.state='posted')
             """.format(
                 account_invoice_report=self.env['account.invoice.report']._table_query
             )


### PR DESCRIPTION
The state value 'open' does not exist on model  account.invoice.report

opw:2666887