### PR TITLE
[FIX] crm: disable inadequate ribbon partner sync alert

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -438,8 +438,11 @@ class Lead(models.Model):
     @api.depends('email_from', 'phone', 'partner_id')
     def _compute_ribbon_message(self):
         for lead in self:
-            will_write_email = lead._get_partner_email_update()
-            will_write_phone = lead._get_partner_phone_update()
+            will_write_email = (
+                lead.email_from != lead._origin.email_from
+                and (bool(lead.email_from) or bool(lead._origin.email_from))  # not when '' and False
+                and lead._get_partner_email_update())
+            will_write_phone = (lead.phone != lead._origin.phone) and lead._get_partner_phone_update()
 
             if will_write_email and will_write_phone:
                 lead.ribbon_message = _('By saving this change, the customer email and phone number will also be updated.')

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -176,6 +176,9 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'country_id': cls.env.ref('base.us').id,
             'zip': '97648',
         })
+        cls.contact_with_name_only = cls.env['res.partner'].create({
+            'name': 'John Fake',
+        })
 
     def _create_leads_batch(self, lead_type='lead', count=10, partner_ids=None, user_ids=None):
         """ Helper tool method creating a batch of leads, useful when dealing


### PR DESCRIPTION
Background: When a partner is added to an existing lead, the lead `email_from`
and `phone` fields are updated with the partner's. However, if the partner
doesn't have a set email address or phone, overriding the lead fields with
empty values is adequately prevented.

However, a ribbon alert appeared to inform of a further synchronization of
information from the lead to the partner, which will not occur if the value was
not changed on the lead itself.

This commit disables that ribbon alert when email/phone was not modified on the
lead.

Form tests are completed/updated to reflect this behavior.

Task-2704904
