### PR TITLE
[FIX] l10n_fr_fec: test wizard should have test_file = True

### DIFF
--- a/addons/l10n_fr_fec/tests/test_wizard.py
+++ b/addons/l10n_fr_fec/tests/test_wizard.py
@@ -41,7 +41,8 @@ class TestAccountFrFec(AccountTestInvoicingCommon):
         cls.wizard = cls.env['account.fr.fec'].create({
             'date_from': fields.Date.today() - timedelta(days=1),
             'date_to': fields.Date.today() + timedelta(days=1),
-            'export_type': 'official'
+            'export_type': 'official',
+            'test_file': True,
         })
 
     def test_generate_fec_sanitize_pieceref(self):


### PR DESCRIPTION
This error is blocking staging.15.0 because of the l10n_standalone test, as there must be some invoice in the demo db used for the tests which is not posted.

The FEC export, if the `test_file` flag is False, tries to lock the fiscal year, and it raises this error:

```
File "/data/build/odoo/addons/account/models/company.py", line 286, in write 
    self._validate_fiscalyear_lock(values)
File "/data/build/odoo/addons/account/models/company.py", line 258, in _validate_fiscalyear_lock
    raise RedirectWarning(error_msg, action_error, _('Show unposted entries')) 
odoo.exceptions.RedirectWarning: ('There are still unposted entries in the period you want to lock. You should either post or delete them.', {'view_mode': 'tree', 'name': 'Unposted Entries', 'res_model': 'account.move', 'type': 'ir.actions.act_window', 'domain': [('id', 'in', [1312])], 'search_view_id': [546, 'search'], 'views': [[536, 'list'], [545, 'form']]}, 'Show unposted entries', None)
```