### PR TITLE
[FIX] hr: don't use write in compute method

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -137,7 +137,7 @@ class User(models.Model):
 
     @api.depends_context('uid')
     def _compute_is_system(self):
-        self.write({'is_system': self.env.user._is_system()})
+        self.is_system = self.env.user._is_system()
 
     def _compute_can_edit(self):
         can_edit = self.env['ir.config_parameter'].sudo().get_param('hr.hr_employee_self_edit') or self.env.user.has_group('hr.group_hr_user')


### PR DESCRIPTION
[FIX] hr: don't use .write() in a computed method 

Before this commit, the computed field _compute_is_system make a write which
one is a bad practice and trigger a lot of others calls on res.user model.

opw-2716468


Related to this msg: https://github.com/odoo/odoo/pull/69292#discussion_r646425135