### PR TITLE
[FIX] base: allow setting default `from-filter` per database

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -264,7 +264,8 @@ class IrMailServer(models.Model):
             smtp_port = tools.config.get('smtp_port', 25) if port is None else port
             smtp_user = user or tools.config.get('smtp_user')
             smtp_password = password or tools.config.get('smtp_password')
-            from_filter = tools.config.get('from_filter')
+            from_filter = self.env['ir.config_parameter'].sudo().get_param(
+                'mail.default.from_filter', tools.config.get('from_filter'))
             smtp_encryption = encryption
             if smtp_encryption is None and tools.config.get('smtp_ssl'):
                 smtp_encryption = 'starttls' # smtp_ssl => STARTTLS as of v7
@@ -642,7 +643,8 @@ class IrMailServer(models.Model):
             return mail_servers[0], email_from
 
         # 5: SMTP config in odoo-bin arguments
-        from_filter = tools.config.get('from_filter')
+        from_filter = self.env['ir.config_parameter'].sudo().get_param(
+            'mail.default.from_filter', tools.config.get('from_filter'))
 
         if self._match_from_filter(email_from, from_filter):
             return None, email_from


### PR DESCRIPTION
Purpose
=======
When there are multiple databases on a single server, it is necessary
to be able to set the "from_filter" for the implicit SMTP server
on a per-database basis, to allow 'opt-in' to the automatic wrapping
of email notifications.
When set to e.g. `notifications@example.com`, and a default SMTP
server is defined in the server-wide config or CLI, outgoing emails
will be automatically rewritten to come from this email, unless the
From/Return-Path domains does match the `mail.catchall.domain` parameter.

Task-2710632