### PR TITLE
[FIX] web: Fix access right issues on external layout prining

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -484,7 +484,7 @@
             </t>
         </t>
 
-        <t t-if="company.external_report_layout_id" t-call="{{company.external_report_layout_id.key}}"><t t-out="0"/></t>
+        <t t-if="company.external_report_layout_id" t-call="{{company.external_report_layout_id.sudo().key}}"><t t-out="0"/></t>
         <t t-else="else" t-call="web.external_layout_standard"><t t-out="0"/></t>
 
     </template>


### PR DESCRIPTION
Purpose
=======

If the user doesn't have access to ir.ui.view (aka no admin or
website access rights), printing a report with a configured
external layout will lead to a traceback, as it's forbidden
for the use to read on the field "key" on the related ir.ui.view.

As we only want to retrieve the view key, this is safe to use
sudo at that point.

TaskID: 2701251

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
