### PR TITLE
[FIX] project: remove duplicate filter in rating.rating search view

### DIFF
--- a/addons/project/views/rating_views.xml
+++ b/addons/project/views/rating_views.xml
@@ -83,7 +83,7 @@
             </xpath>
             <xpath expr="//filter[@name='responsible']" position="replace"></xpath>
             <xpath expr="/search" position="inside">
-                <filter string="Last 30 Days" name="rating_last_30_days" domain="[
+                <filter string="Last 30 Days" name="rating_last_30_days" invisible="1" domain="[
                     ('write_date', '>=', (datetime.datetime.combine(context_today() + relativedelta(days=-30), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"
                 />
                 <separator/>
@@ -188,7 +188,7 @@
                 Let's wait for your customers to manifest themselves.
             </p>
         </field>
-        <field name="context">{'search_default_rating_last_30_days': 1, 'search_default_responsible': 1}</field>
+        <field name="context">{'search_default_last_month': 1, 'search_default_responsible': 1}</field>
     </record>
 
     <record id="rating_rating_action_project_report_kanban" model="ir.actions.act_window.view">


### PR DESCRIPTION
Before this commit, the `Last 30 days` filter is duplicate in the search
view of rating.rating in `Reporting > Customer Ratings` menu of Project
app.

This commit removes the duplicate one.

Part of task-2671848

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
