### PR TITLE
[REV] base, web_editor, mail, digest: remove preserve-comments

### DIFF
--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -125,7 +125,7 @@ class Digest(models.Model):
             digest.next_run_date = digest._get_next_run_date()
 
     def _action_send_to_user(self, user, tips_count=1, consum_tips=True):
-        rendered_body = self.env['mail.render.mixin'].with_context(preserve_comments=True)._render_template(
+        rendered_body = self.env['mail.render.mixin']._render_template(
             'digest.digest_mail_main',
             'digest.digest',
             self.ids,

--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -276,11 +276,8 @@ class MailRenderMixin(models.AbstractModel):
         for record in self.env[model].browse(res_ids):
             variables['object'] = record
             try:
-                render_result = self.env['ir.qweb']._render(
-                    html.fragment_fromstring(template_src, create_parent='div'),
-                    variables,
-                    raise_on_code=is_restricted,
-                )
+                render_result = self.env['ir.qweb']._render(html.fragment_fromstring(
+                    template_src, create_parent='div'), variables, raise_on_code=is_restricted)
                 # remove the rendered tag <div> that was added in order to wrap potentially multiples nodes into one.
                 render_result = render_result[5:-6]
             except QWebCodeFound:

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -47,9 +47,14 @@ class TestMailComposer(MailCommon):
 
         values = mail_compose_message.get_mail_values(self.partner_employee.ids)
 
-        self.assertIn(self.body_html,
+        self.assertIn("""<div>
+    <h1>Hello sir!</h1>
+    <p>Here! <a href="https://www.example.com">
+        A link for you!
+    </a> Make good use of it.</p>
+</div>""",
             values[self.partner_employee.id]['body_html'],
-            'We must preserve (mso) comments in email html')
+            'We must remove comments')
 
     @users('employee')
     def test_mail_mass_mode_compose_with_mso(self):
@@ -69,6 +74,11 @@ class TestMailComposer(MailCommon):
 
         values = composer.get_mail_values(self.partner_employee.ids)
 
-        self.assertIn(self.body_html,
+        self.assertIn("""<div>
+    <h1>Hello sir!</h1>
+    <p>Here! <a href="https://www.example.com">
+        A link for you!
+    </a> Make good use of it.</p>
+</div>""",
             values[self.partner_employee.id]['body_html'],
-            'We must preserve (mso) comments in email html')
+            'We must remove comments')

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -592,8 +592,7 @@ class MailComposer(models.TransientModel):
             res_ids = [res_ids]
 
         subjects = self._render_field('subject', res_ids, options={"render_safe": True})
-        # We want to preserve comments in emails so as to keep mso conditionals
-        bodies = self.with_context(preserve_comments=self.composition_mode == 'mass_mail')._render_field('body', res_ids, post_process=True)
+        bodies = self._render_field('body', res_ids, post_process=True)
         emails_from = self._render_field('email_from', res_ids)
         replies_to = self._render_field('reply_to', res_ids)
         default_recipients = {}

--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -951,10 +951,7 @@ class QWeb(object):
         body = []
         if el.getchildren():
             for item in el:
-                if isinstance(item, etree._Comment):
-                    if self.env.context.get('preserve_comments'):
-                        self._appendText("<!--%s-->" % item.text, options)
-                else:
+                if not isinstance(item, etree._Comment):
                     body.extend(self._compile_node(item, options, indent))
                 # comments can also contains tail text
                 if item.tail is not None:


### PR DESCRIPTION
This reverts commit d17d8523c039ef574062ec20e74d872258e6487f.

There was an error in that commit: QWeb has no attribute env.

This was breaking the database manager, and potentially other views with comments. 