### PR TITLE
[FIX] project: do not copy tasks when duplicating project

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -255,6 +255,7 @@ class Project(models.Model):
     task_count = fields.Integer(compute='_compute_task_count', string="Task Count")
     task_count_with_subtasks = fields.Integer(compute='_compute_task_count')
     task_ids = fields.One2many('project.task', 'project_id', string='Tasks',
+                               copy=False,
                                domain=['|', ('stage_id.fold', '=', False), ('stage_id', '=', False)])
     color = fields.Integer(string='Color Index')
     user_id = fields.Many2one('res.users', string='Project Manager', default=lambda self: self.env.user, tracking=True)


### PR DESCRIPTION
Step to reproduce:
Have a functional support analyst trying to duplicate a project for
whatever reason.

Current behavior:
It spamms the whole accounting team because duplicated tasks are
assigned like previous tasks were assigned.

Expected behavior:
Clean mail inbox.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
