### PR TITLE
[FIX] website: fix the traceback when clicks on Visits/Offline

### DIFF
--- a/addons/web/static/src/legacy/scss/form_view.scss
+++ b/addons/web/static/src/legacy/scss/form_view.scss
@@ -1109,3 +1109,8 @@ $o-form-label-margin-right: 0px;
         }
     }
 }
+
+// No events
+.o_form_view .oe_button_box > .btn.oe_stat_button.o_no_events{
+    pointer-events: none;
+}

--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -185,11 +185,11 @@
                             <i class="fa fa-fw o_button_icon fa-circle text-success"/>
                             <span>Connected</span>
                         </button>
-                        <button class="oe_stat_button o_stat_button_info" disabled="1" attrs="{'invisible': [('is_connected', '=', True)]}">
+                        <button class="oe_stat_button o_stat_button_info o_no_events" disabled="1" attrs="{'invisible': [('is_connected', '=', True)]}">
                             <i class="fa fa-fw o_button_icon fa-circle text-danger"/>
                             <span>Offline</span>
                         </button>
-                        <button id="w_visitor_visit_counter" class="oe_stat_button o_stat_button_info" disabled="1" icon="fa-globe">
+                        <button id="w_visitor_visit_counter" class="oe_stat_button o_stat_button_info o_no_events" disabled="1" icon="fa-globe">
                             <field name="visit_count" widget="statinfo" string="Visits"/>
                         </button>
                         <button name="%(website.website_visitor_page_action)d" type="action"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Go to Website > Visitors > Visitors > Open any visitor > click on edit > click on visits button > throws trace back

Desired behaviour after PR is merged:
- Go to Website > Visitors > Visitors > Open any visitor > click on edit > No errors, you can't click on visits button (because it is a state counter button)

Fixes #78500

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
