### PR TITLE
[IMP] calendar: improve crowded meeting popover design

### DIFF
--- a/addons/calendar/static/src/js/base_calendar.js
+++ b/addons/calendar/static/src/js/base_calendar.js
@@ -38,6 +38,9 @@ const Many2ManyAttendee = FieldMany2ManyTagsAvatar.extend({
     init: function () {
         this._super.apply(this, arguments);
         this.className += this.nodeOptions.block ? ' d-block' : '';
+        if (this.nodeOptions.isPopover) {
+            this.tag_template = 'FieldMany2ManyAttendeePopover';
+        }
     },
 
     //--------------------------------------------------------------------------
@@ -78,6 +81,15 @@ const Many2ManyAttendee = FieldMany2ManyTagsAvatar.extend({
                 return a_org ? -1 : 1;
              });
         }
+        result = {
+            ...result,
+            acceptedCount: result.attendeesData.filter(attendee => attendee.status === 'accepted').length,
+            declinedCount: result.attendeesData.filter(attendee => attendee.status === 'declined').length,
+            previewAttendeesMax: 5
+        }
+
+        result.uncertainCount = result.attendeesData.length - result.acceptedCount - result.declinedCount;
+
         return result;
     },
 });

--- a/addons/calendar/static/src/scss/calendar.scss
+++ b/addons/calendar/static/src/scss/calendar.scss
@@ -74,6 +74,29 @@
     padding-top: 0px !important;
 }
 
+.o_cw_popover:not(.year_event) {
+    max-height: 100%;
+    display: flex;
+}
+
+.o_cw_body {
+    &:not(.year_event) {
+        max-height: calc(100% - 40px);
+        overflow: auto;
+    }
+    &::-webkit-scrollbar {
+        background: gray('200');
+        width: 6px;
+    }
+    &::-webkit-scrollbar-thumb {
+        background: gray('500');
+    }
+}
+
+.o_cw_popover_fields_secondary {
+    max-height: max-content !important;
+}
+
 .o_calendar_attendees {
     max-width:80% !important;
 }
@@ -91,4 +114,8 @@
 }
 .o_attendee_border_tentative {
     border-color: theme-color('light');
+}
+
+.badge.collapse:not(.show) {
+    display: none !important; // necessary to collapse calendar popover partners
 }

--- a/addons/calendar/static/src/xml/base_calendar.xml
+++ b/addons/calendar/static/src/xml/base_calendar.xml
@@ -78,4 +78,41 @@
         </div>
     </t>
 
+    <t t-name="FieldMany2ManyAttendeePopover">
+        <t t-if="elements.length > previewAttendeesMax">
+            <div class="collapse multicollapse">
+                <a class="d-block" type="button" data-toggle="collapse" data-target=".multicollapse" aria-expanded="false">
+                    <i><t t-out="elements.length"/> attendees</i>
+                    <i class="fa fa-angle-up float-right"/>
+                </a>
+            </div>
+            <t t-foreach="elements" t-as="el">
+                <t t-set="color" t-value="el[colorField] || 0"/>
+                <t t-set="colornames" t-value="['No color', 'Red', 'Orange', 'Yellow', 'Light blue', 'Dark purple', 'Salmon pink', 'Medium blue', 'Dark blue', 'Fushia', 'Green', 'Purple']"/>
+                <div t-attf-class="badge badge-pill #{el_index >= previewAttendeesMax ? 'collapse multicollapse' : ''} o_tag_color_#{color}" t-att-data-color="color" t-att-data-index="el_index" t-att-data-id="el.id" t-attf-title="Tag color: #{colornames[color]}">
+                    <t t-set="_badge_text">
+                        <span><img t-attf-src="/web/image/#{avatarModel}/#{el.id}/#{avatarField}" t-att-data-id="el.id" class="rounded-circle o_m2m_avatar"/></span>
+                        <span class="o_badge_text" t-att-title="el.display_name"><span role="img" t-attf-aria-label="Tag color: #{colornames[color]}"/><span class="o_tag_badge_text" t-esc="el.display_name"/></span>
+                    </t>
+                    <span t-out="_badge_text"/>
+                    <a t-if="!readonly" href="#" class="fa fa-times o_delete" title="Delete" aria-label="Delete"/>
+                </div>
+            </t>
+            <div class="collapse show multicollapse">
+                <a class="d-block" type="button" data-toggle="collapse" data-target=".multicollapse" aria-expanded="false">
+                    <b><t t-out="elements.length"/> attendees
+                    <i class="fa fa-angle-down float-right"/>
+                    </b>
+                </a>
+
+                <i t-if="acceptedCount" class="d-block"><t t-out="acceptedCount"/> accepted</i>
+                <i t-if="declinedCount" class="d-block"><t t-out="declinedCount"/> declined</i>
+                <i t-if="uncertainCount" class="d-block"><t t-out="uncertainCount"/> uncertain</i>
+            </div>
+        </t>
+        <t t-else="">
+            <t t-call="FieldMany2ManyTagAvatar"/>
+        </t>
+    </t>
+
 </template>

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -281,15 +281,15 @@
                 <field name="is_highlighted" invisible="1"/>
                 <field name="is_organizer_alone" invisible="1"/>
                 <field name="display_description" invisible="1"/>
-                <field name="location" attrs="{'invisible': [('location', '=', False)]}"/>
-                <field name="description" attrs="{'invisible': [('display_description', '=', False)]}"/>
-                <field name="privacy"/>
-                <field name="alarm_ids" attrs="{'invisible': [('alarm_ids', '=', [])]}"/>
-                <field name="categ_ids" attrs="{'invisible': [('categ_ids', '=', [])]}"/>
+                <field name="location" attrs="{'invisible': [('location', '=', False)]}" options="{'icon': 'fa fa-map-marker'}"/>
+                <field name="description" attrs="{'invisible': [('display_description', '=', False)]}" options="{'icon': 'fa fa-bars'}"/>
+                <field name="privacy" invisible="1"/>
+                <field name="alarm_ids" attrs="{'invisible': [('alarm_ids', '=', [])]}" options="{'icon': 'fa fa-bell-o'}"/>
+                <field name="categ_ids" attrs="{'invisible': [('categ_ids', '=', [])]}" options="{'icon': 'fa fa-tag'}"/>
                 <!-- For recurrence update Dialog -->
                 <field name="recurrency" invisible="1"/>
                 <field name="recurrence_update" invisible="1"/>
-                <field name="partner_id" string="Organizer"/>
+                <field name="partner_id" string="Organizer" options="{'icon': 'fa fa-user-o'}"/>
             </calendar>
         </field>
     </record>

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -273,15 +273,15 @@
                 event_open_popup="true"
                 event_limit="5"
                 color="partner_ids">
+                <field name="location" attrs="{'invisible': [('location', '=', False)]}" options="{'icon': 'fa fa-map-marker'}"/>
                 <field name="attendee_status" invisible="1"/>
-                <field name="partner_ids" options="{'block': True, 'icon': 'fa fa-users'}"
+                <field name="partner_ids" options="{'block': True, 'icon': 'fa fa-users', 'isPopover': True}"
                        filters="1" widget="many2manyattendee" write_model="calendar.filters"
                        write_field="partner_id" filter_field="partner_checked" avatar_field="avatar_128"
                 />
                 <field name="is_highlighted" invisible="1"/>
                 <field name="is_organizer_alone" invisible="1"/>
                 <field name="display_description" invisible="1"/>
-                <field name="location" attrs="{'invisible': [('location', '=', False)]}" options="{'icon': 'fa fa-map-marker'}"/>
                 <field name="description" attrs="{'invisible': [('display_description', '=', False)]}" options="{'icon': 'fa fa-bars'}"/>
                 <field name="privacy" invisible="1"/>
                 <field name="alarm_ids" attrs="{'invisible': [('alarm_ids', '=', [])]}" options="{'icon': 'fa fa-bell-o'}"/>

--- a/addons/web/static/src/legacy/js/views/calendar/calendar_popover.js
+++ b/addons/web/static/src/legacy/js/views/calendar/calendar_popover.js
@@ -200,7 +200,7 @@ var CalendarPopover = Widget.extend(WidgetAdapterMixin, StandaloneFieldManagerMi
                 }
                 self._registerWidget(recordID, field.name, fieldWidget);
                 // Only display the fields whose attributes does not make them invisible
-                let fieldClass = "list-group-item flex-shrink-0 d-flex flex-wrap align-items-center";
+                let fieldClass = "list-group-item flex-shrink-0 d-flex flex-wrap align-items-start";
                 if (fieldWidget.attrs && fieldWidget.attrs.modifiers) {
                     const fieldModifier = record.evalModifiers(_.pick(fieldWidget.attrs.modifiers, 'invisible'));
                     fieldClass += fieldModifier.invisible ? ' o_invisible_modifier' : '';

--- a/addons/web/static/src/legacy/xml/web_calendar.xml
+++ b/addons/web/static/src/legacy/xml/web_calendar.xml
@@ -142,7 +142,7 @@
     </main>
 
     <t t-name="CalendarView.yearEvent.popover">
-        <div class="o_cw_body">
+        <div class="o_cw_body year_event">
             <t t-foreach="groupKeys" t-as="groupKey">
                 <div class="font-weight-bold mt-2" t-esc="groupKey"/>
                 <t t-foreach="groupedEvents[groupKey]" t-as="event">
@@ -165,7 +165,7 @@
     </t>
 
     <t t-name="CalendarView.yearEvent.popover.placeholder">
-        <div class="popover o_cw_popover" style="position: relative">
+        <div class="popover o_cw_popover year_event" style="position: relative">
             <div class="arrow"></div>
             <div class="popover-header"></div>
             <div style="position: absolute; top: 0; right: 0.5rem;">


### PR DESCRIPTION
When meetings are created for many people and with a lot of information, the event pop-up window becomes difficult to read. This PR aims to improve the popover layout for crowded meetings.

task-2685440

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
