### PR TITLE
[FIX] web: fix chineese calendar format

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_model.js
+++ b/addons/web/static/src/js/views/calendar/calendar_model.js
@@ -458,6 +458,7 @@ return AbstractModel.extend({
             monthNamesShort: moment.monthsShort(),
             dayNames: moment.weekdays(),
             dayNamesShort: moment.weekdaysShort(),
+            dayNamesMin: moment.weekdaysMin(),
             firstDay: this.week_start,
             slotLabelFormat: _t.database.parameters.time_format.search("%H") !== -1 ? format24Hour : format12Hour,
             allDaySlot: this.mapping.all_day || this.fields[this.mapping.date_start].type === 'date',

--- a/addons/web/static/src/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/js/views/calendar/calendar_renderer.js
@@ -578,7 +578,7 @@ return AbstractRenderer.extend({
                 });
             },
             'showOtherMonths': true,
-            'dayNamesMin' : this.state.fc_options.dayNamesShort.map(x => x[0]),
+            'dayNamesMin': this.state.fc_options.dayNamesMin.map(x => x[0]),
             'monthNames': this.state.fc_options.monthNamesShort,
             'firstDay': this.state.fc_options.firstDay,
         });


### PR DESCRIPTION
Issue:
The way we generate the dayNamesMin is not compatible with the chineese
translation provided by "moment.js".
This is because the dayNamesShort contains an extra character in front
週 (week). Because of that the names of the days on the
small calendar are all the character 週 (week).

Solution:
There is a variable (weekdaysMin) which is unused and contain a shorter
version of the days this variable is consitent in the other languages so
it should have no side effect and will fix the chinese translation as it
only contains one character.

Introduced by: 1fc33a63beb20d134081c93852e62f5fe0ff67d4

task-2692910

**
![image](https://user-images.githubusercontent.com/48204822/143393839-f9d08faa-71ed-4721-95d0-e05f1cf4a6d8.png)
**
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
