### PR TITLE
[FIX] account_edi: Improve retrieval of partner when importing an EDI

### DIFF
--- a/addons/account_edi/models/account_edi_format.py
+++ b/addons/account_edi/models/account_edi_format.py
@@ -506,21 +506,90 @@ class AccountEdiFormat(models.Model):
         :param vat:     The vat number of the partner.
         :returns:       A partner or an empty recordset if not found.
         '''
-        domains = []
-        for value, domain in (
-            (name, [('name', 'ilike', name)]),
-            (phone, expression.OR([[('phone', '=', phone)], [('mobile', '=', phone)]])),
-            (mail, [('email', '=', mail)]),
-            (vat, [('vat', 'like', vat)]),
-        ):
-            if value is not None:
-                domains.append(domain)
+        def search_with_vat(extra_domain):
+            if not vat:
+                return None
 
-        domain = expression.AND([
-            expression.OR(domains),
-            [('company_id', 'in', [False, self.env.company.id])],
-        ])
-        return self.env['res.partner'].search(domain, limit=1)
+            # Sometimes, the vat is specified with some whitespaces.
+            normalized_vat = vat.replace(' ', '')
+
+            partner = self.env['res.partner'].search([('vat', '=', normalized_vat)], limit=1)
+
+            # Try to remove the country code prefix from the vat.
+            if not partner and len(normalized_vat) > 2 and normalized_vat[:2].isalpha():
+                country_prefix = normalized_vat[:2]
+                normalized_vat = normalized_vat[2:]
+                partner = self.env['res.partner'].search(extra_domain + [
+                    ('vat', '=', normalized_vat),
+                    ('country_id.code', '=', country_prefix.lower()),
+                ], limit=1)
+
+                # The country could be not specified.
+                if not partner:
+                    partner = self.env['res.partner'].search(extra_domain + [
+                        ('vat', '=', normalized_vat),
+                        ('country_id', '=', False),
+                    ], limit=1)
+
+            # The vat could be a string of alphanumeric values without country code but with missing zeros at the
+            # beginning.
+            if not partner:
+                try:
+                    vat_only_alphanumeric = str(int(normalized_vat))
+                except ValueError:
+                    vat_only_alphanumeric = None
+
+                if vat_only_alphanumeric:
+                    query = self.env['res.partner']._where_calc([('active', '=', True)], extra_domain)
+                    tables, where_clause, where_params = query.get_sql()
+
+                    self._cr.execute(f'''
+                        SELECT res_partner.id
+                        FROM {tables}
+                        WHERE {where_clause}
+                        AND res_partner.vat ~ %s
+                        LIMIT 1
+                    ''', where_params + ['^0*%s$' % vat_only_alphanumeric])
+                    partner_row = self._cr.fetchone()
+                    if partner_row:
+                        partner = self.env['res.partner'].browse(partner_row[0])
+
+            return partner
+
+        def search_with_phone_mail(extra_domain):
+            domains = []
+            if phone:
+                domains.append([('phone', '=', phone)])
+                domains.append([('mobile', '=', phone)])
+            if mail:
+                domains.append([('email', '=', mail)])
+
+            if not domains:
+                return None
+
+            domain = expression.OR(domains)
+            if extra_domain:
+                domain = expression.AND([domain, extra_domain])
+            return self.env['res.partner'].search(domain, limit=1)
+
+        def search_with_name(extra_domain):
+            if not name:
+                return None
+            return self.env['res.partner'].search([('name', 'ilike', name)] + extra_domain, limit=1)
+
+        for extra_domain, search_method in [
+            ([('company_id', '=', self.env.company.id)], search_with_vat),
+            ([('company_id', '=', False)], search_with_vat),
+            ([('company_id', '=', self.env.company.id)], search_with_phone_mail),
+            ([('company_id', '=', False)], search_with_phone_mail),
+            ([('company_id', '=', self.env.company.id)], search_with_name),
+            ([('company_id', '=', False)], search_with_name),
+        ]:
+            partner = search_method(extra_domain)
+            if partner:
+                return partner
+
+        return self.env['res.partner']
 
     def _retrieve_product(self, name=None, default_code=None, barcode=None):
         '''Search all products and find one that matches one of the parameters.


### PR DESCRIPTION
'BE0639876138' should match '0639876138' nor '639876138'

issue: 2694097

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
