### PR TITLE
[FIX] hr_recruitment, web: the sidepanel doesn't show users correctly

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
+from odoo.addons.web.models.models import SEARCH_PANEL_LIMIT
 
 
 class Job(models.Model):
@@ -107,6 +108,17 @@ class Job(models.Model):
     def create(self, vals):
         vals['favorite_user_ids'] = vals.get('favorite_user_ids', []) + [(4, self.env.uid)]
         return super(Job, self).create(vals)
+
+    @api.model
+    def search_panel_select_range(self, field_name):
+        if field_name == 'user_id':
+            users = self.search([('user_id', '!=', False)]).user_id
+            available_users = users.search([('id', 'in', users.ids)], limit=SEARCH_PANEL_LIMIT).read(['display_name'])
+            return {
+                'parent_field': False,
+                'values': available_users
+            }
+        return super(Job, self).search_panel_select_range(field_name)
 
     def _creation_subtype(self):
         return self.env.ref('hr_recruitment.mt_job_new')

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -258,7 +258,8 @@ class Base(models.AbstractModel):
 
         Comodel = self.env[field.comodel_name]
         fields = ['display_name']
-        parent_name = Comodel._parent_name if Comodel._parent_name in Comodel._fields else False
+        parent_field = Comodel._fields.get(Comodel._parent_name)
+        parent_name = Comodel._parent_name if parent_field and parent_field.comodel_name == Comodel._name else False
         if parent_name:
             fields.append(parent_name)
         return {


### PR DESCRIPTION
How to replicate:
- Create a user and assign the current company to its
related contact.
- Go to Recruitment -> create a job with the user
created before as Responsible.

Result:
- The user doesn't display in the sidepanel.

Expected:
- The panel should display the user and the other
users that are responsible of at least one job.

Additionally, if the user's contact has no company
assigned, it will display in the panel whether or not
the user is set as responsible in at least one job.

I overwrote the 'search_panel_select_range' to
display only the users that respect the rules listed
above.
I also changed the original search_panel_select_range
and now I don't set parent_field if the parent_field
model is different than the current model

opw-2654573

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
