### PR TITLE
[FIX] web: click on time should work in kanban view

### DIFF
--- a/addons/web/static/src/legacy/js/views/kanban/kanban_record.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_record.js
@@ -683,7 +683,7 @@ var KanbanRecord = Widget.extend(WidgetAdapterMixin, {
             if (elem === event.currentTarget) {
                 ischild = false;
             }
-            var test_event = events && events.click && (events.click.length > 1 || events.click[0].namespace !== 'bs.tooltip');
+            var test_event = events && events.click && !elem.classList.contains('o_quick_editable') && (events.click.length > 1 || events.click[0].namespace !== 'bs.tooltip');
             var testLinkWithHref = elem.nodeName.toLowerCase() === 'a' && elem.href;
             if (ischild) {
                 children.push(elem);


### PR DESCRIPTION
Before this commit:
kanban click on time value does not open the form view.

After this commit:
kanban click on time value will open the form view.

Task-2655411

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
