### PR TITLE
[FIX] sale_timesheet: not display project stat button when SO is draft

### DIFF
--- a/addons/sale_timesheet/views/sale_order_views.xml
+++ b/addons/sale_timesheet/views/sale_order_views.xml
@@ -12,7 +12,7 @@
                            class="oe_stat_button"
                            icon="fa-puzzle-piece"
                            string="Project Overview"
-                           attrs="{'invisible': [('project_ids', '=', [])]}"
+                           attrs="{'invisible': ['|', ('state', 'in', ['draft', 'sent']), ('project_ids', '=', [])]}"
                            groups="project.group_project_manager">
                           <field name="project_ids" invisible="1"/>
                        </button>


### PR DESCRIPTION
Before this commit, when the user creates a quotation and add a SOL with
product contained a project in `project_id` field, the
'Project Overview' stat button is shown even if the quotation is not
confirmed.

This commit changes the visibility condition of this button to display
it only if at least a project is contained in `project_ids` field of
`sale.order` model and if the quotation is confirmed that is when the
quotation becomes a sales order.

Step to reproduce:
=================
1) Go to the Sales app
2) Click on 'Create' button to create a quotation.
3) Add a SOL with 'Customer Care (Prepaid Hours)' product

Actual Behavior:
===============
The 'Project Overview' stat button is displayed.

Expected Behavior:
=================
This stat button should not be displayed while the quotation is not
confirmed to become a sales order.

task-2697063

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
