### PR TITLE
[FIX] google_calendar: prevent traceback when resetting the google to…

### DIFF
--- a/addons/google_calendar/security/ir.model.access.csv
+++ b/addons/google_calendar/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 google_calendar_account_reset,google_calendar_account_reset_access_right,model_google_calendar_account_reset,base.group_system,1,1,1,0
 google_calendar.access_google_calendar_credentials,access_google_calendar_credentials,google_calendar.model_google_calendar_credentials,base.group_user,1,0,0,0
+google_calendar_manager,access_google_calendar_credentials_manager,google_calendar.model_google_calendar_credentials,base.group_system,1,1,0,0

--- a/addons/google_calendar/wizard/reset_account.py
+++ b/addons/google_calendar/wizard/reset_account.py
@@ -45,7 +45,7 @@ class ResetGoogleAccount(models.TransientModel):
                 'need_sync': True,
             })
 
-        self.user_id._set_auth_tokens(False, False, 0)
+        self.user_id.google_cal_account_id._set_auth_tokens(False, False, 0)
         self.user_id.write({
             'google_calendar_sync_token': False,
             'google_calendar_cal_id': False,


### PR DESCRIPTION
…kens from the reset account wizard

Before this commit, the account reset would fail with the following traceback:

```py
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
File "/home/odoo/src/odoo/15.0/odoo/http.py", line 643, in _handle_exception
return super(JsonRequest, self)._handle_exception(exception)
File "/home/odoo/src/odoo/15.0/odoo/http.py", line 301, in _handle_exception
raise exception.with_traceback(None) from new_cause
AttributeError: 'res.users' object has no attribute '_set_auth_tokens'
```

This commit allows to use the wizard.

opw-2705169



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
