### PR TITLE
[FIX] point_of_sale, pos_coupon, pos_hr, pos_restaurant : Check COA not used

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -558,7 +558,7 @@ class PosConfig(models.Model):
             'target': 'self',
         }
 
-    def open_session_cb(self, check_coa=True):
+    def open_session_cb(self):
         """ new session button
 
         create one if none exist

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -520,7 +520,7 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
             * currency : currency of the current pos.session
             * pricelist : the default pricelist of the session
         """
-        self.config.open_session_cb(check_coa=False)
+        self.config.open_session_cb()
         self.pos_session = self.config.current_session_id
         self.currency = self.pos_session.currency_id
         self.pricelist = self.pos_session.config_id.pricelist_id

--- a/addons/point_of_sale/tests/test_anglo_saxon.py
+++ b/addons/point_of_sale/tests/test_anglo_saxon.py
@@ -65,7 +65,7 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
     def test_create_account_move_line(self):
         # This test will check that the correct journal entries are created when a product in real time valuation
         # is sold in a company using anglo-saxon
-        self.pos_config.open_session_cb(check_coa=False)
+        self.pos_config.open_session_cb()
         current_session = self.pos_config.current_session_id
         self.cash_journal.loss_account_id = self.account
         current_session.set_cashbox_pos(0, None)
@@ -148,7 +148,7 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
         self.assertEqual(self.product.quantity_svl, 10)
 
         self.pos_config.module_account = True
-        self.pos_config.open_session_cb(check_coa=False)
+        self.pos_config.open_session_cb()
         pos_session = self.pos_config.current_session_id
         pos_session.set_cashbox_pos(0, None)
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -490,7 +490,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         # open a session, the /pos/ui controller will redirect to it
-        self.main_pos_config.open_session_cb(check_coa=False)
+        self.main_pos_config.open_session_cb()
 
         # needed because tests are run before the module is marked as
         # installed. In js web will only load qweb coming from modules
@@ -512,7 +512,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertEqual(email_count, 1)
 
     def test_02_pos_with_invoiced(self):
-        self.main_pos_config.open_session_cb(check_coa=False)
+        self.main_pos_config.open_session_cb()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ChromeTour', login="accountman")
         n_invoiced = self.env['pos.order'].search_count([('state', '=', 'invoiced')])
         n_paid = self.env['pos.order'].search_count([('state', '=', 'paid')])
@@ -521,9 +521,9 @@ class TestUi(TestPointOfSaleHttpCommon):
 
     def test_04_product_configurator(self):
         self.main_pos_config.write({ 'product_configurator': True })
-        self.main_pos_config.open_session_cb(check_coa=False)
+        self.main_pos_config.open_session_cb()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config, 'ProductConfiguratorTour', login="accountman")
 
     def test_05_ticket_screen(self):
-        self.main_pos_config.open_session_cb(check_coa=False)
+        self.main_pos_config.open_session_cb()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'TicketScreenTour', login="accountman")

--- a/addons/point_of_sale/tests/test_js.py
+++ b/addons/point_of_sale/tests/test_js.py
@@ -13,7 +13,7 @@ class WebSuite(odoo.tests.HttpCase):
 
     def test_pos_js(self):
         # open a session, the /pos/ui controller will redirect to it
-        self.main_pos_config.open_session_cb(check_coa=False)
+        self.main_pos_config.open_session_cb()
 
         # point_of_sale desktop test suite
         self.browser_js("/pos/ui/tests?mod=web", "", "", login="admin", timeout=1800)

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -22,7 +22,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         return untax, sum(tax.get('amount', 0.0) for tax in res['taxes'])
 
     def test_order_refund(self):
-        self.pos_config.open_session_cb(check_coa=False)
+        self.pos_config.open_session_cb()
         current_session = self.pos_config.current_session_id
         # I create a new PoS order with 2 lines
         order = self.PosOrder.create({
@@ -194,7 +194,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         """
 
         # I click on create a new session button
-        self.pos_config.open_session_cb(check_coa=False)
+        self.pos_config.open_session_cb()
         current_session = self.pos_config.current_session_id
 
         # I create a PoS order with 2 units of PCSC234 at 450 EUR
@@ -482,7 +482,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
 
     def test_order_to_invoice(self):
 
-        self.pos_config.open_session_cb(check_coa=False)
+        self.pos_config.open_session_cb()
         current_session = self.pos_config.current_session_id
 
         untax1, atax1 = self.compute_tax(self.product3, 450*0.95, 2)
@@ -598,7 +598,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         """
 
         # I click on create a new session button
-        self.pos_config.open_session_cb(check_coa=False)
+        self.pos_config.open_session_cb()
 
         current_session = self.pos_config.current_session_id
         num_starting_orders = len(current_session.order_ids)
@@ -778,7 +778,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         })
 
         # I click on create a new session button
-        eur_config.open_session_cb(check_coa=False)
+        eur_config.open_session_cb()
         current_session = eur_config.current_session_id
 
         # I create a PoS order with 2 units of PCSC234 at 450 EUR (Tax Incl)
@@ -877,7 +877,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             self.assertAlmostEqual(a, b)
 
     def test_order_to_invoice_no_tax(self):
-        self.pos_config.open_session_cb(check_coa=False)
+        self.pos_config.open_session_cb()
         current_session = self.pos_config.current_session_id
 
         # I create a new PoS order with 2 units of PC1 at 450 EUR (Tax Incl) and 3 units of PCSC349 at 300 EUR. (Tax Excl)
@@ -957,7 +957,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         })
 
         # sell product thru pos
-        self.pos_config.open_session_cb(check_coa=False)
+        self.pos_config.open_session_cb()
         pos_session = self.pos_config.current_session_id
         untax, atax = self.compute_tax(product5, 10.0)
         product5_order = {'data':

--- a/addons/pos_coupon/models/pos_config.py
+++ b/addons/pos_coupon/models/pos_config.py
@@ -44,7 +44,7 @@ class PosConfig(models.Model):
         for config in self:
             config.program_ids = config.coupon_program_ids | config.promo_program_ids
 
-    def open_session_cb(self, check_coa=True):
+    def open_session_cb(self):
         # Check validity of programs before opening a new session
         invalid_reward_products_msg = ""
         for program in self.program_ids:
@@ -67,7 +67,7 @@ class PosConfig(models.Model):
             )
             raise UserError(f"{intro}\n{invalid_reward_products_msg}")
 
-        return super(PosConfig, self).open_session_cb(check_coa)
+        return super(PosConfig, self).open_session_cb()
 
     def use_coupon_code(self, code, creation_date, partner_id, reserved_program_ids):
         coupon_to_check = self.env["coupon.coupon"].search(

--- a/addons/pos_coupon/tests/test_frontend.py
+++ b/addons/pos_coupon/tests/test_frontend.py
@@ -100,7 +100,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             for promo_program in self.promo_programs:
                 pos_config.promo_program_ids.add(promo_program)
 
-        self.main_pos_config.open_session_cb(check_coa=False)
+        self.main_pos_config.open_session_cb()
 
         ##
         # Tour Part 1

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -56,7 +56,7 @@ class TestPosHrHttpCommon(TestPointOfSaleHttpCommon):
 class TestUi(TestPosHrHttpCommon):
     def test_01_pos_hr_tour(self):
         # open a session, the /pos/ui controller will redirect to it
-        self.main_pos_config.open_session_cb(check_coa=False)
+        self.main_pos_config.open_session_cb()
 
         self.start_tour(
             "/pos/ui?config_id=%d" % self.main_pos_config.id,

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -155,7 +155,7 @@ class TestFrontend(odoo.tests.HttpCase):
 
     def test_01_pos_restaurant(self):
 
-        self.pos_config.with_user(self.env.ref('base.user_admin')).open_session_cb(check_coa=False)
+        self.pos_config.with_user(self.env.ref('base.user_admin')).open_session_cb()
 
         self.start_tour("/pos/ui?config_id=%d" % self.pos_config.id, 'pos_restaurant_sync', login="admin")
 
@@ -169,18 +169,18 @@ class TestFrontend(odoo.tests.HttpCase):
         self.assertEqual(2, self.env['pos.order'].search_count([('amount_total', '=', 4.4), ('state', '=', 'paid')]))
 
     def test_02_others(self):
-        self.pos_config.with_user(self.env.ref('base.user_admin')).open_session_cb(check_coa=False)
+        self.pos_config.with_user(self.env.ref('base.user_admin')).open_session_cb()
         self.start_tour("/pos/ui?config_id=%d" % self.pos_config.id, 'SplitBillScreenTour', login="admin")
         self.start_tour("/pos/ui?config_id=%d" % self.pos_config.id, 'ControlButtonsTour', login="admin")
         self.start_tour("/pos/ui?config_id=%d" % self.pos_config.id, 'FloorScreenTour', login="admin")
 
     def test_04_ticket_screen(self):
-        self.pos_config.with_user(self.env.ref('base.user_admin')).open_session_cb(check_coa=False)
+        self.pos_config.with_user(self.env.ref('base.user_admin')).open_session_cb()
         self.start_tour("/pos/ui?config_id=%d" % self.pos_config.id, 'PosResTicketScreenTour', login="admin")
 
     def test_05_tip_screen(self):
         self.pos_config.write({'set_tip_after_payment': True, 'iface_tipproduct': True, 'tip_product_id': self.env.ref('point_of_sale.product_product_tip')})
-        self.pos_config.with_user(self.env.ref('base.user_admin')).open_session_cb(check_coa=False)
+        self.pos_config.with_user(self.env.ref('base.user_admin')).open_session_cb()
         self.start_tour("/pos/ui?config_id=%d" % self.pos_config.id, 'PosResTipScreenTour', login="admin")
 
         order1 = self.env['pos.order'].search([('pos_reference', 'ilike', '%-0001')])


### PR DESCRIPTION
Check COA parameter in the open_session_cb was actually never used

opw-2691615

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
