### PR TITLE
[FIX] pos: check pricelist availability now

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1514,7 +1514,7 @@ exports.Product = Backbone.Model.extend({
     // ORM. After that they are added in this order to the pricelists.
     get_price: function(pricelist, quantity){
         var self = this;
-        var date = moment().startOf('day');
+        var date = moment();
 
         // In case of nested pricelists, it is necessary that all pricelists are made available in
         // the POS. Display a basic alert to the user in this case.


### PR DESCRIPTION
Current behaviour :
In POS, pricelist are based on the day and not the current moment so if a pricelist item start on day X at 01:00, it's not taken into account at day X at 02:00.

Behaviour after PR:
Pricelist are taken into account based on full time.

opw-2691883

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
