### PR TITLE
[IMP] mail, calendar, website_slides: rename activity model

### DIFF
--- a/addons/calendar/static/src/models/activity/activity.js
+++ b/addons/calendar/static/src/models/activity/activity.js
@@ -5,11 +5,11 @@ import { attr } from '@mail/model/model_field';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/activity/activity';
 
-addFields('mail.activity', {
+addFields('Activity', {
     calendar_event_id: attr({ default: false }),
 });
 
-patchModelMethods('mail.activity', {
+patchModelMethods('Activity', {
     /**
      * @override
      */
@@ -22,7 +22,7 @@ patchModelMethods('mail.activity', {
     },
 });
 
-patchRecordMethods('mail.activity', {
+patchRecordMethods('Activity', {
     /**
      * @override
      */

--- a/addons/mail/static/src/components/activity/activity.js
+++ b/addons/mail/static/src/components/activity/activity.js
@@ -34,10 +34,10 @@ export class Activity extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.activity}
+     * @returns {Activity}
      */
     get activity() {
-        return this.messaging && this.messaging.models['mail.activity'].get(this.props.activityLocalId);
+        return this.messaging && this.messaging.models['Activity'].get(this.props.activityLocalId);
     }
 
     /**

--- a/addons/mail/static/src/components/activity/tests/activity_tests.js
+++ b/addons/mail/static/src/components/activity/tests/activity_tests.js
@@ -50,7 +50,7 @@ QUnit.test('activity simplest layout', async function (assert) {
     assert.expect(12);
 
     await this.start();
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         id: 12,
         thread: insert({ id: 42, model: 'res.partner' }),
     });
@@ -121,7 +121,7 @@ QUnit.test('activity with note layout', async function (assert) {
     assert.expect(3);
 
     await this.start();
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         id: 12,
         note: 'There is no good or bad note',
         thread: insert({ id: 42, model: 'res.partner' }),
@@ -151,7 +151,7 @@ QUnit.test('activity info layout when planned after tomorrow', async function (a
     const today = new Date();
     const fiveDaysFromNow = new Date();
     fiveDaysFromNow.setDate(today.getDate() + 5);
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         dateDeadline: date_to_str(fiveDaysFromNow),
         id: 12,
         state: 'planned',
@@ -186,7 +186,7 @@ QUnit.test('activity info layout when planned tomorrow', async function (assert)
     const today = new Date();
     const tomorrow = new Date();
     tomorrow.setDate(today.getDate() + 1);
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         dateDeadline: date_to_str(tomorrow),
         id: 12,
         state: 'planned',
@@ -219,7 +219,7 @@ QUnit.test('activity info layout when planned today', async function (assert) {
 
     await this.start();
     const today = new Date();
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         dateDeadline: date_to_str(today),
         id: 12,
         state: 'today',
@@ -254,7 +254,7 @@ QUnit.test('activity info layout when planned yesterday', async function (assert
     const today = new Date();
     const yesterday = new Date();
     yesterday.setDate(today.getDate() - 1);
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         dateDeadline: date_to_str(yesterday),
         id: 12,
         state: 'overdue',
@@ -289,7 +289,7 @@ QUnit.test('activity info layout when planned before yesterday', async function 
     const today = new Date();
     const fiveDaysBeforeNow = new Date();
     fiveDaysBeforeNow.setDate(today.getDate() - 5);
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         dateDeadline: date_to_str(fiveDaysBeforeNow),
         id: 12,
         state: 'overdue',
@@ -321,7 +321,7 @@ QUnit.test('activity with a summary layout', async function (assert) {
     assert.expect(4);
 
     await this.start();
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         id: 12,
         summary: 'test summary',
         thread: insert({ id: 42, model: 'res.partner' }),
@@ -353,7 +353,7 @@ QUnit.test('activity without summary layout', async function (assert) {
     assert.expect(5);
 
     await this.start();
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         id: 12,
         thread: insert({ id: 42, model: 'res.partner' }),
         type: insert({ id: 1, displayName: "Fake type" }),
@@ -393,7 +393,7 @@ QUnit.test('activity details toggle', async function (assert) {
     const today = new Date();
     const tomorrow = new Date();
     tomorrow.setDate(today.getDate() + 1);
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         creator: insert({ id: 1, display_name: "Admin" }),
         dateCreate: date_to_str(today),
         dateDeadline: date_to_str(tomorrow),
@@ -445,7 +445,7 @@ QUnit.test('activity details layout', async function (assert) {
     const today = new Date();
     const tomorrow = new Date();
     tomorrow.setDate(today.getDate() + 1);
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         assignee: insert({ id: 10, display_name: "Pauvre pomme" }),
         creator: insert({ id: 1, display_name: "Admin" }),
         dateCreate: date_to_str(today),
@@ -521,7 +521,7 @@ QUnit.test('activity with mail template layout', async function (assert) {
     assert.expect(8);
 
     await this.start();
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         id: 12,
         mailTemplates: insert({ id: 1, name: "Dummy mail template" }),
         thread: insert({ id: 42, model: 'res.partner' }),
@@ -607,7 +607,7 @@ QUnit.test('activity with mail template: preview mail', async function (assert) 
     });
 
     await this.start({ env: { bus } });
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         id: 12,
         mailTemplates: insert({
             id: 1,
@@ -650,7 +650,7 @@ QUnit.test('activity with mail template: send mail', async function (assert) {
             }
         },
     });
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         id: 12,
         mailTemplates: insert({
             id: 1,
@@ -684,7 +684,7 @@ QUnit.test('activity upload document is available', async function (assert) {
     const today = new Date();
     const tomorrow = new Date();
     tomorrow.setDate(today.getDate() + 1);
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         canWrite: true,
         category: 'upload_file',
         id: 12,
@@ -715,7 +715,7 @@ QUnit.test('activity click on mark as done', async function (assert) {
     const today = new Date();
     const tomorrow = new Date();
     tomorrow.setDate(today.getDate() + 1);
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         canWrite: true,
         category: 'not_upload_file',
         id: 12,
@@ -760,7 +760,7 @@ QUnit.test('activity mark as done popover should focus feedback input on open [R
     const today = new Date();
     const tomorrow = new Date();
     tomorrow.setDate(today.getDate() + 1);
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         canWrite: true,
         category: 'not_upload_file',
         id: 12,
@@ -823,7 +823,7 @@ QUnit.test('activity click on edit', async function (assert) {
     });
 
     await this.start({ env: { bus } });
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         canWrite: true,
         id: 12,
         mailTemplates: insert({ id: 1, name: "Dummy mail template" }),
@@ -891,8 +891,8 @@ QUnit.test('activity edition', async function (assert) {
     });
 
     await this.start({ env: { bus } });
-    const activity = this.messaging.models['mail.activity'].insert(
-        this.messaging.models['mail.activity'].convertData(
+    const activity = this.messaging.models['Activity'].insert(
+        this.messaging.models['Activity'].convertData(
             this.data['mail.activity'].records[0]
         )
     );
@@ -958,7 +958,7 @@ QUnit.test('activity click on cancel', async function (assert) {
             }
         },
     });
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         canWrite: true,
         id: 12,
         mailTemplates: insert({
@@ -972,10 +972,10 @@ QUnit.test('activity click on cancel', async function (assert) {
     // to check that activity component has been destroyed
     class ParentComponent extends Component {
         /**
-         * @returns {mail.activity}
+         * @returns {Activity}
          */
         get activity() {
-            return this.messaging.models['mail.activity'].get(this.props.activityLocalId);
+            return this.messaging.models['Activity'].get(this.props.activityLocalId);
         }
     }
     ParentComponent.env = this.env;
@@ -1028,7 +1028,7 @@ QUnit.test('activity mark done popover close on ESCAPE', async function (assert)
     assert.expect(2);
 
     await this.start();
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         canWrite: true,
         category: 'not_upload_file',
         id: 12,
@@ -1062,7 +1062,7 @@ QUnit.test('activity mark done popover click on discard', async function (assert
     assert.expect(3);
 
     await this.start();
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         canWrite: true,
         category: 'not_upload_file',
         id: 12,
@@ -1115,7 +1115,7 @@ QUnit.test('data-oe-id & data-oe-model link redirection on click', async functio
         assert.step('do-action:openFormView_some.model_250');
     });
     await this.start({ env: { bus } });
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         canWrite: true,
         category: 'not_upload_file',
         id: 12,

--- a/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover.js
+++ b/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover.js
@@ -28,10 +28,10 @@ export class ActivityMarkDonePopover extends Component {
     }
 
     /**
-     * @returns {mail.activity}
+     * @returns {Activity}
      */
     get activity() {
-        return this.messaging && this.messaging.models['mail.activity'].get(this.props.activityLocalId);
+        return this.messaging && this.messaging.models['Activity'].get(this.props.activityLocalId);
     }
 
     /**

--- a/addons/mail/static/src/components/activity_mark_done_popover/tests/activity_mark_done_popover_tests.js
+++ b/addons/mail/static/src/components/activity_mark_done_popover/tests/activity_mark_done_popover_tests.js
@@ -42,7 +42,7 @@ QUnit.test('activity mark done popover simplest layout', async function (assert)
     assert.expect(6);
 
     await this.start();
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         canWrite: true,
         category: 'not_upload_file',
         id: 12,
@@ -86,7 +86,7 @@ QUnit.test('activity with force next mark done popover simplest layout', async f
     assert.expect(6);
 
     await this.start();
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         canWrite: true,
         category: 'not_upload_file',
         chaining_type: 'trigger',
@@ -148,7 +148,7 @@ QUnit.test('activity mark done popover mark done without feedback', async functi
             return this._super(...arguments);
         },
     });
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         canWrite: true,
         category: 'not_upload_file',
         id: 12,
@@ -184,7 +184,7 @@ QUnit.test('activity mark done popover mark done with feedback', async function 
             return this._super(...arguments);
         },
     });
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         canWrite: true,
         category: 'not_upload_file',
         id: 12,
@@ -228,7 +228,7 @@ QUnit.test('activity mark done popover mark done and schedule next', async funct
         },
         env: { bus },
     });
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         canWrite: true,
         category: 'not_upload_file',
         id: 12,
@@ -269,7 +269,7 @@ QUnit.test('[technical] activity mark done & schedule next with new action', asy
         },
         env: { bus },
     });
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         canWrite: true,
         category: 'not_upload_file',
         id: 12,

--- a/addons/mail/static/src/components/mail_template/mail_template.js
+++ b/addons/mail/static/src/components/mail_template/mail_template.js
@@ -11,10 +11,10 @@ export class MailTemplate extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.activity}
+     * @returns {Activity}
      */
     get activity() {
-        return this.messaging && this.messaging.models['mail.activity'].get(this.props.activityLocalId);
+        return this.messaging && this.messaging.models['Activity'].get(this.props.activityLocalId);
     }
 
     /**

--- a/addons/mail/static/src/models/activity/activity.js
+++ b/addons/mail/static/src/models/activity/activity.js
@@ -5,7 +5,7 @@ import { attr, many2many, many2one } from '@mail/model/model_field';
 import { clear, insert, unlink, unlinkAll } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.activity',
+    name: 'Activity',
     identifyingFields: ['id'],
     modelMethods: {
         /**

--- a/addons/mail/static/src/models/activity_type/activity_type.js
+++ b/addons/mail/static/src/models/activity_type/activity_type.js
@@ -7,7 +7,7 @@ registerModel({
     name: 'mail.activity_type',
     identifyingFields: ['id'],
     fields: {
-        activities: one2many('mail.activity', {
+        activities: one2many('Activity', {
             inverse: 'type',
         }),
         displayName: attr(),

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -276,7 +276,7 @@ registerModel({
     },
     fields: {
         accessToken: attr(),
-        activities: many2many('mail.activity', {
+        activities: many2many('Activity', {
             inverse: 'attachments',
         }),
         /**

--- a/addons/mail/static/src/models/mail_template/mail_template.js
+++ b/addons/mail/static/src/models/mail_template/mail_template.js
@@ -8,7 +8,7 @@ registerModel({
     identifyingFields: ['id'],
     recordMethods: {
         /**
-         * @param {mail.activity} activity
+         * @param {Activity} activity
          */
         preview(activity) {
             const action = {
@@ -35,7 +35,7 @@ registerModel({
             });
         },
         /**
-         * @param {mail.activity} activity
+         * @param {Activity} activity
          */
         async send(activity) {
             await this.async(() => this.env.services.rpc({
@@ -47,7 +47,7 @@ registerModel({
         },
     },
     fields: {
-        activities: many2many('mail.activity', {
+        activities: many2many('Activity', {
             inverse: 'mailTemplates',
         }),
         id: attr({

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1014,8 +1014,8 @@ registerModel({
                 method: 'activity_format',
                 args: [newActivityIds]
             }, { shadow: true }));
-            const activities = this.messaging.models['mail.activity'].insert(activitiesData.map(
-                activityData => this.messaging.models['mail.activity'].convertData(activityData)
+            const activities = this.messaging.models['Activity'].insert(activitiesData.map(
+                activityData => this.messaging.models['Activity'].convertData(activityData)
             ));
             this.update({ activities: replace(activities) });
         },
@@ -1325,7 +1325,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.activity[]}
+         * @returns {Activity[]}
          */
         _computeFutureActivities() {
             return replace(this.activities.filter(activity => activity.state === 'planned'));
@@ -1656,14 +1656,14 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.activity[]}
+         * @returns {Activity[]}
          */
         _computeOverdueActivities() {
             return replace(this.activities.filter(activity => activity.state === 'overdue'));
         },
         /**
          * @private
-         * @returns {mail.activity[]}
+         * @returns {Activity[]}
          */
         _computeTodayActivities() {
             return replace(this.activities.filter(activity => activity.state === 'today'));
@@ -1908,7 +1908,7 @@ registerModel({
          * Determines the `mail.activity` that belong to `this`, assuming `this`
          * has activities (@see hasActivities).
          */
-        activities: one2many('mail.activity', {
+        activities: one2many('Activity', {
             inverse: 'thread',
         }),
         allAttachments: many2many('mail.attachment', {
@@ -2000,10 +2000,10 @@ registerModel({
             inverse: 'followedThread',
         }),
         /**
-         * States the `mail.activity` that belongs to `this` and that are
+         * States the `Activity` that belongs to `this` and that are
          * planned in the future (due later than today).
          */
-        futureActivities: one2many('mail.activity', {
+        futureActivities: one2many('Activity', {
             compute: '_computeFutureActivities',
         }),
         group_based_subscription: attr({
@@ -2296,10 +2296,10 @@ registerModel({
             isCausal: true,
         }),
         /**
-         * States the `mail.activity` that belongs to `this` and that are
+         * States the `Activity` that belongs to `this` and that are
          * overdue (due earlier than today).
          */
-        overdueActivities: one2many('mail.activity', {
+        overdueActivities: one2many('Activity', {
             compute: '_computeOverdueActivities',
         }),
         /**
@@ -2406,10 +2406,10 @@ registerModel({
             inverse: 'thread',
         }),
         /**
-         * States the `mail.activity` that belongs to `this` and that are due
+         * States the `Activity` that belongs to `this` and that are due
          * specifically today.
          */
-        todayActivities: one2many('mail.activity', {
+        todayActivities: one2many('Activity', {
             compute: '_computeTodayActivities',
         }),
         /**

--- a/addons/website_slides/static/src/components/activity/activity_tests.js
+++ b/addons/website_slides/static/src/components/activity/activity_tests.js
@@ -51,7 +51,7 @@ QUnit.test('grant course access', async function (assert) {
             return this._super(...arguments);
         },
     });
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         id: 100,
         canWrite: true,
         thread: insert({
@@ -91,7 +91,7 @@ QUnit.test('refuse course access', async function (assert) {
             return this._super(...arguments);
         },
     });
-    const activity = this.messaging.models['mail.activity'].create({
+    const activity = this.messaging.models['Activity'].create({
         id: 100,
         canWrite: true,
         thread: insert({


### PR DESCRIPTION
Rename javascript model `mail.activity` to `Activity` in order to distinguish javascript model from python model.

Part of task-2701674.
Enterprise: https://github.com/odoo/enterprise/pull/22593