### PR TITLE
[FIX] stock_landed_costs: Remove the real_time validation requirement to use LC.

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -162,6 +162,9 @@ class LandedCost(models.Model):
                 product = line.move_id.product_id
                 if product.cost_method == 'average':
                     cost_to_add_byproduct[product] += cost_to_add
+                # Products with manual inventory valuation are ignored because they do not need to create journal entries.
+                if product.valuation != "real_time":
+                    continue
                 # `remaining_qty` is negative if the move is out and delivered proudcts that were not
                 # in stock.
                 qty_out = 0
@@ -178,9 +181,14 @@ class LandedCost(models.Model):
                     product.with_context(force_company=cost.company_id.id).sudo().standard_price += cost_to_add_byproduct[product] / product.quantity_svl
 
             move_vals['stock_valuation_layer_ids'] = [(6, None, valuation_layer_ids)]
-            move = move.create(move_vals)
-            cost.write({'state': 'done', 'account_move_id': move.id})
-            move.post()
+            # We will only create the accounting entry when there are defined lines (the lines will be those linked to products of real_time valuation category).
+            cost_vals = {'state': 'done'}
+            if move_vals.get("line_ids"):
+                move = move.create(move_vals)
+                cost_vals.update({'account_move_id': move.id})
+            cost.write(cost_vals)
+            if cost.account_move_id:
+                move.post()
 
             if cost.vendor_bill_id and cost.vendor_bill_id.state == 'posted' and cost.company_id.anglo_saxon_accounting:
                 all_amls = cost.vendor_bill_id.line_ids | cost.account_move_id.line_ids
@@ -211,8 +219,7 @@ class LandedCost(models.Model):
         lines = []
 
         for move in self.mapped('picking_ids').mapped('move_lines'):
-            # it doesn't make sense to make a landed cost for a product that isn't set as being valuated in real time at real cost
-            if move.product_id.valuation != 'real_time' or move.product_id.cost_method not in ('fifo', 'average') or move.state == 'cancel' or not move.product_qty:
+            if move.product_id.cost_method not in ('fifo', 'average') or move.state == 'cancel' or not move.product_qty:
                 continue
             vals = {
                 'product_id': move.product_id.id,

--- a/addons/stock_landed_costs/tests/common.py
+++ b/addons/stock_landed_costs/tests/common.py
@@ -28,7 +28,13 @@ class TestStockLandedCostsCommon(AccountingTestCase):
         self.supplier_location_id = self.ref('stock.stock_location_suppliers')
         self.stock_location_id = self.ref('stock.stock_location_stock')
         self.customer_location_id = self.ref('stock.stock_location_customers')
-        self.categ_all = self.env.ref('product.product_category_all')
+        self.categ_manual_periodic = self.env.ref('product.product_category_all').copy({
+            "property_valuation": "manual_periodic",
+            "property_cost_method": "fifo"
+        })
+        self.categ_real_time = self.env.ref('product.product_category_all').copy({
+            "property_valuation": "real_time"
+        })
         # Create account
         self.default_account = self.env['account.account'].create({
             'name': "Purchased Stocks",
@@ -51,7 +57,7 @@ class TestStockLandedCostsCommon(AccountingTestCase):
             'standard_price': 1.0,
             'weight': 10,
             'volume': 1,
-            'categ_id': self.categ_all.id})
+            'categ_id': self.categ_real_time.id})
         self.product_refrigerator.categ_id.property_cost_method = 'fifo'
         self.product_refrigerator.categ_id.property_valuation = 'real_time'
         self.product_oven = self.Product.create({
@@ -60,7 +66,7 @@ class TestStockLandedCostsCommon(AccountingTestCase):
             'standard_price': 1.0,
             'weight': 20,
             'volume': 1.5,
-            'categ_id': self.categ_all.id})
+            'categ_id': self.categ_real_time.id})
         self.product_oven.categ_id.property_cost_method = 'fifo'
         self.product_oven.categ_id.property_valuation = 'real_time'
         # Create service type product 1.Labour 2.Brokerage 3.Transportation 4.Packaging

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs.py
@@ -25,6 +25,7 @@ class TestStockLandedCosts(TestStockLandedCostsCommon):
             'type': 'product',
         })
         product_landed_cost_1.product_tmpl_id.categ_id.property_cost_method = 'fifo'
+        product_landed_cost_1.product_tmpl_id.categ_id.property_valuation = 'real_time'
         product_landed_cost_1.product_tmpl_id.categ_id.property_stock_account_input_categ_id = self.ref('stock_landed_costs.o_expense')
         product_landed_cost_1.product_tmpl_id.categ_id.property_stock_account_output_categ_id = self.ref('stock_landed_costs.o_income')
 
@@ -35,6 +36,7 @@ class TestStockLandedCosts(TestStockLandedCostsCommon):
             'type': 'product',
         })
         product_landed_cost_2.product_tmpl_id.categ_id.property_cost_method = 'fifo'
+        product_landed_cost_2.product_tmpl_id.categ_id.property_valuation = 'real_time'
         product_landed_cost_2.product_tmpl_id.categ_id.property_stock_account_input_categ_id = self.ref('stock_landed_costs.o_expense')
         product_landed_cost_2.product_tmpl_id.categ_id.property_stock_account_output_categ_id = self.ref('stock_landed_costs.o_income')
 

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -101,6 +101,57 @@ class TestLandedCosts(TestStockLandedCostsCommon):
         self.assertEqual(account_entry['debit'], account_entry['credit'], 'Debit and credit are not equal')
         self.assertEqual(account_entry['debit'], 430.0, 'Wrong Account Entry')
 
+    def test_00_landed_costs_on_incoming_shipment_without_real_time(self):
+        chart_of_accounts = self.env.company.chart_template_id
+        generic_coa = self.env.ref('l10n_generic_coa.configurable_chart_template')
+        if chart_of_accounts != generic_coa:
+            raise unittest.SkipTest('Skip this test as it works only with %s (%s loaded)' % (generic_coa.name, chart_of_accounts.name))
+        """ Test landed cost on incoming shipment """
+        #
+        # (A) Purchase product
+
+        #         Services           Quantity       Weight      Volume
+        #         -----------------------------------------------------
+        #         1. Refrigerator         5            10          1
+        #         2. Oven                 10           20          1.5
+
+        # (B) Add some costs on purchase
+
+        #         Services           Amount     Split Method
+        #         -------------------------------------------
+        #         1.labour            10        By Equal
+        #         2.brokerage         150       By Quantity
+        #         3.transportation    250       By Weight
+        #         4.packaging         20        By Volume
+
+        self.product_refrigerator.write({"categ_id": self.categ_manual_periodic.id})
+        self.product_oven.write({"categ_id": self.categ_manual_periodic.id})
+        # Process incoming shipment
+        income_ship = self._process_incoming_shipment()
+        # Create landed costs
+        stock_landed_cost = self._create_landed_costs({
+            'equal_price_unit': 10,
+            'quantity_price_unit': 150,
+            'weight_price_unit': 250,
+            'volume_price_unit': 20}, income_ship)
+        # Compute landed costs
+        stock_landed_cost.compute_landed_cost()
+
+        valid_vals = {
+            'equal': 5.0,
+            'by_quantity_refrigerator': 50.0,
+            'by_quantity_oven': 100.0,
+            'by_weight_refrigerator': 50.0,
+            'by_weight_oven': 200,
+            'by_volume_refrigerator': 5.0,
+            'by_volume_oven': 15.0}
+
+        # Check valuation adjustment line recognized or not
+        self._validate_additional_landed_cost_lines(stock_landed_cost, valid_vals)
+        # Validate the landed cost.
+        stock_landed_cost.button_validate()
+        self.assertFalse(stock_landed_cost.account_move_id)
+
     def test_01_negative_landed_costs_on_incoming_shipment(self):
         chart_of_accounts = self.env.company.chart_template_id
         generic_coa = self.env.ref('l10n_generic_coa.configurable_chart_template')


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**:
Remove the `real_time` validation requirement to use LC.

The requirement to define `real_time` valuation in product categories to use LC is removed (information from `stock.valuation.layer `is used).
Now a journal entry will only be created if any of the lines have real_time validation in the category of the products when the LC is validated.

**Impacted versions**:
- 13.0
 - 14.0
 - 15.0

Related to: https://github.com/OCA/purchase-workflow/pull/1300

cc @Tecnativa TT32954

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr