### PR TITLE
[FIX] sale_timesheet_margin: prevent cost override on product service

### DIFF
--- a/addons/sale_timesheet_margin/models/sale_order_line.py
+++ b/addons/sale_timesheet_margin/models/sale_order_line.py
@@ -8,9 +8,10 @@ class SaleOrderLine(models.Model):
     @api.depends('analytic_line_ids.amount', 'qty_delivered_method')
     def _compute_purchase_price(self):
         timesheet_sols = self.filtered(
-            lambda sol: sol.qty_delivered_method == 'timesheet' and not sol.product_id.standard_price
+            lambda sol: sol.qty_delivered_method == 'timesheet' and not sol.product_id.standard_price and not sol.product_id.service_policy == 'ordered_timesheet'
         )
-        super(SaleOrderLine, self - timesheet_sols)._compute_purchase_price()
+        already_computed_service = self.filtered(lambda sol: sol.create_date is not False and sol.product_id.service_policy == 'ordered_timesheet')
+        super(SaleOrderLine, self - timesheet_sols - already_computed_service)._compute_purchase_price()
         if timesheet_sols:
             group_amount = self.env['account.analytic.line'].read_group(
                 [('so_line', 'in', timesheet_sols.ids), ('project_id', '!=', False)],


### PR DESCRIPTION
### Current behavior
a) For a service product with Invoicing Policy set to Prepaid/Fixed Price, when we create a Sales Order with this product and change his Cost with a custom value and confirm the SO, the product's cost is overridden by the product's default cost.
b) If we create a service, with Invoicing Policy set to Prepaid/Fixed Price, its cost will be 0 even if we update it in the SO

### Steps to reproduce
1. Install Sales and enable Margins in app's settings
2. Install Timesheets
3. Get a service type product with Invoicing Policy set to Prepaid/Fixed Price
4. Create a Sales Order
5. Add the service product from step 2
6. Change his cost
7. Confirm the SO

### Reason
a) Purchase price is recalculated when it should not be so it's overridden by product's standard price
b) When a service with Invoicing Policy set to Prepaid/Fixed Price is created, it will be considered as linked to timesheets and the cost will be 0, waiting to be recalculated with the linked timesheets (which won't happen because no linked timesheet will be created)

#### Details
For b), I added a condition on the service policy because, according to this declaration https://github.com/odoo/odoo/blob/f81063382d551261801288b66e4d75303a05cbb4/addons/sale_timesheet/models/product.py#L11 a service whose invoicing policy is set to Prepaid/Fixed Price will have its delivery method set to 'timesheet' and will therefore be considered as linked to a timesheet (which is false in this case) which will result in a cost equal to 0 

OPW-2689756