### PR TITLE
[FIX] crm: priority stars vertical alignment

### DIFF
--- a/addons/crm/static/src/scss/crm.scss
+++ b/addons/crm/static/src/scss/crm.scss
@@ -1,3 +1,11 @@
+.o_lead_opportunity_form {
+    // Used to add spacing between fields when placed inline without having
+    // empty fields take extra space.
+    div.o_lead_opportunity_form_inline_fields > :not(.o_field_empty) {
+        margin-right: 1.5em;
+    }
+}
+
 .o_opportunity_kanban {
     .ribbon {
         &::before, &::after {

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -239,9 +239,9 @@
                                 <field name="user_id"
                                     context="{'default_sales_team_id': team_id}" widget="many2one_avatar_user"/>
                                 <label for="date_deadline">Expected Closing</label>
-                                <div>
+                                <div class="o_lead_opportunity_form_inline_fields">
                                     <field name="date_deadline" nolabel="1" class="oe_inline"/>
-                                    <field name="priority" widget="priority" nolabel="1" class="oe_inline ml-4"/>
+                                    <field name="priority" widget="priority" nolabel="1" class="oe_inline align-top"/>
                                 </div>
                                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                             </group>


### PR DESCRIPTION
Better aligns the stars with the label when no expected deadline is set
by styling the parent div to space out non-empty children.

Fixes an issue introduced with e70c203.

Task-2709761