### PR TITLE
[FIX] hr_timesheet: authorize project_manager to update task's project

### DIFF
--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -63,5 +63,9 @@
             <field name="groups" eval="[(4, ref('group_timesheet_manager'))]"/>
         </record>
 
+        <record id="project.group_project_manager" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('hr_timesheet.group_hr_timesheet_approver'))]"/>
+        </record>
+
     </data>
 </odoo>

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -323,3 +323,47 @@ class TestTimesheet(TestCommonTimesheet):
             })
         self.assertEqual(wizard_min.save_timesheet().unit_amount, 1, "The timesheet's duration should be 1h (Minimum Duration = 60').")
         self.assertEqual(wizard_round.save_timesheet().unit_amount, 1.25, "The timesheet's duration should be 1h15 (Rounding = 15').")
+
+    def test_task_with_timesheet_project_change(self):
+        '''This test checks that no error is raised when moving a task that contains timesheet to another project.
+           This move implying writing on the account.analytic.line.
+        '''
+
+        project_manager = self.env['res.users'].create({
+            'name': 'user_project_manager',
+            'login': 'user_project_manager',
+            'groups_id': [(6, 0, [self.ref('project.group_project_manager')])],
+        })
+
+        project = self.env['project.project'].create({
+            'name': 'Project With Timesheets',
+            'privacy_visibility': 'employees',
+            'allow_timesheets': True,
+            'user_id': project_manager.id,
+        })
+        second_project = self.env['project.project'].create({
+            'name': 'Project w/ timesheets',
+            'privacy_visibility': 'employees',
+            'allow_timesheets': True,
+            'user_id': project_manager.id,
+        })
+
+        task_1 = self.env['project.task'].create({
+            'name': 'First task',
+            'user_id': self.user_employee2.id,
+            'project_id': project.id
+        })
+
+        timesheet = self.env['account.analytic.line'].create({
+            'name': 'FirstTimeSheet',
+            'project_id': project.id,
+            'task_id': task_1.id,
+            'unit_amount': 2,
+            'employee_id': self.empl_employee2.id
+        })
+
+        task_1.with_user(project_manager).write({
+            'project_id': second_project.id
+        })
+
+        self.assertEqual(timesheet.project_id, second_project, 'The project_id of timesheet should be second_project')


### PR DESCRIPTION
### Expected behavior
Project manager can change task's project of any task including timesheets

### Current behavior
When Project manager with `Timesheets : See own timesheets` permission is updating task's project, an Access Error exception is raised `Only a Timesheets Approver or Manager is allowed to modify a validated entry.`

### Steps to reproduce
*Use demo data to make steps easier*
- Install Project and Timesheets
- Go to Project and select one
- Select any Task with some timesheets
- Edit it and try to change the Project

### Reason
When a user is a project administrator, he can still have basic permissions in Timesheets (`Timesheets : See own timesheets`), which prevents him from modifying the task's project if the task has some validated timesheet
