### PR TITLE
[FIX] website: fix inconsistent edit menu test

### DIFF
--- a/addons/website/static/src/js/menu/content.js
+++ b/addons/website/static/src/js/menu/content.js
@@ -879,6 +879,7 @@ var ContentMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         return new Promise(function (resolve) {
             var dialog = new EditMenuDialog(self, {}, rootID);
             dialog.on('save', self, function () {
+                window.document.body.classList.add('o_wait_reload');
                 // Before reloading the page after menu modification, does the
                 // given action to do.
                 if (beforeReloadCallback) {

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -247,7 +247,6 @@ function clickOnExtraMenuItem(stepOptions) {
         content: "Click on the extra menu dropdown toggle if it is there",
         trigger: '#top_menu',
         run: function () {
-            console.log('click extra');
             const extraMenuButton = this.$anchor[0].querySelector('.o_extra_menu_items a.nav-link');
             if (extraMenuButton) {
                 extraMenuButton.click();

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -36,16 +36,8 @@ tour.register('edit_menus', {
     {
         content: "Click save and wait for the page to be reloaded",
         trigger: '.modal-dialog .btn-primary span:contains("Save")',
-        run: async function () {
-            await new Promise(resolve => {
-                window.onunload = () => {
-                    resolve();
-                };
-                this.$anchor.click();
-            });
-        },
     },
-    wTourUtils.clickOnExtraMenuItem({extra_trigger: 'body:not(:has(.oe_menu_editor))'}),
+    wTourUtils.clickOnExtraMenuItem({extra_trigger: 'body:not(.o_wait_reload)'}),
     {
         content: "There should be a new megamenu item.",
         trigger: '#top_menu .nav-item a.o_mega_menu_toggle:contains("Megaaaaa!")',


### PR DESCRIPTION
[1] introduced a new test on the EditMenuDialog. This test used an
unreliable event 'unload' as a workaround to go to the next step when
saving the dialog.

This commit removes the use of this event, resulting in crashing
randomly the test, to use the .o_wait_reload class, so that the tour
correctly waits for the page to be reloaded.

task-2513588

[1]: 725cad3



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
