### PR TITLE
[FIX] payment: use correct target on onclick event

### DIFF
--- a/addons/payment/static/src/js/payment_form.js
+++ b/addons/payment/static/src/js/payment_form.js
@@ -505,7 +505,7 @@ publicWidget.registry.PaymentForm = publicWidget.Widget.extend({
         ev.stopPropagation();
         ev.preventDefault();
         var self = this;
-        var pm_id = parseInt(ev.target.value);
+        var pm_id = parseInt(ev.currentTarget.value);
 
         var tokenDelete = function () {
             self._rpc({


### PR DESCRIPTION
### Current behavior
If we click on the icon rather than the label we got an error

### Steps to reproduce
- Enable `Online Payment`, configure an acquirer and add the possibility to save the payment method
- Go to the Website and Log in (e.g. as `Marc Demo`)
- Go to your account (from dropdown menu > `My Account`)
- Manage you payment methods and add a new one
- Try to delete the newly added payment method by clicking on the trash icon in the button

or, to get a quick example of this behavior : [CodeSandBox example](https://codesandbox.io/s/currenttarget-vs-target-koq0m)

### Reason
Currently, we rely on the `target` property of the event (triggered after clicking on the button). 
The problem is that, as in this case, if a button has an HTML element as a child and we click on this child, `target` property will target the child whereas in this case we want to retrieve the button and not the child. 

Using `currentTarget` property instead of `target` allows us to retrieve the button no matter what since `currentTarget` always refers to the element to which the event handler has been attached.

### Links
- [CodeSandBox example](https://codesandbox.io/s/currenttarget-vs-target-koq0m)
- [MDN Documentation about `currentTarget`](https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget)

OPW-2660186