### PR TITLE
[IMP] point_of_sale: optionally hide margins & costs for non-managers

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -82,6 +82,8 @@ class PosConfig(models.Model):
         help="The product categories will be displayed with pictures.")
     restrict_price_control = fields.Boolean(string='Restrict Price Modifications to Managers',
         help="Only users with Manager access rights for PoS app can modify the product prices on orders.")
+    is_margins_costs_accessible_to_every_user = fields.Boolean(string='Margins & Costs', default=True,
+        help='When disabled, only PoS manager can view the margin and cost of product among the Product info.')
     cash_control = fields.Boolean(string='Advanced Cash Control', compute='_compute_cash_control', help="Check the amount of the cashbox at opening and closing.")
     set_maximum_difference = fields.Boolean('Set Maximum Difference', help="Set a maximum difference allowed between the expected and counted money during the closing of the session.")
     receipt_header = fields.Text(string='Receipt Header', help="A short text that will be inserted as a header in the printed receipt.")

--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -59,7 +59,7 @@ class ProductProduct(models.Model):
             pricelists = config.available_pricelist_ids
         else:
             pricelists = config.pricelist_id
-        price_per_pricelist_id = pricelists._price_get(self.id, quantity)
+        price_per_pricelist_id = pricelists._price_get(self, quantity)
         pricelist_list = [{'name': pl.name, 'price': price_per_pricelist_id[pl.id]} for pl in pricelists]
 
         # Warehouses

--- a/addons/point_of_sale/static/src/js/Popups/ProductInfoPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ProductInfoPopup.js
@@ -70,6 +70,11 @@ odoo.define('point_of_sale.ProductInfoPopup', function(require) {
             posbus.trigger('search-product-from-info-popup', productName);
             this.cancel()
         }
+        _hasMarginsCostsAccessRights() {
+            const isAccessibleToEveryUser = this.env.pos.config.is_margins_costs_accessible_to_every_user;
+            const isCashierManager = this.env.pos.get_cashier().role === 'manager';
+            return isAccessibleToEveryUser || isCashierManager;
+        }
     }
 
     ProductInfoPopup.template = 'ProductInfoPopup';

--- a/addons/point_of_sale/static/src/xml/Popups/ProductInfoPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/ProductInfoPopup.xml
@@ -30,11 +30,11 @@
                                     <td>Price excl. VAT:</td>
                                     <td><t t-esc="env.pos.format_currency(productInfo.all_prices.price_without_tax)"/></td>
                                 </tr>
-                                <tr>
+                                <tr t-if="_hasMarginsCostsAccessRights()">
                                     <td>Cost:</td>
                                     <td><t t-esc="costCurrency"/></td>
                                 </tr>
-                                <tr>
+                                <tr t-if="_hasMarginsCostsAccessRights()">
                                     <td>Margin:</td>
                                     <td><t t-esc="marginCurrency"/> (<t t-esc="marginPercent"/>%) </td>
                                 </tr>
@@ -78,7 +78,7 @@
                                         <td><span t-esc="supplier.name" class="table-name"/>:</td>
                                         <div class="mobile-line">
                                             <td><t t-esc="supplier.delay"/> Days</td>
-                                            <td><t t-esc="env.pos.format_currency(supplier.price)"/></td>
+                                            <td t-if="_hasMarginsCostsAccessRights()"><t t-esc="env.pos.format_currency(supplier.price)"/></td>
                                         </div>
                                     </tr>
                                 </t>
@@ -118,11 +118,11 @@
                                     <td>Total Price excl. VAT:</td>
                                     <td t-esc="orderPriceWithoutTaxCurrency" class="table-value"/>
                                 </tr>
-                                <tr>
+                                <tr t-if="_hasMarginsCostsAccessRights()">
                                     <td>Total Cost:</td>
                                     <td t-esc="orderCostCurrency" class="table-value"/>
                                 </tr>
-                                <tr>
+                                <tr t-if="_hasMarginsCostsAccessRights()">
                                     <td>Total Margin:</td>
                                     <td class="table-value"><t t-esc="orderMarginCurrency"/> (<t t-esc="orderMarginPercent"/>%)</td>
                                 </tr>

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -377,6 +377,17 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-12 col-lg-6 o_setting_box" id="margins_costs_accessibility">
+                            <div class="o_setting_left_pane">
+                                <field name="is_margins_costs_accessible_to_every_user"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="is_margins_costs_accessible_to_every_user" string="Margins &amp; Costs"/>
+                                <div class="text-muted">
+                                    Show margins &amp; costs on product information
+                                </div>
+                            </div>
+                        </div>
                         <div class="col-12 col-lg-6 o_setting_box" id="pos-loyalty">
                             <div class="o_setting_left_pane">
                                 <field name="module_pos_loyalty" widget="upgrade_boolean" nolabel="1"/>


### PR DESCRIPTION
Currently, the fact that PoS displays to any PoS users the costs and margins
of product (new information popup) makes it difficult to sell in LATAM countries.

In this commit we address this issue by adding the 'Costs & Margins' field
in the settings of each PoS terminal. When this field is disabled, only PoS users
with manager access rights will be able to view the costs and margins data in the
information popup. In order to be compatible with previous behaviour this option
is enabled by default. For this reason, default behaviour is that every PoS user
will have access to the costs and margins of the products.

task-2672063

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
