### PR TITLE
[FIX] mass_mailing: consider ab_testing_schedule_datetime may be false

### DIFF
--- a/addons/mass_mailing/data/mailing_data_templates.xml
+++ b/addons/mass_mailing/data/mailing_data_templates.xml
@@ -15,7 +15,8 @@
                     <b><t t-out="mailing.ab_testing_mailings_count - 1"/> other versions</b> from the same campaign.
                 </p>
                 <p>
-                    <t t-if="mailing.ab_testing_winner_selection == 'manual'">Don't forget to send your prefered version</t>
+		    <t t-if="mailing.ab_testing_winner_selection == 'manual'">Don't forget to send your prefered version</t>
+		    <t t-elif="not mailing.ab_testing_schedule_datetime">Since the date and time for this test has not been scheduled, don't forget to manually send your preferred version.</t>	
                     <t t-else="">
                         Then on <b><t t-out="mailing.ab_testing_schedule_datetime.strftime('%b %d, %Y')"/></b> the <t t-out="mailing.mailing_type_description"/> having the <b><t t-out="ab_testing_winner_selection_description"/></b> will be sent
                     </t> to the remaining <t t-out="remaining_ab_testing_pc"/>% of recipients.

--- a/addons/mass_mailing/i18n/mass_mailing.pot
+++ b/addons/mass_mailing/i18n/mass_mailing.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-24 08:19+0000\n"
-"PO-Revision-Date: 2022-01-24 08:19+0000\n"
+"POT-Creation-Date: 2022-02-01 17:39+0000\n"
+"PO-Revision-Date: 2022-02-01 17:39+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -3465,6 +3465,13 @@ msgstr ""
 #: model:ir.ui.menu,name:mass_mailing.menu_mass_mailing_global_settings
 #: model_terms:ir.ui.view,arch_db:mass_mailing.view_mail_mass_mailing_form
 msgid "Settings"
+msgstr ""
+
+#. module: mass_mailing
+#: model_terms:ir.ui.view,arch_db:mass_mailing.ab_testing_description
+msgid ""
+"Since the date and time for this test has not been scheduled, don't forget "
+"to manually send your preferred version."
 msgstr ""
 
 #. module: mass_mailing


### PR DESCRIPTION
`ab_testing_schedule_datetime` is not a required field, hence it may not be set. 

There is a scenario where `ab_testing_winner_selection='manual'` and `ab_testing_schedule_datetime=False`, then the code will fail on trying to get the date:
`<t t-out="mailing.ab_testing_schedule_datetime.strftime('%b %d, %Y')"/>`

specifically, on trying to call `strftime('%b %d, %Y')` on a boolean (`False`) object.

https://github.com/odoo/upgrade/pull/2993
https://github.com/odoo/upgrade/pull/3062