### PR TITLE
[FIX] point_of_sale: select general type journal in view

### DIFF
--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -633,7 +633,7 @@
                                 <div class="content-group">
                                     <div class="row mt16" title="Whenever you close a session, one entry is generated in the following accounting journal for all the orders not invoiced. Invoices are recorded in accounting separately.">
                                         <label string="Sales Journal" for="journal_id" class="col-lg-3 o_light_label" options="{'no_open': True, 'no_create': True}"/>
-                                        <field name="journal_id" required="1" domain="[('company_id', '=', company_id), ('type', '=', 'sale')]" context="{'default_company_id': company_id, 'default_type': 'sale'}"/>
+                                        <field name="journal_id" required="1" domain="[('company_id', '=', company_id), ('type', 'in', ('general', 'sale'))]" context="{'default_company_id': company_id, 'default_type': 'general'}"/>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
The changes brought with
https://github.com/odoo/odoo/commit/6420b6d778ad24b9b441a7158ba85bc96ba5b60f
changed the default PoS journal's type for `general` instead of `sale`,
but no changes were made to the type's domain in the pos setting's view,
preventing the user to choose that journal again once it has been changed.

opw-2677130