### PR TITLE
[FIX] payment, payment_transfer: add journal in transfer payment acquirer

### DIFF
--- a/addons/payment/models/account_payment_method.py
+++ b/addons/payment/models/account_payment_method.py
@@ -20,7 +20,7 @@ class AccountPaymentMethodLine(models.Model):
     @api.depends('payment_method_id')
     def _compute_payment_acquirer_id(self):
         acquirers = self.env['payment.acquirer'].sudo().search([
-            ('provider', 'in', self.mapped('code')),
+            ('provider', 'in', self.mapped(lambda pm: 'transfer' if pm.code == 'manual' else pm.code)),
             ('company_id', 'in', self.journal_id.company_id.ids),
         ])
 
@@ -34,7 +34,7 @@ class AccountPaymentMethodLine(models.Model):
             acquirers_map[(acquirer.provider, acquirer.company_id)] = acquirer
 
         for line in self:
-            code = line.payment_method_id.code
+            code = 'transfer' if line.payment_method_id.code == 'manual' else line.payment_method_id.code
             company = line.journal_id.company_id
             line.payment_acquirer_id = acquirers_map.get((code, company), False)
 

--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -170,9 +170,10 @@ class PaymentAcquirer(models.Model):
 
     def _compute_journal_id(self):
         for acquirer in self:
+            prov = 'manual' if acquirer.provider == 'transfer' else acquirer.provider
             payment_method = self.env['account.payment.method.line'].search([
                 ('journal_id.company_id', '=', acquirer.company_id.id),
-                ('code', '=', acquirer.provider)
+                ('code', '=', prov)
             ], limit=1)
             if payment_method:
                 acquirer.journal_id = payment_method.journal_id
@@ -181,9 +182,10 @@ class PaymentAcquirer(models.Model):
 
     def _inverse_journal_id(self):
         for acquirer in self:
+            prov = 'manual' if acquirer.provider == 'transfer' else acquirer.provider
             payment_method_line = self.env['account.payment.method.line'].search([
                 ('journal_id.company_id', '=', acquirer.company_id.id),
-                ('code', '=', acquirer.provider)
+                ('code', '=', prov)
             ], limit=1)
             if acquirer.journal_id:
                 if not payment_method_line:

--- a/addons/payment_transfer/views/payment_views.xml
+++ b/addons/payment_transfer/views/payment_views.xml
@@ -11,7 +11,7 @@
             </field>
             <xpath expr="//group[@name='payment_followup']" position="attributes">
                 <attribute name="attrs">
-                    {'invisible': [('provider', '=', 'transfer')]}
+                    {'invisible': [('provider', 'not in', ['transfer', 'test'])]}
                 </attribute>
             </xpath>
         </field>


### PR DESCRIPTION
Could not add the payment journal of the wire transfer payment acquirer

Steps to reproduce:
1. Install the Wire Transfer Payment Acquirer module
2. Go to payment acquirers in Configuration of Invoicing app
3. Open the Wire Transfer
4. The Payment Journal field is invisible

Solution:
Change the invisible condition and check for 'manual' payment method when using transfer

OPW-2687671