### PR TITLE
[FIX] account: fiscal position map included -> included tax

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -611,7 +611,7 @@ class AccountTax(models.Model):
         line_taxes = line_taxes._origin
         incl_tax = prod_taxes.filtered(lambda tax: tax not in line_taxes and tax.price_include)
         if incl_tax:
-            return incl_tax.compute_all(price)['total_excluded']
+            return incl_tax.compute_all(price)['total_included']
         return price
 
     @api.model


### PR DESCRIPTION
1. Install Sales & accounting
2. Create 2 taxes (10% and 20%) make sure both of them are "Included in Price"
3. Create a fiscal position which tax on product 20% -> tax on product 10%
4. Create a product with the tax 20% and a Sales Price of 100$
5. Create a SO, choose any customer
6. Add the 4. product
-> everything is ok, it shows as total 100$ with the tax included correctly
7. In "Other Info" change the fiscal position to use the one created in 3.
-> still ok, the taxes switch to 10% and should have changed to 9.09
8. Remove the product
9. Add it again
-> NOK, the total changed to 83.33$ instead of the 100

opw-2701502

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
