### PR TITLE
[FIX] project: prevent blank space at bottom right of project kanban

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -702,7 +702,7 @@
                                     </div>
                                     <div class="oe_kanban_bottom_right">
                                         <span t-att-class="'o_status_bubble mx-0 o_color_bubble_' + record.last_update_color.value" t-att-title="record.last_update_status.value"></span>
-                                        <field name="user_id" widget="many2one_avatar_user"/>
+                                        <field name="user_id" widget="many2one_avatar_user" t-if="record.user_id.raw_value"/>
                                     </div>
                                 </div>
                             </div>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -841,7 +841,6 @@
                                 widget="many2many_avatar_user"
                                 domain="[('share', '=', False), ('active', '=', True)]"/>
                             <field name="parent_id"
-                                domain="[('parent_id', '=', False)]"
                                 attrs="{'invisible' : [('allow_subtasks', '=', False)]}"
                                 groups="base.group_no_one"
                             />


### PR DESCRIPTION
Prior to this commit:

    - When no user_id were set on the project, a with blank space was shown at
      the bottom right of the kanban card.

After this commit:

    - When no user_id is set on the project, the kanban status is move at the
      bottom right of the kanban card.

task-2703632

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
