### PR TITLE
[FIX] mail: allow switch to activity view with search

### DIFF
--- a/addons/mail/static/src/xml/activity_view.xml
+++ b/addons/mail/static/src/xml/activity_view.xml
@@ -25,10 +25,11 @@
                         </div>
                     </span>
                 </div>
-                <KanbanColumnProgressBarAdapter Component="widgetComponents.KanbanColumnProgressBar"
-                    widgetArgs="[getProgressBarOptions(type[0]), getProgressBarColumnState(type[0])]"
-                    t-if="activityTypeIds.includes(type[0])"
-                    t-on-set-progress-bar-state="_onSetProgressBarState"/>
+                <div t-if="activityTypeIds.includes(type[0])">
+                    <KanbanColumnProgressBarAdapter Component="widgetComponents.KanbanColumnProgressBar"
+                        widgetArgs="[getProgressBarOptions(type[0]), getProgressBarColumnState(type[0])]"
+                        t-on-set-progress-bar-state="_onSetProgressBarState"/>
+                </div>
                 <div t-else="" class="mt24"/>
             </th>
         </tr>


### PR DESCRIPTION
**Current behavior before PR:**

When switching to the activity view from any view, then back to that view,
search something and come back to the activity view, traceback like
"Failed to execute 'insertBefore' on 'Node': The node before which the new node
is to be inserted is not a child of this node."

This is happening because when there are no records in the search result and
the view is switched then the 'Undefined' text node is inserted before
KanbanColumnProgressBarAdapter component which is destroyed.

**Desired behavior after PR is merged:**

Wrap the KanbanColumnProgressBarAdapter inside the div element so that switching
to the activity view will work without any traceback.

Task-2587318





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
