### PR TITLE
[IMP] project, sale_{project, timesheet}: improvements for field service

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -968,7 +968,7 @@ class Task(models.Model):
         help="The current user's personal task stage.")
     partner_id = fields.Many2one('res.partner',
         string='Customer',
-        compute='_compute_partner_id', recursive=True, store=True, readonly=False, tracking=True,
+        compute='_compute_partner_id', store=True, readonly=False, tracking=True,
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
     partner_is_company = fields.Boolean(related='partner_id.is_company', readonly=True)
     commercial_partner_id = fields.Many2one(related='partner_id.commercial_partner_id')
@@ -977,7 +977,7 @@ class Task(models.Model):
         string='Email', readonly=False, store=True, copy=False)
     partner_phone = fields.Char(
         compute='_compute_partner_phone', inverse='_inverse_partner_phone',
-        string="Phone", readonly=False, store=True, copy=False)
+        string="Phone", readonly=False, store=True, tracking=True, copy=False)
     partner_city = fields.Char(related='partner_id.city', readonly=False)
     manager_id = fields.Many2one('res.users', string='Project Manager', related='project_id.user_id', readonly=True)
     company_id = fields.Many2one(

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -927,7 +927,7 @@
                             <field name="display_project_id" string="Project" attrs="{'invisible': [('parent_id', '=', False)]}" domain="[('active', '=', True), ('company_id', '=', company_id)]"/>
                             <field name="user_ids"
                                 class="o_task_user_field"
-                                options="{'no_open': True}"
+                                options="{'no_open': True, 'no_quick_create': True}"
                                 widget="many2many_avatar_user"
                                 domain="[('share', '=', False)]"/>
                         </group>
@@ -1186,7 +1186,7 @@
                                         </b>
                                     </div>
                                     <div class="oe_kanban_bottom_right" t-if="!selection_mode">
-                                        <field name="kanban_state" widget="state_selection" groups="base.group_user" invisible="context.get('fsm_mode', False)"/>
+                                        <field name="kanban_state" widget="state_selection" groups="base.group_user"/>
                                         <t t-if="record.user_ids.raw_value"><field name="user_ids" widget="many2many_avatar_user"/></t>
                                     </div>
                                 </div>

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -139,7 +139,7 @@ class ProjectTask(models.Model):
 
     sale_order_id = fields.Many2one('sale.order', 'Sales Order', compute='_compute_sale_order_id', store=True, help="Sales order to which the task is linked.")
     sale_line_id = fields.Many2one(
-        'sale.order.line', 'Sales Order Item', domain="[('company_id', '=', company_id), ('is_service', '=', True), ('order_partner_id', 'child_of', commercial_partner_id), ('is_expense', '=', False), ('state', 'in', ['sale', 'done'])]",
+        'sale.order.line', 'Sales Order Item', domain="[('company_id', '=', company_id), ('is_service', '=', True), ('order_partner_id', '=?', partner_id), ('is_expense', '=', False), ('state', 'in', ['sale', 'done'])]",
         compute='_compute_sale_line', recursive=True, store=True, readonly=False, copy=False, tracking=True, index=True,
         help="Sales Order Item to which the time spent on this task will be added, in order to be invoiced to your customer.")
     project_sale_order_id = fields.Many2one('sale.order', string="Project's sale order", related='project_id.sale_order_id')


### PR DESCRIPTION
PURPOSE:

generic improvements for field services

SPECIFICATIONS:

For the tasks,

- Fields partner_phone and sale_line_id will be display whether the partner_id
  field is set or not if is_fsm is true
- isplay all sale orders to select and based
  on selected sale line, partner will be set if partner_id is False.
- Remove create option for fields 'user_id', 'displayed_image_id'
- Display the kanban state in the kanban view
- Track the field 'partner_phone' in chatter

LINKS:

Task-2585357
