### PR TITLE
[FIX] pos_coupon : Couldn't start PoS

### DIFF
--- a/addons/pos_coupon/models/pos_config.py
+++ b/addons/pos_coupon/models/pos_config.py
@@ -67,7 +67,7 @@ class PosConfig(models.Model):
             )
             raise UserError(f"{intro}\n{invalid_reward_products_msg}")
 
-        return super(PosConfig, self).open_session_cb(check_coa)
+        return super(PosConfig, self).open_session_cb()
 
     def use_coupon_code(self, code, creation_date, partner_id, reserved_program_ids):
         coupon_to_check = self.env["coupon.coupon"].search(


### PR DESCRIPTION
Current behavior :
When installing l10n_de_pos_cert on runbot module you couldn't start a PoS session

Steps to reproduce :
Duplicate runbot database
Install l10n_de_pos_cert
Try to start a PoS session in a german store

opw-2691615

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
