### PR TITLE
[FIX] web_editor: fix unlink when nested tag

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -416,8 +416,8 @@ export const editorCommands = {
         // we need to remove the contentEditable isolation of links
         // before we apply the unlink, otherwise the command is not performed
         // because the content editable root is the link
-        const closestEl = closestElement(sel.focusNode);
-        if (closestEl.tagName === 'A' && closestEl.getAttribute('contenteditable') === 'true') {
+        const closestEl = closestElement(sel.focusNode, 'a');
+        if (closestEl && closestEl.getAttribute('contenteditable') === 'true') {
             editor._activateContenteditable();
         }
         if (sel.isCollapsed) {


### PR DESCRIPTION
Whenever there was a tag inside a link
(e.g.`<a href="..."><b>link</b></a>`), it was impossible to unlink.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
