### PR TITLE
[FIX] web_editor: properly call addRowBelow

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2817,7 +2817,7 @@ export class OdooEditor extends EventTarget {
         if (cursorDestination) {
             setSelection(...startPos(cursorDestination), ...endPos(cursorDestination), true);
         } else if (direction === DIRECTIONS.RIGHT) {
-            this._addRowBelow();
+            this.execCommand('addRowBelow');
             this._onTabulationInTable(ev);
         }
     }


### PR DESCRIPTION
The call to `addRowBelow` was not updated to the new API.

Task-2698729





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
