### PR TITLE
[FIX] base: in res.config.settings, field.related is a string

### DIFF
--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -760,7 +760,7 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
                 continue
             # we write on a related field like
             # qr_code = fields.Boolean(related='company_id.qr_code', readonly=False)
-            fname0 = field.related[0]
+            fname0, *fnames = field.related.split(".")
             if fname0 not in values:
                 continue
 
@@ -768,7 +768,7 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
             field0 = self._fields[fname0]
             old_value = field0.convert_to_record(
                 field0.convert_to_cache(values[fname0], self), self)
-            for fname in field.related[1:]:
+            for fname in fnames:
                 old_value = next(iter(old_value), old_value)[fname]
 
             # determine the new value


### PR DESCRIPTION
It used to be a tuple.
Cf: 1abe965b59a6acc24b93c25c07c2f9151af4924a

opw-2681777

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
