### PR TITLE
[FIX] point_of_sale : Positive tax for credit note

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2125,11 +2125,18 @@ exports.Orderline = Backbone.Model.extend({
         else
             var price_include = !price_exclude;
         if (tax.amount_type === 'fixed') {
-            var sign_base_amount = Math.sign(base_amount) || 1;
-            // Since base amount has been computed with quantity
-            // we take the abs of quantity
-            // Same logic as bb72dea98de4dae8f59e397f232a0636411d37ce
-            return tax.amount * sign_base_amount * Math.abs(quantity);
+            // Use sign on base_amount and abs on quantity to take into account the sign of the base amount,
+            // which includes the sign of the quantity and the sign of the price_unit
+            // Amount is the fixed price for the tax, it can be negative
+            // Base amount included the sign of the quantity and the sign of the unit price and when
+            // a product is returned, it can be done either by changing the sign of quantity or by changing the
+            // sign of the price unit.
+            // When the price unit is equal to 0, the sign of the quantity is absorbed in base_amount then
+            // a "else" case is needed.
+            if (base_amount)
+                return Math.sign(base_amount) * Math.abs(quantity) * tax.amount;
+            else
+                return quantity * tax.amount;
         }
         if (tax.amount_type === 'percent' && !price_include){
             return base_amount * tax.amount / 100;


### PR DESCRIPTION
Steps:
- Install POS
- Create Tax T :
	- Type : Sales
	- Computation : Fixed
	- Amount : x
- Create a product P with price 0
- Go to POS and select P to sell it (qty = 1). Taxes = x
- Now set qty = -1.

Issue:
- Taxes remain x where it would be expected to be -x.

Cause:
- The calculation of the price doesn't take the sign of the qty into account
  because it takes a "base amount" that takes it into account.
- However, this base amount doesn't give any indication about the qty,
  which is necessary to determine which way the tax should be applied.

Fix:
- Divide the base amount by qty to get the original amount.
- Take the sign of the qty into account.

opw-2655317

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
