### PR TITLE
[IMP] mail: rename activity type model

### DIFF
--- a/addons/mail/static/src/models/activity/activity.js
+++ b/addons/mail/static/src/models/activity/activity.js
@@ -290,7 +290,7 @@ registerModel({
         thread: many2one('mail.thread', {
             inverse: 'activities',
         }),
-        type: many2one('mail.activity_type', {
+        type: many2one('ActivityType', {
             inverse: 'activities',
         }),
     },

--- a/addons/mail/static/src/models/activity_type/activity_type.js
+++ b/addons/mail/static/src/models/activity_type/activity_type.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { attr, one2many } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.activity_type',
+    name: 'ActivityType',
     identifyingFields: ['id'],
     fields: {
         activities: one2many('mail.activity', {


### PR DESCRIPTION
Rename javascript model `mail.activity_type` to `ActivityType` in order to distinguish javascript model from python model.

Part of task-2701674.