### PR TITLE
[FIX] sale: Shipping Amount for Online Orders

### DIFF
--- a/addons/sale/data/mail_data.xml
+++ b/addons/sale/data/mail_data.xml
@@ -279,10 +279,10 @@
                 <td>
                     <strong>Shipping Method:</strong>
                     ${object.carrier_id.name}
-                    % if object.carrier_id.fixed_price == 0.0:
+                    % if object.amount_delivery == 0.0:
                         (Free)
                     % else:
-                        (${format_amount(object.carrier_id.fixed_price, object.currency_id)})
+                        ${format_amount(object.amount_delivery, object.currency_id)}
                     % endif
                 </td>
             </tr>


### PR DESCRIPTION
The price of the shipping method was always the sales price on the product of the delivery method

opw:2646684