### PR TITLE
[FIX] hr_timesheet : round time on task

### DIFF
--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -306,3 +306,20 @@ class TestTimesheet(TestCommonTimesheet):
         self.task1.write({'partner_id': partner2})
 
         self.assertEqual(timesheet_entry.partner_id, partner2, "The timesheet entry's partner should still be equal to the task's partner/customer, after the change")
+
+    def test_add_time_from_wizard(self):
+        config = self.env["res.config.settings"].create({
+                "timesheet_min_duration": 60,
+                "timesheet_rounding": 15,
+            })
+        config.execute()
+        wizard_min = self.env['project.task.create.timesheet'].create({
+                'time_spent': 0.7,
+                'task_id': self.task1.id,
+            })
+        wizard_round = self.env['project.task.create.timesheet'].create({
+                'time_spent': 1.15,
+                'task_id': self.task1.id,
+            })
+        self.assertEqual(wizard_min.save_timesheet().unit_amount, 1, "The timesheet's duration should be 1h (Minimum Duration = 60').")
+        self.assertEqual(wizard_round.save_timesheet().unit_amount, 1.25, "The timesheet's duration should be 1h15 (Rounding = 15').")


### PR DESCRIPTION
Steps :
- Install Sales & Timesheets
- Timesheets > Settings > Time Encoding :
	- Min duration : 60 min
	- Rounding up : 15 min
- Create a Project P
- Create a Product S :
	- Product Type : Service
	- Service Invoicing Policy : Timesheets on tasks
	- Service Tracking : Create a task in an existing project
	- Project : P
- Create a Sales Order SO and add S
- SO > 1 Tasks (smart button) as T > Timesheets (tab) > Add a line :
	- Employee : Mitchell Admin
	- Duration : 0

- Timesheets > Start :
	- Time : 1:09
	- Project : P
	- Task : SO:S
- T > Timesheets (tab) : Note Time = 1:15 (Min duration + Roundup)

- T > Start and Stop
- Confirm Time Spent Wizard : Note Duration = 1:00 (Min Duration)
	- Duration : 1:09
- Save and T > Timesheets (tab) : Note Time = 1:09

Issue:
- Unconsistent behaviors :
	The time is rounded when using Timesheets' timer and from Task's timer to Confirm Time Spent Wizard
	but it is not rounded when confirming the Wizard.

Fix:
- Round it in when confirming the wizard too.

opw-2672249

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
