### PR TITLE
[FIX] mail: use a placeholder when replying to empty message

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -1458,6 +1458,13 @@ msgstr ""
 
 #. module: mail
 #. openerp-web
+#: code:addons/mail/static/src/components/message_in_reply_to_view/message_in_reply_to_view.xml:0
+#, python-format
+msgid "Click to see the attachments"
+msgstr ""
+
+#. module: mail
+#. openerp-web
 #: code:addons/mail/static/src/components/attachment_viewer/attachment_viewer.xml:0
 #: code:addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml:0
 #: code:addons/mail/static/src/components/follower_subtype_list/follower_subtype_list.xml:0
@@ -4800,6 +4807,12 @@ msgstr ""
 #: code:addons/mail/models/mail_thread.py:0
 #, python-format
 msgid "Only logged notes can have their content updated on model '%s'"
+msgstr ""
+
+#. module: mail
+#: code:addons/mail/models/mail_thread.py:0
+#, python-format
+msgid "Only messages type comment can have their content updated"
 msgstr ""
 
 #. module: mail

--- a/addons/mail/static/src/components/message_in_reply_to_view/message_in_reply_to_view.xml
+++ b/addons/mail/static/src/components/message_in_reply_to_view/message_in_reply_to_view.xml
@@ -5,7 +5,15 @@
             <t t-if="messageInReplyToView">
                 <t t-if="!messageInReplyToView.messageView.message.parentMessage.isEmpty">
                     <b class="o_MessageInReplyToView_author text-muted ml-2">@<t t-esc="messageInReplyToView.messageView.message.parentMessage.authorName"/></b>
-                    <span class="o_MessageInReplyToView_body ml-1" t-raw="messageInReplyToView.messageView.message.parentMessage.prettyBody" t-on-click="messageInReplyToView.onClickReply"/>
+                    <span class="o_MessageInReplyToView_body ml-1" t-on-click="messageInReplyToView.onClickReply">
+                        <t t-if="messageInReplyToView.hasBodyBackLink">
+                            <t t-raw="messageInReplyToView.messageView.message.parentMessage.prettyBody"/>
+                        </t>
+                        <t t-if="messageInReplyToView.hasAttachmentBackLink">
+                            <span class="font-italic mr-2">Click to see the attachments</span>
+                            <i class="fa fa-image"/>
+                        </t>
+                    </span>
                 </t>
                 <t t-if="messageInReplyToView.messageView.message.parentMessage.isEmpty">
                     <i class="o_MessageInReplyToView_deletedMessage text-muted ml-2">Original message was deleted</i>

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -398,6 +398,14 @@ function factory(dependencies) {
         }
 
         /**
+         * @private
+         * @returns {boolean}
+         */
+        _computeHasAttachments() {
+            return this.attachments.length > 0;
+        }
+
+        /**
          * @returns {boolean}
          */
         _computeHasReactionIcon() {
@@ -417,6 +425,22 @@ function factory(dependencies) {
                 this.guestAuthor &&
                 this.messaging.currentGuest &&
                 this.messaging.currentGuest === this.guestAuthor
+            );
+        }
+
+        /**
+         * @private
+         * @returns {boolean}
+         */
+        _computeIsBodyEmpty() {
+            return (
+                !this.body ||
+                [
+                    '',
+                    '<p></p>',
+                    '<p><br></p>',
+                    '<p><br/></p>',
+                ].includes(this.body.replace(/\s/g, ''))
             );
         }
 
@@ -450,18 +474,9 @@ function factory(dependencies) {
          * @returns {boolean}
          */
         _computeIsEmpty() {
-            const isBodyEmpty = (
-                !this.body ||
-                [
-                    '',
-                    '<p></p>',
-                    '<p><br></p>',
-                    '<p><br/></p>',
-                ].includes(this.body.replace(/\s/g, ''))
-            );
             return (
-                isBodyEmpty &&
-                this.attachments.length === 0 &&
+                this.isBodyEmpty &&
+                !this.hasAttachments &&
                 this.tracking_value_ids.length === 0 &&
                 !this.subtype_description
             );
@@ -629,6 +644,12 @@ function factory(dependencies) {
             inverse: 'authoredMessages',
         }),
         /**
+         * States whether the message has some attachments.
+         */
+        hasAttachments: attr({
+            compute: '_computeHasAttachments',
+        }),
+        /**
          * Determines whether the message has a reaction icon.
          */
         hasReactionIcon: attr({
@@ -641,6 +662,14 @@ function factory(dependencies) {
         isCurrentUserOrGuestAuthor: attr({
             compute: '_computeIsCurrentUserOrGuestAuthor',
             default: false,
+        }),
+        /**
+         * States if the body field is empty, regardless of editor default
+         * html content. To determine if a message is fully empty, use
+         * `isEmpty`.
+         */
+        isBodyEmpty: attr({
+            compute: '_computeIsBodyEmpty',
         }),
         /**
          * States whether `body` and `subtype_description` contain similar

--- a/addons/mail/static/src/models/message_in_reply_to_view/message_in_reply_to_view.js
+++ b/addons/mail/static/src/models/message_in_reply_to_view/message_in_reply_to_view.js
@@ -42,9 +42,39 @@ function factory(dependencies) {
             threadView.addComponentHint('highlight-reply', parentMessageView);
         }
 
+        /**
+         * @private
+         * @returns {boolean}
+         */
+        _computeHasAttachmentBackLink() {
+            const parentMessage = this.messageView.message.parentMessage;
+            return parentMessage.isBodyEmpty && parentMessage.hasAttachments;
+        }
+
+        /**
+         * @private
+         * @returns {boolean}
+         */
+        _computeHasBodyBackLink() {
+            return !this.messageView.message.parentMessage.isBodyEmpty;
+        }
+
     }
 
     MessageInReplyToView.fields = {
+        /**
+         * Determines if the reply has a back link to an attachment only
+         * message.
+         */
+        hasAttachmentBackLink: attr({
+            compute: '_computeHasAttachmentBackLink',
+        }),
+        /**
+         * Determines if the reply has a back link to a non-empty body.
+         */
+        hasBodyBackLink: attr({
+            compute: '_computeHasBodyBackLink',
+        }),
         messageView: one2one('mail.message_view', {
             inverse: 'messageInReplyToView',
             readonly: true,


### PR DESCRIPTION
Before the PR, when replying to an empty (only attachment) nothing was display
in the message reply preview. This PR introduce a placeholder to handle this
case.

task-2664815
