### PR TITLE
[FIX] mail: prioritize internal users when looking for mentions

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -416,7 +416,8 @@ class DiscussController(http.Controller):
                 'is_active': follower.is_active,
                 # When editing the followers, the "pencil" icon that leads to the edition of subtypes
                 # should be always be displayed and not only when "debug" mode is activated.
-                'is_editable': True
+                'is_editable': True,
+                'partner': follower.partner_id.mail_partner_format()[follower.partner_id],
             })
         return {
             'followers': followers,

--- a/addons/mail/static/src/models/follower/follower.js
+++ b/addons/mail/static/src/models/follower/follower.js
@@ -41,6 +41,9 @@ function factory(dependencies) {
                     data2.partner = insert(partnerData);
                 }
             }
+            if (data.partner) {
+                data2.partner = insertAndReplace(this.models['mail.partner'].convertData(data.partner));
+            }
             return data2;
         }
 


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/73689 all internal users are no longer
known at init. Unlike what was stated in the corresponding PR, the code of
mentions wasn't actually good enough to allow it without any drawback.

This PR fixes the issue by prioritizing internal users on the result of the RPC.

As a bonus the internal user state is immediately returned when fetching
followers, which allows mentions to be accurate even before the RPC is done.

task-2695224
