### PR TITLE
[IMP] mail: rename test models

### DIFF
--- a/addons/mail/static/src/model/tests/model_field_command/clear_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/clear_tests.js
@@ -29,7 +29,7 @@ QUnit.test('clear: should set attribute field undefined if there is no default v
     assert.expect(1);
 
     await this.start();
-    const task = this.messaging.models['test.task'].create({
+    const task = this.messaging.models['TestTask'].create({
         id: 1,
         title: 'test title 1',
     });
@@ -45,7 +45,7 @@ QUnit.test('clear: should set attribute field the default value', async function
     assert.expect(1);
 
     await this.start();
-    const task = this.messaging.models['test.task'].create({
+    const task = this.messaging.models['TestTask'].create({
         id: 1,
         difficulty: 5,
     });
@@ -61,11 +61,11 @@ QUnit.test('clear: should set x2one field undefined if no default value is given
     assert.expect(2);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         address: insertAndReplace({ id: 20 }),
     });
-    const address = this.messaging.models['test.address'].findFromIdentifyingData({ id: 20 });
+    const address = this.messaging.models['TestAddress'].findFromIdentifyingData({ id: 20 });
     contact.update({ address: clear() });
     assert.strictEqual(
         contact.address,
@@ -83,7 +83,7 @@ QUnit.test('clear: should set x2one field the default value', async function (as
     assert.expect(1);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         favorite: insertAndReplace({ description: 'pingpong' }),
         id: 10,
     });
@@ -99,11 +99,11 @@ QUnit.test('clear: should set x2many field empty array if no default value is gi
     assert.expect(2);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         tasks: insertAndReplace({ id: 20 }),
     });
-    const task = this.messaging.models['test.task'].findFromIdentifyingData({ id: 20 });
+    const task = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 20 });
     contact.update({ tasks: clear() });
     assert.ok(
         contact.tasks instanceof Array &&
@@ -121,7 +121,7 @@ QUnit.test('clear: should set x2many field the default value', async function (a
     assert.expect(1);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         hobbies: [
             insertAndReplace({ description: 'basketball' }),

--- a/addons/mail/static/src/model/tests/model_field_command/insert_and_replace_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/insert_and_replace_tests.js
@@ -30,9 +30,9 @@ QUnit.test('insertAndReplace: should create and link a new record for an empty x
     assert.expect(2);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({ id: 10 });
+    const contact = this.messaging.models['TestContact'].create({ id: 10 });
     contact.update({ address: insertAndReplace({ id: 10 }) });
-    const address = this.messaging.models['test.address'].findFromIdentifyingData({ id: 10 });
+    const address = this.messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
     assert.strictEqual(
         contact.address,
         address,
@@ -49,13 +49,13 @@ QUnit.test('insertAndReplace: should create and replace a new record for a non-e
     assert.expect(3);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         address: insertAndReplace({ id: 10 }),
     });
-    const address10 = this.messaging.models['test.address'].findFromIdentifyingData({ id: 10 });
+    const address10 = this.messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
     contact.update({ address: insertAndReplace({ id: 20 }) });
-    const address20 = this.messaging.models['test.address'].findFromIdentifyingData({ id: 20 });
+    const address20 = this.messaging.models['TestAddress'].findFromIdentifyingData({ id: 20 });
     assert.strictEqual(
         contact.address,
         address20,
@@ -77,14 +77,14 @@ QUnit.test('insertAndReplace: should update the existing record for an x2one fie
     assert.expect(2);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         address: insertAndReplace({
             id: 10,
             addressInfo: 'address 10',
         }),
     });
-    const address10 = this.messaging.models['test.address'].findFromIdentifyingData({ id: 10 });
+    const address10 = this.messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
     contact.update({
         address: insertAndReplace({
             id: 10,
@@ -107,13 +107,13 @@ QUnit.test('insertAndReplace: should create and replace the records for an x2man
     assert.expect(4);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         tasks: insertAndReplace({ id: 10 }),
     });
-    const task10 = this.messaging.models['test.task'].findFromIdentifyingData({ id: 10 });
+    const task10 = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 10 });
     contact.update({ tasks: insertAndReplace({ id: 20 }) });
-    const task20 = this.messaging.models['test.task'].findFromIdentifyingData({ id: 20 });
+    const task20 = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 20 });
     assert.strictEqual(
         contact.tasks.length,
         1,
@@ -140,15 +140,15 @@ QUnit.test('insertAndReplace: should update and replace the records for an x2man
     assert.expect(4);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         tasks: insertAndReplace([
             { id: 10, title: 'task 10' },
             { id: 20, title: 'task 20' },
         ]),
     });
-    const task10 = this.messaging.models['test.task'].findFromIdentifyingData({ id: 10 });
-    const task20 = this.messaging.models['test.task'].findFromIdentifyingData({ id: 20 });
+    const task10 = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 10 });
+    const task20 = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 20 });
     contact.update({
         tasks: insertAndReplace({
             id: 10,

--- a/addons/mail/static/src/model/tests/model_field_command/insert_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/insert_tests.js
@@ -30,9 +30,9 @@ QUnit.test('insert: should create and link a new record for an empty x2one field
     assert.expect(2);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({ id: 10 });
+    const contact = this.messaging.models['TestContact'].create({ id: 10 });
     contact.update({ address: insert({ id: 10 }) });
-    const address = this.messaging.models['test.address'].findFromIdentifyingData({ id: 10 });
+    const address = this.messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
     assert.strictEqual(
         contact.address,
         address,
@@ -49,13 +49,13 @@ QUnit.test('insert: should create and replace a new record for a non-empty x2one
     assert.expect(3);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         address: insertAndReplace({ id: 10 }),
     });
-    const address10 = this.messaging.models['test.address'].findFromIdentifyingData({ id: 10 });
+    const address10 = this.messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
     contact.update({ address: insert({ id: 20 }) });
-    const address20 = this.messaging.models['test.address'].findFromIdentifyingData({ id: 20 });
+    const address20 = this.messaging.models['TestAddress'].findFromIdentifyingData({ id: 20 });
     assert.strictEqual(
         contact.address,
         address20,
@@ -77,14 +77,14 @@ QUnit.test('insert: should update the existing record for an x2one field', async
     assert.expect(2);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         address: insertAndReplace({
             id: 10,
             addressInfo: 'address 10',
         }),
     });
-    const address10 = this.messaging.models['test.address'].findFromIdentifyingData({ id: 10 });
+    const address10 = this.messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
     contact.update({
         address: insert({
             id: 10,
@@ -107,9 +107,9 @@ QUnit.test('insert: should create and link a new record for an x2many field', as
     assert.expect(3);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({ id: 10 });
+    const contact = this.messaging.models['TestContact'].create({ id: 10 });
     contact.update({ tasks: insert({ id: 10 }) });
-    const task = this.messaging.models['test.task'].findFromIdentifyingData({ id: 10 });
+    const task = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 10 });
     assert.strictEqual(
         contact.tasks.length,
         1,
@@ -131,13 +131,13 @@ QUnit.test('insert: should create and add a new record for an x2many field', asy
     assert.expect(4);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         tasks: insertAndReplace({ id: 10 }),
     });
-    const task10 = this.messaging.models['test.task'].findFromIdentifyingData({ id: 10 });
+    const task10 = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 10 });
     contact.update({ tasks: insert({ id: 20 }) });
-    const task20 = this.messaging.models['test.task'].findFromIdentifyingData({ id: 20 });
+    const task20 = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 20 });
     assert.strictEqual(
         contact.tasks.length,
         2,
@@ -164,14 +164,14 @@ QUnit.test('insert: should update existing records for an x2many field', async f
     assert.expect(3);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         tasks: insertAndReplace({
             id: 10,
             title: 'task 10',
         }),
     });
-    const task = this.messaging.models['test.task'].findFromIdentifyingData({ id: 10 });
+    const task = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 10 });
     contact.update({
         tasks: insert({
             id: 10,

--- a/addons/mail/static/src/model/tests/model_field_command/link_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/link_tests.js
@@ -30,8 +30,8 @@ QUnit.test('link: should link a record to an empty x2one field', async function 
     assert.expect(2);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({ id: 10 });
-    const address = this.messaging.models['test.address'].create({ id: 10 });
+    const contact = this.messaging.models['TestContact'].create({ id: 10 });
+    const address = this.messaging.models['TestAddress'].create({ id: 10 });
     contact.update({ address: link(address) });
     assert.strictEqual(
         contact.address,
@@ -49,12 +49,12 @@ QUnit.test('link: should replace a record to a non-empty x2one field', async fun
     assert.expect(3);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         address: insertAndReplace({ id: 10 }),
     });
-    const address10 = this.messaging.models['test.address'].findFromIdentifyingData({ id: 10 });
-    const address20 = this.messaging.models['test.address'].create({ id: 20 });
+    const address10 = this.messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
+    const address20 = this.messaging.models['TestAddress'].create({ id: 20 });
     contact.update({ address: link(address20) });
     assert.strictEqual(
         contact.address,
@@ -77,8 +77,8 @@ QUnit.test('link: should link a record to an empty x2many field', async function
     assert.expect(3);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({ id: 10 });
-    const task = this.messaging.models['test.task'].create({ id: 10 });
+    const contact = this.messaging.models['TestContact'].create({ id: 10 });
+    const task = this.messaging.models['TestTask'].create({ id: 10 });
     contact.update({ tasks: link(task) });
     assert.strictEqual(
         contact.tasks.length,
@@ -101,12 +101,12 @@ QUnit.test('link: should link and add a record to a non-empty x2many field', asy
     assert.expect(5);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         tasks: insertAndReplace({ id: 10 }),
     });
-    const task10 = this.messaging.models['test.task'].findFromIdentifyingData({ id: 10 });
-    const task20 = this.messaging.models['test.task'].create({ id: 20 });
+    const task10 = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 10 });
+    const task20 = this.messaging.models['TestTask'].create({ id: 20 });
     contact.update({ tasks: link(task20) });
     assert.strictEqual(
         contact.tasks.length,

--- a/addons/mail/static/src/model/tests/model_field_command/replace_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/replace_tests.js
@@ -30,8 +30,8 @@ QUnit.test('replace: should link a record for an empty x2one field', async funct
     assert.expect(2);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({ id: 10 });
-    const address = this.messaging.models['test.address'].create({ id: 10 });
+    const contact = this.messaging.models['TestContact'].create({ id: 10 });
+    const address = this.messaging.models['TestAddress'].create({ id: 10 });
     contact.update({ address: replace(address) });
     assert.strictEqual(
         contact.address,
@@ -49,12 +49,12 @@ QUnit.test('replace: should replace a record for a non-empty x2one field', async
     assert.expect(3);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         address: insertAndReplace({ id: 10 }),
     });
-    const address10 = this.messaging.models['test.address'].findFromIdentifyingData({ id: 10 });
-    const address20 = this.messaging.models['test.address'].create({ id: 20 });
+    const address10 = this.messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
+    const address20 = this.messaging.models['TestAddress'].create({ id: 20 });
     contact.update({ address: replace(address20) });
     assert.strictEqual(
         contact.address,
@@ -77,8 +77,8 @@ QUnit.test('replace: should link a record for an empty x2many field', async func
     assert.expect(4);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({ id: 10 });
-    const task = this.messaging.models['test.task'].create({ id: 10 });
+    const contact = this.messaging.models['TestContact'].create({ id: 10 });
+    const task = this.messaging.models['TestTask'].create({ id: 10 });
     contact.update({ tasks: replace(task) });
     assert.strictEqual(
         contact.tasks.length,
@@ -106,16 +106,16 @@ QUnit.test('replace: should replace all records for a non-empty field', async fu
     assert.expect(5);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         tasks: insertAndReplace([
             { id: 10 },
             { id: 20 },
         ]),
     });
-    const task10 = this.messaging.models['test.task'].findFromIdentifyingData({ id: 10 });
-    const task20 = this.messaging.models['test.task'].findFromIdentifyingData({ id: 20 });
-    const task30 = this.messaging.models['test.task'].create({ id: 30 });
+    const task10 = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 10 });
+    const task20 = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 20 });
+    const task30 = this.messaging.models['TestTask'].create({ id: 30 });
     contact.update({ tasks: replace(task30) });
     assert.strictEqual(
         contact.tasks.length,
@@ -148,15 +148,15 @@ QUnit.test('replace: should order the existing records for x2many field', async 
     assert.expect(3);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         tasks: insertAndReplace([
             { id: 10 },
             { id: 20 },
         ]),
     });
-    const task10 = this.messaging.models['test.task'].findFromIdentifyingData({ id: 10 });
-    const task20 = this.messaging.models['test.task'].findFromIdentifyingData({ id: 20 });
+    const task10 = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 10 });
+    const task20 = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 20 });
     contact.update({
         tasks: replace([task20, task10]),
     });

--- a/addons/mail/static/src/model/tests/model_field_command/set_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/set_tests.js
@@ -34,7 +34,7 @@ QUnit.test('decrement: should decrease attribute field value', async function (a
     assert.expect(1);
     await this.start();
 
-    const task = this.messaging.models['test.task'].create({
+    const task = this.messaging.models['TestTask'].create({
         id: 10,
         difficulty: 5,
     });
@@ -50,7 +50,7 @@ QUnit.test('increment: should increase attribute field value', async function (a
     assert.expect(1);
     await this.start();
 
-    const task = this.messaging.models['test.task'].create({
+    const task = this.messaging.models['TestTask'].create({
         id: 10,
         difficulty: 5,
     });
@@ -66,7 +66,7 @@ QUnit.test('set: should set a value for attribute field', async function (assert
     assert.expect(1);
     await this.start();
 
-    const task = this.messaging.models['test.task'].create({
+    const task = this.messaging.models['TestTask'].create({
         id: 10,
         difficulty: 5,
     });
@@ -82,7 +82,7 @@ QUnit.test('multiple attribute commands combination', async function (assert) {
     assert.expect(1);
     await this.start();
 
-    const task = this.messaging.models['test.task'].create({
+    const task = this.messaging.models['TestTask'].create({
         id: 10,
         difficulty: 5,
     });

--- a/addons/mail/static/src/model/tests/model_field_command/unlink_all_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/unlink_all_tests.js
@@ -30,11 +30,11 @@ QUnit.test('unlinkAll: should set x2one field undefined', async function (assert
     assert.expect(2);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         address: insertAndReplace({ id: 20 }),
     });
-    const address = this.messaging.models['test.address'].findFromIdentifyingData({ id: 20 });
+    const address = this.messaging.models['TestAddress'].findFromIdentifyingData({ id: 20 });
     contact.update({ address: unlinkAll() });
     assert.strictEqual(
         contact.address,
@@ -52,13 +52,13 @@ QUnit.test('unlinkAll: should set x2many field an empty array', async function (
     assert.expect(2);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         tasks: insertAndReplace({
             id: 20,
         }),
     });
-    const task = this.messaging.models['test.task'].findFromIdentifyingData({ id: 20 });
+    const task = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 20 });
     contact.update({ tasks: unlinkAll() });
     assert.strictEqual(
         contact.tasks.length,

--- a/addons/mail/static/src/model/tests/model_field_command/unlink_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/unlink_tests.js
@@ -31,11 +31,11 @@ QUnit.test('unlink: should unlink the record for x2one field', async function (a
     assert.expect(2);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         address: insertAndReplace({ id: 10 }),
     });
-    const address = this.messaging.models['test.address'].findFromIdentifyingData({ id: 10 });
+    const address = this.messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
     contact.update({ address: unlink() });
     assert.strictEqual(
         contact.address,
@@ -53,15 +53,15 @@ QUnit.test('unlink: should unlink the specified record for x2many field', async 
     assert.expect(2);
     await this.start();
 
-    const contact = this.messaging.models['test.contact'].create({
+    const contact = this.messaging.models['TestContact'].create({
         id: 10,
         tasks: insertAndReplace([
             { id: 10 },
             { id: 20 },
         ]),
     });
-    const task10 = this.messaging.models['test.task'].findFromIdentifyingData({ id: 10 });
-    const task20 = this.messaging.models['test.task'].findFromIdentifyingData({ id: 20 });
+    const task10 = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 10 });
+    const task20 = this.messaging.models['TestTask'].findFromIdentifyingData({ id: 20 });
     contact.update({ tasks: unlink(task10) });
     assert.ok(
         contact.tasks instanceof Array &&

--- a/addons/mail/static/src/model/tests/test_models.js
+++ b/addons/mail/static/src/model/tests/test_models.js
@@ -5,7 +5,7 @@ import { attr, many2one, one2many, one2one } from '@mail/model/model_field';
 import { insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'test.address',
+    name: 'TestAddress',
     identifyingFields: ['id'],
     fields: {
         id: attr({
@@ -13,21 +13,21 @@ registerModel({
             required: true,
         }),
         addressInfo: attr(),
-        contact: one2one('test.contact', {
+        contact: one2one('TestContact', {
             inverse: 'address',
         }),
     },
 });
 
 registerModel({
-    name: 'test.contact',
+    name: 'TestContact',
     identifyingFields: ['id'],
     fields: {
         id: attr({
             readonly: true,
             required: true,
         }),
-        address: one2one('test.address', {
+        address: one2one('TestAddress', {
             inverse: 'contact',
         }),
         favorite: one2one('test.hobby', {
@@ -39,7 +39,7 @@ registerModel({
                 { description: 'fishing' },
             ]),
         }),
-        tasks: one2many('test.task', {
+        tasks: one2many('TestTask', {
             inverse: 'responsible'
         }),
     },
@@ -57,7 +57,7 @@ registerModel({
 });
 
 registerModel({
-    name: 'test.task',
+    name: 'TestTask',
     identifyingFields: ['id'],
     fields: {
         id: attr({
@@ -68,7 +68,7 @@ registerModel({
         difficulty: attr({
             default: 1,
         }),
-        responsible: many2one('test.contact', {
+        responsible: many2one('TestContact', {
             inverse: 'tasks'
         }),
     },


### PR DESCRIPTION
Rename models `test.*` to `Test*` in order to be consistent with the new naming convention for javascript models.

Part of task-2701674.
