### PR TITLE
[REM] mass_mailing: remove the option to change templates on the go

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -392,7 +392,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
         // Overide `d-flex` class which style is `!important`
         $snippetsSideBar.find(`.o_we_website_top_actions > *:not(${selectorToKeep})`).attr('style', 'display: none!important');
         var $snippets_menu = $snippetsSideBar.find("#snippets_menu");
-        var $selectTemplateBtn = $snippets_menu.find('.o_we_select_template');
 
         if (config.device.isMobile) {
             $snippetsSideBar.hide();
@@ -447,9 +446,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
          * Create theme selection screen and check if it must be forced opened.
          * Reforce it opened if the last snippet is removed.
          */
-        const $themeSelector = $(core.qweb.render("mass_mailing.theme_selector", {
-            themes: themesParams
-        }));
         const $themeSelectorNew = $(core.qweb.render("mass_mailing.theme_selector_new", {
             themes: themesParams
         }));
@@ -460,50 +456,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
             $themeSelectorNew.appendTo(this.wysiwyg.$iframeBody);
         }
 
-        /**
-         * Add proposition to install enterprise themes if not installed.
-         */
-        var $mail_themes_upgrade = $themeSelector.find(".o_mass_mailing_themes_upgrade");
-        $mail_themes_upgrade.on("click", function (e) {
-            e.stopImmediatePropagation();
-            e.preventDefault();
-            self.do_action("mass_mailing.action_mass_mailing_configuration");
-        });
-
-        $selectTemplateBtn.on('click', () => {
-            $snippetsSideBar.data('snippetMenu').activateCustomTab($themeSelector);
-            /**
-             * Ensure the parent of the theme selector is not used as parent for a
-             * tooltip as it is overflow auto and would result in the tooltip being
-             * hidden by the body of the mail.
-             */
-            $themeSelector.parent().addClass('o_forbidden_tooltip_parent');
-            $selectTemplateBtn.addClass('active');
-        });
-
-        /**
-         * Switch theme when a theme button is hovered. Confirm change if the theme button
-         * is pressed.
-         */
         var selectedTheme = false;
-        $themeSelector.on("mouseenter", ".dropdown-item", function (e) {
-            e.preventDefault();
-            var themeParams = themesParams[$(e.currentTarget).index()];
-            self._switchThemes(false, themeParams);
-        });
-        $themeSelector.on("mouseleave", ".dropdown-item", function (e) {
-            self._switchThemes(false, selectedTheme);
-        });
-        $themeSelector.on("click", '[data-toggle="dropdown"]', function (e) {
-            var $menu = $themeSelector.find('.dropdown-menu');
-            var isVisible = $menu.hasClass('show');
-            if (isVisible) {
-                e.preventDefault();
-                e.stopImmediatePropagation();
-                $menu.removeClass('show');
-            }
-        });
-
         const selectTheme = (e) => {
             e.preventDefault();
             e.stopImmediatePropagation();
@@ -511,13 +464,8 @@ var MassMailingFieldHtml = FieldHtml.extend({
             self._switchImages(themeParams, $snippets);
 
             selectedTheme = themeParams;
-
-            // Notify form view
-            $themeSelector.find('.dropdown-item.selected').removeClass('selected');
-            $themeSelector.find('.dropdown-item:eq(' + themesParams.indexOf(selectedTheme) + ')').addClass('selected');
         };
 
-        $themeSelector.on("click", ".dropdown-item", selectTheme);
         $themeSelectorNew.on("click", ".dropdown-item", async (e) => {
             e.preventDefault();
             e.stopImmediatePropagation();
@@ -530,10 +478,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
             this.$content.closest('body').removeClass("o_force_mail_theme_choice");
 
             $themeSelectorNew.remove();
-
-            if ($mail_themes_upgrade.length) {
-                $snippets_menu.empty();
-            }
 
             selectTheme(e);
             // Wait the next tick because some mutation have to be processed by
@@ -550,7 +494,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
         selectedTheme = this._getSelectedTheme(themesParams);
         if (selectedTheme) {
             this.$content.closest('body').addClass(selectedTheme.className);
-            $themeSelector.find('.dropdown-item:eq(' + themesParams.indexOf(selectedTheme) + ')').addClass('selected');
             this._switchImages(selectedTheme, $snippets);
         } else if (this.$content.find('.o_layout').length) {
             themesParams.push({

--- a/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
@@ -6,46 +6,6 @@
     margin-bottom: -$o-sheet-cancel-bpadding;
 }
 
-.o_mail_theme_selector {
-    > a {
-        height: $o-we-toolbar-height;
-        line-height: $o-we-toolbar-height;
-        border-radius: 0;
-        background-color: $o-we-sidebar-bg;
-        color: #212629;
-        box-shadow: none !important;
-        display: flex;
-
-        &:first-child {
-            display: none;
-        }
-
-        .o_thumb {
-            background-size: cover;
-            border: 1px solid $o-we-border-color;
-            flex: 1;
-        }
-
-
-        &:hover {
-            background-color: $o-we-sidebar-bg;
-
-            .o_thumb {
-                border: 1px solid black;
-            }
-        }
-
-        &.selected .o_thumb {
-            border: 2px solid $o-brand-odoo;
-            background-color: $o-we-sidebar-bg;
-        }
-
-        &:hover, &:focus, &:active {
-            color: #4e525b;
-        }
-    }
-}
-
 .o_mail_theme_selector_new {
     display: block;
     position: absolute;
@@ -161,7 +121,7 @@ body.o_force_mail_theme_choice {
     #oe_snippets {
         width: 100%;
 
-        .o_mail_theme_selector, .o_mail_theme_selector_new {
+        .o_mail_theme_selector_new {
             .dropdown-toggle {
                 display: none;
             }

--- a/addons/mass_mailing/static/src/xml/mass_mailing.xml
+++ b/addons/mass_mailing/static/src/xml/mass_mailing.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <div t-name="mass_mailing.theme_selector" class="o_mail_theme_selector">
-        <t t-foreach="themes" t-as="theme">
-            <a t-att-id="theme.name" href="#" class="dropdown-item">
-                <div class="o_thumb logo" t-attf-style="background-image: url(#{theme.img}_logo.png)"/>
-            </a>
-        </t>
-    </div>
     <div t-name="mass_mailing.theme_selector_new" class="o_mail_theme_selector_new">
         <t t-foreach="themes" t-as="theme">
             <a t-att-id="theme.name" role="menuitem" href="#" class="dropdown-item">

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -12,9 +12,6 @@
             </button>
         </div>
     </xpath>
-    <xpath expr="//div[@id='snippets_menu']" position="inside">
-        <button type="button" class="o_we_select_template text-uppercase"><span>Select a template</span></button>
-    </xpath>
     <xpath expr="//t[@id='default_snippets']" position="replace">
         <t id="default_snippets">
             <t t-set="company_id" t-value="res_company"/>


### PR DESCRIPTION
Templates in mass_mailing have been redefined in [PR]: all their custom styles have been removed so they all are built in a way that they could be built using the editor only. In that sense they are just collections of styled snippets and we lost the purpose for the "select your template" tab, which is hereby removed.

[PR] https://github.com/odoo/enterprise/pull/21215

task-2702007

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
