### PR TITLE
[FIX] web: webclient, action_adapters: change tab title whenever a pu…

### DIFF
--- a/addons/web/static/src/legacy/action_adapters.js
+++ b/addons/web/static/src/legacy/action_adapters.js
@@ -28,6 +28,7 @@ class ActionAdapter extends ComponentAdapter {
         // In Wowl, we want to have all states pushed during the same setTimeout.
         // This is protected in legacy (backward compatibility) but should not e supported in Wowl
         this.tempQuery = {};
+        this.waitTitle = true;
         let originalUpdateControlPanel;
         useEffect(
             () => {
@@ -38,6 +39,7 @@ class ActionAdapter extends ComponentAdapter {
                 if (!this.wowlEnv.inDialog) {
                     this.pushState(query);
                     this.title.setParts({ action: this.widget.getTitle() });
+                    this.waitTitle = false;
                 }
                 this.wowlEnv.bus.on("ACTION_MANAGER:UPDATE", this, () => {
                     this.env.bus.trigger("close_dialogs");
@@ -75,6 +77,12 @@ class ActionAdapter extends ComponentAdapter {
         if (this.tempQuery) {
             Object.assign(this.tempQuery, query);
             return;
+        }
+        if (!this.waitTitle && this.widget) {
+            const actionTitle = this.widget.getTitle();
+            if (actionTitle) {
+                this.title.setParts({ action: actionTitle });
+            }
         }
         this.router.pushState(query);
     }

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -2383,4 +2383,18 @@ QUnit.module("ActionManager", (hooks) => {
 
         assert.verifySteps(["/web/dataset/search_read"]);
     });
+
+    QUnit.test("pushState also changes the title of the tab", async (assert) => {
+        assert.expect(3);
+
+        const webClient = await createWebClient({ serverData });
+        await doAction(webClient, 3); // list view
+        const titleService = webClient.env.services.title;
+        assert.strictEqual(titleService.current, "{\"zopenerp\":\"Odoo\",\"action\":\"Partners\"}");
+        await click(webClient.el.querySelector(".o_data_row"));
+        await legacyExtraNextTick();
+        assert.strictEqual(titleService.current, "{\"zopenerp\":\"Odoo\",\"action\":\"First record\"}");
+        await click(webClient.el.querySelector(".o_pager_next"));
+        assert.strictEqual(titleService.current, "{\"zopenerp\":\"Odoo\",\"action\":\"Second record\"}");
+    });
 });


### PR DESCRIPTION
…sh state occurs

From a list view with multiple records, go on a record of that list
Click on the pager next button

Before this commit, the browser tab's title was not updated to the second records.

After this commit, it is.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
