### PR TITLE
[FIX] account : Remove double signature on invoice email

### DIFF
--- a/addons/mail/data/mail_data.xml
+++ b/addons/mail/data/mail_data.xml
@@ -269,7 +269,7 @@
                     <t t-esc="access_name"/>
                 </a>
             </div>
-            <t t-if="record.user_id and not record.env.user._is_superuser()">
+            <t t-if="record.user_id and not record.env.user._is_superuser() and signature != ''">
                 <div style="margin: 0px; padding: 0px; font-size:13px;">
                     Best regards,
                 </div>

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -41,6 +41,11 @@ class MailTestStandard(models.Model):
     container_id = fields.Many2one('mail.test.container', tracking=True)
     company_id = fields.Many2one('res.company')
 
+    def _get_share_url(self, redirect, signup_partner, share_token):
+        """This function is required for a test on 'mail.mail_notification_paynow' template (test_message_post/test_mail_add_signature),
+        another model should be created in master"""
+        return '/mail/view'
+
 
 class MailTestActivity(models.Model):
     """ This model can be used to test activities in addition to simple chatter


### PR DESCRIPTION
Current behavior :
When sending an invoice by email there was 2 signature in the mail

Steps to reproduce :
Create an invoice
Send it by email
Check the mail, there are 2 signatures

opw-2703272

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
