### PR TITLE
[FIX] account_edi: search partner based on VAT with spaces

### DIFF
--- a/addons/account_edi/tests/test_import_vendor_bill.py
+++ b/addons/account_edi/tests/test_import_vendor_bill.py
@@ -19,3 +19,4 @@ class TestImportVendorBill(AccountTestInvoicingCommon):
         self.assertEqual(self.partner_a, retrieve_partner('0477472701', 'BE0477472701'))
         self.assertEqual(self.partner_a, retrieve_partner('477472701', 'BE0477472701'))
         self.assertEqual(self.env['res.partner'], retrieve_partner('DE0477472701', 'BE0477472701'))
+        self.assertEqual(self.partner_a, retrieve_partner('CHE-107.787.577 IVA', 'CHE-107.787.577 IVA'))  # note that base_vat forces the space


### PR DESCRIPTION
This solution is not perfect. In order to be, we would need to have a
sanitized function that is used to store the number in the database, and
to use the same function to search in it. This will most likely be done
in master with a refactoring of `base_vat`, on which `account` will
depend one way or another.

In the meantime, we need to support cases that were working before these
fixes:
odoo@bfb2436
odoo@e24c5ba

Since these, it was indeed impossible to detect a partner based on his
VAT for Swiss partners if `base_vat` was installed, which is the
default.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
