### PR TITLE
[FIX] services: bug fix in service apps

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -142,7 +142,7 @@
                                 <field name="mail_template_id" context="{'default_model': 'project.task'}"/>
                                 <field name="rating_template_id" groups="project.group_project_rating" context="{'default_model': 'project.task'}"/>
                                 <field name="sequence" groups="base.group_no_one"/>
-                                <div class="alert alert-warning" role="alert" colspan='2' attrs="{'invisible': ['|', ('rating_template_id','=', False), ('disabled_rating_warning', '=', False)]}">
+                                <div class="alert alert-warning" role="alert" colspan='2' attrs="{'invisible': ['|', ('rating_template_id','=', False), ('disabled_rating_warning', '=', False)]}" groups="project.group_project_rating">
                                     <i class="fa fa-warning" title="Customer disabled on projects"/><b> Customer Ratings</b> are disabled on the following project(s) : <br/>
                                     <field name="disabled_rating_warning" class="mb-0" />
                                 </div>


### PR DESCRIPTION
[FIX] project: hide rating warning when customer ratings is disbled
Purpose of this commit to hide rating warning in project task
stage form view.

So, in this commit add customer ratings group to rating warning
div.

task-2696911

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
