### PR TITLE
[IMP] mail: reactions summary on context menu

### DIFF
--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -164,9 +164,9 @@
                             </t>
                         </div>
                         <AttachmentList t-if="messageView.attachmentList" localId="messageView.attachmentList.localId"/>
-                        <div t-if="messageView.message.messageReactionGroups.length > 0" class="d-flex flex-wrap ml-2">
-                            <t t-foreach="messageView.message.messageReactionGroups" t-as="messageReactionGroup" t-key="messageReactionGroup.localId">
-                                <MessageReactionGroup className="'mr-1 mb-1'" localId="messageReactionGroup.localId"/>
+                        <div t-if="messageView.messageReactionGroupViews.length > 0" class="d-flex flex-wrap ml-2">
+                            <t t-foreach="messageView.messageReactionGroupViews" t-as="messageReactionGroupView" t-key="messageReactionGroupView.localId">
+                                <MessageReactionGroup className="'mr-1 mb-1'" localId="messageReactionGroupView.localId"/>
                             </t>
                         </div>
                     </div>

--- a/addons/mail/static/src/components/message_reaction_group/message_reaction_group.js
+++ b/addons/mail/static/src/components/message_reaction_group/message_reaction_group.js
@@ -6,8 +6,8 @@ const { Component } = owl;
 
 export class MessageReactionGroup extends Component {
 
-    get messageReactionGroup() {
-        return this.messaging.models['MessageReactionGroup'].get(this.props.localId);
+    get messageReactionGroupView() {
+        return this.messaging.models['MessageReactionGroupView'].get(this.props.localId);
     }
 
 }

--- a/addons/mail/static/src/components/message_reaction_group/message_reaction_group.xml
+++ b/addons/mail/static/src/components/message_reaction_group/message_reaction_group.xml
@@ -2,13 +2,20 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.MessageReactionGroup" owl="1">
-        <div class="o_MessageReactionGroup d-flex" t-att-class="{'o-hasUserReacted': messageReactionGroup and messageReactionGroup.hasUserReacted}" t-attf-class="{{ className }}" t-att-title="messageReactionGroup and messageReactionGroup.summary" t-on-click="messageReactionGroup and messageReactionGroup.onClick" t-ref="root">
-            <t t-if="messageReactionGroup">
+        <div class="o_MessageReactionGroup d-flex"
+            t-att-class="{'o-hasUserReacted': messageReactionGroupView and messageReactionGroupView.messageReactionGroup.hasUserReacted}"
+            t-attf-class="{{ className }}"
+            t-att-title="messageReactionGroupView and messageReactionGroupView.messageReactionGroup.summary"
+            t-on-click="messageReactionGroupView and messageReactionGroupView.onClick"
+            t-on-contextmenu="messageReactionGroupView and messageReactionGroupView.onContextMenu"
+            t-ref="root"
+        >
+            <t t-if="messageReactionGroupView">
                 <span class="o_MessageReactionGroup_content mx-1">
-                    <t t-esc="messageReactionGroup.content"/>
+                    <t t-esc="messageReactionGroupView.messageReactionGroup.content"/>
                 </span>
-                <span class="o_MessageReactionGroup_count mx-1" t-att-class="{'o-hasUserReacted': messageReactionGroup.hasUserReacted}">
-                    <t t-esc="messageReactionGroup.count"/>
+                <span class="o_MessageReactionGroup_count mx-1" t-att-class="{'o-hasUserReacted': messageReactionGroupView.messageReactionGroup.hasUserReacted}">
+                    <t t-esc="messageReactionGroupView.messageReactionGroup.count"/>
                 </span>
             </t>
         </div>

--- a/addons/mail/static/src/components/message_reaction_group_summary_view/message_reaction_group_summary_view.js
+++ b/addons/mail/static/src/components/message_reaction_group_summary_view/message_reaction_group_summary_view.js
@@ -1,0 +1,21 @@
+/** @odoo-module **/
+
+const { Component } = owl;
+import { registerMessagingComponent } from '@mail/utils/messaging_component';
+
+export class MessageReactionGroupSummaryView extends Component {
+
+    get messageReactionGroupSummaryView() {
+        return this.messaging.models['MessageReactionGroupSummaryView'].get(this.props.localId);
+    }
+
+}
+
+Object.assign(MessageReactionGroupSummaryView, {
+    props: {
+        localId: String,
+    },
+    template: 'mail.MessageReactionGroupSummaryView',
+});
+
+registerMessagingComponent(MessageReactionGroupSummaryView);

--- a/addons/mail/static/src/components/message_reaction_group_summary_view/message_reaction_group_summary_view.scss
+++ b/addons/mail/static/src/components/message_reaction_group_summary_view/message_reaction_group_summary_view.scss
@@ -1,0 +1,20 @@
+// ------------------------------------------------------------------
+// Style
+// ------------------------------------------------------------------
+
+.o_MessageReactionGroupSummaryView {
+    border-radius: $o-mail-rounded-rectangle-border-radius-sm;
+    border-style: solid;
+    border-width: $border-width;
+    border-color: gray('200');
+    &.o-isHighlighted {
+        background: gray('400');
+        border-color: gray('400');
+    }
+}
+
+.o_MessageReactionGroupSummaryView_reactionCount {
+    &.o-isHighlighted {
+        color: white;
+    }
+}

--- a/addons/mail/static/src/components/message_reaction_group_summary_view/message_reaction_group_summary_view.xml
+++ b/addons/mail/static/src/components/message_reaction_group_summary_view/message_reaction_group_summary_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="mail.MessageReactionGroupSummaryView" owl="1">
+        <div class="o_MessageReactionGroupSummaryView mr-1 mb-1"
+            t-att-class="{ 'o-isHighlighted': messageReactionGroupSummaryView and messageReactionGroupSummaryView.messageReactionGroup === messageReactionGroupSummaryView.messageReactionsSummaryView.highlightedReaction }"
+            t-attf-class="{{ className }}"
+            t-on-click="messageReactionGroupSummaryView and messageReactionGroupSummaryView.onClickReaction(messageReactionGroupSummaryView.messageReactionGroup)"
+            t-ref="root"
+        >
+            <t t-if="messageReactionGroupSummaryView">
+                <span class="o_MessageReactionGroupSummaryView_reactionEmote mx-1" t-esc="messageReactionGroupSummaryView.messageReactionGroup.content"/>
+                <span class="o_MessageReactionGroupSummaryView_reactionCount mx-1" t-att-class="{ 'o-isHighlighted': messageReactionGroupSummaryView.messageReactionGroup === messageReactionGroupSummaryView.messageReactionsSummaryView.highlightedReaction }" t-esc="messageReactionGroupSummaryView.messageReactionGroup.count"/>
+            </t>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mail/static/src/components/message_reactions_summary_view/message_reactions_summary_view.js
+++ b/addons/mail/static/src/components/message_reactions_summary_view/message_reactions_summary_view.js
@@ -1,0 +1,33 @@
+/** @odoo-module **/
+
+import { registerMessagingComponent } from '@mail/utils/messaging_component';
+import { replace } from '@mail/model/model_field_command';
+import { useComponentToModel } from '@mail/component_hooks/use_component_to_model/use_component_to_model';
+
+const { Component } = owl;
+
+export class MessageReactionsSummaryView extends Component {
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    setup() {
+        super.setup();
+        useComponentToModel({ fieldName: 'component', modelName: 'MessageReactionsSummaryView', propNameAsRecordLocalId: 'localId' });
+    }
+
+    get messageReactionsSummaryView() {
+        return this.messaging && this.messaging.models['MessageReactionsSummaryView'].get(this.props.localId);
+    }
+
+}
+
+Object.assign(MessageReactionsSummaryView, {
+    props: {
+        localId: String,
+    },
+    template: 'mail.MessageReactionsSummaryView',
+});
+
+registerMessagingComponent(MessageReactionsSummaryView);

--- a/addons/mail/static/src/components/message_reactions_summary_view/message_reactions_summary_view.scss
+++ b/addons/mail/static/src/components/message_reactions_summary_view/message_reactions_summary_view.scss
@@ -1,0 +1,22 @@
+// ------------------------------------------------------------------
+// Layout
+// ------------------------------------------------------------------
+
+.o_MessageReactionsSummaryView_partnerAvatarContainer {
+    flex: 0 0 $o-mail-message-sidebar-width;
+    height: 36px;
+    max-width: $o-mail-message-sidebar-width;
+    width: 36px;
+}
+
+.o_MessageReactionsSummaryView_reactionsGroup {
+    cursor: pointer;
+}
+
+// ------------------------------------------------------------------
+// Style
+// ------------------------------------------------------------------
+
+.o_MessageReactionsSummaryView {
+    background: gray('200');
+}

--- a/addons/mail/static/src/components/message_reactions_summary_view/message_reactions_summary_view.xml
+++ b/addons/mail/static/src/components/message_reactions_summary_view/message_reactions_summary_view.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="mail.MessageReactionsSummaryView" owl="1">
+        <div class="o_MessageReactionsSummaryView d-flex flex-column h-100" t-attf-class="{{ className }}" t-ref="root">
+            <t t-if="messageReactionsSummaryView and messageReactionsSummaryView.highlightedReaction">
+                <div class="o_MessageReactionsSummaryView_reactionsGroup d-flex flex-row mt-2 mx-2">
+                    <t t-foreach="messageReactionsSummaryView.messageReactionGroupSummaryViews" t-as="reaction" t-key="reaction.localId">
+                        <MessageReactionGroupSummaryView localId="reaction.localId"/>
+                    </t>
+                </div>
+                <div>
+                    <hr/>
+                </div>
+                <div class="o_MessageReactionsSummaryView_content">
+                    <t t-foreach="messageReactionsSummaryView.partners" t-as="partner" t-key="partner.localId">
+                        <div class="o_MessageReactionsSummaryView_partner d-flex flex-row ml-2 mb-2">
+                            <div class="o_MessageReactionsSummaryView_partnerAvatarContainer d-flex justify-content-center position-relative">
+                                <img class="rounded-circle" t-att-src="partner.avatarUrl"/>
+                            </div>
+                            <span class="m-2" t-esc="partner.nameOrDisplayName"/>
+                        </div>
+                    </t>
+                    <t t-foreach="messageReactionsSummaryView.guests" t-as="guest" t-key="guest.localId">
+                        <div class="o_MessageReactionsSummaryView_partner d-flex flex-row ml-2 mb-2">
+                            <div class="o_MessageReactionsSummaryView_partnerAvatarContainer d-flex justify-content-center position-relative">
+                                <img class="rounded-circle" t-att-src="guest.avatarUrl"/>
+                            </div>
+                            <span class="m-2" t-esc="guest.name"/>
+                        </div>
+                    </t>
+                </div>
+            </t>
+            <t t-else="">
+                <div class="o_MessageReactionsSummaryView_noReaction d-flex align-items-center justify-content-center">
+                    <span class="m-2 font-italic">No reaction to display</span>
+                </div>
+            </t>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mail/static/src/components/thread_view/thread_view.js
+++ b/addons/mail/static/src/components/thread_view/thread_view.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
-
+import { clear } from '@mail/model/model_field_command';
 const { Component } = owl;
 
 export class ThreadView extends Component {

--- a/addons/mail/static/src/components/thread_view/thread_view.xml
+++ b/addons/mail/static/src/components/thread_view/thread_view.xml
@@ -38,6 +38,9 @@
                         <t t-elif="threadView.composerView">
                             <div class="o-autogrow"/>
                         </t>
+                        <t t-if="threadView.messageReactionsSummaryView">
+                            <MessageReactionsSummaryView localId="threadView.messageReactionsSummaryView.localId"/>
+                        </t>
                         <t t-if="threadView.composerView">
                             <Composer
                                 className="'o_ThreadView_composer'"

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -735,6 +735,10 @@ registerModel({
             inverse: 'message',
             isCausal: true,
         }),
+        messageReactionsSummaryViews: many('MessageReactionsSummaryView', {
+            inverse: 'message',
+            isCausal: true,
+        }),
         message_type: attr(),
         /**
          * States the views that are displaying this message.

--- a/addons/mail/static/src/models/message_reaction_group/message_reaction_group.js
+++ b/addons/mail/static/src/models/message_reaction_group/message_reaction_group.js
@@ -10,19 +10,6 @@ registerModel({
     identifyingFields: ['message', 'content'],
     recordMethods: {
         /**
-         * Handles click on the reaction group.
-         *
-         * @param {MouseEvent} ev
-         */
-        onClick(ev) {
-            markEventHandled(ev, 'MessageReactionGroup.Click');
-            if (this.hasUserReacted) {
-                this.message.removeReaction(this.content);
-            } else {
-                this.message.addReaction(this.content);
-            }
-        },
-        /**
          * @private
          * @returns {boolean}
          */
@@ -97,6 +84,14 @@ registerModel({
         messageId: attr({
             readonly: true,
             required: true,
+        }),
+        messageReactionGroupViews: many('MessageReactionGroupView', {
+            inverse: 'messageReactionGroup',
+            isCausal: true,
+        }),
+        messageReactionGroupSummaryViews: many('MessageReactionGroupSummaryView', {
+            inverse: 'messageReactionGroup',
+            isCausal: true,
         }),
         /**
          * States the partners that have used this reaction on this message.

--- a/addons/mail/static/src/models/message_reaction_group_summary_view/message_reaction_group_summary_view.js
+++ b/addons/mail/static/src/models/message_reaction_group_summary_view/message_reaction_group_summary_view.js
@@ -1,0 +1,30 @@
+/** @odoo-module **/
+
+import { registerModel } from '@mail/model/model_core';
+import { attr, one } from '@mail/model/model_field';
+import { replace } from '@mail/model/model_field_command';
+
+registerModel({
+    name: 'MessageReactionGroupSummaryView',
+    identifyingFields: ['messageReactionGroup', 'messageReactionsSummaryView'],
+    recordMethods: {
+        /**
+         * @param {MessageReactionGroup} messageReactionGroup
+         */
+        onClickReaction(messageReactionGroup) {
+            this.messageReactionsSummaryView.update({
+                highlightedReaction: replace(messageReactionGroup)
+            });
+        },
+    },
+    fields: {
+        messageReactionGroup: one('MessageReactionGroup', {
+            inverse: 'messageReactionGroupSummaryViews',
+            readonly: true,
+        }),
+        messageReactionsSummaryView: one('MessageReactionsSummaryView', {
+            inverse: 'messageReactionGroupSummaryViews',
+            readonly: true,
+        }),
+    },
+});

--- a/addons/mail/static/src/models/message_reaction_group_view/message_reaction_group_view.js
+++ b/addons/mail/static/src/models/message_reaction_group_view/message_reaction_group_view.js
@@ -1,0 +1,46 @@
+/** @odoo-module **/
+
+import { registerModel } from '@mail/model/model_core';
+import { attr, one } from '@mail/model/model_field';
+import { insertAndReplace } from '@mail/model/model_field_command';
+import { markEventHandled } from '@mail/utils/utils';
+
+registerModel({
+    name: 'MessageReactionGroupView',
+    identifyingFields: ['messageReactionGroup', 'messageView'],
+    recordMethods: {
+        /**
+         * Handles click on the reaction group.
+         *
+         * @param {MouseEvent} ev
+         */
+        onClick(ev) {
+            markEventHandled(ev, 'messageReactionGroupView.Click');
+            if (this.messageReactionGroup.hasUserReacted) {
+                this.messageReactionGroup.message.removeReaction(this.messageReactionGroup.content);
+            } else {
+                this.messageReactionGroup.message.addReaction(this.messageReactionGroup.content);
+            }
+        },
+        /**
+         * Handles right click or long press touch in mobile on the reaction group.
+         *
+         * @param {MouseEvent} ev
+         */
+        onContextMenu(ev) {
+            ev.preventDefault();
+            markEventHandled(ev, 'messageReactionGroupView.onContextMenu');
+            this.messageView.threadView.openReactionsSummary(this.messageReactionGroup);
+        },
+    },
+    fields: {
+        messageReactionGroup: one('MessageReactionGroup', {
+            inverse: 'messageReactionGroupViews',
+            readonly: true,
+        }),
+        messageView: one('MessageView', {
+            inverse: 'messageReactionGroupViews',
+            readonly: true,
+        }),
+    },
+});

--- a/addons/mail/static/src/models/message_reactions_summary_view/message_reactions_summary_view.js
+++ b/addons/mail/static/src/models/message_reactions_summary_view/message_reactions_summary_view.js
@@ -1,0 +1,95 @@
+/** @odoo-module **/
+
+import { registerModel } from '@mail/model/model_core';
+import { attr, one, many } from '@mail/model/model_field';
+import { clear, insertAndReplace, link, replace, unlink } from '@mail/model/model_field_command';
+
+registerModel({
+    name: 'MessageReactionsSummaryView',
+    identifyingFields: ['threadView'],
+    recordMethods: {
+        /**
+         * @private
+         * @returns {FieldCommand}
+         */
+        _computeGuestsWhoReacted() {
+            if (this.highlightedReaction) {
+                return replace(this.highlightedReaction.guests);
+            }
+            else {
+                return clear();
+            }
+        },
+        /**
+         * @private
+         * @returns {FieldCommand}
+         */
+        _computeHighlightedReaction() {
+            if (!this.highlightedReaction) {
+                if(this.message.messageReactionGroups.length > 0) {
+                    return replace(this.message.messageReactionGroups[0]);
+                }
+                if(this.messageReactionGroupSummaryViews.length > 0) {
+                    return replace(this.messageReactionGroupSummaryViews[0].messageReactionGroup);
+                }
+                return clear();
+            }
+        },
+        /**
+         * @private
+         * @returns {FieldCommand}
+         */
+        _computeMessageReactionGroupSummaryViews() {
+            if (!this.highlightedReaction) {
+                return clear();
+            }
+            const messageReactionGroupSummaryViewsData = [];
+            for (const reaction of this.highlightedReaction.message.messageReactionGroups) {
+                messageReactionGroupSummaryViewsData.push({
+                    messageReactionGroup: replace(reaction),
+                });
+            }
+            return insertAndReplace(messageReactionGroupSummaryViewsData);
+        },
+        /**
+         * @private
+         * @returns {FieldCommand}
+         */
+        _computePartnersWhoReacted() {
+            if (this.highlightedReaction) {
+                return replace(this.highlightedReaction.partners);
+            }
+            else {
+                return clear();
+            }
+        },
+    },
+    fields: {
+        /**
+         * States the OWL component of this message reactions summary.
+         */
+        component: attr(),
+        guests: many('Guest', {
+            compute: '_computeGuestsWhoReacted',
+        }),
+        highlightedReaction: one('MessageReactionGroup', {
+            compute: '_computeHighlightedReaction',
+        }),
+        message: one('Message', {
+            inverse: 'messageReactionsSummaryViews',
+            readonly: true,
+        }),
+        messageReactionGroupSummaryViews: many('MessageReactionGroupSummaryView', {
+            compute: '_computeMessageReactionGroupSummaryViews',
+            inverse: 'messageReactionsSummaryView',
+            isCausal: true,
+        }),
+        partners: many('Partner', {
+            compute: '_computePartnersWhoReacted',
+        }),
+        threadView: one('ThreadView', {
+            inverse: 'messageReactionsSummaryView',
+            readonly: true,
+        }),
+    },
+});

--- a/addons/mail/static/src/models/message_view/message_view.js
+++ b/addons/mail/static/src/models/message_view/message_view.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { registerModel } from '@mail/model/model_core';
-import { attr, one } from '@mail/model/model_field';
+import { attr, one, many } from '@mail/model/model_field';
 import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
 import { markEventHandled } from '@mail/utils/utils';
 
@@ -128,6 +128,23 @@ registerModel({
          * @private
          * @returns {FieldCommand}
          */
+        _computeMessageReactionGroupViews() {
+            if (this.message.messageReactionGroups.length === 0) {
+                return clear();
+            }
+            const messageReactionGroupViewsData = [];
+            for (const reaction of this.message.messageReactionGroups) {
+                messageReactionGroupViewsData.push({
+                    messageReactionGroup: replace(reaction),
+                    messageView: replace(this),
+                });
+            }
+            return insertAndReplace(messageReactionGroupViewsData);
+        },
+        /**
+         * @private
+         * @returns {FieldCommand}
+         */
         _computeMessageInReplyToView() {
             return (
                 this.message &&
@@ -224,6 +241,11 @@ registerModel({
             inverse: 'messageView',
             isCausal: true,
             readonly: true,
+        }),
+        messageReactionGroupViews: many('MessageReactionGroupView', {
+            compute: '_computeMessageReactionGroupViews',
+            inverse: 'messageView',
+            isCausal: true,
         }),
         /**
          * States the thread view that is displaying this messages (if any).


### PR DESCRIPTION
This commit allows users to see a summary of reactions for a specific
message by right-clicking on a reaction on desktop and bye long
pressing on a reaction on mobile.

Task-id: 2641441




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
