### PR TITLE
[FIX] projet: fix duplicate id in project demo data

### DIFF
--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -934,7 +934,7 @@ Send it ASAP, its urgent.</field>
             <field name="name">Customer Meeting</field>
             <field name="stage_id" ref="project_stage_1"/>
         </record>
-        <record id="project_task_30" model="project.task">
+        <record id="project_task_34" model="project.task">
             <field name="sequence">10</field>
             <field name="planned_hours">2.0</field>
             <field name="user_ids" eval="False"/>
@@ -943,7 +943,7 @@ Send it ASAP, its urgent.</field>
             <field name="name">Daily Meetings summary</field>
             <field name="stage_id" ref="project_stage_1"/>
         </record>
-        <record id="project_task_31" model="project.task">
+        <record id="project_task_35" model="project.task">
             <field name="sequence">20</field>
             <field name="planned_hours">2.0</field>
             <field name="user_ids" eval="False"/>
@@ -952,7 +952,7 @@ Send it ASAP, its urgent.</field>
             <field name="name">Preparation</field>
             <field name="stage_id" ref="project_stage_1"/>
         </record>
-        <record id="project_task_32" model="project.task">
+        <record id="project_task_36" model="project.task">
             <field name="sequence">30</field>
             <field name="planned_hours">2.0</field>
             <field name="user_ids" eval="False"/>


### PR DESCRIPTION
Before this commit, 3 xmlid are duplicated, so the result is not
expected.

This commit changes the duplicated xmlid to create the 6 tasks as
expected.

Part of task-2671848

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
