### PR TITLE
[IMP] website{_slides_survey}: Add certification attempts tab

### DIFF
--- a/addons/survey/data/mail_template_data.xml
+++ b/addons/survey/data/mail_template_data.xml
@@ -71,7 +71,7 @@
                         <strong t-out="object.survey_id.display_name or ''">Furniture Creation</strong>
                     certification
                 </p>
-                <p>Congratulations for passing the test!</p>
+                <p>Congratulations for passing the test with a score of <strong t-out="object.scoring_percentage"/>% !</p>
             </td></tr>
         </tbody>
     </table>

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -271,11 +271,11 @@
                 <div class="col-12 col-md-8 col-lg-9">
                     <ul class="nav nav-tabs o_wprofile_nav_tabs flex-nowrap" role="tablist" id="profile_extra_info_tablist">
                         <li class="nav-item">
-                            <a role="tab" aria-controls="about" href="#profile_tab_content_about" class="nav-link active" data-bs-toggle="tab">About</a>
+                            <a role="tab" aria-controls="about" href="#profile_tab_content_about" t-attf-class="nav-link #{'active' if not active_tab or active_tab == 'about' else ''}" data-bs-toggle="tab">About</a>
                         </li>
                     </ul>
                     <div class="tab-content py-4 o_wprofile_tabs_content mb-4" id="profile_extra_info_tabcontent">
-                        <div role="tabpanel" class="tab-pane active" id="profile_tab_content_about">
+                        <div role="tabpanel" t-attf-class="tab-pane #{ 'show active' if not active_tab or active_tab == 'about' else '' }" id="profile_tab_content_about">
                             <div class="o_wprofile_email_validation_container mb16 mt16">
                                 <t t-call="website_profile.email_validation_banner">
                                     <t t-set="redirect_url" t-value="'/profile/user/%s' % user.id"/>

--- a/addons/website_slides_survey/controllers/__init__.py
+++ b/addons/website_slides_survey/controllers/__init__.py
@@ -3,3 +3,4 @@
 
 from . import slides
 from . import survey
+from . import website_profile

--- a/addons/website_slides_survey/controllers/website_profile.py
+++ b/addons/website_slides_survey/controllers/website_profile.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.http import request
+from odoo.osv import expression
+from odoo.addons.website_profile.controllers.main import WebsiteProfile
+
+
+class WebsiteSlidesSurvey(WebsiteProfile):
+    def _prepare_user_profile_values(self, user, **kwargs):
+        """Loads all data required to display the certification attempts of the given user"""
+        values = super(WebsiteSlidesSurvey, self)._prepare_user_profile_values(user, **kwargs)
+        values['show_certification_tab'] = ('user' in values) and (
+            values['user'].id == request.env.user.id or \
+            request.env.user.has_group('survey.group_survey_manager')
+        )
+
+        if not values['show_certification_tab']:
+            return values
+
+        domain = expression.AND([
+            [('survey_id.certification', '=', True)],
+            expression.OR([
+                [('email', '=', values['user'].email)],
+                [('partner_id', '=', values['user'].partner_id.id)]
+            ]) if values['user'].email else \
+                [('partner_id', '=', values['user'].partner_id.id)]
+        ])
+
+        if 'certification_search' in kwargs:
+            values['active_tab'] = 'certification'
+            values['certification_search_terms'] = kwargs['certification_search']
+            domain = expression.AND([domain,
+                [('survey_id.title', 'ilike', kwargs['certification_search'])]
+            ])
+
+        UserInputSudo = request.env['survey.user_input'].sudo()
+        values['user_inputs'] = UserInputSudo.search(domain, order='create_date desc')
+
+        return values

--- a/addons/website_slides_survey/views/website_profile.xml
+++ b/addons/website_slides_survey/views/website_profile.xml
@@ -9,6 +9,57 @@
                 </div>
             </t>
         </xpath>
+        <!-- Certification Attempts -->
+        <xpath expr="//ul[hasclass('o_wprofile_nav_tabs')]" position="inside">
+            <li t-if="show_certification_tab" class="nav-item">
+                <a role="tab" aria-controls="certification" href="#profile_tab_content_certification" t-attf-class="nav-link #{ 'active' if active_tab == 'certification' else '' }" data-toggle="tab">
+                    <t t-if="user_inputs" t-out="len(user_inputs)" /> Certification Attempts
+                </a>
+            </li>
+        </xpath>
+        <xpath expr="//div[hasclass('o_wprofile_tabs_content')]" position="inside">
+            <div t-if="show_certification_tab" role="tabpanel" t-attf-class="tab-pane #{ 'show active' if active_tab == 'certification' else '' }" id="profile_tab_content_certification">
+                <h5 class="d-flex justify-content-between align-items-end border-bottom pb-1">
+                    Certification Attempts
+                    <form method="get">
+                        <div class="input-group" role="search">
+                            <input type="text" class="form-control" name="certification_search" t-att-value="certification_search_terms or ''" placeholder="Search Attempts..."/>
+                            <div class="input-group-append">
+                                <button type="submit" class="btn btn-primary" aria-label="Search" title="Search">
+                                    <i class="fa fa-search"/>
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </h5>
+                <t t-if="not user_inputs">
+                    <p t-if="certification_search_terms">No certification found for the given search term.</p>
+                    <p t-else="">You have not taken any certification yet.</p>
+                    <a href="/slides/all?slide_category=certification">
+                        <i class="fa fa-arrow-right"/> See Certifications
+                    </a>
+                </t>
+                <div t-else="" class="card p-3 mb-3" t-foreach="user_inputs" t-as="user_input">
+                    <div class="row">
+                        <div class="col-sm-3" t-out="user_input.create_date" t-options="{'widget': 'datetime'}"/>
+                        <div class="col-sm-4">
+                            <a t-if="user_input.slide_id"
+                                t-attf-href="/slides_survey/slide/get_certification_url?slide_id=#{user_input.slide_id.id}"
+                                t-out="user_input.survey_id.title"/>
+                            <t t-else="" t-out="user_input.survey_id.title"/>
+                        </div>
+                        <div class="col-sm-3">
+                            Attempt n°<t t-out="user_input.attempts_number"/>
+                        </div>
+                        <div class="col-sm-2">
+                            <span t-attf-class="badge #{ 'badge-primary' if user_input.scoring_success else 'badge-danger'}">
+                                <t t-out="user_input.scoring_percentage"/>%
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </xpath>
     </template>
 
      <template id="display_certificate">


### PR DESCRIPTION
This new commit will add a new tab on the user profile that will list the certifications attempts made by the user. With this new tab, the administrators can get a quick overview of the user activity. The default email sent when the user succeed the certification will now include the score obtained by the user on the certification.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr