### PR TITLE
[IMP] mass_mailing: allow responsible to turn off mailing reports

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -23,6 +23,7 @@
     'data': [
         'security/mass_mailing_security.xml',
         'security/ir.model.access.csv',
+        'data/digest_data.xml',
         'data/mail_data.xml',
         'data/mailing_data_templates.xml',
         'data/mass_mailing_data.xml',

--- a/addons/mass_mailing/data/digest_data.xml
+++ b/addons/mass_mailing/data/digest_data.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="digest_mail_main" inherit_id="digest.digest_mail_main">
+            <xpath expr="//div[hasclass('by_odoo')]/t[last()]" position="after">
+                <t t-if="mailing_report_token">
+                    –
+                    <a t-attf-href="/mailing/report/unsubscribe?token=#{mailing_report_token}&amp;user_id=#{user_id}"
+                       target="_blank" style="text-decoration: none;">
+                        <span style="color: #8f8f8f;">Turn off Mailing Reports</span>
+                    </a>
+                </t>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/addons/mass_mailing/i18n/mass_mailing.pot
+++ b/addons/mass_mailing/i18n/mass_mailing.pot
@@ -110,6 +110,11 @@ msgid "21 Jul"
 msgstr ""
 
 #. module: mass_mailing
+#: model:ir.model.fields,field_description:mass_mailing.field_res_config_settings__mass_mailing_reports
+msgid "24H Stat Mailing Reports"
+msgstr ""
+
+#. module: mass_mailing
 #: code:addons/mass_mailing/models/mailing.py:0
 #: code:addons/mass_mailing/models/mailing.py:0
 #, python-format
@@ -449,6 +454,11 @@ msgstr ""
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.view_mail_mass_mailing_form
 msgid "<span name=\"sent\">emails have been sent.</span>"
+msgstr ""
+
+#. module: mass_mailing
+#: model_terms:ir.ui.view,arch_db:mass_mailing.digest_mail_main
+msgid "<span style=\"color: #8f8f8f;\">Turn off Mailing Reports</span>"
 msgstr ""
 
 #. module: mass_mailing
@@ -1147,6 +1157,16 @@ msgstr ""
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.mailing_mailing_view_form_full_width
 msgid "Chat"
+msgstr ""
+
+#. module: mass_mailing
+#: model_terms:ir.ui.view,arch_db:mass_mailing.res_config_settings_view_form
+msgid "Check how well your mailing is doing a day after it has been sent"
+msgstr ""
+
+#. module: mass_mailing
+#: model:ir.model.fields,help:mass_mailing.field_res_config_settings__mass_mailing_reports
+msgid "Check how well your mailing is doing a day after it has been sent."
 msgstr ""
 
 #. module: mass_mailing
@@ -2362,6 +2382,18 @@ msgid "Mailing Lists"
 msgstr ""
 
 #. module: mass_mailing
+#: model_terms:ir.ui.view,arch_db:mass_mailing.mailing_report_deactivated
+msgid "Mailing Reports Turned Off"
+msgstr ""
+
+#. module: mass_mailing
+#: model_terms:ir.ui.view,arch_db:mass_mailing.mailing_report_deactivated
+msgid ""
+"Mailing Reports have been turned off for all users.\n"
+"                                They can be turned back on from the Settings menu."
+msgstr ""
+
+#. module: mass_mailing
 #: model:ir.model,name:mass_mailing.model_mailing_trace
 msgid "Mailing Statistics"
 msgstr ""
@@ -3389,6 +3421,13 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:mass_mailing.mailing_contact_to_list_view_form
 #: model_terms:ir.ui.view,arch_db:mass_mailing.view_mail_mass_mailing_test_form
 msgid "Send a Sample Mail"
+msgstr ""
+
+#. module: mass_mailing
+#: model_terms:ir.ui.view,arch_db:mass_mailing.res_config_settings_view_form
+msgid ""
+"Send a report to the mailing responsible one day after the mailing has been "
+"sent."
 msgstr ""
 
 #. module: mass_mailing

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -924,19 +924,25 @@ class MassMailing(models.Model):
                     # send the KPI mail only if it's the first sending
                     'kpi_mail_required': not mass_mailing.sent_date,
                 })
-
-        mailings = self.env['mailing.mailing'].search([
-            ('kpi_mail_required', '=', True),
-            ('state', '=', 'done'),
-            ('sent_date', '<=', fields.Datetime.now() - relativedelta(days=1)),
-            ('sent_date', '>=', fields.Datetime.now() - relativedelta(days=5)),
-        ])
-        if mailings:
-            mailings._action_send_statistics()
+        if not self.env['ir.config_parameter'].sudo().get_param('mass_mailing.mailing_report_deactivated'):
+            mailings = self.env['mailing.mailing'].search([
+                ('kpi_mail_required', '=', True),
+                ('state', '=', 'done'),
+                ('sent_date', '<=', fields.Datetime.now() - relativedelta(days=1)),
+                ('sent_date', '>=', fields.Datetime.now() - relativedelta(days=5)),
+            ])
+            if mailings:
+                mailings._action_send_statistics()
 
     # ------------------------------------------------------
     # STATISTICS
     # ------------------------------------------------------
+
+    def _get_unsubscribe_token(self, user_id):
+        """Generate a secure hash for this user. It allows to
+        opt out from mailing reports while keeping some security in that process.
+        """
+        return tools.hmac(self.env(su=True), 'mailing-report-deactivated', user_id)
 
     def _action_send_statistics(self):
         """Send an email to the responsible of each finished mailing with the statistics."""
@@ -963,16 +969,20 @@ class MassMailing(models.Model):
                     'mailing_type': mailing_type,
                 },
             )
+            rendering_data = {
+                'body': tools.html_sanitize(link_trackers_body),
+                'company': mail_company,
+                'user': mail_user,
+                'display_mobile_banner': True,
+                ** mailing._prepare_statistics_email_values(),
+            }
+            if mail_user.has_group('mass_mailing.group_mass_mailing_user'):
+                rendering_data['mailing_report_token'] = self._get_unsubscribe_token(mail_user.id)
+                rendering_data['user_id'] = mail_user.id
 
             rendered_body = self.env['ir.qweb']._render(
                 'digest.digest_mail_main',
-                {
-                    'body': tools.html_sanitize(link_trackers_body),
-                    'company': mail_company,
-                    'user': mail_user,
-                    'display_mobile_banner': True,
-                    ** mailing._prepare_statistics_email_values()
-                },
+                rendering_data,
             )
 
             full_mail = self.env['mail.render.mixin']._render_encapsulate(

--- a/addons/mass_mailing/models/res_config_settings.py
+++ b/addons/mass_mailing/models/res_config_settings.py
@@ -7,6 +7,9 @@ from odoo import api, fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
+    def _default_mass_mailing_report(self):
+        return not self.env['ir.config_parameter'].sudo().get_param('mass_mailing.mailing_report_deactivated')
+
     group_mass_mailing_campaign = fields.Boolean(string="Mailing Campaigns", implied_group='mass_mailing.group_mass_mailing_campaign', help="""This is useful if your marketing campaigns are composed of several emails""")
     mass_mailing_outgoing_mail_server = fields.Boolean(string="Dedicated Server", config_parameter='mass_mailing.outgoing_mail_server',
         help='Use a specific mail server in priority. Otherwise Odoo relies on the first outgoing mail server available (based on their sequencing) as it does for normal mails.')
@@ -14,6 +17,9 @@ class ResConfigSettings(models.TransientModel):
     show_blacklist_buttons = fields.Boolean(string="Blacklist Option when Unsubscribing",
                                                  config_parameter='mass_mailing.show_blacklist_buttons',
                                                  help="""Allow the recipient to manage himself his state in the blacklist via the unsubscription page.""")
+    mass_mailing_reports = fields.Boolean(string='24H Stat Mailing Reports',
+                                          help='Check how well your mailing is doing a day after it has been sent.',
+                                          default=_default_mass_mailing_report)
 
     @api.onchange('mass_mailing_outgoing_mail_server')
     def _onchange_mass_mailing_outgoing_mail_server(self):
@@ -25,3 +31,5 @@ class ResConfigSettings(models.TransientModel):
         ab_test_cron = self.env.ref('mass_mailing.ir_cron_mass_mailing_ab_testing').sudo()
         if ab_test_cron and ab_test_cron.active != self.group_mass_mailing_campaign:
             ab_test_cron.active = self.group_mass_mailing_campaign
+
+        self.env['ir.config_parameter'].sudo().set_param('mass_mailing.mailing_report_deactivated', not self.mass_mailing_reports)

--- a/addons/mass_mailing/views/mass_mailing_templates_portal.xml
+++ b/addons/mass_mailing/views/mass_mailing_templates_portal.xml
@@ -1,5 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <template id="mailing_report_deactivated" name="Report Unsubscribed">
+        <t t-call="mass_mailing.layout">
+            <div class="container mt8">
+                <div class="row">
+                    <div class="col-lg-6 offset-lg-3">
+                        <h3>Mailing Reports Turned Off</h3>
+                        <div class="alert alert-success text-center" role="status">
+                            <p>
+                                Mailing Reports have been turned off for all users. <br/>
+                                If needed, they can be turned back on from the
+                                <a t-if="menu_id" t-attf-href="/web#menu_id=#{menu_id}">
+                                    Settings Menu.
+                                </a>
+                                <t t-else="">
+                                    Settings Menu.
+                                </t>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </t>
+    </template>
     <template id="unsubscribe">
         <div class="container o_unsubscribe_form">
             <div class="row">

--- a/addons/mass_mailing/views/res_config_settings_views.xml
+++ b/addons/mass_mailing/views/res_config_settings_views.xml
@@ -42,7 +42,7 @@
                             </div>
                             <div class="col-md-6 o_setting_box col-xs-12" name="allow_blacklist_setting_container">
                                 <div class="o_setting_left_pane" title="Allow the recipient to manage himself his state in the blacklist via the unsubscription page.
-                                If the option is active, the 'Blacklist Me' button is hidden on the unsubscription page.  
+                                If the option is active, the 'Blacklist Me' button is hidden on the unsubscription page.
                                 The 'come Back' button will always be visible in any case to allow leads and partners to re-subscribe.">
                                     <field name="show_blacklist_buttons"/>
                                 </div>
@@ -50,6 +50,17 @@
                                     <label for="show_blacklist_buttons"/>
                                     <div class="text-muted">
                                         Allow recipients to blacklist themselves
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-md-6 o_setting_box col-xs-12" name="mass_mailing_reports_setting_container">
+                                <div class="o_setting_left_pane" title="Send a report to the mailing responsible one day after the mailing has been sent.">
+                                    <field name="mass_mailing_reports"/>
+                                </div>
+                                <div class="o_setting_right_pane">
+                                    <label for="mass_mailing_reports"/>
+                                    <div class="text-muted">
+                                        Check how well your mailing is doing a day after it has been sent
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Purpose
=======
Allow users with enough access rights to disable next-day report on
mass mailing lists. The option has been added in the mass mailing
settings and is enabled by default. Mass mailing reports can also be
disabled with a "Turn off mailing reports" button in the report email
itself. Reports are enabled and disabled for all Responsible.

Task-2692211
