### PR TITLE
[FIX] hr_expense: allow users to read paid expenses

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -166,7 +166,7 @@ class HrExpense(models.Model):
                 residual_field = 'amount_residual'
             else:
                 residual_field = 'amount_residual_currency'
-            payment_term_lines = expense.sheet_id.account_move_id.line_ids \
+            payment_term_lines = expense.sheet_id.account_move_id.sudo().line_ids \
                 .filtered(lambda line: line.expense_id == self and line.account_internal_type in ('receivable', 'payable'))
             expense.amount_residual = -sum(payment_term_lines.mapped(residual_field))
 


### PR DESCRIPTION
Simple users lost the ability to read their own paid expenses due to
missing access rights on account.move.

TaskID: 2698791

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
