### PR TITLE
[FIX] l10n_ch: Fix the invoice title's CSS

### DIFF
--- a/addons/l10n_ch/static/src/scss/report_swissqr.scss
+++ b/addons/l10n_ch/static/src/scss/report_swissqr.scss
@@ -8,6 +8,7 @@
     src: url('../font/LiberationSans-Regular.woff') format('woff');
 }
 
+$l10n-ch-qr-ratio: 1.25;
 
 body {
     padding: 0!important;
@@ -17,22 +18,21 @@ body {
         background: none;
         min-height: 0;
     }
+
+    .swissqr_page_title {
+        color: black;
+        font-weight: bold;
+        height: 7mm * $l10n-ch-qr-ratio;
+        padding: 15px;
+        padding-top: 200px;
+    }
 }
 
 .swissqr_content_v2 {
 
-    /* New QR Bill code */
-    background-color: white;
-
-    /* Disable custom font-family */
-    .o_company_2_layout {
-        font-family: revert;
-    }
-
-    $ratio: 1.25;
-    $receipt_width: 52mm * $ratio;
-    $left_col_width: 46mm * $ratio;
-    $right_col_width: 87mm * $ratio;
+    $receipt_width: 52mm * $l10n-ch-qr-ratio;
+    $left_col_width: 46mm * $l10n-ch-qr-ratio;
+    $right_col_width: 87mm * $l10n-ch-qr-ratio;
     $rounding_offset: 0.25mm;
 
     @mixin font {
@@ -43,6 +43,15 @@ body {
         @include font;
         font-weight: bold;
     }
+
+    /* New QR Bill code */
+    background-color: white;
+
+    /* Disable custom font-family */
+    .o_company_2_layout {
+        font-family: revert;
+    }
+
     .title {
         @include title;
     }
@@ -51,108 +60,101 @@ body {
         @include font;
     }
 
-    .swissqr_page_title {
-        @include title;
-        height: 7mm * $ratio;
-        padding: 15px;
-        padding-top: 200px;
-    }
-
     .swissqr_section_title {
         @include title;
         width: $receipt_width;
-        height: 7mm * $ratio;
-        font-size: 11pt * $ratio;
-        line-height: 9pt * $ratio;
+        height: 7mm * $l10n-ch-qr-ratio;
+        font-size: 11pt * $l10n-ch-qr-ratio;
+        line-height: 9pt * $l10n-ch-qr-ratio;
     }
 
     .swissqr_receipt {
         position: absolute;
         left: 0mm;
-        top: 192mm * $ratio;
-        width: 62mm * $ratio;
-        height: 105mm * $ratio - $rounding_offset;
-        border: 0.75pt * $ratio dashed black;
+        top: 192mm * $l10n-ch-qr-ratio;
+        width: 62mm * $l10n-ch-qr-ratio;
+        height: 105mm * $l10n-ch-qr-ratio - $rounding_offset;
+        border: 0.75pt * $l10n-ch-qr-ratio dashed black;
         border-right: 0pt;
-        padding: 5mm * $ratio;
+        padding: 5mm * $l10n-ch-qr-ratio;
         .title {
-            font-size: 6pt * $ratio;
-            line-height: 9pt * $ratio;
+            font-size: 6pt * $l10n-ch-qr-ratio;
+            line-height: 9pt * $l10n-ch-qr-ratio;
         }
         .content {
-            font-size: 8pt * $ratio;
-            line-height: 9pt * $ratio;
+            font-size: 8pt * $l10n-ch-qr-ratio;
+            line-height: 9pt * $l10n-ch-qr-ratio;
         }
         .receipt_indication_zone {
             width: $receipt_width;
-            height: 56mm * $ratio;
+            height: 56mm * $l10n-ch-qr-ratio;
         }
         .receipt_amount_zone {
             width: $receipt_width;
-            height: 14mm * $ratio;
+            height: 14mm * $l10n-ch-qr-ratio;
             .column {
                 float: left;
                 margin-right: 5mm;
             }
             .content {
-                font-size: 8pt * $ratio;
-                line-height: 11pt * $ratio;
+                font-size: 8pt * $l10n-ch-qr-ratio;
+                line-height: 11pt * $l10n-ch-qr-ratio;
             }
         }
         .receipt_acceptance_point_zone {
             width: $receipt_width;
-            height: 18mm * $ratio;
+            height: 18mm * $l10n-ch-qr-ratio;
             .content {
                 float: right;
-                padding-right: 2mm * $ratio;
-                font-size: 6pt * $ratio;
-                line-height: 8pt * $ratio;
+                padding-right: 2mm * $l10n-ch-qr-ratio;
+                font-size: 6pt * $l10n-ch-qr-ratio;
+                line-height: 8pt * $l10n-ch-qr-ratio;
             }
         }
     }
 
     .swissqr_body {
         position: absolute;
-        top: 192mm * $ratio;
-        left: 62mm * $ratio;
-        width: 148mm * $ratio;
-        height: 105mm * $ratio - $rounding_offset;
-        border: 0.75pt * $ratio dashed black;
-        padding: 5mm * $ratio;
+        top: 192mm * $l10n-ch-qr-ratio;
+        left: 62mm * $l10n-ch-qr-ratio;
+        width: 148mm * $l10n-ch-qr-ratio;
+        height: 105mm * $l10n-ch-qr-ratio - $rounding_offset;
+        border: 0.75pt * $l10n-ch-qr-ratio dashed black;
+        padding: 5mm * $l10n-ch-qr-ratio;
         .title {
-            font-size: 8pt * $ratio;
-            line-height: 11pt * $ratio;
+            font-size: 8pt * $l10n-ch-qr-ratio;
+            line-height: 11pt * $l10n-ch-qr-ratio;
         }
         .content {
-            font-size: 10pt * $ratio;
-            line-height: 11pt * $ratio;
+            font-size: 10pt * $l10n-ch-qr-ratio;
+            line-height: 11pt * $l10n-ch-qr-ratio;
         }
         .swissqr_column_left {
             float: left;
             width: $left_col_width;
             .swissqr_section_title{
-                height: 7mm * $ratio;
+                height: 7mm * $l10n-ch-qr-ratio;
             }
             .swissqr {
-                margin-top: 5mm * $ratio;
-                margin-bottom: 5mm * $ratio;
-                height: 46mm * $ratio;
-                width: 46mm * $ratio;
+                margin-top: 5mm * $l10n-ch-qr-ratio;
+                margin-bottom: 5mm * $l10n-ch-qr-ratio;
+                height: 46mm * $l10n-ch-qr-ratio;
+                width: 46mm * $l10n-ch-qr-ratio;
             }
             .amount_zone {
                 width: $left_col_width;
-                height: 22mm * $ratio;
+                height: 22mm * $l10n-ch-qr-ratio;
                 .column {
                     margin-right: 3mm;
                     float: left;
                 }
                 .title {
-                    font-size: 8pt * $ratio;
-                    line-height: 11pt * $ratio;
+                    font-size: 8pt * $l10n-ch-qr-ratio;
+                    line-height: 11pt * $l10n-ch-qr-ratio;
                 }
                 .content {
-                    font-size: 10pt * $ratio;
-                    line-height: 13pt * $ratio;
+                    font-size: 10pt * $l10n-ch-qr-ratio;
+                    line-height: 13pt * $l10n-ch-qr-ratio;
                 }
             }
         }
@@ -168,13 +170,13 @@ body {
     }
     .vertical_scissors {
         position: absolute;
-        top: 5mm * $ratio;
-        left: -1.8mm * $ratio;
+        top: 5mm * $l10n-ch-qr-ratio;
+        left: -1.8mm * $l10n-ch-qr-ratio;
     }
     .horizontal_scissors {
         position: absolute;
-        top: -2mm * $ratio;
-        left: 6mm * $ratio;
+        top: -2mm * $l10n-ch-qr-ratio;
+        left: 6mm * $l10n-ch-qr-ratio;
     }
 
 }


### PR DESCRIPTION
The title's (S)CSS selector was failing to pick up the invoice title,
because it was inside the .swiss_container_v2 while it should be out of that.

Previous version, v15 was OK: 
(but it also included the old layout that had to be removed)
https://github.com/odoo/odoo/blob/5bb0afc901135c1c44427bcb4e52803121165105/addons/l10n_ch/static/src/scss/report_swissqr.scss#L12-L25

Ticket link: https://www.odoo.com/web#id=2584899&model=project.task

![immagine](https://user-images.githubusercontent.com/1665365/144653931-b239a95f-9080-490f-b74b-c48b78921432.png)

opw-2584899