### PR TITLE
[FIX] stock: correct unassigning moves in reception report

### DIFF
--- a/addons/stock/static/src/js/report_stock_reception.js
+++ b/addons/stock/static/src/js/report_stock_reception.js
@@ -126,15 +126,17 @@ const ReceptionReport = clientAction.extend({
      */
      _onClickUnassign: function (ev) {
         const el = ev.currentTarget;
-        this._switchButton(el);
         const quantity = parseFloat(el.getAttribute('qty'));
         const modelId = parseInt(el.getAttribute('move-id'));
         const inIds = JSON.parse("[" + el.getAttribute('move-ins-ids') + "]");
-        el.closest('td').nextElementSibling.querySelectorAll('.o_print_label').forEach(button => button.setAttribute('disabled', true));
         return this._rpc({
             model: 'report.stock.report_reception',
             args: [false, modelId, quantity, inIds[0]],
             method: 'action_unassign'
+        }).then(() => {
+            // only switch buttons if successful
+            this._switchButton(el);
+            el.closest('td').nextElementSibling.querySelectorAll('.o_print_label').forEach(button => button.setAttribute('disabled', true));
         });
     },
 


### PR DESCRIPTION
Fixes a couple of things;

1. Backorder use case when unassigning a move in reception report.
To reproduce:

- Create a Delivery w/ Demand = 8 of a stored product not in stock
- Create a Receipt w/ Demand = 10 of the product
- Assign 8 of product to delivery (don't forget to activate Reception
  Report in settings
- Mark 4 of product as done > mark as done > create a backorder
- Open reception report in backorder (shows 6 instead of 4, this is a
  known limitation of reception report) + unassign + close report
- Reopen report + assign 4
- Finish the backorder

Expected result: Delivery has 2 moves totaling a demand and reserved
  amount of 8
Actual result: Delivery has 2 moves where 1 is fully reserved but the
  other isn't and cannot be reserved (even though product in stock).

Issue was due to move split during unassign not taking into account that
the amount being unassigned could be greater than the amount still
assigned (due to backorder amount > demand qty since it doesn't know how
much was done in the original receipt). This would lead to the move
linked to the original receipt's move expecting a greater quantity from
the original move (and therefore not reserving any more quantities.)

2. Trying to unassign from an already done move. (i.e. backordered move
from above unassigned after the delivery is already done) isn't allowed,
so in case of unassigning from a done move, we don't do a split.

3. In case of failure of unassigning, fail gracefully (i.e. don't switch
button status since this is misleading).

Discovered during task: 2662730

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
