### PR TITLE
[FIX] base: fix email_formatted if email was not normalized

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -415,7 +415,10 @@ class Partner(models.Model):
     def _compute_email_formatted(self):
         for partner in self:
             if partner.email:
-                partner.email_formatted = tools.formataddr((partner.name or u"False", partner.email or u"False"))
+                partner.email_formatted = tools.formataddr((
+                    partner.name or u"False",
+                    tools.email_normalize(partner.email) or u"False"
+                ))
             else:
                 partner.email_formatted = ''
 

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -147,3 +147,8 @@ class TestPartner(TransactionCase):
         partner_merge_wizard = self.env['base.partner.merge.automatic.wizard'].with_context(
             {'partner_show_db_id': True, 'default_dst_partner_id': test_partner}).new()
         self.assertEqual(partner_merge_wizard.dst_partner_id.display_name, expected_partner_name, "'Destination Contact' name should contain db ID in brackets")
+
+    def test_email_formatted(self):
+        """ Check that email_formatted is correctly formatted"""
+        test_partner = self.env['res.partner'].create({'name': 'My Company Name', "email": "My company <email@example.com>"})
+        self.assertEqual(test_partner.email_formatted, '"My Company Name" <email@example.com>')


### PR DESCRIPTION
Before this commit, if you had an email_formatted in the field email, the
computed field email_formatted will be 'wrong' because double formatted.

Now, we normalize the email before to call the formataddr that will add the
name if provided.

```py
partner.name = "My Company Name"
partner.email = 'My company <email@example.com>'
print(partner.email_formatted)
```

Before this commit:
>"My Company Name" <My company <email@example.com>>

After this commit:
>"My Company Name" <email@example.com>
