### PR TITLE
[IMP] mail: rename activity box view model

### DIFF
--- a/addons/mail/static/src/components/activity_box/activity_box.js
+++ b/addons/mail/static/src/components/activity_box/activity_box.js
@@ -14,7 +14,7 @@ export class ActivityBox extends Component {
      * @returns {Chatter}
      */
     get activityBoxView() {
-        return this.messaging.models['mail.activity_box_view'].get(this.props.activityBoxViewLocalId);
+        return this.messaging.models['ActivityBoxView'].get(this.props.activityBoxViewLocalId);
     }
 
 }

--- a/addons/mail/static/src/models/activity_box_view/activity_box_view.js
+++ b/addons/mail/static/src/models/activity_box_view/activity_box_view.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { attr, one2one } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.activity_box_view',
+    name: 'ActivityBoxView',
     identifyingFields: ['chatter'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -277,7 +277,7 @@ registerModel({
         },
     },
     fields: {
-        activityBoxView: one2one('mail.activity_box_view', {
+        activityBoxView: one2one('ActivityBoxView', {
             compute: '_computeActivityBoxView',
             inverse: 'chatter',
             isCausal: true,


### PR DESCRIPTION
Rename javascript model `mail.activity_box_view` to ActivityBoxView in order to distinguish javascript models from python models.

Part of task-2701674.