### PR TITLE
[FIX] *: Eval context of smart button actions

### DIFF
--- a/addons/crm_iap_lead_website/models/crm_reveal_rule.py
+++ b/addons/crm_iap_lead_website/models/crm_reveal_rule.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import ast
 import datetime
 import itertools
 import logging
@@ -113,13 +114,19 @@ class CRMRevealRule(models.Model):
     def action_get_lead_tree_view(self):
         action = self.env["ir.actions.actions"]._for_xml_id("crm.crm_lead_all_leads")
         action['domain'] = [('id', 'in', self.lead_ids.ids), ('type', '=', 'lead')]
-        action['context'] = dict(action.get('context', {}), create=False)
+        action['context'] = dict(
+            ast.literal_eval(action['context'].strip()),
+            create=False,
+        )
         return action
 
     def action_get_opportunity_tree_view(self):
         action = self.env["ir.actions.actions"]._for_xml_id("crm.crm_lead_opportunities")
         action['domain'] = [('id', 'in', self.lead_ids.ids), ('type', '=', 'opportunity')]
-        action['context'] = dict(action.get('context', {}), create=False)
+        action['context'] = dict(
+            ast.literal_eval(action['context'].strip()),
+            create=False,
+        )
         return action
 
     @api.model

--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import ast
 import random
 import requests
 import string
@@ -173,7 +174,10 @@ class LinkTracker(models.Model):
     def action_view_statistics(self):
         action = self.env['ir.actions.act_window']._for_xml_id('link_tracker.link_tracker_click_action_statistics')
         action['domain'] = [('link_id', '=', self.id)]
-        action['context'] = dict(action.get('context', {}), create=False)
+        action['context'] = dict(
+            ast.literal_eval(action['context'].strip()),
+            create=False,
+        )
         return action
 
     def action_visit_page(self):

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import ast
 from odoo import api, fields, models, _
 from odoo.tools.float_utils import float_round
 
@@ -283,5 +284,8 @@ class ProductionLot(models.Model):
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id("purchase.purchase_form_action")
         action['domain'] = [('id', 'in', self.mapped('purchase_order_ids.id'))]
-        action['context'] = dict(action.get('context', {}), create=False)
+        action['context'] = dict(
+            ast.literal_eval(action['context'].strip()),
+            create=False,
+        )
         return action

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import ast
 from collections import defaultdict
 
 from odoo import api, fields, models, _
@@ -183,5 +184,8 @@ class ProductionLot(models.Model):
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id("sale.action_orders")
         action['domain'] = [('id', 'in', self.mapped('sale_order_ids.id'))]
-        action['context'] = dict(action.get('context', {}), create=False)
+        action['context'] = dict(
+            ast.literal_eval(action['context'].strip()),
+            create=False,
+        )
         return action

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1375,7 +1375,10 @@ class Picking(models.Model):
         action = self.env["ir.actions.actions"]._for_xml_id("stock.action_stock_scrap")
         scraps = self.env['stock.scrap'].search([('picking_id', '=', self.id)])
         action['domain'] = [('id', 'in', scraps.ids)]
-        action['context'] = dict(action.get('context', {}), create=False)
+        action['context'] = dict(
+            literal_eval(action['context'].strip()),
+            create=False,
+        )
         return action
 
     def action_see_packages(self):

--- a/addons/stock_account/models/stock_inventory.py
+++ b/addons/stock_account/models/stock_inventory.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import ast
 from odoo import fields, models
 
 
@@ -28,7 +29,10 @@ class StockInventory(models.Model):
         self.ensure_one()
         action_data = self.env['ir.actions.act_window']._for_xml_id('account.action_move_journal_line')
         action_data['domain'] = [('stock_move_id.id', 'in', self.move_ids.ids)]
-        action_data['context'] = dict(action_data.get('context', {}), create=False)
+        action_data['context'] = dict(
+            ast.literal_eval(action_data['context'].strip()),
+            create=False,
+        )
         return action_data
 
     def post_inventory(self):


### PR DESCRIPTION
*: crm_iap_lead_website, link_tracker, mrp, purchase_stock, sale_stock,
   stock, stock_account.

`action['context']` is always a string representation of a dictionnary.
The dictionnary had to be evaluated before further processing. We were
conservative and decided to use `ast.literal_eval` whenever possible.

Fine-tunning of: 0e6aa2c8c110