### PR TITLE
[FIX] web: legacy compatibility: transmit all props to the action

### DIFF
--- a/addons/web/static/src/legacy/backend_utils.js
+++ b/addons/web/static/src/legacy/backend_utils.js
@@ -228,9 +228,7 @@ export function mapDoActionOptionAPI(legacyOptions) {
         clearBreadcrumbs: legacyOptions.clear_breadcrumbs,
         viewType: legacyOptions.view_type,
         onClose: legacyOptions.on_close,
-        props: {
-            resId: legacyOptions.res_id,
-        },
+        props: Object.assign({ resId: legacyOptions.res_id }, legacyOptions.props),
     });
     if (legacyOptions.controllerState) {
         legacyOptions.props.globalState = getGlobalState(legacyOptions.controllerState);


### PR DESCRIPTION
Make a legacy widget trigger a do_Action with `this.do_action`
in the options, pass the usual options for the doAction itself plus a props object in it.

Before this commit, the action did not receive all the props.

After this commit, it does.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
