### PR TITLE
[fix] point_of_sale: duplicate pos orders #40600

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -664,8 +664,11 @@ class PosOrder(models.Model):
         order_ids = []
         for order in orders:
             existing_order = False
+            domain = []
             if 'server_id' in order['data']:
-                existing_order = self.env['pos.order'].search(['|', ('id', '=', order['data']['server_id']), ('pos_reference', '=', order['data']['name'])], limit=1)
+                domain = ['|', ('id', '=', order['data']['server_id'])]
+            domain.append(('pos_reference', '=', order['data']['name']))
+            existing_order = self.env['pos.order'].search(domain, limit=1)
             if (existing_order and existing_order.state == 'draft') or not existing_order:
                 order_ids.append(self._process_order(order, draft, existing_order))
 

--- a/doc/cla/individual/myousefbs.md
+++ b/doc/cla/individual/myousefbs.md
@@ -1,0 +1,11 @@
+Sudan, 2021-11-30
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Muhammad Yousef  itsmuhammadyousef@gmail.com https://github.com/myousefbs


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes duplicate pos orders with the same pos_reference.

Steps to reproduce::
As this issue has been raised many times with no clear steps to reproduce I had to modify `[pos.order].create_from_ui ()` code to intentionally duplicate orders in the received orders list and pop the server_id key from order dictionary.

Current behavior before PR::
in some cases the the server_id is not received in order info and in result to that the existing code will not search for existing order,
hence `if 'server_id' in order['data']`

Desired behavior after PR is merged::
will always search for existing order with given server_id or pos_reference  before creating a new pos order to avoid duplicate orders.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
