### PR TITLE
[FIX] delivery,sale_mrp: sale price for serial products

### DIFF
--- a/addons/delivery/models/stock_move.py
+++ b/addons/delivery/models/stock_move.py
@@ -36,7 +36,7 @@ class StockMoveLine(models.Model):
         for move_line in self:
             if move_line.move_id.sale_line_id:
                 unit_price = move_line.move_id.sale_line_id.price_reduce_taxinc
-                qty = move_line.product_uom_id._compute_quantity(move_line.move_id.sale_line_id.product_qty, move_line.move_id.sale_line_id.product_uom)
+                qty = move_line.product_uom_id._compute_quantity(move_line.qty_done, move_line.move_id.sale_line_id.product_uom)
             else:
                 unit_price = move_line.product_id.list_price
                 qty = move_line.product_uom_id._compute_quantity(move_line.qty_done, move_line.product_id.uom_id)


### PR DESCRIPTION
Have a [TEST] product tracked by serial number
Create a SO with [TEST], quantity N (at least 2)
Add FEDEX int. delivery to the order
Validate and confirm delivery

On the shipping invoice the product is reported on N lines, one for each
serial number, but the price is not splitted accordingly so the total of
the invoice will be the original price multiplied by N

This commit revert f3488749eed3c4e96f1cc50a2bb2cf87b423c890
not needed anymore after
e13f048a78b41d81602e868a3b0c7ded24ce992b

opw-2703581

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
