### PR TITLE
[FIX] hr_holidays_attendance: allow non HR officer user to refuse leaves

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_leave.py
+++ b/addons/hr_holidays_attendance/models/hr_leave.py
@@ -77,5 +77,5 @@ class HRLeave(models.Model):
 
     def action_refuse(self):
         res = super().action_refuse()
-        self.overtime_id.sudo().unlink()
+        self.sudo().overtime_id.unlink()
         return res


### PR DESCRIPTION
When refusing a leave, we are deleting the associated overtime if any so it can be
used again by the employee. However, we need HR Officer rights to access overtime
field. The sudo() should be used before we try to read the field to avoid errors
in case the manager of the employee does not have HR rights.

Description of the issue/feature this PR addresses:
opw-2701768

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
