### PR TITLE
do not display notebook ul if thee are no pages

### DIFF
--- a/addons/web/static/src/legacy/js/views/form/form_renderer.js
+++ b/addons/web/static/src/legacy/js/views/form/form_renderer.js
@@ -1083,6 +1083,8 @@ var FormRenderer = BasicRenderer.extend({
             });
         });
         this._activateFirstVisibleTab(renderedTabs);
+        // if there is no notebook page to display initially then hide notebook header's ul
+        $headers.toggleClass('o_invisible_modifier', !$headers.find('li:not(.o_invisible_modifier)').length);
         var $notebookHeaders = $('<div class="o_notebook_headers">').append($headers);
         var $notebook = $('<div class="o_notebook">').append($notebookHeaders, $pages);
         $notebook[0].dataset.name = node.attrs.name || '_default_';

--- a/addons/web/static/tests/legacy/views/form_tests.js
+++ b/addons/web/static/tests/legacy/views/form_tests.js
@@ -997,6 +997,30 @@ QUnit.module('Views', {
         form.destroy();
     });
 
+    QUnit.test('hide notebook element if there are no pages', async function (assert) {
+        assert.expect(2);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `<form string="Partners">
+                    <sheet>
+                        <field name="bar"/>
+                        <notebook class="new_class">
+                        </notebook>
+                    </sheet>
+                </form>`,
+        });
+
+        assert.notOk(form.$('.o_notebook .nav li:not(.o_invisible_modifier)').length,
+            "there should not be any visible page");
+        assert.ok(form.$('.o_notebook .nav').hasClass('o_invisible_modifier'),
+            'the notebook headers should be hidden if none of the page is visible');
+
+        form.destroy();
+    });
+
     QUnit.test('autofocus on second notebook page', async function (assert) {
         assert.expect(2);
 


### PR DESCRIPTION
Purpose
When there is no page in notebook, only notebook tag is defined in xml, form still displays notebook header's ul because of that blank grey line is displayed, do not display grey line if there is no page defined.

SPEC
If there is no page to display in notebook then header's ul should not be displayed and hence blank line should not be displayed in form view.

task-2653806

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
