### PR TITLE
[FIX] mail: prevent retrieve of private channel user hasn't access to

### DIFF
--- a/addons/mail/controllers/main.py
+++ b/addons/mail/controllers/main.py
@@ -131,7 +131,7 @@ class MailController(http.Controller):
         request.env['mail.followers'].check_access_rights("read")
         request.env[res_model].check_access_rights("read")
         request.env[res_model].browse(res_id).check_access_rule("read")
-        follower_recs = request.env['mail.followers'].search([('res_model', '=', res_model), ('res_id', '=', res_id)])
+        follower_recs = request.env['mail.followers'].sudo().search([('res_model', '=', res_model), ('res_id', '=', res_id)])
 
         followers = []
         follower_id = None

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2184,7 +2184,8 @@ class MailThread(models.AbstractModel):
                     bus_notifications.append([(self._cr.dbname, 'ir.needaction', partner_id), dict(message_format_values)])
             if channel_ids:
                 channels = self.env['mail.channel'].sudo().browse(channel_ids)
-                bus_notifications += channels._channel_message_notifications(message, message_format_values)
+                message_sudo = message.sudo()
+                bus_notifications += channels._channel_message_notifications(message_sudo, message_format_values)
 
         if bus_notifications:
             self.env['bus.bus'].sudo().sendmany(bus_notifications)


### PR DESCRIPTION
### Current behavior
When a user go to a Project's Task which is followed by a private channel which user doesn't have access to, an AccessError is raised.

### Steps to reproduce
1. Install Project and Discuss
2. Go to Discuss and create a new private channel
3. Go to Project and select any task
4. Add channel from point 2. as follower

*Connect as a normal user (e.g. Marc Demo)*

5. Go to Project and select the same task as point 3.

### Reason
Before, we were looking for followers including channels even if those weren't accessible by the user, which trigger an AccessError according to this rule : 
https://github.com/odoo/odoo/blob/7b2889fe8a3931bf4009c6ed49c9e3842e8b9286/addons/mail/security/mail_security.xml#L5-L14

#### Note
in v13, followers were retrieved with sudo rights :
https://github.com/odoo/odoo/blob/b4a9e5b8307ab1b730effe2de23f15260326ef6c/addons/mail/controllers/main.py#L136

in v15, channels can't be added as followers anymore

OPW-2677064
OPW-2690903