### PR TITLE
[FIX] point_of_sale : PoS right pane moving

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -857,6 +857,7 @@ td {
     flex-direction: column;
     flex-basis: 25%;
     flex-grow: 1;
+    overflow: auto;
 }
 
 .pos .products-widget {


### PR DESCRIPTION
Current behavior:
When having too much product in a category the right pane is moving to the bottom of the page

Steps to reproduce:
Add a large quanity of product and categories to a point of sale
right pane is moved to the bottom of the page

opw-2692706

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
