### PR TITLE
[FIX] base_address_city: Inherit city_id from parent contact

### DIFF
--- a/addons/base_address_city/models/res_partner.py
+++ b/addons/base_address_city/models/res_partner.py
@@ -25,6 +25,11 @@ class Partner(models.Model):
             self.state_id = False
 
     @api.model
+    def _address_fields(self):
+        """Returns the list of address fields that are synced from the parent."""
+        return super(Partner, self)._address_fields() + ['city_id',]
+
+    @api.model
     def _fields_view_get_address(self, arch):
         arch = super(Partner, self)._fields_view_get_address(arch)
         # render the partner address accordingly to address_view_id


### PR DESCRIPTION
If you create an individual contact that has a company contact as the
parent, it will inherit certain fields from that parent, which are
defined by `_address_fields` in `res.partner`.

`base_address_city` allows enforcing picking a city from a pre-defined
list, which gets stored in `city_id` instead of the standard free-text
`city` field on `res.partner`. If you change `city_id`, an `onchange`
will update `city`.

`city_id` was not being inherited from the parent, which means the
contact ends up in an inconsistent state: `city` will be set, but
`city_id` will not.

In the Colombian accounting localization, which uses the enforced city
feature, a municipality code which is part of the record behind
`city_id` is mandatory in certain electronic invoice XML fields that get
sent to Carvajal. This value will incorrectly be 0 if `city_id` is not
set on the contact due to the above issue, causing the invoice to be
rejected.

This fix lets a contact inherit the `city_id` from its parent if
`base_address_city` is installed.

opw-2638687