### PR TITLE
[FIX] web_editor: create step when setting value

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -762,6 +762,7 @@ const Wysiwyg = Widget.extend({
     setValue: function (value) {
         this.$editable.html(value);
         this.odooEditor.sanitize();
+        this.odooEditor.historyStep();
     },
     /**
      * Undo one step of change in the editor.


### PR DESCRIPTION
Before this commit, setting a value from the editor did not created
steps but kept the mutations inside _currentStep.
Commands like delete or enter revert the _currentStep.
So each time enter or delete was pressed just after setValue, the
content being set was lost.

Task-2695041




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
