### PR TITLE
[15.0] lunch: hide create button from the list view of lunch app

### DIFF
--- a/addons/lunch/views/lunch_product_views.xml
+++ b/addons/lunch/views/lunch_product_views.xml
@@ -57,6 +57,7 @@
         <field name="arch" type="xml">
             <xpath expr="//tree" position="attributes">
                 <attribute name="js_class">lunch_list</attribute>
+                <attribute name="create">0</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Lunch App: not able to place lunch orders from the list view of Lunch App -> My Lunch -> New Order list

**Current behaviour before PR:**
Create button visible on the Lunch App -> My Lunch -> New Order list view. when we click on it nothing happens.

**Desired behaviour after PR is merged:**
Like v14 Create button will be invisible and able to add an order from Lunch App -> My Lunch -> New Order by clicking on any records from the list view

Fixes #78272
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
