### PR TITLE
[FIX] web_editor: postprocess snippet once added through powerbox

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1634,10 +1634,13 @@ const Wysiwyg = Widget.extend({
     _getSnippetsCommands: function () {
         const snippetCommandCallback = (selector) => {
             const $separatorBody = $(selector);
-            const $clonedBody = $separatorBody.clone();
+            const $clonedBody = $separatorBody.clone().removeClass('oe_snippet_body');
             const range = getDeepRange(this.odooEditor.editable);
             const block = closestElement(range.endContainer, 'p, div, ol, ul, cl, h1, h2, h3, h4, h5, h6');
-            block && block.after($clonedBody[0]);
+            if (block) {
+                block.after($clonedBody[0]);
+                this.snippetsMenu.callPostSnippetDrop($clonedBody);
+            }
         };
         return [
             {


### PR DESCRIPTION
Whenever adding a snippet from the powerbox, the postprocessing was not
made. This could result in unexpected behavior of the snippet.

Task-2601600



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
