### PR TITLE
[FIX] payment_ogone: better error reason when payment is declined

### DIFF
--- a/addons/payment_ogone/i18n/payment_ogone.pot
+++ b/addons/payment_ogone/i18n/payment_ogone.pot
@@ -139,5 +139,11 @@ msgstr ""
 #. module: payment_ogone
 #: code:addons/payment_ogone/models/payment_transaction.py:0
 #, python-format
+msgid "The payment has been declined: %s"
+msgstr ""
+
+#. module: payment_ogone
+#: code:addons/payment_ogone/models/payment_transaction.py:0
+#, python-format
 msgid "The transaction is not linked to a token."
 msgstr ""

--- a/addons/payment_ogone/models/const.py
+++ b/addons/payment_ogone/models/const.py
@@ -74,4 +74,5 @@ PAYMENT_STATUS_MAPPING = {
     'pending': (41, 46, 50, 51, 52, 55, 56, 81, 82, 91, 92, 99),  # 46 = 3DS
     'done': (5, 8, 9),
     'cancel': (1,),
+    'declined': (2,),
 }

--- a/addons/payment_ogone/models/payment_transaction.py
+++ b/addons/payment_ogone/models/payment_transaction.py
@@ -201,6 +201,17 @@ class PaymentTransaction(models.Model):
             self._set_done()
         elif payment_status in const.PAYMENT_STATUS_MAPPING['cancel']:
             self._set_canceled()
+        elif payment_status in const.PAYMENT_STATUS_MAPPING['declined']:
+            if data.get("NCERRORPLUS"):
+                reason = data.get("NCERRORPLUS")
+            elif data.get("NCERROR"):
+                reason = "Error code: %s" % data.get("NCERROR")
+            else:
+                reason = "Unknown reason"
+            _logger.info("the payment has been declined: %s.", reason)
+            self._set_error(
+                "Ogone: " + _("The payment has been declined: %s", reason)
+            )
         else:  # Classify unknown payment statuses as `error` tx state
             _logger.info("received data with invalid payment status: %s", payment_status)
             self._set_error(


### PR DESCRIPTION
Before this revision, when a payment was declined,
for instance because the authorization is declined by the bank,
or the credit card amount limit is exceeded,
the error was marked as
"Received data with invalid payment status: 2"
which is not very meaningful for the users.

This revision aims to set the reason why the payment
was declined with the meaningful error from ogone.
