### PR TITLE
[14.0][fix] stock: stock.picking.state to draft associating existing picking to a computed field

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -489,16 +489,17 @@ class Picking(models.Model):
             })
             picking_move_lines[picking_id.id].add(move.id)
         for picking in self:
-            if not picking_moves_state_map[picking.id]:
+            picking_id = (picking.ids and picking.ids[0]) or picking.id
+            if not picking_moves_state_map[picking_id]:
                 picking.state = 'draft'
-            elif picking_moves_state_map[picking.id]['any_draft']:
+            elif picking_moves_state_map[picking_id]['any_draft']:
                 picking.state = 'draft'
-            elif picking_moves_state_map[picking.id]['all_cancel']:
+            elif picking_moves_state_map[picking_id]['all_cancel']:
                 picking.state = 'cancel'
-            elif picking_moves_state_map[picking.id]['all_cancel_done']:
+            elif picking_moves_state_map[picking_id]['all_cancel_done']:
                 picking.state = 'done'
             else:
-                relevant_move_state = self.env['stock.move'].browse(picking_move_lines[picking.id])._get_relevant_state_among_moves()
+                relevant_move_state = self.env['stock.move'].browse(picking_move_lines[picking_id])._get_relevant_state_among_moves()
                 if picking.immediate_transfer and relevant_move_state not in ('draft', 'cancel', 'done'):
                     picking.state = 'assigned'
                 elif relevant_move_state == 'partially_available':

--- a/doc/cla/individual/fredzamoabg.md
+++ b/doc/cla/individual/fredzamoabg.md
@@ -1,0 +1,11 @@
+Italy, 2021-11-25
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Alfredo Zamora alfredo.zamora@agilebg.com https://github.com/fredzamoabg


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Associating an existing picking with `state` different to `draft` to a computed field (for example a field in `wizard`) the `state` field is recalculated setting the value to `draft`.

The problem is found here https://github.com/odoo/odoo/blob/a05f4e05b9f4df88948ac3dfc1522828b63bfb64/addons/stock/models/stock_picking.py#L485 where is created a structure with the ID picking taken from `stock.move` as key (that is always an `Integer`) but here https://github.com/odoo/odoo/blob/a05f4e05b9f4df88948ac3dfc1522828b63bfb64/addons/stock/models/stock_picking.py#L492 the data is retrieved from structure using ID of `self` that can be of type `New_id`.

Current behavior before PR:
The picking state is incorrect as is always set to `draft`.

Desired behavior after PR is merged:
The picking state remain as expected.
This is obtained adding to the structure the same type of ID used to retrieve it.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
