### PR TITLE
[FIX] l10n_de: Bad alignment on 2nd sales order line

### DIFF
--- a/addons/l10n_de/static/src/scss/report_din5008.scss
+++ b/addons/l10n_de/static/src/scss/report_din5008.scss
@@ -75,6 +75,12 @@
                     color: $o-default-report-secondary-color;
                 }
             }
+
+            tr {
+                td {
+                    vertical-align: bottom;
+                }
+            }
         }
     }
     &.footer {


### PR DESCRIPTION
Steps to reproduce the bug:

- Install l10n_de
- Create a german company
- Create a SO with two lines with big description
- Print report Sale/Quotation

Bug:

All the elements on the 2nd SO line was aligned with the top

opw:2690117