### PR TITLE
[FIX] mail: hide 'View' button in mail

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2608,7 +2608,11 @@ class MailThread(models.AbstractModel):
         for group_name, group_func, group_data in groups:
             group_data.setdefault('notification_group_name', group_name)
             group_data.setdefault('notification_is_customer', False)
-            group_data.setdefault('has_button_access', True)
+            is_thread_notification = msg_vals and (
+                    msg_vals.get('model', self._name) != 'mail.thread' and
+                    (msg_vals.get('res_id', self.ids[0] if self.ids else False) is not False)
+            )
+            group_data.setdefault('has_button_access', is_thread_notification)
             group_button_access = group_data.setdefault('button_access', {})
             group_button_access.setdefault('url', access_link)
             group_button_access.setdefault('title', view_title)

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -430,3 +430,25 @@ class TestMessagePost(TestMailCommon, TestRecipients):
                 subject='About %s' % test_record.name,
                 body_content=test_record.name,
                 attachments=[('first.txt', b'My first attachment', 'text/plain'), ('second.txt', b'My second attachment', 'text/plain')])
+
+    @mute_logger('odoo.addons.mail.models.mail_mail')
+    def test_post_notify_no_button(self):
+        pdata = self._generate_notify_recipients(self.partner_employee)
+        msg_vals = {
+            'body': 'Message body',
+            'model': False,
+            'res_id': False,
+            'subject': 'Message subject',
+        }
+        link_vals = {
+            'token': 'token_val',
+            'access_token': 'access_token_val',
+            'auth_signup_token': 'auth_signup_token_val',
+            'auth_login': 'auth_login_val',
+        }
+        notify_msg_vals = dict(msg_vals, **link_vals)
+        classify_res = self.env[self.test_record._name]._notify_classify_recipients(pdata, 'Test', msg_vals=notify_msg_vals)
+        # find back information for partner
+        partner_info = next(item for item in classify_res)
+        # check there is sno access button
+        self.assertFalse(partner_info['has_button_access'])


### PR DESCRIPTION
### Expected Behaviour
When a user get a mail from the data cleaning about records to examine, the View button should be linked to the same url as the 'here' hyperlink or not be in the e-mail.

### Observed behaviour
Clicking the link in the View button lead to an error page

Reproducibility
This bug can be reproduced following these steps:
1. Duplicate a contact
2. Wait for the scheduled task to launch
3. Click on the View button of the mail you'll get about te duplicate

### Problem Root Cause
This issue is coming from the way we create the 'View' and 'View Task' button, and can't be changed easily. The easier way to fix this issue is then to hide these button

### Related Issues/PR

- opw-2674138

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
