### PR TITLE
[FIX] uom: Correct uom creation link

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -43,7 +43,7 @@
             parent="menu_purchase_config" sequence="40" groups="uom.group_uom" />
 
         <menuitem
-              action="uom.product_uom_form_action" id="menu_purchase_uom_form_action"
+              action="uom.product_uom_form_action" id="menu_purchase_uom_form_action" active="False"
               parent="purchase.menu_unit_of_measure_in_config_purchase" sequence="5" groups="base.group_no_one"/>
 
         <menuitem

--- a/addons/sale/views/res_config_settings_views.xml
+++ b/addons/sale/views/res_config_settings_views.xml
@@ -61,7 +61,7 @@
                                 </div>
                                 <div class="content-group" attrs="{'invisible': [('group_uom','=',False)]}">
                                     <div class="mt8">
-                                        <button name="%(uom.product_uom_form_action)d" icon="fa-arrow-right" type="action" string="Units of Measure" class="btn-link"/>
+                                        <button name="%(uom.product_uom_categ_form_action)d" icon="fa-arrow-right" type="action" string="Units of Measure" class="btn-link"/>
                                     </div>
                                 </div>
                             </div>

--- a/addons/sale_management/views/sale_management_views.xml
+++ b/addons/sale_management/views/sale_management_views.xml
@@ -27,9 +27,6 @@
     <record id="sale.next_id_16" model="ir.ui.menu">
         <field name="active" eval="True"/>
     </record>
-    <record id="sale.menu_product_uom_form_action" model="ir.ui.menu">
-        <field name="active" eval="True"/>
-    </record>
     <record id="sale.menu_product_uom_categ_form_action" model="ir.ui.menu">
         <field name="active" eval="True"/>
     </record>

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -307,7 +307,7 @@
                                     </div>
                                     <div class="content-group">
                                         <div class="mt8" attrs="{'invisible': [('group_uom', '=', False)]}">
-                                            <button name="%(uom.product_uom_form_action)d" icon="fa-arrow-right" type="action" string="Units Of Measure" class="btn-link"/>
+                                            <button name="%(uom.product_uom_categ_form_action)d" icon="fa-arrow-right" type="action" string="Units Of Measure" class="btn-link"/>
                                         </div>
                                     </div>
                                 </div>

--- a/addons/stock/views/stock_menu_views.xml
+++ b/addons/stock/views/stock_menu_views.xml
@@ -35,7 +35,7 @@
         parent="stock.menu_product_in_config_stock"  sequence="35" groups="uom.group_uom"/>
 
     <menuitem id="menu_stock_uom_form_action" action="uom.product_uom_form_action"
-        name="UoM"
+        name="UoM" active="False"
         parent="product_uom_menu" sequence="35" groups="base.group_no_one"/>
 
     <menuitem id="menu_stock_inventory_control" name="Products" parent="menu_stock_root" sequence="4"/>


### PR DESCRIPTION
Since 6f182eeeab082b094563836a7a3dc2f4e56375f0 UoM should be created through the UoM category tab as the UoM form view is now unusable.
To ensure that this is the case, we remove menu link to the form view and update the other to lead to UoM category instead.

opw-2702953

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
