### PR TITLE
[FIX] mail: members can be added through channel settings' form view

### DIFF
--- a/addons/mail/models/mail_channel_partner.py
+++ b/addons/mail/models/mail_channel_partner.py
@@ -14,7 +14,7 @@ class ChannelPartner(models.Model):
     _table = 'mail_channel_partner'
 
     # identity
-    partner_id = fields.Many2one('res.partner', string='Recipient', ondelete='cascade', readonly=True, index=True)
+    partner_id = fields.Many2one('res.partner', string='Recipient', ondelete='cascade', index=True)
     guest_id = fields.Many2one(string="Guest", comodel_name='mail.guest', ondelete='cascade', readonly=True, index=True)
     partner_email = fields.Char('Email', related='partner_id.email', readonly=False)
     # channel

--- a/addons/mail/views/mail_channel_views.xml
+++ b/addons/mail/views/mail_channel_views.xml
@@ -82,7 +82,7 @@
                             <page string="Members" name="members">
                                 <field name="channel_last_seen_partner_ids" mode="tree" context="{'active_test': False}">
                                     <tree string="Members" editable="bottom">
-                                        <field name="partner_id" required="1"/>
+                                        <field name="partner_id" required="1" attrs="{'readonly': [('id', '!=', False)]}"/>
                                         <field name="partner_email" readonly="1"/>
                                     </tree>
                                 </field>


### PR DESCRIPTION
### Current behavior
When we try to add a member through channel's settings by clicking on "Add a line", a blank line is correctly added but can't be edited.

![example-2677329](https://user-images.githubusercontent.com/91664927/143042196-27bc818d-6bc3-4510-9d43-954001f66e30.png)

### Steps to reproduce
- Install Discuss
- Go to channel settings
- Try to add a member by clicking on "Add a line"

### Reason
Since commit 89eef4cdd419cc23cfb8d3e0af7a7115119549c2 , `partner_id` field as been set to readonly because it doesn't make sense to edit the partner_id of a channel. However, this prevents the possibility of adding a new member. 

( concerned diff : https://github.com/odoo/odoo/pull/75496/files#diff-d02eca5ffaa6b9765330a905661cd6cb917b92d851b473d459ee011bb2c5be3cR17 )

OPW-2677329
