### PR TITLE
[FIX] project : Fix button 'View Task' not displayed in mail to project admin

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1222,11 +1222,17 @@ class Task(models.Model):
         self.ensure_one()
 
         project_user_group_id = self.env.ref('project.group_project_user').id
+        project_manager_group_id = self.env.ref('project.group_project_manager').id
 
         group_func = lambda pdata: pdata['type'] == 'user' and project_user_group_id in pdata['groups']
         if self.project_id.privacy_visibility == 'followers':
             allowed_user_ids = self.project_id.allowed_internal_user_ids.partner_id.ids
-            group_func = lambda pdata: pdata['type'] == 'user' and project_user_group_id in pdata['groups'] and pdata['id'] in allowed_user_ids
+            group_func = lambda pdata:\
+                pdata['type'] == 'user'\
+                and (
+                        project_manager_group_id in pdata['groups']\
+                        or (project_user_group_id in pdata['groups'] and pdata['id'] in allowed_user_ids)
+                )
         new_group = ('group_project_user', group_func, {})
 
         if not self.user_id and not self.stage_id.fold:


### PR DESCRIPTION
Steps:
- Marc demo should already be a project's administrator, but just in case, Users -> Marc Demo -> Access rights -> Project -> Administrator
- Edit a project, in Settings -> Visibility, set on Invited employees, and nobody in Allowed Users
- Log a note to Marc Demo

Issue:
- Mark Demo recieves a mail, but button 'View Task' is not displayed

Fix:
- Same behaviour as in v15.

opw-2671330

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
