### PR TITLE
[FIX] website: fix the position of the ripple effect

### DIFF
--- a/addons/website/static/src/js/content/ripple_effect.js
+++ b/addons/website/static/src/js/content/ripple_effect.js
@@ -54,14 +54,23 @@ publicWidget.registry.RippleEffect = publicWidget.Widget.extend({
             this.rippleEl = document.createElement('span');
             this.rippleEl.classList.add('o_ripple_item');
             this.rippleEl.style.animationDuration = `${this.duration}ms`;
-            this.rippleEl.style.width = `${this.diameter}px`;
-            this.rippleEl.style.height = `${this.diameter}px`;
             this.el.appendChild(this.rippleEl);
         }
 
         clearTimeout(this.timeoutID);
         this._toggleRippleEffect(false);
 
+        // TO DO: In master, replace these 3 following variables by "CONST"
+        // variables and remove them from the "start" where we have left them
+        // only for compatibility.
+        this.offsetY = this.$el.offset().top;
+        this.offsetX = this.$el.offset().left;
+        // The diameter need to be recomputed because a change of window width
+        // can affect the size of a button (e.g. media queries).
+        this.diameter = Math.max(this.$el.outerWidth(), this.$el.outerHeight());
+
+        this.rippleEl.style.width = `${this.diameter}px`;
+        this.rippleEl.style.height = `${this.diameter}px`;
         this.rippleEl.style.top = `${ev.pageY - this.offsetY - this.diameter / 2}px`;
         this.rippleEl.style.left = `${ev.pageX - this.offsetX - this.diameter / 2}px`;
 


### PR DESCRIPTION
Before this commit, the ripple effect did not work when a button was not
in the same location/size when clicked compared to its position/size
when the page was loaded. (e.g. after scrolling the page)

task-2686370

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
