### PR TITLE
[BUG][Fixex][13.0][14.0][15.0] When printing, only 1 page can be printed.

### DIFF
--- a/addons/survey/static/src/css/survey_templates_print.css
+++ b/addons/survey/static/src/css/survey_templates_print.css
@@ -14,4 +14,7 @@
     .js_question-wrapper {
         page-break-inside: avoid;
     }
+    body { 
+        height : auto
+    }
 }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
 When printing, only 1 page can be printed.
Current behavior before PR:
before:
<img width="975" alt="image" src="https://user-images.githubusercontent.com/5398273/142970447-f99b8c7f-dc69-4509-b091-658439c050f4.png">
after:
<img width="986" alt="image" src="https://user-images.githubusercontent.com/5398273/142970488-eeacaa2b-1eab-4eba-acd9-75a5dd43db24.png">

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
