### PR TITLE
[FIX] website: ensure auto tests drop snippets at the end of the page

### DIFF
--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -204,7 +204,9 @@ function dragNDrop(snippet, position = "bottom") {
         moveTrigger: '.oe_drop_zone',
         content: _.str.sprintf(_t("Drag the <b>%s</b> building block and drop it at the bottom of the page."), snippet.name),
         position: position,
-        run: "drag_and_drop #wrap",
+        // Normally no main snippet can be dropped in the default footer but
+        // targeting it allows to force "dropping at the end of the page".
+        run: "drag_and_drop #wrapwrap > footer",
     };
 }
 


### PR DESCRIPTION
This is a backport of [1] which for some reason was merged in 14.3
instead of 14.0 directly. It is now important to have it there as the
theme tours will be run during tests.

Useful when debugging: launching the themes tours automatically will
build the page with the snippets in the right order.

[1]: https://github.com/odoo/odoo/commit/2ee9d4009fa62124dad5410d5bfdca572237dc65

THEMES PR: https://github.com/odoo/design-themes/pull/532