### PR TITLE
[FIX] mail: do not match on empty email

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1591,8 +1591,11 @@ class MailThread(models.AbstractModel):
         """
         # find normalized emails and exclude aliases (to avoid subscribing alias emails to records)
         normalized_email = tools.email_normalize(email)
+        if not normalized_email:
+            return self.env['res.users']
+
         catchall_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
-        if normalized_email and catchall_domain:
+        if catchall_domain:
             left_part = normalized_email.split('@')[0] if normalized_email.split('@')[1] == catchall_domain.lower() else False
             if left_part:
                 if self.env['mail.alias'].sudo().search_count([('alias_name', '=', left_part)]):


### PR DESCRIPTION
No longer match on the first res.users with no email. This was not
very problematic (as we have a fallback on self._uid when using
anyway) but it is more accurate for tracebality of emails.
Users without any email should not be used for gateway.

Partial backport of #80531 for the relevant part
