### PR TITLE
[FIX] tests: fix race condition when spawning chrome

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -761,7 +761,7 @@ class ChromeBrowser():
             port_file = pathlib.Path(self.user_data_dir, 'DevToolsActivePort')
             for _ in range(100):
                 time.sleep(0.1)
-                if port_file.is_file():
+                if port_file.is_file() and port_file.stat().st_size > 5:
                     with port_file.open('r', encoding='utf-8') as f:
                         self.devtools_port = int(f.readline())
                     break


### PR DESCRIPTION
When Chrome is spawned, the `DevToolsActivePort`file is awaited to read
the port. Sometimes the file is read but is still empty, resulting in a
ValueError when trying to cast into integer. This happens when Chrome
did not have time yet to write into the file.

With this commit, we expect the file to contain at least 5 bytes which
is enough to contain the max port number.

