### PR TITLE
[FIX] js_transpiler: exported hoisting function

### DIFF
--- a/odoo/addons/test_assetsbundle/tests/test_js_transpiler.py
+++ b/odoo/addons/test_assetsbundle/tests/test_js_transpiler.py
@@ -209,20 +209,20 @@ export default function sayHelloDefault() {
         expected_result = """odoo.define('@test_assetsbundle/functions', async function (require) {
 'use strict';
 let __exports = {};
-const sayHello = __exports.sayHello = function sayHello() {
+__exports.sayHello = sayHello; function sayHello() {
   console.log("Hello");
 }
 
-const sayHelloWorld = __exports.sayHelloWorld = function sayHelloWorld() {
+__exports.sayHelloWorld = sayHelloWorld; function sayHelloWorld() {
   console.log("Hello world");
 }
 
-const sayAsyncHello = __exports.sayAsyncHello = async function sayAsyncHello() {
+__exports.sayAsyncHello = sayAsyncHello; async function sayAsyncHello() {
   console.log("Hello Async");
 }
 
 
-const sayHelloDefault = __exports[Symbol.for("default")] = function sayHelloDefault() {
+__exports[Symbol.for("default")] = sayHelloDefault; function sayHelloDefault() {
   console.log("Hello Default");
 }
 


### PR DESCRIPTION
After this commit, the js_transpiler will support hoisting function.
So it will be possible to define a hoisting function in an @odoo-module.

Example of a hoisting function:
```
hoisted();
function hoisted() {
  ...
};
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
