### PR TITLE
[IMP] mail: rename attachment box view model

### DIFF
--- a/addons/mail/static/src/components/attachment_box/attachment_box.js
+++ b/addons/mail/static/src/components/attachment_box/attachment_box.js
@@ -21,8 +21,8 @@ export class AttachmentBox extends Component {
          * Useful to programmatically prompts the browser file uploader.
          */
         this._fileUploaderRef = useRef('fileUploader');
-        useComponentToModel({ fieldName: 'component', modelName: 'mail.attachment_box_view', propNameAsRecordLocalId: 'attachmentBoxViewLocalId' });
-        useRefToModel({ fieldName: 'fileUploaderRef', modelName: 'mail.attachment_box_view', propNameAsRecordLocalId: 'attachmentBoxViewLocalId', refName: 'fileUploader' });
+        useComponentToModel({ fieldName: 'component', modelName: 'AttachmentBoxView', propNameAsRecordLocalId: 'attachmentBoxViewLocalId' });
+        useRefToModel({ fieldName: 'fileUploaderRef', modelName: 'AttachmentBoxView', propNameAsRecordLocalId: 'attachmentBoxViewLocalId', refName: 'fileUploader' });
         this._onDropZoneFilesDropped = this._onDropZoneFilesDropped.bind(this);
     }
 
@@ -31,10 +31,10 @@ export class AttachmentBox extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.attachement_box_view|undefined}
+     * @returns {AttachmentBoxView|undefined}
      */
     get attachmentBoxView() {
-        return this.messaging && this.messaging.models['mail.attachment_box_view'].get(this.props.attachmentBoxViewLocalId);
+        return this.messaging && this.messaging.models['AttachmentBoxView'].get(this.props.attachmentBoxViewLocalId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/models/attachment_box_view/attachment_box_view.js
+++ b/addons/mail/static/src/models/attachment_box_view/attachment_box_view.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { attr, one2one } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.attachment_box_view',
+    name: 'AttachmentBoxView',
     identifyingFields: ['chatter'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -282,7 +282,7 @@ registerModel({
             inverse: 'chatter',
             isCausal: true,
         }),
-        attachmentBoxView: one2one('mail.attachment_box_view', {
+        attachmentBoxView: one2one('AttachmentBoxView', {
             inverse: 'chatter',
             isCausal: true,
         }),


### PR DESCRIPTION
Rename javascript model `mail.attachment_box_view` to `AttachmentBoxView` in order to distinguish javascript models from python models.

Part of task-2701674.
