### PR TITLE
[FIX] l10n_ar: demo install together with sale_timesheet

### DIFF
--- a/addons/l10n_ar/__manifest__.py
+++ b/addons/l10n_ar/__manifest__.py
@@ -118,8 +118,6 @@ Master Data:
         'demo/account_customer_refund_demo.xml',
         'demo/account_supplier_invoice_demo.xml',
         'demo/account_supplier_refund_demo.xml',
-        # restore
-        'demo/res_users_demo.xml',
     ],
     'installable': True,
     'auto_install': False,

--- a/addons/l10n_ar/demo/account_customer_invoice_demo.xml
+++ b/addons/l10n_ar/demo/account_customer_invoice_demo.xml
@@ -4,26 +4,24 @@
     <!-- TODO This demo data is for functional testing and demo but also was used for tests. Test cases should be moved to proper tests -->
     <!-- TODO also, once written the proper tests, we should remove price and name information from lines because it is overwriten by "_onchange_product_id" method. That methods is called to set taxes and uom from products -->
     <!-- Invoice to gritti support service, vat 21 -->
-    <record id="demo_invoice_1" model="account.move">
+    <record id="demo_invoice_1" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="res_partner_gritti_agrimensura"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-01'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 642.0, 'quantity': 1}),
         ]"/>
     </record>
 
     <!-- Invoice to CMR with vat 21, 27 and 10,5 -->
-    <record id="demo_invoice_2" model="account.move">
+    <record id="demo_invoice_2" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="res_partner_cmr"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-05'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
             (0, 0, {'product_id': ref('product_product_telefonia'), 'price_unit': 250.0, 'quantity': 1}),
@@ -32,13 +30,12 @@
     </record>
 
     <!-- Invoice to ADHOC with vat cero and 21 -->
-    <record id="demo_invoice_3" model="account.move">
+    <record id="demo_invoice_3" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="l10n_ar.res_partner_adhoc"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-01'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
             (0, 0, {'product_id': ref('product_product_cero'), 'price_unit': 200.0, 'quantity': 1}),
@@ -46,13 +43,12 @@
     </record>
 
     <!-- Invoice to ADHOC with vat exempt and 21 -->
-    <record id="demo_invoice_4" model="account.move">
+    <record id="demo_invoice_4" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="l10n_ar.res_partner_adhoc"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-01'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
             (0, 0, {'product_id': ref('product_product_exento'), 'price_unit': 100.0, 'quantity': 1}),
@@ -60,13 +56,12 @@
     </record>
 
     <!-- Invoice to ADHOC with all type of taxes -->
-    <record id="demo_invoice_5" model="account.move">
+    <record id="demo_invoice_5" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="l10n_ar.res_partner_adhoc"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-13'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
             (0, 0, {'product_id': ref('product_product_telefonia'), 'price_unit': 250.0, 'quantity': 1}),
@@ -78,14 +73,13 @@
     </record>
 
     <!-- Invoice to cerro castor, fiscal position changes taxes to exempt -->
-    <record id="demo_invoice_6" model="account.move">
+    <record id="demo_invoice_6" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="res_partner_cerrocastor"/>
         <field name="journal_id" ref="l10n_ar.sale_expo_journal_ri"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-03'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_incoterm_id" ref="account.incoterm_EXW"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
@@ -98,14 +92,13 @@
     </record>
 
     <!-- Export invoice to expresso, fiscal position changes tax to exempt (type 4 because it have services) -->
-    <record id="demo_invoice_7" model="account.move">
+    <record id="demo_invoice_7" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="res_partner_expresso"/>
         <field name="journal_id" ref="l10n_ar.sale_expo_journal_ri"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-03'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_incoterm_id" ref="account.incoterm_EXW"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
@@ -118,13 +111,12 @@
     </record>
 
     <!-- Invoice to consumidor final -->
-    <record id="demo_invoice_8" model="account.move">
+    <record id="demo_invoice_8" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="l10n_ar.par_cfa"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-13'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 642.0, 'quantity': 1}),
         ]"/>
@@ -135,13 +127,12 @@
         <field name="active" eval="True"/>
     </record>
 
-    <record id="demo_invoice_10" model="account.move">
+    <record id="demo_invoice_10" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="l10n_ar.res_partner_adhoc"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-13'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 1000.0, 'quantity': 5}),
         ]"/>
@@ -149,13 +140,12 @@
     </record>
 
     <!-- Invoice to ADHOC with many lines in order to prove rounding error, with 4 decimals of precision for the currency and 2 decimals for the product the error apperar -->
-    <record id="demo_invoice_11" model="account.move">
+    <record id="demo_invoice_11" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="l10n_ar.res_partner_adhoc"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-13'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 1.12, 'quantity': 1, 'name': 'Support Services 1'}),
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 1.12, 'quantity': 1, 'name': 'Support Services 2'}),
@@ -165,13 +155,12 @@
     </record>
 
     <!-- Invoice to ADHOC with many lines in order to test rounding error, it is required to use a 4 decimal precision in prodct in order to the error occur -->
-    <record id="demo_invoice_12" model="account.move">
+    <record id="demo_invoice_12" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="l10n_ar.res_partner_adhoc"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-13'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 15.7076, 'quantity': 1, 'name': 'Support Services 1'}),
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 5.3076, 'quantity': 2, 'name': 'Support Services 2'}),
@@ -181,13 +170,12 @@
     </record>
 
     <!-- Invoice to ADHOC with many lines in order to test zero amount invoices y rounding error. it is required to set the product decimal precision to 4 and change 260.59 for 260.60 in order to reproduce the error -->
-    <record id="demo_invoice_13" model="account.move">
+    <record id="demo_invoice_13" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="l10n_ar.res_partner_adhoc"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-13'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 24.3, 'quantity': 3, 'name': 'Support Services 1'}),
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 260.59, 'quantity': -1, 'name': 'Support Services 2'}),
@@ -201,14 +189,13 @@
     </record>
 
     <!-- Export invoice to expresso, fiscal position changes tax to exempt (type 1 because only products) -->
-    <record id="demo_invoice_14" model="account.move">
+    <record id="demo_invoice_14" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="res_partner_expresso"/>
         <field name="journal_id" ref="l10n_ar.sale_expo_journal_ri"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-20'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_incoterm_id" ref="account.incoterm_EXW"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
@@ -216,14 +203,13 @@
     </record>
 
     <!-- Export invoice to expresso, fiscal position changes tax to exempt (type 2 because only service) -->
-    <record id="demo_invoice_15" model="account.move">
+    <record id="demo_invoice_15" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="res_partner_expresso"/>
         <field name="journal_id" ref="l10n_ar.sale_expo_journal_ri"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-20'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_incoterm_id" ref="account.incoterm_EXW"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product_product_telefonia'), 'price_unit': 250.0, 'quantity': 1}),
@@ -231,7 +217,7 @@
     </record>
 
     <!-- Export invoice to expresso, fiscal position changes tax to exempt (type 1 because it have products only, used to test refund of expo) -->
-    <record id="demo_invoice_16" model="account.move">
+    <record id="demo_invoice_16" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="res_partner_expresso"/>
         <field name="journal_id" ref="l10n_ar.sale_expo_journal_ri"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
@@ -239,7 +225,6 @@
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-22'"/>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-01'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_incoterm_id" ref="account.incoterm_EXW"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
@@ -247,26 +232,24 @@
     </record>
 
     <!-- Invoice to ADHOC with 100% of discount -->
-    <record id="demo_invoice_17" model="account.move">
+    <record id="demo_invoice_17" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="l10n_ar.res_partner_adhoc"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-13'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 24.3, 'quantity': 3, 'name': 'Support Services 8', 'discount': 100}),
         ]"/>
     </record>
 
     <!-- Invoice to ADHOC with 100% of discount and with different VAT aliquots -->
-    <record id="demo_invoice_18" model="account.move">
+    <record id="demo_invoice_18" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="l10n_ar.res_partner_adhoc"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-13'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 24.3, 'quantity': 3, 'name': 'Support Services 8', 'discount': 100}),
             (0, 0, {'product_id': ref('product_product_telefonia'), 'price_unit': 250.0, 'quantity': 1, 'discount': 100}),
@@ -275,13 +258,12 @@
     </record>
 
     <!-- Invoice to ADHOC with multiple taxes and perceptions -->
-    <record id="demo_invoice_19" model="account.move">
+    <record id="demo_invoice_19" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="l10n_ar.res_partner_adhoc"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">out_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-13'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 24.3, 'quantity': 3, 'name': 'Support Services 8'}),
             (0, 0, {'product_id': ref('product_product_telefonia'), 'price_unit': 250.0, 'quantity': 1}),

--- a/addons/l10n_ar/demo/account_customer_refund_demo.xml
+++ b/addons/l10n_ar/demo/account_customer_refund_demo.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="True">
 
     <!-- Create draft refund for invoice 3 -->
-    <record id="demo_refund_invoice_3" model="account.move.reversal">
+    <record id="demo_refund_invoice_3" model="account.move.reversal" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="reason">Mercadería defectuosa</field>
         <field name="refund_method">refund</field>
         <field name="move_ids" eval="[(4, ref('demo_invoice_3'), 0)]"/>
@@ -13,7 +13,7 @@
     <function model="account.move.reversal" name="reverse_moves" eval="[ref('demo_refund_invoice_3')]"/>
 
     <!-- Create draft refund for invoice 4 -->
-    <record id="demo_refund_invoice_4" model="account.move.reversal">
+    <record id="demo_refund_invoice_4" model="account.move.reversal" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="reason">Venta cancelada</field>
         <field name="refund_method">cancel</field>
         <field name="move_ids" eval="[(4, ref('demo_invoice_4'), 0)]"/>
@@ -24,7 +24,7 @@
     <function model="account.move.reversal" name="reverse_moves" eval="[ref('demo_refund_invoice_4')]"/>
 
     <!-- Create cancel refund for expo invoice 16 (las nc/nd expo invoice no requiere parametro permiso existennte, por eso agregamos este ejemplo) -->
-    <record id="demo_refund_invoice_16" model="account.move.reversal">
+    <record id="demo_refund_invoice_16" model="account.move.reversal" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="reason">Venta cancelada</field>
         <field name="refund_method">cancel</field>
         <field name="move_ids" eval="[(4, ref('demo_invoice_16'), 0)]"/>

--- a/addons/l10n_ar/demo/account_supplier_invoice_demo.xml
+++ b/addons/l10n_ar/demo/account_supplier_invoice_demo.xml
@@ -4,13 +4,12 @@
     <!-- we add l10n_latam_document_number on on a separete line because we need l10n_latam_document_type_id to be auto assigned so that account.move.name can be computed with the _inverse_l10n_latam_document_number -->
 
     <!-- Invoice from gritti support service, auto fiscal position set VAT Not Applicable -->
-    <record id="demo_sup_invoice_1" model="account.move">
+    <record id="demo_sup_invoice_1" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="res_partner_gritti_agrimensura"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">in_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-01'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 642.0, 'quantity': 1}),
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
@@ -22,13 +21,12 @@
     </record>
 
     <!-- Invoice from Foreign with vat 21, 27 and 10,5 -->
-    <record id="demo_sup_invoice_2" model="account.move">
+    <record id="demo_sup_invoice_2" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="res_partner_foreign"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">in_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-01'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
             (0, 0, {'product_id': ref('product_product_telefonia'), 'price_unit': 250.0, 'quantity': 1}),
@@ -37,13 +35,12 @@
     </record>
 
     <!-- Invoice from Foreign with vat zero and 21 -->
-    <record id="demo_sup_invoice_3" model="account.move">
+    <record id="demo_sup_invoice_3" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="res_partner_foreign"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">in_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-11'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
             (0, 0, {'product_id': ref('product_product_cero'), 'price_unit': 200.0, 'quantity': 1}),
@@ -51,13 +48,12 @@
     </record>
 
     <!-- Invoice to Foreign with vat exempt and 21 -->
-    <record id="demo_sup_invoice_4" model="account.move">
+    <record id="demo_sup_invoice_4" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="res_partner_foreign"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">in_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-15'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
             (0, 0, {'product_id': ref('product_product_exento'), 'price_unit': 100.0, 'quantity': 1}),
@@ -65,13 +61,12 @@
     </record>
 
     <!-- Invoice to Foreign with all type of taxes  -->
-    <record id="demo_sup_invoice_5" model="account.move">
+    <record id="demo_sup_invoice_5" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="res_partner_foreign"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">in_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-18'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
             (0, 0, {'product_id': ref('product_product_telefonia'), 'price_unit': 250.0, 'quantity': 1}),
@@ -83,26 +78,24 @@
     </record>
 
     <!-- Service Import to Odoo, fiscal position changes tax not correspond -->
-    <record id="demo_sup_invoice_6" model="account.move">
+    <record id="demo_sup_invoice_6" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="res_partner_odoo"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">in_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-26'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 1642.0, 'quantity': 1}),
         ]"/>
     </record>
 
     <!-- Similar to last one but with line that have tax not correspond with negative amount -->
-    <record id="demo_sup_invoice_7" model="account.move">
+    <record id="demo_sup_invoice_7" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="res_partner_odoo"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">in_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-27'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_2'), 'price_unit': 1642.0, 'quantity': 1}),
             (0, 0, {'product_id': ref('product_product_no_gravado'), 'price_unit': -50.0, 'quantity': 10}),
@@ -110,13 +103,12 @@
     </record>
 
     <!-- Invoice to ADHOC with multiple taxes and perceptions -->
-    <record id="demo_sup_invoice_8" model="account.move">
+    <record id="demo_sup_invoice_8" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="l10n_ar.res_partner_adhoc"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="move_type">in_invoice</field>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-01'"/>
-        <field name="company_id" ref="company_ri"/>
         <field name="invoice_line_ids" eval="[
             (0, 0, {'product_id': ref('product.product_product_27'), 'price_unit': 642.0, 'quantity': 5}),
             (0, 0, {'product_id': ref('product_product_telefonia'), 'price_unit': 250.0, 'quantity': 1}),
@@ -125,7 +117,7 @@
     </record>
 
     <!-- Import Cleareance -->
-    <record id="demo_despacho_1" model="account.move">
+    <record id="demo_despacho_1" model="account.move" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="partner_id" ref="l10n_ar.partner_afip"/>
         <field name="invoice_user_id" ref="base.user_demo"/>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
@@ -133,10 +125,9 @@
         <!-- as we create lines separatelly we need to set journal, if not, misc journal is selected -->
         <field name="journal_id" model="account.journal" search="[('type', '=', 'purchase'), ('company_id', '=', obj().env.company.id)]"/>
         <field name="invoice_date" eval="time.strftime('%Y-%m')+'-13'"/>
-        <field name="company_id" ref="company_ri"/>
     </record>
     <!-- create this lines manually to set taxes and prices -->
-    <record id="demo_despacho_1_line_1" model="account.move.line" context="{'check_move_validity': False}">
+    <record id="demo_despacho_1_line_1" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="move_id" ref="demo_despacho_1"/>
         <field name="price_unit">5064.98</field>
         <field name="name">[AFIP_DESPACHO] Despacho de importación</field>
@@ -146,7 +137,7 @@
         <field name="tax_ids" model="account.tax" eval="[(6, 0, obj().search([('company_id', '=', obj().env.ref('l10n_ar.company_ri').id), ('name', '=', 'IVA 21%'), ('type_tax_use', '=', 'purchase')], limit=1).ids)]"/>
         <field name="account_id" model="account.move.line" eval="obj().env.ref('l10n_ar.product_product_quote_despacho').categ_id.property_account_income_categ_id.id"/>
     </record>
-    <record id="demo_despacho_1_line_2" model="account.move.line" context="{'check_move_validity': False}">
+    <record id="demo_despacho_1_line_2" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="move_id" ref="demo_despacho_1"/>
         <field name="price_unit">152.08</field>
         <field name="name">[AFIP_TASA_EST] Tasa Estadística</field>
@@ -156,7 +147,7 @@
         <field name="tax_ids" model="account.tax" eval="[(6, 0, obj().search([('company_id', '=', obj().env.ref('l10n_ar.company_ri').id), ('name', '=', 'IVA 21%'), ('type_tax_use', '=', 'purchase')], limit=1).ids)]"/>
         <field name="account_id" model="account.move.line" eval="obj().env.ref('l10n_ar.product_product_tasa_estadistica').categ_id.property_account_income_categ_id.id"/>
     </record>
-    <record id="demo_despacho_1_line_3" model="account.move.line" context="{'check_move_validity': False}">
+    <record id="demo_despacho_1_line_3" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="move_id" ref="demo_despacho_1"/>
         <field name="price_unit">10.0</field>
         <field name="name">[AFIP_ARANCEL] Arancel</field>
@@ -166,7 +157,7 @@
         <field name="tax_ids" model="account.tax" eval="[(6, 0, obj().search([('company_id', '=', obj().env.ref('l10n_ar.company_ri').id), ('name', '=', 'IVA No Gravado'), ('type_tax_use', '=', 'purchase')], limit=1).ids)]"/>
         <field name="account_id" model="account.move.line" eval="obj().env.ref('l10n_ar.product_product_arancel').categ_id.property_account_income_categ_id.id"/>
     </record>
-    <record id="demo_despacho_1_line_4" model="account.move.line" context="{'check_move_validity': False}">
+    <record id="demo_despacho_1_line_4" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="move_id" ref="demo_despacho_1"/>
         <field name="price_unit">28.00</field>
         <field name="name">[AFIP_SERV_GUARDA] Servicio de Guarda</field>
@@ -176,7 +167,7 @@
         <field name="tax_ids" model="account.tax" eval="[(6, 0, obj().search([('company_id', '=', obj().env.ref('l10n_ar.company_ri').id), ('name', '=', 'IVA No Gravado'), ('type_tax_use', '=', 'purchase')], limit=1).ids)]"/>
         <field name="account_id" model="account.move.line" eval="obj().env.ref('l10n_ar.product_product_servicio_de_guarda').categ_id.property_account_income_categ_id.id"/>
     </record>
-    <record id="demo_despacho_1_line_5" model="account.move.line" context="{'check_move_validity': False}">
+    <record id="demo_despacho_1_line_5" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="name">FOB Total</field>
         <field name="move_id" ref="demo_despacho_1"/>
         <field name="price_unit">28936.06</field>
@@ -185,7 +176,7 @@
         <field name="tax_ids" model="account.tax" eval="[(6, 0, obj().search([('company_id', '=', obj().env.ref('l10n_ar.company_ri').id), ('name', '=', 'IVA 21%'), ('type_tax_use', '=', 'purchase')], limit=1).ids)]"/>
         <field name="account_id" model="account.move.line" eval="obj().env.ref('product.product_category_all').property_account_income_categ_id.id"/>
     </record>
-    <record id="demo_despacho_1_line_6" model="account.move.line" context="{'check_move_validity': False}">
+    <record id="demo_despacho_1_line_6" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="name">Flete</field>
         <field name="move_id" ref="demo_despacho_1"/>
         <field name="price_unit">1350.00</field>
@@ -194,7 +185,7 @@
         <field name="tax_ids" model="account.tax" eval="[(6, 0, obj().search([('company_id', '=', obj().env.ref('l10n_ar.company_ri').id), ('name', '=', 'IVA 21%'), ('type_tax_use', '=', 'purchase')], limit=1).ids)]"/>
         <field name="account_id" model="account.move.line" eval="obj().env.ref('product.product_category_all').property_account_income_categ_id.id"/>
     </record>
-    <record id="demo_despacho_1_line_7" model="account.move.line" context="{'check_move_validity': False}">
+    <record id="demo_despacho_1_line_7" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="name">Seguro</field>
         <field name="move_id" ref="demo_despacho_1"/>
         <field name="price_unit">130.21</field>
@@ -203,7 +194,7 @@
         <field name="tax_ids" model="account.tax" eval="[(6, 0, obj().search([('company_id', '=', obj().env.ref('l10n_ar.company_ri').id), ('name', '=', 'IVA 21%'), ('type_tax_use', '=', 'purchase')], limit=1).ids)]"/>
         <field name="account_id" model="account.move.line" eval="obj().env.ref('product.product_category_all').property_account_income_categ_id.id"/>
     </record>
-    <record id="demo_despacho_1_line_8" model="account.move.line" context="{'check_move_validity': False}">
+    <record id="demo_despacho_1_line_8" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="name">-FOB Total</field>
         <field name="move_id" ref="demo_despacho_1"/>
         <field name="price_unit">-28936.06</field>
@@ -212,7 +203,7 @@
         <field name="tax_ids" model="account.tax" eval="[(6, 0, obj().search([('company_id', '=', obj().env.ref('l10n_ar.company_ri').id), ('name', '=', 'IVA No Gravado'), ('type_tax_use', '=', 'purchase')], limit=1).ids)]"/>
         <field name="account_id" model="account.move.line" eval="obj().env.ref('product.product_category_all').property_account_income_categ_id.id"/>
     </record>
-    <record id="demo_despacho_1_line_9" model="account.move.line" context="{'check_move_validity': False}">
+    <record id="demo_despacho_1_line_9" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="name">-Flete</field>
         <field name="move_id" ref="demo_despacho_1"/>
         <field name="price_unit">-1350.00</field>
@@ -221,7 +212,7 @@
         <field name="tax_ids" model="account.tax" eval="[(6, 0, obj().search([('company_id', '=', obj().env.ref('l10n_ar.company_ri').id), ('name', '=', 'IVA No Gravado'), ('type_tax_use', '=', 'purchase')], limit=1).ids)]"/>
         <field name="account_id" model="account.move.line" eval="obj().env.ref('product.product_category_all').property_account_income_categ_id.id"/>
     </record>
-    <record id="demo_despacho_1_line_10" model="account.move.line" context="{'check_move_validity': False}">
+    <record id="demo_despacho_1_line_10" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="name">-Seguro</field>
         <field name="move_id" ref="demo_despacho_1"/>
         <field name="price_unit">-130.21</field>

--- a/addons/l10n_ar/demo/account_supplier_refund_demo.xml
+++ b/addons/l10n_ar/demo/account_supplier_refund_demo.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="True">
 
     <!-- Create draft refund for invoice 3 -->
-    <record id="demo_sup_refund_invoice_3" model="account.move.reversal">
+    <record id="demo_sup_refund_invoice_3" model="account.move.reversal" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="reason">Mercadería defectuosa</field>
         <field name="refund_method">refund</field>
         <field name="l10n_latam_document_number">0001-01234567</field>
@@ -13,7 +13,7 @@
     <function model="account.move.reversal" name="reverse_moves" eval="[ref('demo_sup_refund_invoice_3')]"/>
 
     <!-- Create draft refund for invoice 4 -->
-    <record id="demo_sup_refund_invoice_4" model="account.move.reversal">
+    <record id="demo_sup_refund_invoice_4" model="account.move.reversal" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="reason">Venta cancelada</field>
         <field name="refund_method">cancel</field>
         <field name="l10n_latam_document_number">0001-01234566</field>

--- a/addons/l10n_ar/demo/account_tax_demo.xml
+++ b/addons/l10n_ar/demo/account_tax_demo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
 
-    <record id="ri_tax_other_taxes_ventas" model="account.tax">
+    <record id="ri_tax_other_taxes_ventas" model="account.tax" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="name">Other Tax</field>
         <field name="description">Other Tax</field>
         <field name="sequence">4</field>
@@ -42,7 +42,7 @@
         <field name="company_id" ref="l10n_ar.company_ri"/>
     </record>
 
-    <record id="ri_tax_other_taxes_compras" model="account.tax">
+    <record id="ri_tax_other_taxes_compras" model="account.tax" context="{'allowed_company_ids': [ref('company_ri')]}">
         <field name="name">Other Tax</field>
         <field name="description">Other Tax</field>
         <field name="sequence">4</field>

--- a/addons/l10n_ar/demo/res_users_demo.xml
+++ b/addons/l10n_ar/demo/res_users_demo.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-
-    <!-- reset root on main company so that other modules can install without issues -->
-    <record id="base.user_root" model="res.users">
-        <field name="company_id" ref="base.main_company"/>
-    </record>
-
-</odoo>

--- a/addons/l10n_ar/demo/respinsc_demo.xml
+++ b/addons/l10n_ar/demo/respinsc_demo.xml
@@ -28,8 +28,12 @@
 
     <function model="res.users" name="write">
         <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
-        <value eval="{'company_ids': [(4, ref('l10n_ar.company_ri'))],
-                     'company_id': ref('l10n_ar.company_ri')}"/>
+        <value eval="{'company_ids': [(4, ref('l10n_ar.company_ri'))]}"/>
+    </function>
+
+    <function model="res.users" name="write">
+        <value eval="[ref('base.user_root')]"/>
+        <value eval="{'company_id': ref('l10n_ar.company_ri')}"/>
     </function>
 
     <function model="account.chart.template" name="try_loading">

--- a/addons/l10n_ar/demo/respinsc_demo.xml
+++ b/addons/l10n_ar/demo/respinsc_demo.xml
@@ -31,11 +31,6 @@
         <value eval="{'company_ids': [(4, ref('l10n_ar.company_ri'))]}"/>
     </function>
 
-    <function model="res.users" name="write">
-        <value eval="[ref('base.user_root')]"/>
-        <value eval="{'company_id': ref('l10n_ar.company_ri')}"/>
-    </function>
-
     <function model="account.chart.template" name="try_loading">
         <value eval="[ref('l10n_ar.l10nar_ri_chart_template')]"/>
         <value model="res.company" eval="obj().env.ref('l10n_ar.company_ri')"/>


### PR DESCRIPTION
Create a demo database installing l10n_ar and sale_timesheet, something like: `odoo -i l10n_ar,sale_timesheet`

Current behavior:
We get the error
`- 'Hotel Accommodation' belongs to company 'YourCompany' and 'Partner' (partner_id: 'YourCompany, Marc Demo') belongs to another company.
`

Desired behavior:
Everything fine.
There is no need to set company_id = responsable inscripto for partner demo and admin
