### PR TITLE
[FIX] point_of_sale, l10n_fr_pos_cert: allow to close session after 24h

### DIFF
--- a/addons/l10n_fr_pos_cert/models/pos.py
+++ b/addons/l10n_fr_pos_cert/models/pos.py
@@ -28,10 +28,6 @@ class pos_session(models.Model):
 
     def _check_session_timing(self):
         self.ensure_one()
-        date_today = datetime.utcnow()
-        session_start = Datetime.from_string(self.start_at)
-        if not date_today - timedelta(hours=24) <= session_start:
-            raise UserError(_("This session has been opened another day. To comply with the French law, you should close sessions on a daily basis. Please close session %s and open a new one.", self.name))
         return True
 
     def open_frontend_cb(self):

--- a/addons/l10n_fr_pos_cert/static/src/js/Chrome.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/Chrome.js
@@ -1,0 +1,25 @@
+odoo.define('l10n_fr_pos_cert.Chrome', function (require) {
+    'use strict';
+
+    const Chrome = require('point_of_sale.Chrome');
+    const Registries = require('point_of_sale.Registries');
+
+    const PosFrCertChrome = (Chrome) =>
+        class extends Chrome {
+            async start() {
+                await super.start();
+                if (this.env.pos.is_french_country() && this.env.pos.pos_session.start_at) {
+                    const now = Date.now();
+                    let limitDate = new Date(this.env.pos.pos_session.start_at);
+                    limitDate.setDate(limitDate.getDate() + 1);
+                    if (limitDate < now) {
+                        this.showPopup('ClosePosPopup');
+                    }
+                }
+            }
+        };
+
+    Registries.Component.extend(Chrome, PosFrCertChrome);
+
+    return Chrome;
+});

--- a/addons/l10n_fr_pos_cert/static/src/js/Popups/ClosePosPopup.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/Popups/ClosePosPopup.js
@@ -1,0 +1,27 @@
+odoo.define('l10n_fr_pos_cert.ClosePosPopup', function (require) {
+    'use strict';
+
+    const ClosePosPopup = require('point_of_sale.ClosePosPopup');
+    const Registries = require('point_of_sale.Registries');
+
+    const PosFrCertClosePopup = (ClosePosPopup) =>
+        class extends ClosePosPopup {
+            sessionIsOutdated() {
+                let isOutdated = false;
+                if (this.env.pos.is_french_country() && this.env.pos.pos_session.start_at) {
+                    const now = Date.now();
+                    let limitDate = new Date(this.env.pos.pos_session.start_at);
+                    limitDate.setDate(limitDate.getDate() + 1);
+                    isOutdated = limitDate < now;
+                }
+                return isOutdated;
+            }
+            canCancel() {
+                return super.canCancel() && !this.sessionIsOutdated();
+            }
+        };
+
+    Registries.Component.extend(ClosePosPopup, PosFrCertClosePopup);
+
+    return ClosePosPopup;
+});

--- a/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
@@ -115,6 +115,14 @@ odoo.define('point_of_sale.ClosePosPopup', function(require) {
         canCloseSession() {
             return !this.cashControl || !this.hasDifference() || this.state.acceptClosing;
         }
+        canCancel() {
+            return true;
+        }
+        cancelPopup() {
+            if (this.canCancel()) {
+                this.cancel();
+            }
+        }
         closePos() {
             this.trigger('close-pos');
         }

--- a/addons/point_of_sale/static/src/xml/Popups/ClosePosPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/ClosePosPopup.xml
@@ -94,7 +94,7 @@
                     </div>
                 </main>
                 <footer class="footer">
-                    <div class="button" t-on-click="cancel()">Continue Selling</div>
+                    <div class="button" t-att-class="{'disabled': !canCancel()}" t-on-click="cancelPopup()">Continue Selling</div>
                     <div class="button" t-on-click="closePos()">Keep Session Open</div>
                     <div class="button" t-att-class="{'disabled': !canCloseSession()}" t-on-click="closeSession()">Close Session</div>
                 </footer>


### PR DESCRIPTION
- Use a company located in France
- Install point_of_sale and l10n_fr_pos_cert
- Open a POS session
- Make some orders
- Quit session without closing it (Keep session open)
- Come back more than 24 hours later
- Try to open the session (Continue selling)
An UserError is triggered with the following message:
"This session has been opened another day. To comply with the French law,
you should close sessions on a daily basis.
Please close session POS/00007 and open a new one."

However, it is not possible to close the session as the closing control
is managed in the fontend inside the session.
Therefore the POS is stuck as we cannot close the last session, neither open
a new one.

This fix allows an user with the rights to close a session to connect to
the stuck session to close it.
He will only have access to the closing control popup, without the possibility
to continue selling.

opw-2696823




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
