### PR TITLE
[FIX] mail: rename ambiguous get method in model manager

### DIFF
--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -722,7 +722,7 @@ export class ModelManager {
          */
         const nonProxyRecord = new Model({ localId, valid: true });
         const record = !this.env.isDebug() ? nonProxyRecord : new Proxy(nonProxyRecord, {
-            get: function (record, prop) {
+            get: function getFromProxy(record, prop) {
                 if (
                     !Model.__fieldMap[prop] &&
                     !['_super', 'then'].includes(prop) &&
@@ -1329,7 +1329,7 @@ export class ModelManager {
             // Add field accessors.
             for (const field of Model.__fieldList) {
                 Object.defineProperty(Model.prototype, field.fieldName, {
-                    get() { // this is bound to record
+                    get: function getFieldValue() { // this is bound to record
                         for (const listener of this.modelManager._listeners) {
                             this.modelManager._localIdsObservedByListener.get(listener).add(this.localId);
                             listener.lastObservedLocalIds.add(this.localId);


### PR DESCRIPTION
To ease debugging in general, avoid having multiple methods with the same name,
especially in the same file.

This is especially useful when the method name appears in a stack trace, for
example in the performance tool.

Part of task-2702450