### PR TITLE
[FIX] payment: a user should see all his available partner tokens

### DIFF
--- a/addons/payment/tests/test_flows.py
+++ b/addons/payment/tests/test_flows.py
@@ -359,8 +359,7 @@ class TestFlows(PaymentCommon, PaymentHttpCommon):
         acquirer_b.state = 'test'
         token_b = self.create_token(acquirer_id=acquirer_b.id)
 
-        # A partner should see all his tokens on the /my/payment_method route,
-        # even if they are in other companies otherwise he won't ever see them.
+        # User must see both enabled acquirers and tokens
         manage_context = self.get_tx_manage_context()
         self.assertEqual(manage_context['partner_id'], self.partner.id)
         self.assertIn(self.acquirer.id, manage_context['acquirer_ids'])
@@ -374,3 +373,10 @@ class TestFlows(PaymentCommon, PaymentHttpCommon):
         self.assertEqual(manage_context['partner_id'], self.partner.id)
         self.assertEqual(manage_context['acquirer_ids'], [acquirer_b.id])
         self.assertEqual(manage_context['token_ids'], [token_b.id])
+
+        # Archived tokens must be hidden from the user
+        token_b.active = False
+        manage_context = self.get_tx_manage_context()
+        self.assertEqual(manage_context['partner_id'], self.partner.id)
+        self.assertEqual(manage_context['acquirer_ids'], [acquirer_b.id])
+        self.assertEqual(manage_context['token_ids'], [])

--- a/addons/payment/tests/test_multicompany_flows.py
+++ b/addons/payment/tests/test_multicompany_flows.py
@@ -69,3 +69,20 @@ class TestMultiCompanyFlows(PaymentMultiCompanyCommon, PaymentHttpCommon):
         self.assertEqual(processing_values['currency_id'], self.currency.id)
         self.assertEqual(processing_values['partner_id'], self.user_company_a.partner_id.id)
         self.assertEqual(processing_values['reference'], self.reference)
+
+    def test_full_access_to_partner_tokens(self):
+        self.partner = self.portal_partner
+
+        # Log in as user from Company A
+        self.authenticate(self.portal_user.login, self.portal_user.login)
+
+        token = self.create_token()
+        token_company_b = self.create_token(acquirer_id=self.acquirer_company_b.id)
+
+        # A partner should see all his tokens on the /my/payment_method route,
+        # even if they are in other companies otherwise he won't ever see them.
+        manage_context = self.get_tx_manage_context()
+        self.assertEqual(manage_context['partner_id'], self.partner.id)
+        self.assertEqual(manage_context['acquirer_ids'], self.acquirer.ids)
+        self.assertIn(token.id, manage_context['token_ids'])
+        self.assertIn(token_company_b.id, manage_context['token_ids'])


### PR DESCRIPTION
... even if they are in a company in which he has no access rights.

Finetuning of #79253 to keep previous multi-company behavior.
We didn't consider the fact that the previous behavior was fully managed 
in sudo (through request.env.user.partner, which gives a sudoed record) 
and changed the behavior by using an unsudoed search.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
