### PR TITLE
[FIX] sale_timesheet: handle blank uom in product form view

### DIFF
--- a/addons/sale_timesheet/models/product.py
+++ b/addons/sale_timesheet/models/product.py
@@ -35,6 +35,9 @@ class ProductTemplate(models.Model):
     def _compute_service_upsell_threshold_ratio(self):
         product_uom_hour = self.env.ref('uom.product_uom_hour')
         for record in self:
+            if not record.uom_id:
+                record.service_upsell_threshold_ratio = False
+                continue
             record.service_upsell_threshold_ratio = f"1 {record.uom_id.name} = {product_uom_hour.factor / record.uom_id.factor:.2f} Hours"
 
     def _compute_visible_expense_policy(self):


### PR DESCRIPTION
Even though `uom_id` is required by product.template, it's still
possible for users to delete it within the product view and trigger a
compute that depends on it before saving.

Steps to reproduce:
1 - install sale_timesheet + activate UoM
2 - open any product form, click on uom_id and delete the uom

Expected result: No UoM + user cannot save
Actual result: traceback + user can appear to save (but uom defaults
  back to last selected UoM

While this isn't a blocking problem since users won't be able to save
no UoM being selected, we would still rather avoid the traceback so we
default to no service_upsell_threshold_ratio message in this case and
properly prevent the saving.

Task: 2689438
Also fully fixes: odoo/odoo#78693




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
