### PR TITLE
[FIX] mail: inconsistent is typing in composer footer

### DIFF
--- a/addons/mail/static/src/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props.js
+++ b/addons/mail/static/src/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const { Component } = owl;
+const { onPatched } = owl.hooks;
 
 /**
  * Compares `a` and `b` up to the given `propsCompareDepth`.
@@ -55,7 +56,11 @@ function isEqual(a, b, propsCompareDepth) {
  */
 export function useShouldUpdateBasedOnProps({ propsCompareDepth = {} } = {}) {
     const component = Component.current;
+    let forceRender = false;
     component.shouldUpdate = nextProps => {
+        if (forceRender) {
+            return true;
+        }
         const allNewProps = Object.assign({}, nextProps);
         const defaultProps = component.constructor.defaultProps;
         for (const key in defaultProps) {
@@ -63,6 +68,8 @@ export function useShouldUpdateBasedOnProps({ propsCompareDepth = {} } = {}) {
                 allNewProps[key] = defaultProps[key];
             }
         }
-        return !isEqual(component.props, allNewProps, propsCompareDepth);
+        forceRender = !isEqual(component.props, allNewProps, propsCompareDepth);
+        return forceRender;
     };
+    onPatched(() => forceRender = false);
 }


### PR DESCRIPTION
Before this commit, is typing indication in the composer footer
was inconsistent with the user currently typing in conversation.

Steps to reproduce:
- create two conversations with users A and B
- open conversation with user A
- let A typing something
- quickly switch to user B

Observed behavior:
Displays 'User A is typing...' in composer footer of conversation
with user B.

Expected behavior:
Should not display typing in composer footer of conversation
with user B.

The modeling is correct, but the problem is caused by the component
that is not re-rendered, thus still displaying "User A is typing..."
even after changing conversation.
OWL actually plans 2 patches of this component when changing
conversation instead of a single patch. The 1st patch should
have rendered the component correctly, but for some reasons
it's canceled and 2nd patch prevent rendering due to unchanged props.

The `shouldUpdateBasedOnProps` component hook did not consider
update attempts that could be canceled. This commit adds this
consideration, so that it ensures component is eventually
rendered correctly

Task-2705078
