### PR TITLE
[FIX] *: Bad context keys in smart button

### DIFF
--- a/addons/crm_iap_lead_website/models/crm_reveal_rule.py
+++ b/addons/crm_iap_lead_website/models/crm_reveal_rule.py
@@ -113,13 +113,13 @@ class CRMRevealRule(models.Model):
     def action_get_lead_tree_view(self):
         action = self.env["ir.actions.actions"]._for_xml_id("crm.crm_lead_all_leads")
         action['domain'] = [('id', 'in', self.lead_ids.ids), ('type', '=', 'lead')]
-        action['context'] = dict(action.get('context', {}), create=False)
+        action['context'] = dict(self._context, create=False)
         return action
 
     def action_get_opportunity_tree_view(self):
         action = self.env["ir.actions.actions"]._for_xml_id("crm.crm_lead_opportunities")
         action['domain'] = [('id', 'in', self.lead_ids.ids), ('type', '=', 'opportunity')]
-        action['context'] = dict(action.get('context', {}), create=False)
+        action['context'] = dict(self._context, create=False)
         return action
 
     @api.model

--- a/addons/hr_fleet/models/employee.py
+++ b/addons/hr_fleet/models/employee.py
@@ -14,12 +14,13 @@ class Employee(models.Model):
         self.ensure_one()
         cars = self.env['fleet.vehicle.assignation.log'].search([
             ('driver_id', 'in', (self.user_id.partner_id | self.sudo().address_home_id).ids)]).mapped('vehicle_id')
+
         return {
             "type": "ir.actions.act_window",
             "res_model": "fleet.vehicle",
             "views": [[False, "kanban"], [False, "form"], [False, "tree"]],
             "domain": [("id", "in", cars.ids)],
-            "context": dict(create=False),
+            "context": dict(self._context, create=False),
             "name": "History Employee Cars",
         }
 

--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -173,7 +173,7 @@ class LinkTracker(models.Model):
     def action_view_statistics(self):
         action = self.env['ir.actions.act_window']._for_xml_id('link_tracker.link_tracker_click_action_statistics')
         action['domain'] = [('link_id', '=', self.id)]
-        action['context'] = dict(action.get('context', {}), create=False)
+        action['context'] = dict(self._context, create=False)
         return action
 
     def action_visit_page(self):

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -393,7 +393,7 @@ class MassMailing(models.Model):
             'view_mode': 'tree',
             'res_model': self.mailing_model_real,
             'domain': [('id', 'in', res_ids)],
-            'context': dict(create=False)
+            'context': dict(self._context, create=False)
         }
 
     def update_opt_out(self, email, list_ids, value):

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -407,7 +407,7 @@ class MrpProduction(models.Model):
             else:
                 action['views'] = form_view
             action['res_id'] = pickings.id
-        action['context'] = dict(action.get('context', {}), create=False, default_origin=self.name)
+        action['context'] = dict(self._context, default_origin=self.name, create=False)
         return action
 
     @api.depends('product_uom_id', 'product_qty', 'product_id.uom_id')
@@ -1623,7 +1623,7 @@ class MrpProduction(models.Model):
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id("stock.action_stock_scrap")
         action['domain'] = [('production_id', '=', self.id)]
-        action['context'] = dict(action.get('context', {}), create=False)
+        action['context'] = dict(self._context, default_origin=self.name)
         return action
 
     @api.model

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1364,7 +1364,7 @@ class Task(models.Model):
             'res_model': 'project.task',
             'res_id': self.parent_id.id,
             'type': 'ir.actions.act_window',
-            'context': dict(create=False)
+            'context': dict(self._context, create=False)
         }
 
     def action_subtask(self):

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -283,5 +283,5 @@ class ProductionLot(models.Model):
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id("purchase.purchase_form_action")
         action['domain'] = [('id', 'in', self.mapped('purchase_order_ids.id'))]
-        action['context'] = dict(action.get('context', {}), create=False)
+        action['context'] = dict(self._context, create=False)
         return action

--- a/addons/sale_coupon/models/coupon_program.py
+++ b/addons/sale_coupon/models/coupon_program.py
@@ -26,7 +26,7 @@ class CouponProgram(models.Model):
             'search_view_id': [self.env.ref('sale.sale_order_view_search_inherit_quotation').id],
             'type': 'ir.actions.act_window',
             'domain': [('id', 'in', orders.ids)],
-            'context': dict(create=False),
+            'context': dict(self._context, create=False),
         }
 
     def _check_promo_code(self, order, coupon_code):

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -204,7 +204,7 @@ class SaleOrder(models.Model):
             picking_id = picking_id[0]
         else:
             picking_id = pickings[0]
-        action['context'] = dict(action.get('context', {}), default_partner_id=self.partner_id.id, default_picking_type_id=picking_id.picking_type_id.id, default_origin=self.name, default_group_id=picking_id.group_id.id, group_by=[])
+        action['context'] = dict(self._context, default_partner_id=self.partner_id.id, default_picking_type_id=picking_id.picking_type_id.id, default_origin=self.name, default_group_id=picking_id.group_id.id)
         return action
 
     def action_cancel(self):

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -183,5 +183,5 @@ class ProductionLot(models.Model):
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id("sale.action_orders")
         action['domain'] = [('id', 'in', self.mapped('sale_order_ids.id'))]
-        action['context'] = dict(action.get('context', {}), create=False)
+        action['context'] = dict(self._context, create=False)
         return action

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1375,7 +1375,7 @@ class Picking(models.Model):
         action = self.env["ir.actions.actions"]._for_xml_id("stock.action_stock_scrap")
         scraps = self.env['stock.scrap'].search([('picking_id', '=', self.id)])
         action['domain'] = [('id', 'in', scraps.ids)]
-        action['context'] = dict(action.get('context', {}), create=False)
+        action['context'] = dict(self._context, create=False)
         return action
 
     def action_see_packages(self):

--- a/addons/stock_account/models/stock_inventory.py
+++ b/addons/stock_account/models/stock_inventory.py
@@ -28,7 +28,7 @@ class StockInventory(models.Model):
         self.ensure_one()
         action_data = self.env['ir.actions.act_window']._for_xml_id('account.action_move_journal_line')
         action_data['domain'] = [('stock_move_id.id', 'in', self.move_ids.ids)]
-        action_data['context'] = dict(action_data.get('context', {}), create=False)
+        action_data['context'] = dict(self._context, create=False)
         return action_data
 
     def post_inventory(self):


### PR DESCRIPTION
This reverts commit 60da4ee

Current behavior:
When adding a group_by:[opportunity_id] key to the context of the quotations page
the delivery smart button crash when there is more than 1 delivery

Steps to reproduce:
 -Add 'group_by':['opportunity_id'] in context of the quotations page
 -Refresh the page
 -Create a sale with more than 1 delivery
 -When you click on the delivery smart button the app crash

opw-2658775

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
