### PR TITLE
[FIX] web: send correct filter's context when saving filter

### DIFF
--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -407,7 +407,7 @@ export class SearchModel extends EventBus {
      */
     get context() {
         if (!this._context) {
-            this._context = this._getContext();
+            this._context = makeContext([this._getContext(), this.globalContext]);
         }
         return deepCopy(this._context);
     }
@@ -1325,7 +1325,7 @@ export class SearchModel extends EventBus {
      */
     _getContext() {
         const groups = this._getGroups();
-        const contexts = [this.userService.context, this.globalContext];
+        const contexts = [this.userService.context];
         for (const group of groups) {
             for (const activeItem of group.activeItems) {
                 const context = this._getSearchItemContext(activeItem);

--- a/addons/web/static/tests/search/custom_favorite_item_tests.js
+++ b/addons/web/static/tests/search/custom_favorite_item_tests.js
@@ -181,6 +181,7 @@ QUnit.module("Search", (hooks) => {
                 }
             },
             resModel: "foo",
+            context: { someOtherKey: "bar" }, // should not end up in filter's context
             Component: TestComponent,
             searchViewId: false,
         });


### PR DESCRIPTION
Before this commit, the context coming from the action was
merged with the context of the search items to generate the
context of the filter to save, when the user clicked on "Save
current search", whereas it should not.

There is an ActionService test attesting it, but it currently
uses a ListView, which is still legacy, so the new faulty code
wasn't tested.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
