### PR TITLE
[FIX] Qweb: tag '>' char is inserted after the default content

### DIFF
--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -1223,6 +1223,7 @@ class QWeb(object):
             options['_text_concat'].clear()
             code.append(self._indent("else:", indent))
             code.extend(self._compile_tag_open(el, options, indent + 1, not without_attributes))
+            code.extend(self._flushText(options, indent + 1))
             code.extend(default_body)
             options['_text_concat'].extend(_text_concat)
             code.extend(self._compile_tag_close(el, options))

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -1008,6 +1008,32 @@ class TestQWebBasic(TransactionCase):
         rendered = self.env['ir.qweb']._render(t.id, {})
         self.assertEqual(rendered.strip(), result.strip())
 
+    def test_out_default_value(self):
+        t = self.env['ir.ui.view'].create({
+            'name': 'test',
+            'type': 'qweb',
+            'arch_db': '''<t t-name="out-default">
+                <span rows="10" t-out="a">
+                    DEFAULT
+                    <t t-out="'Text'" />
+                </span>
+            </t>'''
+        })
+        result = """
+                <span rows="10">Hello</span>
+        """
+        rendered = self.env['ir.qweb']._render(t.id, {'a': 'Hello'})
+        self.assertEqual(str(rendered.strip()), result.strip())
+
+        result = """
+                <span rows="10">
+                    DEFAULT
+                    Text
+                </span>
+        """
+        rendered = self.env['ir.qweb']._render(t.id, {})
+        self.assertEqual(str(rendered.strip()), result.strip())
+
     def test_esc_markup(self):
         # t-esc is equal to t-out
         t = self.env['ir.ui.view'].create({


### PR DESCRIPTION
All textual content generated by opening the tag must be flushed before inserting the default content