### PR TITLE
[FIX] mail: prevent from losing "read more" / "read less" state

### DIFF
--- a/addons/mail/static/src/components/message/message.js
+++ b/addons/mail/static/src/components/message/message.js
@@ -112,6 +112,21 @@ class Message extends Component {
          * regular time.
          */
         this._intervalId = undefined;
+        /**
+         * States the index of the last "read more" that was inserted.
+         * Useful to remember the state for each "read more" even if their DOM
+         * is re-rendered.
+         */
+        this._lastReadMoreIndex = 0;
+        /**
+         * Determines whether each "read more" is opened or closed. The keys are
+         * index, which is determined by their order of appearance in the DOM.
+         * If body changes so that "read more" count is different, their default
+         * value will be "wrong" at the next render but this is an acceptable
+         * limitation. It's more important to save the state correctly in a
+         * typical non-changing situation.
+         */
+        this._isReadMoreByIndex = new Map();
         this._constructor();
     }
 
@@ -404,6 +419,7 @@ class Message extends Component {
         }
 
         for (const group of groups) {
+            const index = this._lastReadMoreIndex++;
             // Insert link just before the first node
             const $readMoreLess = $('<a>', {
                 class: 'o_Message_readMoreLess',
@@ -412,16 +428,23 @@ class Message extends Component {
             }).insertBefore(group[0]);
 
             // Toggle All next nodes
-            let isReadMore = true;
-            $readMoreLess.click(e => {
-                e.preventDefault();
-                isReadMore = !isReadMore;
+            if (!this._isReadMoreByIndex.has(index)) {
+                this._isReadMoreByIndex.set(index, true);
+            }
+            const updateFromState = () => {
+                const isReadMore = this._isReadMoreByIndex.get(index);
                 for (const $child of group) {
                     $child.hide();
                     $child.toggle(!isReadMore);
                 }
                 $readMoreLess.text(isReadMore ? READ_MORE : READ_LESS);
+            };
+            $readMoreLess.click(e => {
+                e.preventDefault();
+                this._isReadMoreByIndex.set(index, !this._isReadMoreByIndex.get(index));
+                updateFromState();
             });
+            updateFromState();
         }
     }
 
@@ -443,6 +466,7 @@ class Message extends Component {
             for (const el of [...this._contentRef.el.querySelectorAll(':scope .o_Message_readMoreLess')]) {
                 el.remove();
             }
+            this._lastReadMoreIndex = 0;
             this._insertReadMoreLess($(this._contentRef.el));
             this.env.messagingBus.trigger('o-component-message-read-more-less-inserted', {
                 message: this.message,


### PR DESCRIPTION
Instead of "saving" the state into the DOM (which is lost at next render) save
the state of each button in JS.

task-2308951