### PR TITLE
[FIX] stock: print traceability report

### DIFF
--- a/addons/stock/report/stock_traceability.py
+++ b/addons/stock/report/stock_traceability.py
@@ -4,6 +4,7 @@
 from odoo import api, models, _
 from odoo.tools import config
 from odoo.tools import format_datetime
+from markupsafe import Markup
 
 
 rec = 0
@@ -221,11 +222,11 @@ class MrpStockReport(models.TransientModel):
         )
 
         header = self.env['ir.actions.report']._render_template("web.internal_layout", values=rcontext)
-        header = self.env['ir.actions.report']._render_template("web.minimal_layout", values=dict(rcontext, subst=True, body=header))
+        header = self.env['ir.actions.report']._render_template("web.minimal_layout", values=dict(rcontext, subst=True, body=Markup(header.decode())))
 
         return self.env['ir.actions.report']._run_wkhtmltopdf(
             [body],
-            header=header,
+            header=header.decode(),
             landscape=True,
             specific_paperformat_args={'data-report-margin-top': 17, 'data-report-header-spacing': 12}
         )


### PR DESCRIPTION
Step to reproduce:
Try to print traceability report

Current Behaviour:
Traceback due to the encoding of an already encoded hearder.

Behaviour after PR:
No Traceback, the header is decoded in the function to avoid diff in more sensitive area.

opw-2704299
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
