### PR TITLE
[IMP] payment_*: set password widget on sensible fields

### DIFF
--- a/addons/payment_adyen/views/payment_views.xml
+++ b/addons/payment_adyen/views/payment_views.xml
@@ -9,9 +9,9 @@
             <xpath expr='//group[@name="acquirer"]' position='inside'>
                 <group attrs="{'invisible': [('provider', '!=', 'adyen')]}">
                     <field name="adyen_merchant_account" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
-                    <field name="adyen_api_key" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
+                    <field name="adyen_api_key" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}" password="True"/>
                     <field name="adyen_client_key" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
-                    <field name="adyen_hmac_key" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
+                    <field name="adyen_hmac_key" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}" password="True"/>
                     <field name="adyen_checkout_api_url" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
                     <field name="adyen_recurring_api_url" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
                 </group>

--- a/addons/payment_alipay/views/payment_views.xml
+++ b/addons/payment_alipay/views/payment_views.xml
@@ -11,7 +11,7 @@
                     <field name="alipay_payment_method" widget="radio"/>
                     <field name="alipay_seller_email"
                            attrs="{'invisible': [('alipay_payment_method', '=', 'standard_checkout')], 'required': [('provider', '=', 'alipay'), ('alipay_payment_method', '=', 'express_checkout')]}"/>
-                    <field name="alipay_merchant_partner_id" password="True"/>
+                    <field name="alipay_merchant_partner_id"/>
                     <field name="alipay_md5_signature_key" password="True"/>
                 </group>
             </xpath>

--- a/addons/payment_authorize/models/payment_acquirer.py
+++ b/addons/payment_authorize/models/payment_acquirer.py
@@ -30,7 +30,7 @@ class PaymentAcquirer(models.Model):
     # Authorize.Net supports only one currency: "One gateway account is required for each currency"
     # See https://community.developer.authorize.net/t5/The-Authorize-Net-Developer-Blog/Authorize-Net-UK-Europe-Update/ba-p/35957
     authorize_currency_id = fields.Many2one(
-        string="Authorize Currency", comodel_name='res.currency', groups='base.group_system')
+        string="Authorize Currency", comodel_name='res.currency')
     authorize_payment_method_type = fields.Selection(
         string="Allow Payments From",
         help="Determines with what payment method the customer can pay.",

--- a/addons/payment_authorize/views/payment_views.xml
+++ b/addons/payment_authorize/views/payment_views.xml
@@ -13,7 +13,7 @@
                     <field name="authorize_signature_key" password="True" attrs="{'required':[ ('provider', '=', 'authorize'), ('state', '!=', 'disabled')]}"/>
                     <label for="authorize_client_key"/>
                     <div>
-                        <field name="authorize_client_key" password="True"/>
+                        <field name="authorize_client_key"/>
                         <button class="oe_link" icon="fa-refresh" type="object"
                                 name="action_update_merchant_details"
                                 string="Generate Client Key"/>

--- a/addons/payment_buckaroo/views/payment_views.xml
+++ b/addons/payment_buckaroo/views/payment_views.xml
@@ -9,7 +9,7 @@
             <xpath expr='//group[@name="acquirer"]' position='inside'>
                 <group attrs="{'invisible': [('provider', '!=', 'buckaroo')]}">
                     <field name="buckaroo_website_key" attrs="{'required':[ ('provider', '=', 'buckaroo'), ('state', '!=', 'disabled')]}"/>
-                    <field name="buckaroo_secret_key" string="Secret Key" attrs="{'required':[ ('provider', '=', 'buckaroo'), ('state', '!=', 'disabled')]}"/>
+                    <field name="buckaroo_secret_key" string="Secret Key" attrs="{'required':[ ('provider', '=', 'buckaroo'), ('state', '!=', 'disabled')]}" password="True"/>
                 </group>
             </xpath>
         </field>

--- a/addons/payment_ogone/views/payment_views.xml
+++ b/addons/payment_ogone/views/payment_views.xml
@@ -10,9 +10,9 @@
                 <group attrs="{'invisible': [('provider', '!=', 'ogone')]}">
                     <field name="ogone_pspid" attrs="{'required':[('provider', '=', 'ogone'), ('state', '!=', 'disabled')]}"/>
                     <field name="ogone_userid" attrs="{'required':[('provider', '=', 'ogone'), ('state', '!=', 'disabled')]}"/>
-                    <field name="ogone_password" attrs="{'required':[('provider', '=', 'ogone'), ('state', '!=', 'disabled')]}"/>
-                    <field name="ogone_shakey_in" attrs="{'required':[('provider', '=', 'ogone'), ('state', '!=', 'disabled')]}"/>
-                    <field name="ogone_shakey_out" attrs="{'required':[('provider', '=', 'ogone'), ('state', '!=', 'disabled')]}"/>
+                    <field name="ogone_password" attrs="{'required':[('provider', '=', 'ogone'), ('state', '!=', 'disabled')]}" password="True"/>
+                    <field name="ogone_shakey_in" attrs="{'required':[('provider', '=', 'ogone'), ('state', '!=', 'disabled')]}" password="True"/>
+                    <field name="ogone_shakey_out" attrs="{'required':[('provider', '=', 'ogone'), ('state', '!=', 'disabled')]}" password="True"/>
                 </group>
             </xpath>
         </field>

--- a/addons/payment_paypal/views/payment_views.xml
+++ b/addons/payment_paypal/views/payment_views.xml
@@ -10,11 +10,11 @@
                 <group attrs="{'invisible': [('provider', '!=', 'paypal')]}">
                     <field name="paypal_email_account"
                            attrs="{'required':[('provider', '=', 'paypal'), ('state', '!=', 'disabled')]}"/>
-                    <field name="paypal_seller_account"/>
+                    <field name="paypal_seller_account" password="True"/>
                     <!-- This field should no longer be used but is kept in debug mode for the time
                          being, until we are sure that the verification protocol of IPN can be used
                          for DPT notifications -->
-                    <field name="paypal_pdt_token" groups="base.group_no_one"/>
+                    <field name="paypal_pdt_token" groups="base.group_no_one" password="True"/>
                     <field name="paypal_use_ipn"
                            attrs="{'required':[('provider', '=', 'paypal'), ('state', '!=', 'disabled')]}"/>
                     <a href="https://www.odoo.com/documentation/master/applications/general/payment_acquirers/paypal.html"

--- a/addons/payment_payulatam/views/payment_views.xml
+++ b/addons/payment_payulatam/views/payment_views.xml
@@ -13,7 +13,8 @@
                     <field name="payulatam_account_id"
                            attrs="{'required':[('provider', '=', 'payulatam'), ('state', '!=', 'disabled')]}"/>
                     <field name="payulatam_api_key"
-                           attrs="{'required':[('provider', '=', 'payulatam'), ('state', '!=', 'disabled')]}"/>
+                           attrs="{'required':[('provider', '=', 'payulatam'), ('state', '!=', 'disabled')]}"
+                           password="True"/>
                 </group>
             </xpath>
         </field>

--- a/addons/payment_sips/views/payment_views.xml
+++ b/addons/payment_sips/views/payment_views.xml
@@ -9,7 +9,7 @@
             <xpath expr='//group[@name="acquirer"]' position='inside'>
                 <group attrs="{'invisible': [('provider', '!=', 'sips')]}">
                     <field name="sips_merchant_id" attrs="{'required':[ ('provider', '=', 'sips'), ('state', '!=', 'disabled')]}"/>
-                    <field name="sips_secret" string="Secret Key" attrs="{'required':[ ('provider', '=', 'sips'), ('state', '!=', 'disabled')]}"/>
+                    <field name="sips_secret" string="Secret Key" attrs="{'required':[ ('provider', '=', 'sips'), ('state', '!=', 'disabled')]}" password="True"/>
                     <field name="sips_key_version" attrs="{'required':[ ('provider', '=', 'sips'), ('state', '!=', 'disabled')]}" />
                     <field name="sips_test_url" attrs="{'required':[ ('provider', '=', 'sips'), ('state', '!=', 'disabled')]}" groups='base.group_no_one'/>
                     <field name="sips_prod_url" attrs="{'required':[ ('provider', '=', 'sips'), ('state', '!=', 'disabled')]}" groups='base.group_no_one'/>

--- a/addons/payment_stripe/views/payment_views.xml
+++ b/addons/payment_stripe/views/payment_views.xml
@@ -19,7 +19,7 @@
             </xpath>
             <xpath expr="//group[@name='acquirer']" position="inside">
                 <group attrs="{'invisible': [('provider', '!=', 'stripe')]}" name="stripe_credentials">
-                    <field name="stripe_publishable_key" attrs="{'required':[('provider', '=', 'stripe'), ('state', '!=', 'disabled')]}" password="True"/>
+                    <field name="stripe_publishable_key" attrs="{'required':[('provider', '=', 'stripe'), ('state', '!=', 'disabled')]}"/>
                     <field name="stripe_secret_key" attrs="{'required':[('provider', '=', 'stripe'), ('state', '!=', 'disabled')]}" password="True"/>
                     <label for="stripe_webhook_secret"/>
                     <div class="o_row" col="2">


### PR DESCRIPTION
When setting up an acquirer there is sensible information to
be supplied.
There was inconsistency on what was obfuscated and what not.
Now sensible information as passwords and keys is obfuscated
and public information as names and addresses is visible.

task-2694139
