### PR TITLE
[FIX] stock: add address info in the delivery slip and picking operation report

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -32,7 +32,7 @@
                             </div>
                             <div t-if="partner" name="partner_header">
                                 <div t-field="partner.self"
-                                    t-options='{"widget": "contact", "fields": ["name", "phone"], "no_marker": True, "phone_icons": True}'/>
+                                    t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
                                 <p t-if="partner.sudo().vat"><t t-esc="o.company_id.country_id.vat_label or 'Tax ID'"/>: <span t-field="partner.sudo().vat"/></p>
                             </div>
                         </div>

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -37,7 +37,7 @@
                                     </div>
                                     <div t-if="o.partner_id" name="partner_header">
                                         <div t-field="o.partner_id"
-                                           t-options='{"widget": "contact", "fields": ["name", "phone"], "no_marker": True, "phone_icons": True}'/>
+                                           t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
                                         <p t-if="o.sudo().partner_id.vat"><t t-esc="o.company_id.country_id.vat_label or 'Tax ID'"/>: <span t-field="o.sudo().partner_id.vat"/></p>
                                     </div>
                                 </div>


### PR DESCRIPTION
Steps to reproduce the bug:
- Install inventory and sales
- Create a SO > Confirm
- Click on the delivery > print > delivery slip or picking operation

Problem:
Only the name and phone number are in the report

opw-2697221



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
