### PR TITLE
[FIX] website_*: update of the total amount according to shipping method

### DIFF
--- a/addons/website_payment/static/src/js/website_payment_form.js
+++ b/addons/website_payment/static/src/js/website_payment_form.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import core from 'web.core';
 import {_t} from 'web.core';
 import checkoutForm from 'payment.checkout_form';
 
@@ -7,6 +8,14 @@ checkoutForm.include({
     events: _.extend({}, checkoutForm.prototype.events || {}, {
         'change .o_wpayment_fee_impact': '_onFeeParameterChange',
     }),
+
+    /**
+     * @override
+     */
+    start: function () {
+        core.bus.on('update_shipping_cost', this, this._updateShippingCost);
+        return this._super.apply(this, arguments);
+    },
 
     //--------------------------------------------------------------------------
     // Private
@@ -84,6 +93,17 @@ checkoutForm.include({
     // Handlers
     //--------------------------------------------------------------------------
 
+    /**
+     * Update the total amount to be paid.
+     *
+     * Called upon change of shipping method
+     *
+     * @private
+     * @param {float} amount
+     */
+     _updateShippingCost: function (amount) {
+        this.txContext.amount = amount;
+     },
     /**
      * Update the fees associated to each acquirer.
      *

--- a/addons/website_sale_delivery/controllers/main.py
+++ b/addons/website_sale_delivery/controllers/main.py
@@ -117,5 +117,6 @@ class WebsiteSaleDelivery(WebsiteSale):
                 'new_amount_untaxed': Monetary.value_to_html(order.amount_untaxed, {'display_currency': currency}),
                 'new_amount_tax': Monetary.value_to_html(order.amount_tax, {'display_currency': currency}),
                 'new_amount_total': Monetary.value_to_html(order.amount_total, {'display_currency': currency}),
+                'new_amount_total_raw': order.amount_total,
             }
         return {}

--- a/addons/website_sale_delivery/static/src/js/website_sale_delivery.js
+++ b/addons/website_sale_delivery/static/src/js/website_sale_delivery.js
@@ -62,6 +62,15 @@ publicWidget.registry.websiteSaleDelivery = publicWidget.Widget.extend({
         $carrierInput.siblings('.o_wsale_delivery_badge_price').append('<span class="fa fa-circle-o-notch fa-spin"/>');
     },
     /**
+     * Update the total cost according to the selected shipping method
+     * 
+     * @private
+     * @param {float} amount : The new total amount of to be paid
+     */
+    _updateShippingCost: function(amount){
+        core.bus.trigger('update_shipping_cost', amount);
+    },
+    /**
      * @private
      * @param {Object} result
      */
@@ -87,6 +96,9 @@ publicWidget.registry.websiteSaleDelivery = publicWidget.Widget.extend({
             $amountUntaxed.html(result.new_amount_untaxed);
             $amountTax.html(result.new_amount_tax);
             $amountTotal.html(result.new_amount_total);
+        }
+        if (result.new_amount_total_raw !== undefined) {
+            this._updateShippingCost(result.new_amount_total_raw);
         }
     },
     /**


### PR DESCRIPTION
### Expected behaviour

When buying something on the website, the amount to be paid for the client should take into account the choice of the shipping method.

### Observed behaviour

When choosing a different shipping method than the default one, and only if this method is a third party acquire, the total amount is updated on the website but the amount the client will be asked to pay doesn't take into account this change, being computed according to the default shipping method.

### Steps to Reproduce this Issue
1. Select a product on the website and add it to the cart
2. View and validate the cart
3. Change the shipping method
4. Click on the "Pay now" button

### Problem Root Cause

This issue comes from the fact that the amount was written in the view when creating the cart view and wasn't updated by a change of shipping method.

### Related issue
- opw-2686369


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
