### PR TITLE
[FIX] hr_org_chart: fix employee deletion

### DIFF
--- a/addons/hr_org_chart/tests/__init__.py
+++ b/addons/hr_org_chart/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_employee_deletion

--- a/addons/hr_org_chart/tests/test_employee_deletion.py
+++ b/addons/hr_org_chart/tests/test_employee_deletion.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import Form, tagged, TransactionCase
+from odoo.exceptions import MissingError
+
+@tagged('post_install')
+class TestEmployeeDeletion(TransactionCase):
+
+    def test_employee_deletion(self):
+        # Tests an issue with the form view where the employee could be deleted
+        employee_a, employee_b = self.env['hr.employee'].create([
+                {
+                    'name': 'A',
+                },
+                {
+                    'name': 'B',
+                },
+        ])
+        department_a, department_b = self.env['hr.department'].create([
+            {
+                'name': 'DEP A',
+                'manager_id': employee_a.id,
+            },
+            {
+                'name': 'DEP B',
+                'manager_id': employee_b.id,
+            },
+        ])
+        employee_a.write({
+            'parent_id': employee_a.id,
+            'coach_id': employee_a.id,
+            'department_id': department_a.id,
+        })
+        try:
+            with Form(employee_a) as form:
+                form.department_id = department_b
+        except MissingError:
+            self.fail('The employee should not have been deleted')

--- a/addons/hr_org_chart/views/hr_views.xml
+++ b/addons/hr_org_chart/views/hr_views.xml
@@ -8,7 +8,7 @@
             <div id="o_work_employee_main" position="after">
                 <div id="o_employee_right">
                     <h4 class="o_org_chart_title mb16 mt0">Organization Chart</h4>
-                    <field name="child_ids" widget="hr_org_chart"/>
+                    <field name="child_ids" widget="hr_org_chart" readonly="1"/>
                 </div>
             </div>
         </field>
@@ -22,7 +22,7 @@
             <xpath expr="//div[@id='o_work_employee_main']" position="after">
                 <div id="o_employee_right">
                     <h4 class="o_org_chart_title mb16 mt0">Organization Chart</h4>
-                    <field name="child_ids" widget="hr_org_chart"/>
+                    <field name="child_ids" widget="hr_org_chart" readonly="1"/>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
How to reproduce:
1: create two employees (A B)  and two departments (C D)
2: Assign A as manager of C and B as manager of D
3: Assign C as A's department and A as A's manager
4: Change A's department to D -> A is deleted

This is due to `parent_id` being both a computed field and the source
field for a One2many. By changing the `department_id` the `parent_id`
also changed which results in it being report in the `onchange` method.
For some reason however the command sent by the orm is not `UNLINK` but
`DELETE` which results in the `active_id` being deleted.

TaskId-2711428
