### PR TITLE
[FIX] base: compatible with python 3.9

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -304,7 +304,7 @@ class AccountBankStatement(models.Model):
                 self.env['ir.attachment'].create({
                     'name': statement.name and _("Bank Statement %s.pdf") % statement.name or _("Bank Statement.pdf"),
                     'type': 'binary',
-                    'datas': base64.encodestring(content),
+                    'datas': base64.encodebytes(content),
                     'res_model': statement._name,
                     'res_id': statement.id
                 })

--- a/addons/base_import_module/models/base_import_module.py
+++ b/addons/base_import_module/models/base_import_module.py
@@ -17,7 +17,7 @@ class BaseImportModule(models.TransientModel):
     def import_module(self):
         self.ensure_one()
         IrModule = self.env['ir.module.module']
-        zip_data = base64.decodestring(self.module_file)
+        zip_data = base64.decodebytes(self.module_file)
         fp = BytesIO()
         fp.write(zip_data)
         res = IrModule.import_zipfile(fp, force=self.force)

--- a/addons/hw_escpos/controllers/main.py
+++ b/addons/hw_escpos/controllers/main.py
@@ -98,7 +98,7 @@ class EscposDriver(Thread):
 
     def lockedstart(self):
         with self.lock:
-            if not self.isAlive():
+            if not self.is_alive():
                 self.daemon = True
                 self.start()
     

--- a/addons/l10n_be_edi/tests/test_ubl.py
+++ b/addons/l10n_be_edi/tests/test_ubl.py
@@ -20,7 +20,7 @@ class TestUBL(common.TransactionCase):
 
         attachment_id = self.env['ir.attachment'].create({
             'name': 'efff_test.xml',
-            'datas': base64.encodestring(xml_file),
+            'datas': base64.encodebytes(xml_file),
             'res_id': invoice.id,
             'res_model': 'account.move',
         })

--- a/addons/l10n_fr_fec/wizard/account_fr_fec.py
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec.py
@@ -379,7 +379,7 @@ class AccountFrFec(models.TransientModel):
             suffix = '-NONOFFICIAL'
 
         self.write({
-            'fec_data': base64.encodestring(fecvalue),
+            'fec_data': base64.encodebytes(fecvalue),
             # Filename = <siren>FECYYYYMMDD where YYYMMDD is the closing date
             'filename': '%sFEC%s%s.csv' % (company_legal_data['siren'], end_date, suffix),
             })

--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -163,7 +163,7 @@ class AccountMove(models.Model):
                 'name': report_name,
                 'res_id': invoice.id,
                 'res_model': invoice._name,
-                'datas': base64.encodestring(data),
+                'datas': base64.encodebytes(data),
                 'description': description,
                 'type': 'binary',
                 })

--- a/addons/l10n_it_edi/models/ir_mail_server.py
+++ b/addons/l10n_it_edi/models/ir_mail_server.py
@@ -134,7 +134,7 @@ class FetchmailServer(models.Model):
 
         invoice_attachment = self.env['ir.attachment'].create({
                 'name': att_name,
-                'datas': base64.encodestring(att_content),
+                'datas': base64.encodebytes(att_content),
                 'type': 'binary',
                 })
 

--- a/addons/pos_cache/models/pos_cache.py
+++ b/addons/pos_cache/models/pos_cache.py
@@ -30,7 +30,7 @@ class pos_cache(models.Model):
                 display_default_code=False, lang=cache.compute_user_id.lang)
             res = prod_ctx.read(cache.get_product_fields())
             cache.write({
-                'cache': base64.encodestring(json.dumps(res).encode('utf-8')),
+                'cache': base64.encodebytes(json.dumps(res).encode('utf-8')),
             })
 
     @api.model
@@ -48,7 +48,7 @@ class pos_cache(models.Model):
             self.product_fields = str(fields)
             self.refresh_cache()
 
-        return json.loads(base64.decodestring(self.cache).decode('utf-8'))
+        return json.loads(base64.decodebytes(self.cache).decode('utf-8'))
 
 
 class pos_config(models.Model):

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1531,7 +1531,7 @@ class Binary(http.Controller):
             try:
                 attachment = Model.create({
                     'name': filename,
-                    'datas': base64.encodestring(ufile.read()),
+                    'datas': base64.encodebytes(ufile.read()),
                     'res_model': model,
                     'res_id': int(id)
                 })

--- a/addons/website_form/controllers/main.py
+++ b/addons/website_form/controllers/main.py
@@ -245,7 +245,7 @@ class WebsiteForm(http.Controller):
             custom_field = file.field_name not in authorized_fields
             attachment_value = {
                 'name': file.filename,
-                'datas': base64.encodestring(file.read()),
+                'datas': base64.encodebytes(file.read()),
                 'res_model': model_name,
                 'res_id': record.id,
             }

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -181,7 +181,7 @@ class IrActionsReport(models.Model):
             output_stream = io.BytesIO()
             img.convert("RGB").save(output_stream, format="pdf")
             return output_stream
-        return io.BytesIO(base64.decodestring(attachment.datas))
+        return io.BytesIO(base64.decodebytes(attachment.datas))
 
     def retrieve_attachment(self, record):
         '''Retrieve an attachment for a specific record.
@@ -213,7 +213,7 @@ class IrActionsReport(models.Model):
             return None
         attachment_vals = {
             'name': attachment_name,
-            'datas': base64.encodestring(buffer.getvalue()),
+            'datas': base64.encodebytes(buffer.getvalue()),
             'res_model': self.model,
             'res_id': record.id,
             'type': 'binary',

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -67,7 +67,7 @@ class IrUiMenu(models.Model):
         icon_image = False
         if icon_path:
             with tools.file_open(icon_path, 'rb') as icon_file:
-                icon_image = base64.encodestring(icon_file.read())
+                icon_image = base64.encodebytes(icon_file.read())
         return icon_image
 
     @api.constrains('parent_id')

--- a/odoo/addons/base/wizard/base_export_language.py
+++ b/odoo/addons/base/wizard/base_export_language.py
@@ -36,7 +36,7 @@ class BaseLanguageExport(models.TransientModel):
 
         with contextlib.closing(io.BytesIO()) as buf:
             tools.trans_export(lang, mods, buf, this.format, self._cr)
-            out = base64.encodestring(buf.getvalue())
+            out = base64.encodebytes(buf.getvalue())
 
         filename = 'new'
         if lang:

--- a/odoo/addons/base/wizard/base_import_language.py
+++ b/odoo/addons/base/wizard/base_import_language.py
@@ -36,7 +36,7 @@ class BaseLanguageImport(models.TransientModel):
 
         with TemporaryFile('wb+') as buf:
             try:
-                buf.write(base64.decodestring(this.data))
+                buf.write(base64.decodebytes(this.data))
 
                 # now we determine the file format
                 buf.seek(0)

--- a/odoo/addons/test_translation_import/tests/test_term_count.py
+++ b/odoo/addons/test_translation_import/tests/test_term_count.py
@@ -151,7 +151,7 @@ class TestTermCount(common.TransactionCase):
     def test_import_from_po_file(self):
         """Test the import from a single po file works"""
         with file_open('test_translation_import/i18n/tlh.po', 'rb') as f:
-            po_file = base64.encodestring(f.read())
+            po_file = base64.encodebytes(f.read())
 
         import_tlh = self.env["base.language.import"].create({
             'name': 'Klingon',
@@ -174,7 +174,7 @@ class TestTermCount(common.TransactionCase):
     def test_lazy_translation(self):
         """Test the import from a single po file works"""
         with file_open('test_translation_import/i18n/tlh.po', 'rb') as f:
-            po_file = base64.encodestring(f.read())
+            po_file = base64.encodebytes(f.read())
 
         import_tlh = self.env["base.language.import"].create({
             'name': 'Klingon',
@@ -204,7 +204,7 @@ class TestTermCount(common.TransactionCase):
     def test_import_from_csv_file(self):
         """Test the import from a single CSV file works"""
         with file_open('test_translation_import/i18n/dot.csv', 'rb') as f:
-            po_file = base64.encodestring(f.read())
+            po_file = base64.encodebytes(f.read())
 
         import_tlh = self.env["base.language.import"].create({
             'name': 'Dothraki',

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -392,7 +392,7 @@ class ThreadedServer(CommonServer):
         # e.g. threads that exceeded their real time,
         # but which finished before the server could restart.
         for thread in list(self.limits_reached_threads):
-            if not thread.isAlive():
+            if not thread.is_alive():
                 self.limits_reached_threads.remove(thread)
         if self.limits_reached_threads:
             self.limit_reached_time = self.limit_reached_time or time.time()
@@ -490,7 +490,7 @@ class ThreadedServer(CommonServer):
             _logger.debug('process %r (%r)', thread, thread.isDaemon())
             if (thread != me and not thread.isDaemon() and thread.ident != self.main_thread_id and
                     thread not in self.limits_reached_threads):
-                while thread.isAlive() and (time.time() - stop_time) < 1:
+                while thread.is_alive() and (time.time() - stop_time) < 1:
                     # We wait for requests to finish, up to 1 second.
                     _logger.debug('join and sleep')
                     # Need a busyloop here as thread.join() masks signals

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -70,6 +70,8 @@ _CONST_OPCODES = set(opmap[x] for x in [
     # until Python 3.5, literal maps are compiled to creating an empty map
     # (pre-sized) then filling it key by key
     'STORE_MAP',
+    # 3.9
+    'LIST_EXTEND', 'SET_UPDATE',
 ] if x in opmap)
 
 # operations on literal values
@@ -88,6 +90,9 @@ _EXPR_OPCODES = _CONST_OPCODES.union(set(opmap[x] for x in [
     # comprehensions
     'LIST_APPEND', 'MAP_ADD', 'SET_ADD',
     'COMPARE_OP',
+    # specialised comparisons
+    'IS_OP', 'CONTAINS_OP',
+    'DICT_MERGE', 'DICT_UPDATE',
 ] if x in opmap))
 
 _SAFE_OPCODES = _EXPR_OPCODES.union(set(opmap[x] for x in [
@@ -111,6 +116,7 @@ _SAFE_OPCODES = _EXPR_OPCODES.union(set(opmap[x] for x in [
     'RAISE_VARARGS', 'LOAD_NAME', 'STORE_NAME', 'DELETE_NAME', 'LOAD_ATTR',
     'LOAD_FAST', 'STORE_FAST', 'DELETE_FAST', 'UNPACK_SEQUENCE',
     'LOAD_GLOBAL', # Only allows access to restricted globals
+    'RERAISE', 'JUMP_IF_NOT_EXC_MATCH',
 ] if x in opmap))
 
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
base64.encodestring is deprecated since python 3.1 and was removed in
python 3.9
Use the alias instead
https://docs.python.org/3.8/library/base64.html#base64.encodestring

Fixes odoo/odoo#80652
