### PR TITLE
[FIX] point_of_sale : Wrong price when using SO

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1804,6 +1804,7 @@ exports.Orderline = Backbone.Model.extend({
     initialize: function(attr,options){
         this.pos   = options.pos;
         this.order = options.order;
+        this.price_manually_set = options.price_manually_set || false;
         if (options.json) {
             try {
                 this.init_from_JSON(options.json);
@@ -1823,7 +1824,6 @@ exports.Orderline = Backbone.Model.extend({
         this.price_extra = 0;
         this.full_product_name = '';
         this.id = orderline_id++;
-        this.price_manually_set = false;
         this.customerNote = this.customerNote || '';
 
         if (options.price) {
@@ -1836,6 +1836,7 @@ exports.Orderline = Backbone.Model.extend({
         this.product = this.pos.db.get_product_by_id(json.product_id);
         this.set_product_lot(this.product);
         this.price = json.price_unit;
+        this.price_manually_set = json.price_manually_set;
         this.set_discount(json.discount);
         this.set_quantity(json.qty, 'do not recompute unit price');
         this.set_description(json.description);
@@ -2135,7 +2136,8 @@ exports.Orderline = Backbone.Model.extend({
             full_product_name: this.get_full_product_name(),
             price_extra: this.get_price_extra(),
             customer_note: this.get_customer_note(),
-            refunded_orderline_id: this.refunded_orderline_id
+            refunded_orderline_id: this.refunded_orderline_id,
+            price_manually_set: this.price_manually_set
         };
     },
     //used to create a json of the ticket, to be sent to the printer


### PR DESCRIPTION
Current behavior:
When changing unit price in the SO of a product tracked by SN
the price reset to the normal price when entering the SN in the PoS.

Expected behavior:
The modified price from the SO shouldn't be modified in the PoS when entering
the SN

Steps to reproduce:
Create a SO with a product tracked by SN and change the price of the product in the SO
Go to the PoS app and add this SO
Click on the product to add the SN
The price change

opw-2687001

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
