### PR TITLE
[FIX] survey: test if survey exist in survey_layout for background management

### DIFF
--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -14,9 +14,9 @@
                              else ('background-image: url(' + page.background_image_url + ');')
                              if page and page.background_image_url
                              else ('background-image: url(' + survey.background_image_url + ');')
-                             if survey.background_image_url
+                             if survey and survey.background_image_url
                              else '')"/>
-            <attribute name="t-att-class" add="'o_survey_background'"/>
+            <attribute name="t-attf-class" add="o_survey_background" separator=" "/>
         </xpath>
         <xpath expr="//head/t[@t-call-assets][last()]" position="after">
             <t t-call-assets="survey.survey_assets" lazy_load="True"/>


### PR DESCRIPTION
Since fd75481d52878962a782cfe740be25b731c99efd, we use the survey variable to compute the
background_image_url in the survey_layout. In some cases (notably in
survey_session_code template), this layout is used without knowing the
variable 'survey'.

After this commit, the 'survey' variable is tested before usage.

Also, this commit add the o_survey_background class to the t-attf-class that
already exists on 'wrapwrap' selector. Otherwise, by having both t-att-class
and t-attf-class, only the t-att-class is kept.

Task-2703147