### PR TITLE
[FIX] mail: `message_post` on `auth="none"` routes crash

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -25,6 +25,7 @@ from xmlrpc import client as xmlrpclib
 
 from odoo import _, api, exceptions, fields, models, tools, registry, SUPERUSER_ID, Command
 from odoo.exceptions import MissingError
+from odoo.http import request
 from odoo.osv import expression
 
 from odoo.tools.misc import clean_context, split_every
@@ -1807,7 +1808,8 @@ class MailThread(models.AbstractModel):
         record_name = record_name or self.display_name
 
         # Find the message's author
-        if self.env.user._is_public() and 'guest' in self.env.context:
+        # connected users bypass the guest key context to avoid users with a remaining guest cookie on their session
+        if (not request or not request.session.uid) and 'guest' in self.env.context:
             author_guest_id = self.env.context['guest'].id
             author_id, email_from = False, False
         else:


### PR DESCRIPTION
  - Since commit 401fc7efe90fb99ebeef33db5d44d8b97be94ed5 the method
    `message_post` fails as calling `self.env.user._is_public`
    raise a `ValueError` exception when called with a route set as
    `auth="none"`.

    This is due to the fact that the current environment has no user
    with `auth="none"` routes and `_is_public` requires a record.

    To fix the issue, we instead check if the current user doesn't have a `uid`
    on his session, meaning he is not actually connected with his own user
    thus can be considered as being public user on `public` methods and
    not connected on `auth="none"` methods.

    If the code isn't called through a web request (i.e: crons), we also
    check if `odoo.http.request` is not set, thus allowing the `guest`
    context key to continue working.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
