### PR TITLE
[IMP] product: move Product Description fields from template to variant

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -295,6 +295,9 @@
                                 <field name="product_tag_ids" string="Product Template Tags" widget="many2many_tags" readonly="1" options="{'no_open': True, 'color_field': 'color'}"/>
                                 <field name="additional_product_tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_edit_color': 1}"/>
                             </group>
+                            <group name="sale_description" string="Sales Description">
+                                <field name="description_sale" nolabel="1"/>
+                            </group>
                         </group>
                     </sheet>
                 </form>
@@ -341,6 +344,7 @@
                     <field name="company_id" groups="base.group_multi_company" optional="hide" readonly="1"/>
                     <field name="lst_price" optional="show" string="Sales Price"/>
                     <field name="standard_price" optional="show"/>
+                    <field name="description_sale" optional="hide"/>
                     <field name="categ_id" optional="hide"/>
                     <field name="product_tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_edit_color': 1}" optional="hide"/>
                     <field name="type" optional="hide" readonly="1"/>

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -237,6 +237,7 @@ class ProductTemplate(models.Model):
             display_image = bool(product.image_128)
             display_name = product.display_name
             price_extra = (product.price_extra or 0.0) + (sum(no_variant_attributes_price_extra) or 0.0)
+            description_sale = product.description_sale
         else:
             current_attributes_price_extra = [v.price_extra or 0.0 for v in combination]
             product_template = product_template.with_context(current_attributes_price_extra=current_attributes_price_extra)
@@ -251,7 +252,7 @@ class ProductTemplate(models.Model):
             combination_name = combination._get_combination_name()
             if combination_name:
                 display_name = "%s (%s)" % (display_name, combination_name)
-
+            description_sale = self.description_sale
         if pricelist and pricelist.currency_id != product_template.currency_id:
             list_price = product_template.currency_id._convert(
                 list_price, pricelist.currency_id, product_template._get_current_company(pricelist=pricelist),
@@ -274,6 +275,7 @@ class ProductTemplate(models.Model):
             'list_price': list_price,
             'price_extra': price_extra,
             'has_discounted_price': has_discounted_price,
+            'description_sale': description_sale,
         }
 
     def _is_add_to_cart_possible(self, parent_combination=None):

--- a/addons/sale/static/src/js/variant_mixin.js
+++ b/addons/sale/static/src/js/variant_mixin.js
@@ -515,11 +515,29 @@ var VariantMixin = {
         $price.text(self._priceToStr(combination.price));
         $default_price.text(self._priceToStr(combination.list_price));
 
+        if (combination.product_id) {
+            $parent.find('[data-oe-model="product.product"]').attr(
+                'data-oe-id',
+                combination.product_id
+            );
+        }
+
         var isCombinationPossible = true;
         if (!_.isUndefined(combination.is_combination_possible)) {
             isCombinationPossible = combination.is_combination_possible;
         }
         this._toggleDisable($parent, isCombinationPossible);
+
+        if (combination.description_sale) {
+            // This workaround is apparently the only way to keep line breaks
+            // between the backend and the frontend.
+            // Setting directly the text removes line breaks and 'append'
+            // keep them ¯\_(ツ)_/¯
+            $parent.find('#product_description_sale').text('');
+            var text = combination.description_sale;
+            text = text.replaceAll('\n', '<br/>');
+            $parent.find('#product_description_sale').append(text);
+        }
 
         if (combination.has_discounted_price) {
             $default_price

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -653,10 +653,13 @@
                                     </t>
                                 </a>
                             </t>
-                            <p t-field="product.description_sale" class="text-muted my-2" placeholder="A short description that will also appear on documents." />
                             <form t-if="product._is_add_to_cart_possible()" action="/shop/cart/update" method="POST">
                                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" />
                                 <div class="js_product js_main_product mb-3">
+                                    <div>
+                                        <p id="product_description_sale" class="text-muted my-2" t-field="product_variant.description_sale"
+                                              placeholder="A short description that will also appear on documents."/>
+                                    </div>
                                     <div>
                                         <t t-call="website_sale.product_price" />
                                         <small t-if="combination_info['base_unit_price']"


### PR DESCRIPTION
Now each variant of a product has its own "Sales Description".
When creating variants, the "Sales Description" will be inherited from
the template, after that it can be customized. It should allow for a
more detailed description of each variant individually.

Task - 2527336



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
