### PR TITLE
[FIX] mail: Refresh activities after calling mark as done from an editable form

### DIFF
--- a/addons/mail/static/src/models/activity/activity.js
+++ b/addons/mail/static/src/models/activity/activity.js
@@ -146,11 +146,18 @@ function factory(dependencies) {
         }
 
         async fetchAndUpdate() {
-            const [data] = await this.async(() => this.env.services.rpc({
+            const [data] = await this.env.services.rpc({
                 model: 'mail.activity',
                 method: 'activity_format',
                 args: [this.id],
-            }, { shadow: true }));
+            }, { shadow: true }).catch(e => {
+                const errorName = e.message && e.message.data && e.message.data.name;
+                if (errorName === 'odoo.exceptions.MissingError') {
+                    return [];
+                } else {
+                    throw e;
+                }
+            });
             let shouldDelete = false;
             if (data) {
                 this.update(this.constructor.convertData(data));


### PR DESCRIPTION
**Steps to follow**

  - Go to contacts
  - Schedule an activity
  - Click on edit next to the activity
  - Click on the Mark as done button
  -> The activity isn't refreshed

**Cause of the issue**

  - The record is deleted when clicking on the mark as done button
  - The fetchAndUpdate is called after the form is closed
  - An exception is thrown
  -> the method exists early

**Solution**

  Handle odoo.exceptions.MissingError and delete the record client side

opw-2702492