### PR TITLE
[FIX] mail: make rtc dialogs title translatable

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -6029,6 +6029,7 @@ msgstr ""
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/components/rtc_option_list/rtc_option_list.xml:0
+#: code:addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js:0
 #, python-format
 msgid "Settings"
 msgstr ""
@@ -6478,6 +6479,13 @@ msgstr ""
 #: code:addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js:0
 #, python-format
 msgid "The FullScreen mode was denied by the browser"
+msgstr ""
+
+#. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js:0
+#, python-format
+msgid "Change Layout"
 msgstr ""
 
 #. module: mail

--- a/addons/mail/static/src/components/rtc_call_viewer/rtc_call_viewer.xml
+++ b/addons/mail/static/src/components/rtc_call_viewer/rtc_call_viewer.xml
@@ -51,7 +51,7 @@
 
             <!-- Dialogs -->
             <t t-if="messaging.userSetting.rtcConfigurationMenu.isOpen">
-                <Dialog size="'small'" title="'Settings'" t-on-dialog-closed="rtcCallViewer.onRtcSettingsDialogClosed">
+                <Dialog size="'small'" title="rtcCallViewer.settingsTitle" t-on-dialog-closed="rtcCallViewer.onRtcSettingsDialogClosed">
                     <RtcConfigurationMenu/>
                     <t t-set-slot="buttons">
                         <!-- Explicit No buttons -->
@@ -59,7 +59,7 @@
                 </Dialog>
             </t>
             <t t-if="rtcCallViewer and rtcCallViewer.rtcLayoutMenu">
-                <Dialog size="'small'" title="'Change Layout'" t-on-dialog-closed="rtcCallViewer.onLayoutSettingsDialogClosed">
+                <Dialog size="'small'" title="rtcCallViewer.layoutSettingsTitle" t-on-dialog-closed="rtcCallViewer.onLayoutSettingsDialogClosed">
                     <RtcLayoutMenu localId="rtcCallViewer.rtcLayoutMenu.localId"/>
                     <t t-set-slot="buttons">
                         <!-- Explicit No buttons -->

--- a/addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js
+++ b/addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js
@@ -205,6 +205,14 @@ function factory(dependencies) {
 
         /**
          * @private
+         * @returns {string}
+         */
+         _computeLayoutSettingsTitle() {
+            return this.env._t("Change Layout");
+        }
+
+        /**
+         * @private
          */
         _computeMainParticipantCard() {
             if (!this.messaging || !this.threadView) {
@@ -218,6 +226,14 @@ function factory(dependencies) {
                 });
             }
             return unlink();
+        }
+
+        /**
+         * @private
+         * @returns {string}
+         */
+        _computeSettingsTitle() {
+            return this.env._t("Settings");
         }
 
         /**
@@ -370,6 +386,12 @@ function factory(dependencies) {
             compute: '_computeLayout',
         }),
         /**
+         * Text content that is displayed on title of the layout settings dialog.
+         */
+        layoutSettingsTitle: attr({
+            compute: '_computeLayoutSettingsTitle',
+        }),
+        /**
          * If set, the card to be displayed as the "main/spotlight" card.
          */
         mainParticipantCard: one2one('mail.rtc_call_participant_card', {
@@ -392,6 +414,12 @@ function factory(dependencies) {
         rtcLayoutMenu: one2one('mail.rtc_layout_menu', {
             inverse: 'callViewer',
             isCausal: true,
+        }),
+        /**
+         * Text content that is displayed on title of the settings dialog.
+         */
+        settingsTitle: attr({
+            compute: '_computeSettingsTitle',
         }),
         /**
          * Determines if we show the overlay with the control buttons.


### PR DESCRIPTION
Before this commit, the title of RTC dialogs -- like "Change Layout" menu
during a video-conference -- was not properly translated. The titles were
always shown in English as a result.

This commit now properly mark them as translatable string, so they should
now be properly translated in other languages than English.

Task-2703292