### PR TITLE
[FIX] l10n_gcc_invoice: fix traceback on invoice when a section is pr…

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -300,10 +300,10 @@
                                 </t>
                             </tr>
 
-                            <t t-if="current_section and (line_last or lines[line+1].display_type == 'line_section')">
+                            <t t-if="current_section and (line_last or lines[line_index+1].display_type == 'line_section')">
                                 <tr class="is-subtotal text-right">
                                     <td colspan="99">
-                                        <strong class="mr16">Subtotal/الإجمالي الفرعي</strong>
+                                        <strong class="mr16" style="display: inline-block">Subtotal/الإجمالي الفرعي</strong>
                                         <span
                                                 t-esc="current_subtotal"
                                                 t-options='{"widget": "monetary", "display_currency": o.currency_id}'


### PR DESCRIPTION
Backport of #80247 

Description of the issue/feature this PR addresses:
When an invoice had a section, printing the invoice on a GCC country would trigger a traceback






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
