### PR TITLE
[FIX] hr_holidays: fix duration field traceback on hr_leave_report_calendar

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -44,6 +44,7 @@ class LeaveReportCalendar(models.Model):
             hl.employee_id AS employee_id,
             hl.state AS state,
             hl.department_id AS department_id,
+            hl.number_of_days as duration,
             em.company_id AS company_id,
             em.job_id AS job_id,
             COALESCE(

--- a/addons/web/static/src/views/graph/graph_view.js
+++ b/addons/web/static/src/views/graph/graph_view.js
@@ -72,6 +72,12 @@ export class GraphView extends Component {
     onGraphClicked(domain) {
         const { context, resModel, title } = this.model.metaData;
 
+        Object.keys(context).forEach((x) => {
+            if (x === "group_by" || x.startsWith("search_default_")) {
+                delete context[x];
+            }
+        });
+
         const views = {};
         for (const [viewId, viewType] of this.env.config.views || []) {
             views[viewType] = viewId;

--- a/addons/web/static/tests/views/graph_view_tests.js
+++ b/addons/web/static/tests/views/graph_view_tests.js
@@ -2804,6 +2804,56 @@ QUnit.module("Views", (hooks) => {
         await clickOnDataset(graph);
     });
 
+    QUnit.test("Clicking on bar charts removes group_by and search_default_* context keys", async function(assert) {
+        assert.expect(2);
+
+        serviceRegistry.add(
+            "action",
+            {
+                start() {
+                    return {
+                        doAction(actionRequest, options) {
+                            assert.deepEqual(actionRequest, {
+                                context: {
+                                    lang: "en",
+                                    tz: "taht",
+                                    uid: 7,
+                                },
+                                domain: [["bar", "=", true]],
+                                name: "Foo Analysis",
+                                res_model: "foo",
+                                target: "current",
+                                type: "ir.actions.act_window",
+                                views: [
+                                    [false, "list"],
+                                    [false, "form"],
+                                ],
+                            });
+                            assert.deepEqual(options, { viewType: "list" });
+                        },
+                    };
+                },
+            },
+            { force: true }
+        );
+        const graph = await makeView({
+            serverData,
+            type: "graph",
+            resModel: "foo",
+            arch: `
+                <graph string="Foo Analysis">
+                    <field name="bar"/>
+                </graph>
+            `,
+            context: {
+                search_default_user: 1,
+                group_by: 'bar',
+            },
+        });
+
+        await clickOnDataset(graph);
+    });
+
     QUnit.test(
         "clicking on a pie chart trigger a do_action with correct views",
         async function (assert) {


### PR DESCRIPTION
The duration field was removed from the hr_leave_report_calendar model in
https://github.com/odoo/odoo/pull/55568. The field was still accessible in the measures when
using Studio and creating a pivot view.

This PR removes this unused field to avoid a traceback when selected as measure in the pivot view

task-2698879

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
