### PR TITLE
[FIX] base_vat: display correct partner name in error message

### DIFF
--- a/addons/base_vat/i18n/base_vat.pot
+++ b/addons/base_vat/i18n/base_vat.pot
@@ -76,7 +76,7 @@ msgstr ""
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid ""
-"The VAT number [%(wrong_vat)s] for record_label does not seem to be valid. \n"
+"The VAT number [%(wrong_vat)s] for %(record_label)s does not seem to be valid. \n"
 "Note: the expected format is %(expected_format)s"
 msgstr ""
 

--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -227,7 +227,7 @@ class ResPartner(models.Model):
             )
 
         return '\n' + _(
-            'The VAT number [%(wrong_vat)s] for record_label does not seem to be valid. \nNote: the expected format is %(expected_format)s',
+            'The VAT number [%(wrong_vat)s] for %(record_label)s does not seem to be valid. \nNote: the expected format is %(expected_format)s',
             wrong_vat=wrong_vat,
             record_label=record_label,
             expected_format=expected_format,


### PR DESCRIPTION
VAT check error message says 'record_label' instead of real partner name

Steps to reproduce:
1. Install the Contacts app and the VAT Number Validation module
2. Go to the Contacts app
3. Create a contact and define his country and an invalid VAT number
4. Save

Solution:
Modify the error message with the correct placeholder

OPW-2692320