### PR TITLE
[IMP] hr: rename employee model

### DIFF
--- a/addons/hr/static/src/models/employee/employee.js
+++ b/addons/hr/static/src/models/employee/employee.js
@@ -5,7 +5,7 @@ import { attr, one2one } from '@mail/model/model_field';
 import { insert, unlink } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'hr.employee',
+    name: 'Employee',
     identifyingFields: ['id'],
     modelMethods: {
         /**
@@ -56,8 +56,8 @@ registerModel({
                     fields,
                 },
             });
-            this.messaging.models['hr.employee'].insert(employeesData.map(employeeData =>
-                this.messaging.models['hr.employee'].convertData(employeeData)
+            this.messaging.models['Employee'].insert(employeesData.map(employeeData =>
+                this.messaging.models['Employee'].convertData(employeeData)
             ));
         },
         /**
@@ -78,8 +78,8 @@ registerModel({
                     fields,
                 },
             });
-            this.messaging.models['hr.employee'].insert(employeesData.map(employeeData =>
-                this.messaging.models['hr.employee'].convertData(employeeData)
+            this.messaging.models['Employee'].insert(employeesData.map(employeeData =>
+                this.messaging.models['Employee'].convertData(employeeData)
             ));
         },
     },
@@ -89,7 +89,7 @@ registerModel({
          * them if applicable.
          */
         async checkIsUser() {
-            return this.messaging.models['hr.employee'].performRpcRead({
+            return this.messaging.models['Employee'].performRpcRead({
                 ids: [this.id],
                 fields: ['user_id', 'user_partner_id'],
                 context: { active_test: false },

--- a/addons/hr/static/src/models/messaging/messaging.js
+++ b/addons/hr/static/src/models/messaging/messaging.js
@@ -11,7 +11,7 @@ patchRecordMethods('mail.messaging', {
      */
     async getChat({ employeeId }) {
         if (employeeId) {
-            const employee = this.messaging.models['hr.employee'].insert({ id: employeeId });
+            const employee = this.messaging.models['Employee'].insert({ id: employeeId });
             return employee.getChat();
         }
         return this._super(...arguments);
@@ -21,7 +21,7 @@ patchRecordMethods('mail.messaging', {
      */
     async openProfile({ id, model }) {
         if (model === 'hr.employee' || model === 'hr.employee.public') {
-            const employee = this.messaging.models['hr.employee'].insert({ id });
+            const employee = this.messaging.models['Employee'].insert({ id });
             return employee.openProfile();
         }
         return this._super(...arguments);

--- a/addons/hr/static/src/models/partner/partner.js
+++ b/addons/hr/static/src/models/partner/partner.js
@@ -11,7 +11,7 @@ addRecordMethods('mail.partner', {
      * applicable.
      */
     async checkIsEmployee() {
-        await this.async(() => this.messaging.models['hr.employee'].performRpcSearchRead({
+        await this.async(() => this.messaging.models['Employee'].performRpcSearchRead({
             context: { active_test: false },
             domain: [['user_partner_id', '=', this.id]],
             fields: ['user_id', 'user_partner_id'],
@@ -45,7 +45,7 @@ addFields('mail.partner', {
      * Employee related to this partner. It is computed through
      * the inverse relation and should be considered read-only.
      */
-    employee: one2one('hr.employee', {
+    employee: one2one('Employee', {
         inverse: 'partner',
     }),
     /**

--- a/addons/hr/static/src/models/user/user.js
+++ b/addons/hr/static/src/models/user/user.js
@@ -9,7 +9,7 @@ addFields('mail.user', {
     /**
      * Employee related to this user.
      */
-    employee: one2one('hr.employee', {
+    employee: one2one('Employee', {
         inverse: 'user',
     }),
 });


### PR DESCRIPTION
Rename javascript model 'hr.employee' to 'Employee' in order to distinguish javascript model from python model.

Part of task-2701674.