### PR TITLE
[FIX] mail : Automated email

### DIFF
--- a/addons/mail/models/ir_actions_server.py
+++ b/addons/mail/models/ir_actions_server.py
@@ -104,8 +104,9 @@ class ServerActions(models.Model):
         cleaned_ctx = dict(self.env.context)
         cleaned_ctx.pop('default_type', None)
         cleaned_ctx.pop('default_parent_id', None)
-        self.template_id.with_context(cleaned_ctx).send_mail(self._context.get('active_id'), force_send=False,
+        mail_id = self.template_id.with_context(cleaned_ctx).send_mail(self._context.get('active_id'), force_send=True,
                                                              raise_exception=False)
+        self.env['mail.mail'].browse([mail_id]).send()
         return False
 
     def _run_action_next_activity(self, eval_context=None):

--- a/addons/test_mail/tests/test_ir_actions.py
+++ b/addons/test_mail/tests/test_ir_actions.py
@@ -13,9 +13,7 @@ class TestServerActionsEmail(TestMailCommon, TestServerActionsBase):
         self.action.with_context(self.context).run()
         # check an email is waiting for sending
         mail = self.env['mail.mail'].sudo().search([('subject', '=', 'About TestingPartner')])
-        self.assertEqual(len(mail), 1)
-        # check email content
-        self.assertEqual(mail.body, '<p>Hello TestingPartner</p>')
+        self.assertEqual(len(mail), 0)
 
     def test_action_followers(self):
         self.test_partner.message_unsubscribe(self.test_partner.message_partner_ids.ids)


### PR DESCRIPTION
Current behavior :
When creating an automated action to send email on creation
it was actually not sending any email.

Steps to reproduce :
Go to automated action
Create an automated action sending email on lead creation (CRM app)
Create new template and select default_recipient
Create a new lead in the CRM app
No email are sent

opw-2683954

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
