### PR TITLE
[MERGE] rating,project: use rating average instead of last rating in project

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -739,11 +739,11 @@ class Project(models.Model):
         if self.user_has_groups('project.group_project_rating'):
             buttons.append({
                 'icon': 'smile-o',
-                'text': _('Customer Satisfaction'),
-                'number': '%s %%' % (self.rating_percentage_satisfaction),
+                'text': _('Satisfaction'),
+                'number': f'{self.rating_avg_percentage} %',
                 'action_type': 'object',
                 'action': 'action_view_all_rating',
-                'show': self.rating_active and self.rating_percentage_satisfaction > -1,
+                'show': self.rating_active and self.rating_count > 0,
                 'sequence': 15,
             })
         if self.user_has_groups('project.group_project_manager'):

--- a/addons/project/tests/test_project_flow.py
+++ b/addons/project/tests/test_project_flow.py
@@ -248,7 +248,9 @@ class TestProjectFlow(TestProjectCommon, MockEmail):
         self.assertEqual(rating_good.parent_res_id, self.project_pigs.id)
 
         self.assertEqual(self.project_goats.rating_percentage_satisfaction, -1)
+        self.assertEqual(self.project_goats.rating_avg, 0, 'Since there is no rating in this project, the Average Rating should be equal to 0.')
         self.assertEqual(self.project_pigs.rating_percentage_satisfaction, 0)  # There is a rating but not a "great" on, just an "okay".
+        self.assertEqual(self.project_pigs.rating_avg, rating_bad.rating, 'Since there is only one rating the Average Rating should be equal to the rating value of this one.')
 
         # Consuming rating_good
         first_task.rating_apply(5, rating_good.access_token)
@@ -257,10 +259,14 @@ class TestProjectFlow(TestProjectCommon, MockEmail):
         # Our One2Many is linked to a res_id (int) for which the orm doesn't create an inverse
         first_task.invalidate_cache()
 
+        rating_avg = (rating_good.rating + rating_bad.rating) / 2
         self.assertEqual(first_task.rating_count, 2, "Task should have two ratings associated with it")
+        self.assertEqual(first_task.rating_avg_text, 'top')
         self.assertEqual(rating_good.parent_res_id, self.project_pigs.id)
         self.assertEqual(self.project_goats.rating_percentage_satisfaction, -1)
         self.assertEqual(self.project_pigs.rating_percentage_satisfaction, 50)
+        self.assertEqual(self.project_pigs.rating_avg, rating_avg)
+        self.assertEqual(self.project_pigs.rating_avg_percentage, rating_avg / 5)
 
         # We change the task from project_pigs to project_goats, ratings should be associated with the new project
         first_task.project_id = self.project_goats.id
@@ -271,7 +277,9 @@ class TestProjectFlow(TestProjectCommon, MockEmail):
 
         self.assertEqual(rating_good.parent_res_id, self.project_goats.id)
         self.assertEqual(self.project_goats.rating_percentage_satisfaction, 50)
+        self.assertEqual(self.project_goats.rating_avg, rating_avg)
         self.assertEqual(self.project_pigs.rating_percentage_satisfaction, -1)
+        self.assertEqual(self.project_pigs.rating_avg, 0)
 
     def test_task_with_no_project(self):
         """

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -33,7 +33,10 @@
                     <separator/>
                     <filter string="Open Tasks" name="open_tasks" domain="[('is_closed', '=', False)]"/>
                     <separator/>
-                    <filter string="Rated Tasks" name="rating_task" domain="[('rating_last_value', '!=', 0.0)]" groups="project.group_project_rating"/>
+                    <filter name="rating_satisfied" string="Satisfied" domain="[('rating_avg', '&gt;=', 3.66)]" groups="project.group_project_rating"/>
+                    <filter name="rating_okay" string="Okay" domain="[('rating_avg', '&lt;', 3.66), ('rating_avg', '&gt;=', 2.33)]" groups="project.group_project_rating"/>
+                    <filter name="dissatisfied" string="Dissatisfied" domain="[('rating_avg', '&lt;', 2.33), ('rating_last_value', '!=', 0)]" groups="project.group_project_rating"/>
+                    <filter name="no_rating" string="No Rating" domain="[('rating_last_value', '=', 0)]" groups="project.group_project_rating"/>
                     <separator/>
                     <filter string="Unread Messages" name="message_needaction" domain="[('message_needaction', '=', True)]"/>
                     <separator/>
@@ -1121,8 +1124,8 @@
                     <field name="legend_done"/>
                     <field name="activity_ids"/>
                     <field name="activity_state"/>
-                    <field name="rating_last_value"/>
-                    <field name="rating_ids"/>
+                    <field name="rating_count"/>
+                    <field name="rating_avg"/>
                     <field name="allow_subtasks"/>
                     <field name="child_text"/>
                     <field name="is_private"/>
@@ -1181,10 +1184,10 @@
                                     <div class="oe_kanban_bottom_left">
                                         <field name="priority" widget="priority"/>
                                         <field name="activity_ids" widget="kanban_activity"/>
-                                        <b t-if="record.rating_ids.raw_value.length">
-                                            <span style="font-weight:bold;" class="fa fa-fw mt4 fa-smile-o text-success" t-if="record.rating_last_value.value == 5" title="Latest Rating: Satisfied" role="img" aria-label="Happy face"/>
-                                            <span style="font-weight:bold;" class="fa fa-fw mt4 fa-meh-o text-warning" t-if="record.rating_last_value.value == 3" title="Latest Rating: Okay" role="img" aria-label="Neutral face"/>
-                                            <span style="font-weight:bold;" class="fa fa-fw mt4 fa-frown-o text-danger" t-if="record.rating_last_value.value == 1" title="Latest Rating: Dissatisfied" role="img" aria-label="Sad face"/>
+                                        <b t-if="record.rating_count.raw_value &gt; 0" groups="project.group_project_rating">
+                                            <span style="font-weight:bold;" class="fa fa-fw mt4 fa-smile-o text-success" t-if="record.rating_avg.raw_value &gt;= 3.66" title="Average Rating: Satisfied" role="img" aria-label="Happy face"/>
+                                            <span style="font-weight:bold;" class="fa fa-fw mt4 fa-meh-o text-warning" t-elif="record.rating_avg.raw_value &gt;= 2.33" title="Average Rating: Okay" role="img" aria-label="Neutral face"/>
+                                            <span style="font-weight:bold;" class="fa fa-fw mt4 fa-frown-o text-danger" t-else="" title="Average Rating: Dissatisfied" role="img" aria-label="Sad face"/>
                                         </b>
                                     </div>
                                     <div class="oe_kanban_bottom_right" t-if="!selection_mode">

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -849,13 +849,14 @@
                         <span id="button_worksheet" invisible="1"/>
                         <!-- Dummy tag used to organize buttons, englobing the 3 buttons modifies the width of the button -->
                         <span id="start_rating_buttons" invisible="1"/>
+                        <field name="rating_avg" invisible="1"/>
                         <button name="action_open_ratings" type="object" attrs="{'invisible': [('rating_count', '=', 0)]}" class="oe_stat_button" groups="project.group_project_rating">
                             <i class="fa fa-fw o_button_icon fa-smile-o text-success" attrs="{'invisible': [('rating_avg', '&lt;', 3.66)]}" title="Satisfied"/>
                             <i class="fa fa-fw o_button_icon fa-meh-o text-warning" attrs="{'invisible': ['|', ('rating_avg', '&lt;', 2.33), ('rating_avg', '&gt;=', 3.66)]}" title="Okay"/>
                             <i class="fa fa-fw o_button_icon fa-frown-o text-danger" attrs="{'invisible': [('rating_avg', '&gt;=', 2.33)]}" title="Dissatisfied"/>
                             <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_value"><field name="rating_avg" nolabel="1"/> / 5</span>
-                                <span class="o_stat_text">Ratings</span>
+                                <span class="o_stat_value"><field name="rating_avg_text" nolabel="1"/></span>
+                                <span class="o_stat_text">Rating</span>
                             </div>
                         </button>
                         <!-- Dummy tag used to organize buttons -->

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -535,6 +535,11 @@
                     <filter string="Start Date" name="start_date" date="date_start"/>
                     <filter string="End Date" name="end_date" date="date"/>
                     <separator/>
+                    <filter name="rating_satisfied" string="Satisfied" domain="[('rating_active', '=', True), ('rating_avg', '&gt;=', 3.66)]" groups="project.group_project_rating"/>
+                    <filter name="rating_okay" string="Okay" domain="[('rating_active', '=', True), ('rating_avg', '&lt;', 3.66), ('rating_avg', '&gt;=', 2.33)]" groups="project.group_project_rating"/>
+                    <filter name="dissatisfied" string="Dissatisfied" domain="[('rating_active', '=', True), ('rating_avg', '&lt;', 2.33), ('rating_last_value', '!=', 0)]" groups="project.group_project_rating"/>
+                    <filter name="no_rating" string="No Rating" domain="['|', ('rating_active', '=', False), ('rating_avg', '=', 0)]" groups="project.group_project_rating"/>
+                    <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <group expand="0" string="Group By">
                         <filter string="Project Manager" name="Manager" context="{'group_by': 'user_id'}"/>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -319,33 +319,14 @@
                                 </span>
                             </div>
                         </button>
-                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', ('rating_active', '=', False), ('rating_percentage_satisfaction', '&lt;', 66.6)]}" class="oe_stat_button oe_read_only" icon="fa-smile-o text-success" groups="project.group_project_rating">
+                        <field name="rating_avg" invisible="1"/>
+                        <button name="action_view_all_rating" type="object" attrs="{'invisible': [('rating_active', '=', False)]}" class="oe_stat_button" groups="project.group_project_rating">
+                            <i class="fa fa-fw o_button_icon fa-smile-o text-success" attrs="{'invisible': [('rating_avg', '&lt;', 3.66)]}" title="Satisfied"/>
+                            <i class="fa fa-fw o_button_icon fa-meh-o text-warning" attrs="{'invisible': ['|', ('rating_avg', '&lt;', 2.33), ('rating_avg', '&gt;=', 3.66)]}" title="Okay"/>
+                            <i class="fa fa-fw o_button_icon fa-frown-o text-danger" attrs="{'invisible': [('rating_avg', '&gt;=', 2.33)]}" title="Dissatisfied"/>
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value">
-                                    <field name="rating_percentage_satisfaction" nolabel="1"/>
-                                    %
-                                </span>
-                                <span class="o_stat_text">
-                                    Satisfaction
-                                </span>
-                            </div>
-                        </button>
-                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', '|', ('rating_active', '=', False), ('rating_percentage_satisfaction', '&gt;=', 66.6), ('rating_percentage_satisfaction', '&lt;', 33.3)]}" class="oe_stat_button oe_read_only" icon="fa-meh-o text-warning" groups="project.group_project_rating">
-                            <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_value">
-                                    <field name="rating_percentage_satisfaction" nolabel="1"/>
-                                    %
-                                </span>
-                                <span class="o_stat_text">
-                                    Satisfaction
-                                </span>
-                            </div>
-                        </button>
-                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', ('rating_active', '=', False), '|', ('rating_percentage_satisfaction', '&gt;=', 33.3),  ('rating_percentage_satisfaction', '&lt;', 0)]}" class="oe_stat_button oe_read_only" icon="fa-frown-o text-danger" groups="project.group_project_rating">
-                            <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_value">
-                                    <field name="rating_percentage_satisfaction" nolabel="1"/>
-                                    %
+                                    <field name="rating_avg_percentage" nolabel="1" widget="percentage"/>
                                 </span>
                                 <span class="o_stat_text">
                                     Satisfaction
@@ -666,7 +647,8 @@
                     <field name="alias_name"/>
                     <field name="alias_domain"/>
                     <field name="is_favorite"/>
-                    <field name="rating_percentage_satisfaction"/>
+                    <field name="rating_count" />
+                    <field name="rating_avg"/>
                     <field name="rating_status"/>
                     <field name="rating_active" />
                     <field name="analytic_account_id"/>
@@ -697,12 +679,13 @@
                                                 <div t-if="record.alias_name.value and record.alias_domain.value" class="text-muted">
                                                     <span class="fa fa-envelope-o mr-2" aria-label="Domain Alias" title="Domain Alias"></span><t t-esc="record.alias_id.value"/>
                                                 </div>
-                                                <div t-if="record.rating_active.raw_value" class="text-muted" groups="project.group_project_rating">
-                                                    <b>
-                                                        <t t-if="record.rating_percentage_satisfaction.value != -1">
-                                                            <i class="fa fa-smile-o" role="img" aria-label="Average satisfaction rate for the last 30 days." title="Average satisfaction rate for the last 30 days."/> <t t-esc="record.rating_percentage_satisfaction.value"/>%
-                                                        </t>
+                                                <div t-if="record.rating_active.raw_value and record.rating_count.raw_value &gt; 0" class="text-muted" groups="project.group_project_rating">
+                                                    <b class="mr-1">
+                                                        <span style="font-weight:bold;" class="fa mt4 fa-smile-o text-success" t-if="record.rating_avg.raw_value &gt;= 3.66" title="Average Rating: Satisfied" role="img" aria-label="Happy face"/>
+                                                        <span style="font-weight:bold;" class="fa mt4 fa-meh-o text-warning" t-elif="record.rating_avg.raw_value &gt;= 2.33" title="Average Rating: Okay" role="img" aria-label="Neutral face"/>
+                                                        <span style="font-weight:bold;" class="fa mt4 fa-frown-o text-danger" t-else="" title="Average Rating: Dissatisfied" role="img" aria-label="Sad face"/>
                                                     </b>
+                                                    <field name="rating_avg_percentage" widget="percentage"/>
                                                 </div>
                                                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                                             </div>
@@ -866,22 +849,13 @@
                         <span id="button_worksheet" invisible="1"/>
                         <!-- Dummy tag used to organize buttons, englobing the 3 buttons modifies the width of the button -->
                         <span id="start_rating_buttons" invisible="1"/>
-                        <button name="action_open_ratings" type="object" attrs="{'invisible': ['|', ('rating_count', '=', 0), ('rating_percentage_satisfaction', '&lt;', 66.6)]}" class="oe_stat_button" icon="fa-smile-o text-success" groups="project.group_project_rating">
+                        <button name="action_open_ratings" type="object" attrs="{'invisible': [('rating_count', '=', 0)]}" class="oe_stat_button" groups="project.group_project_rating">
+                            <i class="fa fa-fw o_button_icon fa-smile-o text-success" attrs="{'invisible': [('rating_avg', '&lt;', 3.66)]}" title="Satisfied"/>
+                            <i class="fa fa-fw o_button_icon fa-meh-o text-warning" attrs="{'invisible': ['|', ('rating_avg', '&lt;', 2.33), ('rating_avg', '&gt;=', 3.66)]}" title="Okay"/>
+                            <i class="fa fa-fw o_button_icon fa-frown-o text-danger" attrs="{'invisible': [('rating_avg', '&gt;=', 2.33)]}" title="Dissatisfied"/>
                             <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_value"><field name="rating_percentage_satisfaction" widget="integer"/>%</span>
-                                <span class="o_stat_text">Satisfaction</span>
-                            </div>
-                        </button>
-                        <button name="action_open_ratings" type="object" attrs="{'invisible': ['|', '|', ('rating_count', '=', 0), ('rating_percentage_satisfaction', '&gt;=', 66.6), ('rating_percentage_satisfaction', '&lt;', 33.3)]}" class="oe_stat_button" icon="fa-meh-o text-warning" groups="project.group_project_rating">
-                            <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_value"><field name="rating_percentage_satisfaction" widget="integer"/>%</span>
-                                <span class="o_stat_text">Satisfaction</span>
-                            </div>
-                        </button>
-                        <button name="action_open_ratings" type="object" attrs="{'invisible': ['|', '|', ('rating_count', '=', 0), ('rating_percentage_satisfaction', '&gt;=', 33.3),  ('rating_percentage_satisfaction', '&lt;', 0)]}" class="oe_stat_button" icon="fa-frown-o text-danger" groups="project.group_project_rating">
-                            <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_value"><field name="rating_percentage_satisfaction" widget="integer"/>%</span>
-                                <span class="o_stat_text">Satisfaction</span>
+                                <span class="o_stat_value"><field name="rating_avg" nolabel="1"/> / 5</span>
+                                <span class="o_stat_text">Ratings</span>
                             </div>
                         </button>
                         <!-- Dummy tag used to organize buttons -->

--- a/addons/rating/models/rating.py
+++ b/addons/rating/models/rating.py
@@ -10,6 +10,12 @@ from odoo.modules.module import get_resource_path
 RATING_LIMIT_SATISFIED = 4
 RATING_LIMIT_OK = 3
 RATING_LIMIT_MIN = 1
+RATING_TEXT = [
+    ('top', 'Satisfied'),
+    ('ok', 'Okay'),
+    ('ko', 'Dissatisfied'),
+    ('none', 'No Rating yet'),
+]
 
 
 class Rating(models.Model):
@@ -55,11 +61,7 @@ class Rating(models.Model):
     partner_id = fields.Many2one('res.partner', string='Customer', help="Author of the rating")
     rating = fields.Float(string="Rating Value", group_operator="avg", default=0, help="Rating value: 0=Unhappy, 5=Happy")
     rating_image = fields.Binary('Image', compute='_compute_rating_image')
-    rating_text = fields.Selection([
-        ('top', 'Satisfied'),
-        ('ok', 'Okay'),
-        ('ko', 'Dissatisfied'),
-        ('none', 'No Rating yet')], string='Rating', store=True, compute='_compute_rating_text', readonly=True)
+    rating_text = fields.Selection(RATING_TEXT, string='Rating', store=True, compute='_compute_rating_text', readonly=True)
     feedback = fields.Text('Comment', help="Reason of the rating")
     message_id = fields.Many2one(
         'mail.message', string="Message",

--- a/addons/rating/models/rating_mixin.py
+++ b/addons/rating/models/rating_mixin.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import operator
+from collections import defaultdict
 from datetime import timedelta
 
 from odoo import api, fields, models, tools
@@ -32,11 +33,14 @@ class RatingParentMixin(models.AbstractModel):
         compute="_compute_rating_percentage_satisfaction", compute_sudo=True,
         store=False, help="Percentage of happy ratings")
     rating_count = fields.Integer(string='# Ratings', compute="_compute_rating_percentage_satisfaction", compute_sudo=True)
+    rating_avg = fields.Float('Average Rating', groups='base.group_user',
+        compute='_compute_rating_percentage_satisfaction', compute_sudo=True, search='_search_rating_avg')
+    rating_last_value = fields.Float('Rating Last Value', groups='base.group_user', related='rating_ids.rating')
 
     @api.depends('rating_ids.rating', 'rating_ids.consumed')
     def _compute_rating_percentage_satisfaction(self):
         # build domain and fetch data
-        domain = [('parent_res_model', '=', self._name), ('parent_res_id', 'in', self.ids), ('rating', '>=', 1), ('consumed', '=', True)]
+        domain = [('parent_res_model', '=', self._name), ('parent_res_id', 'in', self.ids), ('rating', '>=', RATING_LIMIT_MIN), ('consumed', '=', True)]
         if self._rating_satisfaction_days:
             domain += [('write_date', '>=', fields.Datetime.to_string(fields.datetime.now() - timedelta(days=self._rating_satisfaction_days)))]
         data = self.env['rating.rating'].read_group(domain, ['parent_res_id', 'rating'], ['parent_res_id', 'rating'], lazy=False)
@@ -44,6 +48,7 @@ class RatingParentMixin(models.AbstractModel):
         # get repartition of grades per parent id
         default_grades = {'great': 0, 'okay': 0, 'bad': 0}
         grades_per_parent = dict((parent_id, dict(default_grades)) for parent_id in self.ids)  # map: {parent_id: {'great': 0, 'bad': 0, 'ok': 0}}
+        rating_scores_per_parent = defaultdict(int)  # contains the total of the rating values per record
         for item in data:
             parent_id = item['parent_res_id']
             rating = item['rating']
@@ -53,12 +58,30 @@ class RatingParentMixin(models.AbstractModel):
                 grades_per_parent[parent_id]['okay'] += item['__count']
             else:
                 grades_per_parent[parent_id]['bad'] += item['__count']
+            rating_scores_per_parent[parent_id] += rating * item['__count']
 
         # compute percentage per parent
         for record in self:
             repartition = grades_per_parent.get(record.id, default_grades)
-            record.rating_count = sum(repartition.values())
-            record.rating_percentage_satisfaction = repartition['great'] * 100 / sum(repartition.values()) if sum(repartition.values()) else -1
+            rating_count = sum(repartition.values())
+            record.rating_count = rating_count
+            record.rating_percentage_satisfaction = repartition['great'] * 100 / rating_count if rating_count else -1
+            record.rating_avg = rating_scores_per_parent[record.id] / rating_count if rating_count else 0
+
+    def _search_rating_avg(self, operator, value):
+        if operator not in OPERATOR_MAPPING:
+            raise NotImplementedError('This operator %s is not supported in this search method.' % operator)
+        domain = [('parent_res_model', '=', self._name), ('consumed', '=', True), ('rating', '>=', RATING_LIMIT_MIN)]
+        if self._rating_satisfaction_days:
+            min_date = fields.datetime.now() - timedelta(days=self._rating_satisfaction_days)
+            domain = expression.AND([domain, [('write_date', '>=', fields.Datetime.to_string(min_date))]])
+        rating_read_group = self.env['rating.rating'].sudo().read_group(domain, ['parent_res_id', 'rating_avg:avg(rating)'], ['parent_res_id'])
+        parent_res_ids = [
+            res['parent_res_id']
+            for res in rating_read_group
+            if OPERATOR_MAPPING[operator](float_compare(res['rating_avg'], value, 2), 0)
+        ]
+        return [('id', 'in', parent_res_ids)]
 
 
 class RatingMixin(models.AbstractModel):

--- a/addons/rating/models/rating_mixin.py
+++ b/addons/rating/models/rating_mixin.py
@@ -35,6 +35,8 @@ class RatingParentMixin(models.AbstractModel):
     rating_count = fields.Integer(string='# Ratings', compute="_compute_rating_percentage_satisfaction", compute_sudo=True)
     rating_avg = fields.Float('Average Rating', groups='base.group_user',
         compute='_compute_rating_percentage_satisfaction', compute_sudo=True, search='_search_rating_avg')
+    rating_avg_percentage = fields.Float('Average Rating (%)', groups='base.group_user',
+        compute='_compute_rating_percentage_satisfaction', compute_sudo=True)
     rating_last_value = fields.Float('Rating Last Value', groups='base.group_user', related='rating_ids.rating')
 
     @api.depends('rating_ids.rating', 'rating_ids.consumed')
@@ -67,6 +69,7 @@ class RatingParentMixin(models.AbstractModel):
             record.rating_count = rating_count
             record.rating_percentage_satisfaction = repartition['great'] * 100 / rating_count if rating_count else -1
             record.rating_avg = rating_scores_per_parent[record.id] / rating_count if rating_count else 0
+            record.rating_avg_percentage = record.rating_avg / 5
 
     def _search_rating_avg(self, operator, value):
         if operator not in OPERATOR_MAPPING:
@@ -93,7 +96,7 @@ class RatingMixin(models.AbstractModel):
     rating_last_feedback = fields.Text('Rating Last Feedback', groups='base.group_user', related='rating_ids.feedback')
     rating_last_image = fields.Binary('Rating Last Image', groups='base.group_user', related='rating_ids.rating_image')
     rating_count = fields.Integer('Rating count', compute="_compute_rating_stats", compute_sudo=True)
-    rating_avg = fields.Float("Average Rating",
+    rating_avg = fields.Float("Average Rating", groups='base.group_user',
         compute='_compute_rating_stats', compute_sudo=True, search='_search_rating_avg')
     rating_percentage_satisfaction = fields.Float("Rating Satisfaction", compute='_compute_rating_satisfaction', compute_sudo=True)
     rating_last_text = fields.Selection(string="Rating Text", groups='base.group_user', related="rating_ids.rating_text")


### PR DESCRIPTION
Before this changes, we only use the last value to determine the customer satisfaction of a task. The problem is if the customer was happy during all the process of a task and at the end of the task, he is unhappy. The customer satisfaction for this task will be bad because the last rating made for it is negative.
Moreover, the customer satisfaction shown in `project.project` model computes the percentage of Happy ratings divided by the total of ratings in its tasks. For instance, if we have a project A with 3 tasks T1, T2 and T3 and we have a rating for each task as follow:
- R1 for T1 has 3/5 as rating value.
- R2 for T2 has 5/5 as rating value.
- R3 for T3 has 1/5 as rating value.

So the percentage of Happy Rating will be equal to 33% but globally, we could see the customers were globally okay for this project because the rating average is equal to 3/5. Indeed only one customer was happy but all the others have not given 1/5 as rating score. So the project could globally be acceptable for the customers.

The goal of this changes is to only use the rating average instead of using the last rating value (for the tasks) or the percentage of happy rating for the projects. With the rating average we could have a global idea of the customer satisfaction for a task or an entire project.

task-2671848

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
