### PR TITLE
[REF] web: remove datetime-changed event in preparation for owl-2

### DIFF
--- a/addons/web/static/src/core/datepicker/datepicker.js
+++ b/addons/web/static/src/core/datepicker/datepicker.js
@@ -171,15 +171,15 @@ export class DatePicker extends Component {
 
     /**
      * Called either when the input value has changed or when the boostrap
-     * datepicker is closed. The actual "datetime-changed" emitted by the
-     * component is only triggered if the date value has changed.
+     * datepicker is closed. The onDateTimeChanged prop is only called if the
+     * date value has changed.
      */
     onDateChange() {
         try {
             const date = this.parse(this.inputRef.el.value, this.options);
             if (!date.equals(this.props.date)) {
                 this.state.warning = date > DateTime.local();
-                this.trigger("datetime-changed", { date });
+                this.props.onDateTimeChanged(date);
             }
         } catch (err) {
             // Reset to default (= given) date.
@@ -217,6 +217,7 @@ DatePicker.defaultProps = {
 };
 DatePicker.props = {
     // Components props
+    onDateTimeChanged: Function,
     date: DateTime,
     warn_future: { type: Boolean, optional: true },
     // Bootstrap datepicker options

--- a/addons/web/static/src/legacy/js/components/datepicker.js
+++ b/addons/web/static/src/legacy/js/components/datepicker.js
@@ -48,11 +48,15 @@ odoo.define('web.DatePickerOwl', function (require) {
         }
 
         willUnmount() {
+            $(this.el).off('show.datetimepicker hide.datetimepicker error.datetimepicker');
             this._datetimepicker('destroy');
         }
 
         willUpdateProps(nextProps) {
             for (const prop in nextProps) {
+                if (prop == "onDateTimeChanged") {
+                    continue;
+                }
                 this._datetimepicker(prop, nextProps[prop]);
             }
             if (nextProps.date) {
@@ -122,7 +126,7 @@ odoo.define('web.DatePickerOwl', function (require) {
         _onDateTimePickerHide() {
             const date = this._parseInput(this.inputRef.el.value);
             this.state.warning = date.format('YYYY-MM-DD') > moment().format('YYYY-MM-DD');
-            this.trigger('datetime-changed', { date });
+            this.props.onDateTimeChanged(date);
         }
 
         /**
@@ -149,7 +153,7 @@ odoo.define('web.DatePickerOwl', function (require) {
             const date = this._parseInput(this.inputRef.el.value);
             if (date) {
                 this.state.warning = date.format('YYYY-MM-DD') > moment().format('YYYY-MM-DD');
-                this.trigger('datetime-changed', { date });
+                this.props.onDateTimeChanged(date);
             } else {
                 this.inputRef.el.value = this._formatDate(this.props.date);
             }
@@ -187,6 +191,8 @@ odoo.define('web.DatePickerOwl', function (require) {
     DatePicker.props = {
         // Actual date value
         date: moment,
+        // function to call when the date/time changed
+        onDateTimeChanged: Function,
         // Other props
         buttons: {
             type: Object,

--- a/addons/web/static/src/legacy/js/control_panel/custom_filter_item.js
+++ b/addons/web/static/src/legacy/js/control_panel/custom_filter_item.js
@@ -205,10 +205,10 @@ odoo.define('web.CustomFilterItem', function (require) {
          * @private
          * @param {Object} condition
          * @param {number} valueIndex
-         * @param {OwlEvent} ev
+         * @param {Date} date
          */
-        onDateChanged(condition, valueIndex, ev) {
-            condition.value[valueIndex] = ev.detail.date;
+        onDateTimeChanged(condition, valueIndex, date) {
+            condition.value[valueIndex] = date;
         }
 
         /**

--- a/addons/web/static/src/search/filter_menu/custom_filter_item.js
+++ b/addons/web/static/src/search/filter_menu/custom_filter_item.js
@@ -257,10 +257,10 @@ export class CustomFilterItem extends Component {
     /**
      * @param {Object} condition
      * @param {number} valueIndex
-     * @param {OwlEvent} ev
+     * @param {Date} ev
      */
-    onDateChanged(condition, valueIndex, ev) {
-        condition.value[valueIndex] = ev.detail.date;
+    onDateTimeChanged(condition, valueIndex, date) {
+        condition.value[valueIndex] = date;
     }
 
     /**

--- a/addons/web/static/src/search/filter_menu/custom_filter_item.xml
+++ b/addons/web/static/src/search/filter_menu/custom_filter_item.xml
@@ -33,21 +33,21 @@
                         <t t-if="fieldType === 'date'">
                             <DatePicker
                                 date="condition.value[0]"
-                                t-on-datetime-changed="onDateChanged(condition, 0)"
+                                onDateTimeChanged="date => this.onDateTimeChanged(condition, 0, date)"
                             />
                             <DatePicker t-if="selectedOperator.symbol === 'between'"
                                 date="condition.value[1]"
-                                t-on-datetime-changed="onDateChanged(condition, 1)"
+                                onDateTimeChanged="date => this.onDateTimeChanged(condition, 1, date)"
                             />
                         </t>
                         <t t-elif="fieldType === 'datetime'">
                             <DateTimePicker
                                 date="condition.value[0]"
-                                t-on-datetime-changed="onDateChanged(condition, 0)"
+                                onDateTimeChanged="date => this.onDateTimeChanged(condition, 0, date)"
                             />
                             <DateTimePicker t-if="selectedOperator.symbol === 'between'"
                                 date="condition.value[1]"
-                                t-on-datetime-changed="onDateChanged(condition, 1)"
+                                onDateTimeChanged="date => this.onDateTimeChanged(condition, 1, date)"
                             />
                         </t>
                         <select t-elif="fieldType === 'selection'" class="o_input"

--- a/addons/web/static/tests/core/datepicker_tests.js
+++ b/addons/web/static/tests/core/datepicker_tests.js
@@ -15,10 +15,11 @@ const serviceRegistry = registry.category("services");
 
 /**
  * @param {typeof DatePicker} Picker
- * @param {{ props: any, onDateChange: () => any }} [params={}]
+ * @param {Object} props
+ * @param {DateTime} props.date
  * @returns {Promise<DatePicker>}
  */
-const mountPicker = async (Picker, { props, onDateChange } = {}) => {
+const mountPicker = async (Picker, props) => {
     serviceRegistry
         .add(
             "localization",
@@ -31,12 +32,15 @@ const mountPicker = async (Picker, { props, onDateChange } = {}) => {
 
     class Parent extends Component {}
     Parent.template = xml/* xml */ `
-        <t t-component="props.Picker" t-props="props.props" t-on-datetime-changed="props.onDateChange" />
+        <t t-component="props.Picker" t-props="props.props"/>
     `;
 
     const env = await makeTestEnv();
     const target = getFixture();
-    const parent = await mount(Parent, { env, props: { Picker, props, onDateChange }, target });
+    if (!props.onDateTimeChanged) {
+        props.onDateTimeChanged = () => {};
+    }
+    const parent = await mount(Parent, { env, props: { Picker, props }, target });
     registerCleanup(() => parent.destroy());
     return parent;
 };
@@ -70,9 +74,7 @@ QUnit.module("Components", () => {
         assert.expect(8);
 
         const picker = await mountPicker(DatePicker, {
-            props: {
-                date: DateTime.fromFormat("09/01/1997", "dd/MM/yyyy", { zone: "utc" }),
-            },
+            date: DateTime.fromFormat("09/01/1997", "dd/MM/yyyy", { zone: "utc" }),
         });
 
         assert.containsOnce(picker, "input.o_input.o_datepicker_input");
@@ -102,13 +104,11 @@ QUnit.module("Components", () => {
         assert.expect(5);
 
         const picker = await mountPicker(DatePicker, {
-            props: {
-                date: DateTime.fromFormat("09/01/1997", "dd/MM/yyyy", { zone: "utc" }),
-            },
-            onDateChange: (ev) => {
+            date: DateTime.fromFormat("09/01/1997", "dd/MM/yyyy", { zone: "utc" }),
+            onDateTimeChanged: (date) => {
                 assert.step("datetime-changed");
                 assert.strictEqual(
-                    ev.detail.date.toFormat("dd/MM/yyyy"),
+                    date.toFormat("dd/MM/yyyy"),
                     "08/02/1997",
                     "Event should transmit the correct date"
                 );
@@ -131,15 +131,13 @@ QUnit.module("Components", () => {
         assert.expect(5);
 
         const picker = await mountPicker(DatePicker, {
-            props: {
-                date: DateTime.fromFormat("09/01/1997", "dd/MM/yyyy", { zone: "utc" }),
-                format: "dd MMM, yyyy",
-                locale: useFRLocale(),
-            },
-            onDateChange: (ev) => {
+            date: DateTime.fromFormat("09/01/1997", "dd/MM/yyyy", { zone: "utc" }),
+            format: "dd MMM, yyyy",
+            locale: useFRLocale(),
+            onDateTimeChanged: (date) => {
                 assert.step("datetime-changed");
                 assert.strictEqual(
-                    ev.detail.date.toFormat("dd/MM/yyyy"),
+                    date.toFormat("dd/MM/yyyy"),
                     "01/09/1997",
                     "Event should transmit the correct date"
                 );
@@ -162,17 +160,15 @@ QUnit.module("Components", () => {
         assert.expect(5);
 
         const picker = await mountPicker(DatePicker, {
-            props: {
-                date: DateTime.fromFormat("09/01/1997", "dd/MM/yyyy", {
-                    zone: "utc",
-                    locale: useFRLocale(),
-                }),
-                format: "dd MMM, yyyy",
-            },
-            onDateChange: (ev) => {
+            date: DateTime.fromFormat("09/01/1997", "dd/MM/yyyy", {
+                zone: "utc",
+                locale: useFRLocale(),
+            }),
+            format: "dd MMM, yyyy",
+            onDateTimeChanged: (date) => {
                 assert.step("datetime-changed");
                 assert.strictEqual(
-                    ev.detail.date.toFormat("dd/MM/yyyy"),
+                    date.toFormat("dd/MM/yyyy"),
                     "01/09/1997",
                     "Event should transmit the correct date"
                 );
@@ -195,13 +191,11 @@ QUnit.module("Components", () => {
         assert.expect(5);
 
         const picker = await mountPicker(DatePicker, {
-            props: {
-                date: DateTime.fromFormat("09/01/1997", "dd/MM/yyyy", { zone: "utc" }),
-            },
-            onDateChange: (ev) => {
+            date: DateTime.fromFormat("09/01/1997", "dd/MM/yyyy", { zone: "utc" }),
+            onDateTimeChanged: (date) => {
                 assert.step("datetime-changed");
                 assert.strictEqual(
-                    ev.detail.date.toFormat("dd/MM/yyyy"),
+                    date.toFormat("dd/MM/yyyy"),
                     "08/02/1997",
                     "Event should transmit the correct date"
                 );
@@ -229,10 +223,8 @@ QUnit.module("Components", () => {
         assert.expect(2);
 
         const picker = await mountPicker(DatePicker, {
-            props: {
-                date: DateTime.fromFormat("09/01/1997", "dd/MM/yyyy", { zone: "utc" }),
-                format: "yyyy/MM/dd",
-            },
+            date: DateTime.fromFormat("09/01/1997", "dd/MM/yyyy", { zone: "utc" }),
+            format: "yyyy/MM/dd",
         });
         const input = picker.el.querySelector(".o_datepicker_input");
 
@@ -250,9 +242,7 @@ QUnit.module("Components", () => {
         assert.expect(11);
 
         const picker = await mountPicker(DateTimePicker, {
-            props: {
-                date: DateTime.fromFormat("09/01/1997 12:30:01", "dd/MM/yyyy HH:mm:ss"),
-            },
+            date: DateTime.fromFormat("09/01/1997 12:30:01", "dd/MM/yyyy HH:mm:ss"),
         });
 
         assert.containsOnce(picker, "input.o_input.o_datepicker_input");
@@ -298,11 +288,11 @@ QUnit.module("Components", () => {
         assert.expect(5);
 
         const picker = await mountPicker(DateTimePicker, {
-            props: { date: DateTime.fromFormat("09/01/1997 12:30:01", "dd/MM/yyyy HH:mm:ss") },
-            onDateChange: (ev) => {
+            date: DateTime.fromFormat("09/01/1997 12:30:01", "dd/MM/yyyy HH:mm:ss"),
+            onDateTimeChanged: (date) => {
                 assert.step("datetime-changed");
                 assert.strictEqual(
-                    ev.detail.date.toFormat("dd/MM/yyyy HH:mm:ss"),
+                    date.toFormat("dd/MM/yyyy HH:mm:ss"),
                     "08/02/1997 15:45:05",
                     "Event should transmit the correct date"
                 );
@@ -332,15 +322,13 @@ QUnit.module("Components", () => {
         assert.expect(6);
 
         const picker = await mountPicker(DateTimePicker, {
-            props: {
-                date: DateTime.fromFormat("09/01/1997 12:30:01", "dd/MM/yyyy HH:mm:ss"),
-                format: "dd MMM, yyyy HH:mm:ss",
-                locale: useFRLocale(),
-            },
-            onDateChange: (ev) => {
+            date: DateTime.fromFormat("09/01/1997 12:30:01", "dd/MM/yyyy HH:mm:ss"),
+            format: "dd MMM, yyyy HH:mm:ss",
+            locale: useFRLocale(),
+            onDateTimeChanged: (date) => {
                 assert.step("datetime-changed");
                 assert.strictEqual(
-                    ev.detail.date.toFormat("dd/MM/yyyy HH:mm:ss"),
+                    date.toFormat("dd/MM/yyyy HH:mm:ss"),
                     "01/09/1997 15:45:05",
                     "Event should transmit the correct date"
                 );
@@ -376,11 +364,11 @@ QUnit.module("Components", () => {
         assert.expect(9);
 
         const picker = await mountPicker(DateTimePicker, {
-            props: { date: DateTime.fromFormat("09/01/1997 12:30:01", "dd/MM/yyyy HH:mm:ss") },
-            onDateChange: (ev) => {
+            date: DateTime.fromFormat("09/01/1997 12:30:01", "dd/MM/yyyy HH:mm:ss"),
+            onDateTimeChanged: (date) => {
                 assert.step("datetime-changed");
                 assert.strictEqual(
-                    ev.detail.date.toFormat("dd/MM/yyyy HH:mm:ss"),
+                    date.toFormat("dd/MM/yyyy HH:mm:ss"),
                     "08/02/1997 15:45:05",
                     "Event should transmit the correct date"
                 );
@@ -424,10 +412,8 @@ QUnit.module("Components", () => {
         assert.expect(2);
 
         const picker = await mountPicker(DateTimePicker, {
-            props: {
-                date: DateTime.fromFormat("09/01/1997 12:30:01", "dd/MM/yyyy HH:mm:ss"),
-                format: "HH:mm:ss yyyy/MM/dd",
-            },
+            date: DateTime.fromFormat("09/01/1997 12:30:01", "dd/MM/yyyy HH:mm:ss"),
+            format: "HH:mm:ss yyyy/MM/dd",
         });
         const input = picker.el.querySelector(".o_datepicker_input");
 

--- a/addons/web/static/tests/legacy/components/datepicker_tests.js
+++ b/addons/web/static/tests/legacy/components/datepicker_tests.js
@@ -15,7 +15,7 @@ odoo.define('web.datepicker_tests', function (require) {
             assert.expect(8);
 
             const picker = await createComponent(DatePicker, {
-                props: { date: moment('1997-01-09') },
+                props: { date: moment('1997-01-09'), onDateTimeChanged: () => {} },
             });
 
 
@@ -47,11 +47,11 @@ odoo.define('web.datepicker_tests', function (require) {
             assert.expect(5);
 
             const picker = await createComponent(DatePicker, {
-                props: { date: moment('1997-01-09') },
-                intercepts: {
-                    'datetime-changed': ev => {
+                props: {
+                    date: moment('1997-01-09'),
+                    onDateTimeChanged: date => {
                         assert.step('datetime-changed');
-                        assert.strictEqual(ev.detail.date.format('MM/DD/YYYY'), '02/08/1997',
+                        assert.strictEqual(date.format('MM/DD/YYYY'), '02/08/1997',
                             "Event should transmit the correct date");
                     },
                 }
@@ -88,11 +88,11 @@ odoo.define('web.datepicker_tests', function (require) {
                     date_format: "%d %b, %Y", // Those are important too
                     time_format: "%H:%M:%S",
                 },
-                props: { date: moment('09/01/1997', 'MM/DD/YYYY') },
-                intercepts: {
-                    'datetime-changed': ev => {
+                props: {
+                    date: moment('09/01/1997', 'MM/DD/YYYY'),
+                    onDateTimeChanged: date => {
                         assert.step('datetime-changed');
-                        assert.strictEqual(ev.detail.date.format('MM/DD/YYYY'), '09/02/1997',
+                        assert.strictEqual(date.format('MM/DD/YYYY'), '09/02/1997',
                             "Event should transmit the correct date");
                         hasChanged.resolve();
                     },
@@ -116,11 +116,11 @@ odoo.define('web.datepicker_tests', function (require) {
             assert.expect(5);
 
             const picker = await createComponent(DatePicker, {
-                props: { date: moment('1997-01-09') },
-                intercepts: {
-                    'datetime-changed': ev => {
+                props: {
+                    date: moment('1997-01-09'),
+                    onDateTimeChanged: date => {
                         assert.step('datetime-changed');
-                        assert.strictEqual(ev.detail.date.format('MM/DD/YYYY'), '02/08/1997',
+                        assert.strictEqual(date.format('MM/DD/YYYY'), '02/08/1997',
                             "Event should transmit the correct date");
                     },
                 }
@@ -149,7 +149,7 @@ odoo.define('web.datepicker_tests', function (require) {
 
             testUtils.mock.patch(time, { getLangDateFormat: () => "YYYY/MM/DD" });
             const picker = await createComponent(DatePicker, {
-                props: { date: moment('1997-01-09') },
+                props: { date: moment('1997-01-09'), onDateTimeChanged: () => {} },
             });
             const input = picker.el.querySelector('.o_datepicker_input');
 
@@ -170,7 +170,7 @@ odoo.define('web.datepicker_tests', function (require) {
             assert.expect(11);
 
             const picker = await createComponent(DateTimePicker, {
-                props: { date: moment('1997-01-09 12:30:01') },
+                props: { date: moment('1997-01-09 12:30:01'), onDateTimeChanged: () => {} },
             });
 
             assert.containsOnce(picker, 'input.o_input.o_datepicker_input');
@@ -205,11 +205,11 @@ odoo.define('web.datepicker_tests', function (require) {
             assert.expect(5);
 
             const picker = await createComponent(DateTimePicker, {
-                props: { date: moment('1997-01-09 12:30:01') },
-                intercepts: {
-                    'datetime-changed': ev => {
+                props: {
+                    date: moment('1997-01-09 12:30:01'),
+                    onDateTimeChanged: date => {
                         assert.step('datetime-changed');
-                        assert.strictEqual(ev.detail.date.format('MM/DD/YYYY HH:mm:ss'), '02/08/1997 15:45:05',
+                        assert.strictEqual(date.format('MM/DD/YYYY HH:mm:ss'), '02/08/1997 15:45:05',
                             "Event should transmit the correct date");
                     },
                 }
@@ -253,11 +253,11 @@ odoo.define('web.datepicker_tests', function (require) {
                     date_format: "%d %b, %Y", // Those are important too
                     time_format: "%H:%M:%S",
                 },
-                props: { date: moment('09/01/1997 12:30:01', 'MM/DD/YYYY HH:mm:ss') },
-                intercepts: {
-                    'datetime-changed': ev => {
+                props: {
+                    date: moment('09/01/1997 12:30:01', 'MM/DD/YYYY HH:mm:ss'),
+                    onDateTimeChanged: date => {
                         assert.step('datetime-changed');
-                        assert.strictEqual(ev.detail.date.format('MM/DD/YYYY HH:mm:ss'), '09/02/1997 15:45:05',
+                        assert.strictEqual(date.format('MM/DD/YYYY HH:mm:ss'), '09/02/1997 15:45:05',
                             "Event should transmit the correct date");
                         hasChanged.resolve();
                     },
@@ -293,11 +293,11 @@ odoo.define('web.datepicker_tests', function (require) {
             assert.expect(9);
 
             const picker = await createComponent(DateTimePicker, {
-                props: { date: moment('1997-01-09 12:30:01') },
-                intercepts: {
-                    'datetime-changed': ev => {
+                props: {
+                    date: moment('1997-01-09 12:30:01'),
+                    onDateTimeChanged: date => {
                         assert.step('datetime-changed');
-                        assert.strictEqual(ev.detail.date.format('MM/DD/YYYY HH:mm:ss'), '02/08/1997 15:45:05',
+                        assert.strictEqual(date.format('MM/DD/YYYY HH:mm:ss'), '02/08/1997 15:45:05',
                             "Event should transmit the correct date");
                     },
                 }
@@ -333,7 +333,7 @@ odoo.define('web.datepicker_tests', function (require) {
 
             testUtils.mock.patch(time, { getLangDatetimeFormat: () => "hh:mm:ss YYYY/MM/DD" });
             const picker = await createComponent(DateTimePicker, {
-                props: { date: moment('1997-01-09 12:30:01') },
+                props: { date: moment('1997-01-09 12:30:01'), onDateTimeChanged: () => {} },
             });
             const input = picker.el.querySelector('.o_datepicker_input');
 


### PR DESCRIPTION
In owl-2, t-on will no longer be supported on components. This commit
converts the datetime-changed event to use a callback-prop based
approach.
