### PR TITLE
[FIX] mail: attachment viewer download and print buttons for guest

### DIFF
--- a/addons/mail/static/src/components/attachment_viewer/attachment_viewer.js
+++ b/addons/mail/static/src/components/attachment_viewer/attachment_viewer.js
@@ -226,7 +226,7 @@ export class AttachmentViewer extends Component {
                     </script>
                 </head>
                 <body onload='onloadImage()'>
-                    <img src="${this.attachmentViewer.attachment.defaultSource}" alt=""/>
+                    <img src="${this.attachmentViewer.imageUrl}" alt=""/>
                 </body>
             </html>`);
         printWindow.document.close();

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -58,7 +58,7 @@ function factory(dependencies) {
          */
         download() {
             const downloadLink = document.createElement('a');
-            downloadLink.setAttribute('href', `/web/content/ir.attachment/${this.id}/datas?download=true`);
+            downloadLink.setAttribute('href', this.downloadUrl);
             // Adding 'download' attribute into a link prevents open a new tab or change the current location of the window.
             // This avoids interrupting the activity in the page such as rtc call.
             downloadLink.setAttribute('download','');
@@ -158,10 +158,10 @@ function factory(dependencies) {
          */
         _computeDownloadUrl() {
             if (!this.accessToken && this.originThread && this.originThread.model === 'mail.channel') {
-                return `/mail/channel/${this.originThread.id}/attachment/${this.id}`;
+                return `/mail/channel/${this.originThread.id}/attachment/${this.id}?download=true`;
             }
-            const accessToken = this.accessToken ? `?access_token=${this.accessToken}` : '';
-            return `/web/content/ir.attachment/${this.id}/datas${accessToken}`;
+            const accessToken = this.accessToken ? `access_token=${this.accessToken}&` : '';
+            return `/web/content/ir.attachment/${this.id}/datas?${accessToken}download=true`;
         }
 
         /**


### PR DESCRIPTION
**Current behavior before PR:**

Attachment viewer download and print buttons not working for guests.

**Desired behavior after PR is merged:**

Attachment viewer download and print buttons will work for guests.

LINKS:
Task-2664842

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
