### PR TITLE
Master mass mailing improve send from list flow dht

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -935,6 +935,20 @@ class Lead(models.Model):
             self.write(dict(additional_values))
         return res
 
+    def action_send_mail_to_leads(self):
+        # Send emails from composer to selected leads
+        action = {
+            "type": "ir.actions.act_window",
+            "view_mode": "form",
+            "res_model": "mail.compose.message",
+            "target": "new",
+            "context": {    
+                'default_composition_mode': 'mass_mail',
+                'default_use_template': False,
+            }
+        }
+        return action
+
     def action_set_won(self):
         """ Won semantic: probability = 100 (active untouched) """
         self.action_unarchive()

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -728,17 +728,16 @@
             <field name="binding_view_types">form</field>
         </record>
 
-        <record id="action_lead_mass_mail" model="ir.actions.act_window">
+        <record id="action_lead_mass_mail" model="ir.actions.server">
             <field name="name">Send email</field>
-            <field name="res_model">mail.compose.message</field>
-            <field name="view_mode">form</field>
-            <field name="target">new</field>
-            <field name="context" eval="{
-    'default_composition_mode': 'mass_mail',
-    'default_use_template': False,
-                }"/>
-            <field name="binding_model_id" ref="model_crm_lead"/>
+            <field name="model_id" ref="crm.model_crm_lead"/>
+            <field name="binding_model_id" ref="crm.model_crm_lead"/>
             <field name="binding_view_types">list</field>
+            <field name="state">code</field>
+            <field name="code">
+                if records:
+                    action = records.action_send_mail_to_leads()
+            </field>
         </record>
 
         <!--

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -51,6 +51,22 @@ class Partner(models.Model):
             WHERE R.res_partner_id = %s """, (self.id,))
         return self.env.cr.dictfetchall()[0].get('starred_count')
 
+    def action_send_mail_to_partner(self):
+        # Send emails from composer to selected partners
+        action = {
+            "type": "ir.actions.act_window",
+            "view_mode": "form",
+            "res_model": "mail.compose.message",
+            "target": "new",
+            "context": {
+                "default_composition_mode": 'mass_mail',
+                "default_partner_to": '{{ object.id or \'\' }}',
+                "default_use_template": False,
+                "default_reply_to_force_new": True,
+            }
+        }
+        return action
+
     # ------------------------------------------------------------
     # MESSAGING
     # ------------------------------------------------------------

--- a/addons/mail/views/res_partner_views.xml
+++ b/addons/mail/views/res_partner_views.xml
@@ -60,17 +60,6 @@
             </field>
         </record>
 
-        <record id="res_partner_view_tree_inherit_mail" model="ir.ui.view">
-            <field name="name">res.partner.view.tree.inherit.mail</field>
-            <field name="model">res.partner</field>
-            <field name="inherit_id" ref="base.view_partner_tree"/>
-            <field name="arch" type="xml">
-                <xpath expr="//field[@name='user_id']" position="after">
-                    <field name="activity_ids" optional="show" widget="list_activity"/>
-                </xpath>
-            </field>
-        </record>
-
         <record id="res_partner_view_activity" model="ir.ui.view">
             <field name="name">res.partner.activity</field>
             <field name="model">res.partner</field>
@@ -102,19 +91,34 @@
         </record>
 
         <!--  Replace the default mass-mailing wizard in base with the composition wizard -->
-        <record id="action_partner_mass_mail" model="ir.actions.act_window">
+        <record id="action_partner_mass_mail" model="ir.actions.server">
             <field name="name">Send email</field>
-            <field name="res_model">mail.compose.message</field>
-            <field name="view_mode">form</field>
-            <field name="target">new</field>
-            <field name="context" eval="{
-                'default_composition_mode': 'mass_mail',
-                'default_partner_to': '{{ object.id or \'\' }}',
-                'default_use_template': False,
-                'default_reply_to_force_new': True,
-            }"/>
+            <field name="model_id" ref="base.model_res_partner"/>
             <field name="binding_model_id" ref="base.model_res_partner"/>
             <field name="binding_view_types">list</field>
+            <field name="state">code</field>
+            <field name="code">
+                if records:
+                    action = records.action_send_mail_to_partner()
+            </field>
+        </record>
+
+        <!-- Moves the view below the action 'action_partner_mass_mail' as
+        action should be defined above the view -->
+        <record id="res_partner_view_tree_inherit_mail" model="ir.ui.view">
+            <field name="name">res.partner.view.tree.inherit.mail</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_tree"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='user_id']" position="after">
+                    <field name="activity_ids" optional="show" widget="list_activity"/>
+                </xpath>
+                <xpath expr="//field[1]" position="before">
+                    <header>
+                        <button name="%(mail.action_partner_mass_mail)d" type="action" string="Email"/>
+                    </header>
+                </xpath>
+            </field>
         </record>
 
     </data>

--- a/addons/mass_mailing/models/res_partner.py
+++ b/addons/mass_mailing/models/res_partner.py
@@ -7,3 +7,19 @@ from odoo import models
 class Partner(models.Model):
     _inherit = 'res.partner'
     _mailing_enabled = True
+
+    def action_send_mail_to_partner(self):
+        ''' Send emails from mailing.mailing to selected partners if user 
+        has mass_mailing rights '''
+        action = super(Partner, self).action_send_mail_to_partner()
+        if self.env.user.has_group('mass_mailing.group_mass_mailing_user'):
+            action['context'] = {
+                'default_mailing_domain': [('id', 'in', self.env.context['active_ids'])],
+                'default_mailing_model_id': self.env['ir.model']._get(self._name).id,
+                'default_reply_to': '',
+                'default_reply_to_mode': 'new',
+            }
+            action['res_model'] = "mailing.mailing"
+            action['target'] = 'current'
+            action['view_id'] = [self.env.ref('mass_mailing.mailing_mailing_view_form_nomodel').id, 'form']
+        return action

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -460,6 +460,24 @@
             </field>
         </record>
 
+        <!-- This view is specifically for sending mass mailings from different apps
+        like Contacts/CRM. And for that reason, priority is given high. -->
+        <record id="mailing_mailing_view_form_nomodel" model="ir.ui.view">
+            <field name="name">mailing.mailing.view.form.nomodel</field>
+            <field name="model">mailing.mailing</field>
+            <field name="inherit_id" ref="mass_mailing.view_mail_mass_mailing_form"/>
+            <field name="mode">primary</field>
+            <field name="priority">100</field>
+            <field name="arch" type="xml">
+                <xpath expr="//label[@for='mailing_model_id']" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </xpath>
+                <xpath expr="//div[@name='mailing_model_id_container']" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </xpath>
+            </field>
+        </record>
+
         <record model="ir.ui.view" id="view_mail_mass_mailing_kanban">
             <field name="name">mailing.mailing.kanban</field>
             <field name="model">mailing.mailing</field>

--- a/addons/mass_mailing_crm/models/crm_lead.py
+++ b/addons/mass_mailing_crm/models/crm_lead.py
@@ -7,3 +7,17 @@ from odoo import models
 class CrmLead(models.Model):
     _inherit = 'crm.lead'
     _mailing_enabled = True
+
+    def action_send_mail_to_leads(self):
+        ''' Send emails from mailing.mailing to selected leads if user 
+        has mass_mailing rights '''
+        action = super(CrmLead, self).action_send_mail_to_leads()
+        if self.env.user.has_group('mass_mailing.group_mass_mailing_user'):
+            action['context'] = {
+                'default_mailing_domain': [('id', 'in', self.env.context['active_ids'])],
+                'default_mailing_model_id': self.env['ir.model']._get(self._name).id,
+            }
+            action['res_model'] = "mailing.mailing"
+            action['target'] = 'current'
+            action['view_id'] = [self.env.ref('mass_mailing.mailing_mailing_view_form_nomodel').id, 'form']
+        return action


### PR DESCRIPTION
PURPOSE

Improve the (CRM and CONTACTS)/Email marketing integration and allow users to send beautiful mailing to a manual selection of contacts/leads.

SPECIFICATION:

CURRENT:
- when we send email from crm with mass_mailing install,
  'mail.message.composer' wizard was opening, where we add
  the values of mail in which we don't have any options for editing
  mail body like mass_mailing(use of editor). We can only send plain
  emails or predefined templates.
  
  TO BE:
- we redirect the users to 'mailing.mailing' form view on send email.
  So, he can use editors to create a beautiful mails.

TaskId-2672198