### PR TITLE
[FIX] hr: avoid <footer> not found error in view

### DIFF
--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -12,7 +12,9 @@
             <field name="inherit_id" ref="base.view_users_form_simple_modif"/>
             <field name="mode">primary</field>
             <field name="arch" type="xml">
-                <footer position="replace"/>
+                <footer position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </footer>
                 <h1 position="replace"/>
                 <xpath expr="//field[@name='image_1920']" position="replace"/>
                 <xpath expr="//field[@name='company_id']" position="attributes">
@@ -41,9 +43,6 @@
                     <attribute name="create">false</attribute>
                     <attribute name="js_class">hr_employee_profile_form</attribute>
                 </form>
-                <footer position="attributes">
-                    <attribute name="invisible">1</attribute>
-                </footer>
                 <notebook position="replace">
                         <field name="hr_presence_state" invisible="1"/>
                         <header>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The `<footer>` tag is declared in `base.view_users_form_simple_modif`. In hr module, one view (`hr.res_users_view_form_simple_modif`), which inherit from the base one, is deleting that footer using replace. Later, another view (`hr.res_users_view_form_profile`), which inherits from the previous one, tries to make the footer invisible, which is impossible as it is deleted using replace.

Current behavior before PR:

```
2021-11-29 00:19:14,750 596048 INFO defacto_14 odoo.modules.loading: loading hr/views/res_users.xml 
2021-11-29 00:19:14,784 596048 DEBUG defacto_14 odoo.tools.translate: translation went wrong for ""Element '%s' cannot be located in parent view"", skipped 
2021-11-29 00:19:14,793 596048 INFO defacto_14 odoo.addons.base.models.ir_ui_view: Element '<footer>' cannot be located in parent view
```

Desired behavior after PR is merged: Solves https://github.com/odoo/odoo/pull/79224






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
