### PR TITLE
[FIX] point_of_sale: Add DNS server in the IoT

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_after_init/etc/resolv.conf.tail
+++ b/addons/point_of_sale/tools/posbox/overwrite_after_init/etc/resolv.conf.tail
@@ -1,5 +1,4 @@
 # Edited by Odoo
-domain localdomain
 nameserver 8.8.8.8
 nameserver 8.8.4.4
 nameserver 1.1.1.1

--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
@@ -10,7 +10,6 @@ __base="$(basename ${__file} .sh)"
 
 # Recommends: antiword, graphviz, ghostscript, python-gevent, poppler-utils
 export DEBIAN_FRONTEND=noninteractive
-echo "nameserver 8.8.8.8" >> /etc/resolv.conf
 
 # set locale to en_US
 echo "set locale to en_US"


### PR DESCRIPTION
Currently the resolv.conf file saved when building the image
is not applied because the file is rewritten on each startup.

This commit modifies the name of the file so that the nameservers
are added when starting up when generating the resolv.conf file
We remove the domain localdomain because it is useless in this situation.

Now with this list of DNS servers, they allow other DNS server
to be used if the local DNS server does not resolve the domain.