### PR TITLE
[FIX] google_calendar: don't delete several times the same attendee

### DIFF
--- a/addons/google_calendar/models/calendar_recurrence_rule.py
+++ b/addons/google_calendar/models/calendar_recurrence_rule.py
@@ -106,14 +106,11 @@ class RecurrenceRule(models.Model):
                 if attendee[2].get('displayName') and not partner.name:
                     partner.name = attendee[2].get('displayName')
 
-        unlinked_attendee = self.env['calendar.attendee']
-        for odoo_attendee_email in existing_attendees.mapped('email'):
+        for odoo_attendee_email in set(existing_attendees.mapped('email')):
             # Remove old attendees
             if email_normalize(odoo_attendee_email) not in emails:
                 attendee = existing_attendees.filtered(lambda att: att.email == email_normalize(odoo_attendee_email))
-                unlinked_attendee |= attendee
-                self.calendar_event_ids.write({'partner_ids': [(3, attendee.partner_id.id)]})
-        unlinked_attendee.unlink()
+                self.calendar_event_ids.write({'need_sync': False, 'partner_ids': [(3, attendee.partner_id.id)]})
 
         # Update the recurrence values
         old_event_values = self.base_event_id and self.base_event_id.read(base_event_time_fields)[0]


### PR DESCRIPTION
Small side effect of commit https://github.com/odoo/odoo/commit/b19dc634684aab239575b9a9e784c7420d110b7d

When deleting old attendees, we are removing the partner id associated with the email
from the partner_ids set on the event.

As the same partner can be set on more than one event, we need to loop only once
on each attendee email, otherwise we will face the error "Record does not exist
or has been deleted."

Also, when deleting partner_ids on an event, the attendee is already automatically
removed as well in _attendees_values method, there is no need to do it manually, as
it will raise the error a second time.

opw-2694428
opw-2695915

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
