### PR TITLE
[FIX] env not found in QWeb

### DIFF
--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -952,7 +952,7 @@ class QWeb(object):
         if el.getchildren():
             for item in el:
                 if isinstance(item, etree._Comment):
-                    if self.env.context.get('preserve_comments'):
+                    if self._context.get('preserve_comments', False):
                         self._appendText("<!--%s-->" % item.text, options)
                 else:
                     body.extend(self._compile_node(item, options, indent))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
env doesn't exist in that function at that time. Use `_context` instead of `env.context`.
TBH I didn't test this completely
Fixes #80655
Fixes #80650


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
