### PR TITLE
[FIX] website_event: fix broken arrow

### DIFF
--- a/addons/website_event/static/src/js/website_event.editor.js
+++ b/addons/website_event/static/src/js/website_event.editor.js
@@ -165,7 +165,6 @@ var EventCreateDialog = Dialog.extend({
             locale: {
                 direction: textDirection,
                 format: time.getLangDatetimeFormat().replace(':ss', ''),
-                separator: ' 🠖 ',
                 applyLabel: _t('Apply'),
                 cancelLabel: _t('Cancel'),
                 weekLabel: 'W',

--- a/addons/website_event/static/src/xml/event_create.xml
+++ b/addons/website_event/static/src/xml/event_create.xml
@@ -26,7 +26,7 @@
                 <p class="text-danger mt-1 mb-0 col-md-8 d-none">Please fill in this field</p>
             </div>
             <div class="form-group row d-flex justify-content-between align-items-center" id="event_dates">
-                <label class="col-form-label col-md-2" for="event_start_end">Start 🠖 End</label>
+                <label class="col-form-label col-md-2" for="event_start_end">Start &#8594; End</label>
                 <div class="col-md-10 s_website_form_datetime input-group date o_wevent_form_datetime" data-target-input="nearest">
                     <input type="text" name="event_start_end" class="form-control daterange-input bg-transparent text-dark rounded-0 p-1"/>
                 </div>


### PR DESCRIPTION
# Purpose

Fix the arrow that was not correctly displayed on some ubuntu versions with gnome

# Specifications

Replace the arrow previously used on the label and remove the one in the datepicker widget

# Links
taks-2655272