### PR TITLE
[FIX] mail: attachment viewer not working for other types than image for guest

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -145,11 +145,11 @@ class DiscussController(http.Controller):
         return channel_partner_sudo.env['ir.http']._content_image(model='mail.guest', res_id=guest_id, field='avatar_128')
 
     @http.route('/mail/channel/<int:channel_id>/attachment/<int:attachment_id>', methods=['GET'], type='http', auth='public')
-    def mail_channel_attachment(self, channel_id, attachment_id, **kwargs):
+    def mail_channel_attachment(self, channel_id, attachment_id, download=None, **kwargs):
         channel_partner_sudo = request.env['mail.channel.partner']._get_as_sudo_from_request_or_raise(request=request, channel_id=int(channel_id))
         if not channel_partner_sudo.env['ir.attachment'].search([('id', '=', int(attachment_id)), ('res_id', '=', int(channel_id)), ('res_model', '=', 'mail.channel')], limit=1):
             raise NotFound()
-        return channel_partner_sudo.env['ir.http']._get_content_common(res_id=int(attachment_id), download=True)
+        return channel_partner_sudo.env['ir.http']._get_content_common(res_id=int(attachment_id), download=download)
 
     @http.route([
         '/mail/channel/<int:channel_id>/image/<int:attachment_id>',

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -109,7 +109,12 @@ function factory(dependencies) {
                 return `/web/image/${this.id}?signature=${this.checksum}`;
             }
             if (this.isPdf) {
-                return `/web/static/lib/pdfjs/web/viewer.html?file=/web/content/${this.id}`;
+                const pdf_lib = `/web/static/lib/pdfjs/web/viewer.html?file=`
+                if (!this.accessToken && this.originThread && this.originThread.model === 'mail.channel') {
+                    return `${pdf_lib}/mail/channel/${this.originThread.id}/attachment/${this.id}`;
+                }
+                const accessToken = this.accessToken ? `?access_token%3D${this.accessToken}` : '';
+                return `${pdf_lib}/web/content/${this.id}${accessToken}`;
             }
             if (this.isUrlYoutube) {
                 const urlArr = this.url.split('/');
@@ -123,7 +128,11 @@ function factory(dependencies) {
                 }
                 return `https://www.youtube.com/embed/${token}`;
             }
-            return `/web/content/${this.id}`;
+            if (!this.accessToken && this.originThread && this.originThread.model === 'mail.channel') {
+                return `/mail/channel/${this.originThread.id}/attachment/${this.id}`;
+            }
+            const accessToken = this.accessToken ? `?access_token=${this.accessToken}` : '';
+            return `/web/content/${this.id}${accessToken}`;
         }
 
         /**


### PR DESCRIPTION
**Current behaviour before PR:**

Attachment viewer not working for other types than the image for guest.

**Desired behaviour after PR is merged:**

Attachment viewer will work for guest.

**LINKS:**
Task-2664816

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
