### PR TITLE
[FIX] event: execute the scheduler as root

### DIFF
--- a/addons/event/models/event.py
+++ b/addons/event/models/event.py
@@ -3,7 +3,7 @@
 import logging
 import pytz
 
-from odoo import _, api, fields, models
+from odoo import _, api, fields, models, SUPERUSER_ID
 from odoo.tools import format_datetime
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tools.translate import html_translate
@@ -474,7 +474,7 @@ class EventRegistration(models.Model):
         # auto-trigger after_sub (on subscribe) mail schedulers, if needed
         onsubscribe_schedulers = self.event_id.event_mail_ids.filtered(
             lambda s: s.interval_type == 'after_sub')
-        onsubscribe_schedulers.execute()
+        onsubscribe_schedulers.with_user(SUPERUSER_ID).execute()
 
     def button_reg_close(self):
         """ Close Registration """


### PR DESCRIPTION
Partial backport of 61b4b6777d64218f9
Running the scheduler is similar to running a cron, the user executing
the action is not relevant and may introduce access rights issues
