### PR TITLE
[FIX] account: change control access with non-posted entries

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -283,10 +283,12 @@ class AccountJournal(models.Model):
         self._cr.execute("""
             SELECT aml.id
             FROM account_move_line aml
+            JOIN account_move am ON aml.move_id = am.id
             WHERE aml.journal_id in (%s)
             AND EXISTS (SELECT 1 FROM journal_account_control_rel rel WHERE rel.journal_id = aml.journal_id)
             AND NOT EXISTS (SELECT 1 FROM journal_account_control_rel rel WHERE rel.account_id = aml.account_id AND rel.journal_id = aml.journal_id)
             AND aml.display_type IS NULL
+            AND am.state = 'posted'
         """, tuple(self.ids))
         if self._cr.fetchone():
             raise ValidationError(_('Some journal items already exist in this journal but with other accounts than the allowed ones.'))

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2611,6 +2611,8 @@ class AccountMove(models.Model):
             if move.is_invoice(include_receipts=True) and float_compare(move.amount_total, 0.0, precision_rounding=move.currency_id.rounding) < 0:
                 raise UserError(_("You cannot validate an invoice with a negative total amount. You should create a credit note instead. Use the action menu to transform it into a credit note or refund."))
 
+            move.line_ids._check_constrains_account_id_journal_id()
+
             # Handle case when the invoice_date is not set. In that case, the invoice_date is set at today and then,
             # lines are recomputed accordingly.
             # /!\ 'check_move_validity' must be there since the dynamic lines will be recomputed outside the 'onchange'

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -58,7 +58,7 @@ class TestAccountJournal(AccountTestInvoicingCommon):
         self.env['account.move'].create(move_vals)
 
     def test_account_control_existing_journal_entry(self):
-        self.env['account.move'].create({
+        move = self.env['account.move'].create({
             'line_ids': [
                 (0, 0, {
                     'name': 'debit',
@@ -75,6 +75,7 @@ class TestAccountJournal(AccountTestInvoicingCommon):
             ],
         })
 
+        move.action_post()
         # There is already an other line using the 'default_account_expense' account.
         with self.assertRaises(ValidationError), self.cr.savepoint():
             self.company_data['default_journal_misc'].account_control_ids |= self.company_data['default_account_revenue']


### PR DESCRIPTION
Create a draft journal entry in journal [TEST] with account [A]
Now in the Advanced Settings of [TEST] change control-access: in allowed
accounts input an account different from [A]

The system will block the action but the mentioned entry is just in
draft
It should allow the action and then block the possibility to post the
draft entry

opw-2686274

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
