### PR TITLE
[FIX] sale: Hide partner_shipping_id field on vendor bill form

### DIFF
--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -1167,7 +1167,7 @@
                     <xpath expr="//field[@name='partner_id']" position="after">
                        <field name="partner_shipping_id"
                               groups="sale.group_delivery_invoice_address"
-                              attrs="{'invisible': [('type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund'))]}"/>
+                              attrs="{'invisible': [('type', 'not in', ('out_invoice', 'out_refund', 'out_receipt'))]}"/>
                    </xpath>
                     <xpath expr="//field[@name='invoice_line_ids']//field[@name='discount']" position="attributes">
                         <attribute name="groups">product.group_discount_per_so_line</attribute>


### PR DESCRIPTION
Bug introduced by:
https://github.com/odoo/odoo/commit/bc131c0cfb51c953de8ec41fb820c8c7831eefb5

issue: 2668902

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
