### PR TITLE
[FIX] base{_import_module}: cloc should not count generated code

### DIFF
--- a/addons/base_import_module/tests/__init__.py
+++ b/addons/base_import_module/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import test_cloc

--- a/addons/base_import_module/tests/test_cloc.py
+++ b/addons/base_import_module/tests/test_cloc.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tools import cloc
+from odoo.addons.base.tests import test_cloc
+
+class TestClocFields(test_cloc.TestClocCustomization):
+
+    def test_fields_from_import_module(self):
+        """
+            Check that custom computed fields installed with an imported module
+            is counted as customization
+        """
+        self.env['ir.module.module'].create({
+            'name': 'imported_module',
+            'state': 'installed',
+            'imported': True,
+        })
+        f1 = self.create_field('x_imported_field')
+        self.create_xml_id('import_field', f1.id, 'imported_module')
+        cl = cloc.Cloc()
+        cl.count_customization(self.env)
+        self.assertEqual(cl.code.get('imported_module', 0), 1, 'Count fields with xml_id of imported module')
+        f2 = self.create_field('x_base_field')
+        self.create_xml_id('base_field', f2.id, 'base')
+        cl = cloc.Cloc()
+        cl.count_customization(self.env)
+        self.assertEqual(cl.code.get('base', 0), 0, "Don't count fields from standard module")


### PR DESCRIPTION
* Studio generate computed field "count" when the user add a button
in the button box. Since those lines are written by studio with drag and drop
it should not be counted for the maintenance subscription.

* We can detect them because field created by the user in studio start with x_studio
and fields created outside studio does not have studio_customization
xml_id

* Add test to make no standard module introduce customization in the
database during the install the will be counted by cloc


See https://github.com/odoo/enterprise/pull/22664


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
