### PR TITLE
 [FIX] web: navbar menu not shown on tablet 

### DIFF
--- a/addons/web/static/src/webclient/navbar/navbar.xml
+++ b/addons/web/static/src/webclient/navbar/navbar.xml
@@ -15,7 +15,7 @@
 
         <!-- App Brand -->
         <MenuItem
-          t-if="currentApp"
+          t-if="currentApp and !env.isSmall"
           href="getMenuItemHref(currentApp)"
           payload="currentApp"
           t-esc="currentApp.name"
@@ -24,7 +24,7 @@
         />
 
         <!-- Current App Sections -->
-        <t t-if="currentAppSections.length" t-call="web.NavBar.SectionsMenu">
+        <t t-if="currentAppSections.length and !env.isSmall" t-call="web.NavBar.SectionsMenu">
           <t t-set="sections" t-value="currentAppSections" />
         </t>
 


### PR DESCRIPTION
Before this fix, 'currentApp' returned 'undefined' on mobile but
there is no reason not to return the current app on mobile.
This has been fixed in enterprise repository.

Now that 'currentApp' returns a value, we have to explicitly hide
'menuItem' for small screen.

Steps to reproduce:
* Open Odoo on tablet
* Select an App => BUG

opw-2687424
opw-2688832

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
