### PR TITLE
[REF] various: remove usage and dependency on html2text library

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 
 from odoo import api, fields, models, Command, _
-from odoo.tools import float_compare, float_is_zero
+from odoo.tools import html2plaintext
 from odoo.osv.expression import get_unaccent_wrapper
 from odoo.exceptions import UserError, ValidationError
 import re
 from math import copysign
 from collections import defaultdict
 from dateutil.relativedelta import relativedelta
-import html2text
 
 
 class AccountReconcileModelPartnerMapping(models.Model):
@@ -754,7 +753,7 @@ class AccountReconcileModel(models.Model):
 
         for partner_mapping in self.partner_mapping_line_ids:
             match_payment_ref = re.match(partner_mapping.payment_ref_regex, st_line.payment_ref) if partner_mapping.payment_ref_regex else True
-            match_narration = re.match(partner_mapping.narration_regex, html2text.html2text(st_line.narration or '').rstrip()) if partner_mapping.narration_regex else True
+            match_narration = re.match(partner_mapping.narration_regex, html2plaintext(st_line.narration or '').rstrip()) if partner_mapping.narration_regex else True
 
             if match_payment_ref and match_narration:
                 return partner_mapping.partner_id

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -7,7 +7,6 @@ import base64
 import datetime
 import email
 import email.policy
-import html2text
 import idna
 import logging
 import re
@@ -395,7 +394,7 @@ class IrMailServer(models.Model):
 
         email_body = ustr(body)
         if subtype == 'html' and not body_alternative:
-            msg.add_alternative(html2text.html2text(email_body), subtype='plain', charset='utf-8')
+            msg.add_alternative(tools.html2plaintext(email_body), subtype='plain', charset='utf-8')
             msg.add_alternative(email_body, subtype=subtype, charset='utf-8')
         elif body_alternative:
             msg.add_alternative(ustr(body_alternative), subtype=subtype_alternative, charset='utf-8')

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         'decorator',
         'docutils',
         'gevent',
-        'html2text',
         'idna',
         'Jinja2',
         'lxml',  # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/


### PR DESCRIPTION
We have our own html2plaintext, already used in lot of use cases instead of
just a few for the html2txt library.

Notably for emails: most emails going through Odoo stack use our simple
html2plaintext to format the body alternative. We may therefore use the same
alternative in ir_mail_server when body alternative is not given.

This also helps solving some issues with depending on that library.

Task-2702034
