### PR TITLE
[FIX] purchase: planned date in different TZ

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1233,7 +1233,9 @@ class PurchaseOrderLine(models.Model):
         """Return a datetime which is the noon of the input date(time) according
         to order user's time zone, convert to UTC time.
         """
-        return timezone(self.order_id.user_id.tz or self.company_id.partner_id.tz or 'UTC').localize(datetime.combine(date, time(12))).astimezone(UTC).replace(tzinfo=None)
+        tz = timezone(self.order_id.user_id.tz or self.company_id.partner_id.tz or 'UTC')
+        date = date.astimezone(tz) # date is UTC, applying the offset could change the day
+        return tz.localize(datetime.combine(date, time(12))).astimezone(UTC).replace(tzinfo=None)
 
     def _update_date_planned(self, updated_date):
         self.date_planned = updated_date


### PR DESCRIPTION
Depending on the TZ and the current time, the planned date of a PO may
be incorrect

To reproduce the issue:
1. Setup the server:
    - TZ: Australia/Sydney (UTC+11)
    - Time: 08:00 am
2. Create a PO:
    - Add a product (ensure the product doesn't have any lead time)

Error: The receipt date becomes the date of yesterday

The computation of `date_planned` is based on `date_order`, which is
UTC. Suppose current date is "2021-12-03 08:00 (UTC+11)": `date_order`
is `2021-12-02 21:00`. Therefore, in `_convert_to_middle_of_day`, when
combining the date of `date_order` and the time (12:00), the date day is
not the correct one (02 instead of 03)

Before combining the date and the time, we should first apply the
initial offset to ensure that the date day is correct

OPW-2689883