### PR TITLE
[FIX] mail_group: only check members based on email and no author_id

### DIFF
--- a/addons/mail_group/models/mail_group.py
+++ b/addons/mail_group/models/mail_group.py
@@ -251,9 +251,7 @@ class MailGroup(models.Model):
 
         if alias.alias_contact == 'followers':
             # Members only
-            author_id = message_dict.get('author_id', None)
-            email_from = message_dict.get('email_from')
-            if not self._find_member(email_from, author_id):
+            if not self._find_member(message_dict.get('email_from')):
                 return _('Only members can send email to the mailing list.')
             # Skip the verification because the partner is in the member list
             return

--- a/addons/mail_group/tests/test_mail_group.py
+++ b/addons/mail_group/tests/test_mail_group.py
@@ -78,6 +78,30 @@ class TestMailGroup(TestMailListCommon):
         member = self.test_group._find_member(email, partner_2.id)
         self.assertFalse(member, 'Should not return any member because the only one with the same email has a different partner')
 
+    def test_find_member_for_alias(self):
+        """Test the matching of a mail_group.members, when 2 users have the same partner email, and
+        that the first user was subscribed."""
+        user = self.user_portal
+        user2 = mail_new_test_user(self.env, login='login_2', email=user.email)
+
+        member = self.env['mail.group.member'].create({
+            # subscribe with the first user
+            'partner_id': user.partner_id.id,
+            'mail_group_id': self.test_group.id,
+        })
+        self.assertEqual(member.email, user.email)
+
+        # In case of matching, function return a falsy value.
+        # Should not return string (exception) if at least one members have the same email, whatever
+        # the partner (author_id) that could match this email.
+        msg_dict = {
+            # send mail with the second user
+            'author_id': user2.partner_id.id,
+            'email_from': user2.email,
+        }
+        self.test_group.alias_id.alias_contact = 'followers'
+        self.assertFalse(self.test_group._alias_get_error_message({}, msg_dict, self.test_group.alias_id))
+
     @users('employee')
     def test_join_group(self):
         mail_group = self.env['mail.group'].browse(self.test_group.ids)


### PR DESCRIPTION
In v15, in _find_members, we try to find a members with an email and without
partner_id or a member with the partner_id provided (if provided).

This commit remove the author_id, and so the partner_id to only looking for
members based on their email address.

Author_id could be the wrong since email is not uniq on partner.
We retrieve the same behavior than previously from this way.

courtesy of std for help to find a solution

closes odoo/odoo#80112

fwd-port of 98d7b1417ee82f

Signed-off-by: Jérémy Kersten (jke) <jke@openerp.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
