### PR TITLE
[FIX] base: `ref` call a extra exists for nothing

### DIFF
--- a/odoo/api.py
+++ b/odoo/api.py
@@ -576,11 +576,7 @@ class Environment(Mapping):
         )
 
         if res_model and res_id:
-            record = self[res_model].browse(res_id)
-            if record.exists():
-                return record
-            if raise_if_not_found:
-                raise ValueError('No record found for unique ID %s. It may have been deleted.' % (xml_id))
+            return self[res_model].browse(res_id)
         return None
 
     def is_superuser(self):


### PR DESCRIPTION
Avoid `ref` (on env) method (used everywhere and a lot) to
make a extra `exists` call (one SQL requests). The check of existence
is useless because the `unlink` of `models.py` unlink the IrModelData
linked to a record.

BAD IDEA: forget the cascade deletion