### PR TITLE
[IMP] point_of_sale: more activated settings by default

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -72,7 +72,7 @@ class PosConfig(models.Model):
         help='The receipt will automatically be printed at the end of each order.')
     iface_print_skip_screen = fields.Boolean(string='Skip Preview Screen', default=True,
         help='The receipt screen will be skipped if the receipt can be printed automatically.')
-    iface_tax_included = fields.Selection([('subtotal', 'Tax-Excluded Price'), ('total', 'Tax-Included Price')], string="Tax Display", default='subtotal', required=True)
+    iface_tax_included = fields.Selection([('subtotal', 'Tax-Excluded Price'), ('total', 'Tax-Included Price')], string="Tax Display", default='total', required=True)
     iface_start_categ_id = fields.Many2one('pos.category', string='Initial Category',
         help='The point of sale will display this product category by default. If no category is specified, all available products will be shown.')
     iface_available_categ_ids = fields.Many2many('pos.category', string='Available PoS Product Categories',
@@ -140,7 +140,7 @@ class PosConfig(models.Model):
     module_pos_discount = fields.Boolean("Global Discounts")
     module_pos_loyalty = fields.Boolean("Loyalty Program")
     module_pos_mercury = fields.Boolean(string="Integrated Card Payments")
-    product_configurator = fields.Boolean(string="Product Configurator")
+    product_configurator = fields.Boolean(string="Product Configurator", default=True)
     is_posbox = fields.Boolean("PosBox")
     is_header_or_footer = fields.Boolean("Header & Footer")
     module_pos_hr = fields.Boolean(help="Show employee login screen")

--- a/addons/point_of_sale/models/res_company.py
+++ b/addons/point_of_sale/models/res_company.py
@@ -7,9 +7,9 @@ class ResCompany(models.Model):
     _inherit = 'res.company'
 
     point_of_sale_update_stock_quantities = fields.Selection([
-            ('closing', 'At the session closing (recommended)'),
-            ('real', 'In real time'),
-            ], default='closing', string="Update quantities in stock",
+            ('closing', 'At the session closing'),
+            ('real', 'In real time (recommended)'),
+            ], default='real', string="Update quantities in stock",
             help="At the session closing: A picking is created for the entire session when it's closed\n In real time: Each order sent to the server create its own picking")
 
     @api.constrains('period_lock_date', 'fiscalyear_lock_date')

--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -22,7 +22,7 @@ odoo.define('point_of_sale.tour.ProductScreen', function (require) {
     // Clicking product should add new orderline and select the orderline
     // If orderline exists, increment the quantity
     ProductScreen.do.clickDisplayedProduct('Letter Tray');
-    ProductScreen.check.selectedOrderlineHas('Letter Tray', '1.0', '4.80');
+    ProductScreen.check.selectedOrderlineHas('Letter Tray', '1.0', '5.28');
     ProductScreen.do.clickDisplayedProduct('Desk Organizer');
     ProductScreen.check.selectedOrderlineHas('Desk Organizer', '3.0', '15.30');
 

--- a/addons/pos_coupon/static/src/js/tours/PosCoupon1.tour.js
+++ b/addons/pos_coupon/static/src/js/tours/PosCoupon1.tour.js
@@ -50,7 +50,7 @@ odoo.define('pos_coupon.tour.pos_coupon1', function (require) {
     //   - on cheapest product
     ProductScreen.exec.addOrderline('Letter Tray', '4');
     ProductScreen.exec.addOrderline('Desk Organizer', '9');
-    PosCoupon.check.hasRewardLine('90.0% discount on cheapest product', '-4.32');
+    PosCoupon.check.hasRewardLine('90.0% discount on cheapest product', '-4.75');
     PosCoupon.check.orderTotalIs('62.27');
     PosCoupon.do.enterCode('5678');
     PosCoupon.check.hasRewardLine('Free Product - Desk Organizer', '-15.30');

--- a/addons/pos_coupon/static/src/js/tours/PosCoupon2.tour.js
+++ b/addons/pos_coupon/static/src/js/tours/PosCoupon2.tour.js
@@ -20,10 +20,10 @@ odoo.define('pos_coupon.tour.pos_coupon2', function (require) {
     ProductScreen.exec.addOrderline('Desk Organizer', '10'); // 5.1
     PosCoupon.check.hasRewardLine('on cheapest product', '-4.59');
     ProductScreen.exec.addOrderline('Letter Tray', '4'); // 4.8 tax 10%
-    PosCoupon.check.hasRewardLine('on cheapest product', '-4.32');
+    PosCoupon.check.hasRewardLine('on cheapest product', '-4.75');
     PosCoupon.do.enterCode('123456');
     PosCoupon.check.hasRewardLine('10.0% discount on total amount', '-5.10');
-    PosCoupon.check.hasRewardLine('10.0% discount on total amount', '-1.92');
+    PosCoupon.check.hasRewardLine('10.0% discount on total amount', '-2.11');
     PosCoupon.check.orderTotalIs('64.91');
     PosCoupon.exec.finalizeOrder('Cash', '70');
 


### PR DESCRIPTION
We provide a better experience when more settings are activated by default.

For this reason, we activated by default the following settings:
1. POS Settings
- Inventory Management is set to "In real time"

2. POS Shop Settings
- Product Prices is set to "Tax-Included Price"
- Product Configurator is activated

task-2616749

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
