### PR TITLE
[FIX] web: fix calendar popover opening

### DIFF
--- a/addons/web/static/src/legacy/js/views/calendar/calendar_popover.js
+++ b/addons/web/static/src/legacy/js/views/calendar/calendar_popover.js
@@ -212,10 +212,6 @@ var CalendarPopover = Widget.extend(WidgetAdapterMixin, StandaloneFieldManagerMi
                     if (fieldWidget.attrs.class) {
                         fieldClass += ' ' + fieldWidget.attrs.class;
                     }
-                    if (fieldWidget.attrs.modifiers) {
-                        const fieldModifier = record.evalModifiers(fieldWidget.attrs.modifiers);
-                        fieldClass += fieldModifier.invisible ? ' o_invisible_modifier' : '';
-                    }
                 }
 
                 var $field = $('<li>', {class: fieldClass});

--- a/addons/web/static/tests/legacy/views/calendar_tests.js
+++ b/addons/web/static/tests/legacy/views/calendar_tests.js
@@ -4193,6 +4193,31 @@ QUnit.module('Views', {
 
         calendar.destroy();
     });
+ 
+    QUnit.test("popover ignores readonly field modifier", async function (assert) {
+        assert.expect(1);
+
+        var calendar = await createCalendarView({
+            View: CalendarView,
+            model: "event",
+            data: this.data,
+            arch: `
+                <calendar date_start="start" date_stop="stop" all_day="allday" mode="month">
+                    <field name="name" attrs="{'readonly': [['unknown_field', '=', 42]]}" />
+                </calendar>
+            `,
+            archs: archs,
+            viewOptions: {
+                initialDate: initialDate,
+            },
+        });
+
+        await testUtils.dom.click(calendar.$(`[data-event-id="4"]`));
+        // test would fail here if we don't ignore readonly modifier
+        assert.containsOnce(calendar, ".o_cw_popover");
+
+        calendar.destroy();
+    });
 });
 
 });


### PR DESCRIPTION
Before this commit, the opening of a calendar popover could crash
because we tried to evaluate the domain of the readonly modifier.
Only the invisible modifier is necessary in the calendar popover so
this commit fixes the issue by evaluating only the invisible modifier.
It was also evaluated twice to do both the same thing so this commit
remove the duplicated lines.