### PR TITLE
[FIX] l10n_cl: fix the sum for the subtotal in the invoice lines

### DIFF
--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -162,7 +162,7 @@
 
         <span t-field="line.price_subtotal" position="attributes">
             <attribute name="t-field"></attribute>
-            <attribute name="t-esc">current_subtotal + l10n_cl_values['price_subtotal']</attribute>
+            <attribute name="t-esc">l10n_cl_values['price_subtotal']</attribute>
             <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </span>
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes the subtotal calculation in the invoice report invoice lines

Current behavior before PR: 
For the invoice report, the invoice line subtotal is duplicated

Desired behavior after PR is merged:
The amount is corrected.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
