### PR TITLE
[FIX] sale_timesheet_margin: prevent cost override on product service

### DIFF
--- a/addons/sale_margin/models/sale_order.py
+++ b/addons/sale_margin/models/sale_order.py
@@ -23,7 +23,7 @@ class SaleOrderLine(models.Model):
                 line.purchase_price = 0.0
                 continue
             line = line.with_company(line.company_id)
-            product_cost = line.product_id.standard_price
+            product_cost = line.product_id.standard_price if line.create_date is False or line.product_type != 'service' else line.purchase_price
             line.purchase_price = line._convert_price(product_cost, line.product_id.uom_id)
 
     @api.depends('price_subtotal', 'product_uom_qty', 'purchase_price')


### PR DESCRIPTION
### Current behavior
For a service product with Invoicing Policy set to Prepaid/Fixed Price, when we create a Sales Order with this product and change his Cost with a custom value and confirm the SO, the product's cost is overridden by the product's default cost.

### Steps to reproduce
1. Install Sales
2. Get a service type product with Invoicing Policy set to Prepaid/Fixed Price
3. Create a Sales Order
4. Add the service product from step 2
5. Change his cost
6. Confirm the SO

### Reason
Purchase price is recalculated when it should not be so it's overridden by product's standard price

OPW-2689756
