### PR TITLE
[FIX] sale: send invoice only when ready to be send

### DIFF
--- a/addons/sale/__init__.py
+++ b/addons/sale/__init__.py
@@ -6,3 +6,13 @@ from . import controllers
 from . import report
 from . import wizard
 from . import populate
+
+from odoo.api import Environment, SUPERUSER_ID
+
+
+def _synchronize_cron(cr, registry):
+    env = Environment(cr, SUPERUSER_ID, {'active_test': False})
+    send_invoice_cron = env.ref('sale.send_invoice_cron', raise_if_not_found=False)
+    if send_invoice_cron:
+        config = env['ir.config_parameter'].get_param('sale.automatic_invoice', False)
+        send_invoice_cron.active = bool(config)

--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -73,5 +73,6 @@ This module contains all the common features of Sales Management and eCommerce.
             'sale/static/tests/sales_team_dashboard_tests.js',
         ],
     },
+    'post_init_hook': '_synchronize_cron',
     'license': 'LGPL-3',
 }

--- a/addons/sale/data/sale_data.xml
+++ b/addons/sale/data/sale_data.xml
@@ -16,5 +16,17 @@
             <field name="key">sale.default_confirmation_template</field>
             <field name="value" ref="sale.mail_template_sale_confirmation"/>
         </record>
+
+        <record model="ir.cron" id="send_invoice_cron">
+            <field name="name">automatic invoicing: send ready invoice</field>
+            <field name="model_id" ref="payment.model_payment_transaction" />
+            <field name="state">code</field>
+            <field name="code">model._cron_send_invoice()</field>
+            <field name="user_id" ref="base.user_root" />
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+        </record>
+
     </data>
 </odoo>

--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -119,3 +119,14 @@ class AccountMove(models.Model):
         # OVERRIDE
         self.ensure_one()
         return self.partner_shipping_id.id or super(AccountMove, self)._get_invoice_delivery_partner_id()
+
+    def _action_invoice_ready_to_be_sent(self):
+        # OVERRIDE
+        # Make sure the send invoice CRON is called when an invoice becomes ready to be sent by mail.
+        res = super()._action_invoice_ready_to_be_sent()
+
+        send_invoice_cron = self.env.ref('sale.send_invoice_cron', raise_if_not_found=False)
+        if send_invoice_cron:
+            send_invoice_cron._trigger()
+
+        return res

--- a/addons/sale/models/res_config_settings.py
+++ b/addons/sale/models/res_config_settings.py
@@ -76,6 +76,10 @@ class ResConfigSettings(models.TransientModel):
         if self.default_invoice_policy != 'order':
             self.env['ir.config_parameter'].set_param('sale.automatic_invoice', False)
 
+        send_invoice_cron = self.env.ref('sale.send_invoice_cron', raise_if_not_found=False)
+        if send_invoice_cron:
+            send_invoice_cron.active = self.automatic_invoice
+
     @api.onchange('use_quotation_validity_days')
     def _onchange_use_quotation_validity_days(self):
         if self.quotation_validity_days <= 0:


### PR DESCRIPTION
Issues
------

In the module sale, with the automatic invoicing configured.
Payment transaction generate, post and send the invoice when
they are post process.

In some country the invoice is not directly ready to be sent
due to some edi document

Solution
--------

use the mechanism introduce with https://github.com/odoo/odoo/commit/3a29371eb70309f46e3b8938434287fefc23b351
to delay the sending. Introduce a cron that check invoice to send



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
