### PR TITLE
[FIX] lunch: prevent order of unavailable vendor

### DIFF
--- a/addons/lunch/models/lunch_order.py
+++ b/addons/lunch/models/lunch_order.py
@@ -201,6 +201,9 @@ class LunchOrder(models.Model):
                 raise ValidationError(_('Your wallet does not contain enough money to order that. To add some money to your wallet, please contact your lunch manager.'))
 
     def action_order(self):
+        for order in self:
+            if not order.supplier_id.available_today:
+                raise UserError(_('The vendor related to this order is not available today.'))
         if self.filtered(lambda line: not line.product_id.active):
             raise ValidationError(_('Product is no longer available.'))
         self.write({


### PR DESCRIPTION
There is a default Available Today filter on products view but it is not
enough to prevent a very hungry employee to order a product from a vendor
not available today if he removes the filter.

Description of the issue/feature this PR addresses:
opw-2704736

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
