### PR TITLE
[FIX] mail: improve performance of channel member_count

### DIFF
--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -99,7 +99,7 @@ class TestDiscussFullPerformance(TransactionCase):
         self.maxDiff = None
         self.users[0].flush()
         self.users[0].invalidate_cache()
-        with self.assertQueryCount(emp=90):
+        with self.assertQueryCount(emp=91):
             init_messaging = self.users[0].with_user(self.users[0])._init_messaging()
 
         self.assertEqual(init_messaging, {


### PR DESCRIPTION
Forcing a fetch of all channel partners for all channels is not efficient
because there are too many of them.

Replace by a count done in SQL through `read_group`.

Time goes from 100ms to 3ms for 1000s of members in 100s of channels.

Part of task-2702450