### PR TITLE
[FIX] stock: fix grammar in reordering rule view

### DIFF
--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -217,7 +217,7 @@
           <p class="o_view_nocontent_smiling_face">
             No reordering rule found
           </p><p>
-            Define a minimum stock rule so that Odoo creates automatically requests for quotations or confirmed manufacturing orders to resupply your stock.
+            Define a minimum stock rule so that Odoo automatically creates requests for quotations or confirmed manufacturing orders to resupply your stock.
           </p>
         </field>
     </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
A grammar mistake in reordering rule view

Current behavior before PR:
Sentence grammatically wrong

Desired behavior after PR is merged:
Sentence grammatically correct


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
