### PR TITLE
[FIX] website: allow redirection to external websites

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -346,7 +346,10 @@ class Http(models.AbstractModel):
 
         redirect = cls._serve_redirect()
         if redirect:
-            return request.redirect(_build_url_w_params(redirect.url_to, request.params), code=redirect.redirect_type)
+            return request.redirect(
+                _build_url_w_params(redirect.url_to, request.params),
+                code=redirect.redirect_type,
+                local=False)  # safe because only designers can specify redirects
 
         return False
 


### PR DESCRIPTION
Before this commit, the redirections were only possible localy
(e.g. making a redirection to https://www.bloggiflette.com/potimarroniflette on https://www.odoo.com was redirecting to https://www.odoo.com/potimarroniflette)
