### PR TITLE
[FIX] sale_mrp: not include consu components in kit's COGS

### DIFF
--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -19,10 +19,10 @@ class AccountMoveLine(models.Model):
                 qty_invoiced = sum([x.product_uom_id._compute_quantity(x.quantity, x.product_id.uom_id) for x in so_line.invoice_lines if x.move_id.state == 'posted'])
                 moves = so_line.move_ids
                 average_price_unit = 0
-                components = so_line._get_bom_component_qty(bom)
-                for product_id in components:
-                    product = self.env['product.product'].browse(product_id)
-                    factor = components[product_id]['qty']
+                components_qty = so_line._get_bom_component_qty(bom)
+                storable_components = self.env['product.product'].search([('id', 'in', list(components_qty.keys())), ('type', '=', 'product')])
+                for product in storable_components:
+                    factor = components_qty[product.id]['qty']
                     prod_moves = moves.filtered(lambda m: m.product_id == product)
                     prod_qty_invoiced = factor * qty_invoiced
                     prod_qty_to_invoice = factor * qty_to_invoice

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -23,14 +23,14 @@ class TestSaleMrpKitBom(TransactionCase):
         #   - Quantity: 3
         #   - Components:
         #     * 2 x Kit B
-        #     * 1 x Component A (Cost: $3)
+        #     * 1 x Component A (Cost: $3, Storable)
         #
         # BoM of Kit B:
         #   - BoM Type: Kit
         #   - Quantity: 10
         #   - Components:
-        #     * 2 x Component B (Cost: $4)
-        #     * 3 x Component BB (Cost: $5)
+        #     * 2 x Component B (Cost: $4, Storable)
+        #     * 3 x Component BB (Cost: $5, Consumable)
         # ----------------------------------------------
 
         self.env.user.company_id.anglo_saxon_accounting = True
@@ -89,8 +89,8 @@ class TestSaleMrpKitBom(TransactionCase):
             'company_id': self.env.user.company_id.id,
         })
 
-        self.component_a = self._create_product('Component A', 'consu', 3.00)
-        self.component_b = self._create_product('Component B', 'consu', 4.00)
+        self.component_a = self._create_product('Component A', 'product', 3.00)
+        self.component_b = self._create_product('Component B', 'product', 4.00)
         self.component_bb = self._create_product('Component BB', 'consu', 5.00)
         self.kit_a = self._create_product('Kit A', 'product', 0.00)
         self.kit_b = self._create_product('Kit B', 'consu', 0.00)
@@ -160,9 +160,9 @@ class TestSaleMrpKitBom(TransactionCase):
         self.assertEqual(len(amls), 4)
         stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.stock_output_account)
         self.assertEqual(stock_out_aml.debit, 0)
-        self.assertAlmostEqual(stock_out_aml.credit, 2.53)
+        self.assertAlmostEqual(stock_out_aml.credit, 1.53, "Should not include the value of consumable component")
         cogs_aml = amls.filtered(lambda aml: aml.account_id == self.expense_account)
-        self.assertAlmostEqual(cogs_aml.debit, 2.53)
+        self.assertAlmostEqual(cogs_aml.debit, 1.53, "Should not include the value of consumable component")
         self.assertEqual(cogs_aml.credit, 0)
 
     def test_qty_delivered_with_bom(self):


### PR DESCRIPTION
When selling a storable kits, the consumable components should be
ignored in account lines

To reproduce the issue:
(Need account_accountant,sale_management,mrp)
1. Create a product category PC:
    - Costing Method: FIFO
    - Inventory Valuation: Automated
2. Create 3 products P_kit, P_compo01, P_compo02
    - P_kit:
        - Type: Storable
        - Category: PC
    - P_compo01
        - Type: Storable
        - Category: PC
        - Cost: 5
    - P_compo02:
        - Type: Consumable
        - Category: PC
        - Cost: 6
3. Update P_compo02's on hand qty: 1
4. Create a bill of materials:
    - Product: P_kit
    - Type: Kit
    - Components:
        - 1 x P_compo01
        - 1 x P_compo02
5. Create & Confirm a sale order SO with 1 x P_kit
6. Process the related delivery
7. Create & Post the related invoice

Error: The journal items of the invoice are incorrect, the value of
Expenses and Stock Interim (Delivered) are $11 instead of $5. The
consumable components should be excluded from this value

OPW-2604084

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
