### PR TITLE
[REF] various: remove usage and dependency on html2text library

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -14,7 +14,6 @@ from ssl import SSLError
 import sys
 import threading
 
-import html2text
 import idna
 
 from odoo import api, fields, models, tools, _
@@ -325,7 +324,7 @@ class IrMailServer(models.Model):
 
         email_body = ustr(body)
         if subtype == 'html' and not body_alternative:
-            msg.add_alternative(html2text.html2text(email_body), subtype='plain', charset='utf-8')
+            msg.add_alternative(tools.html2plaintext(email_body), subtype='plain', charset='utf-8')
             msg.add_alternative(email_body, subtype=subtype, charset='utf-8')
         elif body_alternative:
             msg.add_alternative(ustr(body_alternative), subtype=subtype_alternative, charset='utf-8')

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         'decorator',
         'docutils',
         'gevent',
-        'html2text',
         'idna',
         'Jinja2',
         'lxml',  # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/


### PR DESCRIPTION
We have our own html2plaintext, already used in lot of use cases instead of
just a few for the html2txt library.

Notably for emails: most emails going through Odoo stack use our simple
html2plaintext to format the body alternative. We may therefore use the same
alternative in ir_mail_server when body alternative is not given.

This also helps solving some issues with depending on that library.

Task-2702034
