### PR TITLE
[FIX] website: properly mark carousel test tour as a test tour

### DIFF
--- a/addons/website/static/tests/tours/carousel_content_removal.js
+++ b/addons/website/static/tests/tours/carousel_content_removal.js
@@ -5,6 +5,7 @@ var tour = require("web_tour.tour");
 var base = require("web_editor.base");
 
 tour.register("carousel_content_removal", {
+    test: true,
     url: "/",
     wait_for: base.ready(),
 }, [{


### PR DESCRIPTION
Commit [1] and its forward-ports introduced a test tour (properly added
in assets_tests) but was not declared as a test one. Meaning that if you
were in debug=tests, you were able to follow a strange tour not meant
for user testing.

[1]: https://github.com/odoo/odoo/commit/3c194faa930b0d3a537ca8b893b2c0442b5464e7

