### PR TITLE
[FIX] account: Fix available_partner_bank_ids in payment & register payment wizard

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from lxml import etree
 
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError, ValidationError
@@ -44,10 +45,14 @@ class AccountPayment(models.Model):
     is_matched = fields.Boolean(string="Is Matched With a Bank Statement", store=True,
         compute='_compute_reconciliation_status',
         help="Technical field indicating if the payment has been matched with a statement line.")
+    available_partner_bank_ids = fields.Many2many(
+        comodel_name='res.partner.bank',
+        compute='_compute_available_partner_bank_ids',
+    )
     partner_bank_id = fields.Many2one('res.partner.bank', string="Recipient Bank Account",
         readonly=False, store=True,
         compute='_compute_partner_bank_id',
-        domain="[('partner_id', '=', partner_id)]",
+        domain="[('id', 'in', available_partner_bank_ids)]",
         check_company=True)
     is_internal_transfer = fields.Boolean(string="Is Internal Transfer",
         readonly=False, store=True,
@@ -332,20 +337,19 @@ class AccountPayment(models.Model):
             payment.require_partner_bank_account = payment.state == 'draft' and payment.payment_method_code in self._get_method_codes_needing_bank_account()
 
     @api.depends('partner_id', 'company_id', 'payment_type')
+    def _compute_available_partner_bank_ids(self):
+        for pay in self:
+            if pay.payment_type == 'inbound':
+                pay.available_partner_bank_ids = pay.journal_id.bank_account_id
+            else:
+                pay.available_partner_bank_ids = pay.partner_id.bank_ids\
+                        .filtered(lambda x: x.company_id.id in (False, pay.company_id.id))._origin
+
+    @api.depends('available_partner_bank_ids', 'journal_id')
     def _compute_partner_bank_id(self):
         ''' The default partner_bank_id will be the first available on the partner. '''
         for pay in self:
-            if pay.payment_type == 'inbound':
-                bank_partner = pay.company_id.partner_id
-            else:
-                bank_partner = pay.partner_id
-
-            available_partner_bank_accounts = bank_partner.bank_ids.filtered(lambda x: x.company_id.id in (False, pay.company_id.id))
-            if available_partner_bank_accounts:
-                if pay.partner_bank_id not in available_partner_bank_accounts:
-                    pay.partner_bank_id = available_partner_bank_accounts[0]._origin
-            else:
-                pay.partner_bank_id = False
+            pay.partner_bank_id = pay.available_partner_bank_ids[:1]._origin
 
     @api.depends('partner_id', 'destination_account_id', 'journal_id')
     def _compute_is_internal_transfer(self):
@@ -572,6 +576,29 @@ class AccountPayment(models.Model):
     # -------------------------------------------------------------------------
     # LOW-LEVEL METHODS
     # -------------------------------------------------------------------------
+
+    @api.model
+    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+        # OVERRIDE to add the 'available_partner_bank_ids' field dynamically inside the view.
+        # TO BE REMOVED IN MASTER
+        res = super().fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        if view_type == 'form':
+            form_view_id = self.env['ir.model.data'].xmlid_to_res_id('account.view_account_payment_form')
+            if res.get('view_id') == form_view_id:
+                tree = etree.fromstring(res['arch'])
+                if len(tree.xpath("//field[@name='available_partner_bank_ids']")) == 0:
+                    # Don't force people to update the account module.
+                    form_view = self.env.ref('account.view_account_payment_form')
+                    arch_tree = etree.fromstring(form_view.arch)
+                    if arch_tree.tag == 'form':
+                        arch_tree.insert(0, etree.Element('field', attrib={
+                            'name': 'available_partner_bank_ids',
+                            'invisible': '1',
+                        }))
+                        form_view.sudo().write({'arch': etree.tostring(arch_tree, encoding='unicode')})
+                        return super().fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+
+        return res
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -158,6 +158,7 @@
                         <field name="show_partner_bank_account" invisible="1"/>
                         <field name="require_partner_bank_account" invisible="1"/>
                         <field name="hide_payment_method" invisible="1"/>
+                        <field name="available_partner_bank_ids" invisible="1"/>
                         <field name="available_payment_method_ids" invisible="1"/>
                         <field name="suitable_journal_ids" invisible="1"/>
                         <field name="country_code" invisible="1"/>

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -128,21 +128,73 @@ class AccountPaymentRegister(models.TransientModel):
         return ' '.join(sorted(labels))
 
     @api.model
+    def _get_batch_journal(self, batch_result):
+        """ Helper to compute the journal based on the batch.
+
+        :param batch_result:    A batch returned by '_get_batches'.
+        :return:                An account.journal record.
+        """
+        key_values = batch_result['key_values']
+        foreign_currency_id = key_values['currency_id']
+        partner_bank_id = key_values['partner_bank_id']
+
+        currency_domain = [('currency_id', '=', foreign_currency_id)]
+        partner_bank_domain = [('bank_account_id', '=', partner_bank_id)]
+
+        default_domain = [
+            ('type', 'in', ('bank', 'cash')),
+            ('company_id', '=', batch_result['lines'].company_id.id),
+        ]
+
+        if partner_bank_id:
+            extra_domains = (
+                currency_domain + partner_bank_domain,
+                partner_bank_domain,
+                currency_domain,
+                [],
+            )
+        else:
+            extra_domains = (
+                currency_domain,
+                [],
+            )
+
+        for extra_domain in extra_domains:
+            journal = self.env['account.journal'].search(default_domain + extra_domain, limit=1)
+            if journal:
+                return journal
+
+        return self.env['account.journal']
+
+    @api.model
+    def _get_batch_available_partner_banks(self, batch_result, journal):
+        key_values = batch_result['key_values']
+        company = batch_result['lines'].company_id
+
+        # A specific bank account is set on the journal. The user must use this one.
+        if key_values['payment_type'] == 'inbound':
+            # Receiving money on a bank account linked to the journal.
+            return journal.bank_account_id
+        else:
+            # Sending money to a bank account owned by a partner.
+            return batch_result['lines'].partner_id.bank_ids.filtered(lambda x: x.company_id.id in (False, company.id))._origin
+
+    @api.model
     def _get_line_batch_key(self, line):
         ''' Turn the line passed as parameter to a dictionary defining on which way the lines
         will be grouped together.
         :return: A python dictionary.
         '''
         move = line.move_id
-        partner_bank_account = self.env['res.partner.bank']
 
+        partner_bank_account = self.env['res.partner.bank']
         if move.is_invoice(include_receipts=True):
             partner_bank_account = move.partner_bank_id._origin
 
         return {
             'partner_id': line.partner_id.id,
             'account_id': line.account_id.id,
-            'currency_id': (line.currency_id or line.company_currency_id).id,
+            'currency_id': line.currency_id.id,
             'partner_bank_id': partner_bank_account.id,
             'partner_type': 'customer' if line.account_internal_type == 'receivable' else 'supplier',
             'payment_type': 'inbound' if line.balance > 0.0 else 'outbound',
@@ -173,6 +225,7 @@ class AccountPaymentRegister(models.TransientModel):
                 'lines': self.env['account.move.line'],
             })
             batches[serialized_key]['lines'] += line
+
         return list(batches.values())
 
     @api.model
@@ -227,7 +280,6 @@ class AccountPaymentRegister(models.TransientModel):
                     'partner_id': False,
                     'partner_type': False,
                     'payment_type': wizard_values_from_batch['payment_type'],
-                    'partner_bank_id': False,
                     'source_currency_id': False,
                     'source_amount': False,
                     'source_amount_currency': False,
@@ -256,39 +308,40 @@ class AccountPaymentRegister(models.TransientModel):
             else:
                 wizard.group_payment = False
 
-    @api.depends('company_id', 'source_currency_id')
+    @api.depends('can_edit_wizard', 'company_id')
     def _compute_journal_id(self):
         for wizard in self:
-            domain = [
-                ('type', 'in', ('bank', 'cash')),
-                ('company_id', '=', wizard.company_id.id),
-            ]
-            journal = None
-            if wizard.source_currency_id:
-                journal = self.env['account.journal'].search(domain + [('currency_id', '=', wizard.source_currency_id.id)], limit=1)
-            if not journal:
-                journal = self.env['account.journal'].search(domain, limit=1)
-            wizard.journal_id = journal
+            if wizard.can_edit_wizard:
+                batch = wizard._get_batches()[0]
+                wizard.journal_id = wizard._get_batch_journal(batch)
+            else:
+                wizard.journal_id = self.env['account.journal'].search([
+                    ('type', 'in', ('bank', 'cash')),
+                    ('company_id', '=', wizard.company_id.id),
+                ], limit=1)
 
-    @api.depends('company_id', 'can_edit_wizard')
+    @api.depends('can_edit_wizard', 'journal_id')
     def _compute_available_partner_bank_ids(self):
         for wizard in self:
             if wizard.can_edit_wizard:
-                batches = wizard._get_batches()
-                bank_partners = batches[0]['lines'].move_id.bank_partner_id
-                wizard.available_partner_bank_ids = bank_partners.bank_ids\
-                    .filtered(lambda x: x.company_id.id in (False, wizard.company_id.id))._origin
+                batch = wizard._get_batches()[0]
+                wizard.available_partner_bank_ids = wizard._get_batch_available_partner_banks(batch, wizard.journal_id)
             else:
-                wizard.available_partner_bank_ids = False
+                wizard.available_partner_bank_ids = None
 
-    @api.depends('available_partner_bank_ids')
+    @api.depends('journal_id', 'available_partner_bank_ids')
     def _compute_partner_bank_id(self):
         for wizard in self:
             if wizard.can_edit_wizard:
-                batches = wizard._get_batches()
-                wizard.partner_bank_id = self.env['res.partner.bank'].browse(batches[0]['key_values']['partner_bank_id'])
+                batch = wizard._get_batches()[0]
+                partner_bank_id = batch['key_values']['partner_bank_id']
+                available_partner_banks = wizard.available_partner_bank_ids._origin
+                if partner_bank_id and partner_bank_id in available_partner_banks.ids:
+                    wizard.partner_bank_id = self.env['res.partner.bank'].browse(partner_bank_id)
+                else:
+                    wizard.partner_bank_id = available_partner_banks[:1]
             else:
-                wizard.partner_bank_id = False
+                wizard.partner_bank_id = None
 
     @api.depends('journal_id')
     def _compute_currency_id(self):
@@ -427,7 +480,7 @@ class AccountPaymentRegister(models.TransientModel):
                 raise UserError(_("You can't register payments for journal items being either all inbound, either all outbound."))
 
             res['line_ids'] = [(6, 0, available_lines.ids)]
-        
+
         return res
 
     # -------------------------------------------------------------------------
@@ -459,6 +512,12 @@ class AccountPaymentRegister(models.TransientModel):
 
     def _create_payment_vals_from_batch(self, batch_result):
         batch_values = self._get_wizard_values_from_batch(batch_result)
+
+        if batch_values['payment_type'] == 'inbound':
+            partner_bank_id = self.journal_id.bank_account_id.id
+        else:
+            partner_bank_id = batch_result['key_values']['partner_bank_id']
+
         return {
             'date': self.payment_date,
             'amount': batch_values['source_amount_currency'],
@@ -468,7 +527,7 @@ class AccountPaymentRegister(models.TransientModel):
             'journal_id': self.journal_id.id,
             'currency_id': batch_values['source_currency_id'],
             'partner_id': batch_values['partner_id'],
-            'partner_bank_id': batch_result['key_values']['partner_bank_id'],
+            'partner_bank_id': partner_bank_id,
             'payment_method_id': self.payment_method_id.id,
             'destination_account_id': batch_result['lines'][0].account_id.id
         }


### PR DESCRIPTION
When paying an expense, we should take the bank accounts from partner instead of the ones set on the company.
Also, the computation of the partner bank account is different on the wizard and the payment.
To unify both models, the 'available_partner_bank_ids' should also be put on account.payment.

see https://github.com/odoo/odoo/pull/79737

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
