### PR TITLE
[FIX] hr_holidays: fix being able to select invalid time off type

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -129,12 +129,10 @@ class HolidaysType(models.Model):
         FROM
             hr_leave_allocation alloc
         WHERE
-            alloc.id is not null or (
             alloc.employee_id = %s AND
             alloc.active = True AND alloc.state = 'validate' AND
-            alloc.date_to >= %s OR alloc.date_to IS NULL AND
+            (alloc.date_to >= %s OR alloc.date_to IS NULL) AND
             alloc.date_from <= %s 
-            )
         '''
 
         self._cr.execute(query, (employee_id or None, date_to, date_from))
@@ -362,7 +360,7 @@ class HolidaysType(models.Model):
         res = []
         for record in self:
             name = record.name
-            if record.requires_allocation == "yes":
+            if record.requires_allocation == "yes" and not self._context.get('from_manager_leave_form'):
                 name = "%(name)s (%(count)s)" % {
                     'name': name,
                     'count': _('%g remaining out of %g') % (

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -408,7 +408,7 @@
             <field name="holiday_status_id" position="replace"/>
             <div name="title" position="inside">
                 <h1 class="d-flex flex-row justify-content-between">
-                    <field name="holiday_status_id" options="{'no_open': True}"/>
+                    <field name="holiday_status_id" options="{'no_open': True}" context="{'from_manager_leave_form': True ,'employee_id': employee_id}"/>
                 </h1>
             </div>
             <field name="employee_id" position="replace"/>


### PR DESCRIPTION
Prior to this commit, the _search_valid method returns all the time off types.

With this commit, only the time off types that have a valid allocation are returned

task-2711388

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
