### PR TITLE
[FIX] web: fix readonly patch._super

### DIFF
--- a/addons/web/static/src/core/utils/patch.js
+++ b/addons/web/static/src/core/utils/patch.js
@@ -83,6 +83,7 @@ export function patch(obj, patchName, patchValue, options = {}) {
                         Object.defineProperty(this, "_super", {
                             value: _superFn.bind(this),
                             configurable: true,
+                            writable: true,
                         });
                     }
                     const result = patchFn.call(this, ...args);
@@ -90,6 +91,7 @@ export function patch(obj, patchName, patchValue, options = {}) {
                         Object.defineProperty(this, "_super", {
                             value: prevSuper,
                             configurable: true,
+                            writable: true,
                         });
                     }
                     return result;

--- a/addons/web/static/tests/core/utils/patch_tests.js
+++ b/addons/web/static/tests/core/utils/patch_tests.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { patch, unpatch } from "@web/core/utils/patch";
+import legacyUtils from "web.utils";
 
 function makeBaseClass(assert, assertInSetup) {
     class BaseClass {
@@ -1106,6 +1107,28 @@ QUnit.module("utils", () => {
             fn();
 
             assert.verifySteps(["patched", "original"]);
+        });
+
+        QUnit.test("patch an object with a legacy patch", async function (assert) {
+            const a = {
+                doSomething() {
+                    assert.step("a");
+                },
+            };
+            legacyUtils.patch(a, "a.patch.legacy", {
+                doSomething() {
+                    this._super();
+                    assert.step("a.patch.legacy");
+                },
+            });
+            patch(a, "a.patch", {
+                doSomething() {
+                    this._super();
+                    assert.step("a.patch");
+                },
+            });
+            a.doSomething();
+            assert.verifySteps(["a", "a.patch.legacy", "a.patch"]);
         });
 
         QUnit.module("patch 'pure' option");


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/79858,
we define the patch._super with an `Object.defineProperty`.
It works well but it prevents objects from being patched
by the legacy patch method afterwards.