### PR TITLE
[IMP] mail: rename guest model

### DIFF
--- a/addons/mail/static/src/models/guest/guest.js
+++ b/addons/mail/static/src/models/guest/guest.js
@@ -4,7 +4,7 @@ import { attr, one2many, one2one } from '@mail/model/model_field';
 import { registerModel } from '@mail/model/model_core';
 
 registerModel({
-    name: 'mail.guest',
+    name: 'Guest',
     identifyingFields: ['id'],
     modelMethods: {
         /**

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -581,7 +581,7 @@ registerModel({
         failureNotifications: one2many('mail.notification', {
             compute: '_computeFailureNotifications',
         }),
-        guestAuthor: many2one('mail.guest', {
+        guestAuthor: many2one('Guest', {
             inverse: 'authoredMessages',
         }),
         /**

--- a/addons/mail/static/src/models/message_reaction_group/message_reaction_group.js
+++ b/addons/mail/static/src/models/message_reaction_group/message_reaction_group.js
@@ -83,7 +83,7 @@ registerModel({
         /**
          * States the guests that have used this reaction on this message.
          */
-        guests: many2many('mail.guest'),
+        guests: many2many('Guest'),
         hasUserReacted: attr({
             compute: '_computeHasUserReacted',
             default: false,

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -237,7 +237,7 @@ registerModel({
         }),
         commands: one2many('mail.channel_command'),
         companyName: attr(),
-        currentGuest: one2one('mail.guest'),
+        currentGuest: one2one('Guest'),
         currentPartner: one2one('mail.partner'),
         currentUser: one2one('mail.user'),
         device: one2one('mail.device', {

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -102,7 +102,7 @@ registerModel({
                         case 'mail.channel/insert':
                             return this._handleNotificationChannelUpdate(message.payload);
                         case 'mail.guest/insert':
-                            return this.messaging.models['mail.guest'].insert(message.payload);
+                            return this.messaging.models['Guest'].insert(message.payload);
                         case 'mail.message/insert':
                             return this.messaging.models['mail.message'].insert(message.payload);
                         case 'mail.channel.rtc.session/insert':

--- a/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
+++ b/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
@@ -128,7 +128,7 @@ registerModel({
         /**
          * If set, this card represents an invitation of this guest to this call.
          */
-        invitedGuest: many2one('mail.guest'),
+        invitedGuest: many2one('Guest'),
         /**
          * If set, this card represents an invitation of this partner to this call.
          */

--- a/addons/mail/static/src/models/rtc_session/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session/rtc_session.js
@@ -309,7 +309,7 @@ registerModel({
         connectionState: attr({
             default: 'Waiting for the peer to send a RTC offer',
         }),
-        guest: many2one('mail.guest', {
+        guest: many2one('Guest', {
             inverse: 'rtcSessions',
         }),
         /**

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -2009,7 +2009,7 @@ registerModel({
         group_based_subscription: attr({
             default: false,
         }),
-        guestMembers: many2many('mail.guest'),
+        guestMembers: many2many('Guest'),
         /**
          * States whether `this` has activities (`mail.activity.mixin` server side).
          */
@@ -2056,7 +2056,7 @@ registerModel({
          * FIXME should be simplified if we have the mail.channel.partner model
          * in which case the two following fields should be a single relation to that model.
          */
-        invitedGuests: many2many('mail.guest'),
+        invitedGuests: many2many('Guest'),
         /**
          * List of partners that have been invited to the RTC call of this channel.
          */

--- a/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
+++ b/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
@@ -360,7 +360,7 @@ registerModel({
          */
         _applyGuestRename() {
             if (this.hasGuestNameChanged) {
-                this.messaging.models['mail.guest'].performRpcGuestUpdateName({
+                this.messaging.models['Guest'].performRpcGuestUpdateName({
                     id: this.messaging.currentGuest.id,
                     name: this.pendingGuestName.trim(),
                 });

--- a/addons/mail/static/src/models/volume_setting/volume_setting.js
+++ b/addons/mail/static/src/models/volume_setting/volume_setting.js
@@ -28,7 +28,7 @@ registerModel({
         },
     },
     fields: {
-        guest: one2one('mail.guest', {
+        guest: one2one('Guest', {
             inverse: 'volumeSetting',
         }),
         id: attr({

--- a/addons/mail/static/src/models/welcome_view/welcome_view.js
+++ b/addons/mail/static/src/models/welcome_view/welcome_view.js
@@ -27,7 +27,7 @@ registerModel({
          */
         async joinChannel() {
             if (this.hasGuestNameChanged) {
-                await this.messaging.models['mail.guest'].performRpcGuestUpdateName({
+                await this.messaging.models['Guest'].performRpcGuestUpdateName({
                     id: this.messaging.currentGuest.id,
                     name: this.pendingGuestName.trim(),
                 });


### PR DESCRIPTION
Rename javascript model `mail.guest` to `Guest` in order to distinguish javascript model from python model.

Part of task-2701674.