### PR TITLE
[FIX] sale: down payment invoice has correct company

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -125,7 +125,9 @@ class SaleAdvancePaymentInv(models.TransientModel):
 
         if order.fiscal_position_id:
             invoice_vals['fiscal_position_id'] = order.fiscal_position_id.id
-        invoice = self.env['account.move'].sudo().create(invoice_vals).with_user(self.env.uid)
+
+        invoice = self.env['account.move'].with_company(order.company_id).with_user(self.env.uid)\
+            .sudo().create(invoice_vals)
         invoice.message_post_with_view('mail.message_origin_link',
                     values={'self': invoice, 'origin': order},
                     subtype_id=self.env.ref('mail.mt_note').id)


### PR DESCRIPTION
In a multicompany environment, if you create a sale with company A,
then switch to company B to generate the invoice. The latter should
have, as company, company A. This is the case if you generate a
regular invoice while this is not the case if you generate any of
the down payment invoice.

The way the invoice is generated is not the same. To fix that bug,
I set the company of the order to the invoice environment such that
the journal is correctly chosen. Once the journal is chosen, the
company can be deduced correctly.

Signed-off-by: Adrien Minet <admi@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
