### PR TITLE
[FIX] sale: Add product link in sale.order.line

### DIFF
--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -465,7 +465,6 @@
                                             'readonly': [('product_updatable', '=', False)],
                                             'required': [('display_type', '=', False)],
                                         }"
-                                        options="{'no_open': True}"
                                         force_save="1"
                                         context="{
                                             'partner_id': parent.partner_id,
@@ -486,7 +485,6 @@
                                           'readonly': [('product_updatable', '=', False)],
                                           'required': [('display_type', '=', False)],
                                       }"
-                                      options="{'no_open': True}"
                                       context="{
                                           'partner_id': parent.partner_id,
                                           'quantity': product_uom_qty,


### PR DESCRIPTION
**Steps to follow**

  - Click on a product from a sale.order.line
  - The form is switched to edit mode
  -> We can't go to the product page

**Cause of the issue**

  The quick edit feature was introduced in saas-14.4

**Solution**

  - remove the 'no_open' attribute from the product

opw-2688863