### PR TITLE
[IMP] hr_holidays: automatically recover time-off after public holiday edit

### DIFF
--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -3,7 +3,7 @@
 
 from odoo import fields, models, api, _
 from odoo.exceptions import ValidationError
-
+from odoo.osv import expression
 
 class CalendarLeaves(models.Model):
     _inherit = "resource.calendar.leaves"
@@ -29,6 +29,78 @@ class CalendarLeaves(models.Model):
                     existing_leaves = existing_leaves.filtered(lambda l: not l.calendar_id or l.calendar_id == record.calendar_id)
                 if existing_leaves:
                     raise ValidationError(_('Two public holidays cannot overlap each other for the same working hours.'))
+
+    def _get_domain(self, time_domain_dict):
+        domain = []
+        for date in time_domain_dict:
+            domain = expression.OR([domain, [
+                    ('date_to', '>', date['date_from']),
+                    ('date_from', '<', date['date_to'])]
+            ])
+        return expression.AND([domain, [('state', '!=', 'refuse'), ('active', '=', True)]])
+
+    def _get_time_domain_dict(self):
+        return [{
+            'date_from' : record.date_from,
+            'date_to' : record.date_to
+        } for record in self if not record.resource_id]
+
+    def _reevaluate_leaves(self, time_domain_dict):
+        if not time_domain_dict:
+            return
+
+        domain = self._get_domain(time_domain_dict)
+        leaves = self.env['hr.leave'].search(domain)
+        if not leaves:
+            return
+
+        previous_durations = leaves.mapped('number_of_days')
+        previous_states = leaves.mapped('state')
+        leaves.sudo().write({
+            'state': 'draft',
+        })
+        self.env.add_to_compute(self.env['hr.leave']._fields['number_of_days'], leaves)
+        sick_time_status = self.env.ref('hr_holidays.holiday_status_sl')
+        for previous_duration, leave, state in zip(previous_durations, leaves, previous_states):
+            duration_difference = previous_duration - leave.number_of_days
+            if duration_difference > 0 and leave['holiday_allocation_id'] and leave.number_of_days == 0.0:
+                message = _("Due to a change in global time offs, you have been granted %s day(s) back.", duration_difference)
+                leave._notify_change(message)
+            if leave.number_of_days > previous_duration\
+                    and leave.holiday_status_id not in sick_time_status:
+                new_leaves = leave.split_leave(time_domain_dict)
+                leaves |= new_leaves
+                previous_states += [state] * len(new_leaves)
+
+        leaves_to_cancel = self.env['hr.leave']
+        for state, leave in zip(previous_states, leaves):
+            leave.write({'state': state})
+            if leave.number_of_days == 0.0:
+                leaves_to_cancel |= leave
+
+        leaves_to_cancel._force_cancel(_("a new public holiday completely overrides this leave."), 'mail.mt_comment')
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        time_domain_dict = res._get_time_domain_dict()
+        self._reevaluate_leaves(time_domain_dict)
+        return res
+
+    def write(self, vals):
+        time_domain_dict = self._get_time_domain_dict()
+        res = super().write(vals)
+        time_domain_dict.extend(self._get_time_domain_dict())
+        self._reevaluate_leaves(time_domain_dict)
+
+        return res
+
+    def unlink(self):
+        time_domain_dict = self._get_time_domain_dict()
+        res = super().unlink()
+        self._reevaluate_leaves(time_domain_dict)
+
+        return res
 
 class ResourceCalendar(models.Model):
     _inherit = "resource.calendar"

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -690,3 +690,101 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             self.assertEqual(allocation_1day.leaves_taken, leave_1day['number_of_%ss_display' % unit], 'As no days were available in previous allocation, they should have been taken in this one')
             leaves.action_refuse()
             allocations.action_refuse()
+
+    def test_time_off_recovery_on_create(self):
+        time_off = self.env['hr.leave'].create([
+            {
+                'name': 'Holiday Request',
+                'employee_id': self.employee_emp_id,
+                'holiday_status_id': self.holidays_type_1.id,
+                'date_from': '2021-12-06 00:00:00',
+                'date_to': '2021-12-10 23:59:59',
+            },
+            {
+                'name': 'Holiday Request',
+                'employee_id': self.employee_hruser_id,
+                'holiday_status_id': self.holidays_type_1.id,
+                'date_from': '2021-12-06 00:00:00',
+                'date_to': '2021-12-10 23:59:59',
+            }
+        ])
+        self.assertEqual(time_off[0].number_of_days, 5)
+        self.assertEqual(time_off[1].number_of_days, 5)
+        self.env['resource.calendar.leaves'].create({
+            'name': 'Global Time Off',
+            'date_from': '2021-12-07 00:00:00',
+            'date_to': '2021-12-07 23:59:59',
+        })
+        self.assertEqual(time_off[0].number_of_days, 4)
+        self.assertEqual(time_off[1].number_of_days, 4)
+
+    def test_time_off_recovery_on_write(self):
+        global_time_off = self.env['resource.calendar.leaves'].create({
+            'name': 'Global Time Off',
+            'date_from': '2021-12-07 00:00:00',
+            'date_to': '2021-12-07 23:59:59',
+        })
+
+        time_off_1 = self.env['hr.leave'].create({
+            'name': 'Holiday Request',
+            'employee_id': self.employee_emp_id,
+            'holiday_status_id': self.holidays_type_1.id,
+            'date_from': '2021-12-06 00:00:00',
+            'date_to': '2021-12-10 23:59:59',
+        })
+        self.assertEqual(time_off_1.number_of_days, 4)
+
+        time_off_2 = self.env['hr.leave'].create({
+            'name': 'Holiday Request',
+            'employee_id': self.employee_emp_id,
+            'holiday_status_id': self.holidays_type_1.id,
+            'date_from': '2021-12-13 00:00:00',
+            'date_to': '2021-12-17 23:59:59',
+        })
+        self.assertEqual(time_off_2.number_of_days, 5)
+
+        # adding 1 day to the global time off
+        global_time_off.write({
+            'date_to': '2021-12-08 23:59:59',
+        })
+        self.assertEqual(time_off_1.number_of_days, 3)
+
+        # moving the global time off to the next week
+        global_time_off.write({
+            'date_from': '2021-12-15 00:00:00',
+            'date_to': '2021-12-15 23:59:59',
+        })
+        self.assertEqual(time_off_1.number_of_days, 2)
+        self.assertEqual(time_off_2.number_of_days, 4)
+
+    def test_time_off_recovery_on_unlink(self):
+        global_time_off = self.env['resource.calendar.leaves'].create({
+            'name': 'Global Time Off',
+            'date_from': '2021-12-07 00:00:00',
+            'date_to': '2021-12-07 23:59:59',
+        })
+        time_off = self.env['hr.leave'].create({
+            'name': 'Holiday Request',
+            'employee_id': self.employee_emp_id,
+            'holiday_status_id': self.holidays_type_1.id,
+            'date_from': '2021-12-06 00:00:00',
+            'date_to': '2021-12-10 23:59:59',
+        })
+        self.assertEqual(time_off.number_of_days, 4)
+        global_time_off.unlink()
+        self.assertEqual(time_off.number_of_days, 3)
+
+    def test_time_off_auto_cancel(self):
+        time_off = self.env['hr.leave'].create({
+            'name': 'Holiday Request',
+            'employee_id': self.employee_emp_id,
+            'holiday_status_id': self.holidays_type_1.id,
+            'date_from': '2021-11-15 00:00:00',
+            'date_to': '2021-11-19 23:59:59',
+        })
+        self.env['resource.calendar.leaves'].create({
+            'name': 'Global Time Off',
+            'date_from': '2021-11-15 00:00:00',
+            'date_to': '2021-11-19 23:59:59',
+        })
+        self.assertEqual(time_off.active, False)

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -67,7 +67,7 @@
                 <filter name="archive" string="Archived Time Off"
                     domain="[('holiday_status_id.active', '=', False)]" help="Archived Time Off"/>
                 <separator/>
-                <filter name="archived_leaves" string="Deleted Time Off" domain="[('active', '=', False)]" />
+                <filter name="archived_leaves" string="Cancelled Time Off" domain="[('active', '=', False)]" />
                 <filter invisible="1" string="Late Activities" name="activities_overdue"
                     domain="[('my_activity_date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"
                     help="Show all records which has next action date is before today"/>


### PR DESCRIPTION
The aim of this commit is to automatically give back or adapt remaining time-off for employees if a public holiday is edited for a period concerning one of the employee's time off.

Before this commit :
If you plan your holidays long in advance, and if the HR plans some global time off on top of it, you won't be automatically granted your day back.
You'll have to contact them, to cancel your day and take it back. 

After this commit :
If a public holiday is created, modified or deleted, all declared (non-refused) leaves related to that period will have
their duration re-evaluated and individual remaining time offs will be computed accordingly. If the change should augment the duration of any leave and should take day offs from the employee, the time off will be split.
If the duration of the leave is evaluated at 0 after the creation of the public holiday, the leave will
be set as cancelled.

task: #2636215 [Time Off]Grant back time off when public day off is created

