### PR TITLE
[FIX] base: ensure all attachments are in sudo

### DIFF
--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -408,7 +408,7 @@ class AssetsBundle(object):
 
     def is_css_preprocessed(self):
         preprocessed = True
-        old_attachments = self.env['ir.attachment']
+        old_attachments = self.env['ir.attachment'].sudo()
         asset_types = [SassStylesheetAsset, ScssStylesheetAsset, LessStylesheetAsset]
         if self.user_direction == 'rtl':
             asset_types.append(StylesheetAsset)


### PR DESCRIPTION
```
>>> u1 = self.sudo(False).browse(1)
>>> u2 = self.sudo().browse(2)
>>> (u1 + u2).env.su
False
>>> (u2 + u1).env.su
True
```
Ensure all attachments are always in sudo

Before this commit, a low level user could not regenerate the assets

Introduced at 3a98996eed

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/13.0/odoo/addons/base/models/qweb.py", line 333, in _compiled_fn
    return compiled(self, append, new, options, log)
  File "<template>", line 1, in template_web_frontend_layout_191
  File "<decorator-gen-56>", line 2, in _get_asset_nodes
  File "/home/odoo/src/odoo/13.0/odoo/tools/cache.py", line 90, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/home/odoo/src/odoo/13.0/odoo/addons/base/models/ir_qweb.py", line 299, in _get_asset_nodes
    return remains + asset.to_node(css=css, js=js, debug=debug, async_load=async_load, defer_load=defer_load, lazy_load=lazy_load)
  File "/home/odoo/src/odoo/13.0/odoo/addons/base/models/assetsbundle.py", line 137, in to_node
    self.preprocess_css(debug=debug, old_attachments=old_attachments)
  File "/home/odoo/src/odoo/13.0/odoo/addons/base/models/assetsbundle.py", line 463, in preprocess_css
    old_attachments.unlink()
  File "/home/odoo/src/odoo/13.0/odoo/addons/base/models/ir_attachment.py", line 503, in unlink
    self.check('unlink')
  File "/home/odoo/src/odoo/13.0/odoo/addons/base/models/ir_attachment.py", line 386, in check
    raise AccessError(_("Sorry, you are not allowed to access this document."))
odoo.exceptions.AccessError: ('Sorry, you are not allowed to access this document.', None)
```
