### PR TITLE
[FIX] hr_holidays: review allocation and time off validation error messages

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -244,7 +244,7 @@
                 </div>
                 <group>
                     <group name="col_left">
-                        <field name="holiday_status_id" force_save="1" domain="['|', ('requires_allocation', '=', 'no'), '&amp;', ('has_valid_allocation', '=', True), '&amp;', ('virtual_remaining_leaves', '&gt;', 0), ('max_leaves', '>', '0')]" context="{'employee_id':employee_id, 'default_date_from':date_from}" options="{'no_create': True, 'no_open': True, 'request_type':'leave'}" class="w-100"/>
+                        <field name="holiday_status_id" force_save="1" context="{'employee_id':employee_id, 'default_date_from':date_from}" options="{'no_create': True, 'no_open': True, 'request_type':'leave'}" class="w-100"/>
                         <label for="request_date_from" string="Dates" id="label_dates"/>
                         <div>
                             <field name="date_from" invisible="1" widget="daterange"/>


### PR DESCRIPTION
- Do not allow selecting an allocated time off if the employee has no allocation in the selected period
- Display the available allocatiosn and dates in the validation error text if a time off is selected outside the allocation windows

If there is an allocation from Aug 1st to Aug 31st:
    - If a time off is taken between the 1st and 31st of August: ok
    - If a time off longer than the allocated days is taken between the 1st and 31st of August: Validation error message, missing allocated days
    - If a time off is taken before or after the 31st of August: impossible, the time off should not appear in the list
    - If there is a time off between 25/07 and 03/08: the allocated time off is displayed because of the month of August but it can't be validated

- Review the number of allocated days: it displays "0 days remaining out of 0 days" when there is an allocation

task-2667441

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
