### PR TITLE
[FIX] mass_mailing: ignore domain when getting lists recipients

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -477,7 +477,10 @@ class MassMailing(models.Model):
         }
 
     def _get_recipients(self):
-        if self.mailing_domain:
+        if self.mailing_model_name == 'mailing.list' and self.contact_list_ids:
+            domain = [('list_ids', 'in', self.contact_list_ids.ids)]
+            res_ids = self.contact_list_ids.contact_ids.ids
+        elif self.mailing_domain:
             domain = safe_eval(self.mailing_domain)
             try:
                 res_ids = self.env[self.mailing_model_real].search(domain).ids


### PR DESCRIPTION
STR:

1. Create a mailing.
2. Select model Partners.
3. Add a domain.
4. Select model Mailing LIst.
5. Choose lists.
6. Send.

Result before this patch: the domain that was first designed for partners is now applied to mailing list contacts, resulting in unpredictable recipients.

After this patch: the domain is ignored and only the chosen mailing list contacts are selected, predictably.

@Tecnativa TT33121

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
