### PR TITLE
[FIX] web_editor: display drop zones only on dropdowns when shown

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -927,6 +927,15 @@ var SnippetsMenu = Widget.extend({
     _activateInsertionZones: function ($selectorSiblings, $selectorChildren) {
         var self = this;
 
+        // If a dropdown is shown, the drop zones must be created only in this
+        // element.
+        const $editableArea = self.getEditableArea();
+        const $dropdown = $editableArea.find('.dropdown-menu.show').addBack('.dropdown-menu.show').parent();
+        if ($dropdown.length) {
+            $selectorSiblings = $dropdown.find($selectorSiblings);
+            $selectorChildren = $dropdown.find($selectorChildren);
+        }
+
         // Check if the drop zone should be horizontal or vertical
         function setDropZoneDirection($elem, $parent, $sibling) {
             var vertical = false;


### PR DESCRIPTION
It was painful to add an inline snippets, or move elements inside mega
menus. The dropdowns are now behaving as such: if they are shown, the
user can only add or move snippets inside them, but not outside.

task-2668908


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
