### PR TITLE
[IMP] mail: use t-component with component as value

### DIFF
--- a/addons/mail/static/src/components/dialog/dialog.xml
+++ b/addons/mail/static/src/components/dialog/dialog.xml
@@ -5,7 +5,7 @@
         <div class="o_Dialog">
             <t t-if="dialog">
                 <t
-                    t-component="{{ dialog.componentName }}"
+                    t-component="constructor.components[dialog.componentName]"
                     class="o_Dialog_component"
                     t-props="{ localId: dialog.record.localId }"
                     t-ref="component"


### PR DESCRIPTION
Was done with https://github.com/odoo/odoo/pull/80084
But then https://github.com/odoo/odoo/pull/79259 reintroduced
`t-component` with string.

In preparation for using OWL v2 in Discuss code.

Task-2694217
