### PR TITLE
[13.0] account: Fix journal dashboard graph query

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -169,7 +169,8 @@ class account_journal(models.Model):
                 next_date = start_date + timedelta(days=7)
                 query += " UNION ALL ("+select_sql_clause+" and invoice_date_due >= '"+start_date.strftime(DF)+"' and invoice_date_due < '"+next_date.strftime(DF)+"')"
                 start_date = next_date
-
+        # Ensure results returned by postgres match the order of data list
+        query += " ORDER BY aggr_date ASC"
         self.env.cr.execute(query, query_args)
         query_results = self.env.cr.dictfetchall()
         is_sample_data = True


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In the accounting dashboard, sales and purchase journals in kanban view display a graph of due amounts grouped by week, but the amounts are not always set in the proper week.

Current behavior before PR:

The amounts in the graph don't match the correct week and are set randomly

Desired behavior after PR is merged:

The amounts in the graph match the correct week

OPW-2702707
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
