### PR TITLE
[FIX] web_editor: wait popover to be inserted to modify it

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -87,8 +87,10 @@ const LinkPopoverWidget = Widget.extend({
                 tooltip.hide();
             }
         })
-        .popover('show')
-        .data('bs.popover').tip.classList.add('o_edit_menu_popover');
+        .on('inserted.bs.popover.link_popover', () => {
+            this.$target.data('bs.popover').tip.classList.add('o_edit_menu_popover');
+        })
+        .popover('show');
 
 
         this.popover = this.$target.data('bs.popover');


### PR DESCRIPTION
In some circumstance, `this.$target.data('bs.popover').tip` was not
defined until added into the DOM.

Task-2666388



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
