### PR TITLE
[IMP] hr_skills: remove skills edit buttons when no rights

### DIFF
--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -104,7 +104,7 @@
                             <!-- This field uses a custom tree view rendered by the 'hr_resume' widget.
                                 Adding fields in the tree arch below makes them accessible to the widget
                             -->
-                            <field mode="tree" nolabel="1" name="resume_line_ids" widget="hr_resume">
+                            <field mode="tree" nolabel="1" name="resume_line_ids" widget="hr_resume" attrs="{'readonly': True}">
                                 <tree>
                                     <field name="line_type_id"/>
                                     <field name="name"/>
@@ -117,7 +117,7 @@
                         </div>
                         <div class="o_hr_skills_group o_group_skills col-lg-5 d-flex flex-column">
                             <separator string="Skills"/>
-                            <field mode="tree" nolabel="1" name="employee_skill_ids"  widget="hr_skills">
+                            <field mode="tree" nolabel="1" name="employee_skill_ids"  widget="hr_skills" attrs="{'readonly': True}">
                                 <tree>
                                     <field name="skill_type_id" invisible="1"/>
                                     <field name="skill_id"/>


### PR DESCRIPTION
When the user has no rights on the Employee app, he can still
see the information on the employee public view
If the skills module is installed, there are add and remove buttons
displayed even in the absence of user rights.

Buttons should be hidden if the user has no rights to edit the
skills and resume

task-2702678


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
