### PR TITLE
[IMP] mail: rename attachment model

### DIFF
--- a/addons/mail/static/src/components/activity/activity.js
+++ b/addons/mail/static/src/components/activity/activity.js
@@ -107,7 +107,7 @@ export class Activity extends Component {
     /**
      * @private
      * @param {Object} detail
-     * @param {mail.attachment} detail.attachment
+     * @param {Attachment} detail.attachment
      */
     _onAttachmentCreated(detail) {
         this.activity.markAsDone({ attachments: [detail.attachment] });

--- a/addons/mail/static/src/components/attachment_box/tests/attachment_box_tests.js
+++ b/addons/mail/static/src/components/attachment_box/tests/attachment_box_tests.js
@@ -240,7 +240,7 @@ QUnit.test('view attachments', async function (assert) {
         id: 100,
         model: 'res.partner',
     });
-    const firstAttachment = this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 143 });
+    const firstAttachment = this.messaging.models['Attachment'].findFromIdentifyingData({ id: 143 });
     await this.createAttachmentBoxComponent(thread);
 
     await afterNextRender(() =>

--- a/addons/mail/static/src/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog.js
+++ b/addons/mail/static/src/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog.js
@@ -14,10 +14,10 @@ export class AttachmentDeleteConfirmDialog extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.attachment}
+     * @returns {Attachment}
      */
     get attachment() {
-        return this.messaging && this.messaging.models['mail.attachment'].get(this.props.attachmentLocalId);
+        return this.messaging && this.messaging.models['Attachment'].get(this.props.attachmentLocalId);
     }
 
     /**

--- a/addons/mail/static/src/components/attachment_image/tests/attachment_image_tests.js
+++ b/addons/mail/static/src/components/attachment_image/tests/attachment_image_tests.js
@@ -33,7 +33,7 @@ QUnit.test('auto layout with image', async function (assert) {
     assert.expect(3);
 
     const { createMessageComponent } = await this.start();
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.png",
         id: 750,
         mimetype: 'image/png',

--- a/addons/mail/static/src/components/attachment_list/tests/attachment_list_tests.js
+++ b/addons/mail/static/src/components/attachment_list/tests/attachment_list_tests.js
@@ -35,7 +35,7 @@ QUnit.test('simplest layout', async function (assert) {
     assert.expect(8);
 
     const { createMessageComponent } = await this.start();
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',
@@ -57,7 +57,7 @@ QUnit.test('simplest layout', async function (assert) {
     const attachmentEl = document.querySelector('.o_AttachmentList .o_AttachmentCard');
     assert.strictEqual(
         attachmentEl.dataset.id,
-        this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }).localId,
+        this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }).localId,
         "attachment component should be linked to attachment store model"
     );
     assert.strictEqual(
@@ -107,7 +107,7 @@ QUnit.test('simplest layout + editable', async function (assert) {
             return this._super(...arguments);
         },
     });
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',
@@ -163,7 +163,7 @@ QUnit.test('layout with card details and filename and extension', async function
     assert.expect(2);
 
     const { createMessageComponent } = await this.start();
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',
@@ -195,7 +195,7 @@ QUnit.test('view attachment', async function (assert) {
     const { createMessageComponent } = await this.start({
         hasDialog: true,
     });
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.png",
         id: 750,
         mimetype: 'image/png',
@@ -231,7 +231,7 @@ QUnit.test('close attachment viewer', async function (assert) {
     assert.expect(3);
 
     const { createMessageComponent } = await this.start({ hasDialog: true });
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.png",
         id: 750,
         mimetype: 'image/png',
@@ -280,7 +280,7 @@ QUnit.test('clicking on the delete attachment button multiple times should do th
             return this._super(...arguments);
         },
     });
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',
@@ -322,7 +322,7 @@ QUnit.test('[technical] does not crash when the viewer is closed before image lo
     assert.expect(1);
 
     const { createMessageComponent } = await this.start({ hasDialog: true });
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.png",
         id: 750,
         mimetype: 'image/png',
@@ -356,7 +356,7 @@ QUnit.test('plain text file is viewable', async function (assert) {
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',
@@ -381,7 +381,7 @@ QUnit.test('HTML file is viewable', async function (assert) {
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.html",
         id: 750,
         mimetype: 'text/html',
@@ -405,7 +405,7 @@ QUnit.test('ODT file is not viewable', async function (assert) {
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.odt",
         id: 750,
         mimetype: 'application/vnd.oasis.opendocument.text',
@@ -429,7 +429,7 @@ QUnit.test('DOCX file is not viewable', async function (assert) {
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.docx",
         id: 750,
         mimetype: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',

--- a/addons/mail/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_tests.js
@@ -2679,7 +2679,7 @@ QUnit.test('composer state: attachments save and restore', async function (asser
     );
     assert.strictEqual(
         document.querySelector(`.o_Composer .o_AttachmentCard`).dataset.id,
-        this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 1 }).localId,
+        this.messaging.models['Attachment'].findFromIdentifyingData({ id: 1 }).localId,
         "should have correct 1st attachment in the composer"
     );
 
@@ -2693,17 +2693,17 @@ QUnit.test('composer state: attachments save and restore', async function (asser
     );
     assert.strictEqual(
         document.querySelectorAll(`.o_Composer .o_AttachmentCard`)[0].dataset.id,
-        this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 2 }).localId,
+        this.messaging.models['Attachment'].findFromIdentifyingData({ id: 2 }).localId,
         "should have attachment with id 2 as 1st attachment"
     );
     assert.strictEqual(
         document.querySelectorAll(`.o_Composer .o_AttachmentCard`)[1].dataset.id,
-        this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 3 }).localId,
+        this.messaging.models['Attachment'].findFromIdentifyingData({ id: 3 }).localId,
         "should have attachment with id 3 as 2nd attachment"
     );
     assert.strictEqual(
         document.querySelectorAll(`.o_Composer .o_AttachmentCard`)[2].dataset.id,
-        this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 4 }).localId,
+        this.messaging.models['Attachment'].findFromIdentifyingData({ id: 4 }).localId,
         "should have attachment with id 4 as 3rd attachment"
     );
 });

--- a/addons/mail/static/src/components/file_uploader/file_uploader.js
+++ b/addons/mail/static/src/components/file_uploader/file_uploader.js
@@ -89,7 +89,7 @@ export class FileUploader extends Component {
     async _performUpload({ composer, files, thread }) {
         const uploadingAttachments = new Map();
         for (const file of files) {
-            uploadingAttachments.set(file, this.messaging.models['mail.attachment'].insert({
+            uploadingAttachments.set(file, this.messaging.models['Attachment'].insert({
                 composer: composer && replace(composer),
                 filename: file.name,
                 id: geAttachmentNextTemporaryId(),
@@ -149,7 +149,7 @@ export class FileUploader extends Component {
             });
             return;
         }
-        const attachment = this.messaging.models['mail.attachment'].insert({
+        const attachment = this.messaging.models['Attachment'].insert({
             composer: composer && replace(composer),
             originThread: (!composer && thread) ? replace(thread) : undefined,
             ...attachmentData,

--- a/addons/mail/static/src/components/file_uploader/tests/file_uploader_tests.js
+++ b/addons/mail/static/src/components/file_uploader/tests/file_uploader_tests.js
@@ -56,7 +56,7 @@ QUnit.test('no conflicts between file uploaders', async function (assert) {
     );
     await nextAnimationFrame(); // we can't use afterNextRender as fileInput are display:none
     assert.strictEqual(
-        this.messaging.models['mail.attachment'].all().length,
+        this.messaging.models['Attachment'].all().length,
         1,
         'Uploaded file should be the only attachment created'
     );
@@ -72,7 +72,7 @@ QUnit.test('no conflicts between file uploaders', async function (assert) {
     );
     await nextAnimationFrame();
     assert.strictEqual(
-        this.messaging.models['mail.attachment'].all().length,
+        this.messaging.models['Attachment'].all().length,
         2,
         'Uploaded file should be the only attachment added'
     );

--- a/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
+++ b/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
@@ -1015,7 +1015,7 @@ QUnit.test("delete all attachments of message without content should no longer d
 
     await afterNextRender(() => {
         document.querySelector(`.o_AttachmentCard[data-id="${
-            this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 143 }).localId
+            this.messaging.models['Attachment'].findFromIdentifyingData({ id: 143 }).localId
         }"] .o_AttachmentCard_asideItemUnlink`).click();
     });
     await afterNextRender(() =>
@@ -1075,7 +1075,7 @@ QUnit.test('delete all attachments of a message with some text content should st
 
     await afterNextRender(() => {
         document.querySelector(`.o_AttachmentCard[data-id="${
-            this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 143 }).localId
+            this.messaging.models['Attachment'].findFromIdentifyingData({ id: 143 }).localId
         }"] .o_AttachmentCard_asideItemUnlink`).click();
     });
     await afterNextRender(() =>
@@ -1142,7 +1142,7 @@ QUnit.test('delete all attachments of a message with tracking fields should stil
 
     await afterNextRender(() => {
         document.querySelector(`.o_AttachmentCard[data-id="${
-            this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 143 }).localId
+            this.messaging.models['Attachment'].findFromIdentifyingData({ id: 143 }).localId
         }"] .o_AttachmentCard_asideItemUnlink`).click();
     });
     await afterNextRender(() =>

--- a/addons/mail/static/src/models/activity/activity.js
+++ b/addons/mail/static/src/models/activity/activity.js
@@ -161,7 +161,7 @@ registerModel({
         },
         /**
          * @param {Object} param0
-         * @param {mail.attachment[]} [param0.attachments=[]]
+         * @param {Attachment[]} [param0.attachments=[]]
          * @param {string|boolean} [param0.feedback=false]
          */
         async markAsDone({ attachments = [], feedback = false }) {
@@ -233,7 +233,7 @@ registerModel({
     },
     fields: {
         assignee: many2one('User'),
-        attachments: many2many('mail.attachment', {
+        attachments: many2many('Attachment', {
             inverse: 'activities',
         }),
         canWrite: attr({

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -5,7 +5,7 @@ import { attr, many2many, many2one, one2many } from '@mail/model/model_field';
 import { clear, insert } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.attachment',
+    name: 'Attachment',
     identifyingFields: ['id'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/attachment/tests/attachment_tests.js
+++ b/addons/mail/static/src/models/attachment/tests/attachment_tests.js
@@ -26,17 +26,17 @@ QUnit.test('create (txt)', async function (assert) {
     assert.expect(9);
 
     await this.start();
-    assert.notOk(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.notOk(this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
 
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',
         name: "test.txt",
     });
     assert.ok(attachment);
-    assert.ok(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
-    assert.strictEqual(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }), attachment);
+    assert.ok(this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.strictEqual(this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }), attachment);
     assert.strictEqual(attachment.filename, "test.txt");
     assert.strictEqual(attachment.id, 750);
     assert.notOk(attachment.isUploading);
@@ -48,17 +48,17 @@ QUnit.test('displayName', async function (assert) {
     assert.expect(5);
 
     await this.start();
-    assert.notOk(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.notOk(this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
 
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',
         name: "test.txt",
     });
     assert.ok(attachment);
-    assert.ok(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
-    assert.strictEqual(attachment, this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.ok(this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.strictEqual(attachment, this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
     assert.strictEqual(attachment.displayName, "test.txt");
 });
 
@@ -66,17 +66,17 @@ QUnit.test('extension', async function (assert) {
     assert.expect(5);
 
     await this.start();
-    assert.notOk(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.notOk(this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
 
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',
         name: "test.txt",
     });
     assert.ok(attachment);
-    assert.ok(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
-    assert.strictEqual(attachment, this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.ok(this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.strictEqual(attachment, this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
     assert.strictEqual(attachment.extension, 'txt');
 });
 
@@ -84,17 +84,17 @@ QUnit.test('fileType', async function (assert) {
     assert.expect(5);
 
     await this.start();
-    assert.notOk(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.notOk(this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
 
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',
         name: "test.txt",
     });
     assert.ok(attachment);
-    assert.ok(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
-    assert.strictEqual(attachment, this.messaging.models['mail.attachment'].findFromIdentifyingData({
+    assert.ok(this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.strictEqual(attachment, this.messaging.models['Attachment'].findFromIdentifyingData({
         id: 750,
     }));
     assert.ok(attachment.isText);
@@ -104,17 +104,17 @@ QUnit.test('isTextFile', async function (assert) {
     assert.expect(5);
 
     await this.start();
-    assert.notOk(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.notOk(this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
 
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',
         name: "test.txt",
     });
     assert.ok(attachment);
-    assert.ok(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
-    assert.strictEqual(attachment, this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.ok(this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.strictEqual(attachment, this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
     assert.ok(attachment.isText);
 });
 
@@ -122,17 +122,17 @@ QUnit.test('isViewable', async function (assert) {
     assert.expect(5);
 
     await this.start();
-    assert.notOk(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.notOk(this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
 
-    const attachment = this.messaging.models['mail.attachment'].create({
+    const attachment = this.messaging.models['Attachment'].create({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',
         name: "test.txt",
     });
     assert.ok(attachment);
-    assert.ok(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
-    assert.strictEqual(attachment, this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.ok(this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.strictEqual(attachment, this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
     assert.ok(attachment.isViewable);
 });
 

--- a/addons/mail/static/src/models/attachment_card/attachment_card.js
+++ b/addons/mail/static/src/models/attachment_card/attachment_card.js
@@ -65,7 +65,7 @@ registerModel({
         /**
          * Determines the attachment of this card.
          */
-        attachment: many2one('mail.attachment', {
+        attachment: many2one('Attachment', {
             inverse: 'attachmentCards',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/attachment_image/attachment_image.js
+++ b/addons/mail/static/src/models/attachment_image/attachment_image.js
@@ -107,7 +107,7 @@ registerModel({
         /**
          * Determines the attachment of this attachment image..
          */
-        attachment: many2one('mail.attachment', {
+        attachment: many2one('Attachment', {
             inverse: 'attachmentImages',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/attachment_list/attachment_list.js
+++ b/addons/mail/static/src/models/attachment_list/attachment_list.js
@@ -23,7 +23,7 @@ registerModel({
             }));
         },
         /**
-         * @returns {mail.attachment[]}
+         * @returns {Attachment[]}
          */
         _computeAttachments() {
             if (this.message) {
@@ -38,19 +38,19 @@ registerModel({
             return clear();
         },
         /**
-         * @returns {mail.attachment[]}
+         * @returns {Attachment[]}
          */
         _computeImageAttachments() {
             return replace(this.attachments.filter(attachment => attachment.isImage));
         },
         /**
-         * @returns {mail.attachment[]}
+         * @returns {Attachment[]}
          */
         _computeNonImageAttachments() {
             return replace(this.attachments.filter(attachment => !attachment.isImage));
         },
         /**
-         * @returns {mail.attachment[]}
+         * @returns {Attachment[]}
          */
         _computeViewableAttachments() {
             return replace(this.attachments.filter(attachment => attachment.isViewable));
@@ -60,7 +60,7 @@ registerModel({
         /**
          * States the attachments to be displayed by this attachment list.
          */
-        attachments: many2many('mail.attachment', {
+        attachments: many2many('Attachment', {
             compute: '_computeAttachments',
             inverse: 'attachmentLists',
         }),
@@ -104,7 +104,7 @@ registerModel({
         /**
          * States the attachment that are an image.
          */
-        imageAttachments: many2many('mail.attachment', {
+        imageAttachments: many2many('Attachment', {
             compute: '_computeImageAttachments',
         }),
         message: many2one('Message', {
@@ -120,13 +120,13 @@ registerModel({
         /**
          * States the attachment that are not an image.
          */
-        nonImageAttachments: many2many('mail.attachment', {
+        nonImageAttachments: many2many('Attachment', {
             compute: '_computeNonImageAttachments',
         }),
         /**
          * States the attachments that can be viewed inside the browser.
          */
-        viewableAttachments: many2many('mail.attachment', {
+        viewableAttachments: many2many('Attachment', {
             compute: '_computeViewableAttachments',
         }),
     },

--- a/addons/mail/static/src/models/attachment_viewer/attachment_viewer.js
+++ b/addons/mail/static/src/models/attachment_viewer/attachment_viewer.js
@@ -38,13 +38,13 @@ registerModel({
         angle: attr({
             default: 0,
         }),
-        attachment: many2one('mail.attachment'),
+        attachment: many2one('Attachment'),
         attachmentList: many2one('AttachmentList', {
             inverse: 'attachmentViewers',
             readonly: true,
             required: true,
         }),
-        attachments: many2many('mail.attachment', {
+        attachments: many2many('Attachment', {
             inverse: 'attachmentViewers',
             related: 'attachmentList.viewableAttachments',
         }),

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -128,7 +128,7 @@ registerModel({
         /**
          * States which attachments are currently being created in this composer.
          */
-        attachments: one2many('mail.attachment', {
+        attachments: one2many('Attachment', {
             inverse: 'composer',
         }),
         canPostMessage: attr({

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -25,7 +25,7 @@ registerModel({
                     data2.attachments = unlinkAll();
                 } else {
                     data2.attachments = insertAndReplace(data.attachment_ids.map(attachmentData =>
-                        this.messaging.models['mail.attachment'].convertData(attachmentData)
+                        this.messaging.models['Attachment'].convertData(attachmentData)
                     ));
                 }
             }
@@ -535,7 +535,7 @@ registerModel({
         authorName: attr({
             compute: '_computeAuthorName',
         }),
-        attachments: many2many('mail.attachment', {
+        attachments: many2many('Attachment', {
             inverse: 'messages',
         }),
         author: many2one('Partner'),

--- a/addons/mail/static/src/models/message/tests/message_tests.js
+++ b/addons/mail/static/src/models/message/tests/message_tests.js
@@ -34,7 +34,7 @@ QUnit.test('create', async function (assert) {
         id: 100,
         model: 'mail.channel',
     }));
-    assert.notOk(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.notOk(this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
     assert.notOk(this.messaging.models['Message'].findFromIdentifyingData({ id: 4000 }));
 
     const thread = this.messaging.models['Thread'].create({
@@ -63,7 +63,7 @@ QUnit.test('create', async function (assert) {
         id: 100,
         model: 'mail.channel',
     }));
-    assert.ok(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
+    assert.ok(this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
     assert.ok(this.messaging.models['Message'].findFromIdentifyingData({ id: 4000 }));
 
     assert.ok(message);
@@ -89,7 +89,7 @@ QUnit.test('create', async function (assert) {
     assert.ok(message.threads.includes(this.messaging.inbox));
     // from partnerId being in starred_partner_ids
     assert.ok(message.threads.includes(this.messaging.starred));
-    const attachment = this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 });
+    const attachment = this.messaging.models['Attachment'].findFromIdentifyingData({ id: 750 });
     assert.ok(attachment);
     assert.strictEqual(attachment.filename, "test.txt");
     assert.strictEqual(attachment.id, 750);

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -136,7 +136,7 @@ registerModel({
          * @param {integer} [payload.id]
          */
         _handleNotificationAttachmentDelete(payload) {
-            const attachment = this.messaging.models['mail.attachment'].findFromIdentifyingData(payload);
+            const attachment = this.messaging.models['Attachment'].findFromIdentifyingData(payload);
             if (attachment) {
                 attachment.delete();
             }

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1211,7 +1211,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.attachment[]}
+         * @returns {Attachment[]}
          */
         _computeAllAttachments() {
             const allAttachments = [...new Set(this.originThreadAttachments.concat(this.attachments))]
@@ -1911,7 +1911,7 @@ registerModel({
         activities: one2many('Activity', {
             inverse: 'thread',
         }),
-        allAttachments: many2many('mail.attachment', {
+        allAttachments: many2many('Attachment', {
             compute: '_computeAllAttachments',
         }),
         areAttachmentsLoaded: attr({
@@ -1924,7 +1924,7 @@ registerModel({
         areFollowersLoaded: attr({
             default: false,
         }),
-        attachments: many2many('mail.attachment', {
+        attachments: many2many('Attachment', {
             inverse: 'threads',
         }),
         /**
@@ -2291,7 +2291,7 @@ registerModel({
         orderedTypingMemberLocalIds: attr({
             default: [],
         }),
-        originThreadAttachments: one2many('mail.attachment', {
+        originThreadAttachments: one2many('Attachment', {
             inverse: 'originThread',
             isCausal: true,
         }),

--- a/addons/mail/static/src/widgets/form_renderer/form_renderer.js
+++ b/addons/mail/static/src/widgets/form_renderer/form_renderer.js
@@ -176,7 +176,7 @@ FormRenderer.include({
      * @private
      * @param {OdooEvent} ev
      * @param {Object} ev.data
-     * @param {mail.attachment[]} ev.data.attachments
+     * @param {Attachment[]} ev.data.attachments
      * @param {Thread} ev.data.thread
      */
     _onChatterRendered(ev) {},


### PR DESCRIPTION
Rename javascript model `mail.attachment` to `Attachment` in order to distinguish javascript model from python model.

Enterprise: https://github.com/odoo/enterprise/pull/22609
Part of task-2701674.
