### PR TITLE
[IMP] calendar: improve event colors

### DIFF
--- a/addons/calendar/static/src/xml/base_calendar.xml
+++ b/addons/calendar/static/src/xml/base_calendar.xml
@@ -69,7 +69,7 @@
     </t>
 
     <t t-name="Calendar.calendar-box">
-        <div t-attf-class="#{record.is_highlighted ? 'o_event_hightlight' : ''} #{typeof color === 'number' ? _.str.sprintf('o_calendar_color_%s', color) : 'o_calendar_color_1'} fc-event o_event o_attendee_status_#{record.is_alone ? 'alone' : record.attendee_status} py-0" >
+        <div t-attf-class="#{record.is_highlighted ? 'o_event_highlight' : ''} #{typeof color === 'number' ? _.str.sprintf('o_calendar_color_%s', color) : 'o_calendar_color_1'} fc-event o_event o_attendee_status_#{record.is_alone ? 'alone' : record.attendee_status} py-0" >
             <div class="o_event_title mr-2">
                 <span t-if="record.is_alone" class="fa fa-exclamation-circle"/>
                 <t t-esc="record.display_name"/>

--- a/addons/calendar/static/src/xml/base_calendar.xml
+++ b/addons/calendar/static/src/xml/base_calendar.xml
@@ -69,8 +69,8 @@
     </t>
 
     <t t-name="Calendar.calendar-box">
-        <div t-attf-class="#{record.is_highlighted ? 'o_event_highlight' : ''} #{typeof color === 'number' ? _.str.sprintf('o_calendar_color_%s', color) : 'o_calendar_color_1'} fc-event o_event o_attendee_status_#{record.is_alone ? 'alone' : record.attendee_status} py-0" >
-            <div class="o_event_title mr-2">
+        <div t-attf-class="#{record.is_highlighted ? 'o_event_hightlight' : ''} #{typeof color === 'number' ? _.str.sprintf('o_calendar_color_%s', color) : 'o_calendar_color_1'} fc-event o_event o_attendee_status_#{record.is_alone ? 'alone' : record.attendee_status} py-0" >
+            <div t-attf-class="#{record.attendee_status != 'accepted' ? 'font-weight-normal' : ''} o_event_title mr-2">
                 <span t-if="record.is_alone" class="fa fa-exclamation-circle"/>
                 <t t-esc="record.display_name"/>
             </div>

--- a/addons/web/static/src/legacy/scss/web_calendar.scss
+++ b/addons/web/static/src/legacy/scss/web_calendar.scss
@@ -876,7 +876,7 @@ $o-filter_colors: lighten(#000, 46.7%), #F06050, #F4A460, #F7CD1F, #6CC1ED, #814
             color: darken($color, 45%);
             opacity: 1;
 
-            &.o_event_hightlight {
+            &.o_event_highlight {
                 opacity: 1;
 
                 .fc-content {

--- a/addons/web/static/src/legacy/scss/web_calendar.scss
+++ b/addons/web/static/src/legacy/scss/web_calendar.scss
@@ -885,9 +885,9 @@ $o-filter_colors: lighten(#000, 46.7%), #F06050, #F4A460, #F7CD1F, #6CC1ED, #814
             }
 
             &:not(.o_calendar_hatched):not(.o_calendar_striked){
-                background: $color;
+                background: scale-color($color, $lightness: 50%);
                 .fc-bg {
-                    background: mix($color, white);
+                    background: scale-color($color, $lightness: 50%);
                 }
             }
 

--- a/addons/web/static/src/legacy/xml/web_calendar.xml
+++ b/addons/web/static/src/legacy/xml/web_calendar.xml
@@ -12,7 +12,7 @@
     </div>
 
     <t t-name="calendar-box">
-        <div t-att-style="typeof color === 'string' ? ('background-color:' + color) + ';' : ''" t-attf-class="o_event #{record.is_highlighted ? 'o_event_hightlight' : ''} #{typeof color === 'number' ? _.str.sprintf('o_calendar_color_%s', color) : 'o_calendar_color_1'} #{record.is_hatched ? 'o_calendar_hatched o_calendar_hatched_' + (typeof color === 'number' ? color : 1): ''} #{record.is_striked ? 'o_calendar_striked o_calendar_striked_' + (typeof color === 'number' ? color : 1): ''}">
+        <div t-att-style="typeof color === 'string' ? ('background-color:' + color) + ';' : ''" t-attf-class="o_event #{record.is_highlighted ? 'o_event_highlight' : ''} #{typeof color === 'number' ? _.str.sprintf('o_calendar_color_%s', color) : 'o_calendar_color_1'} #{record.is_hatched ? 'o_calendar_hatched o_calendar_hatched_' + (typeof color === 'number' ? color : 1): ''} #{record.is_striked ? 'o_calendar_striked o_calendar_striked_' + (typeof color === 'number' ? color : 1): ''}">
             <span t-if="showTime" class="fc-time"/>
             <div class="o_event_title" t-esc="record.display_name"/>
             <div t-if="showLocation and record.location" t-esc="record.location"/>


### PR DESCRIPTION
In calendar events, the displayed colors are a bit dark and meeting
names in black don't have enough contrast. This commit fixes this
issue and improves general design of the calendar module.

task-2704288

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
