### PR TITLE
[IMP] survey: display final screen in live presentation

### DIFF
--- a/addons/survey/static/src/js/survey_session_manage.js
+++ b/addons/survey/static/src/js/survey_session_manage.js
@@ -165,13 +165,8 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
                 this.$('.o_survey_session_navigation_next').addClass('d-none');
             }
             this.leaderBoard.showLeaderboard(true, this.isScoredQuestion);
-        } else {
-            if (!this.isLastQuestion) {
-                this._nextQuestion();
-            } else if (!this.sessionShowLeaderboard) {
-                // If we have no leaderboard to show, directly end the session
-                this.$('.o_survey_session_close').click();
-            }
+        } else if (!this.isLastQuestion || !this.sessionShowLeaderboard) {
+            this._nextQuestion();
         }
 
         this.currentScreen = screenToDisplay;
@@ -394,7 +389,9 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
                 self.leaderBoard.showLeaderboard(false, false);
             });
         } else {
-            this.$('.o_survey_session_close').click();
+            self.$('.o_survey_session_close').click();
+            self.$('.o_survey_session_results').addClass('d-none');
+            self.$('.o_survey_session_description_done').prepend($("<h1>").text(_t('Thank you!'))).removeClass('d-none');
         }
 
         // Background Management

--- a/addons/survey/views/survey_templates_management.xml
+++ b/addons/survey/views/survey_templates_management.xml
@@ -118,7 +118,7 @@
                             </div>
                             <div class="row">
                                 <div class="col-12 col-md-4 offset-md-4 text-center">
-                                    <input id="session_code" type="text" placeholder="4812"
+                                    <input id="session_code" type="text" placeholder="e.g. 4812" autocomplete="off"
                                            class="form-control o_survey_question_text_box font-weight-bold bg-transparent text-primary text-center rounded-0 p-2 w-100"/>
                                 </div>
                                 <div class="col-12 col-md-4 offset-md-4 text-center o_survey_error text-danger pt-2" role="alert">

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -39,7 +39,7 @@
                         <h1 class="mb-4" t-field="survey.title" />
                         <h2 class="mb-5 font-weight-normal">
                             <span>Go to <a t-att-href="survey.session_link" t-esc="survey.session_link" target="_blank" /></span>
-                            <i class="fa fa-copy font-weight-normal ml-3 o_survey_session_copy" />
+                            <i class="fa fa-link font-weight-normal ml-3 o_survey_session_copy" />
                             <input class="o_survey_session_copy_url d-none" type="text" t-att-value="survey.session_link" />
                         </h2>
                         <h2 class="font-weight-normal"><span>Waiting for attendees...</span>
@@ -105,6 +105,7 @@
                 </div>
             </div>
             <div class="container px-4 pb-3 pt96 d-flex flex-column o_survey_session_manage_container">
+                <div class="o_survey_session_description_done d-none" t-field="survey.description_done" />
                 <a role="button"
                     class="font-weight-bold fa fa-chevron-right o_survey_session_navigation o_survey_session_navigation_next p-3" />
                 <a role="button"
@@ -128,7 +129,7 @@
                                 <span>Waiting for attendees...</span>
                                 <span>
                                     <span class="o_survey_session_answer_count">0</span>
-                                     / 
+                                     /
                                     <span t-esc="survey.session_answer_count" />
                                 </span>
                             </h2>


### PR DESCRIPTION
Purpose
=======
When presenting a live survey, the page does not give a
confirmation message when the survey ends and stays on the last slide.
A "Thank you!" message is now displayed when the presentation ends.

Task-2700222
