### PR TITLE
[FIX] website_sale: missing quote in .pot file

### DIFF
--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -988,7 +988,7 @@ msgstr ""
 
 #. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.res_config_settings_view_form
-msgid DHL Express Connector
+msgid "DHL Express Connector"
 msgstr ""
 
 #. module: website_sale


### PR DESCRIPTION
This commit fixes my mistake in this previous commit: ff7a82f0cb31699e6169654b4bd62a895b2f09b3