### PR TITLE
[FIX] point_of_sale : impossible to open the pos

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2103,7 +2103,10 @@ exports.Orderline = Backbone.Model.extend({
             if (tax_mappings && tax_mappings.length) {
                 _.each(tax_mappings, function(tm) {
                     if (tm.tax_dest_id) {
-                        taxes.push(self.pos.taxes_by_id[tm.tax_dest_id[0]]);
+                        var taxe = self.pos.taxes_by_id[tm.tax_dest_id[0]];
+                        if (taxe) {
+                            taxes.push(taxe);
+                        }
                     }
                 });
             } else{


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Create a TAX A and TAX B
- Create a fiscal position, and TAX A in scr and TAX B in dest, and add other tax map
- Use this fiscal position in POS
- A month latter unactive TAX B (because the law have change).
--> You have an issue during opening the pos


@pimodoo @caburj 

https://11481493-14-0-all.runbot53.odoo.com/pos/ui?config_id=2#cids=1

https://user-images.githubusercontent.com/16716992/145365412-8f63f480-b7bf-410e-aa7b-9c518ce42885.mov



OPW #2704366

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
