### PR TITLE
[FIX] hr_holidays: add default filter

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.xml
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.xml
@@ -56,6 +56,6 @@
         <field name="view_mode">calendar</field>
         <field name="search_view_id" ref="hr_leave_report_calendar_view_search"/>
         <field name="domain">[('employee_id.active','=',True)]</field>
-        <field name="context">{'hide_employee_name': 1}</field>
+        <field name="context">{'hide_employee_name': 1, 'search_default_my_team': 1}</field>
     </record>
 </odoo>

--- a/addons/hr_holidays/views/hr_holidays_views.xml
+++ b/addons/hr_holidays/views/hr_holidays_views.xml
@@ -83,14 +83,6 @@
         sequence="3"/>
 
     <menuitem
-        id="menu_hr_holidays_report_employee_time_off"
-        name="by Employee and Time Off Type"
-        parent="menu_hr_holidays_report"
-        action="action_hr_holidays_by_employee_and_type_report"
-        groups="base.group_no_one"
-        sequence="5"/>
-
-    <menuitem
         id="menu_hr_holidays_configuration"
         name="Configuration"
         parent="menu_hr_holidays_root"


### PR DESCRIPTION
Currently, in the overview page of timeoff, in gantt view all
records of the company are displayed. The purpose of this commit
is to improve the loading time by displaying less information.

So in this commit, added a default filter "My Department" on
overview page.

TaskID: 2695774

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
