### PR TITLE
[FIX] product_expiry: lot expiration_date should have priority

### DIFF
--- a/addons/product_expiry/models/stock_move_line.py
+++ b/addons/product_expiry/models/stock_move_line.py
@@ -14,11 +14,13 @@ class StockMoveLine(models.Model):
         help='This is the date on which the goods with this Serial Number may'
         ' become dangerous and must not be consumed.')
 
-    @api.depends('product_id', 'picking_type_use_create_lots')
+    @api.depends('product_id', 'picking_type_use_create_lots', 'lot_id')
     def _compute_expiration_date(self):
         for move_line in self:
             if move_line.picking_type_use_create_lots:
                 if move_line.product_id.use_expiration_date:
+                    if not move_line.expiration_date and move_line.lot_id.expiration_date:
+                        move_line.expiration_date = move_line.lot_id.expiration_date
                     if not move_line.expiration_date:
                         move_line.expiration_date = fields.Datetime.today() + datetime.timedelta(days=move_line.product_id.expiration_time)
                 else:


### PR DESCRIPTION
Fine-tune of https://github.com/odoo/odoo/commit/4cffec7baa5163dd50f095b6897957053f5115a2. The picking_type_use_create_lots means we should use the expiration_date of the lot.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr