### PR TITLE
[FIX] base_vat: allow disabling VAT check through context

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -174,6 +174,10 @@ class ResPartner(models.Model):
 
     @api.constrains('vat', 'country_id')
     def check_vat(self):
+        # The context key 'no_vat_validation' allows you to store/set a VAT number without doing validations.
+        # This is for API pushes from external platforms where you have no control over VAT numbers.
+        if self.env.context.get('no_vat_validation'):
+            return
         if self.env.context.get('company_id'):
             company = self.env['res.company'].browse(self.env.context['company_id'])
         else:


### PR DESCRIPTION
Before this fix there is no real way to influence the VAT validation.
This can be problematic though as in some cases external platforms push data to you
on which you don't really have control. If an external software pushes an invalid VAT
and your database has the option 'Verify VAT Numbers' checked on there is no way
for you to bypass this though.
This means that before this commit you have to always run VAT number checks on all data,
no matter if they come through the frontend or backend.

After this commit you can supply a context key 'no_vat_validation' though.
This way you could skip doing VAT number validations on (some) records while still
enforcing this in the UI.
This allows you to have crons/external API's push any VAT number while enforcing full
validation through the UI.

This opens up the best of both worlds.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
