### PR TITLE
[FIX] mrp_subcontracting: show correct view when tracked subcontracted

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1329,7 +1329,9 @@ class MrpProduction(models.Model):
                 'product_consumed_qty_uom': consumed_qty,
                 'product_expected_qty_uom': expected_qty
             }))
-        ctx.update({'default_mrp_production_ids': self.ids, 'default_mrp_consumption_warning_line_ids': lines})
+        ctx.update({'default_mrp_production_ids': self.ids,
+                    'default_mrp_consumption_warning_line_ids': lines,
+                    'form_view_ref': False})
         action = self.env["ir.actions.actions"]._for_xml_id("mrp.action_mrp_consumption_warning")
         action['context'] = ctx
         return action

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -197,8 +197,11 @@
                                     context="{'default_product_id': product_id, 'default_company_id': company_id}" attrs="{'invisible': [('product_tracking', 'in', ('none', False))]}"/>
                                 <button name="action_generate_serial" type="object" class="btn btn-primary fa fa-plus-square-o" aria-label="Creates a new serial/lot number" title="Creates a new serial/lot number" role="img" attrs="{'invisible': ['|', ('product_tracking', 'in', ('none', False)), ('lot_producing_id', '!=', False)]}"/>
                             </div>
-                            <field name="bom_id"
-                                context="{'default_product_tmpl_id': product_tmpl_id}" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                            <label for="bom_id" name="bom_label"/>
+                            <div class='o_row d-flex' name="bom_div">
+                                <field name="bom_id"
+                                    context="{'default_product_tmpl_id': product_tmpl_id}" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                            </div>
                         </group>
                         <group name="group_extra_info">
                             <label for="date_planned_start"/>

--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -46,6 +46,8 @@ class MrpProduction(models.Model):
         for sml in self.move_raw_ids.move_line_ids:
             if sml.tracking != 'none' and not sml.lot_id:
                 raise UserError(_('You must enter a serial number for each line of %s') % sml.product_id.display_name)
+        if self.move_raw_ids and not any(self.move_raw_ids.mapped('quantity_done')):
+            raise UserError(_("You must indicate a non-zero amount consumed for at least one of your components"))
         consumption_issues = self._get_consumption_issues()
         if consumption_issues:
             return self._action_generate_consumption_wizard(consumption_issues)

--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -76,7 +76,7 @@ class StockMove(models.Model):
         if self._subcontrating_should_be_record() or self._subcontrating_can_be_record():
             return self._action_record_components()
         action = super(StockMove, self).action_show_details()
-        if self.is_subcontract and self._get_subcontract_production():
+        if self.is_subcontract and all(p._has_been_recorded() for p in self._get_subcontract_production()):
             action['views'] = [(self.env.ref('stock.view_stock_move_operations').id, 'form')]
             action['context'].update({
                 'show_lots_m2o': self.has_tracking != 'none',
@@ -179,6 +179,7 @@ class StockMove(models.Model):
     def _get_subcontract_production(self):
         return self.filtered(lambda m: m.is_subcontract).move_orig_ids.production_id
 
+    # TODO: To be deleted, use self._get_subcontract_production()._has_tracked_component() instead
     def _has_tracked_subcontract_components(self):
         return any(m.has_tracking != 'none' for m in self._get_subcontract_production().move_raw_ids)
 

--- a/addons/mrp_subcontracting/views/mrp_production_views.xml
+++ b/addons/mrp_subcontracting/views/mrp_production_views.xml
@@ -24,7 +24,10 @@
             <xpath expr="//page[@name='miscellaneous']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
-            <xpath expr="//field[@name='bom_id']" position="attributes">
+            <xpath expr="//label[@name='bom_label']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//div[@name='bom_div']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//field[@name='move_byproduct_ids']" position="attributes">


### PR DESCRIPTION
To reproduce:
- create tracked product to subcontract
- create subcontract BoM with no tracked components + strict consumption
- create receipt of subcontracted product (remember to select From =
  subcontractor)
- click on `action_show_details` burger button in Operations

Expected result:
- Detailed Operations window with no move lines in it (i.e.
  stock.view_stock_move_nosuggest_operations view)
Actual Result:
- Detailed Operations window with move lines w/ 0 Done
  (i.e. stock.view_stock_move_operations view _ lines also do
  not get filled in when using the `action_assign_serial_show_details`,
  => twice as many lines as needed end up in view)

Issue appears to be that conditional was incorrectly recreated during a
minor refactoring. stock.view_stock_move_operations view
should only appear when tracked components have all been recorded
already so user can adjust their lots/sn if needed.

Task: 2695173

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
