### PR TITLE
[FIX] sale_management: prevent crash when sale order template lines a…

### DIFF
--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -182,9 +182,9 @@ class SaleOrderLine(models.Model):
         super()._compute_name()
         for line in self:
             if line.product_id and line.order_id.sale_order_template_id:
-                for line in line.order_id.sale_order_template_id.sale_order_template_line_ids:
-                    if line.product_id == line.product_id:
-                        line.name = line.with_context(lang=line.order_id.partner_id.lang).name + line._get_sale_order_line_multiline_description_variants()
+                for template_line in line.order_id.sale_order_template_id.sale_order_template_line_ids:
+                    if line.product_id == template_line.product_id:
+                        line.name = template_line.with_context(lang=line.order_id.partner_id.lang).name + line._get_sale_order_line_multiline_description_variants()
                         break
 
 


### PR DESCRIPTION
…re mixed with rental product

Before this commit, the following traceback would appears when a sale order template was used in rental with rental products.

 ```py
    super()._compute_name()
  File "/home/arj/PycharmProjects/odoo/addons/sale_management/models/sale_order.py", line 187, in _compute_name
    line.name = line.with_context(lang=line.order_id.partner_id.lang).name + line._get_sale_order_line_multiline_description_variants()
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/arj/PycharmProjects/odoo/odoo/http.py", line 643, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/arj/PycharmProjects/odoo/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
AttributeError: 'sale.order.template.line' object has no attribute 'order_id'
2021-12-07 14:27:34,267 95502 INFO subscription werkzeug: 127.0.0.1 - - [07/Dec/2021 14:27:34] "POST /web/dataset/call_kw/sale.order.line/onchange HTTP/1.1" 200 - 16 0.009 0.025
 ```


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
