### PR TITLE
[IMP] payment(_*): imp. handling of webhook notif.

### DIFF
--- a/addons/payment/tests/common.py
+++ b/addons/payment/tests/common.py
@@ -6,6 +6,7 @@ from odoo.addons.account.models.account_payment_method import AccountPaymentMeth
 from odoo.fields import Command
 
 from odoo.addons.payment.tests.utils import PaymentTestUtils
+from odoo import _
 
 _logger = logging.getLogger(__name__)
 
@@ -172,3 +173,11 @@ class PaymentCommon(PaymentTestUtils):
         return self.env['payment.transaction'].sudo().search([
             ('reference', '=', reference),
         ])
+
+    def _assert_not_raises(self, exception_type, my_func, *args):
+        """ Check if a certain type of exception is not raise """
+        try:
+            my_func(*args)
+        except exception_type:
+            self.fail(_("%(func)s raised %(exp)s unexpectedly!",
+                        func=my_func.__name__, exp=exception_type.__name__))

--- a/addons/payment/tests/http_common.py
+++ b/addons/payment/tests/http_common.py
@@ -46,8 +46,18 @@ class PaymentHttpCommon(PaymentTestUtils, HttpCase):
                 formatted_data[k] = v
         return self.opener.get(url, params=formatted_data)
 
-    def _make_json_request(self, url, params):
-        data = self._build_jsonrpc_payload(params)
+    def _make_http_post_request(self, url, params):
+        # Data formatting
+        formatted_data = dict()
+        for k, v in params.items():
+            if isinstance(v, float):
+                formatted_data[k] = str(v)
+            else:
+                formatted_data[k] = v
+        return self.opener.post(url, data=formatted_data)
+
+    def _make_json_request(self, url, params, prepare_payload=True):
+        data = self._build_jsonrpc_payload(params) if prepare_payload else params
         return self.opener.post(url, json=data)
 
     def _get_tx_context(self, response, form_name):

--- a/addons/payment_adyen/tests/common.py
+++ b/addons/payment_adyen/tests/common.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.addons.payment.tests.common import PaymentCommon
 
-
 class AdyenCommon(PaymentCommon):
 
     @classmethod
@@ -12,7 +11,7 @@ class AdyenCommon(PaymentCommon):
             'adyen_merchant_account': 'dummy',
             'adyen_api_key': 'dummy',
             'adyen_client_key': 'dummy',
-            'adyen_hmac_key': 'dummy',
+            'adyen_hmac_key': '12345678',
             'adyen_checkout_api_url': 'https://this.is.an.url',
             'adyen_recurring_api_url': 'https://this.is.an.url',
         })

--- a/addons/payment_alipay/tests/test_alipay.py
+++ b/addons/payment_alipay/tests/test_alipay.py
@@ -3,19 +3,23 @@
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 from odoo.tools import mute_logger
+from werkzeug.exceptions import Forbidden
+from unittest.mock import patch
+
 
 from .common import AlipayCommon
 from ..controllers.main import AlipayController
+from odoo.addons.payment.tests.http_common import PaymentHttpCommon
 
 
 @tagged('post_install', '-at_install')
-class AlipayTest(AlipayCommon):
+class AlipayTest(AlipayCommon, PaymentHttpCommon):
 
     def test_compatible_acquirers(self):
         self.alipay.alipay_payment_method = 'express_checkout'
         acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
             partner_id=self.partner.id,
-            currency_id=self.currency_yuan.id, # 'CNY'
+            currency_id=self.currency_yuan.id,  # 'CNY'
             company_id=self.company.id,
         )
         self.assertIn(self.alipay, acquirers)
@@ -29,7 +33,7 @@ class AlipayTest(AlipayCommon):
         self.alipay.alipay_payment_method = 'standard_checkout'
         acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
             partner_id=self.partner.id,
-            currency_id=self.currency_yuan.id, # 'CNY'
+            currency_id=self.currency_yuan.id,  # 'CNY'
             company_id=self.company.id,
         )
         self.assertIn(self.alipay, acquirers)
@@ -49,7 +53,7 @@ class AlipayTest(AlipayCommon):
         self._test_alipay_redirect_form()
 
     def _test_alipay_redirect_form(self):
-        tx = self.create_transaction(flow='redirect') # Only flow implemented
+        tx = self.create_transaction(flow='redirect')  # Only flow implemented
 
         expected_values = {
             '_input_charset': 'utf-8',
@@ -58,7 +62,7 @@ class AlipayTest(AlipayCommon):
             'partner': self.alipay.alipay_merchant_partner_id,
             'return_url': self._build_url(AlipayController._return_url),
             'subject': self.reference,
-            'total_fee': str(self.amount), # Fees disabled by default
+            'total_fee': str(self.amount),  # Fees disabled by default
         }
 
         if self.alipay.alipay_payment_method == 'standard_checkout':
@@ -153,7 +157,7 @@ class AlipayTest(AlipayCommon):
             })
 
         alipay_post_data['sign'] = self.alipay._alipay_build_sign(alipay_post_data)
-        with self.assertRaises(ValidationError): # unknown transactiion
+        with self.assertRaises(ValidationError):  # unknown transaction
             self.env['payment.transaction']._handle_feedback_data('alipay', alipay_post_data)
 
         tx = self.env['payment.transaction'].create({
@@ -182,7 +186,7 @@ class AlipayTest(AlipayCommon):
 
         self.env['payment.transaction']._handle_feedback_data('alipay', alipay_post_data)
         self.assertEqual(tx.acquirer_reference, '2017112321001003690200384552',
-            'Alipay: notification should not go throught since it has already been validated')
+            'Alipay: notification should not go through since it has already been validated')
 
         # this time it should go through since the transaction is not validated yet
         tx.write({'state': 'draft', 'acquirer_reference': False})
@@ -191,3 +195,46 @@ class AlipayTest(AlipayCommon):
             'Alipay: wrong state after receiving a valid pending notification')
         self.assertEqual(tx.acquirer_reference, '2017112321001003690200384552',
             'Alipay: wrong txn_id after receiving a valid pending notification')
+
+    def test_webhook(self):
+        """ Verify the correctness of error handling during the webhook. """
+
+        webhook_url = self._build_url(AlipayController._notify_url)
+        # Create dummy payload
+        self.reference = 'Test Transaction'
+        alipay_post_data = {
+            'notify_id': '1234567890123456789012345678901234',
+            'out_trade_no': self.reference,
+            'trade_no': '2021111111111111111111111111',
+            'notify_time': '2021-12-01 01:01:01',
+            'notify_type': 'trade_status_sync',
+            'total_fee': '1111.11',
+            'currency': 'CNY',
+            'trade_status': 'TRADE_FINISHED',
+            'service': 'notify_verify',
+            '_input_charset': 'utf-8',
+            'seller_email': 'dummy@alitest.com',
+            'partner': '2088888888888888',
+            'sign_type': 'MD5'
+        }
+
+        tx = self.create_transaction(flow='redirect', reference=self.reference)
+        tx.acquirer_id.alipay_payment_method = 'standard_checkout'
+        alipay_post_data['sign'] = self.alipay._alipay_build_sign(alipay_post_data)
+
+        with patch(
+                'odoo.addons.payment_alipay.controllers.main.AlipayController.send_request',
+                return_value='true'
+        ):
+            self._assert_not_raises(
+                Forbidden,
+                self._make_http_post_request,
+                webhook_url,
+                alipay_post_data
+            )
+
+        with patch(
+                'odoo.addons.payment_alipay.controllers.main.AlipayController.send_request',
+                return_value='false'
+        ):
+            self.assertEqual(self._make_http_post_request(webhook_url, alipay_post_data).status_code, Forbidden().code)

--- a/addons/payment_buckaroo/controllers/main.py
+++ b/addons/payment_buckaroo/controllers/main.py
@@ -2,11 +2,14 @@
 
 import logging
 import pprint
+from werkzeug.exceptions import Forbidden
 
 from odoo import http
 from odoo.http import request
+from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
+
 
 
 class BuckarooController(http.Controller):
@@ -18,6 +21,48 @@ class BuckarooController(http.Controller):
 
         :param dict data: The feedback data
         """
+        self._verify_signature(**data)
+
         _logger.info("received notification data:\n%s", pprint.pformat(data))
         request.env['payment.transaction'].sudo()._handle_feedback_data('buckaroo', data)
         return request.redirect('/payment/status')
+
+    @http.route('/payment/buckaroo/webhook', type='http', auth='public', methods=['POST'], csrf=False)
+    def buckaroo_webhook(self, **data):
+        """ Process the push response event sent by Buckaroo. Push response only informs of the transaction status.
+
+        :return: An empty string to acknowledge the notification with an HTTP 200 response
+        :rtype: str
+        """
+        self._verify_signature(**data)
+        try:
+            # Handle the feedback data crafted with Buckaroo API objects as a regular feedback
+            request.env['payment.transaction'].sudo()._handle_feedback_data('buckaroo', data)
+        except ValidationError: # Acknowledge the notification to avoid getting spammed
+            _logger.exception("unable to handle the event data; skipping to acknowledge")
+        return ''
+
+
+    def _verify_signature(self, **values):
+        """ Check that the signature computed from the feedback matches the received one if not raise an HTTP 403 error.
+
+        :param dict values: The values used to generate the signature
+
+        :rtype: None
+        """
+        received_signature = values.get('BRQ_SIGNATURE')
+
+        if not received_signature:
+            raise Forbidden()
+
+        # Retrieve the acquirer based on the tx reference included in the return url
+        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
+            'buckaroo', values
+        )
+
+        # Compute signature
+        expected_signature = tx_sudo.acquirer_id._buckaroo_generate_digital_sign(values, incoming=True)
+
+        # Compare signatures
+        if received_signature != expected_signature:
+            raise Forbidden()

--- a/addons/payment_buckaroo/models/payment_transaction.py
+++ b/addons/payment_buckaroo/models/payment_transaction.py
@@ -95,16 +95,6 @@ class PaymentTransaction(models.Model):
                 "Buckaroo: " + _("No transaction found matching reference %s.", reference)
             )
 
-        # Verify signature
-        shasign_check = tx.acquirer_id._buckaroo_generate_digital_sign(data, incoming=True)
-        if shasign_check != shasign:
-            raise ValidationError(
-                "Buckaroo: " + _(
-                    "Invalid shasign: received %(sign)s, computed %(check)s",
-                    sign=shasign, check=shasign_check
-                )
-            )
-
         return tx
 
     def _process_feedback_data(self, data):

--- a/addons/payment_ogone/tests/test_ogone.py
+++ b/addons/payment_ogone/tests/test_ogone.py
@@ -5,15 +5,17 @@ from freezegun import freeze_time
 from odoo.fields import Command
 from odoo.tests import tagged
 from odoo.tools import mute_logger
+from werkzeug.exceptions import Forbidden
 
 from odoo.addons.payment import utils as payment_utils
 
 from .common import OgoneCommon
 from ..controllers.main import OgoneController
+from odoo.addons.payment.tests.http_common import PaymentHttpCommon
 
 
 @tagged('post_install', '-at_install')
-class OgoneTest(OgoneCommon):
+class OgoneTest(OgoneCommon, PaymentHttpCommon):
 
     def test_incompatibility_with_validation_operation(self):
         acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
@@ -96,3 +98,30 @@ class OgoneTest(OgoneCommon):
                 value,
                 f"received value {inputs[form_key]} for input {form_key} (expected {value})"
             )
+
+    def test_webhook(self):
+        """ Verify the correctness of error handling during the webhook. """
+        webhook_url = self._build_url('/payment/ogone/test/accept')
+        expected_values = {
+            'PSPID': self.ogone.ogone_pspid,
+            'ORDERID': self.reference,
+        }
+        self.create_transaction(flow='redirect')
+
+        # Raise Forbidden due to missing signature
+        self.assertEqual(self._make_http_post_request(webhook_url, expected_values).status_code, Forbidden().code)
+
+        # Raise Forbidden due to invalid signature
+        expected_values['SHASIGN'] = 'wrong_signature'
+        self.assertEqual(self._make_http_post_request(webhook_url, expected_values).status_code, Forbidden().code)
+
+        # Do not raise Forbidden
+        # Note: SHASIGN content seems to be in uppercase
+        expected_values['SHASIGN'] = u'b00bdc5e8de830a2f1d81b4860ce77d3edc178f7'.upper()
+        expected_values['STATUS'] = 5  # done
+        self._assert_not_raises(
+            Forbidden,
+            self._make_http_post_request,
+            webhook_url,
+            expected_values
+        )

--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -6,6 +6,7 @@ import json
 import logging
 import pprint
 from datetime import datetime
+from werkzeug.exceptions import Forbidden
 
 import werkzeug
 
@@ -91,29 +92,29 @@ class StripeController(http.Controller):
                 tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
                     'stripe', data
                 )
-                if self._verify_webhook_signature(tx_sudo.acquirer_id.stripe_webhook_secret):
-                    # Fetch the PaymentIntent, Charge and PaymentMethod objects from Stripe
-                    if checkout_session.get('payment_intent'):  # Can be None
-                        payment_intent = tx_sudo.acquirer_id._stripe_make_request(
-                            f'payment_intents/{tx_sudo.stripe_payment_intent}', method='GET'
-                        )
-                        _logger.info(
-                            "received payment_intents response:\n%s", pprint.pformat(payment_intent)
-                        )
-                        self._include_payment_intent_in_feedback_data(payment_intent, data)
-                    # Fetch the SetupIntent and PaymentMethod objects from Stripe
-                    if checkout_session.get('setup_intent'):  # Can be None
-                        setup_intent = tx_sudo.acquirer_id._stripe_make_request(
-                            f'setup_intents/{checkout_session.get("setup_intent")}',
-                            payload={'expand[]': 'payment_method'},
-                            method='GET'
-                        )
-                        _logger.info(
-                            "received setup_intents response:\n%s", pprint.pformat(setup_intent)
-                        )
-                        self._include_setup_intent_in_feedback_data(setup_intent, data)
-                    # Handle the feedback data crafted with Stripe API objects as a regular feedback
-                    request.env['payment.transaction'].sudo()._handle_feedback_data('stripe', data)
+                self._verify_webhook_signature(tx_sudo.acquirer_id.stripe_webhook_secret)
+                # Fetch the PaymentIntent, Charge and PaymentMethod objects from Stripe
+                if checkout_session.get('payment_intent'):  # Can be None
+                    payment_intent = tx_sudo.acquirer_id._stripe_make_request(
+                        f'payment_intents/{tx_sudo.stripe_payment_intent}', method='GET'
+                    )
+                    _logger.info(
+                        "received payment_intents response:\n%s", pprint.pformat(payment_intent)
+                    )
+                    self._include_payment_intent_in_feedback_data(payment_intent, data)
+                # Fetch the SetupIntent and PaymentMethod objects from Stripe
+                if checkout_session.get('setup_intent'):  # Can be None
+                    setup_intent = tx_sudo.acquirer_id._stripe_make_request(
+                        f'setup_intents/{checkout_session.get("setup_intent")}',
+                        payload={'expand[]': 'payment_method'},
+                        method='GET'
+                    )
+                    _logger.info(
+                        "received setup_intents response:\n%s", pprint.pformat(setup_intent)
+                    )
+                    self._include_setup_intent_in_feedback_data(setup_intent, data)
+                # Handle the feedback data crafted with Stripe API objects as a regular feedback
+                request.env['payment.transaction'].sudo()._handle_feedback_data('stripe', data)
         except ValidationError:  # Acknowledge the notification to avoid getting spammed
             _logger.exception("unable to handle the event data; skipping to acknowledge")
         return ''
@@ -141,12 +142,11 @@ class StripeController(http.Controller):
         See https://stripe.com/docs/webhooks/signatures#verify-manually.
 
         :param str webhook_secret: The secret webhook key of the acquirer handling the transaction
-        :return: Whether the signatures match
-        :rtype: str
+        :return: None
         """
         if not webhook_secret:
             _logger.warning("ignored webhook event due to undefined webhook secret")
-            return False
+            raise Forbidden()
 
         notification_payload = request.httprequest.data.decode('utf-8')
         signature_entries = request.httprequest.headers.get('Stripe-Signature').split(',')
@@ -156,7 +156,7 @@ class StripeController(http.Controller):
         event_timestamp = int(signature_data['t'])
         if datetime.utcnow().timestamp() - event_timestamp > self.WEBHOOK_AGE_TOLERANCE:
             _logger.warning("ignored webhook event due to age tolerance: %s", event_timestamp)
-            return False
+            raise Forbidden()
 
         # Compare signatures
         received_signature = signature_data['v1']
@@ -166,8 +166,7 @@ class StripeController(http.Controller):
             signed_payload.encode('utf-8'),
             hashlib.sha256
         ).hexdigest()
+
         if not consteq(received_signature, expected_signature):
             _logger.warning("ignored event with invalid signature")
-            return False
-
-        return True
+            raise Forbidden()

--- a/addons/payment_stripe/tests/test_stripe.py
+++ b/addons/payment_stripe/tests/test_stripe.py
@@ -4,26 +4,80 @@ from unittest.mock import patch
 
 from odoo.tests import tagged
 from odoo.tools import mute_logger
+from freezegun import freeze_time
+from werkzeug.exceptions import Forbidden
+from datetime import datetime
 
+import requests
 from .common import StripeCommon
+from odoo.addons.payment.tests.http_common import PaymentHttpCommon
 
 
 @tagged('post_install', '-at_install')
-class StripeTest(StripeCommon):
+class StripeTest(StripeCommon, PaymentHttpCommon):
 
     def test_processing_values(self):
         dummy_session_id = 'cs_test_sbTG0yGwTszAqFUP8Ulecr1bUwEyQEo29M8taYvdP7UA6Qr37qX6uA6w'
-        tx = self.create_transaction(flow='redirect') # We don't really care what the flow is here.
+        tx = self.create_transaction(flow='redirect')  # We don't really care what the flow is here.
 
         # Ensure no external API call is done, we only want to check the processing values logic
         def mock_stripe_create_checkout_session(self):
             return {'id': dummy_session_id}
+
         with patch.object(
-            type(self.env['payment.transaction']),
-            '_stripe_create_checkout_session',
-            mock_stripe_create_checkout_session,
+                type(self.env['payment.transaction']),
+                '_stripe_create_checkout_session',
+                mock_stripe_create_checkout_session,
         ), mute_logger('odoo.addons.payment.models.payment_transaction'):
             processing_values = tx._get_processing_values()
 
         self.assertEqual(processing_values['publishable_key'], self.stripe.stripe_publishable_key)
         self.assertEqual(processing_values['session_id'], dummy_session_id)
+
+    # freeze time for consistent singularize_prefix behavior during the test
+    @freeze_time("2021-11-30 16:12:07")
+    def test_webhook(self):
+        """ Verify the correctness of error handling during the webhook.
+        Note: As JSON-RPC encapsulates the error handling of a request into a 200 response,
+         the raise of 403 can not been check here but only the non raise is verify.
+        """
+
+        def call_webhook(signature):
+            webhook_url = self._build_url('/payment/stripe/webhook')
+            self.reference = 'Test Transaction'
+            payload_id = "pi_1Esnh9AlCFm536g8l8QNh0ud"
+            stripe_post_data = {
+                  "id": payload_id,
+                  "type": "checkout.session.completed",
+                  "object": "event",
+                  "data": {
+                    "object": {
+                      "id": "cs_00000000000000",
+                      "client_reference_id": self.reference,
+                      "object": "checkout.session",
+                      "payment_status": "paid",
+                      "payment_intent": payload_id,
+                    }
+                  }
+                }
+            stripe_signature = 't=' + str(int(datetime.utcnow().timestamp())) + ',v1=' + signature +\
+                               ',v0=e9ea34475beed13f9a4b6376bab215828bd4468bcad526e64129b71044d7b851'
+            self.create_transaction(flow='redirect', stripe_payment_intent=payload_id, reference=self.reference)
+
+            headers = {
+                'host': '127.0.0.1:8069',
+                'User-Agent': 'python-requests/2.22.0',
+                'Accept-Encoding': 'gzip, deflate',
+                'Accept': '*/*',
+                'Connection': 'keep-alive',
+                'Content-type': 'application/json',
+                'Stripe-Signature': stripe_signature
+            }
+
+            return requests.post(webhook_url, json=stripe_post_data, headers=headers)
+
+        self._assert_not_raises(
+            Forbidden,
+            call_webhook,
+            '8bc12af6819ad4d9614582001c372f15e2ce138ad1a25bc981cf8330db814a1f'
+        )


### PR DESCRIPTION
Notification handling in some acquirers presents a subset of the
following issues:
1. The signature of synchronous notifications (redirect payloads) is not
 checked. (PayU money,  PayU Latam, Mollie, Authorize, Buckaroo)
2. When the signature check fails, we raise a ValidationError which
 counts as an HTTP 200 for some providers (it's not the case if they
 expect a specific string). (Adyen, Paypal,  Sips, Stripe)
3. If a ValidationError is raised when processing the feedback data, it
 is allowed to bubble up to the provider. (Alipay, Ogone)

For acquirers of points 2 and 3 we address each issue as follows:
1. If the acquirer has a return route and if it doesn't make a request
 to the provider that already validates the data, check the signature of
 redirect requests.
2. Instead of raising ValidationError's, raise an HTTP 403 FORBIDDEN
 error if the signature check fails.
3. Wrap the call to `_handle_feedback_data` of the webhook method inside
 a try/except clause to catch any ValidationError, log a warning, and
 acknowledge the notification to avoid having the provider disable the
 webhook because of too many failures.

For Alipay acquirer, the verification of the content of the notification
has been also added to the verification that the notification was sent
by Alipay. By verify the authenticity of the signature, we ensure that
the data contained in the notification has not be modified during the
transmission.

For Paypal, handling of errors have been simplify.

If the call to the acquirer involves a jsonrpc request, the error is
encapsulated into a 200 response. That is the reason why for the tests
we only check the non raise of the error.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
