### PR TITLE
[FIX] base: add index for partner on user

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -284,7 +284,7 @@ class Users(models.Model):
         default_user_id = self.env['ir.model.data']._xmlid_to_res_id('base.default_user', raise_if_not_found=False)
         return self.env['res.users'].browse(default_user_id).sudo().groups_id if default_user_id else []
 
-    partner_id = fields.Many2one('res.partner', required=True, ondelete='restrict', auto_join=True,
+    partner_id = fields.Many2one('res.partner', required=True, ondelete='restrict', auto_join=True, index=True,
         string='Related Partner', help='Partner-related data of the user')
     login = fields.Char(required=True, help="Used to log into the system")
     password = fields.Char(


### PR DESCRIPTION
Without this index, finding the user(s) of a partner makes a seq scan, which
could take up to 100ms on my machine with only few thousand users. By adding the
index, the time is reduced to around 5ms.

Part of task-2702450