### PR TITLE
[FIX] base: cron "run now" button runs without ctx

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -82,7 +82,7 @@ class ir_cron(models.Model):
     def method_direct_trigger(self):
         self.check_access_rights('write')
         for cron in self:
-            cron.with_user(cron.user_id).with_context(lastcall=cron.lastcall).ir_actions_server_id.run()
+            cron.with_user(cron.user_id).with_context({'lastcall': cron.lastcall}).ir_actions_server_id.run()
             cron.lastcall = fields.Datetime.now()
         return True
 


### PR DESCRIPTION
Change the lang of your user, translate the name of some records (e.g.
translate the "Customizable Desk" product to "Bureau personnalisable")
and create a cron that simply log the name of that record. Schedule the
cron to be automatically executed, check the created log entry
(`setting > technical > logging`) it is the default english name. Go back
to the cron, click "run now" contextual button, check the created log
entry: it is the translated name.

When they are automatically executed by the cron worker, crons run with a
minimal context without lang. When the user clicks on the "run now"
button his context was wrongly used while executing the code.

Closes #45388
