### PR TITLE
[FIX] project: fix default assigned to for rating in task

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2138,6 +2138,11 @@ class Task(models.Model):
     def _rating_get_parent_field_name(self):
         return 'project_id'
 
+    def rating_get_rated_partner_id(self):
+        """ Overwrite since we have user_ids and not user_id """
+        tasks_with_one_user = self.filtered(lambda task: len(task.user_ids) == 1 and task.user_ids.partner_id)
+        return tasks_with_one_user.user_ids.partner_id or self.env['res.partner']
+
     # ---------------------------------------------------
     # Privacy
     # ---------------------------------------------------

--- a/addons/project/tests/test_project_flow.py
+++ b/addons/project/tests/test_project_flow.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import base64
-
 from .test_project_base import TestProjectCommon
+from odoo import Command
 from odoo.tools import mute_logger
-from odoo.modules.module import get_resource_path
+from odoo.addons.mail.tests.common import MockEmail
 
 
 EMAIL_TPL = """Return-Path: <whatever-2a840@postmaster.twitter.com>
@@ -34,7 +33,7 @@ Raoul Boitempoils
 Integrator at Agrolait"""
 
 
-class TestProjectFlow(TestProjectCommon):
+class TestProjectFlow(TestProjectCommon, MockEmail):
 
     def test_project_process_project_manager_duplicate(self):
         pigs = self.project_pigs.with_user(self.user_projectmanager)
@@ -297,3 +296,38 @@ class TestProjectFlow(TestProjectCommon):
                 self.project_pigs[field]
             except Exception as e:
                 raise AssertionError("Error raised unexpectedly while computing a field of the project ! Exception : " + e.args[0])
+
+    def test_send_rating_review(self):
+        project_settings = self.env["res.config.settings"].create({'group_project_rating': True})
+        project_settings.execute()
+        self.assertTrue(self.project_goats.rating_active, 'The customer ratings should be enabled in this project.')
+
+        won_stage = self.project_goats.type_ids[-1]
+        rating_request_mail_template = self.env.ref('project.rating_project_request_email_template')
+        won_stage.write({'rating_template_id': rating_request_mail_template.id})
+        tasks = self.env['project.task'].with_context(mail_create_nolog=True, default_project_id=self.project_goats.id).create([
+            {'name': 'Goat Task 1', 'user_ids': [Command.set([])]},
+            {'name': 'Goat Task 2', 'user_ids': [Command.link(self.user_projectuser.id)]},
+            {
+                'name': 'Goat Task 3',
+                'user_ids': [
+                    Command.link(self.user_projectmanager.id),
+                    Command.link(self.user_projectuser.id),
+                ],
+            },
+        ])
+
+        with self.mock_mail_gateway():
+            tasks.with_user(self.user_projectmanager).write({'stage_id': won_stage.id})
+
+        tasks.invalidate_cache(fnames=['rating_ids'])
+        for task in tasks:
+            self.assertEqual(len(task.rating_ids), 1, 'This task should have a generated rating when it arrives in the Won stage.')
+            rating_request_message = task.message_ids[:1]
+            if not task.user_ids or len(task.user_ids) > 1:
+                self.assertFalse(task.rating_ids.rated_partner_id, 'This rating should have no assigned user if the task related have no assignees or more than one assignee.')
+                self.assertEqual(rating_request_message.email_from, self.user_projectmanager.partner_id.email_formatted, 'The message should have the email of the Project Manager as email from.')
+            else:
+                self.assertEqual(task.rating_ids.rated_partner_id, task.user_ids.partner_id, 'The rating should have an assigned user if the task has only one assignee.')
+                self.assertEqual(rating_request_message.email_from, task.user_ids.partner_id.email_formatted, 'The message should have the email of the assigned user in the task as email from.')
+            self.assertTrue(self.partner_1 in rating_request_message.partner_ids, 'The customer of the task should be in the partner_ids of the rating request message.')


### PR DESCRIPTION
Before this commit, the default assignee set to a rating in a task is
always empty because we check if the `project.task` has a `user_id`
field to give the partner of this user.
Since it is no longer the case because we can recently assign many users
to a task. That is, it is `user_ids` field and no longer `user_id`
field.

This commit overwrites `rating_get_rated_partner_id` method to set by
default the partner of the user contained in `user_ids` field if this
field contains at most one user. Otherwise, we set no partner. We choose
to not select the first user in the user_ids field because we cannot
consider it is the responsible of the task and not another one.
We cannot create a rating per user because the rating average will no
longer right because at the beginning of the task we could have 5 users
and after we could have more users or less users and so the number of
ratings for this task could be different each time we send a rating
review to the customer.

Part of task-2696911

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
