### PR TITLE
[FIX] l10n_ch: QR bill must have headers in bold

### DIFF
--- a/addons/l10n_ch/static/src/scss/report_swissqr.scss
+++ b/addons/l10n_ch/static/src/scss/report_swissqr.scss
@@ -177,6 +177,10 @@ body {
     }
     @mixin title {
         @include font;
+        font-weight: bold;
+    }
+    .title {
+        @include title;
     }
 
     .swissqr_text {


### PR DESCRIPTION
Fast fix in the CSS, as pointed out by partners in the ticket

Ticket link: https://www.odoo.com/web#id=2630582&model=project.task

opw-2584899