### PR TITLE
[FIX] sale_product_configurator: stop hiding subsequent dialogs after configuration step

### DIFF
--- a/addons/sale_product_configurator/static/src/js/product_configurator_controller.js
+++ b/addons/sale_product_configurator/static/src/js/product_configurator_controller.js
@@ -259,6 +259,16 @@ var ProductConfiguratorFormController = FormController.extend({
     },
 
     /**
+     * Remove "d-none" to allow other modals to display
+     *
+     * @override
+     */
+    destroy: function () {
+        $('.o_dialog_container').removeClass('d-none');
+        this._super.apply(this, arguments);
+    },
+
+    /**
      * Update product configurator form
      * when quantity is updated in the optional products window
      *


### PR DESCRIPTION
Steps to reproduce the bug:
- install `”sale_product_configurator”`
- Go to the sales settings and enable the “Warnings” option
- Create a product with variants
- Add sale warning
- Create a SO and add the product

Problem:
The warning message is not appearing

Solution:
The product configurator does not need to hide modals after the product is added.
This fix ensures that any modals displayed after adding the product (such as warnings, messages, etc.) are correctly displayed and not hidden.

opw-2696002
opw-2679495


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
