### PR TITLE
[FIX] l10n_gcc_invoice: changes a div to allow studio editing on the …

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -21,7 +21,7 @@
             <t t-set="o_sec" t-value="o.with_context(lang='ar_001')"/>
             <t t-set="o" t-value="o.with_context(lang='en_US')"/>
 
-            <page>
+            <div class="page">
                 <h3>
                     <div class="row">
                         <div class="col-4" style="text-align:left">
@@ -480,7 +480,7 @@
                     </div>
                 </p>
 
-            </page>
+            </div>
         </t>
     </template>
 


### PR DESCRIPTION
On the english/arabic invoice, it was not possible to add new elements anywhere except after the footer. This PR enables full use of studio on the report



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
