### PR TITLE
[FIX] mail: ensure unlink-all properly does its job for x2many

### DIFF
--- a/addons/mail/static/src/model/model_field.js
+++ b/addons/mail/static/src/model/model_field.js
@@ -421,7 +421,7 @@ class ModelField {
                         }
                         break;
                     case 'unlink-all':
-                        if (this._setRelationUnlink(record, currentValue, options)) {
+                        if (this._setRelationUnlink(record, this.get(record), options)) {
                             hasChanged = true;
                         }
                         break;


### PR DESCRIPTION
Before this commit, unlink-all would sometimes fail to unlink more than one
record.
This seems to be the case in particular for x2many relations with isCausal true.

Indeed, the delete from isCausal is itself calling unlink-all on the inverse
relation (the same record that was being unlinked-all in the first place) which
would pre-emptively remove it from the same Set that was used during the initial
iteration.

The solution is to make a copy of the Set before iterating it to ensure all
records that were planned to be removed are actually removed.

Candidate fix for task-2410314 and definitely necessary for data integrity in
general.