### PR TITLE
[FIX] account: Manual write-off with tax fixed

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -296,6 +296,7 @@ class AccountReconcileModel(models.Model):
             name = ' '.join([x for x in [base_line_dict.get('name', ''), tax_res['name']] if x])
             new_aml_dicts.append({
                 'account_id': tax_res['account_id'] or base_line_dict['account_id'],
+                'journal_id': base_line_dict.get('journal_id', False),
                 'name': name,
                 'partner_id': base_line_dict.get('partner_id'),
                 'balance': balance,


### PR DESCRIPTION
When the Reconciliation Model had a tax on the writeoff, the journal_id wasn't populated by `widget.get_reconciliation_dict_from_model()`, preventing the reconciliation from happening.

Enterprise PR: https://github.com/odoo/enterprise/pull/22827
Ticket link: https://www.odoo.com/web#id=2689002&model=project.task

opw-2689002