### PR TITLE
[FIX] website_sale: translate Pay Now and Confirm Order

### DIFF
--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -992,6 +992,7 @@ msgid "Config Settings"
 msgstr ""
 
 #. module: website_sale
+#: model_terms:ir.ui.view,arch_db:website_sale.payment
 #: model_terms:ir.ui.view,arch_db:website_sale.wizard_checkout
 msgid "Confirm Order"
 msgstr ""
@@ -2029,6 +2030,11 @@ msgstr ""
 #. module: website_sale
 #: model:ir.model.fields,field_description:website_sale.field_product_public_category__parents_and_self
 msgid "Parents And Self"
+msgstr ""
+
+#. module: website_sale
+#: model_terms:ir.ui.view,arch_db:website_sale.payment
+msgid "Pay Now"
 msgstr ""
 
 #. module: website_sale

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1563,7 +1563,7 @@
                                     <h3 class="mb24">Pay with </h3>
                                     <t t-call="payment.checkout">
                                         <t t-set="footer_template_id" t-value="'website_sale.payment_footer'"/>
-                                        <t t-set="submit_button_label" t-value="'Pay Now'"/>
+                                        <t t-set="submit_button_label">Pay Now</t>
                                     </t>
                                 </div>
                                 <div t-else="" class="alert alert-warning">
@@ -1583,7 +1583,7 @@
                                 <form target="_self" action="/shop/payment/validate" method="post">
                                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" />
                                     <t t-call="website_sale.payment_footer">
-                                        <t t-set="submit_button_label" t-value="'Confirm Order'"/>
+                                        <t t-set="submit_button_label">Confirm Order</t>
                                     </t>
                                 </form>
                             </div>


### PR DESCRIPTION
How to reproduce the problem:
- Install the website_sale module and the German language (and
activate it for the website).
- Go to the website, and choose the German language.
- Add a product to your cart and checkout.
=> on the checkout page, the button "Pay Now" is not translated (
"Confirm Order", if the total amount = 0)

These terms are now added for translation.
The terms were incorreclty formatted in the xml and were not
picked up for translation export. Introduced by this commit:
https://github.com/odoo/odoo/commit/573ed74c121c1572b3fab6f9553ed7f93f7b3f99

opw-2686463