### PR TITLE
[FIX] account_edi: fix attachment embedding with multiple edi installed

### DIFF
--- a/addons/account_edi/models/account_edi_format.py
+++ b/addons/account_edi/models/account_edi_format.py
@@ -296,7 +296,7 @@ class AccountEdiFormat(models.Model):
         """
         # TO OVERRIDE
         self.ensure_one()
-        if self._is_embedding_to_invoice_pdf_needed():
+        if self._is_embedding_to_invoice_pdf_needed() and edi_document.attachment_id:
             pdf_writer.embed_odoo_attachment(edi_document.attachment_id)
 
     ####################################################

--- a/addons/account_edi_facturx/models/account_edi_format.py
+++ b/addons/account_edi_facturx/models/account_edi_format.py
@@ -54,7 +54,9 @@ class AccountEdiFormat(models.Model):
     def _prepare_invoice_report(self, pdf_writer, edi_document):
         self.ensure_one()
         if self.code != 'facturx_1_0_05':
-            super()._prepare_invoice_report(pdf_writer, edi_document)
+            return super()._prepare_invoice_report(pdf_writer, edi_document)
+        if not edi_document.attachment_id:
+            return
 
         pdf_writer.embed_odoo_attachment(edi_document.attachment_id)
         if not pdf_writer.is_pdfa and str2bool(self.env['ir.config_parameter'].sudo().get_param('edi.use_pdfa', 'False')):

--- a/odoo/tools/pdf.py
+++ b/odoo/tools/pdf.py
@@ -162,6 +162,7 @@ class OdooPdfFileWriter(PdfFileWriter):
             })
 
     def embed_odoo_attachment(self, attachment):
+        assert attachment, "embed_odoo_attachment cannot be called without attachment."
         self.addAttachment(attachment.name, attachment.raw, attachment.mimetype)
 
     def cloneReaderDocumentRoot(self, reader):


### PR DESCRIPTION
Recent changes in the edi formats made it so that factur-x would always
be embedded when using any edi.
Fix that and make sure to not try to embed an attachment if none are
given.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
