### PR TITLE
[FIX] pos_cache: error when loading missing products

### DIFF
--- a/addons/pos_cache/static/src/js/pos_cache.js
+++ b/addons/pos_cache/static/src/js/pos_cache.js
@@ -82,6 +82,8 @@ models.PosModel = models.PosModel.extend({
             return new Promise((resolve, reject) => {
                 next(resolve, reject);
             });
+        }).then(() => {
+            self.models.push(self.product_model);
         });
     },
 });


### PR DESCRIPTION
As part of loading orders, we need to make sure we load the missing
products. This process relies on the existence of the `product.product`
model declaration in the PosModel. However, since we are loading
products differently here in pos_cache, the `product.product` model
is removed from the list of models.

We are now return the `product.product` model to the list of models
after loading.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
