### PR TITLE
[FIX] stock: missing field from a compute method dependency

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -78,7 +78,7 @@ class StockMoveLine(models.Model):
             else:
                 line.lots_visible = line.product_id.tracking != 'none'
 
-    @api.depends('product_id', 'product_uom_id', 'product_uom_qty')
+    @api.depends('product_id', 'product_id.uom_id', 'product_uom_id', 'product_uom_qty')
     def _compute_product_qty(self):
         for line in self:
             line.product_qty = line.product_uom_id._compute_quantity(line.product_uom_qty, line.product_id.uom_id, rounding_method='HALF-UP')


### PR DESCRIPTION
The `uom_id` field from the product is used, but the field is missed from the dependency decorator. Because the `product_qty` field is stored, than it will never recalculated when i modify the uom on the product.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
