### PR TITLE
[FIX] pos_hr : Wrong cashier assigned to orders

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -762,6 +762,11 @@ exports.PosModel = Backbone.Model.extend({
     set_cashier: function(employee){
         this.set('cashier', employee);
         this.db.set_cashier(this.get('cashier'));
+        var selectedOrder = this.get_order()
+        if(selectedOrder && !selectedOrder.finalized){
+            selectedOrder.employee = employee
+            this.set_order(selectedOrder)
+        }
     },
     // creates a new empty order and sets it as the current order
     add_new_order: function(options){
@@ -2797,7 +2802,7 @@ exports.Order = Backbone.Model.extend({
                 return paymentline.export_for_printing();
             });
         var client  = this.get('client');
-        var cashier = this.pos.get_cashier();
+        var cashier = this.pos.get_order().employee;
         var company = this.pos.company;
         var date    = new Date();
 

--- a/addons/pos_hr/static/tests/tours/PosHrTour.js
+++ b/addons/pos_hr/static/tests/tours/PosHrTour.js
@@ -66,7 +66,7 @@ odoo.define('point_of_sale.tour.PosHr', function (require) {
     ProductScreen.exec.addOrderline('Desk Pad', '1', '4');
     ProductScreen.check.totalAmountIs('4.0')
     Chrome.do.clickTicketButton();
-    TicketScreen.check.nthRowContains(2, 'Pos Employee2');
+    TicketScreen.check.nthRowContains(2, 'Pos Employee1');
     TicketScreen.check.nthRowContains(3, 'Pos Employee1');
 
     // order for admin


### PR DESCRIPTION
Current behavior:
When changing cashier before going in payment, the order cashier is the old one
but the good cashier is printed on the receipt

Steps to reproduce:
1. Go to Bar POS -> Settings -> Turn on ​Authorized Employees -> Add 2+ Allowed employees -> Save
2. Duplicate tab so it is easy to compare backend Orders vs Receipt -> Open new POS Bar session -> Choose any Employee
3. Add products FIRST -> Then Switch to a different Employee -> Validate the Order
4. On other tab -> Sessions -> Click current session -> Orders -> Refresh if needed
5. Compare the Employee on the Receipt and the Employee of the Order -> Employee does not match

opw-2696159


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
