### PR TITLE
[FIX] web_editor: fix italic and underline in FF

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -19,6 +19,8 @@ import {
     insertText,
     isBlock,
     isBold,
+    isItalic,
+    isUnderline,
     isColorGradient,
     isContentTextNode,
     isShrunkBlock,
@@ -298,6 +300,16 @@ function deleteTable(editor, table) {
     setSelection(p, 0);
 }
 
+function getTextNodes(editor) {
+    const selection = editor.document.getSelection();
+    if (!selection.rangeCount || selection.getRangeAt(0).collapsed) {
+        return null;
+    }
+    getDeepRange(editor.editable, { splitText: true, select: true, correctTripleClick: true });
+    return getSelectedNodes(editor.editable)
+        .filter(n => n.nodeType === Node.TEXT_NODE && n.nodeValue.trim().length);
+}
+
 // This is a whitelist of the commands that are implemented by the
 // editor itself rather than the node prototypes. It might be
 // possible to switch the conditions and test if the method exist on
@@ -355,12 +367,9 @@ export const editorCommands = {
     // Formats
     // -------------------------------------------------------------------------
     bold: editor => {
-        const selection = editor.document.getSelection();
-        if (!selection.rangeCount || selection.getRangeAt(0).collapsed) return;
-        getDeepRange(editor.editable, { splitText: true, select: true, correctTripleClick: true });
-        const isAlreadyBold = getSelectedNodes(editor.editable)
-            .filter(n => n.nodeType === Node.TEXT_NODE && n.nodeValue.trim().length)
-            .find(n => isBold(n.parentElement));
+        const nodes = getTextNodes(editor);
+        if (!nodes) return;
+        const isAlreadyBold = nodes.find(n => isBold(n.parentElement));
         applyInlineStyle(editor, el => {
             if (isAlreadyBold) {
                 const block = closestBlock(el);
@@ -370,8 +379,22 @@ export const editorCommands = {
             }
         });
     },
-    italic: editor => editor.document.execCommand('italic'),
-    underline: editor => editor.document.execCommand('underline'),
+    italic: editor => {
+        const nodes = getTextNodes(editor);
+        if (!nodes) return;
+        const isAlreadyItalic = nodes.find(n => isItalic(n.parentElement));
+        applyInlineStyle(editor, el => {
+            el.style.fontStyle = isAlreadyItalic ? 'normal' : 'italic';
+        });
+    },
+    underline: editor => {
+        const nodes = getTextNodes(editor);
+        if (!nodes) return;
+        const isAlreadyUnderline = nodes.find(n => isUnderline(n.parentElement));
+        applyInlineStyle(editor, el => {
+            el.style.textDecoration = isAlreadyUnderline ? 'none' :  'underline';
+        });
+    },
     strikeThrough: editor => editor.document.execCommand('strikeThrough'),
     removeFormat: editor => {
         editor.document.execCommand('removeFormat');

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -868,6 +868,26 @@ export function isBold(node) {
     const fontWeight = +getComputedStyle(closestElement(node)).fontWeight;
     return fontWeight > 500 || fontWeight > +getComputedStyle(closestBlock(node)).fontWeight;
 }
+/**
+ * Return true if the given node font style equal italic
+ *
+ * @param {Node} node
+ * @returns {boolean}
+ */
+export function isItalic(node) {
+    const fontStyle = getComputedStyle(closestElement(node)).fontStyle;
+    return fontStyle === 'italic';
+}
+/**
+ * Return true if the given node text-decoration style equal underline
+ *
+ * @param {Node} node
+ * @returns {boolean}
+ */
+export function isUnderline(node) {
+    const textDecoration = getComputedStyle(closestElement(node)).textDecorationLine;
+    return textDecoration === 'underline';
+}
 
 export function isUnbreakable(node) {
     if (!node || node.nodeType === Node.TEXT_NODE) {

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -173,7 +173,7 @@ tour.register('rte_translator', {
 }, {
     content: "save new change",
     trigger: 'button[data-action=save]',
-    extra_trigger: '#wrap.o_dirty p u',
+    extra_trigger: '#wrap.o_dirty p span[style="text-decoration: underline;"]',
 
     }, {
     content: "click language dropdown (4)",

--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -427,9 +427,13 @@ class IrTranslation(models.Model):
                 else:
                     translations_to_match.append(translation)
 
+            if translations_to_match:
+                text2term = {field.get_text_content(term): term for term in terms}
             for translation in translations_to_match:
-                matches = get_close_matches(translation.src, terms, 1, 0.9)
-                src = matches[0] if matches else None
+                # match the terms without formatting elements
+                src_text = field.get_text_content(translation.src)
+                matches = get_close_matches(src_text, text2term, 1, 0.9)
+                src = text2term[matches[0]] if matches else None
                 if not src:
                     outdated += translation
                 elif (src, translation.lang) in done:

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -722,6 +722,44 @@ class TestXMLTranslation(TransactionCase):
         self.assertEqual(view.with_env(env_fr).arch_db, archf % new_terms_fr)
         self.assertEqual(view.with_env(env_nl).arch_db, archf % terms_nl)
 
+    def test_sync_xml(self):
+        """ Check translations of 'arch' after xml tags changes in source terms. """
+        archf = '<form string="X">%s</form>'
+        terms_en = ('Bread and cheese',)
+        terms_fr = ('Pain et fromage',)
+        terms_nl = ('Brood and kaas',)
+        view = self.create_view(archf, terms_en, en_US=terms_en, fr_FR=terms_fr, nl_NL=terms_nl)
+
+        env_nolang = self.env(context={})
+        env_en = self.env(context={'lang': 'en_US'})
+        env_fr = self.env(context={'lang': 'fr_FR'})
+        env_nl = self.env(context={'lang': 'nl_NL'})
+
+        self.assertEqual(view.with_env(env_nolang).arch, archf % terms_en)
+        self.assertEqual(view.with_env(env_en).arch, archf % terms_en)
+        self.assertEqual(view.with_env(env_fr).arch, archf % terms_fr)
+        self.assertEqual(view.with_env(env_nl).arch, archf % terms_nl)
+
+        # modify source term in view (add css style)
+        terms_en = ('Bread <span style="font-weight:bold">and</span> cheese',)
+        view.with_env(env_en).write({'arch': archf % terms_en})
+
+        # check whether translations have been kept
+        self.assertEqual(view.with_env(env_nolang).arch, archf % terms_en)
+        self.assertEqual(view.with_env(env_en).arch, archf % terms_en)
+        self.assertEqual(view.with_env(env_fr).arch, archf % terms_fr)
+        self.assertEqual(view.with_env(env_nl).arch, archf % terms_nl)
+
+        # modify source term in view (actual text change)
+        terms_en = ('Bread <span style="font-weight:bold">and</span> butter',)
+        view.with_env(env_en).write({'arch': archf % terms_en})
+
+        # check whether translations have been reset
+        self.assertEqual(view.with_env(env_nolang).arch, archf % terms_en)
+        self.assertEqual(view.with_env(env_en).arch, archf % terms_en)
+        self.assertEqual(view.with_env(env_fr).arch, archf % terms_en)
+        self.assertEqual(view.with_env(env_nl).arch, archf % terms_en)
+
     def test_sync_update(self):
         """ Check translations after major changes in source terms. """
         archf = '<form string="X"><div>%s</div><div>%s</div></form>'
@@ -737,7 +775,7 @@ class TestXMLTranslation(TransactionCase):
         self.assertEqual(len(translations), 2)
 
         # modifying the arch should sync existing translations without errors
-        new_arch = archf % ('Subtotal', 'Subtotal:<br/>')
+        new_arch = archf % ('Subtotal', 'Subtotal : <br/>')
         view.write({"arch_db": new_arch})
 
         translations = self.env['ir.translation'].search([
@@ -746,7 +784,7 @@ class TestXMLTranslation(TransactionCase):
             ('res_id', '=', view.id),
         ])
         # 'Subtotal' being src==value, it will be discared
-        # 'Subtotal:' will be discarded as it match 'Subtotal' instead of 'Subtotal:<br/>'
+        # 'Subtotal:' will be discarded as it match 'Subtotal' instead of 'Subtotal : <br/>'
         self.assertEqual(len(translations), 0)
 
     def test_cache_consistency(self):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1607,6 +1607,11 @@ class _String(Field):
         self.translate(terms.append, value)
         return terms
 
+    def get_text_content(self, term):
+        """ Return the textual content for the given term. """
+        func = getattr(self.translate, 'get_text_content', lambda term: term)
+        return func(term)
+
     def get_trans_func(self, records):
         """ Return a translation function `translate` for `self` on the given
         records; the function call `translate(record_id, value)` translates the

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -319,6 +319,14 @@ def html_translate(callback, value):
     return value
 
 
+def get_text_content(term):
+    """ Return the textual content of the given term. """
+    return html.fromstring(term).text_content()
+
+xml_translate.get_text_content = get_text_content
+html_translate.get_text_content = get_text_content
+
+
 #
 # Warning: better use self.env['ir.translation']._get_source if you can
 #


### PR DESCRIPTION
When selecting the text content of a link
the underline and italic commands were not working in Firefox.

We re-implement the Browser command to fix this.

task-2667950

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
