### PR TITLE
[FIX] mail: prevent crash with discuss sidebar for guest

### DIFF
--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1362,7 +1362,7 @@ function factory(dependencies) {
             }
             const discussSidebarCategory = this._getDiscussSidebarCategory();
             if (!discussSidebarCategory) {
-                throw new Error(`Channel ${this} could not find a matching discuss sidebar category for channel type "${this.channel_type}".`);
+                return clear();
             }
             return insertAndReplace({ category: replace(discussSidebarCategory) });
         }


### PR DESCRIPTION
This exception was meant to catch programming errors but it makes no sense for
guest as it doesn't have any sidebar category.

Follow up on https://github.com/odoo/odoo/pull/81166

task-2712117