### PR TITLE
[FIX] account_journal: ignore line_section/note in account_control

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -286,6 +286,7 @@ class AccountJournal(models.Model):
             WHERE aml.journal_id in (%s)
             AND EXISTS (SELECT 1 FROM journal_account_control_rel rel WHERE rel.journal_id = aml.journal_id)
             AND NOT EXISTS (SELECT 1 FROM journal_account_control_rel rel WHERE rel.account_id = aml.account_id AND rel.journal_id = aml.journal_id)
+            AND aml.display_type IS NULL
         """, tuple(self.ids))
         if self._cr.fetchone():
             raise ValidationError(_('Some journal items already exist in this journal but with other accounts than the allowed ones.'))


### PR DESCRIPTION
When using account control on a journal, line_section and line_note do not
block the process even though they are not in the allowed accounts (they
don't have an account at all).
But when adding new accounts in the account_control_ids field, the
constraint is triggered by those lines.
This PR makes the constraint ignore those lines when assessing if
there's an issue.

opw-2677597

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
