### PR TITLE
[FIX] l10n_nl_edi: fix traceback when posting an invoice

### DIFF
--- a/addons/account_edi_ubl_bis3/data/bis3_templates.xml
+++ b/addons/account_edi_ubl_bis3/data/bis3_templates.xml
@@ -11,6 +11,7 @@
                 xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
                 <t t-set="partner" t-value="partner_vals['partner']"/>
                 <cbc:EndpointID
+                        t-if="partner_vals.get('bis3_endpoint')"
                         t-att-schemeID="partner_vals['bis3_endpoint_scheme']"
                         t-esc="partner_vals['bis3_endpoint']"/>
                 <cac:PartyIdentification t-if="partner_vals.get('partner_identification')">

--- a/addons/l10n_nl_edi/i18n/l10n_nl_edi.pot
+++ b/addons/l10n_nl_edi/i18n/l10n_nl_edi.pot
@@ -1,0 +1,77 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_nl_edi
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 15.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-12-07 10:59+0000\n"
+"PO-Revision-Date: 2021-12-07 10:59+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_nl_edi
+#: code:addons/l10n_nl_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Customer's address must include street, zip and city (%s)."
+msgstr ""
+
+#. module: l10n_nl_edi
+#: code:addons/l10n_nl_edi/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"Customer's country must belong to the EAS (Electronic Address Scheme) code "
+"list."
+msgstr ""
+
+#. module: l10n_nl_edi
+#: model:ir.model,name:l10n_nl_edi.model_account_edi_format
+msgid "EDI format"
+msgstr ""
+
+#. module: l10n_nl_edi
+#: code:addons/l10n_nl_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Each invoice line must have a product or a label."
+msgstr ""
+
+#. module: l10n_nl_edi
+#: code:addons/l10n_nl_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Please define a VAT number for '%s'."
+msgstr ""
+
+#. module: l10n_nl_edi
+#: code:addons/l10n_nl_edi/models/account_edi_format.py:0
+#, python-format
+msgid "The customer %s must have a KvK-nummer or OIN."
+msgstr ""
+
+#. module: l10n_nl_edi
+#: code:addons/l10n_nl_edi/models/account_edi_format.py:0
+#, python-format
+msgid "The supplier %s must have a KvK-nummer or OIN."
+msgstr ""
+
+#. module: l10n_nl_edi
+#: code:addons/l10n_nl_edi/models/account_edi_format.py:0
+#, python-format
+msgid "The supplier %s must have a bank account."
+msgstr ""
+
+#. module: l10n_nl_edi
+#: code:addons/l10n_nl_edi/models/account_edi_format.py:0
+#, python-format
+msgid "The supplier's address must include street, zip and city (%s)."
+msgstr ""
+
+#. module: l10n_nl_edi
+#: code:addons/l10n_nl_edi/models/account_edi_format.py:0
+#, python-format
+msgid "When vat is present, the supplier must have a vat number."
+msgstr ""

--- a/addons/l10n_nl_edi/models/account_edi_format.py
+++ b/addons/l10n_nl_edi/models/account_edi_format.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from odoo import models, _
-
-import base64
 import markupsafe
+from odoo.addons.account_edi_ubl_bis3.models.account_edi_format import COUNTRY_EAS
+
+from odoo import models, _
 
 
 class AccountEdiFormat(models.Model):
@@ -100,6 +100,8 @@ class AccountEdiFormat(models.Model):
             errors.append(_("Customer's address must include street, zip and city (%s).", customer.display_name))
         if customer.country_code == 'NL' and not customer.l10n_nl_kvk and not customer.l10n_nl_oin:
             errors.append(_("The customer %s must have a KvK-nummer or OIN.", customer.display_name))
+        if customer.country_code not in COUNTRY_EAS:
+            errors.append(_("Customer's country must belong to the EAS (Electronic Address Scheme) code list."))
 
         if not invoice.partner_bank_id:
             errors.append(_("The supplier %s must have a bank account.", supplier.display_name))


### PR DESCRIPTION
Steps to reproduce the error:

- Create a new company, set Netherlands as country and fill in the required info (street, zip, city, vat, kvk-number).
- Set a bank account on the company contact.
- Install NL chart of account on this company (Netherlands Accounting package).
- Create a test customer, and don't set any address or set a country not listed in EAS (https://docs.peppol.eu/poacc/billing/3.0/codelist/eas/).
- Create an invoice for this test customer and try to post it.

Before this commit, if a Dutch company had tried to create an invoice for a customer from a country not listed in the Electronic Address Scheme (EAS) codes, Odoo would have given them a traceback error.

Now the code checks if the customer is from an EAS country: if they are, the code renders the bis3 invoice template, if not a UserError is thrown explaining the problem.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
