### PR TITLE
[FIX] account: remove dead code `complete_tax_set`

### DIFF
--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -157,7 +157,7 @@ class ResConfigSettings(models.TransientModel):
         if self.env.company == self.company_id \
                 and self.chart_template_id \
                 and self.chart_template_id != self.company_id.chart_template_id:
-            self.chart_template_id._load(15.0, 15.0, self.env.company)
+            self.chart_template_id._load(self.env.company)
 
     @api.depends('company_id')
     def _compute_has_chart_of_accounts(self):

--- a/addons/account/views/account_chart_template_views.xml
+++ b/addons/account/views/account_chart_template_views.xml
@@ -17,7 +17,6 @@
                         <field name="transfer_account_code_prefix"/>
                         <field name="code_digits" />
                         <field name="visible" />
-                        <field name="complete_tax_set" />
                     </group>
                     <separator string="Default Taxes" colspan="4"/>
                     <field name="tax_template_ids" colspan="4"  nolabel="1"/>

--- a/addons/l10n_ae/data/l10n_ae_chart_data.xml
+++ b/addons/l10n_ae/data/l10n_ae_chart_data.xml
@@ -10,6 +10,5 @@
          <field name="transfer_account_code_prefix">100</field>
          <field name="currency_id" ref="base.AED" />
          <field name="country_id" ref="base.ae"/>
-         <field name="complete_tax_set" eval="True"/>
      </record>
 </odoo>

--- a/addons/l10n_ar/models/account_chart_template.py
+++ b/addons/l10n_ar/models/account_chart_template.py
@@ -44,7 +44,7 @@ class AccountChartTemplate(models.Model):
         }
         return match.get(chart_template_id)
 
-    def _load(self, sale_tax_rate, purchase_tax_rate, company):
+    def _load(self, company):
         """ Set companies AFIP Responsibility and Country if AR CoA is installed, also set tax calculation rounding
         method required in order to properly validate match AFIP invoices.
 
@@ -64,7 +64,7 @@ class AccountChartTemplate(models.Model):
             # the default VAT type.
             company.partner_id.l10n_latam_identification_type_id = self.env.ref('l10n_ar.it_cuit')
 
-        res = super()._load(sale_tax_rate, purchase_tax_rate, company)
+        res = super()._load(company)
 
         # If Responsable Monotributista remove the default purchase tax
         if self == self.env.ref('l10n_ar.l10nar_base_chart_template') or \

--- a/addons/l10n_at/data/account_chart_template.xml
+++ b/addons/l10n_at/data/account_chart_template.xml
@@ -6,7 +6,6 @@
         <!-- Vorlagen: Kontenplan -->
         <record id="l10n_at_chart_template" model="account.chart.template">
             <field name="name">Einheitskontenrahmen Österreich 2010</field>
-            <field name="complete_tax_set" eval="True" />
             <field name="visible" eval="True" />
 
             <field name="property_account_receivable_id" ref="chart_at_template_2000" />

--- a/addons/l10n_at/models/chart_template.py
+++ b/addons/l10n_at/models/chart_template.py
@@ -6,8 +6,8 @@ class AccountChartTemplate(models.Model):
     _inherit = 'account.chart.template'
 
     # Write paperformat and report template used on company
-    def _load(self, sale_tax_rate, purchase_tax_rate, company):
-        res = super(AccountChartTemplate, self)._load(sale_tax_rate, purchase_tax_rate, company)
+    def _load(self, company):
+        res = super(AccountChartTemplate, self)._load(company)
         if self == self.env.ref('l10n_at.l10n_at_chart_template'):
             company.write({
                 'external_report_layout_id': self.env.ref('l10n_din5008.external_layout_din5008').id,

--- a/addons/l10n_ch/models/chart_template.py
+++ b/addons/l10n_ch/models/chart_template.py
@@ -6,8 +6,8 @@ class AccountChartTemplate(models.Model):
     _inherit = 'account.chart.template'
 
     # Write paperformat and report template used on company
-    def _load(self, sale_tax_rate, purchase_tax_rate, company):
-        res = super(AccountChartTemplate, self)._load(sale_tax_rate, purchase_tax_rate, company)
+    def _load(self, company):
+        res = super(AccountChartTemplate, self)._load(company)
         if self == self.env.ref('l10n_ch.l10nch_chart_template'):
             company.write({
                 'external_report_layout_id': self.env.ref('l10n_din5008.external_layout_din5008').id,

--- a/addons/l10n_cl/models/account_chart_template.py
+++ b/addons/l10n_cl/models/account_chart_template.py
@@ -7,9 +7,9 @@ from odoo.http import request
 class AccountChartTemplate(models.Model):
     _inherit = 'account.chart.template'
 
-    def _load(self, sale_tax_rate, purchase_tax_rate, company):
+    def _load(self, company):
         """ Set tax calculation rounding method required in Chilean localization"""
-        res = super()._load(sale_tax_rate, purchase_tax_rate, company)
+        res = super()._load(company)
         if company.account_fiscal_country_id.code == 'CL':
             company.write({'tax_calculation_rounding_method': 'round_globally'})
         return res

--- a/addons/l10n_de/models/chart_template.py
+++ b/addons/l10n_de/models/chart_template.py
@@ -6,8 +6,8 @@ class AccountChartTemplate(models.Model):
     _inherit = 'account.chart.template'
 
     # Write paperformat and report template used on company
-    def _load(self, sale_tax_rate, purchase_tax_rate, company):
-        res = super(AccountChartTemplate, self)._load(sale_tax_rate, purchase_tax_rate, company)
+    def _load(self, company):
+        res = super(AccountChartTemplate, self)._load(company)
         if self in [
             self.env.ref('l10n_de_skr03.l10n_de_chart_template', raise_if_not_found=False),
             self.env.ref('l10n_de_skr04.l10n_chart_de_skr04', raise_if_not_found=False)

--- a/addons/l10n_es/data/account_chart_template_data.xml
+++ b/addons/l10n_es/data/account_chart_template_data.xml
@@ -13,7 +13,6 @@
 
         <record id="account_chart_template_pymes" model="account.chart.template">
             <field name="name">PGCE PYMEs 2008</field>
-            <field name="complete_tax_set" eval="True"/>
             <field name="currency_id" ref="base.EUR"/>
             <field name="cash_account_code_prefix">570</field>
             <field name="bank_account_code_prefix">572</field>
@@ -24,7 +23,6 @@
 
         <record id="account_chart_template_assoc" model="account.chart.template">
         <field name="name">PGCE entidades sin ánimo de lucro 2008</field>
-        <field name="complete_tax_set" eval="True"/>
         <field name="currency_id" ref="base.EUR"/>
         <field name="cash_account_code_prefix">570</field>
         <field name="bank_account_code_prefix">572</field>
@@ -35,7 +33,6 @@
 
     <record id="account_chart_template_full" model="account.chart.template">
         <field name="name">PGCE completo 2008</field>
-        <field name="complete_tax_set" eval="True"/>
         <field name="currency_id" ref="base.EUR"/>
         <field name="cash_account_code_prefix">570</field>
         <field name="bank_account_code_prefix">572</field>

--- a/addons/l10n_eu_oss/models/chart_template.py
+++ b/addons/l10n_eu_oss/models/chart_template.py
@@ -6,8 +6,8 @@ from odoo import models
 class AccountChartTemplate(models.Model):
     _inherit = 'account.chart.template'
 
-    def _load(self, sale_tax_rate, purchase_tax_rate, company):
-        rslt = super()._load(sale_tax_rate, purchase_tax_rate, company)
+    def _load(self, company):
+        rslt = super()._load(company)
 
         if company.account_fiscal_country_id in self.env.ref('base.europe').country_ids:
             company._map_eu_taxes()

--- a/addons/l10n_fr/data/l10n_fr_chart_data.xml
+++ b/addons/l10n_fr/data/l10n_fr_chart_data.xml
@@ -8,7 +8,6 @@
         <field name="bank_account_code_prefix">512</field>
         <field name="cash_account_code_prefix">53</field>
         <field name="transfer_account_code_prefix">58</field>
-        <field name="complete_tax_set" eval="True" />
         <field name="country_id" ref="base.fr"/>
     </record>
 </odoo>

--- a/addons/l10n_generic_coa/data/l10n_generic_coa_post.xml
+++ b/addons/l10n_generic_coa/data/l10n_generic_coa_post.xml
@@ -10,7 +10,6 @@
 <data>
     <!-- Chart template account links -->
     <record id="configurable_chart_template" model="account.chart.template">
-        <field name="complete_tax_set" eval="False"/>
         <field name="use_anglo_saxon" eval="True"/>
 
         <field name="property_account_receivable_id" ref="receivable"/>

--- a/addons/l10n_multilang/models/l10n_multilang.py
+++ b/addons/l10n_multilang/models/l10n_multilang.py
@@ -12,8 +12,8 @@ _logger = logging.getLogger(__name__)
 class AccountChartTemplate(models.Model):
     _inherit = 'account.chart.template'
 
-    def _load(self, sale_tax_rate, purchase_tax_rate, company):
-        res = super(AccountChartTemplate, self)._load(sale_tax_rate, purchase_tax_rate, company)
+    def _load(self, company):
+        res = super(AccountChartTemplate, self)._load(company)
         # Copy chart of account translations when loading chart of account
         for chart_template in self.filtered('spoken_languages'):
             external_id = self.env['ir.model.data'].search([

--- a/addons/l10n_mx/models/chart_template.py
+++ b/addons/l10n_mx/models/chart_template.py
@@ -58,8 +58,8 @@ class AccountChartTemplate(models.Model):
             res['tag_ids'] = [(6, 0, self.env.ref('l10n_mx.account_tag_102_01').ids)]
         return res
 
-    def _load(self, sale_tax_rate, purchase_tax_rate, company):
-        res = super()._load(sale_tax_rate, purchase_tax_rate, company)
+    def _load(self, company):
+        res = super()._load(company)
         if self == self.env.ref('l10n_mx.mx_coa'):
             company.account_journal_payment_debit_account_id.tag_ids = [(6, 0, self.env.ref('l10n_mx.account_tag_102_01').ids)]
             company.account_journal_payment_credit_account_id.tag_ids = [(6, 0, self.env.ref('l10n_mx.account_tag_102_01').ids)]

--- a/addons/l10n_nl/models/account_chart_template.py
+++ b/addons/l10n_nl/models/account_chart_template.py
@@ -6,9 +6,9 @@ from odoo import api, Command, models
 class AccountChartTemplate(models.Model):
     _inherit = 'account.chart.template'
 
-    def _load(self, sale_tax_rate, purchase_tax_rate, company):
+    def _load(self, company):
         # Add tag to 999999 account
-        res = super(AccountChartTemplate, self)._load(sale_tax_rate, purchase_tax_rate, company)
+        res = super(AccountChartTemplate, self)._load(company)
         if company.account_fiscal_country_id.code == 'NL':
             account = self.env['account.account'].search([('code', '=', '999999'), ('company_id', '=', self.env.company.id)])
             if account:

--- a/addons/l10n_ua/data/account_chart_template_config.xml
+++ b/addons/l10n_ua/data/account_chart_template_config.xml
@@ -6,7 +6,6 @@
             <field name="property_account_payable_id" ref="ua_psbp_631"/>
             <field name="property_account_expense_categ_id" ref="ua_psbp_901"/>
             <field name="property_account_income_categ_id" ref="ua_psbp_701"/>
-            <field name="complete_tax_set" eval="True"/>
             <field name="use_anglo_saxon" eval="True"/>
             <field name="property_stock_account_input_categ_id" ref="ua_psbp_2812"/>
             <field name="property_stock_account_output_categ_id" ref="ua_psbp_2811"/>
@@ -21,7 +20,6 @@
             <field name="property_account_payable_id" ref="ua_ias_1200"/>
             <field name="property_account_expense_categ_id" ref="ua_ias_2200"/>
             <field name="property_account_income_categ_id" ref="ua_ias_2000"/>
-            <field name="complete_tax_set" eval="True"/>
             <field name="use_anglo_saxon" eval="True"/>
             <field name="property_stock_account_input_categ_id" ref="ua_ias_1201"/>
             <field name="property_stock_account_output_categ_id" ref="ua_ias_1121"/>

--- a/addons/point_of_sale/models/chart_template.py
+++ b/addons/point_of_sale/models/chart_template.py
@@ -5,7 +5,7 @@ from odoo import api, models
 class AccountChartTemplate(models.Model):
     _inherit = 'account.chart.template'
 
-    def _load(self, sale_tax_rate, purchase_tax_rate, company):
+    def _load(self, company):
         """Remove the payment methods that are created for the company before installing the chart of accounts.
 
         Keeping these existing pos.payment.method records interferes with the installation of chart of accounts
@@ -13,6 +13,6 @@ class AccountChartTemplate(models.Model):
         deleted during the loading of chart of accounts.
         """
         self.env['pos.payment.method'].search([('company_id', '=', company.id)]).unlink()
-        result = super(AccountChartTemplate, self)._load(sale_tax_rate, purchase_tax_rate, company)
+        result = super(AccountChartTemplate, self)._load(company)
         self.env['pos.config'].post_install_pos_localisation(companies=company)
         return result

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -335,7 +335,7 @@ class TestPurchaseToInvoice(AccountTestInvoicingCommon):
         company_b = self.env['res.company'].create({
             'name': 'Company B',
         })
-        self.env.ref('l10n_generic_coa.configurable_chart_template')._load(15.0, 15.0, company_b)
+        self.env.ref('l10n_generic_coa.configurable_chart_template')._load(company_b)
 
         partner = self.env['res.partner'].create({
             'name': 'AAAAA',


### PR DESCRIPTION
This field was used in version 9.0 [1] to allow users to select their
tax rate, but it was removed in version 12 [2]

[1] https://github.com/odoo/odoo/commit/c04065abd8f62c9a211c8fa824f5eecf68e61b73
[2] https://github.com/odoo/odoo/commit/87f0d2eefb77bfc6a9a0fa7f7dcd1475c7c34639





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
