### PR TITLE
[IMP] base_import: improve the speed of the imports

### DIFF
--- a/addons/base_import/__manifest__.py
+++ b/addons/base_import/__manifest__.py
@@ -21,7 +21,7 @@ Re-implement Odoo's file import system:
 * In a module, so that administrators and users of Odoo who do not
   need or want an online import can avoid it being available to users.
 """,
-    'depends': ['web'],
+    'depends': ['web', 'bus'],
     'version': '2.0',
     'category': 'Hidden/Tools',
     'installable': True,

--- a/addons/base_import/static/src/legacy/js/import_action.js
+++ b/addons/base_import/static/src/legacy/js/import_action.js
@@ -342,12 +342,10 @@ var DataImport = AbstractAction.extend({
             if (field) {
                 if (['boolean', 'many2one', 'many2many', 'selection'].includes(type) && this.value === 'skip_record') {
                     options.import_skip_records.push(field);
-                } else if (['many2one', "many2many", "selection"].includes(type)) {
-                    if (this.value === 'set_empty') {
-                        options.import_set_empty_fields.push(field);
-                    } else {
-                        options.name_create_enabled_fields[field] = this.value === 'create';
-                    }
+                } else if (['many2one', 'many2many', 'selection'].includes(type) && this.value === 'set_empty') {
+                    options.import_set_empty_fields.push(field);
+                } else if (['many2one', 'many2many'].includes(type)) {
+                    options.name_create_enabled_fields[field] = this.value === 'create';
                 // for selection, include also 'skip' that will be interpreted as 'None' in backend.
                 } else if (['boolean','selection'].includes(type) && this.value !== 'prevent') {
                     options.fallback_values[field] = {

--- a/addons/base_import/static/src/legacy/xml/base_import.xml
+++ b/addons/base_import/static/src/legacy/xml/base_import.xml
@@ -332,7 +332,7 @@ lines composed only of empty cells">
             </span>
             <div class="d-flex align-items-center mt-2">
                 <div class="progress flex-grow-1">
-                    <div class="progress-bar progress-bar-striped" role="progressbar"
+                    <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"
                          aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
                         <span>0%</span>
                     </div>

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -388,6 +388,8 @@ class ThreadedServer(CommonServer):
             self.limits_reached_threads.add(threading.currentThread())
 
         for thread in threading.enumerate():
+            if getattr(thread, 'ignore_limit_time', None):
+                continue
             if not thread.daemon or getattr(thread, 'type', None) == 'cron':
                 # We apply the limits on cron threads and HTTP requests,
                 # longpolling requests excluded.


### PR DESCRIPTION
Purpose
=======
Improve the general performance of the import.

Specification
=============
Currently, each batch has his own HTTP request.

Because we need to parse the file until the end (we might need to read
more lines in the file if the method load skip some records, possibly
until the end), the file is opened / parsed for each batch which is
very inefficient.

Instead, we want to have only one HTTP request for the entire import,
we want to open / parse the file only once for all the batches.

For this purpose, we use the bus to communicate to the UI the
progression of the import.

Technical
=========
Odoo thread have a maximum lifetime defined by "--limit-time-real".
As we now have only one thread for the entire import, we might exceed
this limit, so we needed a way to bypass it.

Here are some benchmark, we can see that the more batches we have,
bigger is the impact of this improvement. And it's not that huge
because most of the time is already spent by the ORM to create the
records.

Here is a benchmark done on the <product.product> model (time is in
seconds).

```
Records | Batch | v14 | v15 | My branch
---------------------------------------
    30k |  2000 | 293 | 311 |       236
    30k |  1000 | 351 | 437 |       233
     1k |   200 |   9 |   9 |         7
```

Task-2688176