### PR TITLE
[FIX] payment_adyen: discard refund notifications for unknown source txs

### DIFF
--- a/addons/payment_adyen/models/payment_transaction.py
+++ b/addons/payment_adyen/models/payment_transaction.py
@@ -167,7 +167,13 @@ class PaymentTransaction(models.Model):
             source_tx = self.search(
                 [('acquirer_reference', '=', source_acquirer_reference), ('provider', '=', 'adyen')]
             )
-            tx = self._adyen_create_refund_tx_from_feedback_data(source_tx, data)
+            if source_tx:
+                # Manually create a refund transaction with a new reference. The reference of
+                # the refund transaction was personalized from Adyen and could be identical to
+                # that of an existing transaction.
+                tx = self._adyen_create_refund_tx_from_feedback_data(source_tx, data)
+            else:  # The refund was initiated for an unknown source transaction
+                pass  # Don't do anything with the refund notification
 
         if not tx:
             raise ValidationError(


### PR DESCRIPTION
Before this commit, a ValueError would be raised upon receiving a refund
notification for a source transaction whose reference was not found in
the database. As only ValidationError's are caught by the webhook
controller, the acknowledgment string was never returned to Adyen and
the endpoint was automatically disabled.

This commit adds a check on the existence of the source transaction to
allow discarding refund notifications if it is not found.

task-2704522