### PR TITLE
[IMP] packaging: add fonttools in packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -53,6 +53,8 @@ Recommends:
  ${python3:Recommends},
  postgresql,
  python3-ldap,
+Suggests:
+ python3-fonttools
 Description: Open Source Apps To Grow Your Business
  Odoo, formerly known as OpenERP, is a suite of open-source business apps
  written in Python and released under the LGPLv3 license. This suite of


### PR DESCRIPTION
Since 60e9632a00, the fonttools lib is used in pdf conversion to PDF/A.
While this tool is not ~absolutely~ mandatory to run Odoo, this lib is
necessary to produce PDF/A compliant PDF files.

This commit ~includes~ suggests the `fonttools` in the packaging.

For informations:
* Debian buster provides 3.35.1
* Ubuntu focal provides 4.5.0
* Fedora 30 provides 3.38.0
