### PR TITLE
[FIX] product: close Labels Printing wizard after download

### DIFF
--- a/addons/product/wizard/product_label_layout.py
+++ b/addons/product/wizard/product_label_layout.py
@@ -67,4 +67,6 @@ class ProductLabelLayout(models.TransientModel):
         xml_id, data = self._prepare_report_data()
         if not xml_id:
             raise UserError(_('Unable to find report template for %s format', self.print_format))
-        return self.env.ref(xml_id).report_action(None, data=data)
+        report_action = self.env.ref(xml_id).report_action(None, data=data)
+        report_action.update({'close_on_report_download': True})
+        return report_action


### PR DESCRIPTION
### Current behavior
When the download is finished, the wizard stay open

### Expected behavior 
Wizard should automatically close after downloading

### Reason
The key `close_on_report_download` wasn't defined during new wizard implementation ( commit d9f45ba6941939b3d4b40beb5abbc330be84d695 )

Linked PR : https://github.com/odoo/enterprise/pull/22826
OPW-2710611