### PR TITLE
[FIX] delivery: add product_template.country_of_origin field

### DIFF
--- a/addons/delivery/models/product_template.py
+++ b/addons/delivery/models/product_template.py
@@ -11,3 +11,9 @@ class ProductTemplate(models.Model):
         string="HS Code",
         help="Standardized code for international shipping and goods declaration. At the moment, only used for the FedEx shipping provider.",
     )
+    country_of_origin = fields.Many2one(
+        'res.country',
+        'Origin of Goods',
+        help="Rules of origin determine where goods originate, i.e. not where they have been shipped from, but where they have been produced or manufactured.\n"
+             "As such, the ‘origin’ is the 'economic nationality' of goods traded in commerce.",
+    )

--- a/addons/delivery/views/product_template_view.xml
+++ b/addons/delivery/views/product_template_view.xml
@@ -8,6 +8,7 @@
     <field name="arch" type="xml">
 	       <xpath expr="//group[@name='group_lots_and_weight']" position="inside">
             <field name="hs_code"/>
+            <field name="country_of_origin"/>
         </xpath>
     </field>
 </record>


### PR DESCRIPTION
The "country of origin" is required for the commercial invoice
generation with delivery providers. Until then we were using the
warehouse country, but it would make more sense to be able to precise it
directly in the product form.

This commit is part of more important upcoming changes brought in Odoo
enterprise, especially with Fedex, Easypost, DHL and UPS.

task-2701428