### PR TITLE
[IMP] payment: add 'payment tokens' on refund transaction

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -602,6 +602,7 @@ class PaymentTransaction(models.Model):
             'operation': 'refund',
             'source_transaction_id': self.id,
             'partner_id': self.partner_id.id,
+            'token_id': self.token_id.id,
             **custom_create_values,
         })
 


### PR DESCRIPTION
Whenever making a refund for a transaction with a saved token
the token will appear also on the refund transaction.
It is useful to keep track of which token was used in each
transaction, this remains true for refunds.
The token will also appear on the payments.

Task - 2694760


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
