### PR TITLE
[FIX] hr_holidays: restrict creation of allocations

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -37,7 +37,7 @@ class HolidaysAllocation(models.Model):
 
     def _domain_holiday_status_id(self):
         if self.user_has_groups('hr_holidays.group_hr_holidays_user'):
-            return []
+            return [('requires_allocation', '=', 'yes')]
         return [('employee_requests', '=', 'yes')]
 
     name = fields.Char('Description', compute='_compute_description', inverse='_inverse_description', search='_search_description', compute_sudo=False)

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -110,10 +110,11 @@
             <tree string="Time Off Type">
                 <field name="sequence" widget="handle"/>
                 <field name="display_name"/>
+                <field name="allocation_validation_type"/>
+                <field name="employee_requests" optional="hide"/>
                 <field name="requires_allocation" optional="hide"/>
-                <field name="leave_validation_type"  optional="hide"/>
-                <field name="allocation_validation_type"  optional="hide"/>
-                <field name="company_id" groups="base.group_multi_company"/>
+                <field name="leave_validation_type" optional="hide"/>
+                <field name="company_id" groups="base.group_multi_company" optional="hide"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
Purpose: It does not make much sense to create allocations of such an
Time Off Types that don't require allocation.

task - 2658250

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
