### PR TITLE
[FIX] point_of_sale: client name is blank string

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientDetailsEdit.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientDetailsEdit.js
@@ -49,8 +49,18 @@ odoo.define('point_of_sale.ClientDetailsEdit', function(require) {
                     processedChanges[key] = value;
                 }
             }
-            if ((!this.props.partner.name && !processedChanges.name) ||
-                processedChanges.name === '' ){
+
+            let savedName = this.props.partner.name;
+            let newName = processedChanges.name;
+            let isMissingName = false;
+            // if invalid name in db (undefined or empty/blank string)
+            if (!savedName || (savedName && savedName.trim() === '') )
+                isMissingName = true;
+            // if new input
+            if (typeof newName === 'string')
+                isMissingName = newName.trim() === '';
+
+            if (isMissingName) {
                 return this.showPopup('ErrorPopup', {
                   title: _t('A Customer Name Is Required'),
                 });


### PR DESCRIPTION
When editing client's details, name is a required field.
Thus, when the name is an empty string '', an errorPopup
is displayed. However, when the name is a blank string
e.g. ' ', saving is permitted.

We fixed this by taking into consideration the blank string input.

task-2699913

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
