### PR TITLE
[FIX] mail: improve performance of messaging menu counter

### DIFF
--- a/addons/mail/static/src/models/messaging_menu/messaging_menu.js
+++ b/addons/mail/static/src/models/messaging_menu/messaging_menu.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { registerNewModel } from '@mail/model/model_core';
-import { attr } from '@mail/model/model_field';
+import { attr, one2many } from '@mail/model/model_field';
 
 function factory(dependencies) {
 
@@ -51,11 +51,7 @@ function factory(dependencies) {
                 return 0;
             }
             const inboxCounter = this.messaging.inbox ? this.messaging.inbox.counter : 0;
-            const unreadChannelsCounter = this.messaging.models['mail.thread'].all(channel => (
-                channel.model === 'mail.channel' &&
-                channel.isPinned &&
-                channel.localMessageUnreadCounter > 0
-            )).length;
+            const unreadChannelsCounter = this.pinnedAndUnreadChannels.length;
             const notificationGroupsCounter = this.messaging.notificationGroupManager
                 ? this.messaging.notificationGroupManager.groups.reduce(
                     (total, group) => total + group.notifications.length,
@@ -95,6 +91,13 @@ function factory(dependencies) {
          */
         isOpen: attr({
             default: false,
+        }),
+        /**
+         * States all the pinned channels that have unread messages.
+         */
+        pinnedAndUnreadChannels: one2many('mail.thread', {
+            inverse: 'messagingMenuAsPinnedAndUnreadChannel',
+            readonly: true,
         }),
     };
     MessagingMenu.identifyingFields = ['messaging'];

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1658,6 +1658,19 @@ function factory(dependencies) {
 
         /**
          * @private
+         * @returns {FieldCommand}
+         */
+        _computeMessagingMenuAsPinnedAndUnreadChannel() {
+            if (!this.messaging.messagingMenu) {
+                return clear();
+            }
+            return (this.model === 'mail.channel' && this.isPinned && this.localMessageUnreadCounter > 0)
+                ? replace(this.messaging.messagingMenu)
+                : clear();
+        }
+
+        /**
+         * @private
          * @returns {mail.message[]}
          */
         _computeNeedactionMessagesAsOriginThread() {
@@ -2315,6 +2328,11 @@ function factory(dependencies) {
         messagingAsRingingThread: many2one('mail.messaging', {
             compute: '_computeMessagingAsRingingThread',
             inverse: 'ringingThreads',
+            readonly: true,
+        }),
+        messagingMenuAsPinnedAndUnreadChannel: many2one('mail.messaging_menu', {
+            compute: '_computeMessagingMenuAsPinnedAndUnreadChannel',
+            inverse: 'pinnedAndUnreadChannels',
             readonly: true,
         }),
         model: attr({


### PR DESCRIPTION
Avoid iterating over all channels every time a new channel is added.

Part of task-2702450