### PR TITLE
[FIX] sale_stock: let public users open the DO

### DIFF
--- a/addons/sale_stock/controllers/portal.py
+++ b/addons/sale_stock/controllers/portal.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import exceptions
+from odoo import exceptions, SUPERUSER_ID
 from odoo.addons.sale.controllers.portal import CustomerPortal
 from odoo.http import request, route
 from odoo.tools import consteq
@@ -29,8 +29,8 @@ class SaleStockPortal(CustomerPortal):
         except exceptions.AccessError:
             return request.redirect('/my')
 
-        # print report as sudo, since it require access to product, taxes, payment term etc.. and portal does not have those access rights.
-        pdf = request.env.ref('stock.action_report_delivery').sudo()._render_qweb_pdf([picking_sudo.id])[0]
+        # print report as SUPERUSER, since it require access to product, taxes, payment term etc.. and portal does not have those access rights.
+        pdf = request.env.ref('stock.action_report_delivery').with_user(SUPERUSER_ID)._render_qweb_pdf([picking_sudo.id])[0]
         pdfhttpheaders = [
             ('Content-Type', 'application/pdf'),
             ('Content-Length', len(pdf)),

--- a/addons/sale_stock/tests/__init__.py
+++ b/addons/sale_stock/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_sale_stock_report
 from . import test_sale_order_dates
 from . import test_sale_stock_multicompany
 from . import test_sale_stock_accrued_entries
+from . import test_sale_stock_access_rights

--- a/addons/sale_stock/tests/test_sale_stock_access_rights.py
+++ b/addons/sale_stock/tests/test_sale_stock_access_rights.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import HttpCase, tagged, Form
+from odoo.addons.sale.tests.common import TestSaleCommon
+from odoo.addons.mail.tests.common import mail_new_test_user
+
+
+@tagged('post_install', '-at_install')
+class TestControllersAccessRights(HttpCase, TestSaleCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.portal_user = mail_new_test_user(cls.env, login='jimmy-portal', groups='base.group_portal')
+
+    def test_SO_and_DO_portal_acess(self):
+        """ Ensure that it is possible to open both SO and DO, either using the access token
+        or being connected as portal user"""
+        so_form = Form(self.env['sale.order'])
+        so_form.partner_id = self.portal_user.partner_id
+        with so_form.order_line.new() as line:
+            line.product_id = self.product_a
+        so = so_form.save()
+        so.action_confirm()
+        picking = so.picking_ids
+
+        # Try to open SO/DO using the access token or being connected as portal user
+        for login in (None, self.portal_user.login):
+            so_url = '/my/orders/%s' % so.id
+            picking_url = '/my/picking/pdf/%s' % picking.id
+
+            self.authenticate(login, login)
+
+            if not login:
+                so._portal_ensure_token()
+                so_token = so.access_token
+                so_url = '%s?access_token=%s' % (so_url, so_token)
+                picking_url = '%s?access_token=%s' % (picking_url, so_token)
+
+            response = self.url_open(
+                url=so_url,
+                allow_redirects=False,
+            )
+            self.assertEqual(response.status_code, 200, 'Should be correct %s' % ('with a connected user' if login else 'using access token'))
+            response = self.url_open(
+                url=picking_url,
+                allow_redirects=False,
+            )
+            self.assertEqual(response.status_code, 200, 'Should be correct %s' % ('with a connected user' if login else 'using access token'))


### PR DESCRIPTION
From the portal view of a SO, when a public/portal user tries to open
the delivery order, he will have an error

To reproduce the issue:
(Need sale_management. Use demo data)
1. Create & Confirm a SO:
    - Customer: Joel Willis
    - Add some products
2. Log in as portal (i.e., Joel Willis)
3. Open the SO
4. Open the Delivery Order

Error: It leads to a 403 error page.

When rendering the template, the `sudo` flag is forced to False. Since,
in this case, this is a public controller that uses a token, we can use
`SUPERUSER_ID` (see [1] for more details)

[1] 61b4b6777d64218f94c51ec839c187fdc7b2034f

OPW-2689053