### PR TITLE
[FIX] mail: do not allow guests for group restricted channels

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -318,6 +318,13 @@ class Channel(models.Model):
                         group_name=channel.group_public_id.name,
                         partner_names=', '.join(partner.name for partner in invalid_partners)
                     ))
+                if guests:
+                    raise UserError(_(
+                        'Channel "%(channel_name)s" only accepts members of group "%(group_name)s". Forbidden for: %(guest_names)s',
+                        channel_name=channel.name,
+                        group_name=channel.group_public_id.name,
+                        guest_names=', '.join(guest.name for guest in guests)
+                    ))
             existing_partners = self.env['res.partner'].search([('id', 'in', partners.ids), ('channel_ids', 'in', channel.id)])
             members_to_create += [{
                 'partner_id': partner.id,

--- a/addons/mail/tests/test_mail_channel_as_guest.py
+++ b/addons/mail/tests/test_mail_channel_as_guest.py
@@ -11,5 +11,6 @@ class TestMailGuestPages(HttpCase):
         modules load correctly on the welcome and channel page"""
         channel = self.env['mail.channel'].create({
             'name': 'Test channel',
+            'public': 'public',
         })
         self.start_tour(f"/chat/{channel.id}/{channel.uuid}", "mail/static/tests/tours/mail_channel_as_guest_tour.js")


### PR DESCRIPTION
**Before this commit:**

When user shares the invitation link of the channel(groups restricted), guests
are allowed to access it.

**After this commit**:

Guests will not be allowed to access channels that are restricted to groups.

**Task**-2679184