### PR TITLE
[FIX] hr_holidays: fix change of employee_id in context

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -10,7 +10,7 @@ from collections import namedtuple, defaultdict
 from datetime import datetime, timedelta, time
 from pytz import timezone, UTC
 
-from odoo import api, fields, models, tools, SUPERUSER_ID
+from odoo import api, Command, fields, models, tools, SUPERUSER_ID
 from odoo.addons.base.models.res_partner import _tz_get
 from odoo.addons.resource.models.resource import float_to_time, HOURS_PER_DAY
 from odoo.exceptions import AccessError, UserError, ValidationError
@@ -25,6 +25,12 @@ _logger = logging.getLogger(__name__)
 # Used to agglomerate the attendances in order to find the hour_from and hour_to
 # See _compute_date_from_to
 DummyAttendance = namedtuple('DummyAttendance', 'hour_from, hour_to, dayofweek, day_period, week_type')
+
+def get_employee_from_context(values, context, user_employee_id):
+    employee_ids_list = [value[2] for value in values.get('employee_ids', []) if len(value) == 3 and value[0] == Command.SET]
+    employee_ids = employee_ids_list[-1] if employee_ids_list else []
+    employee_id_value = employee_ids[0] if employee_ids else False
+    return employee_id_value or context.get('default_employee_id', context.get('employee_id', user_employee_id))
 
 class HolidaysRequest(models.Model):
     """ Leave Requests Access specifications
@@ -779,8 +785,9 @@ class HolidaysRequest(models.Model):
         # Try to force the leave_type name_get when creating new records
         # This is called right after pressing create and returns the name_get for
         # most fields in the view.
-        if 'employee_id' in field_onchange:
-            self = self.with_context(employee_id=int(field_onchange['employee_id']))
+        if field_onchange.get('employee_id') and 'employee_id' not in self._context and values:
+            employee_id = get_employee_from_context(values, self._context, self.env.user.employee_id.id)
+            self = self.with_context(employee_id=employee_id)
         return super().onchange(values, field_name, field_onchange)
 
     def name_get(self):

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -11,14 +11,15 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
 from odoo.addons.resource.models.resource import HOURS_PER_DAY
+from odoo.addons.hr_holidays.models.hr_leave import get_employee_from_context
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tools.translate import _
 from odoo.tools.float_utils import float_round
 from odoo.tools.date_utils import get_timedelta
 from odoo.osv import expression
 
-_logger = logging.getLogger(__name__)
 
+_logger = logging.getLogger(__name__)
 
 class HolidaysAllocation(models.Model):
     """ Allocation Requests Access specifications: similar to leave requests """
@@ -274,7 +275,8 @@ class HolidaysAllocation(models.Model):
                 allocation.employee_ids = False
                 allocation.mode_company_id = False
             else:
-                allocation.employee_ids = self.env.context.get('default_employee_id') or self.env.user.employee_id
+                employee_ids = self.env.context.get('default_employee_id', self.env.user.employee_id)
+                allocation.employee_ids = [employee_ids] if isinstance(employee_ids, int) else employee_ids
 
     @api.depends('holiday_type', 'employee_id')
     def _compute_department_id(self):
@@ -464,8 +466,9 @@ class HolidaysAllocation(models.Model):
         # Try to force the leave_type name_get when creating new records
         # This is called right after pressing create and returns the name_get for
         # most fields in the view.
-        if 'employee_id' in field_onchange:
-            self = self.with_context(employee_id=int(field_onchange['employee_id']))
+        if field_onchange.get('employee_id') and 'employee_id' not in self._context and values:
+            employee_id = get_employee_from_context(values, self._context, self.env.user.employee_id.id)
+            self = self.with_context(employee_id=employee_id)
         return super().onchange(values, field_name, field_onchange)
 
     def name_get(self):

--- a/addons/hr_holidays/static/src/js/form/allocation_leave_form.js
+++ b/addons/hr_holidays/static/src/js/form/allocation_leave_form.js
@@ -1,0 +1,41 @@
+/** @odoo-module **/
+
+import viewRegistry from 'web.view_registry';
+
+import FormController from "web.FormController";
+import FormView from "web.FormView";
+
+export const AllocationLeaveFormController = FormController.extend({
+    /**
+     * @override
+    */
+    async _applyChanges(dataPointID, changes, event) {
+        const result = await this._super.apply(this, arguments);
+        const formData = event.target.record.data;
+        if (formData.holiday_status_id) {
+            let nameSearchContext = {'holiday_status_name_get': false};
+            const employee_id = formData.employee_id;
+            if (employee_id) {
+                nameSearchContext = {'holiday_status_name_get': true, 'employee_id': employee_id.data.id};
+            }
+            const nameSearch = await this._rpc({
+                model: 'hr.leave.type',
+                method: 'name_get',
+                args: [formData.holiday_status_id.data.id],
+                context: nameSearchContext,
+                limit: 1
+            });
+            this.$el.find("div[name='holiday_status_id']").find('input')[0].value = nameSearch[0][1];
+        }
+        return result;
+    }
+
+});
+
+export const AllocationLeaveFormView = FormView.extend({
+    config: Object.assign({}, FormView.prototype.config, {
+        Controller: AllocationLeaveFormController,
+    }),
+});
+
+viewRegistry.add('allocation_leave_form', AllocationLeaveFormView);

--- a/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_employee_controller.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_employee_controller.js
@@ -26,7 +26,7 @@ export const TimeOffCalendarEmployeeController = TimeOffCalendarController.exten
 
     _getAllocationContext() {
         const context = this._super(...arguments);
-        context.default_employee_ids = this.context.employee_id;
+        context.default_employee_id = this.context.employee_id[0];
         return context;
     },
 

--- a/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_renderer.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_renderer.js
@@ -40,7 +40,7 @@ export const TimeOffCalendarRenderer = TimeOffPopoverRenderer.extend({
         return await this._rpc({
             model: 'hr.leave.type',
             method: 'get_days_all_request',
-            context: session.user_context,
+            context: this.state.context,
         });
     },
 

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -64,7 +64,7 @@
         <field name="model">hr.leave.allocation</field>
         <field name="priority">32</field>
         <field name="arch" type="xml">
-            <form string="Allocation Request">
+            <form string="Allocation Request" js_class="allocation_leave_form">
                 <field name="can_reset" invisible="1"/>
                 <field name="can_approve" invisible="1"/>
                 <field name="holiday_type" invisible="1"/>
@@ -98,7 +98,7 @@
                     <group>
                         <group>
                             <field name="type_request_unit" invisible="1"/>
-                            <field name="holiday_status_id" context="{'employee_id':employee_id, 'default_date_from':current_date, 'request_type':'allocation'}"/>
+                            <field name="holiday_status_id" context="{'employee_id':employee_id, 'default_date_from':current_date, 'request_type':'allocation'}" options="{'always_reload': True}"/>
                             <field name="allocation_type" invisible="1" widget="radio"
                                 attrs="{'readonly': ['|', ('is_officer', '=', False), ('state', 'not in', ('draft', 'confirm'))]}"/>
                             <field name="is_officer" invisible="1"/>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -204,7 +204,7 @@
         <field name="model">hr.leave</field>
         <field name="priority">32</field>
         <field name="arch" type="xml">
-            <form string="Time Off Request">
+            <form string="Time Off Request" js_class="allocation_leave_form">
             <field name="active" invisible="1"/>
             <field name="can_reset" invisible="1"/>
             <field name="can_approve" invisible="1"/>


### PR DESCRIPTION
# Observed behavior

When logged in as another employee than Mitchell Admin (or equivalent employee who has an ID of 1 in the database),
the number of days allocated and displayed in the time off type name when creating a time off from the dashboard is by default the one of Mitchell Admin.

# Expected behavior

The allocation in the time off type should reflect the allocation of the employee

# Steps to reproduce

1) Create a new user and an employee for this user
2) With the credentials of this user, create a new time off from the dashboard calendar
3) The default time off type has the allocations of Mitchell Admin (or equivalent employee who has an ID of 1 in the database)

task-2712193

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
