### PR TITLE
[FIX] web: missing dependency in the ui_service

### DIFF
--- a/addons/web/static/src/core/ui/ui_service.js
+++ b/addons/web/static/src/core/ui/ui_service.js
@@ -36,6 +36,7 @@ export function useActiveElement(refName = null) {
 }
 
 export const uiService = {
+    dependencies: ["localization"],
     start(env) {
         let ui = {};
 


### PR DESCRIPTION
This commit adds the "localization" dependency to the ui_service.
The BlockUi component used by ui_service uses the _t function added by
the localization service.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
