### PR TITLE
[FIX] survey: Report style declaration

### DIFF
--- a/addons/survey/__manifest__.py
+++ b/addons/survey/__manifest__.py
@@ -85,7 +85,7 @@ sent mails with personal token for the invitation of the survey.
             'survey/static/src/js/survey_session_leaderboard.js',
             'survey/static/src/js/survey_session_manage.js',
         ],
-        'web.report_assets_pdf': [
+        'web.report_assets_common': [
             'survey/static/src/scss/survey_reports.scss',
         ],
         'web.assets_backend': [


### PR DESCRIPTION
 [FIX] survey: Report style declaration

It seems the `.scss` weren't recognized when loaded via the bundle
`report_assets_pdf` when rendering certifications

p/feedback report
