### PR TITLE
[FIX] account: Fix move.name with year different to date using sequence.mixin.constraint_start_date

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1154,7 +1154,7 @@ class AccountMove(models.Model):
             elif (move.name and move.name != '/') or move.state != 'posted':
                 try:
                     if not move.posted_before:
-                        move._constrains_date_sequence()
+                        move.with_context(force_constraint_date=True)._constrains_date_sequence()
                     # Has already a name or is not posted, we don't add to a batch
                     continue
                 except ValidationError:

--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -56,10 +56,11 @@ class SequenceMixin(models.AbstractModel):
             'sequence.mixin.constraint_start_date',
             '1970-01-01'
         ))
+        force_constraint_date = self.env.context.get('force_constraint_date')
         for record in self:
             date = fields.Date.to_date(record[record._sequence_date_field])
             sequence = record[record._sequence_field]
-            if sequence and date and date > constraint_date:
+            if sequence and (force_constraint_date or (date and date > constraint_date)):
                 format_values = record._get_sequence_format_param(sequence)[1]
                 if (
                     format_values['year'] and format_values['year'] != date.year % 10**len(str(format_values['year']))


### PR DESCRIPTION
# Steps to reproduce:
1. Set a sequence.mixin.constraint_start_date configuration parameter
2. Create a new invoice with future year in the date
2.1 Notice that the invoice name is assigned with future year
3. Change the date to current year
3.1 Notice that the invoice name is not re-assigned

Now, delete the sequence.mixin.constraint_start_date configuration parameter
and repeat the steps

3.1 Notice that now the invoice name is re-assigned

# Expected:
If the invoice is in draft state and the name was assigned but the
invoice was not even posted
So the name should be recomputed to current date
instead of set the record name with wrong date

cc @qdp-odoo 