### PR TITLE
[IMP] website: set step on numeric input

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1915,7 +1915,8 @@ const ListUserValueWidget = UserValueWidget.extend({
         'click we-button.o_we_list_add_existing': '_onAddExistingItemClick',
         'click we-select.o_we_user_value_widget.o_we_add_list_item': '_onAddItemSelectClick',
         'click we-button.o_we_checkbox_wrapper': '_onAddItemCheckboxClick',
-        'change table input': '_onListItemChange',
+        'input table input': '_onListItemBlurInput',
+        'blur table input': '_onListItemBlurInput',
     },
 
     /**
@@ -2142,8 +2143,9 @@ const ListUserValueWidget = UserValueWidget.extend({
     },
     /**
      * @private
+     * @param {Boolean} [preview]
      */
-    _notifyCurrentState() {
+    _notifyCurrentState(preview = false) {
         const values = [...this.listTable.querySelectorAll('.o_we_list_record_name input')].map(el => {
             let id = this.isCustom ? el.value : el.name;
             if (this.el.dataset.idMode && this.el.dataset.idMode === "name") {
@@ -2170,7 +2172,11 @@ const ListUserValueWidget = UserValueWidget.extend({
             });
         }
         this._value = JSON.stringify(values);
-        this.notifyValueChange(false);
+        if (preview) {
+            this._onUserValuePreview();
+        } else {
+            this._onUserValueChange();
+        }
         if (!this.createWidget && !this.isCustom) {
             this._reloadSelectDropdown(values);
         }
@@ -2245,9 +2251,19 @@ const ListUserValueWidget = UserValueWidget.extend({
     },
     /**
      * @private
+     * @param {Event} ev
      */
-    _onListItemChange() {
-        this._notifyCurrentState();
+    _onListItemBlurInput(ev) {
+        const preview = ev.type === 'input';
+        if (preview || !this.el.contains(ev.relatedTarget) || this.el.dataset.renderOnInputBlur) {
+            // We call the function below only if the element that recovers the
+            // focus after this blur is not an element of the we-list or if it
+            // is an input event (preview). This allows to use the TAB key to go
+            // from one input to another in the list. This behavior can be
+            // cancelled if the widget has reloadOnInputBlur = "true" in its
+            // dataset.
+            this._notifyCurrentState(preview);
+        }
     },
     /**
      * @private

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2220,6 +2220,9 @@ const ListUserValueWidget = UserValueWidget.extend({
         }
         this._addItemToTable(undefined, this.el.dataset.defaultValue, recordData);
         this._notifyCurrentState();
+        // Scroll to the new list element.
+        this.el.querySelector('tr:last-child')
+            .scrollIntoView({behavior: 'smooth', block: 'nearest'});
     },
     /**
      * @private

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -220,6 +220,7 @@ body.editor_enable.editor_has_snippets {
 
 // SNIPPET PANEL
 #oe_snippets {
+    @include o-input-number-no-arrows();
     @include o-position-absolute(var(--o-we-toolbar-height), 0, 0, auto);
     position: fixed;
     z-index: $o-we-zindex;
@@ -1411,7 +1412,6 @@ body.editor_enable.editor_has_snippets {
                 overflow-y: auto;
 
                 table {
-                    @include o-input-number-no-arrows();
                     table-layout: auto;
                     width: 100%;
                     margin-bottom: $o-we-sidebar-content-field-spacing / 2;

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -249,7 +249,7 @@
             <div>
                 <we-input class="o_we_user_value_widget" title="Border Width">
                     <div class="o_custom_border_width_input">
-                        <input name="custom_border_width" type="text" class="text-end" size="2"/>
+                        <input name="custom_border_width" type="number" class="text-end" size="2"/>
                         <span>px</span>
                     </div>
                 </we-input>

--- a/addons/website/static/src/snippets/s_chart/options.js
+++ b/addons/website/static/src/snippets/s_chart/options.js
@@ -305,6 +305,9 @@ options.registry.InnerChart = options.Class.extend({
         const newEl = document.createElement(tag);
         const contentEl = document.createElement('input');
         contentEl.type = 'text';
+        if (tag === 'td') {
+            contentEl.type = 'number';
+        }
         contentEl.value = value || '';
         if (backgroundColor) {
             contentEl.dataset.backgroundColor = backgroundColor;

--- a/addons/website/static/src/snippets/s_chart/options.js
+++ b/addons/website/static/src/snippets/s_chart/options.js
@@ -17,7 +17,7 @@ options.registry.InnerChart = options.Class.extend({
         'click we-button.add_row': '_onAddRowClick',
         'click we-button.o_we_matrix_remove_col': '_onRemoveColumnClick',
         'click we-button.o_we_matrix_remove_row': '_onRemoveRowClick',
-        'blur we-matrix input': '_onMatrixInputFocusOut',
+        'input we-matrix input': '_onMatrixInputInput',
         'focus we-matrix input': '_onMatrixInputFocus',
     }),
 
@@ -476,9 +476,8 @@ options.registry.InnerChart = options.Class.extend({
     },
     /**
      * @private
-     * @param {Event} ev
      */
-    _onMatrixInputFocusOut: function (ev) {
+    _onMatrixInputInput() {
         this._reloadGraph();
     },
     /**

--- a/addons/website/static/tests/tours/snippet_social_media.js
+++ b/addons/website/static/tests/tours/snippet_social_media.js
@@ -20,7 +20,7 @@ const addNewSocialNetwork = function (optionIndex, linkIndex, url) {
     {
         content: "Change added Option label",
         trigger: `we-list table input:eq(${optionIndex})`,
-        run: `text ${url}`,
+        run: `text_blur ${url}`,
     },
     {
         content: "Ensure new link is changed",
@@ -79,7 +79,7 @@ wTourUtils.registerWebsitePreviewTour('snippet_social_media', {
     {
         content: 'Change custom social to unsupported link',
         trigger: 'we-list table input:eq(5)',
-        run: 'text https://www.paypal.com/abc',
+        run: 'text_blur https://www.paypal.com/abc',
     },
     {
         content: "Ensure paypal icon is found",
@@ -118,7 +118,7 @@ wTourUtils.registerWebsitePreviewTour('snippet_social_media', {
     {
         content: 'Change url of the DB instagram link',
         trigger: 'we-list table input:eq(3)',
-        run: 'text https://instagram.com/odoo.official/',
+        run: 'text_blur https://instagram.com/odoo.official/',
     },
     {
         content: 'Save',

--- a/addons/website/views/snippets/s_chart.xml
+++ b/addons/website/views/snippets/s_chart.xml
@@ -53,8 +53,8 @@
                     </tr>
                 </table>
             </we-matrix>
-            <we-input string="Min Axis" data-select-data-attribute="" data-dependencies="bar_chart_opt, horizontal_bar_chart_opt, line_chart_opt" data-attribute-name="minValue"/>
-            <we-input string="Max Axis" data-select-data-attribute="" data-dependencies="bar_chart_opt, horizontal_bar_chart_opt, line_chart_opt" data-attribute-name="maxValue"/>
+            <we-input string="Min Axis" data-step="1" data-select-data-attribute="" data-dependencies="bar_chart_opt, horizontal_bar_chart_opt, line_chart_opt" data-attribute-name="minValue"/>
+            <we-input string="Max Axis" data-step="1" data-select-data-attribute="" data-dependencies="bar_chart_opt, horizontal_bar_chart_opt, line_chart_opt" data-attribute-name="maxValue"/>
             <we-colorpicker string="Background" data-name="chart_bg_color_opt"
                 data-color-change=""
                 data-attribute-name="backgroundColor"

--- a/addons/website/views/snippets/s_social_media.xml
+++ b/addons/website/views/snippets/s_social_media.xml
@@ -32,7 +32,8 @@
             <we-list string="Social Networks" t-att-data-add-item-title="add_item_title"
                 data-render-list-items="" data-has-default="multiple" data-name="social_media_list"
                 data-default-value="https://www.example.com" data-id-mode="name"
-                data-new-elements-not-toggleable="true" data-no-preview="true"/>
+                data-new-elements-not-toggleable="true" data-no-preview="true"
+                data-render-on-input-blur="true"/>
         </div>
     </xpath>
 </template>

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -20,7 +20,7 @@
                 <we-button data-customize-website-views="website_sale.products_list_view">List</we-button>
             </we-select>
             <we-row string="Size" class="o_we_sublevel_1">
-                <we-input data-set-ppg="" data-no-preview="true" data-reload="/"/>
+                <we-input data-set-ppg="" data-step="1" data-no-preview="true" data-reload="/"/>
                 <span class="mx-2 o_wsale_ppr_by">by</span>
                 <we-select class="o_wsale_ppr_submenu" data-dependencies="grid_view_opt" data-no-preview="true" data-reload="/">
                     <we-button data-set-ppr="2">2</we-button>


### PR DESCRIPTION
Some (we-)inputs that handle numerical values, could not increment/decrement their value with the keyboard arrows. 
This PR adds the necessary attributes to make this work.

In addition, this PR permits to go from a we-list input to another with the tab key. The we-list and the we-matrix can also trigger a preview and the list scrolls to new elements just after the creation

task-2601533