### PR TITLE
[FIX] hr_holidays: show Dashboard data in mobile

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar.js
@@ -225,7 +225,7 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
                             const elem = QWeb.render('hr_holidays.dashboard_calendar_header_mobile', {
                                 timeoff: data,
                             });
-                            self.$el.find('.o_calendar_filter_item[data-value=' + data[4] + '] .o_cw_filter_title').append(elem);
+                            self.$el.find('.o_calendar_filter_item[data-value=' + data[3] + '] .o_cw_filter_title').append(elem);
                         });
                     } else {
                         const elem = QWeb.render('hr_holidays.dashboard_calendar_header', {


### PR DESCRIPTION
The number of leaves taken / available was no longer available
in mobile.

TaskID: 2701070

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
