### PR TITLE
[FIX] account: fix _is_end_of_seq_chain exception when sequence is empty

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -263,7 +263,7 @@ class SequenceMixin(models.AbstractModel):
         :return: True if self are the last elements of the chain.
         """
         batched = defaultdict(lambda: {'last_rec': self.browse(), 'seq_list': []})
-        for record in self:
+        for record in self.filtered(lambda x: x[x._sequence_field]):
             format, format_values = record._get_sequence_format_param(record[record._sequence_field])
             seq = format_values.pop('seq')
             batch = batched[(format, frozendict(format_values))]


### PR DESCRIPTION
Prevent calling _get_sequence_format_param() with None as parameter in _is_end_of_seq_chain() when sequence is empty.
Would cause an error when deleting an invoice with an empty sequence.

Task: 2697771