### PR TITLE
[FIX] l10n_syscohada: wrong currency for RDC

### DIFF
--- a/addons/l10n_syscohada/data/l10n_syscohada_chart_data.xml
+++ b/addons/l10n_syscohada/data/l10n_syscohada_chart_data.xml
@@ -12,7 +12,7 @@
         <field name="cash_account_code_prefix">51</field>
         <field name="transfer_account_code_prefix">588</field>
         <field name="code_digits">6</field>
-        <field name="currency_id" ref="base.XOF"/>
+        <field name="currency_id" ref="base.CDF"/>
     </record>
 
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The default currency for RDC is not correct when you are installing the accounting module

Current behavior before PR:
At the moment, the default currency for Democratic Republic of the Congo (RDC) is XOF when you're installing accounting.
But the currency for RDC is the Congolese Franc (CDF), as say here: https://www.privacyshield.gov/article?id=Congo-Democratic-Republic-Currency-Money

Desired behavior after PR is merged:
Change the default currency for Democratic Republic of the Congo to CDF when installing accounting


opw-2591586

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
