### PR TITLE
[REF] sms,mail: remove no_edit attribute from fields

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -15,7 +15,7 @@
                         <group name="activity_details" string="Activity Settings">
                             <field name="active" invisible="1"/>
                             <field name="category"/>
-                            <field name="default_user_id" options="{'no_create': True, 'no_edit': True}" domain="[('share', '=', False)]"/>
+                            <field name="default_user_id" options="{'no_create': True}" domain="[('share', '=', False)]"/>
                             <field name="res_model" groups="base.group_no_one"/>
                             <field name="res_model_change" invisible="1"/>
                             <field name="initial_res_model" invisible="1"/>

--- a/addons/mail/wizard/mail_template_preview_views.xml
+++ b/addons/mail/wizard/mail_template_preview_views.xml
@@ -16,7 +16,7 @@
                             <span class="col-md-5 col-lg-4 col-sm-12 pl-0">Choose an example <field name="model_id" readonly="1"/> record:</span>
                             <div class="col-md-7 col-lg-6 col-sm-12 pl-0">
                                 <field name="resource_ref" readonly="False"
-                                    options="{'hide_model': True, 'no_create': True, 'no_edit': True, 'no_open': True}"
+                                    options="{'hide_model': True, 'no_create': True, 'no_open': True}"
                                     attrs="{'invisible': [('no_record', '=', True)]}"/>
                                 <b attrs="{'invisible': [('no_record', '=', False)]}" class="text-warning">No record for this model</b>
                             </div>

--- a/addons/sms/wizard/sms_template_preview_views.xml
+++ b/addons/sms/wizard/sms_template_preview_views.xml
@@ -12,7 +12,7 @@
                     <div class="o_row">
                         <span>Choose an example <field name="model_id" readonly="1"/> record:</span>
                         <div>
-                            <field name="resource_ref" class="oe_inline" options="{'hide_model': True, 'no_create': True, 'no_edit': True, 'no_open': True}" attrs="{'invisible': [('no_record', '=', True)]}"/>
+                            <field name="resource_ref" class="oe_inline" options="{'hide_model': True, 'no_create': True, 'no_open': True}" attrs="{'invisible': [('no_record', '=', True)]}"/>
                             <span class="text-warning" attrs="{'invisible': [('no_record', '=', False)]}">No records</span>
                         </div>
                     </div>


### PR DESCRIPTION
It turns out that the 'no_edit' attribute of the fields is deprecated and doesn't do anything (there is no JavaScript or Python code using it). We will hence remove that attribute from the views to clean them.

task-2686290

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
