### PR TITLE
[FIX] mrp: fix the qty in the BOM report

### DIFF
--- a/addons/mrp/static/src/js/mrp_bom_report.js
+++ b/addons/mrp/static/src/js/mrp_bom_report.js
@@ -111,8 +111,8 @@ var MrpBomReport = stock_report_generic.extend({
         this.$buttonPrint.find('.o_mrp_bom_print').on('click', this._onClickPrint.bind(this));
         this.$buttonPrint.find('.o_mrp_bom_print_unfolded').on('click', this._onClickPrint.bind(this));
         this.$searchView = $(QWeb.render('mrp.report_bom_search', _.omit(this.data, 'lines')));
-        this.$searchView.find('.o_mrp_bom_report_qty').on('change', this._onChangeQty.bind(this));
-        this.$searchView.find('.o_mrp_bom_report_variants').on('change', this._onChangeVariants.bind(this));
+        this.$searchView.find('.o_mrp_bom_report_qty').on('change', this._onChangeQty.bind(this)).change();
+        this.$searchView.find('.o_mrp_bom_report_variants').on('change', this._onChangeVariants.bind(this)).change();
         this.$searchView.find('.o_mrp_bom_report_type').on('change', this._onChangeType.bind(this));
     },
     _onClickPrint: function (ev) {


### PR DESCRIPTION
Steps to reproduce the bug:
 - Create a BOM:
    - Set the quantity of the finished product and component as more than 1
- Save > Go to BOM Structure & Cost > the quantity in the input is set on 3
- Print

Problem:
The report generated shows the qty and cost for production of 1 unit of product, regardless of the BOM quantity set in the input

The "_onClickPrint" function tries to get the quantity of the bom in the context,
but since the value of "this.given_context.searchQty" is null, the function will use the default value of 1.
The "searchQty" is only set in the "onchange", so we can manually trigger it when initiating the page so that the "searchQty" is set correctly

opw-2691632






https://user-images.githubusercontent.com/78867936/143548372-b1a2661d-8067-49c0-8b6d-c1c9aba2d3f1.mp4


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
