### PR TITLE
[FIX] *: cleanup manifest files

### DIFF
--- a/addons/auth_oauth/__manifest__.py
+++ b/addons/auth_oauth/__manifest__.py
@@ -8,7 +8,6 @@
 Allow users to login through OAuth2 Provider.
 =============================================
 """,
-    'maintainer': 'Odoo S.A.',
     'depends': ['base', 'web', 'base_setup', 'auth_signup'],
     'data': [
         'data/auth_oauth_data.xml',

--- a/addons/base_address_city/__manifest__.py
+++ b/addons/base_address_city/__manifest__.py
@@ -5,7 +5,6 @@
     'summary': 'Add a many2one field city on addresses',
     'sequence': '19',
     'category': 'Hidden/Tools',
-    'complexity': 'easy',
     'description': """
 City Management in Addresses
 ============================

--- a/addons/base_address_extended/__manifest__.py
+++ b/addons/base_address_extended/__manifest__.py
@@ -5,7 +5,6 @@
     'summary': 'Add extra fields on addresses',
     'sequence': '19',
     'category': 'Hidden',
-    'complexity': 'easy',
     'description': """
 Extended Addresses Management
 =============================

--- a/addons/bus/__manifest__.py
+++ b/addons/bus/__manifest__.py
@@ -2,7 +2,6 @@
     'name' : 'IM Bus',
     'version': '1.0',
     'category': 'Hidden',
-    'complexity': 'easy',
     'description': "Instant Messaging Bus allow you to send messages to users, in live.",
     'depends': ['base', 'web'],
     'data': [

--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -69,7 +69,6 @@
         'data/mail_activity_demo.xml',
         'data/crm_lead_demo.xml',
     ],
-    'css': ['static/src/css/crm.css'],
     'installable': True,
     'application': True,
     'auto_install': False,

--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -5,7 +5,6 @@
     'sequence': 210,
     'summary': 'Chat with your website visitors',
     'category': 'Website/Live Chat',
-    'complexity': 'easy',
     'website': 'https://www.odoo.com/app/live-chat',
     'description':
         """

--- a/addons/l10n_ae_pos/__manifest__.py
+++ b/addons/l10n_ae_pos/__manifest__.py
@@ -9,7 +9,11 @@ United Arab Emirates POS Localization
 =======================================================
     """,
     'depends': ['l10n_ae', 'point_of_sale'],
-    'qweb': ['static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml'],
     'auto_install': True,
     'license': 'LGPL-3',
+    'assets': {
+        'point_of_sale.assets': [
+            'l10n_ae_pos/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml',
+        ],
+    },
 }

--- a/addons/lunch/__manifest__.py
+++ b/addons/lunch/__manifest__.py
@@ -40,7 +40,6 @@ If you want to save your employees' time and avoid them to always have coins in 
     'demo': ['data/lunch_demo.xml'],
     'installable': True,
     'application': True,
-    'certificate': '001292377792581874189',
     'assets': {
         'web.assets_backend': [
             'lunch/static/src/scss/lunch_view.scss',

--- a/addons/pos_restaurant_adyen/__manifest__.py
+++ b/addons/pos_restaurant_adyen/__manifest__.py
@@ -12,7 +12,7 @@
     'data': [
         'views/pos_payment_method_views.xml',
         ],
-    'auto-install': True,
+    'auto_install': True,
     'assets': {
         'point_of_sale.assets': [
             'pos_restaurant_adyen/static/**/*',

--- a/odoo/addons/test_assetsbundle/__manifest__.py
+++ b/odoo/addons/test_assetsbundle/__manifest__.py
@@ -4,7 +4,6 @@
     'version': '0.1',
     'category': 'Hidden/Tests',
     'description': """A module to verify the Assets Bundle mechanism.""",
-    'maintainer': 'Odoo SA',
     'depends': ['base'],
     'installable': True,
     'data': [

--- a/odoo/addons/test_converter/__manifest__.py
+++ b/odoo/addons/test_converter/__manifest__.py
@@ -5,7 +5,6 @@
     'version': '0.1',
     'category': 'Hidden/Tests',
     'description': """Tests of field conversions""",
-    'maintainer': 'OpenERP SA',
     'depends': ['base'],
     'data': ['ir.model.access.csv'],
     'installable': True,

--- a/odoo/addons/test_lint/__manifest__.py
+++ b/odoo/addons/test_lint/__manifest__.py
@@ -4,7 +4,6 @@
     'version': '0.1',
     'category': 'Hidden/Tests',
     'description': """A module to test Odoo code with various linters.""",
-    'maintainer': 'Odoo SA',
     'depends': ['base'],
     'installable': True,
     'auto_install': False,


### PR DESCRIPTION
*: base_address_city, base_address_extended, bus, crm, im_livechat,
   l10n_ae_pos, lunch, pos_restaurant_adyen, test_assetsbundle,
   test_converter, test_lint.

It is spelled `auto_install`, the `complexity` key is long gone, `qweb`
has been moved to `assets: {'web.assets_qweb': []}`. `js` and `css` are
long gone too, `maintainer` is redundant with `author` which is
"Odoo S.A." by default already, the `certificate` key is long gone.