### PR TITLE
[IMP] mail: rename attachment card model

### DIFF
--- a/addons/mail/static/src/components/attachment_card/attachment_card.js
+++ b/addons/mail/static/src/components/attachment_card/attachment_card.js
@@ -11,7 +11,7 @@ export class AttachmentCard extends Component {
      */
     setup() {
         super.setup();
-        useComponentToModel({ fieldName: 'component', modelName: 'mail.attachment_card', propNameAsRecordLocalId: 'attachmentCardLocalId' });
+        useComponentToModel({ fieldName: 'component', modelName: 'AttachmentCard', propNameAsRecordLocalId: 'attachmentCardLocalId' });
     }
 
     //--------------------------------------------------------------------------
@@ -19,10 +19,10 @@ export class AttachmentCard extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.attachment_card}
+     * @returns {AttachmentCard}
      */
     get attachmentCard() {
-        return this.messaging && this.messaging.models['mail.attachment_card'].get(this.props.attachmentCardLocalId);
+        return this.messaging && this.messaging.models['AttachmentCard'].get(this.props.attachmentCardLocalId);
     }
 
 }

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -282,7 +282,7 @@ registerModel({
         /**
          * States the attachment cards that are displaying this attachment.
          */
-        attachmentCards: one2many('mail.attachment_card', {
+        attachmentCards: one2many('AttachmentCard', {
             inverse: 'attachment',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/attachment_card/attachment_card.js
+++ b/addons/mail/static/src/models/attachment_card/attachment_card.js
@@ -5,7 +5,7 @@ import { attr, many2one } from '@mail/model/model_field';
 import { insert, insertAndReplace, replace } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.attachment_card',
+    name: 'AttachmentCard',
     identifyingFields: ['attachmentList', 'attachment'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/attachment_list/attachment_list.js
+++ b/addons/mail/static/src/models/attachment_list/attachment_list.js
@@ -67,7 +67,7 @@ registerModel({
         /**
          * States the attachment cards that are displaying this nonImageAttachments.
          */
-        attachmentCards: one2many('mail.attachment_card', {
+        attachmentCards: one2many('AttachmentCard', {
             compute: '_computeAttachmentCards',
             inverse: 'attachmentList',
             isCausal: true,


### PR DESCRIPTION
Rename javascript model `mail.attachment_card` to `AttachmentCard` in order to distinguish javascript models from python models.

Part of task-2701674.
