### PR TITLE
[FIX] l10n_generic_coa: fix cash difference gain account type

### DIFF
--- a/addons/l10n_generic_coa/data/account.account.template.csv
+++ b/addons/l10n_generic_coa/data/account.account.template.csv
@@ -18,7 +18,7 @@
 "dividends","Dividends","3020","account.data_account_type_equity","l10n_generic_coa.configurable_chart_template","","False"
 "income","Product Sales","4000","account.data_account_type_revenue","l10n_generic_coa.configurable_chart_template","account.account_tag_operating","False"
 "income_currency_exchange","Foreign Exchange Gain","4410","account.data_account_type_revenue","l10n_generic_coa.configurable_chart_template","account.account_tag_financing","False"
-"cash_diff_income","Cash Difference Gain","4420","account.data_account_type_revenue","l10n_generic_coa.configurable_chart_template","account.account_tag_investing","False"
+"cash_diff_income","Cash Difference Gain","4420","account.data_account_type_other_income","l10n_generic_coa.configurable_chart_template","account.account_tag_investing","False"
 "other_income","Other Income","4500","account.data_account_type_other_income","l10n_generic_coa.configurable_chart_template","","False"
 "cost_of_goods_sold","Cost of Goods Sold","5000","account.data_account_type_direct_costs","l10n_generic_coa.configurable_chart_template","account.account_tag_operating","False"
 "expense","Expenses","6000","account.data_account_type_expenses","l10n_generic_coa.configurable_chart_template","account.account_tag_operating","False"


### PR DESCRIPTION
Cash difference gain income is ancillary income, not related to the main activity of the company.
Currently, Cash DIfference Gain account has _account.data_account_type_revenue_ type, but it should have _account.data_account_type_other_income_ type.

Task: https://www.odoo.com/web#id=2702804&cids=1&menu_id=4720&action=4043&model=project.task&view_type=form



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
