### PR TITLE
[FIX] web: click on time should work in kanban view

### DIFF
--- a/addons/web/static/src/legacy/js/fields/abstract_field.js
+++ b/addons/web/static/src/legacy/js/fields/abstract_field.js
@@ -35,7 +35,6 @@ var Widget = require('web.Widget');
 
 var AbstractField = Widget.extend({
     events: {
-        'click': '_onClick',
         'keydown': '_onKeydown',
     },
     custom_events: {
@@ -224,6 +223,9 @@ var AbstractField = Widget.extend({
             self.$el.attr('name', self.name);
             self.$el.addClass('o_field_widget');
             self.$el.toggleClass('o_quick_editable', self._canQuickEdit);
+            if (self.viewType === 'form') {
+                self.$el.on('click', self._onClick.bind(self));
+            }
             return self._render();
         });
     },

--- a/addons/web/static/tests/legacy/views/kanban_tests.js
+++ b/addons/web/static/tests/legacy/views/kanban_tests.js
@@ -2794,6 +2794,43 @@ QUnit.module('Views', {
         kanban.destroy();
     });
 
+    QUnit.test('Open record when clicking on widget field', async function (assert) {
+        assert.expect(2);
+
+        const kanban = await createView({
+            View: KanbanView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <kanban>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div class="oe_kanban_global_click">
+                                <field name="salary" widget="monetary"/>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>`,
+            archs: {
+                'product,false,form': '<form string="Product"><field name="display_name"/></form>',
+            },
+            intercepts: {
+                switch_view(ev) {
+                    assert.deepEqual({
+                        res_id: ev.data.res_id,
+                        view_type: ev.data.view_type,
+                    }, {
+                        res_id: 1,
+                        view_type: 'form',
+                    }, "should trigger an event to open the form view");
+                },
+            },
+        });
+        assert.containsN(kanban, '.o_kanban_record:not(.o_kanban_ghost)', 4);
+        kanban.$(".oe_kanban_global_click .o_field_monetary[name=salary]:eq(0)").click();
+        kanban.destroy();
+    });
+
     QUnit.test('o2m loaded in only one batch', async function (assert) {
         assert.expect(9);
 


### PR DESCRIPTION
Before this commit:
kanban click on time value does not open the form view.

After this commit:
kanban click on time value will open the form view.

Task-2655411