### PR TITLE
[FIX] mail: do not match anybody without an email

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1532,8 +1532,11 @@ class MailThread(models.AbstractModel):
         """
         # find normalized emails and exclude aliases (to avoid subscribing alias emails to records)
         normalized_email = tools.email_normalize(email)
+        if not normalized_email:
+            return self.env['res.users']
+
         catchall_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
-        if normalized_email and catchall_domain:
+        if catchall_domain:
             left_part = normalized_email.split('@')[0] if normalized_email.split('@')[1] == catchall_domain.lower() else False
             if left_part:
                 if self.env['mail.alias'].sudo().search_count([('alias_name', '=', left_part)]):

--- a/addons/mail_group/models/mail_group.py
+++ b/addons/mail_group/models/mail_group.py
@@ -681,6 +681,10 @@ class MailGroup(models.Model):
         - A member whose email match the given email and has partner
         """
         order = 'partner_id ASC'
+        if not email_normalize(email):
+            # empty email should match nobody
+            return {}
+
         domain = [('email_normalized', '=', email_normalize(email))]
         if partner_id:
             domain = expression.OR([

--- a/addons/mail_group/tests/test_mail_group.py
+++ b/addons/mail_group/tests/test_mail_group.py
@@ -61,6 +61,11 @@ class TestMailGroup(TestMailListCommon):
             'mail_group_id': self.test_group.id,
         })
 
+        self.env['mail.group.member'].create({
+            'email': "Alice",
+            'mail_group_id': self.test_group.id,
+        })
+
         member = self.test_group._find_member(email)
         self.assertEqual(member, member_1, 'When no partner is provided, return the member without partner in priority')
 
@@ -77,6 +82,10 @@ class TestMailGroup(TestMailListCommon):
         member_1.unlink()
         member = self.test_group._find_member(email, partner_2.id)
         self.assertFalse(member, 'Should not return any member because the only one with the same email has a different partner')
+
+        member = self.test_group._find_member('', None)
+        self.assertEqual(member, None, 'When no email nor partner is provided, return nobody')
+
 
     def test_find_member_for_alias(self):
         """Test the matching of a mail_group.members, when 2 users have the same partner email, and


### PR DESCRIPTION
When trying to identify the user sending an email, do not match with a user without email.

Sometimes we get an email without a valid From address (spammers or bugs), the previous code was trying to find users with this (empty) email.
In historical databases, we often have many users without an email address, they should not match the search.

`_mail_find_user_for_gateway`:
No longer match on the first res.users with no email. This was not problematic (as we have a fallback on `self._uid` anyway) but it is more accurate for tracebality of emails.

`_mail_find_partner_from_emails`
This method correctly detects and exclude empty emails and does not need to be patched.

`_find_members`
This one is called from `_alias_get_error_message` to verify the sender is in the group with the `followers` restriction. On large mailing list, it is not uncommon to have members with empty emails (migration, historical reasons,...). They should not be able to send emails nor be used for the verification.