### PR TITLE
[IMP] web: add field name on priority hover text

### DIFF
--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -2555,7 +2555,7 @@ var PriorityWidget = AbstractField.extend({
         const isReadonly = this.record.evalModifiers(this.attrs.modifiers).readonly;
         _.each(this.field.selection.slice(1), function (choice, index) {
             const tag = isReadonly ? '<span>' : '<a href="#">';
-            self.$el.append(self._renderStar(tag, index_value >= index + 1, index + 1, choice[1], index_value));
+            self.$el.append(self._renderStar(tag, index_value >= index + 1, index + 1, `${self.string}: ${choice[1]}`, index_value));
         });
     },
 

--- a/addons/web/static/tests/legacy/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/basic_fields_tests.js
@@ -6409,6 +6409,33 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.test('priority widget tooltip', async function (assert) {
+        assert.expect(2);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `<form string="Partners">
+                    <sheet>
+                        <group>
+                            <field name="selection" widget="priority"/>
+                        </group>
+                    </sheet>
+                </form>`,
+            res_id: 1,
+        });
+
+        // check title attribute (for basic html tooltip on all the stars)
+        const $stars = form.$('.o_field_widget.o_priority').find('a.o_priority_star');
+        assert.strictEqual($stars[0].title, 'Selection: Blocked',
+            "Should set field label and correct selection label as title attribute (tooltip)");
+        assert.strictEqual($stars[1].title, 'Selection: Done',
+            "Should set field label and correct selection label as title attribute (tooltip)");
+
+        form.destroy();
+    });
+
     QUnit.test('priority widget in form view', async function (assert) {
         assert.expect(22);
 


### PR DESCRIPTION
PURPOSE

To add the field name along with the hover text.

SPECIFICATIONS

With this commit, we have added the field name in the hover text.
This will explain what 'Stars' are. Currently, only this text is displaying
so users can not understand what is 'medium', high', and 'very high'.
This is the goal of this commit.

PR #80213
Task-2691338

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
