### PR TITLE
[FIX] product : label report in studio

### DIFF
--- a/addons/product/report/product_label_report.py
+++ b/addons/product/report/product_label_report.py
@@ -18,10 +18,10 @@ def _prepare_data(env, data):
 
     total = 0
     quantity_by_product = defaultdict(list)
-    for p, q in data.get('quantity_by_product').items():
-        product = Product.browse(int(p))
-        quantity_by_product[product].append((product.barcode, q))
-        total += q
+    for p, q in data.get('quantity_by_product', {}).items():
+            product = Product.browse(int(p))
+            quantity_by_product[product].append((product.barcode, q))
+            total += q
     if data.get('custom_barcodes'):
         # we expect custom barcodes format as: {product: [(barcode, qty_of_barcode)]}
         for product, barcodes_qtys in data.get('custom_barcodes').items():


### PR DESCRIPTION
Current behavior :
When trying to edit a produt report in studio you had a traceback

Steps to reproduce :
Go in inventory
Go in any product
Click the studio icon
Go in the report section
Click any reports

opw-2679102

linked with : https://github.com/odoo/enterprise/pull/22757

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
