### PR TITLE
[FIX] Move module category to base to make dependencies right

### DIFF
--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <data noupdate="1">
-        <record model="ir.module.category" id="base.module_category_services_timesheets">
-            <field name="description">Helps you manage the timesheets.</field>
-            <field name="sequence">13</field>
-        </record>
-
         <record id="group_hr_timesheet_user" model="res.groups">
             <field name="name">See own timesheets</field>
             <field name="category_id" ref="base.module_category_services_timesheets"/>

--- a/odoo/addons/base/data/ir_module_category_data.xml
+++ b/odoo/addons/base/data/ir_module_category_data.xml
@@ -12,8 +12,8 @@
             <field name="sequence">15</field>
         </record>
 
-	<record model="ir.module.category" id="base.module_category_services_timesheets">
-            <field name="description">Helps you manage the timesheets.</field>
+	<record model="ir.module.category" id="module_category_services_timesheets">
+            <field name="name">Helps you manage the timesheets.</field>
             <field name="sequence">13</field>
         </record>
 

--- a/odoo/addons/base/data/ir_module_category_data.xml
+++ b/odoo/addons/base/data/ir_module_category_data.xml
@@ -12,6 +12,11 @@
             <field name="sequence">15</field>
         </record>
 
+	<record model="ir.module.category" id="base.module_category_services_timesheets">
+            <field name="description">Helps you manage the timesheets.</field>
+            <field name="sequence">13</field>
+        </record>
+
         <record model="ir.module.category" id="module_category_accounting_localizations">
             <field name="name">Localization</field>
             <field name="sequence">65</field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Before the category was in the module while referenced in the base.

ValueError: External ID not found in the system: base.module_category_services_timesheets

        <record model="ir.module.module" id="base.module_timesheet_grid">
            <field name="name">timesheet_grid</field>
            <field name="shortdesc">Timesheets</field>
            <field name="sequence">65</field>
            <field name="category_id" ref="base.module_category_services_timesheets"/>
            <field name="application" eval="True"/>
            <field name="summary">Track time &amp; costs</field>
            <field name="license">OEEL-1</field>
            <field name="author">Odoo S.A.</field>
            <field name="to_buy" eval="True"/>
            <field name="icon">/base/static/img/icons/timesheet_grid.png</field>
            <field name="website">https://www.odoo.com/page/timesheet-mobile-app?utm_source=db&amp;utm_medium=module</field
        </record>

Current behavior before PR:

Cannot upgrade from 13.0 to 14.0

Desired behavior after PR is merged:

Upgrade is working again.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
