### PR TITLE
[FIX] point_of_sale,pos_sale: import tax from orderline

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1814,6 +1814,7 @@ exports.Orderline = Backbone.Model.extend({
             return;
         }
         this.product = options.product;
+        this.tax_ids = options.tax_ids;
         this.set_product_lot(this.product);
         this.set_quantity(1);
         this.discount = 0;

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
@@ -147,6 +147,7 @@ odoo.define('pos_sale.SaleOrderManagementScreen', function (require) {
                         order: this.env.pos.get_order(),
                         product: this.env.pos.db.get_product_by_id(line.product_id[0]),
                         price: line.price_unit,
+                        tax_ids: orderFiscalPos ? undefined : line.tax_id,
                         price_manually_set: true,
                         sale_order_origin_id: clickedOrder,
                         sale_order_line_id: line,


### PR DESCRIPTION
Set up a [TEST] product with a tax A
Create a SO with [TEST] and a tax B and confirm
Open POS, import the created SO

[TEST] will be imported with tax A
while tax B should be pulled from the sale order line instead

opw-2699793

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
