### PR TITLE
[IMP] hr+resource: populate: link users and resource calendars

### DIFF
--- a/addons/resource/populate/__init__.py
+++ b/addons/resource/populate/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
-from . import populate
-from .tests import test_resource_model
+from . import resource_calendar

--- a/addons/resource/populate/resource_calendar.py
+++ b/addons/resource/populate/resource_calendar.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import random
+
+from odoo import models
+from odoo.tools import populate
+
+
+class ResourceCalendar(models.Model):
+    _inherit = "resource.calendar"
+    _populate_dependencies = ["res.company"]  # multi-company setup
+    _populate_sizes = {
+        "small": 10,  # 1-2 per company
+        "medium": 30,  # 3 per company
+        "large": 250  # 5 per company
+    }
+
+    def _populate_factories(self):
+        company_ids = self.env.registry.populated_models["res.company"]
+
+        return [
+            ("company_id", populate.iterate(company_ids)),
+            ("name", populate.iterate(["A little {counter}", "A lot {counter}"])),
+        ]
+
+    def _populate(self, size):
+        records = super()._populate(size)
+
+        # Randomly remove 1 half day from schedule
+        a_lot = records.filtered_domain([("name", "like", "A lot")])
+        for record in a_lot:
+            att_id = record.attendance_ids[random.randint(0, 9)]
+            record.write({
+                'attendance_ids': [(3, att_id.id)],
+            })
+
+        # Randomly remove 3 to 5 half days from schedule
+        a_little = records - a_lot
+        for record in a_little:
+            to_pop = random.sample(range(10), random.randint(3, 5))
+            record.write({
+                'attendance_ids': [(3, record.attendance_ids[idx].id) for idx in to_pop],
+            })
+        return records


### PR DESCRIPTION
Previously for `appointment`, now for `appointment_hr`, the computation of
users' availability for appointment slots can be dependent on that person's
work schedule if:

* The user is linked to an employee
* The user's employee has working hours defined (resource calendar)

This commit provides working hours to all employees and a user to some, within
a multi-company setup.

Task-2728093
See odoo/enterprise#22642
See Task-2631088
