### PR TITLE
[REF] various: remove usage and dependency on html2text library

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
@@ -94,7 +94,6 @@ PKGS_TO_INSTALL="
     python3-passlib \
     python3-libsass \
     python3-qrcode \
-    python3-html2text \
     python3-unittest2 \
     python3-simplejson"
 

--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,6 @@ Depends:
  python3-dateutil,
  python3-decorator,
  python3-docutils,
- python3-html2text,
  python3-pil,
  python3-jinja2,
  python3-libsass,

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -13,8 +13,6 @@ import re
 import smtplib
 import threading
 
-import html2text
-
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import except_orm, UserError
 from odoo.tools import ustr, pycompat, encapsulate_email, email_domain_extract
@@ -379,7 +377,7 @@ class IrMailServer(models.Model):
 
         if subtype == 'html' and not body_alternative:
             # Always provide alternative text body ourselves if possible.
-            text = html2text.html2text(email_body)
+            text = tools.html2plaintext(email_body)
             alternative_part = MIMEMultipart(_subtype="alternative")
             alternative_part.attach(MIMEText(text, _charset='utf-8', _subtype='plain'))
             alternative_part.attach(email_text_part)

--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -14,6 +14,7 @@ from . import test_ir_attachment
 from . import test_ir_cron
 from . import test_ir_http
 from . import test_ir_filters
+from . import test_ir_mail_server
 from . import test_ir_model
 from . import test_ir_sequence
 from . import test_ir_sequence_date_range

--- a/odoo/addons/base/tests/test_ir_mail_server.py
+++ b/odoo/addons/base/tests/test_ir_mail_server.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import tools
+from odoo.addons.base.tests import test_mail_examples
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged('mail_server')
+class TestIrMailServer(TransactionCase):
+
+    def test_mail_body(self):
+        bodies = [
+            'content',
+            '<p>content</p>',
+            '<head><meta content="text/html; charset=utf-8" http-equiv="Content-Type"></head><body><p>content</p></body>',
+            test_mail_examples.MISC_HTML_SOURCE,
+            test_mail_examples.QUOTE_THUNDERBIRD_HTML,
+        ]
+        expected_list = [
+            'content',
+            'content',
+            'content',
+            "test1\n\n**test2**\n\n_test3_\n\n_test4_\n\n~~test5~~\n\ntest6\n\n  * test7\n  * test8\n\n  1. test9\n  2. test10\n\n> test11\n\n> > test12\n>>\n\n>>  \n>\n\n[google](http://google.com) [test link](javascript:alert\('malicious code'\))",
+            'On 01/05/2016 10:24 AM, Raoul Poilvache wrote:  \n\n> **_Test reply. The suite._**  \n>\n>\n>  \n>\n>\n> \--  \n>\n>\n> Raoul Poilvache\n\nTop cool !!!  \n  \n\n    \n    \n    -- \n    Raoul Poilvache\n    ',
+        ]
+        for body, expected in zip(bodies, expected_list):
+            message = self.env['ir.mail_server'].build_email(
+                'john.doe@from.example.com',
+                'destinataire@to.example.com',
+                body=body,
+                subject='Subject',
+                subtype='html',
+            )
+            body_alternative = False
+            for part in message.walk():
+                if part.get_content_type() == 'text/plain':
+                    body_alternative = tools.ustr(part.get_payload(decode=True))
+                    # remove ending new lines as it just adds noise
+                    body_alternative = body_alternative.strip('\n')
+            self.assertEqual(body_alternative, expected)

--- a/odoo/addons/base/tests/test_ir_mail_server.py
+++ b/odoo/addons/base/tests/test_ir_mail_server.py
@@ -22,8 +22,8 @@ class TestIrMailServer(TransactionCase):
             'content',
             'content',
             'content',
-            "test1\n\n**test2**\n\n_test3_\n\n_test4_\n\n~~test5~~\n\ntest6\n\n  * test7\n  * test8\n\n  1. test9\n  2. test10\n\n> test11\n\n> > test12\n>>\n\n>>  \n>\n\n[google](http://google.com) [test link](javascript:alert\('malicious code'\))",
-            'On 01/05/2016 10:24 AM, Raoul Poilvache wrote:  \n\n> **_Test reply. The suite._**  \n>\n>\n>  \n>\n>\n> \--  \n>\n>\n> Raoul Poilvache\n\nTop cool !!!  \n  \n\n    \n    \n    -- \n    Raoul Poilvache\n    ',
+            "test1\n*test2*\ntest3\ntest4\ntest5\ntest6   test7\ntest8    test9\ntest10\ntest11\ntest12\ngoogle [1]\ntest link [2]\n\n\n[1] http://google.com\n[2] javascript:alert('malicious code')",
+            'On 01/05/2016 10:24 AM, Raoul\nPoilvache wrote:\n\n* Test reply. The suite. *\n\n--\nRaoul Poilvache\n\nTop cool !!!\n\n--\nRaoul Poilvache',
         ]
         for body, expected in zip(bodies, expected_list):
             message = self.env['ir.mail_server'].build_email(

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ gevent==1.5.0 ; python_version >= '3.7'
 gevent==1.4.0 ; sys_platform == 'win32' and python_version < '3.7'
 greenlet==0.4.10 ; python_version < '3.7'
 greenlet==0.4.15 ; python_version >= '3.7'
-html2text==2018.1.9
 Jinja2==2.10.1
 libsass==0.17.0
 lxml==3.7.1 ; sys_platform != 'win32' and python_version < '3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ requires =
   python3-docutils
   python3-gevent
   python3-greenlet
-  python3-html2text
   python3-jinja2
   python3-lxml
   python3-mako

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         'decorator',
         'docutils',
         'gevent',
-        'html2text',
         'Jinja2',
         'lxml',  # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/
         'libsass',

--- a/setup/package.dfdebian
+++ b/setup/package.dfdebian
@@ -28,7 +28,6 @@ RUN apt-get update -qq &&  \
         python3-decorator \
         python3-docutils \
         python3-gevent \
-        python3-html2text \
         python3-pil \
         python3-jinja2 \
         python3-libsass \

--- a/setup/package.dffedora
+++ b/setup/package.dffedora
@@ -15,7 +15,6 @@ RUN dnf update -d 0 -e 0 -y && \
 	  python3-docutils \
 	  python3-gevent \
 	  python3-greenlet \
-	  python3-html2text \
 	  python3-jinja2 \
 	  python3-lxml \
 	  python3-mako \


### PR DESCRIPTION
We have our own html2plaintext, already used in lot of use cases instead of
just a few for the html2txt library.

Notably for emails: most emails going through Odoo stack use our simple
html2plaintext to format the body alternative. We may therefore use the same
alternative in ir_mail_server when body alternative is not given.

This also helps solving some issues with depending on that library.

Task-2702034
