### PR TITLE
[IMP] web: Run JS tests

### DIFF
--- a/addons/point_of_sale/static/src/js/debug_manager.js
+++ b/addons/point_of_sale/static/src/js/debug_manager.js
@@ -11,7 +11,7 @@ function runPoSJSTests({ env }) {
                 name: env._t("JS Tests"),
                 target: "new",
                 type: "ir.actions.act_url",
-                url: "/pos/ui/tests?mod=*",
+                url: "/pos/ui/tests?debug=assets",
             });
         },
         sequence: 35,

--- a/addons/web/static/src/core/debug/debug_providers.js
+++ b/addons/web/static/src/core/debug/debug_providers.js
@@ -28,6 +28,22 @@ commandProviderRegistry.add("debug", {
                 category: "debug",
                 name: env._t("Deactivate debug mode"),
             });
+            result.push({
+                action() {
+                    const runTestsURL = browser.location.origin + "/web/tests?debug=assets";
+                    browser.open(runTestsURL);
+                },
+                category: "debug",
+                name: env._t("Run JS Tests"),
+            });
+            result.push({
+                action() {
+                    const runTestsURL = browser.location.origin + "/web/tests/mobile?debug=assets";
+                    browser.open(runTestsURL);
+                },
+                category: "debug",
+                name: env._t("Run JS Mobile Tests"),
+            });
         } else {
             if (options.searchValue.toLowerCase() === "debug") {
                 result.push({

--- a/addons/web/static/src/webclient/debug_items.js
+++ b/addons/web/static/src/webclient/debug_items.js
@@ -6,7 +6,7 @@ import dialogs from "web.view_dialogs";
 import { ComponentAdapter } from "web.OwlCompatibility";
 
 function runJSTestsItem({ env }) {
-    const runTestsURL = browser.location.origin + "/web/tests?mod=*";
+    const runTestsURL = browser.location.origin + "/web/tests?debug=assets";
     return {
         type: "item",
         description: env._t("Run JS Tests"),
@@ -19,7 +19,7 @@ function runJSTestsItem({ env }) {
 }
 
 function runJSTestsMobileItem({ env }) {
-    const runTestsMobileURL = browser.location.origin + "/web/tests/mobile?mod=*";
+    const runTestsMobileURL = browser.location.origin + "/web/tests/mobile?debug=assets";
     return {
         type: "item",
         description: env._t("Run JS Mobile Tests"),


### PR DESCRIPTION
After this commit, the tests launched from the debug tools or the
command palette will be in debug=assets mode.

This commit adds the "Run JS tests" and "Run Mobile JS tests" commands.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
