### PR TITLE
[FIX] stock: no double language product name in delivery slip

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -205,7 +205,7 @@ class Product(models.Model):
         if picking_code == 'incoming':
             return self.description_pickingin or description
         if picking_code == 'outgoing':
-            return self.description_pickingout or self.name
+            return self.description_pickingout or ''
         if picking_code == 'internal':
             return self.description_picking or description
 

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -43,7 +43,7 @@
                             <tr t-foreach="lines" t-as="move">
                                 <td>
                                     <span t-field="move.product_id"/>
-                                    <p t-if="move.description_picking != move.product_id.name">
+                                    <p t-if="move.description_picking != ''">
                                         <span t-field="move.description_picking"/>
                                     </p>
                                 </td>


### PR DESCRIPTION
When switch languages of a customer, printing a delivery slip shows two different languages on the description of the product instead of the new language that was set on the customer.

Steps to reproduce:
- Create a sales order
- Print delivery slip
- Go to customer contact and change language
- Print delivery slip again, it will now show the description in two different languages
- Duplicate sales order or create new sales order and print delivery slip
- the new report will now be in the language that was set

When a delivery was created and there was no 
default description for the selected product, the description was set as the name of the product in the current language, so when the user was changing the language, in the delivery slip they could saw the
name translated and the old name as the product description. Considering that the delivery description can be changed by editing the delivery, I set an
empty description instead of the product name if there's no default description for the product.

opw-2685177

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
