### PR TITLE
[FIX] web_editor: show pointer cursor when hovering colors

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -944,6 +944,7 @@ body.editor_enable.editor_has_snippets {
                 height: $o-we-sidebar-content-field-colorpicker-size;
                 border: $o-we-sidebar-content-field-border-width solid $o-we-sidebar-content-field-border-color;
                 border-radius: 10rem;
+                cursor: pointer;
 
                 &::after {
                     box-shadow: $o-we-sidebar-content-field-colorpicker-shadow;


### PR DESCRIPTION
Prior to this commit, when the user was hovering on colors in the
web editor, the cursor would stay with its default appearance.
Some users weren't able to tell if this was an interactive
element or not.

With this commit, we change the cursor to the pointer cursor when a user
is hovering the element so that they have a visual element indicating
that it's interactive.

task-2687469

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
