### PR TITLE
[IMP] base_address_city: address field sync city_id.

### DIFF
--- a/addons/base_address_city/models/res_partner.py
+++ b/addons/base_address_city/models/res_partner.py
@@ -92,3 +92,7 @@ class Partner(models.Model):
 
         arch = etree.tostring(doc, encoding='unicode')
         return arch
+
+    @api.model
+    def _address_fields(self):
+        return super()._address_fields() + ["city_id"]

--- a/addons/base_address_city/tests/__init__.py
+++ b/addons/base_address_city/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_address_fields

--- a/addons/base_address_city/tests/test_address_fields.py
+++ b/addons/base_address_city/tests/test_address_fields.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+
+
+class TestAddressFields(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Partner = cls.env["res.partner"]
+        cls.country_us = cls.env.ref("base.us")
+        cls.country_us.write({"enforce_cities": True})
+        cls.city_a = cls.env["res.city"].create({"name": "City A", "country_id": cls.country_us.id})
+        cls.city_b = cls.env["res.city"].create({"name": "City B", "country_id": cls.country_us.id})
+
+    def test_partner_operations(self):
+        company = self.Partner.create({
+            "is_company": True,
+            "name": "Test Company",
+            "country_id": self.country_us.id,
+            "city_id": self.city_a.id
+        })
+        child = self.Partner.create({
+            "name": "Test child",
+            "parent_id": company.id
+        })
+        self.assertEqual(child.city_id, self.city_a)
+        company.city_id = self.city_b
+        self.assertEqual(child.city_id, self.city_b)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
`_address_fields` are used by `update_address` [1], which is in turn
called by `_fields_sync` and `_children_sync`.

This mechanism is in charge of synchronizing parent/children address fields
for contacts of type == "contact", as they don't really have an address of
their own. They simply copy the address of their parent.

Without this fix, an inconsistency is created between the value of city_id
and the value of the parent.

[1]: https://github.com/odoo/odoo/blob/20648ef21/odoo/addons/base/models/res_partner.py#L429

Related to: https://github.com/OCA/partner-contact/pull/1179#discussion_r754219521

cc @Tecnativa TT33047

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr