### PR TITLE
[FIX] sale: typo so analysis not last 30 days


### DIFF
--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -1291,7 +1291,7 @@
             <field name="res_model">sale.report</field>
             <field name="view_mode">graph</field>
             <field name="domain">[('state','not in',('draft','cancel'))]</field>
-            <field name="context">{'search_default_Sales': 1, 'time_ranges': {'field':'date_order', 'range':'last_30_days'}, 'search_default_team_id': [active_id]}</field>
+            <field name="context">{'search_default_Sales': 1, 'time_ranges': {'field':'date', 'range':'last_30_days'}, 'search_default_team_id': [active_id]}</field>
             <field name="help">This report performs analysis on your sales orders. Analysis check your sales revenues and sort it by different group criteria (salesman, partner, product, etc.) Use this report to perform analysis on sales not having invoiced yet. If you want to analyse your turnover, you should use the Invoice Analysis report in the Accounting application.</field>
         </record>
 


### PR DESCRIPTION

In 0cc30bf08382128a77455a51d831ef45ccdfdb48 confirmation_date was
replaced by date_order. But this cause the "last 30 days" range to not
work on sale.report because for the model the field is called date.

opw-2703405
