### PR TITLE
[IMP] event: add event revenue reporting

### DIFF
--- a/addons/event_sale/__manifest__.py
+++ b/addons/event_sale/__manifest__.py
@@ -22,6 +22,7 @@ this event.
     'data': [
         'views/event_ticket_views.xml',
         'views/event_registration_views.xml',
+        'views/event_sale_report_views.xml',
         'views/event_views.xml',
         'views/sale_order_views.xml',
         'data/event_sale_data.xml',
@@ -32,7 +33,9 @@ this event.
         'wizard/event_edit_registration.xml',
         'wizard/event_configurator_views.xml',
     ],
-    'demo': ['data/event_demo.xml'],
+    'demo': [
+        'data/event_sale_demo.xml'
+    ],
     'installable': True,
     'auto_install': True,
     'assets': {

--- a/addons/event_sale/data/event_sale_demo.xml
+++ b/addons/event_sale/data/event_sale_demo.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="event_sale_order_1" model="sale.order">
+            <field name="user_id" ref="base.user_admin"/>
+            <field name="partner_id" ref="base.res_partner_1"/>
+            <field name="pricelist_id" ref="product.list0"/>
+        </record>
+
+        <record id="event_sale_order_2" model="sale.order">
+            <field name="user_id" ref="base.user_admin"/>
+            <field name="partner_id" ref="base.res_partner_2"/>
+            <field name="pricelist_id" ref="product.list0"/>
+        </record>
+
+        <record id="event_sale_order_3" model="sale.order">
+            <field name="user_id" ref="base.user_admin"/>
+            <field name="partner_id" ref="base.res_partner_3"/>
+            <field name="pricelist_id" ref="product.list0"/>
+        </record>
+
+        <record id="event_sale_order_line_1" model="sale.order.line">
+            <field name="order_id" ref="event_sale.event_sale_order_1"/>
+            <field name="name">Event Registration</field>
+            <field name="product_id" ref="event_sale.product_product_event"/>
+            <field name="price_unit">0</field>
+            <field name="product_uom_qty">5.0</field>
+            <field name="event_id" ref="event.event_0"/>
+            <field name="event_ticket_id" ref="event.event_0_ticket_0"/>
+        </record>
+
+        <record id="event_sale_order_line_2" model="sale.order.line">
+            <field name="order_id" ref="event_sale.event_sale_order_1"/>
+            <field name="name">Event Registration</field>
+            <field name="product_id" ref="event_sale.product_product_event"/>
+            <field name="price_unit">15</field>
+            <field name="product_uom_qty">3.0</field>
+            <field name="event_id" ref="event.event_0"/>
+            <field name="event_ticket_id" ref="event.event_0_ticket_1"/>
+        </record>
+
+        <record id="event_sale_order_line_3" model="sale.order.line">
+            <field name="order_id" ref="event_sale.event_sale_order_2"/>
+            <field name="name">Event Registration</field>
+            <field name="product_id" ref="event_sale.product_product_event"/>
+            <field name="price_unit">50</field>
+            <field name="product_uom_qty">1.0</field>
+            <field name="event_id" ref="event.event_2"/>
+            <field name="event_ticket_id" ref="event.event_2_ticket_1"/>
+        </record>
+
+        <record id="event_sale_order_line_4" model="sale.order.line">
+            <field name="order_id" ref="event_sale.event_sale_order_3"/>
+            <field name="name">Event Registration</field>
+            <field name="product_id" ref="event_sale.product_product_event"/>
+            <field name="price_unit">35</field>
+            <field name="product_uom_qty">1.0</field>
+            <field name="event_id" ref="event.event_2"/>
+            <field name="event_ticket_id" ref="event.event_2_ticket_2"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/event_sale/models/__init__.py
+++ b/addons/event_sale/models/__init__.py
@@ -5,4 +5,5 @@ from . import event_event
 from . import event_registration
 from . import event_ticket
 from . import sale_order
+from . import event_sale_report
 from . import product

--- a/addons/event_sale/models/event_sale_report.py
+++ b/addons/event_sale/models/event_sale_report.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, tools
+
+
+class EventSaleReport(models.Model):
+    _name = 'event.sale.report'
+    _description = 'Event Sales Report'
+    _auto = False
+    _rec_name = 'id'
+
+    event_id = fields.Many2one('event.event', string='Event', readonly=True)
+    event_ticket_ids = fields.Many2one('event.event.ticket', string='Event Ticket', readonly=True)
+    sale_price_total = fields.Float('Total Revenues', readonly=True)
+    sale_price_subtotal = fields.Float('Untaxed Total Revenues', readonly=True)
+    seats_available = fields.Integer('Seats Available', readonly=True)
+
+    def init(self):
+        tools.drop_view_if_exists(self._cr, self._table)
+        self._cr.execute('CREATE OR REPLACE VIEW %s AS (%s);' % (self._table, self._query()))
+
+    def _query(self):
+        return """
+            %(with_clause)s
+            %(select_clause)s
+            FROM event_sale
+            %(join_clause)s
+            %(group_by_clause)s
+        """ % {
+            'with_clause': self._with_clause(),
+            'select_clause': self._select_clause(),
+            'join_clause': self._join_clause(),
+            'group_by_clause': self._group_by_clause(),
+        }
+
+    def _with_clause(self):
+        return """
+            WITH event_sale AS (
+                SELECT
+                    sale_order_line.event_id as event_id,
+                    sale_order_line.event_ticket_id as event_ticket_ids,
+                    SUM(sale_order_line.price_total) / CASE COALESCE(sale_order.currency_rate, 0) WHEN 0 THEN 1.0 ELSE sale_order.currency_rate END as sale_price_total,
+                    SUM(sale_order_line.price_subtotal) / CASE COALESCE(sale_order.currency_rate, 0) WHEN 0 THEN 1.0 ELSE sale_order.currency_rate END as sale_price_subtotal
+                FROM sale_order_line
+                LEFT JOIN sale_order ON sale_order.id = sale_order_line.order_id
+                WHERE sale_order_line.event_id IS NOT NULL
+                GROUP BY
+                    sale_order_line.event_id,
+                    sale_order_line.event_ticket_id,
+                    sale_order.currency_rate
+            )
+        """
+
+    def _select_clause(self):
+        return """
+            SELECT
+                ROW_NUMBER() OVER (ORDER BY event_sale.event_id) as id,
+                event_sale.event_id as event_id,
+                event_sale.event_ticket_ids as event_ticket_ids,
+                SUM(event_sale.sale_price_total) as sale_price_total,
+                SUM(event_sale.sale_price_subtotal) as sale_price_subtotal,
+                event_event_ticket.seats_available as seats_available
+        """
+
+    def _join_clause(self):
+        return """
+            LEFT JOIN event_event_ticket ON event_sale.event_ticket_ids = event_event_ticket.id
+        """
+
+    def _group_by_clause(self):
+        return """
+            GROUP BY
+                event_sale.event_id,
+                event_sale.event_ticket_ids,
+                event_event_ticket.seats_available
+        """
+
+    def action_show_revenues(self):
+        return self.env['ir.actions.act_window']._for_xml_id('event_sale.event_sale_report_action')

--- a/addons/event_sale/security/ir.model.access.csv
+++ b/addons/event_sale/security/ir.model.access.csv
@@ -4,3 +4,4 @@ access_product_product_event_manager,product.product.event.manager,product.model
 access_registration_editor,access.registration.editor,model_registration_editor,sales_team.group_sale_salesman,1,1,1,0
 access_registration_editor_line,access.registration.editor.line,model_registration_editor_line,sales_team.group_sale_salesman,1,1,1,1
 access_event_event_configurator,access.event.event.configurator,model_event_event_configurator,sales_team.group_sale_salesman,1,1,1,0
+access_event_sale_report_manager,access.event.sale.report,model_event_sale_report,event.group_event_manager,1,1,1,1

--- a/addons/event_sale/views/event_sale_report_views.xml
+++ b/addons/event_sale/views/event_sale_report_views.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_event_sale_report_graph" model="ir.ui.view">
+        <field name="name">event.sale.report.view.graph</field>
+        <field name="model">event.sale.report</field>
+        <field name="arch" type="xml">
+            <graph string="Revenues" sample="1">
+                <field name="seats_available" type="measure"/>
+                <field name="sale_price_subtotal" type="measure"/>
+                <field name="sale_price_total" type="measure"/>
+            </graph>
+        </field>
+    </record>
+
+    <record id="view_event_sale_report_tree" model="ir.ui.view">
+        <field name="name">event.sale.report.view.tree</field>
+        <field name="model">event.sale.report</field>
+        <field name="arch" type="xml">
+            <tree string="Revenues" edit="false">
+                <field name="event_id"/>
+                <field name="event_ticket_ids"/>
+                <field name="sale_price_total"/>
+                <field name="sale_price_subtotal"/>
+                <field name="seats_available"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_event_sale_report_search" model="ir.ui.view">
+        <field name="name">event.sale.report.view.search</field>
+        <field name="model">event.sale.report</field>
+        <field name="arch" type="xml">
+            <search string="Event Sales Analysis">
+                <filter string="By Event" name="group_by_event_id" context="{'group_by': 'event_id' }"/>
+                <filter string="By Ticket" name="group_by_ticket_id" context="{'group_by': 'event_ticket_ids'}"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="event_sale_report_action" model="ir.actions.act_window">
+        <field name="name">Revenues</field>
+        <field name="res_model">event.sale.report</field>
+        <field name="view_mode">graph,pivot</field>
+        <field name="context">{
+            'search_default_group_by_event_id': 1,
+            'search_default_group_by_ticket_id': 1
+        }</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No Event Revenues yet!
+            </p><p>
+                Come back once tickets have been sold to overview your sales income.
+            </p>
+        </field>
+    </record>
+
+    <record id="action_show_revenues" model="ir.actions.server">
+        <field name="name">Revenue</field>
+        <field name="model_id" ref="model_event_sale_report"/>
+        <field name="state">code</field>
+        <field name="code">action = model.action_show_revenues()</field>
+    </record>
+
+    <menuitem name="Revenues"
+        id="menu_action_show_revenues"
+        action="action_show_revenues"
+        sequence="5"
+        parent="event.menu_reporting_events"
+        groups="event.group_event_user"/>
+</odoo>

--- a/addons/website_event_sale/__manifest__.py
+++ b/addons/website_event_sale/__manifest__.py
@@ -12,6 +12,7 @@ Sell event tickets through eCommerce app.
     'data': [
         'data/event_data.xml',
         'views/event_event_views.xml',
+        'views/event_sale_report_views.xml',
         'views/website_event_templates.xml',
         'views/website_sale_templates.xml',
         'security/ir.model.access.csv',

--- a/addons/website_event_sale/models/__init__.py
+++ b/addons/website_event_sale/models/__init__.py
@@ -3,4 +3,5 @@
 from . import product
 from . import product_pricelist
 from . import sale_order
+from . import event_sale_report
 from . import website

--- a/addons/website_event_sale/models/event_sale_report.py
+++ b/addons/website_event_sale/models/event_sale_report.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import ast
+from odoo import fields, models
+
+
+class EventSaleReport(models.Model):
+    _inherit = 'event.sale.report'
+
+    is_published = fields.Boolean('Is Published', readonly=True)
+
+    def _query(self):
+        return """
+            %(with_clause)s
+            %(select_clause)s
+            FROM event_sale
+            %(join_clause)s
+            %(group_by_clause)s
+        """ % {
+            'with_clause': self._with_clause(),
+            'select_clause': self._select_clause(),
+            'join_clause': self._join_clause(),
+            'group_by_clause': self._group_by_clause()
+        }
+
+    def _select_clause(self):
+        return """
+            SELECT
+                ROW_NUMBER() OVER (ORDER BY event_sale.event_id) as id,
+                event_sale.event_id as event_id,
+                event_sale.event_ticket_ids as event_ticket_ids,
+                SUM(event_sale.sale_price_total) as sale_price_total,
+                SUM(event_sale.sale_price_subtotal) as sale_price_subtotal,
+                event_event_ticket.seats_available as seats_available,
+                event_event.is_published as is_published
+        """
+
+    def _join_clause(self):
+        return """
+            LEFT JOIN event_event_ticket ON event_sale.event_ticket_ids = event_event_ticket.id
+            LEFT JOIN event_event ON event_event.id = event_sale.event_id
+        """
+
+    def _group_by_clause(self):
+        return """
+            GROUP BY
+                event_sale.event_id,
+                event_sale.event_ticket_ids,
+                event_event_ticket.seats_available,
+                event_event.is_published
+        """
+
+    def action_show_revenues(self):
+        action = super().action_show_revenues()
+        action['context'] = dict(ast.literal_eval(action.get('context', {})),
+            search_default_is_published=1
+        )
+        return action

--- a/addons/website_event_sale/views/event_sale_report_views.xml
+++ b/addons/website_event_sale/views/event_sale_report_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_event_sale_report_tree" model="ir.ui.view">
+        <field name="name">event.sale.report.view.tree.inherit</field>
+        <field name="model">event.sale.report</field>
+        <field name="inherit_id" ref="event_sale.view_event_sale_report_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='sale_price_subtotal']" position="after">
+                <field name="is_published"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_event_sale_report_search" model="ir.ui.view">
+        <field name="name">event.sale.report.view.search.inherit</field>
+        <field name="model">event.sale.report</field>
+        <field name="inherit_id" ref="event_sale.view_event_sale_report_search"/>
+        <field name="arch" type="xml">
+            <xpath expr="//search" position="inside">
+                <filter string="Published" name="is_published" domain="[('is_published', '=', True)]"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
As an event manager, it can be difficult to estimate how much of the revenue was generated by the events. To give clear insights, we will add new reports to the 'event' module.

With those new reports, the user can group the revenues by event and/or by ticket. The user will then be able to quickly see which tickets and events are the most profitable ones. The reports will be accessible only if the user installed the 'sale' module.

task-2679881

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
