### PR TITLE
[FIX] web_editor, mass_mailing: add tests for convert_inline and fix discovered issues

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -84,7 +84,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
 
             convertInline.attachmentThumbnailToLinkImg($editable);
             convertInline.fontToImg($editable);
-            convertInline.classToStyle($editable);
+            convertInline.classToStyle($editable, self.cssRules);
             convertInline.bootstrapToTable($editable);
             convertInline.cardToTable($editable);
             convertInline.listGroupToTable($editable);

--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -115,6 +115,10 @@ var MassMailingFieldHtml = FieldHtml.extend({
         this.$content.find('.o_layout').addBack().data('name', 'Mailing');
         // We don't want to drop snippets directly within the wysiwyg.
         this.$content.removeClass('o_editable');
+        // Force compute CSS rules even without the style-inline node option.
+        if (this.mode === 'edit' && !this.cssRules) {
+            this.cssRules = convertInline.getCSSRules(this.wysiwyg.getEditable()[0].ownerDocument);
+        }
     },
     /**
      * Returns true if the editable area is empty.

--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -72,26 +72,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
             self._isDirty = self.wysiwyg.isDirty();
             self._doAction();
 
-            // fix outlook image rendering bug (this change will be kept in both
-            // fields)
-            _.each(['width', 'height'], function (attribute) {
-                $editable.find('img').attr(attribute, function () {
-                    return $(this)[attribute]();
-                }).css(attribute, function () {
-                    return $(this).get(0).style[attribute] || attribute === 'width' ? $(this)[attribute]() + 'px' : '';
-                });
-            });
-
-            convertInline.attachmentThumbnailToLinkImg($editable);
-            convertInline.fontToImg($editable);
-            convertInline.classToStyle($editable, self.cssRules);
-            convertInline.bootstrapToTable($editable);
-            convertInline.cardToTable($editable);
-            convertInline.listGroupToTable($editable);
-            convertInline.addTables($editable);
-            convertInline.formatTables($editable);
-            convertInline.normalizeColors($editable);
-            convertInline.normalizeRem($editable);
+            convertInline.toInline($editable, self.cssRules);
 
             self.trigger_up('field_changed', {
                 dataPointID: self.dataPointID,

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -512,6 +512,14 @@ function bootstrapToTable($editable) {
                     $currentCol = grid[0];
                     _applyColspanToGridElement($currentCol, columnSize);
                     gridIndex = columnSize;
+                    if (columnIndex === $bootstrapColumns.length - 1 && gridIndex < 12) {
+                        // We handled all the columns but there is still space
+                        // in the row. Insert the columns and fill the row.
+                        grid[gridIndex].attr('colspan', 12 - gridIndex);
+                        $currentRow.append(...grid.filter(td => td.attr('colspan')));
+                        // Adapt width to colspan.
+                        _applyColspanToGridElement(grid[gridIndex], 12 - gridIndex);
+                    }
                 }
                 if ($currentCol) {
                     for (const attr of bootstrapColumn.attributes) {

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -460,7 +460,7 @@ function bootstrapToTable($editable) {
             //    by sharing the available space between them.
             const $flexColumns = $bootstrapColumns.filter((i, column) => !/\d/.test(column.className.match(reColMatch)[0] || '0'));
             const colTotalSize = $bootstrapColumns.toArray().map(child => _getColumnSize(child)).reduce((a, b) => a + b);
-            const colSize = Math.round((12 - colTotalSize) / $flexColumns.length);
+            const colSize = Math.max(1, Math.round((12 - colTotalSize) / $flexColumns.length));
             for (const flexColumn of $flexColumns) {
                 flexColumn.classList.remove(flexColumn.className.match(reColMatch)[0].trim());
                 flexColumn.classList.add(`col-${colSize}`);

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -198,29 +198,6 @@ function getMatchedCSSRules(a) {
         delete style['text-decoration-thickness'];
     }
 
-    // color and text-align inheritance do not seem to get past <td> elements on
-    // some mail clients. TODO: This is hacky as it applies a color/text-align
-    // style to all descendants of nodes with a color style. We can probably do
-    // this more elegantly.
-    if (style.color || style['text-align']) {
-        function _styleDescendants(node, styleName) {
-            const camelCased = styleName.replace(/-(\w)/g, match => match[1].toUpperCase());
-            node.style[camelCased] = style[styleName];
-            for (const child of $(node).children()) {
-                if (child.style[camelCased] !== style[styleName]) {
-                    break;
-                }
-                _styleDescendants(child, styleName);
-            }
-        }
-        if (style.color) {
-            _styleDescendants(a, 'color');
-        }
-        if (style['text-align']) {
-            _styleDescendants(a, 'text-align');
-        }
-    }
-
     // flexboxes are not supported in Windows Outlook
     for (const styleName in style) {
         if (styleName.includes('flex') || `${style[styleName]}`.includes('flex')) {

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -638,14 +638,14 @@ function addTables($editable) {
         $(snippet).remove();
 
         // If snippet doesn't have a table as child, wrap its contents in one.
-        if (!$col.children().filter('table')) {
+        if (!$col.children().filter('table').length) {
             const $tableB = _createTable();
             $tableB[0].style.width
             const $rowB = $('<tr/>');
             const $colB = $('<td/>');
             $rowB.append($colB);
             $tableB.append($rowB);
-            for (const child of [...$table[0].childNodes]) {
+            for (const child of [...$col[0].childNodes]) {
                 $colB.append(child);
             }
             $col.append($tableB);

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -653,39 +653,41 @@ function addTables($editable) {
     }
 }
 
-const rePadding = /(\d+)/;
+const rePadding = /([\d.]+)/;
 function formatTables($editable) {
     for (const table of $editable.find('table.o_mail_snippet_general, .o_mail_snippet_general table')) {
         const $table = $(table);
-        const tablePaddingTop = +$table.css('padding-top').match(rePadding)[1];
-        const tablePaddingRight = +$table.css('padding-right').match(rePadding)[1];
-        const tablePaddingBottom = +$table.css('padding-bottom').match(rePadding)[1];
-        const tablePaddingLeft = +$table.css('padding-left').match(rePadding)[1];
+        const tablePaddingTop = parseFloat($table.css('padding-top').match(rePadding)[1]);
+        const tablePaddingRight = parseFloat($table.css('padding-right').match(rePadding)[1]);
+        const tablePaddingBottom = parseFloat($table.css('padding-bottom').match(rePadding)[1]);
+        const tablePaddingLeft = parseFloat($table.css('padding-left').match(rePadding)[1]);
+        const $rows = $table.find('tr').filter((i, tr) => $(tr).closest('table').is($table));
         const $columns = $table.find('td').filter((i, td) => $(td).closest('table').is($table));
-        let columnIndex = 0;
         for (const column of $columns) {
             const $column = $(column);
-            if ($column.css('padding')) {
-                const columnPaddingRight = +$column.css('padding-right').match(rePadding)[1];
-                const columnPaddingLeft = +$column.css('padding-left').match(rePadding)[1];
-                $column.css({
-                    'padding-right': columnPaddingRight + tablePaddingRight,
-                    'padding-left': columnPaddingLeft + tablePaddingLeft,
-                });
-                if (!columnIndex) {
-                    const columnPaddingTop = +$column.css('padding-top').match(rePadding)[1];
-                    $column.css({
-                        'padding-top': columnPaddingTop + tablePaddingTop,
-                    });
-                }
-                if (columnIndex === $columns.length - 1) {
-                    const columnPaddingBottom = +$column.css('padding-bottom').match(rePadding)[1];
-                    $column.css({
-                        'padding-bottom': columnPaddingBottom + tablePaddingBottom,
-                    });
-                }
+            const $columnsInRow = $column.closest('tr').find('td');
+            const columnIndex = $columnsInRow.toArray().findIndex(col => $(col).is($column));
+            const rowIndex = $rows.toArray().findIndex(row => $(row).is($column.closest('tr')));
+            if (!rowIndex) {
+                const match = $column.css('padding-top').match(rePadding);
+                const columnPaddingTop = match ? parseFloat(match[1]) : 0;
+                $column.css('padding-top', columnPaddingTop + tablePaddingTop);
             }
-            columnIndex += 1;
+            if (columnIndex === $columnsInRow.length - 1) {
+                const match = $column.css('padding-right').match(rePadding);
+                const columnPaddingRight = match ? parseFloat(match[1]) : 0;
+                $column.css('padding-right', columnPaddingRight + tablePaddingRight);
+            }
+            if (rowIndex === $rows.length - 1) {
+                const match = $column.css('padding-bottom').match(rePadding);
+                const columnPaddingBottom = match ? parseFloat(match[1]) : 0;
+                $column.css('padding-bottom', columnPaddingBottom + tablePaddingBottom);
+            }
+            if (!columnIndex) {
+                const match = $column.css('padding-left').match(rePadding);
+                const columnPaddingLeft = match ? parseFloat(match[1]) : 0;
+                $column.css('padding-left', columnPaddingLeft + tablePaddingLeft);
+            }
         }
         $table.css('padding', '');
     }

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -606,6 +606,8 @@ function listGroupToTable($editable) {
                 $row.append($col);
                 $table.append($row);
                 $(child).remove();
+            } else if (child.nodeName === 'LI') {
+                $table.append(...child.childNodes);
             } else {
                 $table.append(child);
             }

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -788,7 +788,8 @@ function normalizeRem($editable) {
         const remMatch = node.getAttribute('style').match(/[\d\.]+\s*rem/g);
         for (const rem of remMatch || []) {
             const remValue = parseFloat(rem.replace(/[^\d\.]/g, ''));
-            node.setAttribute('style', node.getAttribute('style').replace(rem, remValue * rootFontSize + 'px'));
+            const pxValue = Math.round(remValue * rootFontSize * 10) / 10;
+            node.setAttribute('style', node.getAttribute('style').replace(rem, pxValue + 'px'));
         }
     }
 }

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -693,7 +693,7 @@ function formatTables($editable) {
     }
     // Ensure a tbody in every table and cancel its default style.
     for (const table of $editable.find('table:not(:has(tbody))')) {
-        $(table).contents().wrap('<tbody style="vertical-align: top"/>');
+        $(table).contents().wrap('<tbody style="vertical-align: top;"/>');
     }
     // Children will only take 100% height if the parent has a height property.
     for (const node of $editable.find('*').filter((i, n) => (
@@ -701,7 +701,15 @@ function formatTables($editable) {
             !n.parentElement.style.getPropertyValue('height') ||
             n.parentElement.style.getPropertyValue('height').includes('%'))
     ))) {
-        node.parentElement.style.setProperty('height', '0');
+        let parent = node.parentElement;
+        let height = parent.style.getPropertyValue('height');
+        while (parent && height && height.includes('%')) {
+            parent = parent.parentElement;
+            height = parent.style.getPropertyValue('height');
+        }
+        if (parent) {
+            parent.style.setProperty('height', '0');
+        }
     }
 }
 

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -1010,4 +1010,5 @@ export default {
     listGroupToTable: listGroupToTable,
     normalizeColors: normalizeColors,
     normalizeRem: normalizeRem,
+    toInline: toInline,
 };

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -284,7 +284,7 @@ function classToStyle($editable, cssRules) {
         const $target = $(node);
         const css = _getMatchedCSSRules(node, cssRules);
         // Flexbox
-        for (const styleName in node.style) {
+        for (const styleName of node.style) {
             if (styleName.includes('flex') || `${node.style[styleName]}`.includes('flex')) {
                 node.style[styleName] = '';
             }

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -324,6 +324,42 @@ function classToStyle($editable, cssRules) {
     });
 }
 /**
+ * Convert the contents of an editable area (as a JQuery element) into content
+ * that is widely compatible with email clients. If no CSS Rules are given, they
+ * will be computed for the editable element's owner document.
+ *
+ * @param {JQuery} $editable
+ * @param {Object[]} [cssRules] Array<{selector: string;
+ *                                   style: {[styleName]: string};
+ *                                   specificity: number;}>
+ */
+function toInline($editable, cssRules) {
+    if (!cssRules) {
+        cssRules = getCSSRules($editable[0].ownerDocument);
+    }
+
+    // Fix outlook image rendering bug (this change will be kept in both
+    // fields).
+    _.each(['width', 'height'], function (attribute) {
+        $editable.find('img').attr(attribute, function () {
+            return $(this)[attribute]();
+        }).css(attribute, function () {
+            return $(this).get(0).style[attribute] || attribute === 'width' ? $(this)[attribute]() + 'px' : '';
+        });
+    });
+
+    attachmentThumbnailToLinkImg($editable);
+    fontToImg($editable);
+    classToStyle($editable, cssRules);
+    bootstrapToTable($editable);
+    cardToTable($editable);
+    listGroupToTable($editable);
+    addTables($editable);
+    formatTables($editable);
+    normalizeColors($editable);
+    normalizeRem($editable);
+}
+/**
  * Convert font icons to images.
  *
  * @param {jQuery} $editable - the element in which the font icons have to be
@@ -953,25 +989,7 @@ FieldHtml.include({
         $odooEditor.removeClass('odoo-editor');
         $editable.html(html);
 
-        attachmentThumbnailToLinkImg($editable);
-        fontToImg($editable);
-        classToStyle($editable, this.cssRules);
-        bootstrapToTable($editable);
-        cardToTable($editable);
-        listGroupToTable($editable);
-        addTables($editable);
-        formatTables($editable);
-        normalizeColors($editable);
-        normalizeRem($editable);
-
-        // fix outlook image rendering bug
-        _.each(['width', 'height'], function(attribute) {
-            $editable.find('img').attr(attribute, function(){
-                return $(this)[attribute]();
-            }).css(attribute, function(){
-                return $(this).get(0).style[attribute] || attribute === 'width' ? $(this)[attribute]() + 'px' : '';
-            });
-        });
+        toInline($editable, this.cssRules);
         $odooEditor.addClass('odoo-editor');
 
         this.wysiwyg.setValue($editable.html(), {

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -955,7 +955,9 @@ FieldHtml.include({
 
     _createWysiwygIntance: function () {
         return this._super(...arguments).then(() => {
-            this.cssRules = getCSSRules(this.wysiwyg.getEditable()[0].ownerDocument);
+            if (this.nodeOptions['style-inline'] && this.mode === "edit") {
+                this.cssRules = getCSSRules(this.wysiwyg.getEditable()[0].ownerDocument);
+            }
         });
     },
 

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -312,7 +312,7 @@ function classToStyle($editable, cssRules) {
         }
         // Apple Mail
         if (node.nodeName === 'TD' && !node.childNodes.length) {
-            $(node).html('&nbsp;');
+            $(node).append('&nbsp;');
         }
         // Outlook
         if (node.nodeName === 'A' && $target.hasClass('btn') && !$target.hasClass('btn-link') && !$target.children().length) {

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -4,8 +4,457 @@
 import FieldHtml from 'web_editor.field.html';
 import { isBlock, rgbToHex } from '../../../lib/odoo-editor/src/utils/utils';
 
-const SELECTORS_IGNORE = /(^\*$|:hover|:before|:after|:active|:link|::|'|\([^(),]+[,(])/;
+//--------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------
 
+const RE_COL_MATCH = /(^| )col(-[\w\d]+)*( |$)/;
+const RE_OFFSET_MATCH = /(^| )offset(-[\w\d]+)*( |$)/;
+const RE_PADDING = /([\d.]+)/;
+const SELECTORS_IGNORE = /(^\*$|:hover|:before|:after|:active|:link|::|'|\([^(),]+[,(])/;
+// Attributes all tables should have in a mailing.
+const TABLE_ATTRIBUTES = {
+    cellspacing: 0,
+    cellpadding: 0,
+    border: 0,
+    width: '100%',
+    align: 'center',
+    role: 'presentation',
+};
+// Cancel tables default styles.
+const TABLE_STYLES = {
+    'border-collapse': 'collapse',
+    'text-align': 'inherit',
+    'font-size': 'unset',
+    'line-height': 'unset',
+};
+
+//--------------------------------------------------------------------------
+// Public
+//--------------------------------------------------------------------------
+
+/**
+ * Convert snippets and mailing bodies to tables.
+ *
+ * @param {JQuery} $editable
+ */
+function addTables($editable) {
+    for (const snippet of $editable.find('.o_mail_snippet_general, .o_layout')) {
+        // Convert all snippets and the mailing itself into table > tr > td
+        const $table = _createTable(snippet.attributes);
+        const $row = $('<tr/>');
+        const $col = $('<td/>');
+        $row.append($col);
+        $table.append($row);
+        for (const child of [...snippet.childNodes]) {
+            $col.append(child);
+        }
+        $(snippet).before($table);
+        $(snippet).remove();
+
+        // If snippet doesn't have a table as child, wrap its contents in one.
+        if (!$col.children().filter('table').length) {
+            const $tableB = _createTable();
+            $tableB[0].style.width
+            const $rowB = $('<tr/>');
+            const $colB = $('<td/>');
+            $rowB.append($colB);
+            $tableB.append($rowB);
+            for (const child of [...$col[0].childNodes]) {
+                $colB.append(child);
+            }
+            $col.append($tableB);
+        }
+    }
+}
+/**
+ * Convert CSS display for attachment link to real image.
+ * Without this post process, the display depends on the CSS and the picture
+ * does not appear when we use the html without css (to send by email for e.g.)
+ *
+ * @param {jQuery} $editable
+ */
+function attachmentThumbnailToLinkImg($editable) {
+    $editable.find('a[href*="/web/content/"][data-mimetype]').filter(':empty, :containsExact( )').each(function () {
+        var $link = $(this);
+        var $img = $('<img/>')
+            .attr('src', $link.css('background-image').replace(/(^url\(['"])|(['"]\)$)/g, ''))
+            .css('height', Math.max(1, $link.height()) + 'px')
+            .css('width', Math.max(1, $link.width()) + 'px');
+        $link.prepend($img);
+    });
+}
+/**
+ * Convert Bootstrap rows and columns to actual tables.
+ *
+ * Note: Because of the limited support of media queries in emails, this doesn't
+ * support the mixing and matching of column options (e.g., "col-4 col-sm-6" and
+ * "col col-4" aren't supported).
+ *
+ * @param {jQuery} $editable
+ */
+function bootstrapToTable($editable) {
+    // First give all rows in columns a separate container parent.
+    $editable.find('.row').filter((i, row) => RE_COL_MATCH.test(row.parentElement.className)).wrap('<div class="o_fake_table"/>');
+
+    // These containers from the mass mailing masonry snippet require full
+    // height contents, which is only possible if the table itself has a set
+    // height. We also need to restyle it because of the change in structure.
+    $editable.find('.o_masonry_grid_container').css('padding', 0)
+    .find('> .o_fake_table').css('height', function() { return $(this).height() });
+    for (const masonryRow of $editable.find('.o_masonry_grid_container > .o_fake_table > .row.h-100')) {
+        masonryRow.style.removeProperty('height');
+        masonryRow.parentElement.style.setProperty('height', '100%');
+    }
+
+    // Now convert all containers with rows to tables.
+    for (const container of $editable.find('.container:has(.row), .container-fluid:has(.row), .o_fake_table:has(.row)')) {
+        const $container = $(container);
+
+
+        // TABLE
+        const $table = _createTable(container.attributes);
+        for (const child of [...container.childNodes]) {
+            $table.append(child);
+        }
+        $table.removeClass('container container-fluid o_fake_table');
+        if (!$table[0].className) {
+            $table.removeAttr('class');
+        }
+        $container.before($table);
+        $container.remove();
+
+
+        // ROWS
+        // First give all siblings of rows a separate row/col parent combo.
+        $table.children().filter((i, child) => isBlock(child) && !$(child).hasClass('row')).wrap('<div class="row"><div class="col-12"/></div>');
+
+        const $bootstrapRows = $table.children().filter('.row');
+        for (const bootstrapRow of $bootstrapRows) {
+            const $bootstrapRow = $(bootstrapRow);
+            const $row = $('<tr/>');
+            for (const attr of bootstrapRow.attributes) {
+                $row.attr(attr.name, attr.value);
+            }
+            $row.removeClass('row');
+            if (!$row[0].className) {
+                $row.removeAttr('class');
+            }
+            for (const child of [...bootstrapRow.childNodes]) {
+                $row.append(child);
+            }
+            $bootstrapRow.before($row);
+            $bootstrapRow.remove();
+
+
+            // COLUMNS
+            const $bootstrapColumns = $row.children().filter((i, column) => column.className && column.className.match(RE_COL_MATCH));
+
+            // 1. Replace generic "col" classes with specific "col-n", computed
+            //    by sharing the available space between them.
+            const $flexColumns = $bootstrapColumns.filter((i, column) => !/\d/.test(column.className.match(RE_COL_MATCH)[0] || '0'));
+            const colTotalSize = $bootstrapColumns.toArray().map(child => _getColumnSize(child)).reduce((a, b) => a + b);
+            const colSize = Math.max(1, Math.round((12 - colTotalSize) / $flexColumns.length));
+            for (const flexColumn of $flexColumns) {
+                flexColumn.classList.remove(flexColumn.className.match(RE_COL_MATCH)[0].trim());
+                flexColumn.classList.add(`col-${colSize}`);
+            }
+
+            // 2. Create and fill up the row(s) with grid(s).
+            let grid = _createColumnGrid();
+            let gridIndex = 0;
+            let $currentRow = $($row[0].cloneNode());
+            $row.after($currentRow);
+            let $currentCol;
+            let columnIndex = 0;
+            for (const bootstrapColumn of $bootstrapColumns) {
+                const columnSize = _getColumnSize(bootstrapColumn);
+                if (gridIndex + columnSize < 12) {
+                    $currentCol = grid[gridIndex];
+                    _applyColspan($currentCol, columnSize);
+                    if (columnIndex === $bootstrapColumns.length - 1) {
+                        // We handled all the columns but there is still space
+                        // in the row. Insert the columns and fill the row.
+                        grid[gridIndex].attr('colspan', 12 - gridIndex);
+                        $currentRow.append(...grid.filter(td => td.attr('colspan')));
+                    }
+                    gridIndex += columnSize;
+                } else if (gridIndex + columnSize === 12) {
+                    // Finish the row.
+                    $currentCol = grid[gridIndex];
+                    _applyColspan($currentCol, columnSize);
+                    $currentRow.append(...grid.filter(td => td.attr('colspan')));
+                    if (columnIndex !== $bootstrapColumns.length - 1) {
+                        // The row was filled before we handled all of its
+                        // columns. Create a new one and start again from there.
+                        const $previousRow = $currentRow;
+                        $currentRow = $($currentRow[0].cloneNode());
+                        $previousRow.after($currentRow);
+                        grid = _createColumnGrid();
+                        gridIndex = 0;
+                    }
+                } else {
+                    // Fill the row with what was in the grid before it
+                    // overflowed.
+                    _applyColspan(grid[gridIndex], 12 - gridIndex);
+                    $currentRow.append(...grid.filter(td => td.attr('colspan')));
+                    // Start a new row that starts with the current col.
+                    const $previousRow = $currentRow;
+                    $currentRow = $($currentRow[0].cloneNode());
+                    $previousRow.after($currentRow);
+                    grid = _createColumnGrid();
+                    $currentCol = grid[0];
+                    _applyColspan($currentCol, columnSize);
+                    gridIndex = columnSize;
+                    if (columnIndex === $bootstrapColumns.length - 1 && gridIndex < 12) {
+                        // We handled all the columns but there is still space
+                        // in the row. Insert the columns and fill the row.
+                        grid[gridIndex].attr('colspan', 12 - gridIndex);
+                        $currentRow.append(...grid.filter(td => td.attr('colspan')));
+                        // Adapt width to colspan.
+                        _applyColspan(grid[gridIndex], 12 - gridIndex);
+                    }
+                }
+                if ($currentCol) {
+                    for (const attr of bootstrapColumn.attributes) {
+                        if (attr.name !== 'colspan') {
+                            $currentCol.attr(attr.name, attr.value);
+                        }
+                    }
+                    const colMatch = bootstrapColumn.className.match(RE_COL_MATCH);
+                    $currentCol.removeClass(colMatch[0]);
+                    if (!$currentCol[0].className) {
+                        $currentCol.removeAttr('class');
+                    }
+                    for (const child of [...bootstrapColumn.childNodes]) {
+                        $currentCol.append(child);
+                    }
+                    // Adapt width to colspan.
+                    _applyColspan($currentCol, +$currentCol.attr('colspan'));
+                }
+                columnIndex++;
+            }
+            $row.remove(); // $row was cloned and inserted already
+        }
+    }
+}
+/**
+ * Convert Bootstrap cards to table structures.
+ *
+ * @param {JQuery} $editable
+ */
+function cardToTable($editable) {
+    for (const card of $editable.find('.card')) {
+        const $card = $(card);
+        const $table = _createTable(card.attributes);
+        for (const child of [...card.childNodes]) {
+            if (child.nodeType === Node.TEXT_NODE) {
+                $table.append(child);
+            } else {
+                const $row = $('<tr/>');
+                const $col = $('<td/>');
+                if (child.nodeName === 'IMG') {
+                    $col.append(child);
+                } else {
+                    for (const attr of child.attributes) {
+                        $col.attr(attr.name, attr.value);
+                    }
+                    for (const descendant of [...child.childNodes]) {
+                        $col.append(descendant);
+                    }
+                    $(child).remove();
+                }
+                $row.append($col);
+                $table.append($row);
+            }
+        }
+        $card.before($table);
+        $card.remove();
+    }
+}
+/**
+ * Convert CSS style to inline style (leave the classes on elements but forces
+ * the style they give as inline style).
+ *
+ * @param {jQuery} $editable
+ * @param {Object} cssRules
+ */
+function classToStyle($editable, cssRules) {
+    _applyOverDescendants($editable[0], function (node) {
+        const $target = $(node);
+        const css = _getMatchedCSSRules(node, cssRules);
+        // Flexbox
+        for (const styleName in node.style) {
+            if (styleName.includes('flex') || `${node.style[styleName]}`.includes('flex')) {
+                node.style[styleName] = '';
+            }
+        }
+
+        // Do not apply css that would override inline styles (which are prioritary).
+        let style = $target.attr('style') || '';
+        for (const [key, value] of Object.entries(css)) {
+            if (!(new RegExp(`(^|;)\\s*${key}`).test(style))) {
+                style = `${key}:${value};${style}`;
+            }
+        };
+        if (_.isEmpty(style)) {
+            $target.removeAttr('style');
+        } else {
+            $target.attr('style', style);
+        }
+        if ($target.get(0).style.width) {
+            $target.attr('width', $target.css('width')); // Widths need to be applied as attributes as well.
+        }
+
+        // Media list images should not have an inline height
+        if (node.nodeName === 'IMG' && $target.hasClass('s_media_list_img')) {
+            $target.css('height', '');
+        }
+        // Apple Mail
+        if (node.nodeName === 'TD' && !node.childNodes.length) {
+            $(node).html('&nbsp;');
+        }
+        // Outlook
+        if (node.nodeName === 'A' && $target.hasClass('btn') && !$target.hasClass('btn-link') && !$target.children().length) {
+            $target.prepend(`<!--[if mso]><i style="letter-spacing: 25px; mso-font-width: -100%; mso-text-raise: 30pt;">&nbsp;</i><![endif]-->`);
+            $target.append(`<!--[if mso]><i style="letter-spacing: 25px; mso-font-width: -100%;">&nbsp;</i><![endif]-->`);
+        } else if (node.nodeName === 'IMG' && $target.is('.mx-auto.d-block')) {
+            $target.wrap('<p class="o_outlook_hack" style="text-align:center;margin:0"/>');
+        }
+    });
+}
+/**
+ * Convert font icons to images.
+ *
+ * @param {jQuery} $editable - the element in which the font icons have to be
+ *                           converted to images
+ */
+function fontToImg($editable) {
+    var fonts = odoo.__DEBUG__.services["wysiwyg.fonts"];
+
+    $editable.find('.fa').each(function () {
+        var $font = $(this);
+        var icon, content;
+        _.find(fonts.fontIcons, function (font) {
+            return _.find(fonts.getCssSelectors(font.parser), function (data) {
+                if ($font.is(data.selector.replace(/::?before/g, ''))) {
+                    icon = data.names[0].split('-').shift();
+                    content = data.css.match(/content:\s*['"]?(.)['"]?/)[1];
+                    return true;
+                }
+            });
+        });
+        if (content) {
+            var color = $font.css('color').replace(/\s/g, '');
+            let $backgroundColoredElement = $font;
+            let bg, isTransparent;
+            do {
+                bg = $backgroundColoredElement.css('background-color').replace(/\s/g, '');
+                isTransparent = bg === 'transparent' || bg === 'rgba(0,0,0,0)';
+                $backgroundColoredElement = $backgroundColoredElement.parent();
+            } while (isTransparent && $backgroundColoredElement[0]);
+            if (bg === 'rgba(0,0,0,0)' && isTransparent) {
+                // default on white rather than black background since opacity
+                // is not supported.
+                bg = 'rgb(255,255,255)';
+            }
+            const style = $font.attr('style');
+            const width = $font.width();
+            const height = $font.height();
+            const lineHeight = $font.css('line-height');
+            // Compute the padding.
+            // First get the dimensions of the icon itself (::before)
+            $font.css({height: 'fit-content', width: 'fit-content', 'line-height': 'normal'});
+            const hPadding = width && (width - $font.width()) / 2;
+            const vPadding = height && (height - $font.height()) / 2;
+            let padding = '';
+            if (hPadding || vPadding) {
+                padding = vPadding ? vPadding + 'px ' : '0 ';
+                padding += hPadding ? hPadding + 'px' : '0';
+            }
+            const $img = $('<img/>').attr({
+                width, height,
+                src: `/web_editor/font_to_img/${content.charCodeAt(0)}/${window.encodeURI(color)}/${window.encodeURI(bg)}/${Math.max(1, $font.height())}`,
+                'data-class': $font.attr('class'),
+                'data-style': style,
+                class: $font.attr('class').replace(new RegExp('(^|\\s+)' + icon + '(-[^\\s]+)?', 'gi'), ''), // remove inline font-awsome style
+                style,
+            }).css({
+                'box-sizing': 'border-box', // keep the fontawesome's dimensions
+                'line-height': lineHeight,
+                padding, width: width + 'px', height: height + 'px',
+            });
+            $font.replaceWith($img);
+        } else {
+            $font.remove();
+        }
+    });
+}
+/**
+ * Format table styles so they display well in most mail clients. This implies
+ * moving table paddings to its cells, adding tbody (with canceled styles) where
+ * needed, and adding pixel heights to parents of elements with percent heights.
+ *
+ * @param {JQuery} $editable
+ */
+function formatTables($editable) {
+    for (const table of $editable.find('table.o_mail_snippet_general, .o_mail_snippet_general table')) {
+        const $table = $(table);
+        const tablePaddingTop = parseFloat($table.css('padding-top').match(RE_PADDING)[1]);
+        const tablePaddingRight = parseFloat($table.css('padding-right').match(RE_PADDING)[1]);
+        const tablePaddingBottom = parseFloat($table.css('padding-bottom').match(RE_PADDING)[1]);
+        const tablePaddingLeft = parseFloat($table.css('padding-left').match(RE_PADDING)[1]);
+        const $rows = $table.find('tr').filter((i, tr) => $(tr).closest('table').is($table));
+        const $columns = $table.find('td').filter((i, td) => $(td).closest('table').is($table));
+        for (const column of $columns) {
+            const $column = $(column);
+            const $columnsInRow = $column.closest('tr').find('td');
+            const columnIndex = $columnsInRow.toArray().findIndex(col => $(col).is($column));
+            const rowIndex = $rows.toArray().findIndex(row => $(row).is($column.closest('tr')));
+            if (!rowIndex) {
+                const match = $column.css('padding-top').match(RE_PADDING);
+                const columnPaddingTop = match ? parseFloat(match[1]) : 0;
+                $column.css('padding-top', columnPaddingTop + tablePaddingTop);
+            }
+            if (columnIndex === $columnsInRow.length - 1) {
+                const match = $column.css('padding-right').match(RE_PADDING);
+                const columnPaddingRight = match ? parseFloat(match[1]) : 0;
+                $column.css('padding-right', columnPaddingRight + tablePaddingRight);
+            }
+            if (rowIndex === $rows.length - 1) {
+                const match = $column.css('padding-bottom').match(RE_PADDING);
+                const columnPaddingBottom = match ? parseFloat(match[1]) : 0;
+                $column.css('padding-bottom', columnPaddingBottom + tablePaddingBottom);
+            }
+            if (!columnIndex) {
+                const match = $column.css('padding-left').match(RE_PADDING);
+                const columnPaddingLeft = match ? parseFloat(match[1]) : 0;
+                $column.css('padding-left', columnPaddingLeft + tablePaddingLeft);
+            }
+        }
+        $table.css('padding', '');
+    }
+    // Ensure a tbody in every table and cancel its default style.
+    for (const table of $editable.find('table:not(:has(tbody))')) {
+        $(table).contents().wrap('<tbody style="vertical-align: top;"/>');
+    }
+    // Children will only take 100% height if the parent has a height property.
+    for (const node of $editable.find('*').filter((i, n) => (
+        n.style && n.style.getPropertyValue('height') === '100%' && (
+            !n.parentElement.style.getPropertyValue('height') ||
+            n.parentElement.style.getPropertyValue('height').includes('%'))
+    ))) {
+        let parent = node.parentElement;
+        let height = parent.style.getPropertyValue('height');
+        while (parent && height && height.includes('%')) {
+            parent = parent.parentElement;
+            height = parent.style.getPropertyValue('height');
+        }
+        if (parent) {
+            parent.style.setProperty('height', '0');
+        }
+    }
+}
 /**
  * Parse through the given document's stylesheets, preprocess(*) them and return
  * the result as an array of objects, each containing a selector string , a
@@ -112,29 +561,138 @@ function getCSSRules(doc) {
     return groupedRules;
 }
 /**
- * Take a css style declaration return a "normalized" version of it (as a
- * standard object) for the purposes of emails. This means removing its styles
- * that are invalid, describe animations or aren't standard css (webkit
- * extensions). It also involves adding the "!important" suffix to styles that
- * have that priority, so they can be handled without access to the full
- * declaration.
+ * Convert Bootstrap list groups and their items to table structures.
  *
- * @param {CSSStyleDeclaration} style
- * @returns {Object} {[styleName]: string}
+ * @param {JQuery} $editable
  */
-function _normalizeStyle(style) {
-    const normalizedStyle = {};
-    for (const styleName of style) {
-        const value = style[styleName];
-        if (value && !styleName.includes('animation') && !styleName.includes('-webkit') && _.isString(value)) {
-            const normalizedStyleName = styleName.replace(/-(.)/g, (a, b) => b.toUpperCase());
-            normalizedStyle[styleName] = style[normalizedStyleName];
-            if (style.getPropertyPriority(styleName) === 'important') {
-                normalizedStyle[styleName] += ' !important';
+function listGroupToTable($editable) {
+    for (const listGroup of $editable.find('.list-group')) {
+        const $listGroup = $(listGroup);
+        let $table;
+        if ($listGroup.find('.list-group-item').length) {
+            $table = _createTable(listGroup.attributes);
+        } else {
+            $table = $(listGroup.cloneNode());
+            for (const attr of $listGroup.attributes) {
+                $table.attr(attr.name, attr.value);
             }
         }
+        for (const child of [...listGroup.childNodes]) {
+            const $child = $(child);
+            if ($child.hasClass('list-group-item')) {
+                // List groups are <ul>s that render like tables. Their
+                // li.list-group-item children should translate to tr > td.
+                const $row = $('<tr/>');
+                const $col = $('<td/>');
+                for (const attr of child.attributes) {
+                    $col.attr(attr.name, attr.value);
+                }
+                for (const descendant of [...child.childNodes]) {
+                    $col.append(descendant);
+                }
+                $col.removeClass('list-group-item');
+                if (!$col[0].className) {
+                    $col.removeAttr('class');
+                }
+                $row.append($col);
+                $table.append($row);
+                $(child).remove();
+            } else if (child.nodeName === 'LI') {
+                $table.append(...child.childNodes);
+            } else {
+                $table.append(child);
+            }
+        }
+        $table.removeClass('list-group');
+        if (!$table[0].className) {
+            $table.removeAttr('class');
+        }
+        if ($listGroup.is('td')) {
+            $listGroup.append($table);
+            $listGroup.removeClass('list-group');
+            if (!$listGroup[0].className) {
+                $listGroup.removeAttr('class');
+            }
+        } else {
+            $listGroup.before($table);
+            $listGroup.remove();
+        }
     }
-    return normalizedStyle;
+}
+/**
+ * Convert all styles containing rgb colors to hexadecimal colors.
+ * Note: ignores rgba colors, which are not supported in Microsoft Outlook.
+ *
+ * @param {JQuery} $editable
+ */
+function normalizeColors($editable) {
+    for (const node of $editable.find('[style*="rgb"]')) {
+        const rgbMatch = node.getAttribute('style').match(/rgb?\(([\d\.]*,?\s?){3,4}\)/g);
+        for (const rgb of rgbMatch || []) {
+            node.setAttribute('style', node.getAttribute('style').replace(rgb, rgbToHex(rgb)));
+        }
+    }
+}
+/**
+ * Convert all css values that use the rem unit to px.
+ *
+ * @param {JQuery} $editable
+ */
+function normalizeRem($editable) {
+    const rootFontSizeProperty = $editable.closest('html').css('font-size');
+    const rootFontSize = parseFloat(rootFontSizeProperty.replace(/[^\d\.]/g, ''));
+    for (const node of $editable.find('[style*="rem"]')) {
+        const remMatch = node.getAttribute('style').match(/[\d\.]+\s*rem/g);
+        for (const rem of remMatch || []) {
+            const remValue = parseFloat(rem.replace(/[^\d\.]/g, ''));
+            const pxValue = Math.round(remValue * rootFontSize * 10) / 10;
+            node.setAttribute('style', node.getAttribute('style').replace(rem, pxValue + 'px'));
+        }
+    }
+}
+
+//--------------------------------------------------------------------------
+// Private
+//--------------------------------------------------------------------------
+
+/**
+ * Take a JQuery element and apply a colspan to it. In this context, this
+ * implies to also apply a width to it, that corresponds to the colspan.
+ *
+ * @param {JQuery} $element
+ * @param {number} colspan
+ */
+function _applyColspan($element, colspan) {
+    $element.attr('colspan', colspan);
+    const width = Math.round(+$element.attr('colspan') * 100 / 12) + '%';
+    $element.attr('width', width);
+    $element.css('width', width);
+}
+/*
+ * Utility function to apply function over descendants elements
+ *
+ * This is needed until the following issue of jQuery is solved:
+ *  https://github.com./jquery/sizzle/issues/403
+ *
+ * @param {Element} node The root Element node
+ * @param {Function} func The function applied over descendants
+ */
+function _applyOverDescendants(node, func) {
+    node = node.firstChild;
+    while (node) {
+        if (node.nodeType === 1) {
+            func(node);
+            _applyOverDescendants(node, func);
+        }
+        var $node = $(node);
+        if (node.nodeName === 'A' && $node.hasClass('btn') && !$node.children().length && $(node).parents('.o_outlook_hack').length)  {
+            node = $(node).parents('.o_outlook_hack')[0];
+        }
+        else if (node.nodeName === 'IMG' && $node.parent('p').hasClass('o_outlook_hack')) {
+            node = $node.parent()[0];
+        }
+        node = node.nextSibling;
+    }
 }
 /**
  * Take a selector and return its specificity according to the w3 specification.
@@ -152,16 +710,77 @@ function _computeSpecificity(selector) {
     selector = selector.replace(/(^|\s+|:+)[a-z0-9_-]+/gi, a => { if (!a.includes(':not(')) c++; return ''; });
     return (a * 100) + (b * 10) + c;
 }
-
 /**
- * Returns the css rules which applies on an element, tweaked so that they are
+ * Return an array of twelve table cells as JQuery elements.
+ *
+ * @returns {JQuery[]}
+ */
+function _createColumnGrid() {
+    return new Array(12).fill().map(() => $('<td/>'));
+}
+/**
+ * Return a table as a JQuery element, with its default styles and attributes,
+ * as well as the applicable given attributes, if any.
+ *
+ * @see TABLE_ATTRIBUTES
+ * @see TABLE_STYLES
+ * @param {NamedNodeMap | Attr[]} [attributes] default: []
+ * @returns {JQuery}
+ */
+function _createTable(attributes = []) {
+    const $table = $('<table/>');
+    $table.attr(TABLE_ATTRIBUTES);
+    $table[0].style.setProperty('width', '100%', 'important');
+    for (const attr of attributes) {
+        if (!(attr.name === 'width' && attr.value === '100%')) {
+            $table.attr(attr.name, attr.value);
+        }
+    }
+    if ($table.hasClass('o_layout')) {
+        // The top mailing element inherits the body's font size and line-height
+        // and should keep them.
+        const layoutStyles = {...TABLE_STYLES};
+        delete layoutStyles['font-size'];
+        delete layoutStyles['line-height'];
+        $table.css(layoutStyles);
+    } else {
+        for (const styleName in TABLE_STYLES) {
+            if (!('style' in attributes && attributes.style.value.includes(styleName + ':'))) {
+                $table.css(styleName, TABLE_STYLES[styleName]);
+            }
+        }
+    }
+    return $table;
+}
+/**
+ * Take a Bootstrap grid column element and return its size, computed by using
+ * its Bootstrap classes.
+ *
+ * @see RE_COL_MATCH
+ * @see RE_OFFSET_MATCH
+ * @param {Element} column
+ * @returns {number}
+ */
+function _getColumnSize(column) {
+    const colMatch = column.className.match(RE_COL_MATCH);
+    const colOptions = colMatch[2] && colMatch[2].substr(1).split('-');
+    const colSize = colOptions && (colOptions.length === 2 ? +colOptions[1] : +colOptions[0]) || 0;
+    const offsetMatch = column.className.match(RE_OFFSET_MATCH);
+    const offsetOptions = offsetMatch && offsetMatch[2] && offsetMatch[2].substr(1).split('-');
+    const offsetSize = offsetOptions && (offsetOptions.length === 2 ? +offsetOptions[1] : +offsetOptions[0]) || 0;
+    return colSize + offsetSize;
+}
+/**
+ * Return the CSS rules which applies on an element, tweaked so that they are
  * browser/mail client ok.
  *
- * @param {DOMElement} node
- * @param {Object} cssRules
- * @returns {Object} css property name -> css property value
+ * @param {Node} node
+ * @param {Object[]} Array<{selector: string;
+ *                          style: {[styleName]: string};
+ *                          specificity: number;}>
+ * @returns {Object} {[styleName]: string}
  */
-function getMatchedCSSRules(node, cssRules) {
+function _getMatchedCSSRules(node, cssRules) {
     node.matches = node.matches || node.webkitMatchesSelector || node.mozMatchesSelector || node.msMatchesSelector || node.oMatchesSelector;
     const css = [];
     for (const rule of cssRules) {
@@ -262,606 +881,34 @@ function getMatchedCSSRules(node, cssRules) {
 
     return style;
 }
-
 /**
- * Converts font icons to images.
+ * Take a css style declaration return a "normalized" version of it (as a
+ * standard object) for the purposes of emails. This means removing its styles
+ * that are invalid, describe animations or aren't standard css (webkit
+ * extensions). It also involves adding the "!important" suffix to styles that
+ * have that priority, so they can be handled without access to the full
+ * declaration.
  *
- * @param {jQuery} $editable - the element in which the font icons have to be
- *                           converted to images
+ * @param {CSSStyleDeclaration} style
+ * @returns {Object} {[styleName]: string}
  */
-function fontToImg($editable) {
-    var fonts = odoo.__DEBUG__.services["wysiwyg.fonts"];
-
-    $editable.find('.fa').each(function () {
-        var $font = $(this);
-        var icon, content;
-        _.find(fonts.fontIcons, function (font) {
-            return _.find(fonts.getCssSelectors(font.parser), function (data) {
-                if ($font.is(data.selector.replace(/::?before/g, ''))) {
-                    icon = data.names[0].split('-').shift();
-                    content = data.css.match(/content:\s*['"]?(.)['"]?/)[1];
-                    return true;
-                }
-            });
-        });
-        if (content) {
-            var color = $font.css('color').replace(/\s/g, '');
-            let $backgroundColoredElement = $font;
-            let bg, isTransparent;
-            do {
-                bg = $backgroundColoredElement.css('background-color').replace(/\s/g, '');
-                isTransparent = bg === 'transparent' || bg === 'rgba(0,0,0,0)';
-                $backgroundColoredElement = $backgroundColoredElement.parent();
-            } while (isTransparent && $backgroundColoredElement[0]);
-            if (bg === 'rgba(0,0,0,0)' && isTransparent) {
-                // default on white rather than black background since opacity
-                // is not supported.
-                bg = 'rgb(255,255,255)';
-            }
-            const style = $font.attr('style');
-            const width = $font.width();
-            const height = $font.height();
-            const lineHeight = $font.css('line-height');
-            // Compute the padding.
-            // First get the dimensions of the icon itself (::before)
-            $font.css({height: 'fit-content', width: 'fit-content', 'line-height': 'normal'});
-            const hPadding = width && (width - $font.width()) / 2;
-            const vPadding = height && (height - $font.height()) / 2;
-            let padding = '';
-            if (hPadding || vPadding) {
-                padding = vPadding ? vPadding + 'px ' : '0 ';
-                padding += hPadding ? hPadding + 'px' : '0';
-            }
-            const $img = $('<img/>').attr({
-                width, height,
-                src: `/web_editor/font_to_img/${content.charCodeAt(0)}/${window.encodeURI(color)}/${window.encodeURI(bg)}/${Math.max(1, $font.height())}`,
-                'data-class': $font.attr('class'),
-                'data-style': style,
-                class: $font.attr('class').replace(new RegExp('(^|\\s+)' + icon + '(-[^\\s]+)?', 'gi'), ''), // remove inline font-awsome style
-                style,
-            }).css({
-                'box-sizing': 'border-box', // keep the fontawesome's dimensions
-                'line-height': lineHeight,
-                padding, width: width + 'px', height: height + 'px',
-            });
-            $font.replaceWith($img);
-        } else {
-            $font.remove();
-        }
-    });
-}
-
-/*
- * Utility function to apply function over descendants elements
- *
- * This is needed until the following issue of jQuery is solved:
- *  https://github.com./jquery/sizzle/issues/403
- *
- * @param {Element} node The root Element node
- * @param {Function} func The function applied over descendants
- */
-function applyOverDescendants(node, func) {
-    node = node.firstChild;
-    while (node) {
-        if (node.nodeType === 1) {
-            func(node);
-            applyOverDescendants(node, func);
-        }
-        var $node = $(node);
-        if (node.nodeName === 'A' && $node.hasClass('btn') && !$node.children().length && $(node).parents('.o_outlook_hack').length)  {
-            node = $(node).parents('.o_outlook_hack')[0];
-        }
-        else if (node.nodeName === 'IMG' && $node.parent('p').hasClass('o_outlook_hack')) {
-            node = $node.parent()[0];
-        }
-        node = node.nextSibling;
-    }
-}
-
-const reColMatch = /(^| )col(-[\w\d]+)*( |$)/;
-const reOffsetMatch = /(^| )offset(-[\w\d]+)*( |$)/;
-function _getColumnSize(column) {
-    const colMatch = column.className.match(reColMatch);
-    const colOptions = colMatch[2] && colMatch[2].substr(1).split('-');
-    const colSize = colOptions && (colOptions.length === 2 ? +colOptions[1] : +colOptions[0]) || 0;
-    const offsetMatch = column.className.match(reOffsetMatch);
-    const offsetOptions = offsetMatch && offsetMatch[2] && offsetMatch[2].substr(1).split('-');
-    const offsetSize = offsetOptions && (offsetOptions.length === 2 ? +offsetOptions[1] : +offsetOptions[0]) || 0;
-    return colSize + offsetSize;
-}
-
-
-// Attributes all tables should have in a mailing.
-const tableAttributes = {
-    cellspacing: 0,
-    cellpadding: 0,
-    border: 0,
-    width: '100%',
-    align: 'center',
-    role: 'presentation',
-};
-// Cancel tables default styles.
-const tableStyles = {
-    'border-collapse': 'collapse',
-    'text-align': 'inherit',
-    'font-size': 'unset',
-    'line-height': 'unset',
-};
-function _createTable(attributes = []) {
-    const $table = $('<table/>');
-    $table.attr(tableAttributes);
-    $table[0].style.setProperty('width', '100%', 'important');
-    for (const attr of attributes) {
-        if (!(attr.name === 'width' && attr.value === '100%')) {
-            $table.attr(attr.name, attr.value);
-        }
-    }
-    if ($table.hasClass('o_layout')) {
-        // The top mailing element inherits the body's font size and line-height
-        // and should keep them.
-        const layoutStyles = {...tableStyles};
-        delete layoutStyles['font-size'];
-        delete layoutStyles['line-height'];
-        $table.css(layoutStyles);
-    } else {
-        for (const styleName in tableStyles) {
-            if (!('style' in attributes && attributes.style.value.includes(styleName + ':'))) {
-                $table.css(styleName, tableStyles[styleName]);
+function _normalizeStyle(style) {
+    const normalizedStyle = {};
+    for (const styleName of style) {
+        const value = style[styleName];
+        if (value && !styleName.includes('animation') && !styleName.includes('-webkit') && _.isString(value)) {
+            const normalizedStyleName = styleName.replace(/-(.)/g, (a, b) => b.toUpperCase());
+            normalizedStyle[styleName] = style[normalizedStyleName];
+            if (style.getPropertyPriority(styleName) === 'important') {
+                normalizedStyle[styleName] += ' !important';
             }
         }
     }
-    return $table;
+    return normalizedStyle;
 }
-function _createColumnGrid() {
-    return new Array(12).fill().map(() => $('<td/>'));
-}
-function _applyColspanToGridElement($gridElement, colspan) {
-    $gridElement.attr('colspan', colspan);
-    const width = Math.round(+$gridElement.attr('colspan') * 100 / 12) + '%';
-    $gridElement.attr('width', width);
-    $gridElement.css('width', width);
-}
-
-/**
- * Converts bootstrap rows and columns to actual tables.
- *
- * Note: Because of the limited support of media queries in emails, this doesn't
- * support the mixing and matching of column options (e.g., "col-4 col-sm-6" and
- * "col col-4" aren't supported).
- *
- * @param {jQuery} $editable
- */
-function bootstrapToTable($editable) {
-    // First give all rows in columns a separate container parent.
-    $editable.find('.row').filter((i, row) => reColMatch.test(row.parentElement.className)).wrap('<div class="o_fake_table"/>');
-
-    // These containers from the mass mailing masonry snippet require full
-    // height contents, which is only possible if the table itself has a set
-    // height. We also need to restyle it because of the change in structure.
-    $editable.find('.o_masonry_grid_container').css('padding', 0)
-    .find('> .o_fake_table').css('height', function() { return $(this).height() });
-    for (const masonryRow of $editable.find('.o_masonry_grid_container > .o_fake_table > .row.h-100')) {
-        masonryRow.style.removeProperty('height');
-        masonryRow.parentElement.style.setProperty('height', '100%');
-    }
-
-    // Now convert all containers with rows to tables.
-    for (const container of $editable.find('.container:has(.row), .container-fluid:has(.row), .o_fake_table:has(.row)')) {
-        const $container = $(container);
-
-
-        // TABLE
-        const $table = _createTable(container.attributes);
-        for (const child of [...container.childNodes]) {
-            $table.append(child);
-        }
-        $table.removeClass('container container-fluid o_fake_table');
-        if (!$table[0].className) {
-            $table.removeAttr('class');
-        }
-        $container.before($table);
-        $container.remove();
-
-
-        // ROWS
-        // First give all siblings of rows a separate row/col parent combo.
-        $table.children().filter((i, child) => isBlock(child) && !$(child).hasClass('row')).wrap('<div class="row"><div class="col-12"/></div>');
-
-        const $bootstrapRows = $table.children().filter('.row');
-        for (const bootstrapRow of $bootstrapRows) {
-            const $bootstrapRow = $(bootstrapRow);
-            const $row = $('<tr/>');
-            for (const attr of bootstrapRow.attributes) {
-                $row.attr(attr.name, attr.value);
-            }
-            $row.removeClass('row');
-            if (!$row[0].className) {
-                $row.removeAttr('class');
-            }
-            for (const child of [...bootstrapRow.childNodes]) {
-                $row.append(child);
-            }
-            $bootstrapRow.before($row);
-            $bootstrapRow.remove();
-
-
-            // COLUMNS
-            const $bootstrapColumns = $row.children().filter((i, column) => column.className && column.className.match(reColMatch));
-
-            // 1. Replace generic "col" classes with specific "col-n", computed
-            //    by sharing the available space between them.
-            const $flexColumns = $bootstrapColumns.filter((i, column) => !/\d/.test(column.className.match(reColMatch)[0] || '0'));
-            const colTotalSize = $bootstrapColumns.toArray().map(child => _getColumnSize(child)).reduce((a, b) => a + b);
-            const colSize = Math.max(1, Math.round((12 - colTotalSize) / $flexColumns.length));
-            for (const flexColumn of $flexColumns) {
-                flexColumn.classList.remove(flexColumn.className.match(reColMatch)[0].trim());
-                flexColumn.classList.add(`col-${colSize}`);
-            }
-
-            // 2. Create and fill up the row(s) with grid(s).
-            let grid = _createColumnGrid();
-            let gridIndex = 0;
-            let $currentRow = $($row[0].cloneNode());
-            $row.after($currentRow);
-            let $currentCol;
-            let columnIndex = 0;
-            for (const bootstrapColumn of $bootstrapColumns) {
-                const columnSize = _getColumnSize(bootstrapColumn);
-                if (gridIndex + columnSize < 12) {
-                    $currentCol = grid[gridIndex];
-                    _applyColspanToGridElement($currentCol, columnSize);
-                    if (columnIndex === $bootstrapColumns.length - 1) {
-                        // We handled all the columns but there is still space
-                        // in the row. Insert the columns and fill the row.
-                        grid[gridIndex].attr('colspan', 12 - gridIndex);
-                        $currentRow.append(...grid.filter(td => td.attr('colspan')));
-                    }
-                    gridIndex += columnSize;
-                } else if (gridIndex + columnSize === 12) {
-                    // Finish the row.
-                    $currentCol = grid[gridIndex];
-                    _applyColspanToGridElement($currentCol, columnSize);
-                    $currentRow.append(...grid.filter(td => td.attr('colspan')));
-                    if (columnIndex !== $bootstrapColumns.length - 1) {
-                        // The row was filled before we handled all of its
-                        // columns. Create a new one and start again from there.
-                        const $previousRow = $currentRow;
-                        $currentRow = $($currentRow[0].cloneNode());
-                        $previousRow.after($currentRow);
-                        grid = _createColumnGrid();
-                        gridIndex = 0;
-                    }
-                } else {
-                    // Fill the row with what was in the grid before it
-                    // overflowed.
-                    _applyColspanToGridElement(grid[gridIndex], 12 - gridIndex);
-                    $currentRow.append(...grid.filter(td => td.attr('colspan')));
-                    // Start a new row that starts with the current col.
-                    const $previousRow = $currentRow;
-                    $currentRow = $($currentRow[0].cloneNode());
-                    $previousRow.after($currentRow);
-                    grid = _createColumnGrid();
-                    $currentCol = grid[0];
-                    _applyColspanToGridElement($currentCol, columnSize);
-                    gridIndex = columnSize;
-                    if (columnIndex === $bootstrapColumns.length - 1 && gridIndex < 12) {
-                        // We handled all the columns but there is still space
-                        // in the row. Insert the columns and fill the row.
-                        grid[gridIndex].attr('colspan', 12 - gridIndex);
-                        $currentRow.append(...grid.filter(td => td.attr('colspan')));
-                        // Adapt width to colspan.
-                        _applyColspanToGridElement(grid[gridIndex], 12 - gridIndex);
-                    }
-                }
-                if ($currentCol) {
-                    for (const attr of bootstrapColumn.attributes) {
-                        if (attr.name !== 'colspan') {
-                            $currentCol.attr(attr.name, attr.value);
-                        }
-                    }
-                    const colMatch = bootstrapColumn.className.match(reColMatch);
-                    $currentCol.removeClass(colMatch[0]);
-                    if (!$currentCol[0].className) {
-                        $currentCol.removeAttr('class');
-                    }
-                    for (const child of [...bootstrapColumn.childNodes]) {
-                        $currentCol.append(child);
-                    }
-                    // Adapt width to colspan.
-                    _applyColspanToGridElement($currentCol, +$currentCol.attr('colspan'));
-                }
-                columnIndex++;
-            }
-            $row.remove(); // $row was cloned and inserted already
-        }
-    }
-}
-
-function cardToTable($editable) {
-    for (const card of $editable.find('.card')) {
-        const $card = $(card);
-        // Table
-        const $table = _createTable(card.attributes);
-        for (const child of [...card.childNodes]) {
-            if (child.nodeType === Node.TEXT_NODE) {
-                $table.append(child);
-            } else {
-                const $row = $('<tr/>');
-                const $col = $('<td/>');
-                if (child.nodeName === 'IMG') {
-                    $col.append(child);
-                } else {
-                    for (const attr of child.attributes) {
-                        $col.attr(attr.name, attr.value);
-                    }
-                    for (const descendant of [...child.childNodes]) {
-                        $col.append(descendant);
-                    }
-                    $(child).remove();
-                }
-                $row.append($col);
-                $table.append($row);
-            }
-        }
-        $card.before($table);
-        $card.remove();
-    }
-}
-
-function listGroupToTable($editable) {
-    for (const listGroup of $editable.find('.list-group')) {
-        const $listGroup = $(listGroup);
-        // Table
-        let $table;
-        if ($listGroup.find('.list-group-item').length) {
-            $table = _createTable(listGroup.attributes);
-        } else {
-            $table = $(listGroup.cloneNode());
-            for (const attr of $listGroup.attributes) {
-                $table.attr(attr.name, attr.value);
-            }
-        }
-        for (const child of [...listGroup.childNodes]) {
-            const $child = $(child);
-            if ($child.hasClass('list-group-item')) {
-                // List groups are <ul>s that render like tables. Their
-                // li.list-group-item children should translate to tr > td.
-                const $row = $('<tr/>');
-                const $col = $('<td/>');
-                for (const attr of child.attributes) {
-                    $col.attr(attr.name, attr.value);
-                }
-                for (const descendant of [...child.childNodes]) {
-                    $col.append(descendant);
-                }
-                $col.removeClass('list-group-item');
-                $row.append($col);
-                $table.append($row);
-                $(child).remove();
-            } else if (child.nodeName === 'LI') {
-                $table.append(...child.childNodes);
-            } else {
-                $table.append(child);
-            }
-        }
-        $table.removeClass('list-group');
-        if ($listGroup.is('td')) {
-            $listGroup.append($table);
-            $listGroup.removeClass('list-group');
-        } else {
-            $listGroup.before($table);
-            $listGroup.remove();
-        }
-    }
-}
-
-/**
- * Convert snippets and mailing bodies to tables.
- *
- * @param {JQuery} $editable
- */
-function addTables($editable) {
-    for (const snippet of $editable.find('.o_mail_snippet_general, .o_layout')) {
-        // Convert all snippets and the mailing itself into table > tr > td
-        const $table = _createTable(snippet.attributes);
-        const $row = $('<tr/>');
-        const $col = $('<td/>');
-        $row.append($col);
-        $table.append($row);
-        for (const child of [...snippet.childNodes]) {
-            $col.append(child);
-        }
-        $(snippet).before($table);
-        $(snippet).remove();
-
-        // If snippet doesn't have a table as child, wrap its contents in one.
-        if (!$col.children().filter('table').length) {
-            const $tableB = _createTable();
-            $tableB[0].style.width
-            const $rowB = $('<tr/>');
-            const $colB = $('<td/>');
-            $rowB.append($colB);
-            $tableB.append($rowB);
-            for (const child of [...$col[0].childNodes]) {
-                $colB.append(child);
-            }
-            $col.append($tableB);
-        }
-    }
-}
-
-const rePadding = /([\d.]+)/;
-/**
- * Format table styles so they display well in most mail clients. This implies
- * moving table paddings to its cells, adding tbody (with canceled styles) where
- * needed, and adding pixel heights to parents of elements with percent heights.
- *
- * @param {JQuery} $editable
- */
-function formatTables($editable) {
-    for (const table of $editable.find('table.o_mail_snippet_general, .o_mail_snippet_general table')) {
-        const $table = $(table);
-        const tablePaddingTop = parseFloat($table.css('padding-top').match(rePadding)[1]);
-        const tablePaddingRight = parseFloat($table.css('padding-right').match(rePadding)[1]);
-        const tablePaddingBottom = parseFloat($table.css('padding-bottom').match(rePadding)[1]);
-        const tablePaddingLeft = parseFloat($table.css('padding-left').match(rePadding)[1]);
-        const $rows = $table.find('tr').filter((i, tr) => $(tr).closest('table').is($table));
-        const $columns = $table.find('td').filter((i, td) => $(td).closest('table').is($table));
-        for (const column of $columns) {
-            const $column = $(column);
-            const $columnsInRow = $column.closest('tr').find('td');
-            const columnIndex = $columnsInRow.toArray().findIndex(col => $(col).is($column));
-            const rowIndex = $rows.toArray().findIndex(row => $(row).is($column.closest('tr')));
-            if (!rowIndex) {
-                const match = $column.css('padding-top').match(rePadding);
-                const columnPaddingTop = match ? parseFloat(match[1]) : 0;
-                $column.css('padding-top', columnPaddingTop + tablePaddingTop);
-            }
-            if (columnIndex === $columnsInRow.length - 1) {
-                const match = $column.css('padding-right').match(rePadding);
-                const columnPaddingRight = match ? parseFloat(match[1]) : 0;
-                $column.css('padding-right', columnPaddingRight + tablePaddingRight);
-            }
-            if (rowIndex === $rows.length - 1) {
-                const match = $column.css('padding-bottom').match(rePadding);
-                const columnPaddingBottom = match ? parseFloat(match[1]) : 0;
-                $column.css('padding-bottom', columnPaddingBottom + tablePaddingBottom);
-            }
-            if (!columnIndex) {
-                const match = $column.css('padding-left').match(rePadding);
-                const columnPaddingLeft = match ? parseFloat(match[1]) : 0;
-                $column.css('padding-left', columnPaddingLeft + tablePaddingLeft);
-            }
-        }
-        $table.css('padding', '');
-    }
-    // Ensure a tbody in every table and cancel its default style.
-    for (const table of $editable.find('table:not(:has(tbody))')) {
-        $(table).contents().wrap('<tbody style="vertical-align: top;"/>');
-    }
-    // Children will only take 100% height if the parent has a height property.
-    for (const node of $editable.find('*').filter((i, n) => (
-        n.style && n.style.getPropertyValue('height') === '100%' && (
-            !n.parentElement.style.getPropertyValue('height') ||
-            n.parentElement.style.getPropertyValue('height').includes('%'))
-    ))) {
-        let parent = node.parentElement;
-        let height = parent.style.getPropertyValue('height');
-        while (parent && height && height.includes('%')) {
-            parent = parent.parentElement;
-            height = parent.style.getPropertyValue('height');
-        }
-        if (parent) {
-            parent.style.setProperty('height', '0');
-        }
-    }
-}
-
-/**
- * Converts css style to inline style (leave the classes on elements but forces
- * the style they give as inline style).
- *
- * @param {jQuery} $editable
- * @param {Object} cssRules
- */
-function classToStyle($editable, cssRules) {
-    applyOverDescendants($editable[0], function (node) {
-        const $target = $(node);
-        const css = getMatchedCSSRules(node, cssRules);
-        // Flexbox
-        for (const styleName in node.style) {
-            if (styleName.includes('flex') || `${node.style[styleName]}`.includes('flex')) {
-                node.style[styleName] = '';
-            }
-        }
-
-        // Do not apply css that would override inline styles (which are prioritary).
-        let style = $target.attr('style') || '';
-        for (const [key, value] of Object.entries(css)) {
-            if (!(new RegExp(`(^|;)\\s*${key}`).test(style))) {
-                style = `${key}:${value};${style}`;
-            }
-        };
-        if (_.isEmpty(style)) {
-            $target.removeAttr('style');
-        } else {
-            $target.attr('style', style);
-        }
-        if ($target.get(0).style.width) {
-            $target.attr('width', $target.css('width')); // Widths need to be applied as attributes as well.
-        }
-
-        // Media list images should not have an inline height
-        if (node.nodeName === 'IMG' && $target.hasClass('s_media_list_img')) {
-            $target.css('height', '');
-        }
-        // Apple Mail
-        if (node.nodeName === 'TD' && !node.childNodes.length) {
-            $(node).html('&nbsp;');
-        }
-        // Outlook
-        if (node.nodeName === 'A' && $target.hasClass('btn') && !$target.hasClass('btn-link') && !$target.children().length) {
-            $target.prepend(`<!--[if mso]><i style="letter-spacing: 25px; mso-font-width: -100%; mso-text-raise: 30pt;">&nbsp;</i><![endif]-->`);
-            $target.append(`<!--[if mso]><i style="letter-spacing: 25px; mso-font-width: -100%;">&nbsp;</i><![endif]-->`);
-        } else if (node.nodeName === 'IMG' && $target.is('.mx-auto.d-block')) {
-            $target.wrap('<p class="o_outlook_hack" style="text-align:center;margin:0"/>');
-        }
-    });
-}
-
-/**
- * Converts all styles containing rgb colors to hexadecimal colors.
- * Note: ignores rgba colors, which are not supported in Microsoft Outlook.
- *
- * @param {JQuery} $editable
- */
-function normalizeColors($editable) {
-    for (const node of $editable.find('[style*="rgb"]')) {
-        const rgbMatch = node.getAttribute('style').match(/rgb?\(([\d\.]*,?\s?){3,4}\)/g);
-        for (const rgb of rgbMatch || []) {
-            node.setAttribute('style', node.getAttribute('style').replace(rgb, rgbToHex(rgb)));
-        }
-    }
-}
-
-/**
- * Converts all css values that use the rem unit to px.
- *
- * @param {JQuery} $editable
- */
-function normalizeRem($editable) {
-    const rootFontSizeProperty = $editable.closest('html').css('font-size');
-    const rootFontSize = parseFloat(rootFontSizeProperty.replace(/[^\d\.]/g, ''));
-    for (const node of $editable.find('[style*="rem"]')) {
-        const remMatch = node.getAttribute('style').match(/[\d\.]+\s*rem/g);
-        for (const rem of remMatch || []) {
-            const remValue = parseFloat(rem.replace(/[^\d\.]/g, ''));
-            const pxValue = Math.round(remValue * rootFontSize * 10) / 10;
-            node.setAttribute('style', node.getAttribute('style').replace(rem, pxValue + 'px'));
-        }
-    }
-}
-
-/**
- * Converts css display for attachment link to real image.
- * Without this post process, the display depends on the css and the picture
- * does not appear when we use the html without css (to send by email for e.g.)
- *
- * @param {jQuery} $editable
- */
-function attachmentThumbnailToLinkImg($editable) {
-    $editable.find('a[href*="/web/content/"][data-mimetype]').filter(':empty, :containsExact( )').each(function () {
-        var $link = $(this);
-        var $img = $('<img/>')
-            .attr('src', $link.css('background-image').replace(/(^url\(['"])|(['"]\)$)/g, ''))
-            .css('height', Math.max(1, $link.height()) + 'px')
-            .css('width', Math.max(1, $link.width()) + 'px');
-        $link.prepend($img);
-    });
-}
-
 
 //--------------------------------------------------------------------------
+// Widget
 //--------------------------------------------------------------------------
 
 
@@ -934,15 +981,15 @@ FieldHtml.include({
 });
 
 export default {
-    getCSSRules: getCSSRules,
-    fontToImg: fontToImg,
+    addTables: addTables,
+    attachmentThumbnailToLinkImg: attachmentThumbnailToLinkImg,
     bootstrapToTable: bootstrapToTable,
     cardToTable: cardToTable,
-    listGroupToTable: listGroupToTable,
-    addTables: addTables,
-    formatTables: formatTables,
     classToStyle: classToStyle,
+    fontToImg: fontToImg,
+    formatTables: formatTables,
+    getCSSRules: getCSSRules,
+    listGroupToTable: listGroupToTable,
     normalizeColors: normalizeColors,
     normalizeRem: normalizeRem,
-    attachmentThumbnailToLinkImg: attachmentThumbnailToLinkImg,
 };

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -344,6 +344,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
                     cwindow.document
                         .open("text/html", "replace")
                         .write(
+                            '<!DOCTYPE html><html>' +
                             '<head>' +
                                 '<meta charset="utf-8"/>' +
                                 '<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>\n' +
@@ -362,7 +363,8 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
                                         'window.top.' + self._onUpdateIframeId + '(' + _avoidDoubleLoad + ')' +
                                     '}' +
                                 '</script>\n' +
-                            '</body>');
+                            '</body>' +
+                            '</html>');
 
                     var height = cwindow.document.body.scrollHeight;
                     self.$iframe.css('height', Math.max(30, Math.min(height, 500)) + 'px');

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
@@ -157,7 +157,7 @@ Wysiwyg.include({
                 });
                 self.$iframe[0].contentWindow.document
                     .open("text/html", "replace")
-                    .write(iframeContent);
+                    .write(`<!DOCTYPE html><html>${iframeContent}</html>`);
             });
             self.options.document = self.$iframe[0].contentWindow.document;
         });

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -521,7 +521,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(1);
 
         $editable.html(`<div class="container"><div class="row"><div class="col">Hello</div></div></div>`);
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         const containerStyle = `padding:0 16px 0 16px;margin:0 auto 0 auto;box-sizing:border-box;max-width:1140px;width:100%;`;
         const rowStyle = `margin:0 -16px 0 -16px;box-sizing:border-box;`;
         const colStyle = `padding:0 16px 0 16px;box-sizing:border-box;max-width:100%;width:100%;position:relative;`;
@@ -549,8 +549,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-border-radius"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border-radius" style="border-radius:30%;box-sizing:border-box;"></div>`,
             "should have converted border-[position]-radius styles (from class) to border-radius");
@@ -566,8 +565,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-border"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border" style="border-style:dotted dashed none solid;box-sizing:border-box;"></div>`,
             "should have converted border-[position]-style styles (from class) to border-style");
@@ -581,8 +579,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-margin"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-margin" style="margin:0 20px 30px 40px;box-sizing:border-box;"></div>`,
             "should have converted margin-[position] styles (from class) to margin");
@@ -596,8 +593,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-padding"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-padding" style="padding:10px 0 30px 40px;box-sizing:border-box;"></div>`,
             "should have converted padding-[position] styles (from class) to padding");
@@ -614,8 +610,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-border-uniform"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border-uniform" style="border-style:dotted;box-sizing:border-box;"></div>`,
             "should have converted uniform border-[position]-style styles (from class) to border-style");
@@ -630,8 +625,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-margin-uniform"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-margin-uniform" style="margin:10px;box-sizing:border-box;"></div>`,
             "should have converted uniform margin-[position] styles (from class) to margin");
@@ -646,8 +640,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-padding-uniform"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-padding-uniform" style="padding:10px;box-sizing:border-box;"></div>`,
             "should have converted uniform padding-[position] styles (from class) to padding");
@@ -664,8 +657,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-border-inherit"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border-inherit" style="box-sizing:border-box;border-left-style:solid;border-bottom-style:inherit;border-right-style:dashed;border-top-style:dotted;"></div>`,
             "should not have converted border-[position]-style styles (from class) to border-style as they include an inherit");
@@ -680,8 +672,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-margin-inherit"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-margin-inherit" style="box-sizing:border-box;margin-left:40px;margin-bottom:30px;margin-right:inherit;margin-top:10px;"></div>`,
             "should not have converted margin-[position] styles (from class) to margin as they include an inherit");
@@ -696,8 +687,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-padding-inherit"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-padding-inherit" style="box-sizing:border-box;padding-left:40px;padding-bottom:inherit;padding-right:20px;padding-top:10px;"></div>`,
             "should have converted padding-[position] styles (from class) to padding as they include an inherit");
@@ -716,8 +706,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-margin-initial"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-margin-initial" style="box-sizing:border-box;margin-left:40px;margin-bottom:30px;margin-right:20px;margin-top:initial;"></div>`,
             "should not have converted margin-[position] styles (from class) to margin as they include an initial");
@@ -732,8 +721,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-padding-initial"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-padding-initial" style="box-sizing:border-box;padding-left:initial;padding-bottom:30px;padding-right:20px;padding-top:10px;"></div>`,
             "should not have converted padding-[position] styles (from class) to padding as they include an initial");
@@ -758,8 +746,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-decoration"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-decoration" style="text-decoration:underline;box-sizing:border-box;"></div>`,
             "should have removed all text-decoration-[prop] styles (from class) and kept a simple text-decoration");
@@ -775,8 +762,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-border-initial"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border-initial" style="box-sizing:border-box;border-bottom-style:double;border-right-style:dashed;border-top-style:dotted;"></div>`,
             "should have removed border initial");
@@ -789,13 +775,12 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-block"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-block" style="box-sizing:border-box;"></div>`,
             "should have removed display block");
         $editable.html(`<div class="btn-block"></div>`);
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="btn-block" style="box-sizing:border-box;width:100%;display:block;" width="100%"></div>`,
             "should not have removed display block for .btn-block");
@@ -808,8 +793,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-unimportant-color"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-unimportant-color" style="box-sizing:border-box;color:blue;"></div>`,
             "should have converted a simple color");
@@ -819,8 +803,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-important-color test-unimportant-color"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-important-color test-unimportant-color" style="box-sizing:border-box;color:red;"></div>`,
             "should have converted an important color and removed the !important");
@@ -834,8 +817,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-animation"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-animation" style="box-sizing:border-box;"></div>`,
             "should have removed animation style");
@@ -851,8 +833,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-animation-specific"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-animation-specific" style="box-sizing:border-box;"></div>`,
             "should have removed all specific animation styles");
@@ -866,8 +847,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-flex"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-flex" style="box-sizing:border-box;"></div>`,
             "should have removed all flex styles");
@@ -883,8 +863,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-flex-specific"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-flex-specific" style="box-sizing:border-box;"></div>`,
             "should have removed all specific flex styles");
@@ -911,8 +890,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $iframeEditable.html(`<div class="o_layout" style="padding: 50px;"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($iframeEditable);
+        convertInline.classToStyle($iframeEditable, convertInline.getCSSRules($iframeEditable[0].ownerDocument));
         assert.strictEqual($iframeEditable.html(),
             `<div class="o_layout" style="box-sizing:border-box;font-size:50px;color:white;background-color:red;padding: 50px;"></div>`,
             "should have given all styles of body to .o_layout");
@@ -944,20 +922,19 @@ QUnit.module('convert_inline', {}, function () {
         `, 2);
 
         $editable.html(`<span class="test-color"></span>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<span class="test-color" style="box-sizing:border-box;color:blue;"></span>`,
             "should have prioritized the last defined style");
 
         $editable.html(`<div class="test-color"></div>`);
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-color" style="box-sizing:border-box;color:green;"></div>`,
             "should have prioritized the more specific style");
 
         $editable.html(`<div class="test-color" style="color: yellow;"></div>`);
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-color" style="box-sizing:border-box;color: yellow;"></div>`,
             "should have prioritized the inline style");
@@ -968,8 +945,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable.html(`<div class="test-color"></div>`);
-        document._rulesCache = undefined;
-        convertInline.classToStyle($editable);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-color" style="box-sizing:border-box;color:black;"></div>`,
             "should have prioritized the important style");

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -1,0 +1,986 @@
+/** @odoo-module **/
+import convertInline from '@web_editor/js/backend/convert_inline';
+import {getGridHtml, getTableHtml, getRegularGridHtml, getRegularTableHtml} from 'web_editor.test_utils';
+
+
+QUnit.module('web_editor', {}, function () {
+QUnit.module('convert_inline', {}, function () {
+    const $editable = $('<div/>');
+
+    QUnit.module('Convert Bootstrap grids to tables');
+    // Test bootstrapToTable, cardToTable and listGroupToTable
+
+    QUnit.test('convert a single-row regular grid', async function (assert) {
+        assert.expect(4);
+
+        // 1x1
+        $editable.html(getRegularGridHtml(1, 1));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(), getRegularTableHtml(1, 1, 12, 100),
+            "should have converted a 1x1 grid to an equivalent table");
+
+        // 1x2
+        $editable.html(getRegularGridHtml(1, 2));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(), getRegularTableHtml(1, 2, 6, 50),
+            "should have converted a 1x2 grid to an equivalent table");
+
+        // 1x3
+        $editable.html(getRegularGridHtml(1, 3));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(), getRegularTableHtml(1, 3, 4, 33),
+            "should have converted a 1x3 grid to an equivalent table");
+
+        // 1x12
+        $editable.html(getRegularGridHtml(1, 12));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(), getRegularTableHtml(1, 12, 1, 8),
+            "should have converted a 1x12 grid to an equivalent table");
+    });
+    QUnit.test('convert a single-row regular overflowing grid', async function (assert) {
+        assert.expect(4);
+
+        // 1x13
+        $editable.html(getRegularGridHtml(1, 13));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(),
+            getRegularTableHtml(1, 12, 1, 8).slice(0, -8) +
+                `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 12)</td></tr></table>`,
+            "should have converted a 1x13 grid to an equivalent table (overflowing)");
+
+        // 1x14
+        $editable.html(getRegularGridHtml(1, 14));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(),
+            getRegularTableHtml(1, 12, 1, 8).slice(0, -8) +
+                `<tr><td colspan="1" width="8%" style="width: 8%;">(0, 12)</td>` +
+                `<td colspan="11" width="92%" style="width: 92%;">(0, 13)</td></tr></table>`,
+            "should have converted a 1x14 grid to an equivalent table (overflowing)");
+
+        // 1x25
+        $editable.html(getRegularGridHtml(1, 25));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(),
+            getRegularTableHtml(1, 12, 1, 8).slice(0, -8) +
+            getRegularTableHtml(1, 12, 1, 8).replace(/\(0, (\d+)\)/g, (s, c) => `(0, ${+c + 12})`)
+                .replace(/^<table[^<]*>/, '').slice(0, -8) +
+                `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 24)</td></tr></table>`,
+            "should have converted a 1x25 grid to an equivalent table (overflowing)");
+
+        // 1x26
+        $editable.html(getRegularGridHtml(1, 26));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(),
+            getRegularTableHtml(1, 12, 1, 8).slice(0, -8) +
+            getRegularTableHtml(1, 12, 1, 8).replace(/\(0, (\d+)\)/g, (s, c) => `(0, ${+c + 12})`)
+                .replace(/^<table[^<]*>/, '').slice(0, -8) +
+                `<tr><td colspan="1" width="8%" style="width: 8%;">(0, 24)</td>` +
+                `<td colspan="11" width="92%" style="width: 92%;">(0, 25)</td></tr></table>`,
+            "should have converted a 1x26 grid to an equivalent table (overflowing)");
+    });
+    QUnit.test('convert a multi-row regular grid', async function (assert) {
+        assert.expect(4);
+
+        // 2x1
+        $editable.html(getRegularGridHtml(2, 1));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(), getRegularTableHtml(2, 1, 12, 100),
+            "should have converted a 2x1 grid to an equivalent table");
+
+        // 2x[1,2]
+        $editable.html(getRegularGridHtml(2, [1, 2]));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(), getRegularTableHtml(2, [1, 2], [12, 6], [100, 50]),
+            "should have converted a 2x[1,2] grid to an equivalent table");
+
+        // 3x3
+        $editable.html(getRegularGridHtml(3, 3));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(), getRegularTableHtml(3, 3, 4, 33),
+            "should have converted a 3x3 grid to an equivalent table");
+
+        // 3x[3,2,1]
+        $editable.html(getRegularGridHtml(3, [3,2,1]));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(), getRegularTableHtml(3, [3, 2, 1], [4, 6, 12], [33, 50, 100]),
+            "should have converted a 3x[3,2,1] grid to an equivalent table");
+    });
+    QUnit.test('convert a multi-row regular overflowing grid', async function (assert) {
+        assert.expect(4);
+
+        // 2x[13,1]
+        $editable.html(getRegularGridHtml(2, [13, 1]));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(),
+            getRegularTableHtml(1, 12, 1, 8).slice(0, -8) +
+                `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 12)</td></tr>` +
+                `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 0)</td></tr></table>`,
+            "should have converted a 2x[13,1] grid to an equivalent table (overflowing)");
+
+        // 2x[1,13]
+        $editable.html(getRegularGridHtml(2, [1, 13]));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(),
+            getRegularTableHtml(2, [1, 12], [12, 1], [100, 8]).slice(0, -8) +
+                `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 12)</td></tr></table>`,
+            "should have converted a 2x[1,13] grid to an equivalent table (overflowing)");
+
+        // 3x[1,13,6]
+        $editable.html(getRegularGridHtml(3, [1, 13, 6]));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(),
+            getRegularTableHtml(2, [1, 12], [12, 1], [100, 8]).slice(0, -8) +
+                `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 12)</td></tr>` +
+                getRegularTableHtml(1, 6, 2, 17).replace(/\(0,/g, `(2,`).replace(/^<table[^<]*>/, ''),
+            "should have converted a 3x[1,13,6] grid to an equivalent table (overflowing)");
+
+        // 3x[1,6,13]
+        $editable.html(getRegularGridHtml(3, [1, 6, 13]));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(),
+            getRegularTableHtml(3, [1, 6, 12], [12, 2, 1], [100, 17, 8]).slice(0, -8) +
+                `<tr><td colspan="12" width="100%" style="width: 100%;">(2, 12)</td></tr></table>`,
+            "should have converted a 3x[1,6,13] grid to an equivalent table (overflowing)");
+    });
+    QUnit.test('convert a single-row irregular grid', async function (assert) {assert.expect(4);
+        assert.expect(2);
+
+        // 1x2
+        $editable.html(getGridHtml([[8, 4]]));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(), getTableHtml([[[8, 67], [4, 33]]]),
+            "should have converted a 1x2 irregular grid to an equivalent table");
+
+        // 1x3
+        $editable.html(getGridHtml([[2, 3, 7]]));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(), getTableHtml([[[2, 17], [3, 25], [7, 58]]]),
+            "should have converted a 1x3 grid to an equivalent table");
+    });
+    QUnit.test('convert a single-row irregular overflowing grid', async function (assert) {assert.expect(4);
+        assert.expect(2);
+
+        // 1x2
+        $editable.html(getGridHtml([[8, 5]]));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(), getTableHtml([
+                [[8, 67], [4, 33, '']],
+                [[5, 42, '(0, 1)'], [7, 58, '']],
+            ]),
+            "should have converted a 1x2 irregular overflowing grid to an equivalent table");
+
+        // 1x3
+        $editable.html(getGridHtml([[7, 6, 9]]));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(), getTableHtml([
+                [[7, 58], [5, 42, '']],
+                [[6, 50, '(0, 1)'], [6, 50, '']],
+                [[9, 75, '(0, 2)'], [3, 25, '']],
+            ]),
+            "should have converted a 1x3 irregular overflowing grid to an equivalent table");
+    });
+    QUnit.test('convert a multi-row irregular grid', async function (assert) {
+        assert.expect(2);
+
+        // 2x2
+        $editable.html(getGridHtml([[1, 11], [2, 10]]));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(), getTableHtml([[[1, 8], [11, 92]], [[2, 17], [10, 83]]]),
+            "should have converted a 2x2 irregular grid to an equivalent table");
+
+        // 2x[2,3]
+        $editable.html(getGridHtml([[3, 9], [4, 6, 2]]));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(), getTableHtml([[[3, 25], [9, 75]], [[4, 33], [6, 50], [2, 17]]]),
+            "should have converted a 2x[2,3] irregular grid to an equivalent table");
+    });
+    QUnit.test('convert a multi-row irregular overflowing grid', async function (assert) {
+        assert.expect(3);
+
+        // 2x2 (both rows overflow)
+        $editable.html(getGridHtml([[6, 8], [7, 9]]));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(),
+            getTableHtml([
+                [[6, 50], [6, 50, '']],
+                [[8, 67, '(0, 1)'], [4, 33, '']],
+                [[7, 58, '(1, 0)'], [5, 42, '']],
+                [[9, 75, '(1, 1)'], [3, 25, '']],
+            ]),
+            "should have converted a 2x[1,13] irregular grid to an equivalent table (both rows overflowing)");
+
+        // 2x[2,3] (first row overflows)
+        $editable.html(getGridHtml([[5, 8], [4, 2, 6]]));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(),
+            getTableHtml([
+                [[5, 42], [7, 58, '']],
+                [[8, 67, '(0, 1)'], [4, 33, '']],
+                [[4, 33, '(1, 0)'], [2, 17, '(1, 1)'], [6, 50, '(1, 2)']],
+            ]),
+            "should have converted a 2x[2,3] irregular grid to an equivalent table (first row overflowing)");
+
+        // 2x[3,2] (second row overflows)
+        $editable.html(getGridHtml([[4, 2, 6], [5, 8]]));
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(),
+            getTableHtml([
+                [[4, 33], [2, 17], [6, 50]],
+                [[5, 42], [7, 58, '']],
+                [[8, 67, '(1, 1)'], [4, 33, '']],
+            ]),
+            "should have converted a 2x[3,2] irregular grid to an equivalent table (second row overflowing)");
+    });
+    QUnit.test('convert a card to a table', async function (assert) {
+        assert.expect(1);
+
+        $editable.html(
+            `<div class="card">` +
+                `<div class="card-header">` +
+                    `<span>HEADER</span>` +
+                `</div>` +
+                `<div class="card-body">` +
+                    `<h2 class="card-title">TITLE</h2>` +
+                    `<small>BODY <img></small>` +
+                `</div>` +
+                `<div class="card-footer">` +
+                    `<a href="#" class="btn">FOOTER</a>` +
+                `</div>` +
+            `</div>`);
+        convertInline.cardToTable($editable);
+        assert.strictEqual($editable.html(),
+            getRegularTableHtml(3, 1, 12, 100)
+                .split('style="').join('class="card" style="')
+                .replace(/<td[^>]*>\(0, 0\)<\/td>/, '<td class="card-header"><span>HEADER</span></td>')
+                .replace(/<td[^>]*>\(1, 0\)<\/td>/, '<td class="card-body"><h2 class="card-title">TITLE</h2><small>BODY <img></small></td>')
+                .replace(/<td[^>]*>\(2, 0\)<\/td>/, '<td class="card-footer"><a href="#" class="btn">FOOTER</a></td>'),
+            "should have converted a card structure into a table");
+    });
+    QUnit.test('convert a list group to a table', async function (assert) {
+        assert.expect(1);
+
+        $editable.html(
+            `<ul class="list-group list-group-flush">` +
+                `<li class="list-group-item">` +
+                    `<strong>(0, 0)</strong>` +
+                `</li>` +
+                `<li class="list-group-item a">` +
+                    `(1, 0)` +
+                `</li>` +
+                `<li><img></li>` +
+                `<li class="list-group-item">` +
+                    `<strong class="b">(2, 0)</strong>` +
+                `</li>` +
+            `</ul>`);
+        convertInline.listGroupToTable($editable);
+        assert.strictEqual($editable.html(),
+            getRegularTableHtml(3, 1, 12, 100)
+                .split('style="').join('class="list-group-flush" style="')
+                .replace(/<td[^>]*>(\(0, 0\))<\/td>/, '<td><strong>$1</strong></td>')
+                .replace(/<td[^>]*>(\(1, 0\))<\/td>/, '<td class="a">$1</td>')
+                .replace(/<tr><td[^>]*>(\(2, 0\))<\/td>/, '<img><tr><td><strong class="b">$1</strong></td>'),
+            "should have converted a list group structure into a table");
+    });
+
+    QUnit.module('Normalize styles');
+    // Test normalizeColors, normalizeRem and formatTables
+
+    QUnit.test('convert rgb color to hexadecimal', async function (assert) {
+        assert.expect(1);
+
+        $editable.html(
+            `<div style="color: rgb(0, 0, 0);">` +
+                `<div class="a" style="padding: 0; background-color:rgb(255,255,255)" width="100%">` +
+                    `<p style="border: 1px rgb(50, 100,200 ) solid; color: rgb(35, 134, 54);">Test</p>` +
+                `</div>` +
+            `</div>`
+        );
+        convertInline.normalizeColors($editable);
+        assert.strictEqual($editable.html(),
+            `<div style="color: #000000;">` +
+                `<div class="a" style="padding: 0; background-color:#ffffff" width="100%">` +
+                    `<p style="border: 1px #3264c8 solid; color: #238636;">Test</p>` +
+                `</div>` +
+            `</div>`,
+            "should have converted several rgb colors to hexadecimal"
+        );
+    });
+    QUnit.test('convert rem sizes to px', async function (assert) {
+        assert.expect(2);
+
+        const testDom = `<div style="font-size: 2rem;">` +
+            `<div class="a" style="color: #000000; padding: 2.5 rem" width="100%">` +
+                `<p style="border: 1.2rem #aaaaaa solid; margin: 3.79rem;">Test</p>` +
+            `</div>` +
+        `</div>`;
+
+        document.body.append($editable[0]);
+        $editable.html(testDom);
+        convertInline.normalizeRem($editable);
+        assert.strictEqual($editable.html(),
+            `<div style="font-size: 24px;">` +
+                `<div class="a" style="color: #000000; padding: 30px" width="100%">` +
+                    `<p style="border: 14.4px #aaaaaa solid; margin: 45.5px;">Test</p>` +
+                `</div>` +
+            `</div>`,
+            "should have converted several rem sizes to px using the default rem size"
+        );
+
+        const html = document.createElement('html');
+        html.style.setProperty('font-size', '20px');
+        html.append($editable[0]);
+        $editable.html(testDom);
+        convertInline.normalizeRem($editable);
+        assert.strictEqual($editable.html(),
+            `<div style="font-size: 40px;">` +
+                `<div class="a" style="color: #000000; padding: 50px" width="100%">` +
+                    `<p style="border: 24px #aaaaaa solid; margin: 75.8px;">Test</p>` +
+                `</div>` +
+            `</div>`,
+            "should have converted several rem sizes to px using a set rem size"
+        );
+
+        $editable.remove();
+    });
+    QUnit.test('move padding from snippet containers to cells', async function (assert) {
+        assert.expect(1);
+
+        const testTable = `<table class="o_mail_snippet_general" style="padding: 10px 20px 30px 40px;">` +
+            `<tbody>` +
+                `<tr>` +
+                    `<td style="padding-top: 1px; padding-right: 2px;">(0, 0, 0)</td>` +
+                    `<td style="padding: 3px 4px 5px 6px;">(0, 1, 0)</td>` +
+                    `<td style="padding: 7px;">(0, 2, 0)</td>` +
+                    `<td style="padding: 8px 9px;">(0, 3, 0)</td>` +
+                    `<td style="padding-right: 9.1px;">(0, 4, 0)</td>` +
+                `</tr>` +
+                `<tr>` +
+                    `<td>` +
+                        `<table style="padding: 50px 60px 70px 80px;">` +
+                            `<tbody>` +
+                                `<tr>` +
+                                    `<td style="padding: 1px 2px 3px 4px;">(0, 0, 1)</td>` +
+                                    `<td style="padding: 5px;">(0, 1, 1)</td>` +
+                                    `<td style="padding: 6px 7px;">(0, 2, 1)</td>` +
+                                    `<td style="padding-top: 8px; padding-right: 9px;">(0, 3, 1)</td>` +
+                                `</tr>` +
+                            `</tbody>` +
+                        `</table>` +
+                    `</td>` +
+                `</tr>` +
+                `<tr>` +
+                    `<td style="padding-left: 9.1px;">(1, 0, 0)</td>` +
+                    `<td style="padding: 9px 8px 7px 6px;">(1, 1, 0)</td>` +
+                    `<td style="padding: 5px;">(1, 2, 0)</td>` +
+                    `<td style="padding: 4px 3px;">(1, 3, 0)</td>` +
+                    `<td style="padding-bottom: 2px; padding-right: 1px;">(1, 4, 0)</td>` +
+                `</tr>` +
+            `</tbody>` +
+        `</table>`;
+
+        const expectedTable = `<table class="o_mail_snippet_general" style="">` +
+            `<tbody>` +
+                `<tr>` +
+                    `<td style="padding-top: 11px; padding-right: 2px; padding-left: 40px;">(0, 0, 0)</td>` + // TL
+                    `<td style="padding: 13px 4px 5px 6px;">(0, 1, 0)</td>` + // T
+                    `<td style="padding: 17px 7px 7px;">(0, 2, 0)</td>` + // T
+                    `<td style="padding: 18px 9px 8px;">(0, 3, 0)</td>` + // T
+                    `<td style="padding-right: 29.1px; padding-top: 10px;">(0, 4, 0)</td>` + // TR
+                `</tr>` +
+                `<tr>` +
+                    `<td style="padding-left: 40px;">` + // L
+                        `<table style="">` +
+                            `<tbody>` +
+                                `<tr>` +
+                                    `<td style="padding: 51px 2px 73px 84px;">(0, 0, 1)</td>` + // TBL
+                                    `<td style="padding: 55px 5px 75px;">(0, 1, 1)</td>` + // TB
+                                    `<td style="padding: 56px 7px 76px;">(0, 2, 1)</td>` + // TB
+                                    `<td style="padding-top: 58px; padding-right: 69px; padding-bottom: 70px;">(0, 3, 1)</td>` + // TBR
+                                `</tr>` +
+                            `</tbody>` +
+                        `</table>` +
+                    `</td>` +
+                `</tr>` +
+                `<tr>` +
+                    `<td style="padding-left: 49.1px; padding-bottom: 30px;">(1, 0, 0)</td>` + // BL
+                    `<td style="padding: 9px 8px 37px 6px;">(1, 1, 0)</td>` + // B
+                    `<td style="padding: 5px 5px 35px;">(1, 2, 0)</td>` + // B
+                    `<td style="padding: 4px 3px 34px;">(1, 3, 0)</td>` + // B
+                    `<td style="padding-bottom: 32px; padding-right: 21px;">(1, 4, 0)</td>` + // BR
+                `</tr>` +
+            `</tbody>` +
+        `</table>`;
+
+        // table.o_mail_snippet_general
+        $editable.html(testTable);
+        convertInline.formatTables($editable);
+        assert.strictEqual($editable.html(), expectedTable,
+            "should have moved the padding from table.o_mail_snippet_general and table in it to their respective cells"
+        );
+    });
+    QUnit.test('add a tbody to any table that doesn\'t have one', async function (assert) {
+        assert.expect(1);
+
+        $editable.html(`<table><tr><td>I don't have a body :'(</td></tr></table>`);
+        $editable.find('tr').unwrap();
+        convertInline.formatTables($editable);
+        assert.strictEqual($editable.html(), `<table><tbody style="vertical-align: top;"><tr><td>I don't have a body :'(</td></tr></tbody></table>`,
+            "should have added a tbody to a table that didn't have one"
+        );
+    });
+    QUnit.test('add number heights to parents of elements with percent heights', async function (assert) {
+        assert.expect(3);
+
+        $editable.html(`<table><tbody><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`);
+        convertInline.formatTables($editable);
+        assert.strictEqual($editable.html(), `<table><tbody style="height: 0px;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`,
+            "should have added a 0 height to the parent of a 100% height element"
+        );
+
+        $editable.html(`<table><tbody style="height: 200px;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`);
+        convertInline.formatTables($editable);
+        assert.strictEqual($editable.html(), `<table><tbody style="height: 200px;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`,
+            "should not have changed the height of the parent of a 100% height element"
+        );
+
+        $editable.html(`<table><tbody style="height: 50%;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`);
+        convertInline.formatTables($editable);
+        assert.strictEqual($editable.html(), `<table style="height: 0px;"><tbody style="height: 50%;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`,
+            "should have changed the height of the grandparent of a 100% height element"
+        );
+    });
+
+    QUnit.module('Convert snippets and mailing bodies to tables');
+    // Test addTables
+
+    QUnit.test('convert snippets to tables', async function (assert) {
+        assert.expect(2);
+
+        $editable.html(
+            `<div class="o_mail_snippet_general">` +
+                `<div>Snippet</div>` +
+            `</div>`
+        );
+        convertInline.addTables($editable);
+        assert.strictEqual($editable.html(),
+            getRegularTableHtml(1, 1, 12, 100)
+                .split('style=').join('class="o_mail_snippet_general" style=')
+                .replace(/<td[^>]*>\(0, 0\)/, '<td>' + getRegularTableHtml(1, 1, 12, 100).replace(/<td[^>]*>\(0, 0\)/, '<td><div>Snippet</div>')),
+            "should have converted .o_mail_snippet_general to a special table structure with a table in it"
+        );
+
+        $editable.html(
+            `<div class="o_mail_snippet_general">` +
+                `<table><tbody><tr><td>Snippet</td></tr></tbody></table>` +
+            `</div>`
+        );
+        convertInline.addTables($editable);
+        assert.strictEqual($editable.html(),
+            getRegularTableHtml(1, 1, 12, 100)
+                .split('style=').join('class="o_mail_snippet_general" style=')
+                .replace(/<td[^>]*>\(0, 0\)/, '<td><table><tbody><tr><td>Snippet</td></tr></tbody></table>'),
+            "should have converted .o_mail_snippet_general to a special table structure, keeping the table in it"
+        );
+    });
+    QUnit.test('convert mailing bodies to tables', async function (assert) {
+        assert.expect(2);
+
+        $editable.html(
+            `<div class="o_layout">` +
+                `<div>Mailing</div>` +
+            `</div>`
+        );
+        convertInline.addTables($editable);
+        assert.strictEqual($editable.html(),
+            getRegularTableHtml(1, 1, 12, 100)
+                .split('style=').join('class="o_layout" style=')
+                .replace(' font-size: unset; line-height: unset;', '') // o_layout keeps those default values
+                .replace(/<td[^>]*>\(0, 0\)/, '<td>' + getRegularTableHtml(1, 1, 12, 100).replace(/<td[^>]*>\(0, 0\)/, '<td><div>Mailing</div>')),
+            "should have converted .o_layout to a special table structure with a table in it"
+        );
+
+        $editable.html(
+            `<div class="o_layout">` +
+                `<table><tbody><tr><td>Mailing</td></tr></tbody></table>` +
+            `</div>`
+        );
+        convertInline.addTables($editable);
+        assert.strictEqual($editable.html(),
+            getRegularTableHtml(1, 1, 12, 100)
+                .split('style=').join('class="o_layout" style=')
+                .replace(' font-size: unset; line-height: unset;', '') // o_layout keeps those default values
+                .replace(/<td[^>]*>\(0, 0\)/, '<td><table><tbody><tr><td>Mailing</td></tr></tbody></table>'),
+            "should have converted .o_layout to a special table structure, keeping the table in it"
+        );
+    });
+
+    QUnit.module('Convert classes to inline styles');
+    // Test classToStyle
+
+    QUnit.test('convert Bootstrap classes to inline styles', async function (assert) {
+        assert.expect(1);
+
+        $editable.html(`<div class="container"><div class="row"><div class="col">Hello</div></div></div>`);
+        convertInline.classToStyle($editable);
+        const containerStyle = `padding:0 16px 0 16px;margin:0 auto 0 auto;box-sizing:border-box;max-width:1140px;width:100%;`;
+        const rowStyle = `margin:0 -16px 0 -16px;box-sizing:border-box;`;
+        const colStyle = `padding:0 16px 0 16px;box-sizing:border-box;max-width:100%;width:100%;position:relative;`;
+        assert.strictEqual($editable.html(),
+            `<div class="container" style="${containerStyle}" width="100%">` +
+            `<div class="row" style="${rowStyle}">` +
+            `<div class="col" style="${colStyle}" width="100%">Hello</div></div></div>`,
+            "should have converted the classes of a simple Bootstrap grid to inline styles"
+        );
+    });
+    QUnit.test('simplify border/margin/padding styles', async function (assert) {
+        assert.expect(12);
+
+        const $styleSheet = $('<style type="text/css" title="test-stylesheet"/>');
+        document.head.appendChild($styleSheet[0])
+        const styleSheet = [...document.styleSheets].find(sheet => sheet.title === 'test-stylesheet');
+
+        // border-radius
+        styleSheet.insertRule(`
+            .test-border-radius {
+                border-top-right-radius: 10%;
+                border-bottom-right-radius: 20%;
+                border-bottom-left-radius: 30%;
+                border-top-left-radius: 40%;
+            }
+        `, 0);
+        $editable.html(`<div class="test-border-radius"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-border-radius" style="border-radius:30%;box-sizing:border-box;"></div>`,
+            "should have converted border-[position]-radius styles (from class) to border-radius");
+        styleSheet.deleteRule(0);
+
+        // convert all positional styles to a style in the form `property: a b c d`
+
+        styleSheet.insertRule(`
+            .test-border {
+                border-top-style: dotted;
+                border-right-style: dashed;
+                border-left-style: solid;
+            }
+        `, 0);
+        $editable.html(`<div class="test-border"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-border" style="border-style:dotted dashed none solid;box-sizing:border-box;"></div>`,
+            "should have converted border-[position]-style styles (from class) to border-style");
+        styleSheet.deleteRule(0);
+
+        styleSheet.insertRule(`
+            .test-margin {
+                margin-right: 20px;
+                margin-bottom: 30px;
+                margin-left: 40px;
+            }
+        `, 0);
+        $editable.html(`<div class="test-margin"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-margin" style="margin:0 20px 30px 40px;box-sizing:border-box;"></div>`,
+            "should have converted margin-[position] styles (from class) to margin");
+        styleSheet.deleteRule(0);
+
+        styleSheet.insertRule(`
+            .test-padding {
+                padding-top: 10px;
+                padding-bottom: 30px;
+                padding-left: 40px;
+            }
+        `, 0);
+        $editable.html(`<div class="test-padding"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-padding" style="padding:10px 0 30px 40px;box-sizing:border-box;"></div>`,
+            "should have converted padding-[position] styles (from class) to padding");
+        styleSheet.deleteRule(0);
+
+        // convert all positional styles to a style in the form `property: a`
+
+        styleSheet.insertRule(`
+            .test-border-uniform {
+                border-top-style: dotted;
+                border-right-style: dotted;
+                border-bottom-style: dotted;
+                border-left-style: dotted;
+            }
+        `, 0);
+        $editable.html(`<div class="test-border-uniform"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-border-uniform" style="border-style:dotted;box-sizing:border-box;"></div>`,
+            "should have converted uniform border-[position]-style styles (from class) to border-style");
+        styleSheet.deleteRule(0);
+
+        styleSheet.insertRule(`
+            .test-margin-uniform {
+                margin-top: 10px;
+                margin-right: 10px;
+                margin-bottom: 10px;
+                margin-left: 10px;
+            }
+        `, 0);
+        $editable.html(`<div class="test-margin-uniform"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-margin-uniform" style="margin:10px;box-sizing:border-box;"></div>`,
+            "should have converted uniform margin-[position] styles (from class) to margin");
+        styleSheet.deleteRule(0);
+
+        styleSheet.insertRule(`
+            .test-padding-uniform {
+                padding-top: 10px;
+                padding-right: 10px;
+                padding-bottom: 10px;
+                padding-left: 10px;
+            }
+        `, 0);
+        $editable.html(`<div class="test-padding-uniform"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-padding-uniform" style="padding:10px;box-sizing:border-box;"></div>`,
+            "should have converted uniform padding-[position] styles (from class) to padding");
+        styleSheet.deleteRule(0);
+
+        // do not convert positional styles that include an "inherit" value
+
+        styleSheet.insertRule(`
+            .test-border-inherit {
+                border-top-style: dotted;
+                border-right-style: dashed;
+                border-bottom-style: inherit;
+                border-left-style: solid;
+            }
+        `, 0);
+        $editable.html(`<div class="test-border-inherit"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-border-inherit" style="box-sizing:border-box;border-left-style:solid;border-bottom-style:inherit;border-right-style:dashed;border-top-style:dotted;"></div>`,
+            "should not have converted border-[position]-style styles (from class) to border-style as they include an inherit");
+        styleSheet.deleteRule(0);
+
+        styleSheet.insertRule(`
+            .test-margin-inherit {
+                margin-top: 10px;
+                margin-right: inherit;
+                margin-bottom: 30px;
+                margin-left: 40px;
+            }
+        `, 0);
+        $editable.html(`<div class="test-margin-inherit"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-margin-inherit" style="box-sizing:border-box;margin-left:40px;margin-bottom:30px;margin-right:inherit;margin-top:10px;"></div>`,
+            "should not have converted margin-[position] styles (from class) to margin as they include an inherit");
+        styleSheet.deleteRule(0);
+
+        styleSheet.insertRule(`
+            .test-padding-inherit {
+                padding-top: 10px;
+                padding-right: 20px;
+                padding-bottom: inherit;
+                padding-left: 40px;
+            }
+        `, 0);
+        $editable.html(`<div class="test-padding-inherit"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-padding-inherit" style="box-sizing:border-box;padding-left:40px;padding-bottom:inherit;padding-right:20px;padding-top:10px;"></div>`,
+            "should have converted padding-[position] styles (from class) to padding as they include an inherit");
+        styleSheet.deleteRule(0);
+
+        // do not convert positional styles that include an "initial" value
+
+        // note: `border: initial` is automatically removed (tested in "remove
+        // unsupported styles")
+        styleSheet.insertRule(`
+            .test-margin-initial {
+                margin-top: initial;
+                margin-right: 20px;
+                margin-bottom: 30px;
+                margin-left: 40px;
+            }
+        `, 0);
+        $editable.html(`<div class="test-margin-initial"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-margin-initial" style="box-sizing:border-box;margin-left:40px;margin-bottom:30px;margin-right:20px;margin-top:initial;"></div>`,
+            "should not have converted margin-[position] styles (from class) to margin as they include an initial");
+        styleSheet.deleteRule(0);
+
+        styleSheet.insertRule(`
+            .test-padding-initial {
+                padding-top: 10px;
+                padding-right: 20px;
+                padding-bottom: 30px;
+                padding-left: initial;
+            }
+        `, 0);
+        $editable.html(`<div class="test-padding-initial"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-padding-initial" style="box-sizing:border-box;padding-left:initial;padding-bottom:30px;padding-right:20px;padding-top:10px;"></div>`,
+            "should not have converted padding-[position] styles (from class) to padding as they include an initial");
+        styleSheet.deleteRule(0);
+
+        $styleSheet.remove();
+    });
+    QUnit.test('remove unsupported styles', async function (assert) {
+        assert.expect(10);
+
+        const $styleSheet = $('<style type="text/css" title="test-stylesheet"/>');
+        document.head.appendChild($styleSheet[0])
+        const styleSheet = [...document.styleSheets].find(sheet => sheet.title === 'test-stylesheet');
+
+        // text-decoration-[prop]
+        styleSheet.insertRule(`
+            .test-decoration {
+                text-decoration-line: underline;
+                text-decoration-color: red;
+                text-decoration-style: solid;
+                text-decoration-thickness: 10px;
+            }
+        `, 0);
+        $editable.html(`<div class="test-decoration"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-decoration" style="text-decoration:underline;box-sizing:border-box;"></div>`,
+            "should have removed all text-decoration-[prop] styles (from class) and kept a simple text-decoration");
+        styleSheet.deleteRule(0);
+
+        // border[\w-]*: initial
+        styleSheet.insertRule(`
+            .test-border-initial {
+                border-top-style: dotted;
+                border-right-style: dashed;
+                border-bottom-style: double;
+                border-left-style: initial;
+            }
+        `, 0);
+        $editable.html(`<div class="test-border-initial"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-border-initial" style="box-sizing:border-box;border-bottom-style:double;border-right-style:dashed;border-top-style:dotted;"></div>`,
+            "should have removed border initial");
+        styleSheet.deleteRule(0);
+
+        // display: block (except for .btn-block)
+        styleSheet.insertRule(`
+            .test-block {
+                display: block;
+            }
+        `, 0);
+        $editable.html(`<div class="test-block"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-block" style="box-sizing:border-box;"></div>`,
+            "should have removed display block");
+        $editable.html(`<div class="btn-block"></div>`);
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="btn-block" style="box-sizing:border-box;width:100%;display:block;" width="100%"></div>`,
+            "should not have removed display block for .btn-block");
+        styleSheet.deleteRule(0);
+
+        // !important
+        styleSheet.insertRule(`
+            .test-unimportant-color {
+                color: blue;
+            }
+        `, 0);
+        $editable.html(`<div class="test-unimportant-color"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-unimportant-color" style="box-sizing:border-box;color:blue;"></div>`,
+            "should have converted a simple color");
+        styleSheet.insertRule(`
+            .test-important-color {
+                color: red !important;
+            }
+        `, 0);
+        $editable.html(`<div class="test-important-color test-unimportant-color"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-important-color test-unimportant-color" style="box-sizing:border-box;color:red;"></div>`,
+            "should have converted an important color and removed the !important");
+        styleSheet.deleteRule(0);
+        styleSheet.deleteRule(0);
+
+        // animation
+        styleSheet.insertRule(`
+            .test-animation {
+                animation: example 5s linear 2s infinite alternate;
+            }
+        `, 0);
+        $editable.html(`<div class="test-animation"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-animation" style="box-sizing:border-box;"></div>`,
+            "should have removed animation style");
+        styleSheet.deleteRule(0);
+        styleSheet.insertRule(`
+            .test-animation-specific {
+                animation-name: example;
+                animation-duration: 5s;
+                animation-timing-function: linear;
+                animation-delay: 2s;
+                animation-iteration-count: infinite;
+                animation-direction: alternate;
+            }
+        `, 0);
+        $editable.html(`<div class="test-animation-specific"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-animation-specific" style="box-sizing:border-box;"></div>`,
+            "should have removed all specific animation styles");
+        styleSheet.deleteRule(0);
+
+        // flex
+        styleSheet.insertRule(`
+            .test-flex {
+                flex: 0 1 auto;
+                flex-flow: column wrap;
+            }
+        `, 0);
+        $editable.html(`<div class="test-flex"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-flex" style="box-sizing:border-box;"></div>`,
+            "should have removed all flex styles");
+        styleSheet.deleteRule(0);
+        styleSheet.insertRule(`
+            .test-flex-specific {
+                display: flex;
+                flex-direction: row;
+                flex-wrap: wrap;
+                flex-basis: auto;
+                flex-shrink: 3;
+                flex-grow: 4;
+            }
+        `, 0);
+        $editable.html(`<div class="test-flex-specific"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-flex-specific" style="box-sizing:border-box;"></div>`,
+            "should have removed all specific flex styles");
+        styleSheet.deleteRule(0);
+
+        $styleSheet.remove();
+    });
+    QUnit.test('give .o_layout the styles of the body', async function (assert) {
+        assert.expect(1);
+
+        const $iframe = $('<iframe></iframe>');
+        $(document.body).append($iframe);
+        const $iframeEditable = $('<div/>');
+        $iframe.contents().find('body').append($iframeEditable);
+        const $styleSheet = $('<style type="text/css" title="test-stylesheet"/>');
+        $iframe.contents().find('head').append($styleSheet);
+        const styleSheet = [...$iframe.contents()[0].styleSheets].find(sheet => sheet.title === 'test-stylesheet');
+
+        styleSheet.insertRule(`
+            body {
+                background-color: red;
+                color: white;
+                font-size: 50px;
+            }
+        `, 0);
+        $iframeEditable.html(`<div class="o_layout" style="padding: 50px;"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($iframeEditable);
+        assert.strictEqual($iframeEditable.html(),
+            `<div class="o_layout" style="box-sizing:border-box;font-size:50px;color:white;background-color:red;padding: 50px;"></div>`,
+            "should have given all styles of body to .o_layout");
+        styleSheet.deleteRule(0);
+
+        $iframe.remove();
+    });
+    QUnit.test('convert classes to styles, preserving specificity', async function (assert) {
+        assert.expect(4);
+
+        const $styleSheet = $('<style type="text/css" title="test-stylesheet"/>');
+        document.head.appendChild($styleSheet[0])
+        const styleSheet = [...document.styleSheets].find(sheet => sheet.title === 'test-stylesheet');
+
+        styleSheet.insertRule(`
+            div.test-color {
+                color: green;
+            }
+        `, 0);
+        styleSheet.insertRule(`
+            .test-color {
+                color: red;
+            }
+        `, 1);
+        styleSheet.insertRule(`
+            .test-color {
+                color: blue;
+            }
+        `, 2);
+
+        $editable.html(`<span class="test-color"></span>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<span class="test-color" style="box-sizing:border-box;color:blue;"></span>`,
+            "should have prioritized the last defined style");
+
+        $editable.html(`<div class="test-color"></div>`);
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-color" style="box-sizing:border-box;color:green;"></div>`,
+            "should have prioritized the more specific style");
+
+        $editable.html(`<div class="test-color" style="color: yellow;"></div>`);
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-color" style="box-sizing:border-box;color: yellow;"></div>`,
+            "should have prioritized the inline style");
+
+        styleSheet.insertRule(`
+            .test-color {
+                color: black !important;
+            }
+        `, 0);
+        $editable.html(`<div class="test-color"></div>`);
+        document._rulesCache = undefined;
+        convertInline.classToStyle($editable);
+        assert.strictEqual($editable.html(),
+            `<div class="test-color" style="box-sizing:border-box;color:black;"></div>`,
+            "should have prioritized the important style");
+
+        styleSheet.deleteRule(0);
+        styleSheet.deleteRule(0);
+        styleSheet.deleteRule(0);
+        styleSheet.deleteRule(0);
+
+        $styleSheet.remove();
+    });
+});
+
+});

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -5,7 +5,7 @@ import {getGridHtml, getTableHtml, getRegularGridHtml, getRegularTableHtml} from
 
 QUnit.module('web_editor', {}, function () {
 QUnit.module('convert_inline', {}, function () {
-    const $editable = $('<div/>');
+    let $editable;
 
     QUnit.module('Convert Bootstrap grids to tables');
     // Test bootstrapToTable, cardToTable and listGroupToTable
@@ -14,25 +14,25 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(4);
 
         // 1x1
-        $editable.html(getRegularGridHtml(1, 1));
+        $editable = $(`<div>${getRegularGridHtml(1, 1)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getRegularTableHtml(1, 1, 12, 100),
             "should have converted a 1x1 grid to an equivalent table");
 
         // 1x2
-        $editable.html(getRegularGridHtml(1, 2));
+        $editable = $(`<div>${getRegularGridHtml(1, 2)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getRegularTableHtml(1, 2, 6, 50),
             "should have converted a 1x2 grid to an equivalent table");
 
         // 1x3
-        $editable.html(getRegularGridHtml(1, 3));
+        $editable = $(`<div>${getRegularGridHtml(1, 3)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getRegularTableHtml(1, 3, 4, 33),
             "should have converted a 1x3 grid to an equivalent table");
 
         // 1x12
-        $editable.html(getRegularGridHtml(1, 12));
+        $editable = $(`<div>${getRegularGridHtml(1, 12)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getRegularTableHtml(1, 12, 1, 8),
             "should have converted a 1x12 grid to an equivalent table");
@@ -41,7 +41,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(4);
 
         // 1x13
-        $editable.html(getRegularGridHtml(1, 13));
+        $editable = $(`<div>${getRegularGridHtml(1, 13)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 12, 1, 8).slice(0, -8) +
@@ -49,7 +49,7 @@ QUnit.module('convert_inline', {}, function () {
             "should have converted a 1x13 grid to an equivalent table (overflowing)");
 
         // 1x14
-        $editable.html(getRegularGridHtml(1, 14));
+        $editable = $(`<div>${getRegularGridHtml(1, 14)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 12, 1, 8).slice(0, -8) +
@@ -58,7 +58,7 @@ QUnit.module('convert_inline', {}, function () {
             "should have converted a 1x14 grid to an equivalent table (overflowing)");
 
         // 1x25
-        $editable.html(getRegularGridHtml(1, 25));
+        $editable = $(`<div>${getRegularGridHtml(1, 25)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 12, 1, 8).slice(0, -8) +
@@ -68,7 +68,7 @@ QUnit.module('convert_inline', {}, function () {
             "should have converted a 1x25 grid to an equivalent table (overflowing)");
 
         // 1x26
-        $editable.html(getRegularGridHtml(1, 26));
+        $editable = $(`<div>${getRegularGridHtml(1, 26)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 12, 1, 8).slice(0, -8) +
@@ -82,25 +82,25 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(4);
 
         // 2x1
-        $editable.html(getRegularGridHtml(2, 1));
+        $editable = $(`<div>${getRegularGridHtml(2, 1)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getRegularTableHtml(2, 1, 12, 100),
             "should have converted a 2x1 grid to an equivalent table");
 
         // 2x[1,2]
-        $editable.html(getRegularGridHtml(2, [1, 2]));
+        $editable = $(`<div>${getRegularGridHtml(2, [1, 2])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getRegularTableHtml(2, [1, 2], [12, 6], [100, 50]),
             "should have converted a 2x[1,2] grid to an equivalent table");
 
         // 3x3
-        $editable.html(getRegularGridHtml(3, 3));
+        $editable = $(`<div>${getRegularGridHtml(3, 3)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getRegularTableHtml(3, 3, 4, 33),
             "should have converted a 3x3 grid to an equivalent table");
 
         // 3x[3,2,1]
-        $editable.html(getRegularGridHtml(3, [3,2,1]));
+        $editable = $(`<div>${getRegularGridHtml(3, [3,2,1])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getRegularTableHtml(3, [3, 2, 1], [4, 6, 12], [33, 50, 100]),
             "should have converted a 3x[3,2,1] grid to an equivalent table");
@@ -109,7 +109,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(4);
 
         // 2x[13,1]
-        $editable.html(getRegularGridHtml(2, [13, 1]));
+        $editable = $(`<div>${getRegularGridHtml(2, [13, 1])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 12, 1, 8).slice(0, -8) +
@@ -118,7 +118,7 @@ QUnit.module('convert_inline', {}, function () {
             "should have converted a 2x[13,1] grid to an equivalent table (overflowing)");
 
         // 2x[1,13]
-        $editable.html(getRegularGridHtml(2, [1, 13]));
+        $editable = $(`<div>${getRegularGridHtml(2, [1, 13])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(2, [1, 12], [12, 1], [100, 8]).slice(0, -8) +
@@ -126,7 +126,7 @@ QUnit.module('convert_inline', {}, function () {
             "should have converted a 2x[1,13] grid to an equivalent table (overflowing)");
 
         // 3x[1,13,6]
-        $editable.html(getRegularGridHtml(3, [1, 13, 6]));
+        $editable = $(`<div>${getRegularGridHtml(3, [1, 13, 6])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(2, [1, 12], [12, 1], [100, 8]).slice(0, -8) +
@@ -135,7 +135,7 @@ QUnit.module('convert_inline', {}, function () {
             "should have converted a 3x[1,13,6] grid to an equivalent table (overflowing)");
 
         // 3x[1,6,13]
-        $editable.html(getRegularGridHtml(3, [1, 6, 13]));
+        $editable = $(`<div>${getRegularGridHtml(3, [1, 6, 13])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(3, [1, 6, 12], [12, 2, 1], [100, 17, 8]).slice(0, -8) +
@@ -146,13 +146,13 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(2);
 
         // 1x2
-        $editable.html(getGridHtml([[8, 4]]));
+        $editable = $(`<div>${getGridHtml([[8, 4]])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getTableHtml([[[8, 67], [4, 33]]]),
             "should have converted a 1x2 irregular grid to an equivalent table");
 
         // 1x3
-        $editable.html(getGridHtml([[2, 3, 7]]));
+        $editable = $(`<div>${getGridHtml([[2, 3, 7]])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getTableHtml([[[2, 17], [3, 25], [7, 58]]]),
             "should have converted a 1x3 grid to an equivalent table");
@@ -161,7 +161,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(2);
 
         // 1x2
-        $editable.html(getGridHtml([[8, 5]]));
+        $editable = $(`<div>${getGridHtml([[8, 5]])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getTableHtml([
                 [[8, 67], [4, 33, '']],
@@ -170,7 +170,7 @@ QUnit.module('convert_inline', {}, function () {
             "should have converted a 1x2 irregular overflowing grid to an equivalent table");
 
         // 1x3
-        $editable.html(getGridHtml([[7, 6, 9]]));
+        $editable = $(`<div>${getGridHtml([[7, 6, 9]])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getTableHtml([
                 [[7, 58], [5, 42, '']],
@@ -183,13 +183,13 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(2);
 
         // 2x2
-        $editable.html(getGridHtml([[1, 11], [2, 10]]));
+        $editable = $(`<div>${getGridHtml([[1, 11], [2, 10]])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getTableHtml([[[1, 8], [11, 92]], [[2, 17], [10, 83]]]),
             "should have converted a 2x2 irregular grid to an equivalent table");
 
         // 2x[2,3]
-        $editable.html(getGridHtml([[3, 9], [4, 6, 2]]));
+        $editable = $(`<div>${getGridHtml([[3, 9], [4, 6, 2]])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getTableHtml([[[3, 25], [9, 75]], [[4, 33], [6, 50], [2, 17]]]),
             "should have converted a 2x[2,3] irregular grid to an equivalent table");
@@ -198,7 +198,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(3);
 
         // 2x2 (both rows overflow)
-        $editable.html(getGridHtml([[6, 8], [7, 9]]));
+        $editable = $(`<div>${getGridHtml([[6, 8], [7, 9]])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getTableHtml([
@@ -210,7 +210,7 @@ QUnit.module('convert_inline', {}, function () {
             "should have converted a 2x[1,13] irregular grid to an equivalent table (both rows overflowing)");
 
         // 2x[2,3] (first row overflows)
-        $editable.html(getGridHtml([[5, 8], [4, 2, 6]]));
+        $editable = $(`<div>${getGridHtml([[5, 8], [4, 2, 6]])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getTableHtml([
@@ -221,7 +221,7 @@ QUnit.module('convert_inline', {}, function () {
             "should have converted a 2x[2,3] irregular grid to an equivalent table (first row overflowing)");
 
         // 2x[3,2] (second row overflows)
-        $editable.html(getGridHtml([[4, 2, 6], [5, 8]]));
+        $editable = $(`<div>${getGridHtml([[4, 2, 6], [5, 8]])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getTableHtml([
@@ -314,8 +314,8 @@ QUnit.module('convert_inline', {}, function () {
             `</div>` +
         `</div>`;
 
+        $editable = $(`<div>${testDom}</div>`);
         document.body.append($editable[0]);
-        $editable.html(testDom);
         convertInline.normalizeRem($editable);
         assert.strictEqual($editable.html(),
             `<div style="font-size: 24px;">` +
@@ -325,11 +325,12 @@ QUnit.module('convert_inline', {}, function () {
             `</div>`,
             "should have converted several rem sizes to px using the default rem size"
         );
+        $editable.remove();
 
         const html = document.createElement('html');
         html.style.setProperty('font-size', '20px');
+        $editable = $(`<div>${testDom}</div>`);
         html.append($editable[0]);
-        $editable.html(testDom);
         convertInline.normalizeRem($editable);
         assert.strictEqual($editable.html(),
             `<div style="font-size: 40px;">` +
@@ -339,7 +340,6 @@ QUnit.module('convert_inline', {}, function () {
             `</div>`,
             "should have converted several rem sizes to px using a set rem size"
         );
-
         $editable.remove();
     });
     QUnit.test('move padding from snippet containers to cells', async function (assert) {
@@ -412,7 +412,7 @@ QUnit.module('convert_inline', {}, function () {
         `</table>`;
 
         // table.o_mail_snippet_general
-        $editable.html(testTable);
+        $editable = $(`<div>${testTable}</div>`);
         convertInline.formatTables($editable);
         assert.strictEqual($editable.html(), expectedTable,
             "should have moved the padding from table.o_mail_snippet_general and table in it to their respective cells"
@@ -421,7 +421,7 @@ QUnit.module('convert_inline', {}, function () {
     QUnit.test('add a tbody to any table that doesn\'t have one', async function (assert) {
         assert.expect(1);
 
-        $editable.html(`<table><tr><td>I don't have a body :'(</td></tr></table>`);
+        $editable = $(`<div>${`<table><tr><td>I don't have a body :'(</td></tr></table>`}</div>`);
         $editable.find('tr').unwrap();
         convertInline.formatTables($editable);
         assert.strictEqual($editable.html(), `<table><tbody style="vertical-align: top;"><tr><td>I don't have a body :'(</td></tr></tbody></table>`,
@@ -431,19 +431,19 @@ QUnit.module('convert_inline', {}, function () {
     QUnit.test('add number heights to parents of elements with percent heights', async function (assert) {
         assert.expect(3);
 
-        $editable.html(`<table><tbody><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`);
+        $editable = $(`<div>${`<table><tbody><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`}</div>`);
         convertInline.formatTables($editable);
         assert.strictEqual($editable.html(), `<table><tbody style="height: 0px;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`,
             "should have added a 0 height to the parent of a 100% height element"
         );
 
-        $editable.html(`<table><tbody style="height: 200px;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`);
+        $editable = $(`<div>${`<table><tbody style="height: 200px;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`}</div>`);
         convertInline.formatTables($editable);
         assert.strictEqual($editable.html(), `<table><tbody style="height: 200px;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`,
             "should not have changed the height of the parent of a 100% height element"
         );
 
-        $editable.html(`<table><tbody style="height: 50%;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`);
+        $editable = $(`<div>${`<table><tbody style="height: 50%;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`}</div>`);
         convertInline.formatTables($editable);
         assert.strictEqual($editable.html(), `<table style="height: 0px;"><tbody style="height: 50%;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`,
             "should have changed the height of the grandparent of a 100% height element"
@@ -520,7 +520,7 @@ QUnit.module('convert_inline', {}, function () {
     QUnit.test('convert Bootstrap classes to inline styles', async function (assert) {
         assert.expect(1);
 
-        $editable.html(`<div class="container"><div class="row"><div class="col">Hello</div></div></div>`);
+        $editable = $(`<div>${`<div class="container"><div class="row"><div class="col">Hello</div></div></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         const containerStyle = `padding:0 16px 0 16px;margin:0 auto 0 auto;box-sizing:border-box;max-width:1140px;width:100%;`;
         const rowStyle = `margin:0 -16px 0 -16px;box-sizing:border-box;`;
@@ -548,7 +548,7 @@ QUnit.module('convert_inline', {}, function () {
                 border-top-left-radius: 40%;
             }
         `, 0);
-        $editable.html(`<div class="test-border-radius"></div>`);
+        $editable = $(`<div>${`<div class="test-border-radius"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border-radius" style="border-radius:30%;box-sizing:border-box;"></div>`,
@@ -564,7 +564,7 @@ QUnit.module('convert_inline', {}, function () {
                 border-left-style: solid;
             }
         `, 0);
-        $editable.html(`<div class="test-border"></div>`);
+        $editable = $(`<div>${`<div class="test-border"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border" style="border-style:dotted dashed none solid;box-sizing:border-box;"></div>`,
@@ -578,7 +578,7 @@ QUnit.module('convert_inline', {}, function () {
                 margin-left: 40px;
             }
         `, 0);
-        $editable.html(`<div class="test-margin"></div>`);
+        $editable = $(`<div>${`<div class="test-margin"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-margin" style="margin:0 20px 30px 40px;box-sizing:border-box;"></div>`,
@@ -592,7 +592,7 @@ QUnit.module('convert_inline', {}, function () {
                 padding-left: 40px;
             }
         `, 0);
-        $editable.html(`<div class="test-padding"></div>`);
+        $editable = $(`<div>${`<div class="test-padding"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-padding" style="padding:10px 0 30px 40px;box-sizing:border-box;"></div>`,
@@ -609,7 +609,7 @@ QUnit.module('convert_inline', {}, function () {
                 border-left-style: dotted;
             }
         `, 0);
-        $editable.html(`<div class="test-border-uniform"></div>`);
+        $editable = $(`<div>${`<div class="test-border-uniform"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border-uniform" style="border-style:dotted;box-sizing:border-box;"></div>`,
@@ -624,7 +624,7 @@ QUnit.module('convert_inline', {}, function () {
                 margin-left: 10px;
             }
         `, 0);
-        $editable.html(`<div class="test-margin-uniform"></div>`);
+        $editable = $(`<div>${`<div class="test-margin-uniform"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-margin-uniform" style="margin:10px;box-sizing:border-box;"></div>`,
@@ -639,7 +639,7 @@ QUnit.module('convert_inline', {}, function () {
                 padding-left: 10px;
             }
         `, 0);
-        $editable.html(`<div class="test-padding-uniform"></div>`);
+        $editable = $(`<div>${`<div class="test-padding-uniform"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-padding-uniform" style="padding:10px;box-sizing:border-box;"></div>`,
@@ -656,7 +656,7 @@ QUnit.module('convert_inline', {}, function () {
                 border-left-style: solid;
             }
         `, 0);
-        $editable.html(`<div class="test-border-inherit"></div>`);
+        $editable = $(`<div>${`<div class="test-border-inherit"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border-inherit" style="box-sizing:border-box;border-left-style:solid;border-bottom-style:inherit;border-right-style:dashed;border-top-style:dotted;"></div>`,
@@ -671,7 +671,7 @@ QUnit.module('convert_inline', {}, function () {
                 margin-left: 40px;
             }
         `, 0);
-        $editable.html(`<div class="test-margin-inherit"></div>`);
+        $editable = $(`<div>${`<div class="test-margin-inherit"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-margin-inherit" style="box-sizing:border-box;margin-left:40px;margin-bottom:30px;margin-right:inherit;margin-top:10px;"></div>`,
@@ -686,7 +686,7 @@ QUnit.module('convert_inline', {}, function () {
                 padding-left: 40px;
             }
         `, 0);
-        $editable.html(`<div class="test-padding-inherit"></div>`);
+        $editable = $(`<div>${`<div class="test-padding-inherit"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-padding-inherit" style="box-sizing:border-box;padding-left:40px;padding-bottom:inherit;padding-right:20px;padding-top:10px;"></div>`,
@@ -705,7 +705,7 @@ QUnit.module('convert_inline', {}, function () {
                 margin-left: 40px;
             }
         `, 0);
-        $editable.html(`<div class="test-margin-initial"></div>`);
+        $editable = $(`<div>${`<div class="test-margin-initial"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-margin-initial" style="box-sizing:border-box;margin-left:40px;margin-bottom:30px;margin-right:20px;margin-top:initial;"></div>`,
@@ -720,7 +720,7 @@ QUnit.module('convert_inline', {}, function () {
                 padding-left: initial;
             }
         `, 0);
-        $editable.html(`<div class="test-padding-initial"></div>`);
+        $editable = $(`<div>${`<div class="test-padding-initial"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-padding-initial" style="box-sizing:border-box;padding-left:initial;padding-bottom:30px;padding-right:20px;padding-top:10px;"></div>`,
@@ -745,7 +745,7 @@ QUnit.module('convert_inline', {}, function () {
                 text-decoration-thickness: 10px;
             }
         `, 0);
-        $editable.html(`<div class="test-decoration"></div>`);
+        $editable = $(`<div>${`<div class="test-decoration"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-decoration" style="text-decoration:underline;box-sizing:border-box;"></div>`,
@@ -761,7 +761,7 @@ QUnit.module('convert_inline', {}, function () {
                 border-left-style: initial;
             }
         `, 0);
-        $editable.html(`<div class="test-border-initial"></div>`);
+        $editable = $(`<div>${`<div class="test-border-initial"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border-initial" style="box-sizing:border-box;border-bottom-style:double;border-right-style:dashed;border-top-style:dotted;"></div>`,
@@ -774,12 +774,12 @@ QUnit.module('convert_inline', {}, function () {
                 display: block;
             }
         `, 0);
-        $editable.html(`<div class="test-block"></div>`);
+        $editable = $(`<div>${`<div class="test-block"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-block" style="box-sizing:border-box;"></div>`,
             "should have removed display block");
-        $editable.html(`<div class="btn-block"></div>`);
+        $editable = $(`<div>${`<div class="btn-block"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="btn-block" style="box-sizing:border-box;width:100%;display:block;" width="100%"></div>`,
@@ -792,7 +792,7 @@ QUnit.module('convert_inline', {}, function () {
                 color: blue;
             }
         `, 0);
-        $editable.html(`<div class="test-unimportant-color"></div>`);
+        $editable = $(`<div>${`<div class="test-unimportant-color"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-unimportant-color" style="box-sizing:border-box;color:blue;"></div>`,
@@ -802,7 +802,7 @@ QUnit.module('convert_inline', {}, function () {
                 color: red !important;
             }
         `, 0);
-        $editable.html(`<div class="test-important-color test-unimportant-color"></div>`);
+        $editable = $(`<div>${`<div class="test-important-color test-unimportant-color"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-important-color test-unimportant-color" style="box-sizing:border-box;color:red;"></div>`,
@@ -816,7 +816,7 @@ QUnit.module('convert_inline', {}, function () {
                 animation: example 5s linear 2s infinite alternate;
             }
         `, 0);
-        $editable.html(`<div class="test-animation"></div>`);
+        $editable = $(`<div>${`<div class="test-animation"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-animation" style="box-sizing:border-box;"></div>`,
@@ -832,7 +832,7 @@ QUnit.module('convert_inline', {}, function () {
                 animation-direction: alternate;
             }
         `, 0);
-        $editable.html(`<div class="test-animation-specific"></div>`);
+        $editable = $(`<div>${`<div class="test-animation-specific"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-animation-specific" style="box-sizing:border-box;"></div>`,
@@ -846,7 +846,7 @@ QUnit.module('convert_inline', {}, function () {
                 flex-flow: column wrap;
             }
         `, 0);
-        $editable.html(`<div class="test-flex"></div>`);
+        $editable = $(`<div>${`<div class="test-flex"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-flex" style="box-sizing:border-box;"></div>`,
@@ -862,7 +862,7 @@ QUnit.module('convert_inline', {}, function () {
                 flex-grow: 4;
             }
         `, 0);
-        $editable.html(`<div class="test-flex-specific"></div>`);
+        $editable = $(`<div>${`<div class="test-flex-specific"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-flex-specific" style="box-sizing:border-box;"></div>`,
@@ -889,7 +889,7 @@ QUnit.module('convert_inline', {}, function () {
                 font-size: 50px;
             }
         `, 0);
-        $iframeEditable.html(`<div class="o_layout" style="padding: 50px;"></div>`);
+        $iframeEditable.append(`<div class="o_layout" style="padding: 50px;"></div>`);
         convertInline.classToStyle($iframeEditable, convertInline.getCSSRules($iframeEditable[0].ownerDocument));
         assert.strictEqual($iframeEditable.html(),
             `<div class="o_layout" style="box-sizing:border-box;font-size:50px;color:white;background-color:red;padding: 50px;"></div>`,
@@ -921,19 +921,19 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 2);
 
-        $editable.html(`<span class="test-color"></span>`);
+        $editable = $(`<div>${`<span class="test-color"></span>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<span class="test-color" style="box-sizing:border-box;color:blue;"></span>`,
             "should have prioritized the last defined style");
 
-        $editable.html(`<div class="test-color"></div>`);
+        $editable = $(`<div>${`<div class="test-color"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-color" style="box-sizing:border-box;color:green;"></div>`,
             "should have prioritized the more specific style");
 
-        $editable.html(`<div class="test-color" style="color: yellow;"></div>`);
+        $editable = $(`<div>${`<div class="test-color" style="color: yellow;"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-color" style="box-sizing:border-box;color: yellow;"></div>`,
@@ -944,7 +944,7 @@ QUnit.module('convert_inline', {}, function () {
                 color: black !important;
             }
         `, 0);
-        $editable.html(`<div class="test-color"></div>`);
+        $editable = $(`<div>${`<div class="test-color"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-color" style="box-sizing:border-box;color:black;"></div>`,

--- a/addons/web_editor/static/tests/test_utils.js
+++ b/addons/web_editor/static/tests/test_utils.js
@@ -722,6 +722,137 @@ var textInput = function (target, char) {
     }
 };
 
+//--------------------------------------------------------------------------
+// Convert Inline
+//--------------------------------------------------------------------------
+
+const tableAttributes = {
+    cellspacing: 0,
+    cellpadding: 0,
+    border: 0,
+    width: '100%',
+    align: 'center',
+    role: 'presentation',
+};
+const tableAttributesString = Object.keys(tableAttributes).map(key => `${key}="${tableAttributes[key]}"`).join(' ');
+const tableStyles = {
+    'border-collapse': 'collapse',
+    'text-align': 'inherit',
+    'font-size': 'unset',
+    'line-height': 'unset',
+};
+const tableStylesString = Object.keys(tableStyles).map(key => `${key}: ${tableStyles[key]};`).join(' ');
+/**
+ * Take a matrix representing a grid and return an HTML string of the Bootstrap
+ * grid. The matrix is an array of rows, with each row being an array of cells.
+ * Each cell can be represented either by a 0 < number < 13 (col-#) or a falsy
+ * value (col). Each cell has its coordinates `(row index, column index)` as
+ * text content.
+ * Eg: [                        // <div class="container">
+ *      [                       //     <div class="row">
+ *          1,                  //         <div class="col-1">(0, 0)</div>
+ *          11,                 //         <div class="col-11">(0, 1)</div>
+ *      ],                      //     </div>
+ *      [                       //     <div class="row">
+ *          false,              //         <div class="col">(1, 0)</div>
+ *      ],                      //     </div>
+ * ]                            // </div>
+ *
+ * @param {Array<Array<Number|null>>} matrix
+ * @returns {string}
+ */
+function getGridHtml(matrix) {
+    return (
+        `<div class="container">` +
+        matrix.map((row, iRow) => (
+            `<div class="row">` +
+            row.map((col, iCol) => (
+                `<div class="${col ? 'col-' + col : 'col'}">(${iRow}, ${iCol})</div>`
+            )).join('') +
+            `</div>`
+        )).join('') +
+        `</div>`
+    );
+}
+/**
+ * Take a matrix representing a table and return an HTML string of the table.
+ * The matrix is an array of rows, with each row being an array of cells. Each
+ * cell is represented by a tuple of numbers [colspan, width (in percent)]. A
+ * cell can have a string as third value to represent its text content. The
+ * default text content of each cell is its coordinates `(row index, column
+ * index)`.
+ * Eg: [                        // <table> (note: extra attrs and styles apply)
+ *      [                       //   <tr>
+ *          [1, 8],             //     <td colspan="1" width="8%">(0, 0)</td>
+ *          [11, 92]            //     <td colspan="11" width="92%">(0, 1)</td>
+ *      ],                      //   </tr>
+ *      [                       //   <tr>
+ *          [2, 17, 'A'],       //     <td colspan="2" width="17%">A</td>
+ *          [10, 83],           //     <td colspan="10" width="83%">(1, 1)</td>
+ *      ],                      //   </tr>
+ * ]                            // </table>
+ *
+ * @param {Array<Array<Array<[Number, Number, string?]>>>} matrix
+ * @returns {string}
+ */
+function getTableHtml(matrix) {
+    return (
+        `<table ${tableAttributesString} style="width: 100% !important; ${tableStylesString}">` +
+        matrix.map((row, iRow) => (
+            `<tr>` +
+            row.map((col, iCol) => (
+                `<td colspan="${col[0]}" width="${col[1]}%" style="width: ${col[1]}%;">` +
+                (col.length === 3 ? col[2] : `(${iRow}, ${iCol})`) +
+                `</td>`
+            )).join('') +
+            `</tr>`
+        )).join('') +
+        `</table>`
+    );
+}
+/**
+ * Take a number of rows and a number of columns (or number of columns per
+ * individual row) and return an HTML string of the corresponding grid. Every
+ * column is a regular Bootstrap "col" (no col-#).
+ * Eg: [2, 3] <=> getGridHtml([[false, false, false], [false, false, false]])
+ * Eg: [2, [2, 1]] <=> getGridHtml([[false, false], [false]])
+ *
+ * @see getGridHtml
+ * @param {Number} nRows
+ * @param {Number|Number[]} nCols
+ * @returns {string}
+ */
+function getRegularGridHtml(nRows, nCols) {
+    const matrix = new Array(nRows).fill().map((_, iRow) => (
+        new Array(Array.isArray(nCols) ? nCols[iRow] : nCols).fill()
+    ));
+    return getGridHtml(matrix);
+};
+/**
+ * Take a number of rows, a number of columns (or number of columns per
+ * individual row), a colspan (or colspan per individual row) and a width (or
+ * width per individual row, in percent), and return an HTML string of the
+ * corresponding table. Every cell in a row has the same colspan/width.
+ * Eg: [2, 2, 6, 50] <=> getTableHtml([[[6, 50], [6, 50]], [[6, 50], [6, 50]]])
+ * Eg: [2, [2, 1], [6, 12], [50, 100]] <=> getTableHtml([[[6, 50], [6, 50]], [[12, 100]]])
+ *
+ * @see getTableHtml
+ * @param {Number} nRows
+ * @param {Number|Number[]} nCols
+ * @param {Number|Number[]} colspan
+ * @param {Number|Number[]} width
+ * @returns {string}
+ */
+function getRegularTableHtml(nRows, nCols, colspan, width) {
+    const matrix = new Array(nRows).fill().map((_, iRow) => (
+        new Array(Array.isArray(nCols) ? nCols[iRow] : nCols).fill().map(() => ([
+            Array.isArray(colspan) ? colspan[iRow] : colspan,
+            Array.isArray(width) ? width[iRow] : width,
+        ])))
+    );
+    return getTableHtml(matrix);
+}
+
 return {
     wysiwygData: wysiwygData,
     createWysiwyg: createWysiwyg,
@@ -730,6 +861,10 @@ return {
     keydown: keydown,
     patch: patch,
     unpatch: unpatch,
+    getGridHtml: getGridHtml,
+    getTableHtml: getTableHtml,
+    getRegularGridHtml: getRegularGridHtml,
+    getRegularTableHtml: getRegularTableHtml,
 };
 
 


### PR DESCRIPTION
This provide tests for the main unit testable functions of `convert_inline`, as well as a couple of test utils to that purpose.

As a result of these tests:
- This fixes an issue with the conversion to table of rows that had such long columns that they should span more than two rows.
- When converting the last row of a grid to a table row, we may end up having handled all of its columns, but there is still space in the row. This ensures we properly insert the columns and fill the row.
- When converting a list-group to a table, we sometimes ended up with <li> in <td> element, which is non-sense and is hereby corrected.
- For the purpose of good compatibility across email clients, we need paddings to be applied to cells rather than to tables. The mechanism in charge of that wrongly added up the paddings, and excessively rounded them to integers. This commit fixes these issues.
- A percentage height will only be applied on an element whose parent has a set pixel height. This is why convert_inline applies a pixel height to the parent of each element with a percentage height when possible. But it failed in the case where said parent also had a percentage height. This keeps looking up the tree until we find an appropriate suitor for that pixel height.
- When converting an rem size to a pixel size, we sometimes ended up with values with many decimal places. This rounds them to one decimal place.
- There was dead code in `addTables` that would never get triggered. When fixing that, the code crashed because of a reference to the wrong variable. Those two problems are hereby fixed.
- There was a section of code in `getMatchedCSSRules` that didn't do anything. Essentially its loop did `a === b ? a = b : break`. As for what was done before the loop (a = b), it's what is done with the styles returned by `getMatchedCSSRules` in `classToStyle`.
- This covers minor refactors in convert_inline, and adds docstrings to some of its functions that were missing them.
- This introduces a doctype declaration in the initialization of html fields iframes and wysiwyg iframes. That prevents the browser from rendering in [Quirks mode](https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode) which makes tables override the usual style inheritance patterns. As a result, this fixes an issue with text colors and alignments that were lost on converting divs to table structures.
- When saving an email, its contents pass through convert_inline to ensure wide e-mail client compatibility. One phase of that process is the conversion of classes to inline styles, which involves parsing through all the styles in all the stylesheets of the document, and matching them with each element in the DOM. That is an extremely expensive process and because of that, saving an e-mail can take a very long time depending on how large the DOM is. This refactors it for performance gains. Tested on an exaggeratingly big DOM, what used to take about 12s now takes about 5s:
    - The process of parsing through the document's stylesheets is now done on opening the email (about 500ms) rather than on saving it so we split the processing time between the two.
    - When parsing the stylesheets, we now also preprocess them by grouping whatever can be grouped together and precomputing the specificity so   as to sort them appropriately. This has the benefit of considerably reducing the number of rules to iterate over for each element (from 11k+ to 3k+).
    - In the process, some things were re-written for improved readability.
- This simply reorders (alphabetically and public/private), renames and document (with docstrings) all functions of convert_inline.
- This adds a `toInline` function that replaces the code that was duplicated between convert_inline and mass_mailing_widget. The duplication was confusing and error prone.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
