### PR TITLE
[FIX] [microsoft,google]_calendar: fix import statement for python 3.10

### DIFF
--- a/addons/google_calendar/utils/google_event.py
+++ b/addons/google_calendar/utils/google_event.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tools import email_normalize
+from collections.abc import Set
 import logging
 from typing import Iterator, Mapping
-from collections import abc
+
+from odoo.tools import email_normalize
 
 _logger = logging.getLogger(__name__)
 
 
-class GoogleEvent(abc.Set):
+class GoogleEvent(Set):
     """This helper class holds the values of a Google event.
     Inspired by Odoo recordset, one instance can be a single Google event or a
     (immutable) set of Google events.

--- a/addons/microsoft_calendar/utils/microsoft_event.py
+++ b/addons/microsoft_calendar/utils/microsoft_event.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo.api import model
+from collections.abc import Set
 from typing import Iterator, Mapping
-from collections import abc
+
+from odoo.api import model
 
 
-class MicrosoftEvent(abc.Set):
+class MicrosoftEvent(Set):
     """This helper class holds the values of a Microsoft event.
     Inspired by Odoo recordset, one instance can be a single Microsoft event or a
     (immutable) set of Microsoft events.


### PR DESCRIPTION
From warning:
py.warnings: /usr/lib/python3/dist-packages/html5lib/_trie/_base.py:3:
DeprecationWarning: Using or importing the ABCs from 'collections' instead
of from 'collections.abc' is deprecated since Python 3.3,
and in 3.10 it will stop working
