### PR TITLE
[FIX] mail_group: display the date of the message

### DIFF
--- a/addons/mail_group/models/mail_group_message.py
+++ b/addons/mail_group/models/mail_group_message.py
@@ -51,6 +51,7 @@ class MailGroupMessage(models.Model):
         string='Status', index=True, copy=False,
         required=True, default='pending_moderation')
     moderator_id = fields.Many2one('res.users', string='Moderated By')
+    create_date = fields.Datetime(string='Posted')
 
     @api.depends('email_from')
     def _compute_email_from_normalized(self):

--- a/addons/mail_group/views/mail_group_message_views.xml
+++ b/addons/mail_group/views/mail_group_message_views.xml
@@ -5,7 +5,7 @@
         <field name="model">mail.group.message</field>
         <field name="arch" type="xml">
             <tree sample="1">
-                <field name="create_date" string="Date"/>
+                <field name="create_date"/>
                 <field name="author_id"/>
                 <field name="email_from"/>
                 <field name="subject"/>
@@ -81,6 +81,7 @@
                             <field name="author_moderation" invisible="1"/>
                         </div>
                         <field name="mail_group_id"/>
+                        <field name="create_date"/>
                         <field name="attachment_ids" widget="many2many_binary"/>
                         <field name="body" options="{'style-inline': true}"/>
                     </group>


### PR DESCRIPTION
This will avoid spending half hour hunting why an inactive employee
was sendig a spam before realising it was from 2 years ago (true
story)

Task id: 2709447