### PR TITLE
[REF] web: rework env.config

### DIFF
--- a/addons/board/static/src/add_to_board/add_to_board.js
+++ b/addons/board/static/src/add_to_board/add_to_board.js
@@ -24,7 +24,7 @@ export class AddToBoard extends Component {
     setup() {
         this.notification = useService("notification");
         this.rpc = useService("rpc");
-        this.state = useState({ name: this.env.config.displayName });
+        this.state = useState({ name: this.env.config.getDisplayName() });
 
         useAutofocus();
     }
@@ -58,7 +58,7 @@ export class AddToBoard extends Component {
                     type: "warning",
                 }
             );
-            this.state.name = this.env.config.displayName;
+            this.state.name = this.env.config.getDisplayName();
         } else {
             this.notification.add(this.env._t("Could not add filter to dashboard"), {
                 type: "danger",

--- a/addons/web/static/src/legacy/action_adapters.js
+++ b/addons/web/static/src/legacy/action_adapters.js
@@ -44,7 +44,7 @@ class ActionAdapter extends ComponentAdapter {
                 });
                 originalUpdateControlPanel = this.__widget.updateControlPanel.bind(this.__widget);
                 this.__widget.updateControlPanel = (newProps) => {
-                    this.trigger("controller-title-updated", this.__widget.getTitle());
+                    this.wowlEnv.config.setDisplayName(this.__widget.getTitle());
                     return originalUpdateControlPanel(newProps);
                 };
                 core.bus.trigger("DOM_updated");
@@ -77,7 +77,7 @@ class ActionAdapter extends ComponentAdapter {
         if (this.widget) {
             const actionTitle = this.widget.getTitle();
             if (actionTitle) {
-                this.trigger("controller-title-updated", actionTitle);
+                this.wowlEnv.config.setDisplayName(actionTitle);
             }
         }
         this.router.pushState(query);

--- a/addons/web/static/src/legacy/action_adapters.js
+++ b/addons/web/static/src/legacy/action_adapters.js
@@ -28,7 +28,6 @@ class ActionAdapter extends ComponentAdapter {
         // In Wowl, we want to have all states pushed during the same setTimeout.
         // This is protected in legacy (backward compatibility) but should not e supported in Wowl
         this.tempQuery = {};
-        this.waitTitle = true;
         let originalUpdateControlPanel;
         useEffect(
             () => {
@@ -38,8 +37,6 @@ class ActionAdapter extends ComponentAdapter {
                 this.__widget = this.widget;
                 if (!this.wowlEnv.inDialog) {
                     this.pushState(query);
-                    this.title.setParts({ action: this.widget.getTitle() });
-                    this.waitTitle = false;
                 }
                 this.wowlEnv.bus.on("ACTION_MANAGER:UPDATE", this, () => {
                     this.env.bus.trigger("close_dialogs");
@@ -50,7 +47,6 @@ class ActionAdapter extends ComponentAdapter {
                     this.trigger("controller-title-updated", this.__widget.getTitle());
                     return originalUpdateControlPanel(newProps);
                 };
-                this.trigger("controller-title-updated", this.__widget.getTitle());
                 core.bus.trigger("DOM_updated");
 
                 return () => {
@@ -78,10 +74,10 @@ class ActionAdapter extends ComponentAdapter {
             Object.assign(this.tempQuery, query);
             return;
         }
-        if (!this.waitTitle && this.widget) {
+        if (this.widget) {
             const actionTitle = this.widget.getTitle();
             if (actionTitle) {
-                this.title.setParts({ action: actionTitle });
+                this.trigger("controller-title-updated", actionTitle);
             }
         }
         this.router.pushState(query);

--- a/addons/web/static/src/legacy/backend_utils.js
+++ b/addons/web/static/src/legacy/backend_utils.js
@@ -264,7 +264,7 @@ export function breadcrumbsToLegacy(breadcrumbs) {
     if (!breadcrumbs) {
         return;
     }
-    return breadcrumbs.slice().map((bc) => {
+    return breadcrumbs.slice(0, -1).map((bc) => {
         return { title: bc.name, controllerID: bc.jsId };
     });
 }

--- a/addons/web/static/src/legacy/legacy_client_actions.js
+++ b/addons/web/static/src/legacy/legacy_client_actions.js
@@ -31,11 +31,12 @@ function registerClientAction(name, action) {
                 for (const key in this.props) {
                     if (key === "action" || key === "actionId") {
                         continue;
-                    } else if (key === "breadcrumbs") {
-                        options[key] = breadcrumbsToLegacy(this.props[key]);
                     } else {
                         options[key] = this.props[key];
                     }
+                }
+                if (this.env.config.breadcrumbs) {
+                    options.breadcrumbs = breadcrumbsToLegacy(this.env.config.breadcrumbs);
                 }
 
                 // always add user context to the action context

--- a/addons/web/static/src/legacy/legacy_views.js
+++ b/addons/web/static/src/legacy/legacy_views.js
@@ -57,7 +57,7 @@ function registerView(name, LegacyView) {
                 context: Object.assign({}, this.user.context, this.props.action.context),
             });
 
-            const { actionFlags, breadcrumbs = [] } = this.env.config;
+            const { actionFlags, breadcrumbs } = this.env.config;
             this.viewParams = Object.assign({}, actionFlags, {
                 action,
                 // legacy views automatically add the last part of the breadcrumbs

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -15,8 +15,10 @@
                         t-on-click.prevent="trigger('breadcrumb-clicked', { controllerID: bc.controllerID })"
                         title="Previous menu"
                         >
-                        <a t-if="bc.title" href="#" t-esc="bc.title"/>
-                        <em t-else="" class="text-warning">Unnamed</em>
+                        <a href="#">
+                            <t t-if="bc.title" t-esc="bc.title"/>
+                            <em t-else="" class="text-warning">Unnamed</em>
+                        </a>
                     </li>
                     <li class="breadcrumb-item active">
                         <span t-attf-class="{{props.breadcrumbs.length ? 'text-muted' : 'text-900' }}" t-if="props.title" t-esc="props.title"/>

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -29,13 +29,13 @@
                     </t>
 
                     <div class="o_cp_pager" role="search">
-                        <t t-if="env.config.getPagerProps">
-                            <t t-set="pagerProps" t-value="env.config.getPagerProps()" />
+                        <t t-set="pagerProps" t-value="env.config.getPagerProps()" />
+                        <t t-if="pagerProps">
                             <Pager t-if="pagerProps.total > 0" t-props="pagerProps" />
                         </t>
                     </div>
 
-                    <t t-if="(env.config.viewSwitcherEntries or []).length">
+                    <t t-if="env.config.viewSwitcherEntries.length">
                         <nav class="btn-group o_cp_switch_buttons">
                             <t t-foreach="env.config.viewSwitcherEntries" t-as="view" t-key="view.type">
                                 <button class="btn btn-light fa fa-lg o_switch_view "
@@ -53,20 +53,19 @@
 
     <t t-name="web.Breadcrumbs" owl="1">
         <ol class="breadcrumb">
-            <t t-foreach="env.config.breadcrumbs or []" t-as="breadcrumb" t-key="breadcrumb.jsId">
-                <li class="breadcrumb-item"
-                    t-att-class="{ o_back_button: breadcrumb_last}"
-                    t-on-click.prevent="onBreadcrumbClicked(breadcrumb.jsId)"
-                    >
+            <t t-foreach="env.config.breadcrumbs" t-as="breadcrumb" t-key="breadcrumb.jsId">
+                <t t-set="isPenultimate" t-value="breadcrumb_index === env.config.breadcrumbs.length - 2"/>
+                <li t-if="!breadcrumb_last" class="breadcrumb-item" t-att-class="{ o_back_button: isPenultimate}" t-on-click.prevent="onBreadcrumbClicked(breadcrumb.jsId)">
                     <a href="#">
-                        <t t-esc="breadcrumb.name"/>
+                        <t t-if="breadcrumb.name" t-esc="breadcrumb.name"/>
+                        <em t-else="" class="text-warning">Unnamed</em>
                     </a>
                 </li>
+                <li t-else="" class="breadcrumb-item active">
+                    <t t-if="breadcrumb.name" t-esc="breadcrumb.name"/>
+                    <em t-else="" class="text-warning">Unnamed</em>
+                </li>
             </t>
-            <li class="breadcrumb-item active">
-                <t t-if="env.config.displayName" t-esc="env.config.displayName" />
-                <em t-else="" class="text-warning">Unnamed</em>
-            </li>
         </ol>
     </t>
 

--- a/addons/web/static/src/search/favorite_menu/custom_favorite_item.js
+++ b/addons/web/static/src/search/favorite_menu/custom_favorite_item.js
@@ -14,7 +14,7 @@ export class CustomFavoriteItem extends Component {
         this.descriptionRef = useRef("description");
         useAutofocus();
         this.state = useState({
-            description: this.env.config.displayName,
+            description: this.env.config.getDisplayName(),
             isDefault: false,
             isShared: false,
         });
@@ -46,7 +46,7 @@ export class CustomFavoriteItem extends Component {
         this.env.searchModel.createNewFavorite({ description, isDefault, isShared });
 
         Object.assign(this.state, {
-            description: this.env.config.displayName,
+            description: this.env.config.getDisplayName(),
             isDefault: false,
             isShared: false,
         });

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -14,6 +14,47 @@ const viewRegistry = registry.category("views");
 const { Component, hooks } = owl;
 const { useSubEnv } = hooks;
 
+/** @typedef {Object} Config
+ *  @property {integer|false} actionId
+ *  @property {string|false} actionType
+ *  @property {Object} actionFlags
+ *  @property {() => []} breadcrumbs
+ *  @property {() => string} getDisplayName
+ *  @property {(string) => void} setDisplayName
+ *  @property {() => Object} getPagerProps
+ *  @property {Object[]} viewSwitcherEntry
+ *  @property {Object[]} viewSwitcherEntry
+ */
+
+/**
+ * Returns the default config to use if no config, or an incomplete config has
+ * been provided in the env, which can happen with standalone views.
+ * @returns {Config}
+ */
+export function getDefaultConfig() {
+    let displayName;
+    const config = {
+        actionId: false,
+        actionType: false,
+        actionFlags: {},
+        breadcrumbs: [
+            {
+                get name() {
+                    return displayName;
+                },
+            },
+        ],
+        getDisplayName: () => displayName,
+        getPagerProps: () => {},
+        setDisplayName: (newDisplayName) => {
+            displayName = newDisplayName;
+        },
+        viewSwitcherEntries: [],
+        views: [],
+    };
+    return config;
+}
+
 /** @typedef {Object} ViewProps
  *  @property {string} resModel
  *  @property {string} type
@@ -106,7 +147,10 @@ export class View extends Component {
 
         useSubEnv({
             keepLast: new KeepLast(),
-            config: { ...(this.env.config || {}) },
+            config: {
+                ...getDefaultConfig(),
+                ...this.env.config,
+            },
         });
         useActionLinks({ resModel });
     }
@@ -119,7 +163,7 @@ export class View extends Component {
         // determine views for which descriptions should be obtained
         let { viewId, searchViewId } = this.props;
 
-        const views = deepCopy(this.env.config.views || []);
+        const views = deepCopy(this.env.config.views);
         const view = views.find((v) => v[1] === type) || [];
         if (view.length) {
             view[0] = viewId !== undefined ? viewId : view[0];

--- a/addons/web/static/tests/search/control_panel.js
+++ b/addons/web/static/tests/search/control_panel.js
@@ -45,21 +45,18 @@ QUnit.module("Search", (hooks) => {
         assert.containsNone(controlPanel, ".o_cp_switch_buttons");
 
         assert.containsOnce(controlPanel, ".breadcrumb");
-        assert.containsOnce(controlPanel, ".breadcrumb li.breadcrumb-item");
-        assert.strictEqual(
-            controlPanel.el.querySelector("li.breadcrumb-item").innerText,
-            "Unnamed"
-        );
     });
 
-    QUnit.test("breadcrumbs prop", async (assert) => {
+    QUnit.test("breadcrumbs", async (assert) => {
         const controlPanel = await makeWithSearch({
             serverData,
             resModel: "foo",
             Component: ControlPanel,
             config: {
-                breadcrumbs: [{ jsId: "controller_7", name: "Previous" }],
-                displayName: "Current",
+                breadcrumbs: [
+                    { jsId: "controller_7", name: "Previous" },
+                    { jsId: "controller_9", name: "Current" },
+                ],
             },
             searchMenuTypes: [],
         });
@@ -78,7 +75,7 @@ QUnit.module("Search", (hooks) => {
         assert.verifySteps(["controller_7"]);
     });
 
-    QUnit.test("viewSwitcherEntries prop", async (assert) => {
+    QUnit.test("view switcher", async (assert) => {
         const controlPanel = await makeWithSearch({
             serverData,
             resModel: "foo",

--- a/addons/web/static/tests/search/custom_favorite_item_tests.js
+++ b/addons/web/static/tests/search/custom_favorite_item_tests.js
@@ -81,7 +81,7 @@ QUnit.module("Search", (hooks) => {
             searchMenuTypes: ["favorite"],
             searchViewId: false,
             config: {
-                displayName: "Action Name",
+                getDisplayName: () => "Action Name",
             },
         });
 
@@ -296,7 +296,7 @@ QUnit.module("Search", (hooks) => {
                     if (args.model === "ir.filters" && args.method === "create_or_replace") {
                         const irFilter = args.args[0];
                         assert.deepEqual(irFilter, {
-                            action_id: undefined,
+                            action_id: false,
                             context: { group_by: [] },
                             domain: "[]",
                             is_default: false,

--- a/addons/web/static/tests/search/favorite_menu_tests.js
+++ b/addons/web/static/tests/search/favorite_menu_tests.js
@@ -68,7 +68,7 @@ QUnit.module("Search", (hooks) => {
                 searchMenuTypes: ["favorite"],
                 searchViewId: false,
                 config: {
-                    displayName: "Action Name",
+                    getDisplayName: () => "Action Name",
                 },
             });
 
@@ -101,7 +101,7 @@ QUnit.module("Search", (hooks) => {
             searchMenuTypes: ["favorite"],
             searchViewId: false,
             config: {
-                displayName: "Action Name",
+                getDisplayName: () => "Action Name",
             },
         });
 

--- a/addons/web/static/tests/search/helpers.js
+++ b/addons/web/static/tests/search/helpers.js
@@ -6,11 +6,12 @@ import { ormService } from "@web/core/orm_service";
 import { registry } from "@web/core/registry";
 import { CustomFavoriteItem } from "@web/search/favorite_menu/custom_favorite_item";
 import { WithSearch } from "@web/search/with_search/with_search";
+import { getDefaultConfig } from "@web/views/view";
 import { viewService } from "@web/views/view_service";
 import { actionService } from "@web/webclient/actions/action_service";
 import { registerCleanup } from "../helpers/cleanup";
 import { makeTestEnv } from "../helpers/mock_env";
-import { click, getFixture, mouseEnter, triggerEvent, triggerEvents } from "../helpers/utils";
+import { click, getFixture, mouseEnter, triggerEvent } from "../helpers/utils";
 
 const serviceRegistry = registry.category("services");
 const favoriteMenuRegistry = registry.category("favoriteMenu");
@@ -38,7 +39,10 @@ export const makeWithSearch = async (params) => {
 
     const serverData = props.serverData || undefined;
     const mockRPC = props.mockRPC || undefined;
-    const config = props.config || {};
+    const config = {
+        ...getDefaultConfig(),
+        ...props.config,
+    };
 
     delete props.serverData;
     delete props.mockRPC;

--- a/addons/web/static/tests/views/graph_view_tests.js
+++ b/addons/web/static/tests/views/graph_view_tests.js
@@ -1320,8 +1320,18 @@ QUnit.module("Views", (hooks) => {
             label: "",
         });
         checkLegend(assert, graph, ["true / xphone", "false / xphone", "false / xpad"]);
-        checkTooltip(assert, graph, { lines: [{ label: "true / xphone", value: "3 (37.50%)" }] }, 0);
-        checkTooltip(assert, graph, { lines: [{ label: "false / xphone", value: "1 (12.50%)" }] }, 1);
+        checkTooltip(
+            assert,
+            graph,
+            { lines: [{ label: "true / xphone", value: "3 (37.50%)" }] },
+            0
+        );
+        checkTooltip(
+            assert,
+            graph,
+            { lines: [{ label: "false / xphone", value: "1 (12.50%)" }] },
+            1
+        );
         checkTooltip(assert, graph, { lines: [{ label: "false / xpad", value: "4 (50.00%)" }] }, 2);
     });
 
@@ -2732,17 +2742,15 @@ QUnit.module("Views", (hooks) => {
     );
 
     QUnit.test("action name is displayed in breadcrumbs", async function (assert) {
-        assert.expect(1);
-        const graph = await makeView({
-            serverData,
-            type: "graph",
-            resModel: "foo",
-            config: {
-                displayName: "Glou glou",
-            },
+        const webClient = await createWebClient({ serverData });
+        await doAction(webClient, {
+            name: "Glou glou",
+            res_model: "foo",
+            type: "ir.actions.act_window",
+            views: [[false, "graph"]],
         });
         assert.strictEqual(
-            graph.el.querySelector(".o_control_panel .breadcrumb-item.active").innerText,
+            webClient.el.querySelector(".o_control_panel .breadcrumb-item.active").innerText,
             "Glou glou"
         );
     });

--- a/addons/web/static/tests/views/helpers.js
+++ b/addons/web/static/tests/views/helpers.js
@@ -3,7 +3,7 @@
 import { registerCleanup } from "@web/../tests/helpers/cleanup";
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
 import { getFixture } from "@web/../tests/helpers/utils";
-import { View } from "@web/views/view";
+import { getDefaultConfig, View } from "@web/views/view";
 import { _fieldsViewGet } from "../helpers/mock_server";
 import { addLegacyMockEnvironment } from "../webclient/helpers";
 
@@ -27,7 +27,10 @@ export const makeView = async (params) => {
     const props = { ...params };
     const serverData = props.serverData;
     const mockRPC = props.mockRPC;
-    const config = props.config || {};
+    const config = {
+        ...getDefaultConfig(),
+        ...props.config,
+    };
     const legacyParams = props.legacyParams || {};
 
     delete props.serverData;

--- a/addons/web/static/tests/views/layout_tests.js
+++ b/addons/web/static/tests/views/layout_tests.js
@@ -5,6 +5,7 @@ import { makeWithSearch, setupControlPanelServiceRegistry } from "@web/../tests/
 import { dialogService } from "@web/core/dialog/dialog_service";
 import { registry } from "@web/core/registry";
 import { Layout } from "@web/views/layout";
+import { getDefaultConfig } from "@web/views/view";
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
 
 const { Component, hooks, mount, tags } = owl;
@@ -126,7 +127,12 @@ QUnit.module("Views", (hooks) => {
 
         class ToyB extends Component {
             setup() {
-                useSubEnv({ config: { SearchPanel } });
+                useSubEnv({
+                    config: {
+                        ...getDefaultConfig(),
+                        SearchPanel,
+                    },
+                });
             }
         }
         ToyB.template = xml`

--- a/addons/web/static/tests/webclient/actions/client_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/client_action_tests.js
@@ -333,15 +333,15 @@ QUnit.module("ActionManager", (hooks) => {
             setup() {
                 this.breadcrumbTitle = "myOwlAction";
                 const { breadcrumbs } = this.env.config;
-                assert.strictEqual(breadcrumbs.length, 1);
+                assert.strictEqual(breadcrumbs.length, 2);
                 assert.strictEqual(breadcrumbs[0].name, "Favorite Ponies");
             }
             mounted() {
-                this.trigger("controller-title-updated", this.breadcrumbTitle);
+                this.env.config.setDisplayName(this.breadcrumbTitle);
             }
             onClick() {
                 this.breadcrumbTitle = "newOwlTitle";
-                this.trigger("controller-title-updated", this.breadcrumbTitle);
+                this.env.config.setDisplayName(this.breadcrumbTitle);
             }
         }
         ClientAction.template = tags.xml`<div class="my_owl_action" t-on-click="onClick">owl client action</div>`;

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -2410,11 +2410,24 @@ QUnit.module("ActionManager", (hooks) => {
         const webClient = await createWebClient({ serverData });
         await doAction(webClient, 3); // list view
         const titleService = webClient.env.services.title;
-        assert.strictEqual(titleService.current, "{\"zopenerp\":\"Odoo\",\"action\":\"Partners\"}");
+        assert.strictEqual(titleService.current, '{"zopenerp":"Odoo","action":"Partners"}');
         await click(webClient.el.querySelector(".o_data_row"));
         await legacyExtraNextTick();
-        assert.strictEqual(titleService.current, "{\"zopenerp\":\"Odoo\",\"action\":\"First record\"}");
+        assert.strictEqual(titleService.current, '{"zopenerp":"Odoo","action":"First record"}');
         await click(webClient.el.querySelector(".o_pager_next"));
-        assert.strictEqual(titleService.current, "{\"zopenerp\":\"Odoo\",\"action\":\"Second record\"}");
+        assert.strictEqual(titleService.current, '{"zopenerp":"Odoo","action":"Second record"}');
+    });
+
+    QUnit.test("action part of title is updated when an action is mounted", async (assert) => {
+        // use a PivotView because we need a view converted to wowl
+        // those two lines can be removed once the list view is converted to wowl
+        serverData.actions[3].views.unshift([false, "pivot"]);
+        serverData.views["partner,false,pivot"] = "<pivot/>";
+        serviceRegistry.add("user", makeFakeUserService());
+
+        const webClient = await createWebClient({ serverData });
+        await doAction(webClient, 3);
+        const titleService = webClient.env.services.title;
+        assert.strictEqual(titleService.current, '{"zopenerp":"Odoo","action":"Partners"}');
     });
 });


### PR DESCRIPTION
The motivation of this commit comes from breadcrumbs.

Breadcrumbs work as follows: for each controller in the stack of
the ActionService, there is an entry in the breadcrumbs. Except
for the last entry (which corresponds to the currently displayed
controller), the value to display is computed by the ActionService
and stored in this.env.config.breadcrumbs. For the last entry,
we use the displayName set in this.env.config.

When a view wants to update its displayName (e.g. the form view
when we switch to another record), it updates the displayName in
the config, which thus correctly updates the breadcrumbs. However,
this doesn't change the internal values in the ActionService, so if
another controller is stacked over the current one, the penultimate
entry is wrong. To update the internal state of the ActionService,
the event 'controller-title-updated' must be triggered as well,
which is cumbersome. Note that we don't really face the issue yet
because among already converted views, none of them need to update
its displayName in the breadcrumbs.

This commit aims at uniformizing the way the (n-1) first entries
and the last one behave, by replacing the "breadcrumbs" key in the
config by a function "getBreadcrumbs" which returns all breadcrumbs
entries (the n-1 first ones, and the last, current one). We also
replace the "displayName" key by "getDisplayName" such that it
uses a single source of truth, located in the ActionService. Finally,
this commit introduces the notion of "default config" which ensures
that standalone views, or views in tests, have a valid config with
expected keys.