### PR TITLE
[FIX] hr_expense: use contact bank account for employee expense

### DIFF
--- a/addons/hr_expense/wizard/account_payment_register.py
+++ b/addons/hr_expense/wizard/account_payment_register.py
@@ -15,8 +15,8 @@ class AccountPaymentRegister(models.TransientModel):
         # OVERRIDE to set the bank account defined on the employee
         res = super()._get_line_batch_key(line)
         expense_sheet = self.env['hr.expense.sheet'].search([('payment_mode', '=', 'own_account'), ('account_move_id', 'in', line.move_id.ids)])
-        if expense_sheet.employee_id.bank_account_id and not line.move_id.partner_bank_id:
-            res['partner_bank_id'] = expense_sheet.employee_id.bank_account_id.id
+        if expense_sheet and not line.move_id.partner_bank_id:
+            res['partner_bank_id'] = expense_sheet.employee_id.bank_account_id.id or line.partner_id.bank_ids and line.partner_id.bank_ids.ids[0]
         return res
 
     def _create_payments(self):


### PR DESCRIPTION
Steps to reproduce:
1. Install the Expenses and Contacts Apps
2. Go to the Contacts App
3. Add a bank account to the private address linked to a specific employee
4. Go to the Expenses App
5. Create an expense for the employee and try to register the payment
6. The bank account will not show up

Solution:
If the employee doesn't have a bank account selected in the Employee form, we select the first bank account of his private address

OPW-2655450