### PR TITLE
[FIX] l10_fr: according to the french law invoice_date and date shoul…

### DIFF
--- a/addons/l10n_fr/models/l10n_fr.py
+++ b/addons/l10n_fr/models/l10n_fr.py
@@ -19,7 +19,7 @@ class AccountMove(models.Model):
         return super()._get_accounting_date(invoice_date, has_tax)
 
     @api.constrains('move_type', 'date', 'invoice_date')
-    def _check_duplicate_supplier_reference(self):
+    def _check_french_date_invoice_date(self):
         moves = self.filtered(lambda move: move.company_id._is_vat_french() and move.date and move.invoice_date \
                               and move.is_sale_document(include_receipts=True) and move.date != move.invoice_date)
         if moves:


### PR DESCRIPTION
…d be the same.

By importing invoices or with the reverse wizard it is possible to have date != invoice_date in customer invoice (or refund). It is not legal.

https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000027356476/

@qdp-odoo 
@oco-odoo 
@sla-subteno-it
@alexis-via 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
