### PR TITLE
[FIX] purchase_product_matrix: fix warning message on product variants

### DIFF
--- a/addons/purchase_product_matrix/models/purchase.py
+++ b/addons/purchase_product_matrix/models/purchase.py
@@ -101,8 +101,9 @@ class PurchaseOrder(models.Model):
                 res = False
                 self.update(dict(order_line=new_lines))
                 for line in self.order_line.filtered(lambda line: line.product_template_id == product_template):
-                    res = line._product_id_change() or res
+                    line._product_id_change()
                     line._onchange_quantity()
+                    res = line.onchange_product_id_warning() or res
                 return res
 
     def _get_matrix(self, product_template):


### PR DESCRIPTION
Steps to reproduce the bug:
- install `”purchase_product_matrix”`
- Go to the purchase settings and enable “Warnings” option
- Create a product with variants
- Add purchase warning
- Create a PO and add the product

Problem:
The warning message is not appearing

Solution:
the `”_product_id_change()”` function has no return.
To trigger the warning message, we have to call the `”onchange_product_id_warning”` manually because it is not triggered automatically in the grid case

opw-2696007




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
