### PR TITLE
[FIX] hr_holidays: bring back missing import

### DIFF
--- a/addons/hr_holidays/__manifest__.py
+++ b/addons/hr_holidays/__manifest__.py
@@ -66,12 +66,13 @@ A synchronization with an internal agenda (Meetings of the CRM module) is also p
             'hr_holidays/static/src/models/*/*.js',
         ],
         'web.assets_backend': [
-            'hr_holidays/static/src/js/time_off_calendar/*.js',
+            'hr_holidays/static/src/js/**/*.js',
             'hr_holidays/static/src/models/*/*.js',
             'hr_holidays/static/src/components/*/*.scss',
             'hr_holidays/static/src/dashboard/**/*.js',
             'hr_holidays/static/src/dashboard/**/*.scss',
             'hr_holidays/static/src/leave_stats/**/*.js',
+            'hr_holidays/static/src/scss/*.scss',
         ],
         'web.tests_assets': [
             'hr_holidays/static/tests/helpers/**/*',


### PR DESCRIPTION
The custom calendar CSS was no longer imported.

Follow-up of #80397
TaskID: 2675380

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
