### PR TITLE
[13.0][FIX] purchase_stock: add explicit move reference on price difference account move line and correction price line

### DIFF
--- a/addons/purchase_stock/models/account_invoice.py
+++ b/addons/purchase_stock/models/account_invoice.py
@@ -149,6 +149,7 @@ class AccountMove(models.Model):
                         'analytic_tag_ids': [(6, 0, line.analytic_tag_ids.ids)],
                         'exclude_from_invoice_tab': True,
                         'is_anglo_saxon_line': True,
+                        'ref': move.ref,
                     }
                     vals.update(line._get_fields_onchange_subtotal(price_subtotal=vals['price_subtotal']))
                     lines_vals_list.append(vals)
@@ -168,6 +169,7 @@ class AccountMove(models.Model):
                         'analytic_tag_ids': [(6, 0, line.analytic_tag_ids.ids)],
                         'exclude_from_invoice_tab': True,
                         'is_anglo_saxon_line': True,
+                        'ref': move.ref,
                     }
                     vals.update(line._get_fields_onchange_subtotal(price_subtotal=vals['price_subtotal']))
                     lines_vals_list.append(vals)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Having an **Inventory Valuation Automated (Realtime)** activated for a purchased product with a **Price Difference Account** set, using **Anglo Saxon Accouting** leads to lose bill reference once bill is posted.

Current behavior before PR:
- Create a bill for a purchased product with Inventory Valuation Automated using Anglo Saxon Accouting and set a Price Difference Account for that Product/Category (Force to create a Price Difference Journal Item)
- Set a reference
- After post the Bill, reference is lost.

Desired behavior after PR is merged:
- Do not lose the reference

CC @ForgeFlow 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
