### PR TITLE
[FIX] website: allow non 400 normal google font


### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -177,7 +177,7 @@ const FontFamilyPickerUserValueWidget = SelectUserValueWidget.extend({
                         let isValidFamily = false;
 
                         try {
-                            const result = await fetch("https://fonts.googleapis.com/css?family=" + m[1], {method: 'HEAD'});
+                            const result = await fetch("https://fonts.googleapis.com/css?family=" + m[1]+':300,300i,400,400i,700,700i', {method: 'HEAD'});
                             // Google fonts server returns a 400 status code if family is not valid.
                             if (result.ok) {
                                 isValidFamily = true;


### PR DESCRIPTION

When adding a google font, the website test if it is valid with an URL
like:

https://fonts.googleapis.com/css?family=Open+Sans+Condensed

but this is only testing the normal with weight 400 version which might
not be available (for "open sans condensed" only 300 and 700 weight is
available).

Instead with this fix we try:

https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,300i,400,400i,700,700i

which is what is being queried when the font is really used and will
only fail if all types are missing (in which case it is a good thing
that it fails).

opw-2678485
