### PR TITLE
[FIX] point_of_sale: '+/-' button misbehaving with default quantity

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -187,6 +187,11 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
             } else {
                 let { buffer } = event.detail;
                 let val = buffer === null ? 'remove' : buffer;
+                let currentOrderline = this.env.pos.get_order().get_selected_orderline();
+                if (currentOrderline && event.detail.key === '-') {
+                    let currentQuantity = currentOrderline.get_quantity();
+                    val = currentQuantity.toString().startsWith('-') ? currentQuantity.toString().replace('-', '') : `-${currentQuantity}`
+                }
                 this._setValue(val);
             }
         }


### PR DESCRIPTION
    [FIX] point_of_sale: '+/-' button misbehaving with default quantity
    
    When we add a product and then press the '+/-' button to inverse the quantity
    (useful for the refund process) the product quantity changes to 0. Expected
    behaviour is that is should change to -1 instead.
    
    task-2669793
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
