### PR TITLE
[FIX] l10n_fr_pos_cert: should only prevent on explicit order deletion

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/js/pos.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/pos.js
@@ -54,10 +54,10 @@ models.Order = models.Order.extend({
       result = Boolean(result || this.pos.is_french_country());
       return result;
     },
-    destroy: function(reason) {
+    destroy: function(option) {
         // SUGGESTION: It's probably more appropriate to apply this restriction
         // in the TicketScreen.
-        if (this.pos.is_french_country() && this.get_orderlines().length) {
+        if (option && option.reason == 'abandon' && this.pos.is_french_country() && this.get_orderlines().length) {
             Gui.showPopup("ErrorPopup", {
                 'title': _t("Fiscal Data Module error"),
                 'body':  _t("Deleting of orders is not allowed."),


### PR DESCRIPTION
It's not allowed to delete order for french certification which was
supposed to be fixed here: 46ffe6d3fba3baf1d84af732feaac71dabaaf35f
However, it introduced another problem of not being able to delete
the finalized/validated orders. It's because the check of preventing
the deletion, we are not discriminating the validated order. This
commit fixes the issue by only applying the rule on orders that are
being explicitly deleted (reason of deletion is "abandon").

TICKET-ID: 2710892


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
