### PR TITLE
[FIX] stock, mrp: fix the manufacturing product moves filter

### DIFF
--- a/addons/mrp/views/stock_move_views.xml
+++ b/addons/mrp/views/stock_move_views.xml
@@ -139,6 +139,18 @@
             </field>
         </record>
 
+        <record id="stock_move_line_view_search" model="ir.ui.view">
+            <field name="name">stock.move.line.search</field>
+            <field name="model">stock.move.line</field>
+            <field name="inherit_id" ref="stock.stock_move_line_view_search" />
+            <field name="arch" type="xml">
+                <filter name="manufacturing" position="attributes">
+                    <attribute name="invisible">0</attribute>
+                    <attribute name="domain">[('move_id.production_id', '!=', False)]</attribute>
+                </filter>
+            </field>
+        </record>
+
     <menuitem id="menu_mrp_traceability"
           name="Lots/Serial Numbers"
           parent="menu_mrp_bom"

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -79,7 +79,7 @@
                 <filter string="Incoming" name="incoming" domain="[('picking_id.picking_type_id.code', '=', 'incoming')]"/>
                 <filter string="Outgoing" name="outgoing" domain="[('picking_id.picking_type_id.code', '=', 'outgoing')]"/>
                 <filter string="Internal" name="internal" domain="[('picking_id.picking_type_id.code', '=', 'internal')]"/>
-                <filter string="Manufacturing" name="manufacturing" domain="[('picking_id.picking_type_id.code', '=', 'mrp_operation')]"/>
+                <filter string="Manufacturing" name="manufacturing" domain="[('picking_id.picking_type_id.code', '=', 'mrp_operation')]" invisible="1"/>
                 <separator/>
                 <group expand="0" string="Group By">
                     <filter string="Product" name="groupby_product_id" domain="[]" context="{'group_by': 'product_id'}"/>


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product > add a BOM
- Create a MO> add the product > confirm > Mark as done
- Go to the product form > click on product moves
- The move linked to the MO is displayed
- Add the "Manufacturing" filter
- No move is displayed

Solution:
Display all "stock.move.line" which are linked to a "stock.move" with a "mrp.production"

Bug2:
The "Manufacturing" filter should be defined in the MRP module instead of the stock
otherwise, users who do not have MRP installed will have access to this filter as well

opw-2697254




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
