### PR TITLE
[FIX] crm: update query counter

### DIFF
--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -174,7 +174,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         leads.flush()
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=6921):  # 6909-6915 generally
+            with self.assertQueryCount(user_sales_manager=6922):  # 6909-6915 generally
                 self.env['crm.team'].browse(sales_teams.ids)._action_assign_leads(work_days=30)
 
         # teams assign


### PR DESCRIPTION
Sometimes an additional query happens. Logged once in about 2 weeks but let us
avoid red runbot.
