### PR TITLE
[FIX] account: create account from contact

### DIFF
--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -27,6 +27,7 @@
                            <group name="left_main_group">
                              <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                              <field name="user_type_id" widget="account_hierarchy_selection"/>
+                             <field name="reconcile" attrs="{'invisible': ['|', ('internal_type','=','liquidity'), ('internal_group', '=', 'off_balance')]}"/>
                              <field name="group_id"/>
                              <field name="internal_type" invisible="1" readonly="1"/>
                              <field name="internal_group" invisible="1" readonly="1"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: [#80775](https://github.com/odoo/odoo/issues/80775)

Current behavior before PR: it is not possible to create a payable / receivable account from partner since reconcile boolean is not set and not present in view for setting it.

This PR simply adds that boolean in view so that it can be taken into account when creating the account (boolean is automatically set to True when selecting user_type as Payable or Receivable as done in account.account tree view)

Desired behavior after PR is merged: you can create payable / receivable account directly from partner




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
