### PR TITLE
[FIX] account: clash in resequence

### DIFF
--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -396,6 +396,25 @@ class TestSequenceMixin(AccountTestInvoicingCommon):
             account.unlink()
             env0.cr.commit()
 
+    def test_resequence_clash(self):
+        """Resequence doesn't clash when it uses a name set in the same batch
+        but that will be overriden later."""
+        moves = self.env['account.move']
+        for i in range(3):
+            moves += self.create_move(name=str(i))
+        moves.action_post()
+
+        mistake = moves[1]
+        mistake.button_draft()
+        mistake.posted_before = False
+        mistake.unlink()
+        moves -= mistake
+
+        self.env['account.resequence.wizard'].create({
+            'move_ids': moves.ids,
+            'first_name': '2',
+        }).resequence()
+
     @freeze_time('2021-10-01 00:00:00')
     def test_change_journal_on_first_account_move(self):
         """Changing the journal on the first move is allowed"""

--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -25,6 +25,8 @@ class ReSequenceWizard(models.TransientModel):
     @api.model
     def default_get(self, fields_list):
         values = super(ReSequenceWizard, self).default_get(fields_list)
+        if 'move_ids' not in fields_list:
+            return values
         active_move_ids = self.env['account.move']
         if self.env.context['active_model'] == 'account.move' and 'active_ids' in self.env.context:
             active_move_ids = self.env['account.move'].browse(self.env.context['active_ids'])
@@ -133,6 +135,7 @@ class ReSequenceWizard(models.TransientModel):
         if self.move_ids.journal_id and self.move_ids.journal_id.restrict_mode_hash_table:
             if self.ordering == 'date':
                 raise UserError(_('You can not reorder sequence by date when the journal is locked with a hash.'))
+        self.env['account.move'].browse(int(k) for k in new_values.keys()).name = False
         for move_id in self.move_ids:
             if str(move_id.id) in new_values:
                 if self.ordering == 'keep':


### PR DESCRIPTION
Have 3 moves named 0, 1 and 2
Delete move 1 to make a hole.
Resequence, starting the sequence at 2.

Expected: new names are 2 and 3

Result: an error because 1 is renamed to 2 but 2 still exists, leading
to a (temporary) duplicated name, which is not allowed.

We clear all the names to be resequenced before doing it in order to
avoid that.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
