### PR TITLE
[FIX] web_editor: prevent focus when editor is not loaded

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -776,7 +776,7 @@ const Wysiwyg = Widget.extend({
      * Set cursor to the editor latest position before blur or to the last editable node, ready to type.
      */
     focus: function () {
-        if (!this.odooEditor.historyResetLatestComputedSelection()) {
+        if (this.odooEditor && !this.odooEditor.historyResetLatestComputedSelection()) {
             // If the editor don't have an history step to focus to,
             // We place the cursor after the end of the editor exiting content.
             const range = document.createRange();


### PR DESCRIPTION
It is possible that the wysiwyg focus method is called before the
odooEditor being loaded. This commit insure that the odooEditor
properly being loaded.

Task-2704538




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
