### PR TITLE
[IMP] hr_skills: remove skills edit buttons when no rights

### DIFF
--- a/addons/hr_skills/static/src/css/hr_skills.scss
+++ b/addons/hr_skills/static/src/css/hr_skills.scss
@@ -16,9 +16,14 @@
             }
         }
 
-        // Use 'cursor:pointer' where is needed only
+        &.o_hr_skills_editable {
+            .o_data_row {
+                cursor: pointer;
+            }
+        }
+
         .o_data_row {
-            cursor: pointer;
+            cursor: default;
         }
 
         // Deny user interaction to headers but keep access to buttons

--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -59,7 +59,7 @@
             <xpath expr="//page[@name='public']" position="before">
                 <page name="public" string="Resumé">
                     <div class="row">
-                        <div class="o_hr_skills_group o_group_resume col-lg-7 d-flex">
+                        <div class="o_hr_skills_editable o_hr_skills_group o_group_resume col-lg-7 d-flex">
                             <!-- This field uses a custom tree view rendered by the 'hr_resume' widget.
                                 Adding fields in the tree arch below makes them accessible to the widget
                             -->
@@ -74,7 +74,7 @@
                                 </tree>
                             </field>
                         </div>
-                        <div class="o_hr_skills_group o_group_skills col-lg-5 d-flex flex-column">
+                        <div class="o_hr_skills_editable o_hr_skills_group o_group_skills col-lg-5 d-flex flex-column">
                             <separator string="Skills"/>
                             <field mode="tree" nolabel="1" name="employee_skill_ids"  widget="hr_skills">
                                 <tree>
@@ -104,7 +104,7 @@
                             <!-- This field uses a custom tree view rendered by the 'hr_resume' widget.
                                 Adding fields in the tree arch below makes them accessible to the widget
                             -->
-                            <field mode="tree" nolabel="1" name="resume_line_ids" widget="hr_resume">
+                            <field mode="tree" nolabel="1" name="resume_line_ids" widget="hr_resume" attrs="{'readonly': True}" options="{'no_open': True}">
                                 <tree>
                                     <field name="line_type_id"/>
                                     <field name="name"/>
@@ -117,7 +117,7 @@
                         </div>
                         <div class="o_hr_skills_group o_group_skills col-lg-5 d-flex flex-column">
                             <separator string="Skills"/>
-                            <field mode="tree" nolabel="1" name="employee_skill_ids"  widget="hr_skills">
+                            <field mode="tree" nolabel="1" name="employee_skill_ids"  widget="hr_skills" attrs="{'readonly': True}"  options="{'no_open': True}">
                                 <tree>
                                     <field name="skill_type_id" invisible="1"/>
                                     <field name="skill_id"/>


### PR DESCRIPTION
When the user has no rights on the Employee app, he can still
see the information on the employee public view
If the skills module is installed, there are add and remove buttons
displayed even in the absence of user rights.

Buttons should be hidden if the user has no rights to edit the
skills and resume

task-2702678

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
