### PR TITLE
[FIX] pos_coupon, pos_restaurant : Promotion program

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -843,6 +843,10 @@ class PosOrder(models.Model):
             'tip_amount': order.tip_amount,
         }
 
+    def _get_fields_for_order_line(self):
+        """This function is here to be overriden"""
+        return []
+
     def export_for_ui(self):
         """ Returns a list of dict with each item having similar signature as the return of
             `export_as_JSON` of models.Order. This is useful for back-and-forth communication

--- a/addons/pos_coupon/models/pos_order.py
+++ b/addons/pos_coupon/models/pos_order.py
@@ -62,6 +62,10 @@ class PosOrder(models.Model):
             for coupon in self.generated_coupon_ids
         ]
 
+    def _get_fields_for_order_line(self):
+        fields = super(PosOrder, self)._get_fields_for_order_line()
+        fields.append('is_program_reward')
+        return fields
 
 class PosOrderLine(models.Model):
     _inherit = "pos.order.line"

--- a/addons/pos_coupon/static/src/js/coupon.js
+++ b/addons/pos_coupon/static/src/js/coupon.js
@@ -1048,7 +1048,6 @@ odoo.define('pos_coupon.pos', function (require) {
                 this.is_program_reward = json.is_program_reward;
                 this.program_id = json.program_id;
                 this.coupon_id = json.coupon_id;
-                this.tax_ids = json.tax_ids[0][2];
             }
             _orderline_super.init_from_JSON.apply(this, [json]);
         },

--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -48,7 +48,8 @@ class PosOrder(models.Model):
             next(order_line for order_line in order_lines if order_line['id'] == order_line_id)['pack_lot_ids'] = list(pack_lots)
 
     def _get_fields_for_order_line(self):
-        return [
+        fields = super(PosOrder, self)._get_fields_for_order_line()
+        fields.extend([
             'id',
             'discount',
             'product_id',
@@ -60,7 +61,8 @@ class PosOrder(models.Model):
             'mp_dirty',
             'full_product_name',
             'customer_note',
-        ]
+        ])
+        return fields
 
     def _get_order_lines(self, orders):
         """Add pos_order_lines to the orders.


### PR DESCRIPTION
Current behavior :
When you add a promotion campagn to a PoS the promotion is applied
on every line of every order everytime you load the order. This cause situations
where you have multiple discount for a single product.

Steps to reproduce:
- create a standrard promotion program (automatically applied, 10%)
- set that promotion on the PoS (bar)
- open a session, chooses a table and make an order --> promotion correctly applied
- get out of the table and go back to the same table --> 2 additional lines are created because of the promotion

opw-2699544

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
