### PR TITLE
[FIX] sale: do not force order responsible

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -461,7 +461,8 @@ class SaleOrder(models.Model):
     @api.depends('partner_id')
     def _compute_user_id(self):
         for order in self:
-            order.user_id = order.partner_id.user_id or order.partner_id.commercial_partner_id.user_id or self.env.user
+            if not order.user_id:
+                order.user_id = order.partner_id.user_id or order.partner_id.commercial_partner_id.user_id or self.env.user
 
     @api.depends('partner_id', 'user_id')
     def _compute_team_id(self):


### PR DESCRIPTION
With recent update to computed fields [1] order responsible is now always
changed to the partner responsible, or its commercial entity responsible.

This cause issues, notably with ACLs 'own documents only'. Indeed a salesperson
could update or set a partner on an order that would change the responsible and
lead to ACLs issues. Moreover some functional flows automatically set a partner
(online registrations, ...) that would make the responsible change without a
clear notification or warning.

We prefer to keep a less intrusive behavior, aka setting a responsible when
no one is set.

Task-2703285 (event performance)
Task-2703289 (event testing)

[1] odoo/odoo@210c9daebcb6765f8379972b2da54a2c411c2e8d
