### PR TITLE
[IMP] web: add tooltip on Dropdown

### DIFF
--- a/addons/web/static/src/core/commands/default_providers.js
+++ b/addons/web/static/src/core/commands/default_providers.js
@@ -72,6 +72,7 @@ commandProviderRegistry.add("data-hotkeys", {
             const description =
                 el.title ||
                 el.dataset.originalTitle || // LEGACY: bootstrap moves title to data-original-title
+                el.dataset.tooltip ||
                 el.placeholder ||
                 (el.innerText &&
                     `${el.innerText.slice(0, 50)}${el.innerText.length > 50 ? "..." : ""}`) ||

--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -303,6 +303,10 @@ Dropdown.props = {
         type: String,
         optional: true,
     },
+    tooltip: {
+        type: String,
+        optional: true,
+    },
     title: {
         type: String,
         optional: true,

--- a/addons/web/static/src/core/dropdown/dropdown.xml
+++ b/addons/web/static/src/core/dropdown/dropdown.xml
@@ -16,6 +16,7 @@
         t-on-mouseenter="onTogglerMouseEnter"
         t-att-title="props.title"
         t-att-data-hotkey="props.hotkey"
+        t-att-data-tooltip="props.tooltip"
         t-ref="togglerRef"
       >
         <t t-slot="toggler" />

--- a/addons/web/static/tests/core/dropdown_tests.js
+++ b/addons/web/static/tests/core/dropdown_tests.js
@@ -919,4 +919,18 @@ QUnit.module("Components", ({ beforeEach }) => {
         assert.containsNone(parent.el, ".dropdown-menu", "all menus are now closed");
         assert.strictEqual(hotkeyRegistrationsCount, 0, "no hotkey registration left");
     });
+
+    QUnit.test("Dropdown with a tooltip", async (assert) => {
+        assert.expect(1);
+
+        class Parent extends owl.Component {}
+        Parent.template = owl.tags.xml`<Dropdown tooltip="'My tooltip'"></Dropdown>`;
+
+        env = await makeTestEnv();
+        parent = await mount(Parent, { env, target });
+        assert.strictEqual(
+            parent.el.querySelector("button.dropdown-toggle").dataset.tooltip,
+            "My tooltip"
+        );
+    });
 });


### PR DESCRIPTION
This commit adds the possibility to add a tooltip on a Dropdown.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
