### PR TITLE
[IMP] hr_timesheet: set week grid_range in timesheet grid view

### DIFF
--- a/addons/hr_timesheet/report/hr_timesheet_report_view.xml
+++ b/addons/hr_timesheet/report/hr_timesheet_report_view.xml
@@ -5,7 +5,7 @@
             <field name="name">Timesheets by Employee</field>
             <field name="res_model">account.analytic.line</field>
             <field name="domain">[('project_id', '!=', False)]</field>
-            <field name="context">{'search_default_groupby_employee':1,}</field>
+            <field name="context">{'search_default_groupby_employee':1, 'grid_range': 'week'}</field>
             <field name="search_view_id" ref="hr_timesheet_line_search"/>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
@@ -55,7 +55,7 @@
             <field name="name">Timesheets by Project</field>
             <field name="res_model">account.analytic.line</field>
             <field name="domain">[('project_id', '!=', False)]</field>
-            <field name="context">{'search_default_groupby_project': 1}</field>
+            <field name="context">{'search_default_groupby_project': 1, 'grid_range': 'week'}</field>
             <field name="search_view_id" ref="hr_timesheet_line_search"/>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
@@ -105,7 +105,7 @@
             <field name="name">Timesheets by Task</field>
             <field name="res_model">account.analytic.line</field>
             <field name="domain">[('project_id', '!=', False)]</field>
-            <field name="context">{'search_default_groupby_project':1,'search_default_groupby_task':1,}</field>
+            <field name="context">{'search_default_groupby_project':1,'search_default_groupby_task':1, 'grid_range': 'week'}</field>
             <field name="search_view_id" ref="hr_timesheet_line_search"/>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">


### PR DESCRIPTION
 This commit sets `week` as `grid_range` in the grid view of `Timesheets by Project`,
`Timesheets by Task` and `Timesheets by Employee`.  

closes #80495 
task-2658828