### PR TITLE
[FIX] base{_import_module}: cloc should not count generated code

### DIFF
--- a/addons/base_import_module/tests/__init__.py
+++ b/addons/base_import_module/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import test_cloc

--- a/addons/base_import_module/tests/test_cloc.py
+++ b/addons/base_import_module/tests/test_cloc.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tools import cloc
+from odoo.addons.base.tests import test_cloc
+
+class TestClocFields(test_cloc.TestClocCommon):
+
+    def test_fields_from_import_module(self):
+        """
+            Check that custom computed fields installed with an imported module
+            is counted as customization
+        """
+        # Make sure previous test is still working with base_import_module installed
+        self.common_test_field_count()
+        self.env['ir.module.module'].create({
+            'name': 'imported_module',
+            'state': 'installed',
+            'imported': True,
+        })
+        f1 = self.create_field('x_imported_field')
+        self.create_xml_id('import_field', f1.id, 'imported_module')
+        cl = cloc.Cloc()
+        cl.count_customization(self.env)
+        self.assertEqual(cl.code.get('imported_module', 0), 1, 'Count fields with xml_id of imported module')
+        f2 = self.create_field('x_base_field')
+        self.create_xml_id('base_field', f2.id, 'base')
+        self.assertEqual(cl.code.get('base', 0), 0, "Don't count fields from standard module")

--- a/odoo/addons/base/tests/test_cloc.py
+++ b/odoo/addons/base/tests/test_cloc.py
@@ -2,7 +2,7 @@
 import sys
 
 from odoo.tools import cloc
-from odoo.tests.common import TransactionCase
+from odoo.tests import TransactionCase, tagged
 
 XML_TEST = """<!-- Comment -->
 <?xml version="1.0" encoding="UTF-8"?>
@@ -79,7 +79,55 @@ function() {
 }
 '''
 
-class TestCloc(TransactionCase):
+class TestClocCommon(TransactionCase):
+    def create_xml_id(self, name, res_id, module='studio_customization'):
+        self.env['ir.model.data'].create({
+            'name': name,
+            'model': 'ir.model.fields',
+            'res_id': res_id,
+            'module': module,
+        })
+
+    def create_field(self, name):
+        return self.env['ir.model.fields'].with_context(studio=True).create({
+            'name': name,
+            'field_description': name,
+            'model': 'res.partner',
+            'model_id': self.env.ref('base.model_res_partner').id,
+            'ttype': 'integer',
+            'store': False,
+            'compute': "for rec in self: rec['x_invoice_count'] = 10",
+        })
+
+    def common_test_field_count(self):
+        """
+            Check that we count custom fields with no module or studio not auto generated
+            Having an xml_id but no existing module is consider as not belonging to a module
+        """
+        f1 = self.create_field('x_invoice_count')
+        self.create_xml_id('invoice_count', f1.id)
+        cl = cloc.Cloc()
+        cl.count_customization(self.env)
+        self.assertEqual(cl.code.get('odoo/studio', 0), 0, 'Studio auto generated count field should not be counted in cloc')
+        f2 = self.create_field('x_studio_custom_field')
+        self.create_xml_id('studio_custom', f2.id)
+        cl = cloc.Cloc()
+        cl.count_customization(self.env)
+        self.assertEqual(cl.code.get('odoo/studio', 0), 1, 'Count other studio computed field')
+        f3 = self.create_field('x_custom_field')
+        cl = cloc.Cloc()
+        cl.count_customization(self.env)
+        self.assertEqual(cl.code.get('odoo/studio', 0), 2, 'Count fields without xml_id')
+        f4 = self.create_field('x_custom_field_export')
+        self.create_xml_id('studio_custom', f4.id, '__export__')
+        cl = cloc.Cloc()
+        cl.count_customization(self.env)
+        self.assertEqual(cl.code.get('odoo/studio', 0), 3, 'Count fields with xml_id but without module')
+
+
+
+class TestCloc(TestClocCommon):
+
     def test_parser(self):
         cl = cloc.Cloc()
         xml_count = cl.parse_xml(XML_TEST)
@@ -96,3 +144,18 @@ class TestCloc(TransactionCase):
             self.assertEqual(py_count, (8, 16))
         js_count = cl.parse_js(JS_TEST)
         self.assertEqual(js_count, (10, 17))
+
+    def test_ignore_auto_generated_computed_field(self):
+        self.common_test_field_count()
+
+@tagged('post_install', '-at_install')
+class TestClocStdNoCusto(TestClocCommon):
+
+    def test_no_custo_install(self):
+        """
+            Make sure after the installation of module
+            no database customization is counted
+        """
+        cl = cloc.Cloc()
+        cl.count_customization(self.env)
+        self.assertEqual(cl.code.get('odoo/studio', 0), 0, 'Module should not generate customization in database')

--- a/odoo/tools/cloc.py
+++ b/odoo/tools/cloc.py
@@ -163,7 +163,12 @@ class Cloc(object):
             SELECT f.id, m.name FROM ir_model_fields AS f
                 LEFT JOIN ir_model_data AS d ON (d.res_id = f.id AND d.model = 'ir.model.fields')
                 LEFT JOIN ir_module_module AS m ON m.name = d.module
-            WHERE f.compute IS NOT null AND (m.name IS null {})
+            WHERE f.compute IS NOT null AND (
+                -- Do not count studio field
+                (m.name IS null AND (d.module != 'studio_customization' or d.module is NULL))
+                -- Unless they start with x_studio
+                OR (d.module = 'studio_customization' AND f.name ilike 'x_studio%')
+                {})
         """.format(imported_module)
         env.cr.execute(query)
         data = {r[0]: r[1] for r in env.cr.fetchall()}


### PR DESCRIPTION
* Studio generate computed field "count" when the user add a button
in the button box. Since those lines are written by studio with drag and drop
it should not be counted for the maintenance subscription.

We can detect them because field created by the user in studio start with x_studio
and fields created outside studio does not have studio_customization
xml_id

* Add test to make no standard module introduce customization in the
database during the install the will be counted by cloc

see https://github.com/odoo/enterprise/pull/22664

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
