### PR TITLE
[FIX] webclient: navbar: consistently adapt menu items

### DIFF
--- a/addons/web/static/src/core/utils/hooks.js
+++ b/addons/web/static/src/core/utils/hooks.js
@@ -250,3 +250,17 @@ export function useService(serviceName) {
     }
     return service;
 }
+
+/**
+ * Executes "callback" when the component is being destroyed
+ * @param  {Function} callback
+ */
+export function onDestroyed(callback) {
+    const component = useComponent();
+    const _destroy = component.__destroy;
+    component.__destroy = (...args) => {
+        _destroy.call(component, ...args);
+        // callback is called after super to guarantee the component is actually destroyed
+        callback();
+    };
+}

--- a/addons/web/static/src/webclient/navbar/navbar.js
+++ b/addons/web/static/src/webclient/navbar/navbar.js
@@ -2,7 +2,7 @@
 
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
-import { useEffect, useService } from "@web/core/utils/hooks";
+import { useEffect, useService, onDestroyed } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 import { debounce } from "@web/core/utils/timing";
 import { ErrorHandler, NotUpdatable } from "@web/core/utils/components";
@@ -53,6 +53,7 @@ export class NavBar extends Component {
         this.menuService = useService("menu");
         this.appSubMenus = useRef("appSubMenus");
         const debouncedAdapt = debounce(this.adapt.bind(this), 250);
+        onDestroyed(() => debouncedAdapt.cancel());
         useExternalListener(window, "resize", debouncedAdapt);
     }
 

--- a/addons/web/static/tests/core/utils/hooks_tests.js
+++ b/addons/web/static/tests/core/utils/hooks_tests.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { uiService } from "@web/core/ui/ui_service";
-import { useAutofocus, useBus, useEffect, useListener, useService } from "@web/core/utils/hooks";
+import { useAutofocus, useBus, useEffect, useListener, useService, onDestroyed } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 import { makeTestEnv } from "../../helpers/mock_env";
 import { click, getFixture, nextTick } from "../../helpers/utils";
@@ -426,6 +426,24 @@ QUnit.module("utils", () => {
             const comp = await mount(MyComponent, { env, target });
             assert.strictEqual(comp.toyService, null);
             comp.unmount();
+        });
+
+        QUnit.module("onDestroyed");
+
+        QUnit.test("onDestroyed is called", async (assert) => {
+            assert.expect(3);
+            class MyComponent extends Component {
+                setup() {
+                    onDestroyed(() => assert.step("onDestroyed"));
+                }
+            }
+            MyComponent.template = tags.xml`<div/>`;
+
+            const target = getFixture();
+            const component = await owl.mount(MyComponent, {target});
+            assert.verifySteps([]);
+            component.destroy();
+            assert.verifySteps(["onDestroyed"]);
         });
     });
 });

--- a/addons/web/static/tests/webclient/navbar_tests.js
+++ b/addons/web/static/tests/webclient/navbar_tests.js
@@ -9,7 +9,7 @@ import { actionService } from "@web/webclient/actions/action_service";
 import { hotkeyService } from "@web/core/hotkeys/hotkey_service";
 import { NavBar } from "@web/webclient/navbar/navbar";
 import { clearRegistryWithCleanup, makeTestEnv } from "../helpers/mock_env";
-import { click, getFixture, nextTick, patchWithCleanup } from "../helpers/utils";
+import { click, getFixture, nextTick, patchWithCleanup, makeDeferred } from "../helpers/utils";
 
 const { Component, mount, tags } = owl;
 const { xml } = tags;
@@ -419,4 +419,39 @@ QUnit.test("'more' menu sections properly updated on app change", async (assert)
         "'more' menu should contain App2 sections"
     );
     navbar.destroy();
+});
+
+QUnit.test("Do not execute adapt when navbar is destroyed", async (assert) => {
+    assert.expect(5);
+
+    let prom = makeDeferred();
+
+    patchWithCleanup(browser, {
+        setTimeout: async (handler, delay, ...args) => { await prom; return handler(...args); },
+        clearTimeout: () => {},
+    });
+    class MyNavbar extends NavBar {
+        async adapt() {
+            assert.step("adapt NavBar");
+            return super.adapt();
+        }
+    }
+    const env = await makeTestEnv(baseConfig);
+
+    const target = getFixture();
+
+    // Set menu and mount
+    env.services.menu.setCurrentMenu(1);
+    const navbar = await mount(MyNavbar, { env, target });
+    assert.verifySteps(["adapt NavBar"]);
+    window.dispatchEvent(new Event("resize"));
+    prom.resolve();
+    await prom;
+    prom = makeDeferred();
+    assert.verifySteps(["adapt NavBar"]);
+    window.dispatchEvent(new Event("resize"));
+    navbar.destroy();
+    prom.resolve();
+    await prom;
+    assert.verifySteps([]);
 });


### PR DESCRIPTION
The use case happens in studio.
have some overflowing app submenus in an app
go into studio

refresh with a simple F5.

Before this commit, the navbar's overflowing buttons wouldn't put themselves inside the "more" dropdown
This was because the studio client action also reacts to change in the menu service, so the technical flow was:
- laodState (webClient)
- setMenu (MENU-CHANGED on the bus), then because of it:
  - studio client action > render (1)
  - studio navbar > render (with adapt right after that render!) (2)
  - studio navbar > render (because of 1) which cancels the render in 2 without cancelling the promise, that is
  adapt is still called.

To remedy this, the standard use of useEffect and useBus are is put into place.

After this commit, the studio navbar has its owverflowing menu items in the dropdown

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
