### PR TITLE
[IMP] web: show add button in kanban view without edit

### DIFF
--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -1154,7 +1154,7 @@ var FieldX2Many = AbstractField.extend(WidgetAdapterMixin, {
                                             !!JSON.parse(arch.attrs.delete) :
                                             true;
             this.editable = arch.attrs.editable;
-            this._canQuickEdit = arch.tag === 'tree';
+            this._canQuickEdit = true;
         } else {
             this._canQuickEdit = false;
         }
@@ -1539,7 +1539,7 @@ var FieldX2Many = AbstractField.extend(WidgetAdapterMixin, {
      * @private
      */
     _renderButtons: function () {
-        if (!this.isReadonly && this.view.arch.tag === 'kanban') {
+        if (this.view.arch.tag === 'kanban') {
             const renderingContext = this._getButtonsRenderingContext();
             this.$buttons = $(qweb.render('KanbanView.buttons', renderingContext));
             this.$buttons.on('click', 'button.o-kanban-button-new', this._onAddRecord.bind(this));

--- a/addons/web/static/tests/legacy/fields/relational_fields/field_many2many_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields/field_many2many_tests.js
@@ -186,8 +186,8 @@ QUnit.module('fields', {}, function () {
 
             assert.ok(!form.$('.o_kanban_view .delete_icon').length,
                 'delete icon should not be visible in readonly');
-            assert.ok(!form.$('.o_field_many2many .o-kanban-button-new').length,
-                '"Add" button should not be visible in readonly');
+            assert.ok(form.$('.o_field_many2many .o-kanban-button-new').length,
+                '"Add" button should be visible in readonly');
 
             await testUtils.form.clickEdit(form);
 
@@ -335,8 +335,8 @@ QUnit.module('fields', {}, function () {
                 session: { user_context: {} },
             });
 
-            assert.ok(!form.$('.o-kanban-button-new').length,
-                '"Add" button should not be available in readonly');
+            assert.ok(form.$('.o-kanban-button-new').length,
+                '"Add" button should be available in readonly');
 
             await testUtils.form.clickEdit(form);
 

--- a/addons/web/static/tests/legacy/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields/field_one2many_tests.js
@@ -2432,8 +2432,8 @@ QUnit.module('fields', {}, function () {
 
             assert.ok(!form.$('.o_kanban_view .delete_icon').length,
                 'delete icon should not be visible in readonly');
-            assert.ok(!form.$('.o_field_one2many .o-kanban-button-new').length,
-                '"Create" button should not be visible in readonly');
+            assert.ok(form.$('.o_field_one2many .o-kanban-button-new').length,
+                '"Create" button should be visible in readonly');
 
             await testUtils.form.clickEdit(form);
 
@@ -5870,9 +5870,6 @@ QUnit.module('fields', {}, function () {
             // click on the button
             await testUtils.dom.click(form.$(btn1Disabled));
             await testUtils.dom.click(form.$(btn1Warn));
-
-            // switch to edit mode
-            await testUtils.form.clickEdit(form);
 
             // click on existing buttons
             await testUtils.dom.click(form.$(btn1Disabled));


### PR DESCRIPTION
Purpose
=======
Show to users how they can create sub-elements without them needing to go into edit more.

Task-2710543