### PR TITLE
[FIX] point_of_sale: name is not properly renamed into partner_id

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -71,13 +71,13 @@ class ProductProduct(models.Model):
             for w in self.env['stock.warehouse'].search([])]
 
         # Suppliers
-        key = itemgetter('name')
+        key = itemgetter('partner_id')
         supplier_list = []
         for key, group in groupby(sorted(self.seller_ids, key=key), key=key):
             for s in list(group):
                 if not((s.date_start and s.date_start > date.today()) or (s.date_end and s.date_end < date.today()) or (s.min_qty > quantity)):
                     supplier_list.append({
-                        'name': s.name.name,
+                        'name': s.partner_id.name,
                         'delay': s.delay,
                         'price': s.price
                     })


### PR DESCRIPTION
In this commit (f3fe2d50d99698eb0261c2309bd63f9f64b3d703),
the field 'name' is renamed into 'partner_id'. However,
this renaming was not applied properly in point_of_sale.
We fix this in the current commit.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
