### PR TITLE
[FIX] mail_group: avoid "Re: False" reply

### DIFF
--- a/addons/mail_group/wizard/mail_group_message_reject.py
+++ b/addons/mail_group/wizard/mail_group_message_reject.py
@@ -19,7 +19,7 @@ class MailGroupMessageReject(models.TransientModel):
     @api.depends('mail_group_message_id')
     def _compute_subject(self):
         for wizard in self:
-            wizard.subject = _('Re: %s', wizard.mail_group_message_id.subject)
+            wizard.subject = _('Re: %s', wizard.mail_group_message_id.subject or '')
 
     @api.depends('body')
     def _compute_send_email(self):


### PR DESCRIPTION
If the subject is not set, the wizard set the subject as "Re: False"
![Screenshot 2021-11-25 at 08-15-57 Odoo - False](https://user-images.githubusercontent.com/564822/143399017-01f8248f-6dbb-4808-91ea-7f88d3a5687c.png)
