### PR TITLE
[FIX] pos_hr: cash opening is not triggered when logged in by scan

### DIFF
--- a/addons/pos_hr/static/src/js/LoginScreen.js
+++ b/addons/pos_hr/static/src/js/LoginScreen.js
@@ -24,6 +24,8 @@ odoo.define('pos_hr.LoginScreen', function (require) {
         back() {
             this.props.resolve({ confirmed: false, payload: false });
             this.trigger('close-temp-screen');
+            this.env.pos.hasLoggedIn = true;
+            posbus.trigger('start-cash-control');
         }
         confirm() {
             this.props.resolve({ confirmed: true, payload: true });
@@ -46,8 +48,6 @@ odoo.define('pos_hr.LoginScreen', function (require) {
             if (employee) {
                 this.env.pos.set_cashier(employee);
                 this.back();
-                this.env.pos.hasLoggedIn = true;
-                posbus.trigger('start-cash-control');
             }
         }
         async _barcodeCashierAction(code) {


### PR DESCRIPTION
When logging in as employee using barcode scanner, the event to
show the opening cash control is not triggered, therefore, only the
first user to login using the selection popup that the cash opening
will be initiated. We fix this issue by lifting the event trigger
at the `back` method.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
