### PR TITLE
[FIX] mail: manually prefetch needed channel partner in channel info

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -3,6 +3,7 @@
 
 import base64
 import logging
+from collections import defaultdict
 from hashlib import sha512
 from secrets import choice
 
@@ -731,6 +732,22 @@ class Channel(models.Model):
         channel_infos = []
         rtc_sessions_by_channel = self.sudo().rtc_session_ids._mail_rtc_session_format_by_channel()
         channel_last_message_ids = dict((r['id'], r['message_id']) for r in self._channel_last_message_ids())
+        all_needed_members_domain = expression.OR([
+            [('channel_id.channel_type', '!=', 'channel')],
+            [('rtc_inviting_session_id', '!=', False)],
+            [('partner_id', '=', self.env.user.partner_id.id)] if self.env.user and self.env.user.partner_id else expression.FALSE_LEAF,
+        ])
+        all_needed_members = self.env['mail.channel.partner'].search(expression.AND([[('channel_id', 'in', self.ids)], all_needed_members_domain]))
+        partner_format_by_partner = all_needed_members.partner_id.mail_partner_format()
+        members_by_channel = defaultdict(lambda: self.env['mail.channel.partner'])
+        invited_members_by_channel = defaultdict(lambda: self.env['mail.channel.partner'])
+        member_of_current_user_by_channel = defaultdict(lambda: self.env['mail.channel.partner'])
+        for member in all_needed_members:
+            members_by_channel[member.channel_id] |= member
+            if member.rtc_inviting_session_id:
+                invited_members_by_channel[member.channel_id] |= member
+            if self.env.user and self.env.user.partner_id and member.partner_id == self.env.user.partner_id:
+                member_of_current_user_by_channel[member.channel_id] = member
         for channel in self:
             info = {
                 'avatarCacheKey': channel._get_avatar_cache_key(),
@@ -748,14 +765,12 @@ class Channel(models.Model):
             }
             # add last message preview (only used in mobile)
             info['last_message_id'] = channel_last_message_ids.get(channel.id, False)
-            # listeners of the channel
-            channel_partners = channel.channel_last_seen_partner_ids
             info['memberCount'] = channel.member_count
             # find the channel partner state, if logged user
             if self.env.user and self.env.user.partner_id:
                 info['message_needaction_counter'] = channel.message_needaction_counter
                 info['message_unread_counter'] = channel.message_unread_counter
-                partner_channel = channel_partners.filtered(lambda pc: pc.partner_id == self.env.user.partner_id)
+                partner_channel = member_of_current_user_by_channel.get(channel, self.env['mail.channel.partner'])
                 if partner_channel:
                     partner_channel = partner_channel[0]
                     info['state'] = partner_channel.fold_state or 'open'
@@ -771,18 +786,18 @@ class Channel(models.Model):
                 # avoid sending potentially a lot of members for big channels
                 # exclude chat and other small channels from this optimization because they are
                 # assumed to be smaller and it's important to know the member list for them
-                info['members'] = sorted(list(channel_partners.partner_id.mail_partner_format().values()), key=lambda p: p['id'])
+                info['members'] = sorted(list(partner_format_by_partner[member.partner_id] for member in members_by_channel[channel] if member.partner_id), key=lambda p: p['id'])
                 info['seen_partners_info'] = sorted([{
                     'id': cp.id,
                     'partner_id': cp.partner_id.id,
                     'fetched_message_id': cp.fetched_message_id.id,
                     'seen_message_id': cp.seen_message_id.id,
-                } for cp in channel_partners], key=lambda p: p['partner_id'])
+                } for cp in members_by_channel[channel] if cp.partner_id], key=lambda p: p['partner_id'])
 
             # add RTC sessions info
             info.update({
-                'invitedGuests': [('insert', [{'id': guest.id, 'name': guest.name} for guest in channel_partners.filtered('rtc_inviting_session_id').guest_id])],
-                'invitedPartners': [('insert', [{'id': partner.id, 'name': partner.name} for partner in channel_partners.filtered('rtc_inviting_session_id').partner_id])],
+                'invitedGuests': [('insert', [{'id': member.guest_id.id, 'name': member.guest_id.name} for member in invited_members_by_channel[channel] if member.guest_id])],
+                'invitedPartners': [('insert', [{'id': member.partner_id.id, 'name': member.partner_id.name} for member in invited_members_by_channel[channel] if member.partner_id])],
                 'rtcSessions': [('insert', rtc_sessions_by_channel.get(channel, []))],
             })
 

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -99,7 +99,7 @@ class TestDiscussFullPerformance(TransactionCase):
         self.maxDiff = None
         self.users[0].flush()
         self.users[0].invalidate_cache()
-        with self.assertQueryCount(emp=91):
+        with self.assertQueryCount(emp=101):
             init_messaging = self.users[0].with_user(self.users[0])._init_messaging()
 
         self.assertEqual(init_messaging, {


### PR DESCRIPTION
Before this commit, it would fetch all channels partners of all channels, even
for big channels and for members that were not useful to known anything about.

This commit reduces the number of fetched members to a more reasonable level,
and ensure the formatting of those members is done only once, instead of once
per channel.

Time goes from 90ms to 1ms for 1000s of members in 100s of channels.

Part of task-2702450