### PR TITLE
[FIX] website_event_questions: fix propagation from template

### DIFF
--- a/addons/website_event_questions/models/event_event.py
+++ b/addons/website_event_questions/models/event_event.py
@@ -53,7 +53,7 @@ class EventEvent(models.Model):
                 command = [(3, question.id) for question in questions_toremove]
             else:
                 command = [(5, 0)]
-            if event.event_type_id.use_mail_schedule:
+            if event.event_type_id.use_questions:
                 command += [
                     (0, 0, {
                         'title': question.title,


### PR DESCRIPTION
A wrong field is used to control propagation of questions from event template
to child events. Currently an event template must use automated emails to
propagate its questions, instead of correctly checking the question enabled
field ``use_questions``.

As most templates use automated email this was not seen before.

Task-2703285 (event performance)
Task-2703289 (event testing)
