### PR TITLE
[FIX] web_editor: apply changes on exit code view

### DIFF
--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -228,7 +228,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
             }
             this.wysiwyg.odooEditor.observerActive();
             this.wysiwyg.setValue($codeview.val());
-            this.wysiwyg.odooEditor.historyStep();
+            this.wysiwyg.odooEditor.historyStep(true);
         } else {
             this.resizerHandleObserver = new MutationObserver((mutations, observer) => {
                 for (let mutation of mutations) {


### PR DESCRIPTION
When leaving the code view, we need to apply its html to the editable. This failed in mass_mailing because the editor rolled back the changes due to the top element being unremovable. To avoid that, we set the `skipRollback` argument of `historyStep` to `true` and thereby trust the user's changes.

task-2701024

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
