### PR TITLE
[IMP] l10n_id: update Indonesian generic COA

### DIFF
--- a/addons/l10n_id/data/account.account.template.csv
+++ b/addons/l10n_id/data/account.account.template.csv
@@ -10,7 +10,6 @@ a_1_112006,1112006,BNI Giro,account.data_account_type_liquidity,TRUE,l10n_id_cha
 a_1_112007,1112007,Mandiri Giro,account.data_account_type_liquidity,TRUE,l10n_id_chart
 a_1_121001,1121001,Account Receivable,account.data_account_type_receivable,TRUE,l10n_id_chart
 a_1_1210011,11210011,Account Receivable (PoS),account.data_account_type_receivable,TRUE,l10n_id_chart
-a_1_121002,1121002,Employee Liabilities,account.data_account_type_current_assets,TRUE,l10n_id_chart
 a_1_130001,1130001,"Meat Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
 a_1_130002,1130002,"Fish Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
 a_1_130003,1130003,"Vegetables Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
@@ -29,50 +28,51 @@ a_1_130015,1130015,"House Supplies Inventory",account.data_account_type_current_
 a_1_130016,1130016,"Electronic Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
 a_1_130017,1130017,"Toys Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
 a_1_130018,1130018,"Other Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_141001,1141001,"Building Rent",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_141002,1141002,"Prepaid Insurance",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_141003,1141003,"Prepaid Advertisement-Free",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_151001,1151001,"Prepaid Tax Pph 22",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_151002,1151002,"Prepaid Tax Pph 23",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_151003,1151003,"Prepaid Tax Pph 25",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_180000,1180000,"Down Payment",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_211003,1211003,"Owner Receivable",account.data_account_type_current_assets,TRUE,l10n_id_chart
-a_1_211004,1211004,"Other Receivable",account.data_account_type_current_assets,TRUE,l10n_id_chart
-a_1_221001,1221001,"Land",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_221002,1221002,"Office Building",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_221003,1221003,"Vehicle",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_221004,1221004,"Office Supplies",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_221005,1221005,"Software",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_221006,1221006,"Office Furniture",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_228101,1228101,"Accumulation Building Depreciation",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_228102,1228102,"Accumulation Vehicle Depreciation",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_228103,1228103,"Accumulation Office Supplies Depreciation",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_228104,1228104,"Accumulation Software Depreciation",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_228105,1228105,"Accumulation Office Furniture Depreciation",account.data_account_type_prepayments,FALSE,l10n_id_chart
+a_1_140001,1140001,"Owner Receivable",account.data_account_type_receivable,TRUE,l10n_id_chart
+a_1_140002,1140002,"Other Receivable",account.data_account_type_receivable,TRUE,l10n_id_chart
+a_1_150011,1150011,"Prepaid Building Rent",account.data_account_type_prepayments,FALSE,l10n_id_chart
+a_1_150012,1150012,"Prepaid Insurance",account.data_account_type_prepayments,FALSE,l10n_id_chart
+a_1_150013,1150013,"Prepaid Advertisement-Free",account.data_account_type_prepayments,FALSE,l10n_id_chart
+a_1_150021,1150021,"Prepaid Tax Pph 22",account.data_account_type_prepayments,FALSE,l10n_id_chart
+a_1_150022,1150022,"Prepaid Tax Pph 23",account.data_account_type_prepayments,FALSE,l10n_id_chart
+a_1_150023,1150023,"Prepaid Tax Pph 25",account.data_account_type_prepayments,FALSE,l10n_id_chart
+a_1_180000,1180000,"Down Payment",account.data_account_type_current_assets,FALSE,l10n_id_chart
+a_1_221001,1221001,"Land",account.data_account_type_fixed_assets,FALSE,l10n_id_chart
+a_1_221002,1221002,"Office Building",account.data_account_type_fixed_assets,FALSE,l10n_id_chart
+a_1_221003,1221003,"Vehicle",account.data_account_type_fixed_assets,FALSE,l10n_id_chart
+a_1_221004,1221004,"Office Supplies",account.data_account_type_fixed_assets,FALSE,l10n_id_chart
+a_1_221005,1221005,"Software",account.data_account_type_fixed_assets,FALSE,l10n_id_chart
+a_1_221006,1221006,"Office Furniture",account.data_account_type_fixed_assets,FALSE,l10n_id_chart
+a_1_228101,1228101,"Accumulation Building Depreciation",account.data_account_type_non_current_assets,FALSE,l10n_id_chart
+a_1_228102,1228102,"Accumulation Vehicle Depreciation",account.data_account_type_non_current_assets,FALSE,l10n_id_chart
+a_1_228103,1228103,"Accumulation Office Supplies Depreciation",account.data_account_type_non_current_assets,FALSE,l10n_id_chart
+a_1_228104,1228104,"Accumulation Software Depreciation",account.data_account_type_non_current_assets,FALSE,l10n_id_chart
+a_1_228105,1228105,"Accumulation Office Furniture Depreciation",account.data_account_type_non_current_assets,FALSE,l10n_id_chart
+a_2_000001,2000001,"Long-term Debts",account.data_account_type_non_current_liabilities,FALSE,l10n_id_chart
 a_2_110001,2110001,"Trade Receivable",account.data_account_type_payable,TRUE,l10n_id_chart
 a_2_110002,2110002,"Shareholder Deposit",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
 a_2_110003,2110003,"Third-Party Deposit",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
 a_2_110004,2110004,"Salary Deposit",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_121001,2121001,"Tax Payable Pph 21",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_121002,2121002,"Tax Payable Pph 23",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_121003,2121003,"Tax Payable Pph 25",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_121004,2121004,"Tax Payable 4 (2)",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_121005,2121005,"Tax Payable Pph 29",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
+a_2_121001,2121001,"Tax Payable Pph 21",account.data_account_type_payable,TRUE,l10n_id_chart
+a_2_121002,2121002,"Tax Payable Pph 23",account.data_account_type_payable,TRUE,l10n_id_chart
+a_2_121003,2121003,"Tax Payable Pph 25",account.data_account_type_payable,TRUE,l10n_id_chart
+a_2_121004,2121004,"Tax Payable 4 (2)",account.data_account_type_payable,TRUE,l10n_id_chart
+a_2_121005,2121005,"Tax Payable Pph 29",account.data_account_type_payable,TRUE,l10n_id_chart
 a_2_122101,2122101,"VAT Purchase",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
 a_2_122102,2122102,"VAT Sales",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
 a_2_211001,2211001,"Bank Loan",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
 a_2_211002,2211002,"Leasing Deposit",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511001,2511001,"Accrued Payable Electricity",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511002,2511002,"Accrued Payable Jamsostek",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511003,2511003,"Accrued Payable Water",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511004,2511004,"Accrued Payable Telp & Internet",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511005,2511005,"Accrued Payable Security Management",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511006,2511006,"Accrued Payable Bank",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511007,2511007,"Accrued Payable PBB",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511008,2511008,"Accrued Payable Business License",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511009,2511009,"Accrued Payable Insurance",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511010,2511010,"Accrued Payable Education",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511011,2511011,"Accrued Payable Health Insurance/BPJS",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
+a_2_511001,2511001,"Accrued Payable Electricity",account.data_account_type_payable,TRUE,l10n_id_chart
+a_2_511002,2511002,"Accrued Payable Jamsostek",account.data_account_type_payable,TRUE,l10n_id_chart
+a_2_511003,2511003,"Accrued Payable Water",account.data_account_type_payable,TRUE,l10n_id_chart
+a_2_511004,2511004,"Accrued Payable Telp & Internet",account.data_account_type_payable,TRUE,l10n_id_chart
+a_2_511005,2511005,"Accrued Payable Security Management",account.data_account_type_payable,TRUE,l10n_id_chart
+a_2_511006,2511006,"Accrued Payable Bank",account.data_account_type_payable,TRUE,l10n_id_chart
+a_2_511007,2511007,"Accrued Payable PBB",account.data_account_type_payable,TRUE,l10n_id_chart
+a_2_511008,2511008,"Accrued Payable Business License",account.data_account_type_payable,TRUE,l10n_id_chart
+a_2_511009,2511009,"Accrued Payable Insurance",account.data_account_type_payable,TRUE,l10n_id_chart
+a_2_511010,2511010,"Accrued Payable Education",account.data_account_type_payable,TRUE,l10n_id_chart
+a_2_511011,2511011,"Accrued Payable Health Insurance/BPJS",account.data_account_type_payable,TRUE,l10n_id_chart
 a_2_811001,2811001,"Advance Sales",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
 a_2_811002,2811002,"Customer Deposit",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
 a_2_811003,2811003,"Bonus Point",account.data_account_type_current_liabilities,FALSE,l10n_id_chart

--- a/addons/l10n_id/i18n_extra/id.po
+++ b/addons/l10n_id/i18n_extra/id.po
@@ -178,8 +178,8 @@ msgid "Building Maintenance Costs"
 msgstr "Biaya Pemeliharaan & Perawatan Gedung"
 
 #. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_141001
-msgid "Building Rent"
+#: model:account.account.template,name:l10n_id.a_1_150011
+msgid "Prepaid Building Rent"
 msgstr "Sewa Bangunan"
 
 #. module: l10n_id
@@ -286,11 +286,6 @@ msgstr "Tunjangan/ Bonus Karyawan"
 #: model:account.account.template,name:l10n_id.a_6_110003
 msgid "Employee Health Benefits"
 msgstr "Tunjangan Kesehatan Karyawan"
-
-#. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_121002
-msgid "Employee Liabilities"
-msgstr "Piutang Karyawan"
 
 #. module: l10n_id
 #: model:account.account.template,name:l10n_id.a_6_110004
@@ -537,7 +532,7 @@ msgid "Other Necessities"
 msgstr "Keperluan Lain-lain"
 
 #. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_211004
+#: model:account.account.template,name:l10n_id.a_1_140002
 msgid "Other Receivable"
 msgstr "Piutang lainnya"
 
@@ -547,7 +542,7 @@ msgid "Owner Necessities"
 msgstr "Keperluan Owner"
 
 #. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_211003
+#: model:account.account.template,name:l10n_id.a_1_140001
 msgid "Owner Receivable"
 msgstr "Piutang Owner"
 
@@ -602,12 +597,12 @@ msgid "Pph 21 Benefit"
 msgstr "Tunjangan PPH Pasal 21"
 
 #. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_141003
+#: model:account.account.template,name:l10n_id.a_1_150013
 msgid "Prepaid Advertisement-Free"
 msgstr "Beban Iklan Dibayar Dimuka"
 
 #. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_141002
+#: model:account.account.template,name:l10n_id.a_1_150012
 msgid "Prepaid Insurance"
 msgstr "Asuransi Dibayar Dimuka"
 
@@ -617,17 +612,17 @@ msgid "Prepaid Phone Bills"
 msgstr "Pulsa"
 
 #. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_151001
+#: model:account.account.template,name:l10n_id.a_1_150021
 msgid "Prepaid Tax Pph 22"
 msgstr "Pajak Dibayar Dimuka PPH 22"
 
 #. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_151002
+#: model:account.account.template,name:l10n_id.a_1_150022
 msgid "Prepaid Tax Pph 23"
 msgstr "Pajak Dibayar Dimuka PPH 23"
 
 #. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_151003
+#: model:account.account.template,name:l10n_id.a_1_150023
 msgid "Prepaid Tax Pph 25"
 msgstr "Pajak Dibayar Dimuka PPH 25"
 
@@ -827,3 +822,8 @@ msgstr "PDAM"
 #: model:account.account.template,name:l10n_id.a_6_110007
 msgid "Work Uniform"
 msgstr "Pakaian Kerja"
+
+#. module: l10n_id
+#: model:account.account.template,name:l10n_id.a_2_000001
+msgid "Long-term Debts"
+msgstr "Kewajiban Jangka Panjang"

--- a/addons/l10n_id/i18n_extra/l10n_id.pot
+++ b/addons/l10n_id/i18n_extra/l10n_id.pot
@@ -177,8 +177,8 @@ msgid "Building Maintenance Costs"
 msgstr ""
 
 #. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_141001
-msgid "Building Rent"
+#: model:account.account.template,name:l10n_id.a_1_150011
+msgid "Prepaid Building Rent"
 msgstr ""
 
 #. module: l10n_id
@@ -284,11 +284,6 @@ msgstr ""
 #. module: l10n_id
 #: model:account.account.template,name:l10n_id.a_6_110003
 msgid "Employee Health Benefits"
-msgstr ""
-
-#. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_121002
-msgid "Employee Liabilities"
 msgstr ""
 
 #. module: l10n_id
@@ -536,7 +531,7 @@ msgid "Other Necessities"
 msgstr ""
 
 #. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_211004
+#: model:account.account.template,name:l10n_id.a_1_140002
 msgid "Other Receivable"
 msgstr ""
 
@@ -546,7 +541,7 @@ msgid "Owner Necessities"
 msgstr ""
 
 #. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_211003
+#: model:account.account.template,name:l10n_id.a_1_140001
 msgid "Owner Receivable"
 msgstr ""
 
@@ -601,12 +596,12 @@ msgid "Pph 21 Benefit"
 msgstr ""
 
 #. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_141003
+#: model:account.account.template,name:l10n_id.a_1_150013
 msgid "Prepaid Advertisement-Free"
 msgstr ""
 
 #. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_141002
+#: model:account.account.template,name:l10n_id.a_1_150012
 msgid "Prepaid Insurance"
 msgstr ""
 
@@ -616,17 +611,17 @@ msgid "Prepaid Phone Bills"
 msgstr ""
 
 #. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_151001
+#: model:account.account.template,name:l10n_id.a_1_150021
 msgid "Prepaid Tax Pph 22"
 msgstr ""
 
 #. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_151002
+#: model:account.account.template,name:l10n_id.a_1_150022
 msgid "Prepaid Tax Pph 23"
 msgstr ""
 
 #. module: l10n_id
-#: model:account.account.template,name:l10n_id.a_1_151003
+#: model:account.account.template,name:l10n_id.a_1_150023
 msgid "Prepaid Tax Pph 25"
 msgstr ""
 
@@ -825,4 +820,9 @@ msgstr ""
 #. module: l10n_id
 #: model:account.account.template,name:l10n_id.a_6_110007
 msgid "Work Uniform"
+msgstr ""
+
+#. module: l10n_id
+#: model:account.account.template,name:l10n_id.a_2_000001
+msgid "Long-term Debts"
 msgstr ""


### PR DESCRIPTION
Some accounts in the Indonesian COA are wrong, and it could do with some extra ones.
Errors mostly come from accounts having a wrong type assigned to them.
For instance, no account were labeled as fixed assets (instead most were labeled prepayments, which are current assets).

Also update the translation accordingly.

Task id=2699652

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
