### PR TITLE
[FIX][hr_timesheet]: Fix access rights issue for timesheet entries

### DIFF
--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -62,7 +62,7 @@
     <template id="report_timesheet">
         <t t-call="web.html_container">
             <t t-call="web.external_layout">
-                <t t-set="company" t-value="docs.mapped('project_id')[0].company_id if len(docs.mapped('project_id')) == 1 else docs.env.company"/>
+                <t t-set="company" t-value="docs.mapped('project_id')[0].sudo().company_id if len(docs.mapped('project_id')) == 1 else docs.env.company"/>
                 <t t-set="show_task" t-value="bool(docs.mapped('task_id'))"/>
                 <t t-set="show_project" t-value="len(docs.mapped('project_id')) > 1"/>
                 <div class="page">


### PR DESCRIPTION
Steps to reproduce the issue:

- Create a user
- Remove groups 'Website/Editor and Designer' and 'Website/Restricted Editor' for the newly created user.
- Try to print 'Timesheet Entries'(Project -> select Timesheets -> select all timesheets -> print timesheet entries)

Error: 

" Error when render the template
AccessError: You are not allowed to access 'View' (ir.ui.view) records.

This operation is allowed for the following groups:
	- Administration/Settings
	- Website/Editor and Designer
	- Website/Restricted Editor

Contact your administrator to request access if necessary.
Template: web.external_layout
Path: /t/t[5]/t
Node: <t t-out="0"/>"

In this commit fetch company_id with sudo.

opw: 2698441
