### PR TITLE
[FIX] payment_payulatam: Set right domain on response url

### DIFF
--- a/addons/payment_payulatam/models/payment.py
+++ b/addons/payment_payulatam/models/payment.py
@@ -44,7 +44,6 @@ class PaymentAcquirerPayulatam(models.Model):
         return md5(data_string.encode('utf-8')).hexdigest()
 
     def payulatam_form_generate_values(self, values):
-        base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
         tx = self.env['payment.transaction'].search([('reference', '=', values.get('reference'))])
         # payulatam will not allow any payment twise even if payment was failed last time.
         # so, replace reference code if payment is not done or pending.
@@ -61,7 +60,7 @@ class PaymentAcquirerPayulatam(models.Model):
             taxReturnBase='0',
             currency=values['currency'].name,
             buyerEmail=values['partner_email'],
-            responseUrl=urls.url_join(base_url, '/payment/payulatam/response'),
+            responseUrl=urls.url_join(self.get_base_url(), '/payment/payulatam/response'),
         )
         payulatam_values['signature'] = self._payulatam_generate_sign("in", payulatam_values)
         return payulatam_values


### PR DESCRIPTION
Steps to reproduce the issue:

- Install the module eCommerce
- Activate PayU Latam payment acquire in test mode and
  set it to Website 2
- Set a domain for each website
- Go to Website 2
- Add any product to cart and go to checkout
- Select PayU Latam as payment acquire and click on pay
- Select any payment method, finish the payment and click
  on the "Back to the store" button

Issue:

    Redirect to the first website (instead of Website 2),
    therefore, the user has not the receipt of the payment.

Cause:

    The domain of the response url is set to the ir.config_parameter
    'web.base.url'.

Solution:

    Use the function `self.get_base_url()` to get the right domain
    (already what is done in other payments acquires).

opw-2652582