### PR TITLE
[FIX] web_editor: wait for the editor to be loaded in tests

### DIFF
--- a/addons/web_editor/static/tests/field_html_tests.js
+++ b/addons/web_editor/static/tests/field_html_tests.js
@@ -17,11 +17,12 @@ const { legacyExtraNextTick, patchWithCleanup } = require("@web/../tests/helpers
 
 var _t = core._t;
 
-FieldHtml.include({
-    _onLoadWysiwyg: function () {
-        this._super.apply(this, arguments);
-        if (FieldHtml._resolveTestPromise) {
-            FieldHtml._resolveTestPromise();
+let _formResolveTestPromise;
+FormController.include({
+    _setEditMode: async function () {
+        await this._super.apply(this, arguments);
+        if (_formResolveTestPromise) {
+            _formResolveTestPromise();
         }
     }
 });
@@ -180,7 +181,7 @@ QUnit.module('web_editor', {}, function () {
             assert.strictEqual($field.attr('style'), 'height: 100px',
                 "should have applied the style correctly");
 
-            const promise = new Promise((resolve) => FieldHtml._resolveTestPromise = resolve);
+            const promise = new Promise((resolve) => _formResolveTestPromise = resolve);
             await testUtils.form.clickEdit(form);
             await promise;
             $field = form.$('.oe_form_field[name="body"]');
@@ -204,7 +205,7 @@ QUnit.module('web_editor', {}, function () {
                 res_id: 6,
             });
             // check that there is no error on clicking Edit
-            const promise = new Promise((resolve) => FieldHtml._resolveTestPromise = resolve);
+            const promise = new Promise((resolve) => _formResolveTestPromise = resolve);
             await testUtils.form.clickEdit(form);
             await promise;
             assert.containsOnce(form, '.o_form_editable');
@@ -233,7 +234,7 @@ QUnit.module('web_editor', {}, function () {
                 }
             }, true);
 
-            const promise = new Promise((resolve) => FieldHtml._resolveTestPromise = resolve);
+            const promise = new Promise((resolve) => _formResolveTestPromise = resolve);
             await testUtils.form.clickEdit(form);
             await promise;
             await testUtils.dom.click(form.$('.o_form_button_save'));
@@ -452,7 +453,7 @@ QUnit.module('web_editor', {}, function () {
                 '<p><a href="https://www.external.com" target="_blank">External website</a></p>',
                 "should have rendered a div with correct content in readonly");
 
-            const promise = new Promise((resolve) => FieldHtml._resolveTestPromise = resolve);
+            const promise = new Promise((resolve) => _formResolveTestPromise = resolve);
             await testUtils.form.clickEdit(form);
             await promise;
             $field = form.$('.oe_form_field[name="body"]');
@@ -501,7 +502,7 @@ QUnit.module('web_editor', {}, function () {
                 '<p><a href="' + window.location.href.replace(/&/g, "&amp;") + '/test">This website</a></p>',
                 "should have rendered a div with correct content in readonly");
 
-            const promise = new Promise((resolve) => FieldHtml._resolveTestPromise = resolve);
+            const promise = new Promise((resolve) => _formResolveTestPromise = resolve);
             await testUtils.form.clickEdit(form);
             await promise;
             $field = form.$('.oe_form_field[name="body"]');
@@ -550,7 +551,7 @@ QUnit.module('web_editor', {}, function () {
             assert.strictEqual($field.children('.o_readonly').html(), '<p>New external link</p>',
                 "should have rendered a div with correct content in readonly");
 
-            const promise = new Promise((resolve) => FieldHtml._resolveTestPromise = resolve);
+            const promise = new Promise((resolve) => _formResolveTestPromise = resolve);
             await testUtils.form.clickEdit(form);
             await promise;
             $field = form.$('.oe_form_field[name="body"]');
@@ -600,7 +601,7 @@ QUnit.module('web_editor', {}, function () {
             assert.strictEqual($field.children('.o_readonly').html(), '<p>New internal link</p>',
                 "should have rendered a div with correct content in readonly");
 
-            let promise = new Promise((resolve) => FieldHtml._resolveTestPromise = resolve);
+            let promise = new Promise((resolve) => _formResolveTestPromise = resolve);
             await testUtils.form.clickEdit(form);
             await promise;
             $field = form.$('.oe_form_field[name="body"]');
@@ -631,7 +632,7 @@ QUnit.module('web_editor', {}, function () {
                 '<p><a href="' + window.location.href.replace(/&/g, "&amp;") + '/test">New internal link</a></p>',
                 "the link should be created with the right format");
 
-            promise = new Promise((resolve) => FieldHtml._resolveTestPromise = resolve);
+            promise = new Promise((resolve) => _formResolveTestPromise = resolve);
             await testUtils.form.clickEdit(form);
             await promise;
 


### PR DESCRIPTION
In a undeterministic circumstance, the editor element is not
in the page at the moment of checking it. There is probably
some promises somewhere that remains unresolved and
prevent the element to be inserted in time.

Task-2682104




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
