### PR TITLE
[FIX] product, sale: attribute values not removeable

### DIFF
--- a/addons/sale/tests/__init__.py
+++ b/addons/sale/tests/__init__.py
@@ -11,3 +11,4 @@ from . import test_access_rights
 from . import test_sale_refund
 from . import test_sale_signature
 from . import test_sale_transaction
+from . import test_variant_archive

--- a/addons/sale/tests/test_variant_archive.py
+++ b/addons/sale/tests/test_variant_archive.py
@@ -1,0 +1,135 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.exceptions import UserError
+from odoo.tests import Form
+from odoo.tools import mute_logger
+from odoo.tests.common import SavepointCase
+
+
+class TestArchiveVariant(SavepointCase):
+    at_install = False
+    post_install = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.setUpClassTemplate()
+        cls.setUpClassAttribute()
+        cls.setUpClassProduct()
+        cls.partner = cls.env["res.partner"].create({"name": "Partner"})
+
+    @classmethod
+    def setUpClassTemplate(cls):
+        cls.template_model = cls.env["product.template"]
+        cls.pen = cls.template_model.create({"name": "pen"})
+        cls.car = cls.template_model.create({"name": "car"})
+
+    @classmethod
+    def setUpClassAttribute(cls):
+        cls.attribute_model = cls.env["product.attribute"]
+        cls.value_model = cls.env["product.attribute.value"]
+        cls.attribute_line_model = cls.env["product.template.attribute.line"]
+        cls.attribute_value_model = cls.env["product.template.attribute.value"]
+        cls.attribute = cls.attribute_model.create({"name": "color"})
+        cls.values = cls.env["product.attribute.value"]
+        for color in ["red", "blue"]:
+            value = cls.value_model.create(
+                {"attribute_id": cls.attribute.id, "name": color}
+            )
+            setattr(cls, color, value)
+            cls.values |= value
+
+    @classmethod
+    def setUpClassProduct(cls):
+        cls.product_model = cls.env["product.product"]
+        cls.pen_attribute_line = cls.attribute_line_model.create(
+            {
+                "product_tmpl_id": cls.pen.id,
+                "attribute_id": cls.attribute.id,
+                "value_ids": [(6, 0, cls.values.ids)],
+            }
+        )
+        cls.car_attribute_line = cls.attribute_line_model.create(
+            {
+                "product_tmpl_id": cls.car.id,
+                "attribute_id": cls.attribute.id,
+                "value_ids": [(6, 0, cls.values.ids)],
+            }
+        )
+        cls.attribute_lines = cls.pen_attribute_line | cls.car_attribute_line
+
+    @classmethod
+    def _create_sale_order(cls, products):
+        """Create a sale order with given products."""
+        sale_form = Form(cls.env["sale.order"])
+        sale_form.partner_id = cls.partner
+        with mute_logger("odoo.tests.common.onchange"):
+            for product in products:
+                with sale_form.order_line.new() as line:
+                    line.product_id = product
+                    line.product_uom_qty = 1
+        return sale_form.save()
+
+    def _get_template_value(self, value, attribute_line=None):
+        domain = [("product_attribute_value_id", "=", value.id)]
+        if attribute_line is not None:
+            domain.append(("attribute_line_id", "=", attribute_line.id))
+        return self.attribute_value_model.search(domain)
+
+    def test_value_unlink(self):
+        # No SO has been created, therefore we should be able to unlink values.
+        remaining_values = self.values - self.red
+        # Remove red from the attribute lines
+        self.attribute_lines.write(
+            {"value_ids": [(6, 0, remaining_values.ids)]}
+        )
+        # then unlink it
+        self.red.unlink()
+        updated_values = self.attribute.value_ids
+        self.assertEqual(len(updated_values), 1)
+        self.assertNotIn(self.red, updated_values)
+
+    def test_value_archive(self):
+        # If a value is only referenced by archived variants, then
+        # the value should be archived instead.
+        template_values = self._get_template_value(self.red)
+        products = template_values.ptav_product_variant_ids
+        # There should be red car and red pen in the recordset
+        self.assertEqual(len(products), 2)
+        self._create_sale_order(products)
+        # Trying to unlink the value here should raise an exception
+        # since it's still referenced by the car and pen product templates
+        regex = f"You cannot delete the value color: red"
+        with self.assertRaisesRegex(UserError, regex):
+            self.red.unlink()
+        # Remove the value from the set
+        self.attribute_lines.write({"value_ids": [(3, self.red.id, 0)]})
+        # The variants should be archived instead of unlinked,
+        # since they are referenced by a sale.order.line
+        self.assertFalse(any(products.mapped("active")))
+        # now, since the the variant is archived, we shouldn't be able
+        self.red.unlink()
+        self.assertFalse(self.red.active)
+
+    def test_value_non_archiveable(self):
+        # Even if one variant is archived, it should be possible to
+        # archive or unlink an attribute value, as long there is an
+        # active variant.
+        pen_template_value = self._get_template_value(
+            self.red, self.pen_attribute_line
+        )
+        red_pen = pen_template_value.ptav_product_variant_ids
+        self.assertEqual(len(red_pen), 1)
+        self._create_sale_order(red_pen)
+        # Remove the value from the set
+        self.pen_attribute_line.value_ids = [(3, self.red.id, 0)]
+        # The variant should be archived instead of unlinked,
+        # since it's referenced by a sale.order.line
+        self.assertFalse(red_pen.active)
+        # The red car variant is still active, so we shouldn't be able
+        # to archive or unlink the value, and odoo should raise
+        # an exception saying that red is still referenced by car
+        regex = r"You cannot delete the value color: red.*car"
+        with self.assertRaisesRegex(UserError, regex):
+            self.red.unlink()


### PR DESCRIPTION
**Expected behavior:**
We should be able to remove a `product.attribute.value` if it is not referenced by any `product.template`

**Current behavior:**
If a `product.product` is referenced by a `sale.order.line` and we try to remove a `product.attribute.value` which defines this product, then the variant is archived instead of unlinked.
Also, we removed the link from the `product.template` to `product.attribute.value` (through `product.template.attribute.value`).
At this point, odoo considers that this value isn't referenced by any product, 
and if we try to remove it, we get and exception, coming from the `ONDELETE RESTRICT`
constraint, on `product.product.product_template_attribute_value_ids`.
This is because we still have a reference from `product.product` to `product.attribute.value` 
through `product.template.attribute.value`.

**Steps to reproduce:**

https://user-images.githubusercontent.com/13200247/143596930-3aaaeb54-3030-43a5-adc5-ec635c22e030.mp4

1) install sale / stock
2) create the following
      - product.attribute: color
      - product.attribute.value: blue, red
      - product.template: pen
3) Attach attribute to the product, and create a sale order line with the variant `red pen`.
4) Now, remove the `red` color from the `pen` template, and the `red pen` variant will be archived.
5) Now, go on the `color` attribute and try to remove the red color.

**Desired behavior after PR is merged:**
If all `product.product` referencing a `product.attribute.value` are archived, then the `product.attribute.value` is archived instead of `unlinked`.

OPW ref: coming soon
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
