### PR TITLE
[IMP] tests: avoid double logs on build page

### DIFF
--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -45,6 +45,7 @@ from . import test_res_partner
 from . import test_res_partner_bank
 from . import test_res_users
 from . import test_reports
+from . import test_test_retry
 from . import test_test_suite
 from . import test_tests_tags
 from . import test_form_create

--- a/odoo/addons/base/tests/test_test_retry.py
+++ b/odoo/addons/base/tests/test_test_retry.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests import BaseCase, tagged
+
+import logging
+import os
+
+_logger = logging.getLogger(__name__)
+
+@tagged('-standard', 'test_retry', 'test_retry_success')
+class TestRetry(BaseCase):
+    """ Check some tests behaviour when ODOO_TEST_FAILURE_RETRIES is set"""
+
+    def test_log_levels(self):
+        _logger.debug('test debug')
+        _logger.info('test info')
+        _logger.runbot('test 25')
+
+    def test_retry_success(self):
+        tests_run_count = int(os.environ.get('ODOO_TEST_FAILURE_RETRIES', 0)) + 1
+        self.count = getattr(self, 'count', 0) + 1
+        self.assertEqual(tests_run_count, self.count)
+
+@tagged('-standard', 'test_retry', 'test_retry_failures')
+class TestRetryFailures(BaseCase):
+    def test_retry_failure_assert(self):
+        self.assertFalse(1 == 1)
+
+    def test_retry_failure_log(self):
+        _logger.error('Failure')

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -363,7 +363,7 @@ class BaseCase(unittest.TestCase, metaclass=MetaCase):
             if retry:
                 _logger.runbot(f'Retrying a failed test: {self}')
             if retry < tests_run_count-1:
-                with result.soft_fail(), lower_logging(25) as quiet_log:
+                with result.soft_fail(), lower_logging(25, logging.INFO) as quiet_log:
                     super().run(result)
                     failure = result.had_failure or quiet_log.had_error_log
             else:  # last try

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -795,12 +795,13 @@ class mute_logger(logging.Handler):
 class lower_logging(logging.Handler):
     """Temporary lower the max logging level.
     """
-    def __init__(self, max_level):
+    def __init__(self, max_level, to_level=None):
         super().__init__()
         self.old_handlers = None
         self.old_propagate = None
         self.had_error_log = False
         self.max_level = max_level
+        self.to_level = to_level or max_level
 
     def __enter__(self):
         logger = logging.getLogger()
@@ -819,13 +820,14 @@ class lower_logging(logging.Handler):
     def emit(self, record):
         if record.levelno > self.max_level:
             record.levelname = f'_{record.levelname}'
-            record.levelno = self.max_level
+            record.levelno = self.to_level
             self.had_error_log = True
             record.args = tuple(arg.replace('Traceback (most recent call last):', '_Traceback_ (most recent call last):') if type(arg) is str else arg for arg in record.args)  # pylint: disable=unidiomatic-typecheck
 
-        for handler in self.old_handlers:
-            if handler.level <= record.levelno:
-                handler.emit(record)
+        if logging.getLogger(record.name).isEnabledFor(record.levelno):
+            for handler in self.old_handlers:
+                if handler.level <= record.levelno:
+                    handler.emit(record)
 
 
 _ph = object()


### PR DESCRIPTION
Since auto-retry, real errors will lead to doubled errors on runbot.
This can be noisy and hard to understand.

This commit will help with this by using a lower log level on the first
execution. Log 25 are kepts.
