### PR TITLE
[FIX] l10n_*: Change Bank Suspense Account type

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -166,7 +166,7 @@ class AccountChartTemplate(models.Model):
         return self.env['account.account'].create({
             'name': _("Bank Suspense Account"),
             'code': self.env['account.account']._search_new_account_code(company, code_digits, company.bank_account_code_prefix or ''),
-            'user_type_id': self.env.ref('account.data_account_type_current_liabilities').id,
+            'user_type_id': self.env.ref('account.data_account_type_current_assets').id,
             'company_id': company.id,
         })
 

--- a/addons/l10n_be/data/account.account.template.csv
+++ b/addons/l10n_be/data/account.account.template.csv
@@ -253,7 +253,7 @@
 "a493","Deferred income","493","account.data_account_type_current_liabilities","l10n_be.l10nbe_chart_template","","False"
 "a496","Foreign currency translation differences - Assets","496","account.data_account_type_current_assets","l10n_be.l10nbe_chart_template","","False"
 "a497","Foreign currency translation differences - Liabilities","497","account.data_account_type_current_liabilities","l10n_be.l10nbe_chart_template","","False"
-"a499","Suspense account","499","account.data_account_type_current_liabilities","l10n_be.l10nbe_chart_template","","False"
+"a499","Suspense account","499","account.data_account_type_current_assets","l10n_be.l10nbe_chart_template","","False"
 "a500","Current investments other than shares, fixed income securities and term accounts - Cost","500","account.data_account_type_current_assets","l10n_be.l10nbe_chart_template","","False"
 "a509","Current investments other than shares, fixed income securities and term accounts - Amounts written down","509","account.data_account_type_current_assets","l10n_be.l10nbe_chart_template","","False"
 "a510","Shares and current investments other than fixed income investments - Acquisition value","510","account.data_account_type_current_assets","l10n_be.l10nbe_chart_template","","False"

--- a/addons/l10n_cz/data/account.account.template.csv
+++ b/addons/l10n_cz/data/account.account.template.csv
@@ -82,7 +82,7 @@
 "chart_cz_256000","Dluhové cenné papíry se splatností do jednoho roku držené do splatnosti","256000","l10n_cz.cz_chart_template","account.data_account_type_liquidity","False"
 "chart_cz_257000","Ostatní cenné papíry","257000","l10n_cz.cz_chart_template","account.data_account_type_liquidity","False"
 "chart_cz_259000","Pořízování krátkodobého finančního majetku","259000","l10n_cz.cz_chart_template","account.data_account_type_liquidity","False"
-"chart_cz_261000","Peníze na cestě","261000","l10n_cz.cz_chart_template","account.data_account_type_liquidity","False"
+"chart_cz_261000","Peníze na cestě","261000","l10n_cz.cz_chart_template","account.data_account_type_current_assets","False"
 "chart_cz_291000","Opravná položka ke krátkodobému finančnímu majetku","291000","l10n_cz.cz_chart_template","account.data_account_type_liquidity","False"
 "chart_cz_311000","Odběratelé","311000","l10n_cz.cz_chart_template","account.data_account_type_receivable","True"
 "chart_cz_313000","Pohledávky za eskontované cenné papíry","313000","l10n_cz.cz_chart_template","account.data_account_type_receivable","True"

--- a/addons/l10n_ro/data/account.account.template.csv
+++ b/addons/l10n_ro/data/account.account.template.csv
@@ -284,7 +284,7 @@
 "pcg_5114","Efecte remise spre scontare","5114","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
 "pcg_5121","Conturi la bănci în lei","5121","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
 "pcg_5124","Conturi la bănci în valută","5124","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5125","Sume în curs de decontare","5125","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
+"pcg_5125","Sume în curs de decontare","5125","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
 "pcg_5186","Dobânzi de plătit","5186","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
 "pcg_5187","Dobânzi de încasat","5187","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
 "pcg_5191","Credite bancare pe termen scurt","5191","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"

--- a/addons/l10n_sk/data/account.account.template.csv
+++ b/addons/l10n_sk/data/account.account.template.csv
@@ -73,7 +73,7 @@
 "chart_sk_256000","Dlhové cenné papiere so splatnosťou do jedného roka držané do splatnosti","256000","l10n_sk.sk_chart_template","account.data_account_type_liquidity","False"
 "chart_sk_257000","Ostatné realizovateľné cenné papiere","257000","l10n_sk.sk_chart_template","account.data_account_type_liquidity","False"
 "chart_sk_259000","Obstaranie krátkodobého finančného majetku","259000","l10n_sk.sk_chart_template","account.data_account_type_liquidity","False"
-"chart_sk_261000","Peniaze na ceste","261000","l10n_sk.sk_chart_template","account.data_account_type_liquidity","False"
+"chart_sk_261000","Peniaze na ceste","261000","l10n_sk.sk_chart_template","account.data_account_type_current_assets","False"
 "chart_sk_291000","Opravné položky ku krátkodobému finančnému majetku","291000","l10n_sk.sk_chart_template","account.data_account_type_liquidity","False"
 "chart_sk_311000","Odberatelia","311000","l10n_sk.sk_chart_template","account.data_account_type_receivable","True"
 "chart_sk_312000","Zmenky na inkaso","312000","l10n_sk.sk_chart_template","account.data_account_type_receivable","True"


### PR DESCRIPTION
Currently, Bank Suspense Account has "Current Liabilities" type, while it should be "Current Assets"

Task ID: 2702804


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr