### PR TITLE
[FIX] project: prevent archived assignees from not being visible

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -918,7 +918,7 @@ class Task(models.Model):
         help="Sum of the time planned of all the sub-tasks linked to this task. Usually less than or equal to the initially planned time of this task.")
     # Tracking of this field is done in the write function
     user_ids = fields.Many2many('res.users', relation='project_task_user_rel', column1='task_id', column2='user_id',
-        string='Assignees', default=lambda self: self.env.user)
+        string='Assignees', default=lambda self: self.env.user, context={'active_test': False})
     # User names displayed in project sharing views
     portal_user_names = fields.Char(compute='_compute_portal_user_names', compute_sudo=True, search='_search_portal_user_names')
     # Second Many2many containing the actual personal stage for the current user

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -18,7 +18,7 @@
                <search string="Tasks">
                     <field name="name" string="Task"/>
                     <field name="tag_ids"/>
-                    <field name="user_ids"/>
+                    <field name="user_ids" context="{'active_test': False}"/>
                     <field string="Project" name="display_project_id"/>
                     <field name="stage_id"/>
                     <field name="partner_id" operator="child_of"/>
@@ -839,7 +839,7 @@
                                 class="o_task_user_field"
                                 options="{'no_open': True}"
                                 widget="many2many_avatar_user"
-                                domain="[('share', '=', False)]"/>
+                                domain="[('share', '=', False), ('active', '=', True)]"/>
                             <field name="parent_id"
                                 domain="[('parent_id', '=', False)]"
                                 attrs="{'invisible' : [('allow_subtasks', '=', False)]}"
@@ -871,7 +871,7 @@
                                     <field name="name"/>
                                     <field name="display_project_id" string="Project" optional="hide"/>
                                     <field name="partner_id" optional="hide"/>
-                                    <field name="user_ids" widget="many2many_avatar_user" optional="show"/>
+                                    <field name="user_ids" widget="many2many_avatar_user" optional="show" domain="[('active', '=', True)]"/>
                                     <field name="company_id" groups="base.group_multi_company" optional="hide"/>
                                     <field name="activity_ids" widget="list_activity" optional="hide"/>
                                     <field name="date_deadline" attrs="{'invisible': [('is_closed', '=', True)]}" optional="show"/>
@@ -888,7 +888,7 @@
                                     <field name="is_closed" invisible="1" />
                                     <field name="name" />
                                     <field name="project_id" optional="hide" />
-                                    <field name="user_ids" widget="many2many_avatar_user" optional="show"/>
+                                    <field name="user_ids" widget="many2many_avatar_user" optional="show" domain="[('active', '=', True)]"/>
                                     <field name="company_id" optional="hide" groups="base.group_multi_company" />
                                     <field name="activity_ids" widget="list_activity" optional="hide"/>
                                     <field name="date_deadline" attrs="{'invisible': [('is_closed', '=', True)]}" optional="show" />
@@ -999,7 +999,7 @@
                 <form>
                     <group>
                         <field name="name" string = "Task Title" placeholder="e.g. New Design"/>
-                        <field name="user_ids" options="{'no_open': True,'no_create': True}" domain="[('share', '=', False)]"
+                        <field name="user_ids" options="{'no_open': True,'no_create': True}" domain="[('share', '=', False), ('active', '=', True)]"
                             widget="many2many_tags"/>
                         <field name="company_id" invisible="1"/>
                         <field name="parent_id" invisible="1" groups="base.group_no_one"/>
@@ -1126,7 +1126,7 @@
                     <field name="project_id" optional="show" readonly="1"/>
                     <field name="partner_id" optional="hide"/>
                     <field name="parent_id" optional="hide" attrs="{'invisible': [('allow_subtasks', '=', False)]}" groups="base.group_no_one"/>
-                    <field name="user_ids" optional="show" widget="many2many_avatar_user"/>
+                    <field name="user_ids" optional="show" widget="many2many_avatar_user" domain="[('active', '=', True)]"/>
                     <field name="company_id" groups="base.group_multi_company" optional="show"/>
                     <field name="activity_ids" widget="list_activity" optional="show"/>
                     <field name="date_deadline" optional="hide" widget="remaining_days" attrs="{'invisible': [('is_closed', '=', True)]}"/>


### PR DESCRIPTION
Prior to this fix:

    - Archived users are no more shown in the assignees

After this commit:

    - All users, including archived ones will be shown in the assignees.

task-2703358

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
