### PR TITLE
[FIX] hr_recruitment_survey: fix creation of an empty registration

### DIFF
--- a/addons/hr_recruitment_survey/i18n/hr_recruitment_survey.pot
+++ b/addons/hr_recruitment_survey/i18n/hr_recruitment_survey.pot
@@ -267,6 +267,12 @@ msgstr ""
 #. module: hr_recruitment_survey
 #: code:addons/hr_recruitment_survey/models/survey_invite.py:0
 #, python-format
+msgid "The survey %(survey_link)s has been sent to %(partner_link)s"
+msgstr ""
+
+#. module: hr_recruitment_survey
+#: code:addons/hr_recruitment_survey/models/survey_invite.py:0
+#, python-format
 msgid "The survey has been sent to \"%s\"."
 msgstr ""
 

--- a/addons/hr_recruitment_survey/models/hr_applicant.py
+++ b/addons/hr_recruitment_survey/models/hr_applicant.py
@@ -31,4 +31,4 @@ class Applicant(models.Model):
                 'phone': self.partner_phone,
                 'mobile': self.partner_mobile
             })
-        return self.survey_id.with_context(default_partner_ids=self.partner_id.ids, active_model='hr.applicant', active_id=self.id).action_send_survey()
+        return self.survey_id.with_context(default_applicant_id=self.id, default_partner_ids=self.partner_id.ids).action_send_survey()

--- a/addons/hr_recruitment_survey/models/survey_invite.py
+++ b/addons/hr_recruitment_survey/models/survey_invite.py
@@ -1,24 +1,30 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models, _
+from odoo.tools.misc import clean_context
 
 
 class SurveyInvite(models.TransientModel):
     _inherit = "survey.invite"
 
-    applicant_id = fields.Many2one('hr.applicant', string='Applicant', default=lambda self: self.env.context.get('active_id', None) if self.env.context.get('active_model') == 'hr.applicant' else False)
+    applicant_id = fields.Many2one('hr.applicant', string='Applicant')
 
     def action_invite(self):
         self.ensure_one()
-
-        if self.applicant_id and not self.applicant_id.response_id:
-            response = self.applicant_id.survey_id._create_answer(partner=self.applicant_id.partner_id)
-            self.applicant_id.response_id = response.id
-
         if self.applicant_id:
-            body = _('The survey has been sent to "%s".', self.applicant_id.partner_name)
-            self.applicant_id.message_post(body=body)
+            survey = self.survey_id.with_context(clean_context(self.env.context))
 
+            if not self.applicant_id.response_id:
+                self.applicant_id.write({
+                    'response_id': survey._create_answer(partner=self.applicant_id.partner_id).id
+                })
+
+            partner = self.applicant_id.partner_id
+            survey_link = '<a href="#" data-oe-model="%s" data-oe-id="%s">%s</a>' % (survey._name, survey.id, survey.title)
+            partner_link = '<a href="#" data-oe-model="%s" data-oe-id="%s">%s</a>' % (partner._name, partner.id, partner.name)
+            content = _('The survey %(survey_link)s has been sent to %(partner_link)s', survey_link=survey_link, partner_link=partner_link)
+            body = '<p>%s</p>' % content
+            self.applicant_id.message_post(body=body)
         return super().action_invite()
 
 


### PR DESCRIPTION
Before - when sharing Recruitment Form from surveys app, additional empty
registration was created.

task - 2694600


