### PR TITLE
[FIX] web: speedup basic_model._updateRecordsData

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -5081,6 +5081,7 @@ var BasicModel = AbstractModel.extend({
         var fieldsInfo = view ? view.fieldsInfo : fieldInfo.fieldsInfo;
         var fields = view ? view.fields : fieldInfo.relatedFields;
         var viewType = view ? view.type : fieldInfo.viewType;
+        var id2Values = new Map(values.map((value) => [value.id, value]))
 
         _.each(records, function (record) {
             var x2mList = self.localData[record.data[fieldName]];
@@ -5088,7 +5089,7 @@ var BasicModel = AbstractModel.extend({
             _.each(x2mList.res_ids, function (res_id) {
                 var dataPoint = self._makeDataPoint({
                     modelName: field.relation,
-                    data: _.findWhere(values, {id: res_id}),
+                    data: id2Values.get(res_id),
                     fields: fields,
                     fieldsInfo: fieldsInfo,
                     parentID: x2mList.id,


### PR DESCRIPTION
Speedup `basic_model._updateRecordsData` for
many2many fields such as `fetchmail.server.message_ids`
and `mail_channel.channel_message_ids`.

Calling `_.findWhere(values)` inside two nested `_.each`
calls can be quite slow when the number of values
is big.

Remove the call to `_.findWhere` by first
creating a Map res_id -> data and then calling
Map.get to retrieve the data for a given res_id
when making a DataPoint

The issue this fix solves happens in v13, v14 and v15 (master wasn't tested).

#### speedup

Time reported (on Chrome) for loading the fetchmail.server tree view.
The search_read call is included.

| len(message_ids) | Before PR | After PR |
|:-----------------:|:----------:|:---------:|
|          5000         |   1.4s        |   291ms |
|        10 000        |    4.6.s      |   475ms |
|        20 000        |    18s        |   860ms |
|        200 000      |   26m       |      7s     |

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
