### PR TITLE
[FIX] pos_discount: pos app is stuck when changing the discount

### DIFF
--- a/addons/pos_discount/static/src/js/DiscountButton.js
+++ b/addons/pos_discount/static/src/js/DiscountButton.js
@@ -37,12 +37,9 @@ odoo.define('pos_discount.DiscountButton', function(require) {
             }
 
             // Remove existing discounts
-            var i = 0;
-            while ( i < lines.length ) {
-                if (lines[i].get_product() === product) {
-                    order.remove_orderline(lines[i]);
-                } else {
-                    i++;
+            for (const line of lines) {
+                if (line.get_product() === product) {
+                    order.remove_orderline(line);
                 }
             }
 


### PR DESCRIPTION
To reproduce:
1. Install pos_discount and pos_coupon.
2. Start a session and add item to the order.
3. Add global discount.
4. Change global discount. Stuck.

This is because in some modules, get_orderlines is overridden. Instead
of returning the original object containing the orderlines, it returns
a different array instance containing the lines. This is the reason the
while loop is stuck. With this change, whether get_orderlines return the
container or a copy, we are sure that it won't be stuck in the for loop.

TASK-ID: 2697861

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
