### PR TITLE
[FIX] web_editor: remove dependency with mail 

### DIFF
--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -9,7 +9,7 @@ Odoo Web Editor widget.
 ==========================
 
 """,
-    'depends': ['web', 'mail'],
+    'depends': ['web'],
     'data': [
         'security/ir.model.access.csv',
         'data/editor_assets.xml',

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -82,7 +82,11 @@ const Wysiwyg = Widget.extend({
         const commands = this._getCommands();
 
         let editorCollaborationOptions;
-        if (options.collaborationChannel) {
+        if (
+            options.collaborationChannel &&
+            // Hack: check if mail module is installed.
+            this.getSession()['notification_type']
+        ) {
             editorCollaborationOptions = this.setupCollaboration(options.collaborationChannel);
         }
 


### PR DESCRIPTION
The web_editor dependency with mail was problematic:
- web_editor would not auto_intall without the mail being installed
- A circular dependency problem with discuss

In order to avoid creating a new module shared by mail
and web editor, the use of a hack has been decided.
By checking if `notification_type` is in the session, we ensure
that the module mail is defined.

Task-2698655





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
