### PR TITLE
[FIX] hr_holidays: fix wrong employee_id fallback

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -146,7 +146,7 @@ class HolidaysType(models.Model):
     def _compute_valid(self):
         date_to = self._context.get('default_date_to', fields.Datetime.today())
         date_from = self._context.get('default_date_from', fields.Datetime.today())
-        employee_id = self._context.get('default_employee_id', self._context.get('employee_id', self.env.user.employee_id))
+        employee_id = self._context.get('default_employee_id', self._context.get('employee_id', self.env.user.employee_id.id))
         for holiday_type in self:
             if holiday_type.requires_allocation:
                 allocation = self.env['hr.leave.allocation'].search([


### PR DESCRIPTION
A wrong fallback value was used, the domain is expecting the employee ID
and not the employee record.

TaskID: 2675380

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
