### PR TITLE
[FIX] l10n_fr: Re-remove negative tax groups

### DIFF
--- a/addons/l10n_fr/data/account_tax_group_data.xml
+++ b/addons/l10n_fr/data/account_tax_group_data.xml
@@ -26,25 +26,5 @@
             <field name="country_id" ref="base.fr"/>
         </record>
 
-        <record id="tax_group_intra_20" model="account.tax.group">
-            <field name="name">TVA -20.0%</field>
-            <field name="country_id" ref="base.fr"/>
-        </record>
-        <record id="tax_group_intra_85" model="account.tax.group">
-            <field name="name">TVA -8.5%</field>
-            <field name="country_id" ref="base.fr"/>
-        </record>
-        <record id="tax_group_intra_55" model="account.tax.group">
-            <field name="name">TVA -5.5%</field>
-            <field name="country_id" ref="base.fr"/>
-        </record>
-        <record id="tax_group_intra_10" model="account.tax.group">
-            <field name="name">TVA -10.0%</field>
-            <field name="country_id" ref="base.fr"/>
-        </record>
-        <record id="tax_group_intra_21" model="account.tax.group">
-            <field name="name">TVA -2.1%</field>
-            <field name="country_id" ref="base.fr"/>
-        </record>
     </data>
 </odoo>


### PR DESCRIPTION
These negative tax groups were removed in a previous commit:
1687248
The message of the previous commit was:
Remove the negative tax groups from account_data. The negative tax groups have no application. The taxes that were in the negative tax groups are reassigned to their positive counterparts.

The previous commit was accidentally overwritten in a forward-port:
odoo#77295

closes odoo#76586