### PR TITLE
[IMP] web_editor: improve snippet search placeholder message

### DIFF
--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -23,7 +23,7 @@
     </div>
 
     <div class="o_snippet_search_filter">
-        <input type="text" class="o_snippet_search_filter_input" placeholder="Search..."/>
+        <input type="text" class="o_snippet_search_filter_input" placeholder="Search for a block (e.g. numbers, image wall, ...)"/>
         <i role="button" class="fa fa-times o_snippet_search_filter_reset d-none"/>
     </div>
 


### PR DESCRIPTION
Tests showed that users didn't understand the goal of the search bar
above the snippets block under the tabs.

This commit changes the placeholder of the search bar to better
indicate its purpose.

task-2607728

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
