### PR TITLE
[13.0][FIX] account: remove readonly on auto_post

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1010,7 +1010,7 @@
                                 <group id="other_tab_entry_group">
                                     <group name="misc_group">
                                         <field name="auto_post"
-                                               attrs="{'invisible': [('type', '!=', 'entry')], 'readonly': [('reversed_entry_id', '!=', False)]}"/>
+                                               attrs="{'invisible': [('type', '!=', 'entry')]}"/>
                                         <field name="reversed_entry_id"
                                                attrs="{'invisible': ['|', ('reversed_entry_id', '=', False), ('type', '!=', 'entry')]}"/>
                                         <field name="to_check"


### PR DESCRIPTION
goal:
The aim of this commit is to allow user to post a reversed entry even
when the date for the reversed has been set in the future.

before this commit:
if the entry move is generated using the reverse entry button and a
date in the future, the reverse entry is created with auto_post True
and is readonly in the view resulting in the user being unable to post
the move himself.

after this commit:
auto_post can be manually set to false and the user can post the move
himself.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
