### PR TITLE
[FIX] l10n_fr_fec: Cleanup spaces in FEC export

### DIFF
--- a/addons/l10n_fr_fec/tests/__init__.py
+++ b/addons/l10n_fr_fec/tests/__init__.py
@@ -1,0 +1,4 @@
+#-*- coding:utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_wizard

--- a/addons/l10n_fr_fec/tests/test_wizard.py
+++ b/addons/l10n_fr_fec/tests/test_wizard.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import base64
+from datetime import timedelta
+
+from odoo.addons.account.tests.account_test_savepoint import AccountTestInvoicingCommon
+from odoo.tests import tagged
+from odoo import fields
+
+
+@tagged('post_install', '-at_install')
+class TestAccountFrFec(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        company = cls.company_data['company']
+        cls.env.user.company_id = company
+        company.vat = 'FR13542107651'
+
+        lines_data = [(1437.12, 'Hello\tDarkness'), (1676.64, 'my\rold\nfriend'), (3353.28, '\t\t\r')]
+        today = fields.Date.today().strftime('%Y-%m-%d')
+        cls.invoice_a = cls.env['account.move'].create({
+            'type': 'out_invoice',
+            'partner_id': cls.partner_a.id,
+            'date': today,
+            'invoice_date': today,
+            'currency_id': cls.company_data['company'].currency_id.id,
+            'invoice_line_ids': [(0, None, {
+                'name': name,
+                'product_id': cls.product_a.id,
+                'quantity': 1,
+                'tax_ids': [(6, 0, [cls.tax_sale_a.id])],
+                'price_unit': price_unit,
+            }) for price_unit, name in lines_data]
+        })
+        cls.invoice_a.action_post()
+
+        cls.wizard = cls.env['account.fr.fec'].create({
+            'date_from': fields.Date.today() - timedelta(days=1),
+            'date_to': fields.Date.today() + timedelta(days=1),
+            'export_type': 'official'
+        })
+
+    def test_generate_fec_sanitize_pieceref(self):
+        self.wizard.generate_fec()
+        today = fields.Date.today().strftime('%Y%m%d')
+        expected_content = (
+            "JournalCode|JournalLib|EcritureNum|EcritureDate|CompteNum|CompteLib|CompAuxNum|CompAuxLib|PieceRef|PieceDate|EcritureLib|Debit|Credit|EcritureLet|DateLet|ValidDate|Montantdevise|Idevise\r\n"
+            f"INV|Customer Invoices|INV/2021/0001|{today}|400000|Product Sales|||-|{today}|Hello Darkness|0,00| 000000000001437,12|||{today}||\r\n"
+            f"INV|Customer Invoices|INV/2021/0001|{today}|400000|Product Sales|||-|{today}|my old friend|0,00| 000000000001676,64|||{today}||\r\n"
+            f"INV|Customer Invoices|INV/2021/0001|{today}|400000|Product Sales|||-|{today}|/|0,00| 000000000003353,28|||{today}||\r\n"
+            f"INV|Customer Invoices|INV/2021/0001|{today}|251000|Tax Received|||-|{today}|Tax 15.00%|0,00| 000000000000970,06|||{today}||\r\n"
+            f"INV|Customer Invoices|INV/2021/0001|{today}|121000|Account Receivable|{self.partner_a.id}|partner_a|-|{today}|INV/2021/0001| 000000000007437,10|0,00|||{today}||"
+        )
+        content = base64.b64decode(self.wizard.fec_data).decode()
+        self.assertEqual(expected_content, content)

--- a/addons/l10n_fr_fec/wizard/account_fr_fec.py
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec.py
@@ -294,12 +294,12 @@ class AccountFrFec(models.TransientModel):
         # LINES
         sql_query = '''
         SELECT
-            replace(replace(aj.code, '|', '/'), '\t', '') AS JournalCode,
-            replace(replace(COALESCE(aj__name.value, aj.name), '|', '/'), '\t', '') AS JournalLib,
-            replace(replace(am.name, '|', '/'), '\t', '') AS EcritureNum,
+            REGEXP_REPLACE(replace(aj.code, '|', '/'), '[\\t\\r\\n]', ' ', 'g') AS JournalCode,
+            REGEXP_REPLACE(replace(COALESCE(aj__name.value, aj.name), '|', '/'), '[\\t\\r\\n]', ' ', 'g') AS JournalLib,
+            REGEXP_REPLACE(replace(am.name, '|', '/'), '[\\t\\r\\n]', ' ', 'g') AS EcritureNum,
             TO_CHAR(am.date, 'YYYYMMDD') AS EcritureDate,
             aa.code AS CompteNum,
-            replace(replace(aa.name, '|', '/'), '\t', '') AS CompteLib,
+            REGEXP_REPLACE(replace(aa.name, '|', '/'), '[\\t\\r\\n]', ' ', 'g') AS CompteLib,
             CASE WHEN aat.type IN ('receivable', 'payable')
             THEN
                 CASE WHEN rp.ref IS null OR rp.ref = ''
@@ -310,18 +310,18 @@ class AccountFrFec(models.TransientModel):
             END
             AS CompAuxNum,
             CASE WHEN aat.type IN ('receivable', 'payable')
-            THEN COALESCE(replace(replace(rp.name, '|', '/'), '\t', ''), '')
+            THEN COALESCE(REGEXP_REPLACE(replace(rp.name, '|', '/'), '[\\t\\r\\n]', ' ', 'g'), '')
             ELSE ''
             END AS CompAuxLib,
             CASE WHEN am.ref IS null OR am.ref = ''
             THEN '-'
-            ELSE replace(replace(am.ref, '|', '/'), '\t', '')
+            ELSE REGEXP_REPLACE(replace(am.ref, '|', '/'), '[\\t\\r\\n]', ' ', 'g')
             END
             AS PieceRef,
             TO_CHAR(am.date, 'YYYYMMDD') AS PieceDate,
             CASE WHEN aml.name IS NULL OR aml.name = '' THEN '/'
-                WHEN aml.name SIMILAR TO '[\t|\s|\n]*' THEN '/'
-                ELSE replace(replace(replace(replace(aml.name, '|', '/'), '\t', ''), '\n', ''), '\r', '') END AS EcritureLib,
+                WHEN aml.name SIMILAR TO '[\\t|\\s|\\n]*' THEN '/'
+                ELSE REGEXP_REPLACE(replace(aml.name, '|', '/'), '[\\t\\n\\r]', ' ', 'g') END AS EcritureLib,
             replace(CASE WHEN aml.debit = 0 THEN '0,00' ELSE to_char(aml.debit, '000000000000000D99') END, '.', ',') AS Debit,
             replace(CASE WHEN aml.credit = 0 THEN '0,00' ELSE to_char(aml.credit, '000000000000000D99') END, '.', ',') AS Credit,
             CASE WHEN rec.name IS NULL THEN '' ELSE rec.name END AS EcritureLet,


### PR DESCRIPTION
The fields of the FEC export must be sanitized.
All tabs, carriage returns and newlines must be excised.

Ticket link: https://www.odoo.com/web#id=2672261&model=project.task

opw-2672261