### PR TITLE
[FIX] mail: avoid costly debug operations

### DIFF
--- a/addons/mail/static/src/components/rtc_option_list/rtc_option_list.xml
+++ b/addons/mail/static/src/components/rtc_option_list/rtc_option_list.xml
@@ -24,7 +24,7 @@
                     <i class="o_RtcOptionList_buttonIcon fa fa-lg fa-cog"/>
                     <span class="o_RtcOptionList_buttonText">Settings</span>
                 </button>
-                <t t-if="env.isDebug()">
+                <t t-if="messaging.modelManager.isDebug">
                     <button class="o_RtcOptionList_button" t-on-click="rtcOptionList.onClickDownloadLogs">
                         <i class="o_RtcOptionList_buttonIcon fa fa-lg fa-file-text-o"/>
                         <span class="o_RtcOptionList_buttonText">Download logs</span>

--- a/addons/mail/static/src/model/model_field.js
+++ b/addons/mail/static/src/model/model_field.js
@@ -569,7 +569,8 @@ export class ModelField {
      * @returns {boolean} whether the value changed for the current field
      */
     _setRelationLinkX2Many(record, newValue, { hasToUpdateInverse = true } = {}) {
-        const recordsToLink = this._convertX2ManyValue(newValue);
+        const hasToVerify = record.modelManager.isDebug;
+        const recordsToLink = this._convertX2ManyValue(newValue, { hasToVerify });
         const otherRecords = this.read(record);
 
         let hasChanged = false;
@@ -607,7 +608,9 @@ export class ModelField {
      * @returns {boolean} whether the value changed for the current field
      */
     _setRelationLinkX2One(record, recordToLink, { hasToUpdateInverse = true } = {}) {
-        this._verifyRelationalValue(recordToLink);
+        if (record.modelManager.isDebug) {
+            this._verifyRelationalValue(recordToLink);
+        }
         const prevOtherRecord = this.read(record);
         // other record already linked, avoid linking twice
         if (prevOtherRecord === recordToLink) {
@@ -648,7 +651,8 @@ export class ModelField {
         let hasToReorder = false;
         const otherRecordsSet = this.read(record);
         const otherRecordsList = [...otherRecordsSet];
-        const recordsToReplaceList = [...this._convertX2ManyValue(newValue)];
+        const hasToVerify = record.modelManager.isDebug;
+        const recordsToReplaceList = [...this._convertX2ManyValue(newValue, { hasToVerify })];
         const recordsToReplaceSet = new Set(recordsToReplaceList);
 
         // records to link

--- a/addons/mail/static/src/models/rtc/rtc.js
+++ b/addons/mail/static/src/models/rtc/rtc.js
@@ -384,7 +384,7 @@ function factory(dependencies) {
          * @param {String} [param2.state] current state of the connection
          */
         _addLogEntry(token, entry, { error, step, state } = {}) {
-            if (!this.env.isDebug()) {
+            if (!this.modelManager.isDebug) {
                 return;
             }
             if (!(token in this.logs)) {

--- a/addons/mail/static/src/utils/test_utils.js
+++ b/addons/mail/static/src/utils/test_utils.js
@@ -644,6 +644,14 @@ async function start(param0 = {}) {
                 messagingBus,
             },
             /**
+             * Override to ensure tests run in debug mode to catch all potential
+             * programming errors and provide better message when they happen.
+             */
+            init(...args) {
+                this._super(...args);
+                this.modelManager.isDebug = true;
+            },
+            /**
              * Override:
              * - to ensure the test setup is complete before starting otherwise
              *   for example the mock server might not be ready yet at init


### PR DESCRIPTION
These errors should not happen in production, it is only helpful for debugging.

The opportunity is taken to limit our debug code to a messaging specific debug,
as debug '1' is used in production to see extra features, and debug 'assets' is
necessary to get decent stack trace.

The easiest way to enable this debug mode at the time of this commit is to
either manually set the value to true in the code, or to type the following line
in the browser console if editing the code is not an option:
`odoo.__DEBUG__.messaging.modelManager.isDebug = true;`

Part of task-2702450