### PR TITLE
[FIX] hr_holidays: confirm allocation request with no validation needed

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -649,14 +649,14 @@ class HolidaysAllocation(models.Model):
                     raise UserError(_('Only a time off Manager can reset other people allocation.'))
                 continue
 
-            if not is_officer and self.env.user != holiday.employee_id.leave_manager_id:
+            if not is_officer and self.env.user != holiday.employee_id.leave_manager_id and not val_type == 'no':
                 raise UserError(_('Only a time off Officer/Responsible or Manager can approve or refuse time off requests.'))
 
             if is_officer or self.env.user == holiday.employee_id.leave_manager_id:
                 # use ir.rule based first access check: department, members, ... (see security.xml)
                 holiday.check_access_rule('write')
 
-            if holiday.employee_id == current_employee and not is_manager:
+            if holiday.employee_id == current_employee and not is_manager and not val_type == 'no':
                 raise UserError(_('Only a time off Manager can approve its own requests.'))
 
             if (state == 'validate1' and val_type == 'both') or (state == 'validate' and val_type == 'manager'):

--- a/addons/hr_holidays/tests/test_allocation_access_rights.py
+++ b/addons/hr_holidays/tests/test_allocation_access_rights.py
@@ -17,7 +17,7 @@ class TestAllocationRights(TestHrHolidaysCommon):
         self.employee_emp.parent_id = False
         self.employee_emp.leave_manager_id = False
 
-        self.lt_no_validation = self.env['hr.leave.type'].create({
+        self.lt_no_allocation = self.env['hr.leave.type'].create({
             'name': 'Validation = HR',
             'allocation_validation_type': 'officer',
             'requires_allocation': 'no',
@@ -36,6 +36,13 @@ class TestAllocationRights(TestHrHolidaysCommon):
             'allocation_validation_type': 'set',
             'requires_allocation': 'yes',
             'employee_requests': 'no',
+        })
+
+        self.lt_allocation_no_validation = self.env['hr.leave.type'].create({
+            'name': 'Validation = user',
+            'allocation_validation_type': 'no',
+            'requires_allocation': 'yes',
+            'employee_requests': 'yes',
         })
 
     def request_allocation(self, user, values={}):
@@ -65,6 +72,24 @@ class TestAccessRightsSimpleUser(TestAllocationRights):
         values = {
             'employee_id': self.employee_emp.id,
             'holiday_status_id': self.lt_allocation_manager.id,
+        }
+        with self.assertRaises(AccessError):
+            self.request_allocation(self.user_employee.id, values)
+
+    def test_simple_user_request_allocation_no_validation(self):
+        """ A simple user can request and automatically validate an allocation with no validation """
+        values = {
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': self.lt_allocation_no_validation.id,
+        }
+        allocation = self.request_allocation(self.user_employee.id, values)
+        self.assertEqual(allocation.state, 'validate', "It should be validated")
+
+    def test_simple_user_request_allocation_no_validation_other(self):
+        """ A simple user cannot request an other user's allocation with no validation """
+        values = {
+            'employee_id': self.employee_hruser.id,
+            'holiday_status_id': self.lt_allocation_no_validation.id,
         }
         with self.assertRaises(AccessError):
             self.request_allocation(self.user_employee.id, values)


### PR DESCRIPTION
An employee could not confirm an allocation request of a type that doesn't need validation

Steps to reproduce:
1. Connect as admin
2. Install and open the Time Off app
3. Create a time off type in Configuration->Time Off Types with
	- Requires allocation: Yes
	- Approval: No validation needed
4. Connect as demo
5. Open the Time Off app and create an allocation request of the type created just before and try to save

Solution:
Add a condition before raising the error that checks the allocation validation type

OPW-2683477