### PR TITLE
[IMP] payment_payulatam: support webhooks

### DIFF
--- a/addons/payment_payulatam/controllers/main.py
+++ b/addons/payment_payulatam/controllers/main.py
@@ -2,8 +2,12 @@
 
 import logging
 import pprint
+import hmac
+
+import werkzeug.exceptions
 
 from odoo import http
+from odoo.exceptions import ValidationError
 from odoo.http import request
 
 _logger = logging.getLogger(__name__)
@@ -11,9 +15,55 @@ _logger = logging.getLogger(__name__)
 
 class PayuLatamController(http.Controller):
     _return_url = '/payment/payulatam/return'
+    _webhook_url = '/payment/payulatam/webhook'
 
     @http.route(_return_url, type='http', auth='public', methods=['GET'])
     def payulatam_return(self, **data):
         _logger.info("handling redirection from PayU Latam with data:\n%s", pprint.pformat(data))
+        self._verify_signature(data)
         request.env['payment.transaction'].sudo()._handle_notification_data('payulatam', data)
         return request.redirect('/payment/status')
+
+    @http.route(_webhook_url, type='http', auth='public', methods=['POST'], csrf=False)
+    def payulatam_webhook(self, **data):
+        _logger.info("handling confirmation from PayU Latam with data:\n%s", pprint.pformat(data))
+        state_pol = data.get('state_pol')
+        if state_pol == '4':
+            lapTransactionState = 'APPROVED'
+        elif state_pol == '6':
+            lapTransactionState = 'DECLINED'
+        elif state_pol == '5':
+            lapTransactionState = 'EXPIRED'
+        else:
+            lapTransactionState = f'INVALID state_pol {state_pol}'
+
+        data = {
+            'signature': data.get('sign'),
+            'TX_VALUE': data.get('value'),
+            'currency': data.get('currency'),
+            'referenceCode': data.get('reference_sale'),
+            'transactionId': data.get('transaction_id'),
+            'transactionState': data.get('state_pol'),
+            'message': data.get('response_message_pol'),
+            'lapTransactionState': lapTransactionState,
+        }
+
+        self._verify_signature(data)
+
+        try:
+            request.env['payment.transaction'].sudo()._handle_notification_data('payulatam', data)
+        except ValidationError:
+            _logger.warning(
+                'An error occurred while handling the confirmation from PayU with data:\n%s',
+                pprint.pformat(data))
+        return http.Response(status=200)
+
+    def _verify_signature(self, data):
+        sign = data.get('signature')
+        reference = data.get('referenceCode')
+        tx = request.env['payment.transaction'].sudo().search(
+            [('reference', '=', reference), ('provider', '=', 'payulatam')])
+        sign_check = tx.acquirer_id._payulatam_generate_sign(data, incoming=True)
+        if not hmac.compare_digest(sign_check, sign):
+            _logger.warning('Invalid signature %s', sign)
+            raise werkzeug.exceptions.Forbidden

--- a/addons/payment_payulatam/models/payment_transaction.py
+++ b/addons/payment_payulatam/models/payment_transaction.py
@@ -75,6 +75,7 @@ class PaymentTransaction(models.Model):
             'buyerFullName': self.partner_name,
             'buyerEmail': self.partner_email,
             'responseUrl': urls.url_join(self.get_base_url(), PayuLatamController._return_url),
+            'confirmationUrl': urls.url_join(self.get_base_url(), PayuLatamController._webhook_url),
             'api_url': api_url,
         }
         if self.acquirer_id.state != 'enabled':
@@ -113,16 +114,6 @@ class PaymentTransaction(models.Model):
         if not tx:
             raise ValidationError(
                 "PayU Latam: " + _("No transaction found matching reference %s.", reference)
-            )
-
-        # Verify signature
-        sign_check = tx.acquirer_id._payulatam_generate_sign(notification_data, incoming=True)
-        if not hmac.compare_digest(sign_check, sign):
-            raise ValidationError(
-                "PayU Latam: " + _(
-                    "Invalid sign: received %(sign)s, computed %(check)s.",
-                    sign=sign, check=sign_check
-                )
             )
 
         return tx

--- a/addons/payment_payulatam/views/payment_payulatam_templates.xml
+++ b/addons/payment_payulatam/views/payment_payulatam_templates.xml
@@ -18,6 +18,7 @@
             <input type="hidden" name="buyerFullName" t-att-value="buyerFullName"/>
             <input type="hidden" name="buyerEmail" t-att-value="buyerEmail"/>
             <input type="hidden" name="responseUrl" t-att-value="responseUrl"/>
+            <input type="hidden" name="confirmationUrl" t-att-value="confirmationUrl"/>
         </form>
     </template>
 


### PR DESCRIPTION
Pass a confirmation url to payulatam payment request in order to get
asynchronous confirmation of a payment

The webhook is at <base_url>/payment/payulatam/webhook

task-2701097