### PR TITLE
[FIX] product,point_of_sale: price not found when nested and is in 2nd item

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -212,7 +212,9 @@ class Pricelist(models.Model):
                         continue
 
                 if rule.base == 'pricelist' and rule.base_pricelist_id:
-                    price = rule.base_pricelist_id._compute_price_rule([(product, qty, partner)], date, uom_id)[product.id][0]  # TDE: 0 = price, 1 = rule
+                    price, sub_suitable_rule = rule.base_pricelist_id._compute_price_rule([(product, qty, partner)], date, uom_id)[product.id]
+                    if not sub_suitable_rule:
+                        continue
                     src_currency = rule.base_pricelist_id.currency_id
                 else:
                     # if base option is public price take sale price else cost price of product


### PR DESCRIPTION
To replicate:
- Create three pricelist: A, B and C
- Create two items on pricelist A, related to B and C (using the field
  "Other Pricelist")
- On pricelist C, define a price for a product X
- Create a sale order, select pricelist A and select product X

Current behavior before this change:
Price is looked into B. Since it's not there, the default sales price
is taken.

Expected behavior after this change:
If the product is not found into the 1st item, it's looked into next
ones.

OPW #2706881



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
