### PR TITLE
[FIX] mail: invisible reply icon on temporary or transient messages

### DIFF
--- a/addons/mail/static/src/models/message_action_list/message_action_list.js
+++ b/addons/mail/static/src/models/message_action_list/message_action_list.js
@@ -149,6 +149,7 @@ function factory(dependencies) {
         _computeHasReplyIcon() {
             return Boolean(
                 this.messaging && this.messaging.inbox &&
+                this.message && !this.message.isTemporary && !this.message.isTransient &&
                 this.messageView && this.messageView.threadView && this.messageView.threadView.thread && (
                     this.messageView.threadView.thread === this.messaging.inbox ||
                     this.messageView.threadView.thread.model === 'mail.channel'


### PR DESCRIPTION
**Current behavior before PR:**

Replying to the answer of /who command in a channel leads to the reply not being
associated with the correct message, it should simply not be possible.

**Desired behavior after PR is merged:**

The reply icon will not be visible for a temporary or transient message.

Task-2700389


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
