### PR TITLE
Bulk/Batch insert (models.py)

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from psycopg2 import Error, OperationalError
+from psycopg2 import Error
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError

--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timedelta
 import logging
 import pytz
-from psycopg2 import sql, OperationalError, errorcodes
+from psycopg2 import sql
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -59,7 +59,7 @@ from .tools import frozendict, lazy_classproperty, ormcache, \
                    groupby, discardattr, partition
 from .tools.config import config
 from .tools.func import frame_codeinfo
-from .tools.misc import CountingStream, clean_context, DEFAULT_SERVER_DATETIME_FORMAT, DEFAULT_SERVER_DATE_FORMAT, get_lang
+from .tools.misc import CountingStream, clean_context, DEFAULT_SERVER_DATETIME_FORMAT, DEFAULT_SERVER_DATE_FORMAT, get_lang, split_every
 from .tools.translate import _
 from .tools import date_utils
 from .tools import populate
@@ -75,6 +75,9 @@ regex_pg_name = re.compile(r'^[a-z_][a-z0-9_$]*$', re.I)
 regex_field_agg = re.compile(r'(\w+)(?::(\w+)(?:\((\w+)\))?)?')
 
 AUTOINIT_RECALCULATE_STORED_FIELDS = 1000
+
+INSERT_BATCH_SIZE = 100
+SQL_DEFAULT = psycopg2.extensions.AsIs("DEFAULT")
 
 def check_object_name(name):
     """ Check if the given name is a valid model name.
@@ -4186,57 +4189,45 @@ Fields:
         """ Create records from the stored field values in ``data_list``. """
         assert data_list
         cr = self.env.cr
-        quote = '"{}"'.format
 
-        # insert rows
+        # insert rows in batches of maximum INSERT_BATCH_SIZE
         ids = []                                # ids of created records
         other_fields = OrderedSet()             # non-column fields
         translated_fields = OrderedSet()        # translated fields
 
-        for data in data_list:
-            # determine column values
-            stored = data['stored']
-            columns = {}
-            for name, val in sorted(stored.items()):
-                field = self._fields[name]
-                assert field.store
+        for data_sublist in split_every(INSERT_BATCH_SIZE, data_list):
+            stored_list = [data['stored'] for data in data_sublist]
+            fnames = sorted({name for stored in stored_list for name in stored})
 
+            columns = []
+            rows = [[] for _ in stored_list]
+            for fname in fnames:
+                field = self._fields[fname]
                 if field.column_type:
-                    col_val = field.convert_to_column(val, self, stored)
-                    columns[name] = col_val
                     if field.translate is True:
                         translated_fields.add(field)
+                    columns.append(fname)
+                    for stored, row in zip(stored_list, rows):
+                        if fname in stored:
+                            row.append(field.convert_to_column(stored[fname], self, stored))
+                        else:
+                            row.append(SQL_DEFAULT)
                 else:
                     other_fields.add(field)
 
-            # Insert rows one by one
-            # - as records don't all specify the same columns, code building batch-insert query
-            #   was very complex
-            # - and the gains were low, so not worth spending so much complexity
-            #
-            # It also seems that we have to be careful with INSERTs in batch, because they have the
-            # same problem as SELECTs:
-            # If we inject a lot of data in a single query, we fall into pathological perfs in
-            # terms of SQL parser and the execution of the query itself.
-            # In SELECT queries, we inject max 1000 ids (integers) when we can, because we know
-            # that this limit is well managed by PostgreSQL.
-            # In INSERT queries, we inject integers (small) and larger data (TEXT blocks for
-            # example).
-            #
-            # The problem then becomes: how to "estimate" the right size of the batch to have
-            # good performance?
-            #
-            # This requires extensive testing, and it was preferred not to introduce INSERTs in
-            # batch, to avoid regressions as much as possible.
-            #
-            # That said, we haven't closed the door completely.
-            if not columns:  # Manage the case where we create empty record
-                columns = {'id': psycopg2.extensions.AsIs('DEFAULT')}
+            if not columns:
+                # manage the case where we create empty records
+                columns = ['id']
+                for row in rows:
+                    row.append(SQL_DEFAULT)
 
-            header = ", ".join(quote(name) for name in columns)
-            query = f'INSERT INTO "{self._table}" ({header}) VALUES %s RETURNING id'
-            cr.execute(query, [tuple(columns.values())])
-            ids.append(cr.fetchone()[0])
+            header = ", ".join(f'"{column}"' for column in columns)
+            template = ", ".join("%s" for _ in rows)
+            cr.execute(
+                f'INSERT INTO "{self._table}" ({header}) VALUES {template} RETURNING "id"',
+                [tuple(row) for row in rows],
+            )
+            ids.extend(id_ for id_, in cr.fetchall())
 
         # put the new records in cache, and update inverse fields, for many2one
         #
@@ -4244,11 +4235,12 @@ Fields:
         cachetoclear = []
         records = self.browse(ids)
         inverses_update = defaultdict(list)     # {(field, value): ids}
+        common_set_vals = set(LOG_ACCESS_COLUMNS + [self.CONCURRENCY_CHECK_FIELD, 'id', 'parent_path'])
         for data, record in zip(data_list, records):
             data['record'] = record
             # DLE P104: test_inherit.py, test_50_search_one2many
             vals = dict({k: v for d in data['inherited'].values() for k, v in d.items()}, **data['stored'])
-            set_vals = list(vals) + LOG_ACCESS_COLUMNS + [self.CONCURRENCY_CHECK_FIELD, 'id', 'parent_path']
+            set_vals = common_set_vals.union(vals)
             for field in self._fields.values():
                 if field.type in ('one2many', 'many2many'):
                     self.env.cache.set(record, field, ())

--- a/odoo/tools/cache.py
+++ b/odoo/tools/cache.py
@@ -47,7 +47,7 @@ class ormcache(object):
 
     Methods implementing this decorator should never return a Recordset,
     because the underlying cursor will eventually be closed and raise a
-    `psycopg2.OperationalError`.
+    `psycopg2.InterfaceError`.
     """
     def __init__(self, *args, **kwargs):
         self.args = args


### PR DESCRIPTION
# POC: Batch `INSERT INTO` of `_create` method (`BaseModel`)

## Idea
When we create several of record in database, we make one "INSERT INTO" (one sql request) by values (by record) which isn't efficient. Then make a bulk insert instead.

The goal is to batch the insertion of record and by extension speed up `create` method when we give it many values. 

## HOW TO
Make a batched version of our INSERT INTO loop in the `_create` method.

### Performance testing
To test, we use the "populate script" of odoo-bin and by changing the batch size of it to get data depending on the number of values/record to create (check the branch `master-create-insert-batch-with-measurements-ryv`).
Because we know that the drawback of this approach is when values_list are sparse (we need to fill a lot of DEFAULT value). Then create a model ('worst.case') with 100 fields and with a "populate script" which create most sparse as possible values_list.

## `create` vs `_create` vs insertion loop vs 'insert into'

- `create` measure the time of the all `create` method of `BaseModel` (then not calculate the time of inherited create)
- `_create` measure the time of the all `_create` method of `BaseModel`
- 'Insertion loop' measure the time of the insertion loop: convert_to_column + creation of query + the 'INSERT INTO'. (we focus on this one)
- 'INSERT INTO' measure only the time made by the insert into queries.

Then  `create` contains `_create`, `_create` contains 'Insertion loop'  and  'Insertion loop' contains 'INSERT INTO'. 

### Time figures
#### Before
![time_spend_Before](https://user-images.githubusercontent.com/53175387/146756014-c4a48548-1a4f-471d-bdab-67acf8363857.png)

#### After
![time_spend_After](https://user-images.githubusercontent.com/53175387/146756037-25b42319-50a5-4295-841d-a2ddab932123.png)

### % Time figures
It is the % of time of the `create` method of each step (we try to improve the red and green ones) :

#### Before
![%_time_spend_Before](https://user-images.githubusercontent.com/53175387/146756062-3741a79a-8465-4a2f-aa8a-f321b803ee88.png)

#### After
![%_time_spend_After](https://user-images.githubusercontent.com/53175387/146756066-148d7af1-2186-48f9-9c5e-a7553ac7ccdb.png)

## Focus on the 'insertion loop' time (what we change)
### Graph
![time_vs_batch_time](https://user-images.githubusercontent.com/53175387/146756161-ee992a0f-e0ee-431a-b0f3-492aade89224.png)

### Table Results

#### `create`
![create_tab](https://user-images.githubusercontent.com/53175387/146756176-7e040bab-167f-43c3-b5d9-c2721683ad8a.png)

#### `_create`
![_create_tab](https://user-images.githubusercontent.com/53175387/146756195-f7199e3b-fc5c-40a3-81f4-2e9b3bb2d682.png)

#### 'insertion loop'
![insert_loop_tab](https://user-images.githubusercontent.com/53175387/146756208-cb9a0322-c585-47e3-b5b5-57bac5f0efcf.png)

#### 'insert into'
![insert_tab](https://user-images.githubusercontent.com/53175387/146756216-ea78807a-01db-45ba-bbd9-8287fb4eea48.png)

## Note

- The result are noisy, then is hard to conclude anything when the difference is small and the variance is high.
- The `mail.follower` aren't created in batch (fix in https://github.com/odoo/odoo/pull/80954), it is why we have only the data for mono create.

## Conclusion

It is clearly worth it for small model where the time of `create` method is mainly due to the insertion in DB. Also, the test was done on my compute where the database is local and the psql use a SSD: we can expect better result with a remote psql server and/or traditional hard disk.
In another hand, it increases a bit the complexity of the code.