### PR TITLE
[IMP] mail: add capital letters to the "Read More / Less" button

### DIFF
--- a/addons/mail/static/src/components/message/message.js
+++ b/addons/mail/static/src/components/message/message.js
@@ -12,8 +12,8 @@ import { getLangDatetimeFormat } from 'web.time';
 const { Component, useState } = owl;
 const { onWillUnmount, useRef } = owl.hooks;
 
-const READ_MORE = _lt("read more");
-const READ_LESS = _lt("read less");
+const READ_MORE = _lt("Read More");
+const READ_LESS = _lt("Read Less");
 
 export class Message extends Component {
 

--- a/addons/mail/static/src/widgets/form_renderer/tests/form_renderer_tests.js
+++ b/addons/mail/static/src/widgets/form_renderer/tests/form_renderer_tests.js
@@ -750,8 +750,8 @@ QUnit.test('read more links becomes read less after being clicked', async functi
     );
     assert.strictEqual(
         document.querySelector('.o_Message_readMoreLess').textContent,
-        'read more',
-        "read more/less link should contain 'read more' as text"
+        'Read More',
+        "Read More/Less link should contain 'Read More' as text"
     );
 
     await afterNextRender(() => this.afterEvent({
@@ -762,15 +762,15 @@ QUnit.test('read more links becomes read less after being clicked', async functi
     }));
     assert.strictEqual(
         document.querySelector('.o_Message_readMoreLess').textContent,
-        'read more',
-        "read more/less link should contain 'read more' as text"
+        'Read More',
+        "Read More/Less link should contain 'Read More' as text"
     );
 
     document.querySelector('.o_Message_readMoreLess').click();
     assert.strictEqual(
         document.querySelector('.o_Message_readMoreLess').textContent,
-        'read less',
-        "read more/less link should contain 'read less' as text after it has been clicked"
+        'Read Less',
+        "Read Less/Less link should contain 'Read Less' as text after it has been clicked"
     );
 });
 
@@ -1027,15 +1027,15 @@ QUnit.test('[TECHNICAL] unfolded read more/less links should not fold on message
     });
     assert.strictEqual(
         document.querySelector('.o_Message_readMoreLess').textContent,
-        "read more",
-        "read more/less link on message should be folded initially (read more)"
+        "Read More",
+        "Read More/Less link on message should be folded initially (Read More)"
     );
 
     document.querySelector('.o_Message_readMoreLess').click(),
     assert.strictEqual(
         document.querySelector('.o_Message_readMoreLess').textContent,
-        "read less",
-        "read more/less link on message should be unfolded after a click from initial rendering (read less)"
+        "Read Less",
+        "Read More/Less link on message should be unfolded after a click from initial rendering (read less)"
     );
 
     await afterNextRender(
@@ -1043,8 +1043,8 @@ QUnit.test('[TECHNICAL] unfolded read more/less links should not fold on message
     );
     assert.strictEqual(
         document.querySelector('.o_Message_readMoreLess').textContent,
-        "read less",
-        "read more/less link on message should still be unfolded after a click on message aside of this button click (read less)"
+        "Read Less",
+        "Read More/Less link on message should still be unfolded after a click on message aside of this button click (Read Less)"
     );
 });
 


### PR DESCRIPTION
Purpose
=======
In the chatter, when we reply to an email, the parent email is folded
behind a "read more" button. Add capital letters to this button to make
it more visible.

Task-2656302