### PR TITLE
[FIX] project,sale_timesheet: fix project update right panel values

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2070,6 +2070,7 @@ class Task(models.Model):
             'res_model': 'project.task',
             'type': 'ir.actions.act_window',
             'context': {**self._context, 'default_depend_on_ids': [Command.link(self.id)], 'show_project_update': False},
+            'domain': [('depend_on_ids', '=', self.id)],
         }
         if self.dependent_tasks_count == 1:
             action['view_mode'] = 'form'
@@ -2078,7 +2079,6 @@ class Task(models.Model):
         else:
             action['name'] = _('Dependent Tasks')
             action['view_mode'] = 'tree,form,kanban,calendar,pivot,graph,activity'
-            action['domain'] = [('depend_on_ids', '=', self.id)]
         return action
 
     def action_recurring_tasks(self):

--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -307,7 +307,7 @@ class Project(models.Model):
 
     def _get_sale_order_lines(self):
         sale_orders = self.sale_order_id | self.tasks.sale_order_id
-        return self.env['sale.order.line'].search([('order_id', 'in', sale_orders.ids), ('is_service', '=', True)], order='id asc')
+        return self.env['sale.order.line'].search([('order_id', 'in', sale_orders.ids), ('is_service', '=', True), ('is_downpayment', '=', False)], order='id asc')
 
     def _get_sold_items(self):
         sols = self._get_sale_order_lines()
@@ -325,15 +325,16 @@ class Project(models.Model):
             name = [x[1] for x in sol.name_get()] if number_sale_orders > 1 else sol.name
             qty_delivered = sol.product_uom._compute_quantity(sol.qty_delivered, self.env.company.timesheet_encode_uom_id, raise_if_failure=False)
             product_uom_qty = sol.product_uom._compute_quantity(sol.product_uom_qty, self.env.company.timesheet_encode_uom_id, raise_if_failure=False)
-            sold_items['data'].append({
-                'name': name,
-                'value': '%s / %s %s' % (formatLang(self.env, qty_delivered, 1), formatLang(self.env, product_uom_qty, 1), sol.product_uom.name if sol.product_uom == product_uom_unit else self.env.company.timesheet_encode_uom_id.name),
-                'color': 'red' if qty_delivered > product_uom_qty else 'black'
-            })
-            #We only want to consider hours and days for this calculation
-            if sol.product_uom.category_id == self.env.company.timesheet_encode_uom_id.category_id:
-                sold_items['total_sold'] += product_uom_qty
-                sold_items['effective_sold'] += sol.product_uom._compute_quantity(qty_delivered, self.env.company.timesheet_encode_uom_id, raise_if_failure=False)
+            if qty_delivered > 0 or product_uom_qty > 0:
+                sold_items['data'].append({
+                    'name': name,
+                    'value': '%s / %s %s' % (formatLang(self.env, qty_delivered, 1), formatLang(self.env, product_uom_qty, 1), sol.product_uom.name if sol.product_uom == product_uom_unit else self.env.company.timesheet_encode_uom_id.name),
+                    'color': 'red' if qty_delivered > product_uom_qty else 'black'
+                })
+                #We only want to consider hours and days for this calculation, and eventually units if the service policy is not based on milestones
+                if sol.product_uom.category_id == self.env.company.timesheet_encode_uom_id.category_id or (sol.product_uom == product_uom_unit and sol.product_id.service_policy != 'delivered_manual'):
+                    sold_items['total_sold'] += product_uom_qty
+                    sold_items['effective_sold'] += sol.product_uom._compute_quantity(qty_delivered, self.env.company.timesheet_encode_uom_id, raise_if_failure=False)
         remaining = sold_items['total_sold'] - sold_items['effective_sold']
         sold_items['remaining'] = {
             'value': remaining,


### PR DESCRIPTION
Prior to this commit:
- Some of the project update right panel values were wrong (the number of sold and
effective hours were wrong if the service is in units, and eventual down payments are
now removed from the list of SOLs)

task-2703516

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
