### PR TITLE
[FIX] stock: delivery slip missing address

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -32,7 +32,7 @@
                             </div>
                             <div t-if="partner" name="partner_header">
                                 <div t-field="partner.self"
-                                    t-options='{"widget": "contact", "fields": ["name", "phone"], "no_marker": True, "phone_icons": True}'/>
+                                    t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
                                 <p t-if="partner.sudo().vat"><t t-esc="o.company_id.country_id.vat_label or 'Tax ID'"/>: <span t-field="partner.sudo().vat"/></p>
                             </div>
                         </div>


### PR DESCRIPTION
commit af13e76629d0ad1684f2be26a578f210ea4f1552
reworked delivery split to add interwarehouse addresses but also
removed the address in a usual case.

opw-2701998
