### PR TITLE
[IMP] crm: set opportunity language to contact's lang

### DIFF
--- a/addons/crm/controllers/main.py
+++ b/addons/crm/controllers/main.py
@@ -38,7 +38,7 @@ class CrmController(http.Controller):
         comparison, record, redirect = MailController._check_token_and_record_or_redirect('crm.lead', int(res_id), token)
         if comparison and record:
             try:
-                record.convert_opportunity(record.partner_id.id)
+                record.convert_opportunity(record.partner_id)
             except Exception:
                 _logger.exception("Could not convert crm.lead to opportunity")
                 return MailController._redirect_to_messaging()

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1532,10 +1532,8 @@ class Lead(models.Model):
             upd_values['stage_id'] = stage.id
         return upd_values
 
-    def convert_opportunity(self, partner_id, user_ids=False, team_id=False):
-        customer = False
-        if partner_id:
-            customer = self.env['res.partner'].browse(partner_id)
+    def convert_opportunity(self, partner, user_ids=False, team_id=False):
+        customer = partner if partner else self.env['res.partner']
         for lead in self:
             if not lead.active or lead.probability == 100:
                 continue

--- a/addons/crm/models/crm_team_member.py
+++ b/addons/crm/models/crm_team_member.py
@@ -169,7 +169,7 @@ class TeamMember(models.Model):
                 weights[member_index] = weights[member_index] - 1
 
                 lead.with_context(mail_auto_subscribe_no_notify=True).convert_opportunity(
-                    lead.partner_id.id,
+                    lead.partner_id,
                     user_ids=member_data['team_member'].user_id.ids
                 )
 

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -123,8 +123,14 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'is_won': True,
         })
 
+        # countries and langs
         base_us = cls.env.ref('base.us')
+        cls.env['res.lang']._activate_lang('fr_FR')
+        cls.env['res.lang']._activate_lang('en_US')
+        cls.lang_fr = cls.env['res.lang']._lang_get('fr_FR')
+        cls.lang_en = cls.env['res.lang']._lang_get('en_US')
 
+        # leads
         cls.lead_1 = cls.env['crm.lead'].create({
             'name': 'Nibbler Spacecraft Request',
             'type': 'lead',
@@ -133,6 +139,8 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'partner_id': False,
             'contact_name': 'Amy Wong',
             'email_from': 'amy.wong@test.example.com',
+            'lang_id': cls.lang_fr.id,
+            'phone': '+1 202 555 9999',
             'country_id': cls.env.ref('base.us').id,
             'probability': 20,
         })
@@ -196,6 +204,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'mobile': cls.test_phone_data[0],
             'title': cls.env.ref('base.res_partner_title_mister').id,
             'function': 'Delivery Boy',
+            'lang': cls.lang_en.code,
             'phone': False,
             'parent_id': cls.contact_company_1.id,
             'is_company': False,
@@ -207,6 +216,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
         cls.contact_2 = cls.env['res.partner'].create({
             'name': 'Turanga Leela',
             'email': cls.test_email_data[2],
+            'lang': cls.lang_en.code,
             'mobile': cls.test_phone_data[1],
             'phone': cls.test_phone_data[2],
             'parent_id': False,
@@ -223,6 +233,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'street': 'Mom Friendly Robot Street',
             'city': 'New new York',
             'country_id': base_us.id,
+            'lang': cls.lang_en.code,
             'mobile': '+1 202 555 0888',
             'zip': '87654',
         })

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -455,7 +455,7 @@ class TestCRMLead(TestCrmCommon):
         lead = self.lead_1.with_user(self.env.user)
         self.assertEqual(lead.team_id, self.sales_team_1)
 
-        lead.convert_opportunity(self.contact_1.id)
+        lead.convert_opportunity(self.contact_1)
         self.assertEqual(lead.team_id, self.sales_team_1)
 
         lead.action_set_won()

--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -143,7 +143,7 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
         self.assertEqual(lead.stage_id, self.stage_team1_1)
         self.assertEqual(lead.email_from, 'amy.wong@test.example.com')
         self.assertEqual(lead.lang_id, self.lang_fr)
-        lead.convert_opportunity(self.contact_2.id)
+        lead.convert_opportunity(self.contact_2)
 
         self.assertEqual(lead.type, 'opportunity')
         self.assertEqual(lead.partner_id, self.contact_2)
@@ -162,7 +162,7 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
         lead = self.lead_1.with_user(self.env.user)
         lead.action_archive()
         self.assertFalse(lead.active)
-        lead.convert_opportunity(self.contact_2.id)
+        lead.convert_opportunity(self.contact_2)
 
         self.assertEqual(lead.type, 'lead')
         self.assertEqual(lead.partner_id, self.env['res.partner'])
@@ -177,7 +177,7 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
         self.assertEqual(lead.stage_id, self.stage_gen_won)
         self.assertEqual(lead.probability, 100)
 
-        lead.convert_opportunity(self.contact_2.id)
+        lead.convert_opportunity(self.contact_2)
         self.assertEqual(lead.type, 'lead')
         self.assertEqual(lead.partner_id, self.env['res.partner'])
 
@@ -356,7 +356,7 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
             'street': 'my street',
             'city': 'my city',
         })
-        lead.convert_opportunity(partner.id)
+        lead.convert_opportunity(partner)
         self.assertEqual(lead.email_from, 'demo@test.com', 'Email From should be preserved during conversion')
         self.assertEqual(lead.lang_id, self.lang_fr, 'Lang should be preserved during conversion')
         self.assertEqual(lead.street, 'my street', 'Street should be preserved during conversion')

--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -123,6 +123,9 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
         """ Ensure initial data to avoid spaghetti test update afterwards """
         self.assertFalse(self.lead_1.date_conversion)
         self.assertEqual(self.lead_1.date_open, Datetime.from_string('2020-01-15 11:30:00'))
+        self.assertEqual(self.lead_1.lang_id, self.lang_fr)
+        self.assertFalse(self.lead_1.mobile)
+        self.assertEqual(self.lead_1.phone, '+1 202 555 9999')
         self.assertEqual(self.lead_1.user_id, self.user_sales_leads)
         self.assertEqual(self.lead_1.team_id, self.sales_team_1)
         self.assertEqual(self.lead_1.stage_id, self.stage_team1_1)
@@ -139,11 +142,13 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
         self.assertEqual(lead.team_id, self.sales_team_1)
         self.assertEqual(lead.stage_id, self.stage_team1_1)
         self.assertEqual(lead.email_from, 'amy.wong@test.example.com')
+        self.assertEqual(lead.lang_id, self.lang_fr)
         lead.convert_opportunity(self.contact_2.id)
 
         self.assertEqual(lead.type, 'opportunity')
         self.assertEqual(lead.partner_id, self.contact_2)
         self.assertEqual(lead.email_from, self.contact_2.email)
+        self.assertEqual(lead.lang_id, self.lang_en)
         self.assertEqual(lead.mobile, self.contact_2.mobile)
         self.assertEqual(lead.phone, '123456789')
         self.assertEqual(lead.team_id, self.sales_team_1)
@@ -271,8 +276,10 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
         # self.assertEqual(self.lead_1.stage_id, self.stage_gen_1)
         # partner creation test
         new_partner = self.lead_1.partner_id
-        self.assertEqual(new_partner.name, 'Amy Wong')
         self.assertEqual(new_partner.email, 'amy.wong@test.example.com')
+        self.assertEqual(new_partner.lang, self.lang_fr.code)
+        self.assertEqual(new_partner.phone, '+1 202 555 9999')
+        self.assertEqual(new_partner.name, 'Amy Wong')
 
     @users('user_sales_manager')
     def test_lead_convert_action_exist(self):
@@ -345,13 +352,16 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
             'partner_id': partner.id,
             'type': 'lead',
             'email_from': 'demo@test.com',
+            'lang_id': self.lang_fr.id,
             'street': 'my street',
             'city': 'my city',
         })
         lead.convert_opportunity(partner.id)
         self.assertEqual(lead.email_from, 'demo@test.com', 'Email From should be preserved during conversion')
+        self.assertEqual(lead.lang_id, self.lang_fr, 'Lang should be preserved during conversion')
         self.assertEqual(lead.street, 'my street', 'Street should be preserved during conversion')
         self.assertEqual(lead.city, 'my city', 'City should be preserved during conversion')
+        self.assertEqual(partner.lang, 'en_US')
 
     @users('user_sales_manager')
     def test_lead_merge(self):

--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -42,7 +42,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=222):  # crm only: 217 - generally 219, sometimes +2/+3 on runbot
+        with self.assertQueryCount(user_sales_manager=222):  # crm only: 217 - generally 218 runbot / 219 enterprise, sometimes +2/+3 on runbot
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert)
@@ -166,7 +166,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         test_leads = self._create_leads_batch(count=50, user_ids=[False])
         user_ids = self.assign_users.ids
 
-        with self.assertQueryCount(user_sales_manager=1336):  # still some randomness (1266 generally on runbot) - crm only: 1257
+        with self.assertQueryCount(user_sales_manager=1338):  # still some randomness (1268 generally on runbot - 1269 enterprise) - crm only: 1259
             mass_convert = self.env['crm.lead2opportunity.partner.mass'].with_context({
                 'active_model': 'crm.lead',
                 'active_ids': test_leads.ids,

--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -48,7 +48,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         leads.flush()
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=1388):  # 1376-1379 generally
+            with self.assertQueryCount(user_sales_manager=1378):  # 1366-1369 generally
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
@@ -174,7 +174,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         leads.flush()
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=7272):  # 7263-7269 generally
+            with self.assertQueryCount(user_sales_manager=7152):  # 7143-7149 generally
                 self.env['crm.team'].browse(sales_teams.ids)._action_assign_leads(work_days=30)
 
         # teams assign

--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -48,7 +48,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         leads.flush()
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=1388):  # 1381 generally
+            with self.assertQueryCount(user_sales_manager=1388):  # 1376-1379 generally
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
@@ -92,7 +92,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         leads.flush()
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=674):  # 668 generally, sometimes 672
+            with self.assertQueryCount(user_sales_manager=674):  # 668-669 generally, sometimes 672
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
@@ -174,7 +174,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         leads.flush()
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=7179):  # 7170-7176 generally
+            with self.assertQueryCount(user_sales_manager=7272):  # 7263-7269 generally
                 self.env['crm.team'].browse(sales_teams.ids)._action_assign_leads(work_days=30)
 
         # teams assign

--- a/addons/crm/wizard/crm_lead_to_opportunity.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity.py
@@ -152,7 +152,7 @@ class Lead2OpportunityPartner(models.TransientModel):
                 self._convert_handle_partner(
                     lead, self.action, self.partner_id.id or lead.partner_id.id)
 
-            lead.convert_opportunity(lead.partner_id.id, user_ids=False, team_id=False)
+            lead.convert_opportunity(lead.partner_id, user_ids=False, team_id=False)
 
         leads_to_allocate = leads
         if not self.force_assignment:

--- a/addons/event_crm/models/event_registration.py
+++ b/addons/event_crm/models/event_registration.py
@@ -214,6 +214,7 @@ class EventRegistration(models.Model):
                 'contact_name': self._find_first_notnull('name'),
                 'email_from': self._find_first_notnull('email'),
                 'phone': self._find_first_notnull('phone'),
+                'lang_id': False,
             }
         contact_vals.update({
             'name': "%s - %s" % (self.event_id.name, valid_partner.name or self._find_first_notnull('name') or self._find_first_notnull('email')),

--- a/addons/test_crm_full/tests/test_performance.py
+++ b/addons/test_crm_full/tests/test_performance.py
@@ -42,7 +42,7 @@ class TestCrmPerformance(CrmPerformanceCase):
         country_be = self.env.ref('base.be')
         lang_be_id = self.env['res.lang']._lang_get_id('fr_BE')
 
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=281):  # tcf only: 281 (~280 - 274) - com runbot: 273
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=282):  # tcf only: 282 (~281 - 275) - com runbot: 274
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             crm_values = [
                 {'country_id': country_be.id,
@@ -89,7 +89,7 @@ class TestCrmPerformance(CrmPerformanceCase):
     @warmup
     def test_lead_create_form_partner(self):
         """ Test a single lead creation using Form with a partner """
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=189):  # tcf only: 174 - com runbot: 175
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=193):  # tcf only: 178 - com runbot: 179
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['crm.lead']) as lead_form:
                 lead_form.partner_id = self.partners[0]

--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -186,7 +186,7 @@ class CrmLead(models.Model):
             message += '<p>%s</p>' % html_escape(comment)
         for lead in self:
             lead.message_post(body=message)
-            lead.sudo().convert_opportunity(lead.partner_id.id)  # sudo required to convert partner data
+            lead.sudo().convert_opportunity(lead.partner_id)  # sudo required to convert partner data
 
     def partner_desinterested(self, comment=False, contacted=False, spam=False):
         if contacted:
@@ -274,7 +274,7 @@ class CrmLead(models.Model):
 
         lead = self.create(values)
         lead.assign_salesman_of_assigned_partner()
-        lead.convert_opportunity(lead.partner_id.id)
+        lead.convert_opportunity(lead.partner_id)
         return {
             'id': lead.id
         }


### PR DESCRIPTION
Purpose
=======
When creating an opportunity, set the language of the Lead/Opportunity
to the partner's language if it is set instead of leaving it blank.

Task-2709436