### PR TITLE
[FIX] discuss: clicking on attachment download closes current rtc call

### DIFF
--- a/addons/mail/static/src/components/attachment_viewer/attachment_viewer.js
+++ b/addons/mail/static/src/components/attachment_viewer/attachment_viewer.js
@@ -136,8 +136,7 @@ export class AttachmentViewer extends Component {
      * @private
      */
     _download() {
-        const id = this.attachmentViewer.attachment.id;
-        this.env.services.navigate(`/web/content/ir.attachment/${id}/datas`, { download: true });
+        this.attachmentViewer.attachment.download();
     }
 
     /**

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -57,7 +57,12 @@ function factory(dependencies) {
          * Send the attachment for the browser to download.
          */
         download() {
-            this.env.services.navigate(`/web/content/ir.attachment/${this.id}/datas`, { download: true });
+            const downloadLink = document.createElement('a');
+            downloadLink.setAttribute('href', `/web/content/ir.attachment/${this.id}/datas?download=true`);
+            // Adding 'download' attribute into a link prevents open a new tab or change the current location of the window.
+            // This avoids interrupting the activity in the page such as rtc call.
+            downloadLink.setAttribute('download','');
+            downloadLink.click();
         }
 
         /**


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Calling .navigate() interrupting the current call.
Using <a> with 'download' attribute to download the attachment.

**Current behavior before PR:**
clicking on attachment download closes current rtc call.

Desired behavior after PR is merged:
Problem fixed.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
