### PR TITLE
[FIX] account: Add tax_repartition_line_id in tax details

### DIFF
--- a/addons/account/models/account_move_line_tax_details.py
+++ b/addons/account/models/account_move_line_tax_details.py
@@ -381,6 +381,7 @@ class AccountMoveLine(models.Model):
 
                     tax_line.tax_line_id AS tax_id,
                     tax_line.group_tax_id,
+                    tax_line.tax_repartition_line_id,
 
                     tax_line.company_id,
                     comp_curr.id AS company_currency_id,
@@ -454,6 +455,7 @@ class AccountMoveLine(models.Model):
                 sub.group_tax_id,
                 sub.tax_exigible,
                 sub.base_account_id,
+                sub.tax_repartition_line_id,
 
                 sub.base_amount,
                 ROUND(


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
