### PR TITLE
[FIX] translate text

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-16 07:08+0000\n"
-"PO-Revision-Date: 2021-08-16 07:08+0000\n"
+"POT-Creation-Date: 2021-12-09 16:49+0000\n"
+"PO-Revision-Date: 2021-12-09 16:49+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -50,6 +50,14 @@ msgstr ""
 #: code:addons/point_of_sale/models/pos_config.py:0
 #, python-format
 msgid "%(pos_name)s (not used)"
+msgstr ""
+
+#. module: point_of_sale
+#. openerp-web
+#: code:addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js:0
+#, python-format
+msgid ""
+"%s has a total amount of %s, are you sure you want to delete this order ?"
 msgstr ""
 
 #. module: point_of_sale
@@ -1828,6 +1836,13 @@ msgstr ""
 #: code:addons/point_of_sale/models/pos_category.py:0
 #, python-format
 msgid "Error ! You cannot create recursive categories."
+msgstr ""
+
+#. module: point_of_sale
+#. openerp-web
+#: code:addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js:0
+#, python-format
+msgid "Existing orderlines"
 msgstr ""
 
 #. module: point_of_sale

--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -83,10 +83,11 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
             const screen = order.get_screen_data();
             if (['ProductScreen', 'PaymentScreen'].includes(screen.name) && order.get_orderlines().length > 0) {
                 const { confirmed } = await this.showPopup('ConfirmPopup', {
-                    title: 'Existing orderlines',
-                    body: `${order.name} has total amount of ${this.getTotal(
-                        order
-                    )}, are you sure you want delete this order?`,
+                    title: this.env._t('Existing orderlines'),
+                    body: _.str.sprintf(
+                      this.env._t('%s has a total amount of %s, are you sure you want to delete this order ?'),
+                      order.name, this.getTotal(order)
+                    ),
                 });
                 if (!confirmed) return;
             }

--- a/doc/cla/corporate/akretion.md
+++ b/doc/cla/corporate/akretion.md
@@ -35,6 +35,7 @@ David Beal david.beal@akretion.com https://github.com/bealdav
 Florian da Costa florian.dacosta@akretion.com https://github.com/florian-dacosta
 Magno Barcelo da Costa magno.costa@akretion.com.br https://github.com/mbcosta
 Mourad El Hadj Mimoune mourad.elhadj.mimoune@akretion.com https://github.com/mourad-ehm
+Pierrick Brun pierrick.brun@akretion.com https://github.com/PierrickBrun
 Raphaël Reverdy raphael.reverdy@akretion.com https://github.com/hparfr
 Raphaël Valyi raphael.valyi@akretion.com https://github.com/rvalyi
 Renato Lima renato.lima@akretion.com https://github.com/renatonlima


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Add translate capabilities for a text in pos

Current behavior before PR:

![Capture d’écran de 2021-12-08 15-10-40](https://user-images.githubusercontent.com/8819682/145222913-755ca9ce-7155-4467-a41f-ffbbb0e7df3d.png)

The text is never translated (It should be in french like the rest of the text)

Desired behavior after PR is merged:

Text can be translated


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
