### PR TITLE
[FIX] sale: render the report as superuser

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -3,7 +3,7 @@
 
 import binascii
 
-from odoo import fields, http, _
+from odoo import fields, http, SUPERUSER_ID, _
 from odoo.exceptions import AccessError, MissingError
 from odoo.http import request
 from odoo.addons.payment.controllers.portal import PaymentProcessing
@@ -231,7 +231,7 @@ class CustomerPortal(CustomerPortal):
             order_sudo.action_confirm()
             order_sudo._send_order_confirmation_mail()
 
-        pdf = request.env.ref('sale.action_report_saleorder').sudo()._render_qweb_pdf([order_sudo.id])[0]
+        pdf = request.env.ref('sale.action_report_saleorder').with_user(SUPERUSER_ID)._render_qweb_pdf([order_sudo.id])[0]
 
         _message_post_helper(
             'sale.order', order_sudo.id, _('Order signed by %s') % (name,),


### PR DESCRIPTION
Same as 5dde19c92ecee, sudo is not enough but the report needs to 
rendered with the user 1.
The access token proves the user has the access, the fact that he is a
portal, employee or public should not change the result
