### PR TITLE
[FIX] web: MockServer search

### DIFF
--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -406,8 +406,6 @@ export class MockServer {
                 return this.mockLoadAction(args);
             case "/web/dataset/search_read":
                 return this.mockSearchReadController(args);
-            case "/web/dataset/search":
-                return this.mockSearchController(args);
         }
         if (
             route.indexOf("/web/image") >= 0 ||
@@ -1530,7 +1528,7 @@ export class MockServer {
             sort: kwargs.order || args[4],
             context: kwargs.context,
         });
-        return result.records;
+        return result.records.map((r) => r.id);
     }
 
     /**

--- a/addons/web/static/tests/mock_server_tests.js
+++ b/addons/web/static/tests/mock_server_tests.js
@@ -87,8 +87,7 @@ QUnit.test("performRPC: search with active_test=false", async function (assert) 
             context: { active_test: false },
         },
     });
-    const ids = result.map((record) => record.id);
-    assert.deepEqual(ids, [1, 2]);
+    assert.deepEqual(result, [1, 2]);
 });
 
 QUnit.test("performRPC: search with active_test=true", async function (assert) {
@@ -102,8 +101,7 @@ QUnit.test("performRPC: search with active_test=true", async function (assert) {
             context: { active_test: true },
         },
     });
-    const ids = result.map((record) => record.id);
-    assert.deepEqual(ids, [1]);
+    assert.deepEqual(result, [1]);
 });
 
 QUnit.test("performRPC: search_read with active_test=false", async function (assert) {


### PR DESCRIPTION
The mockSearch function should not return the list of records for a
domain and a model but the list of ids.

The path "/web/dataset/search" does not exist.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
