### PR TITLE
[14.0][FIX] account: remove readonly on auto_post

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1078,7 +1078,7 @@
                                                widget="email"
                                                attrs="{'invisible': ['|', ('move_type', 'not in', ('in_invoice', 'in_refund')), ('invoice_source_email', '=', False)]}"/>
                                         <field name="auto_post"
-                                               attrs="{'readonly': ['|',('reversed_entry_id', '!=', False),('state','!=','draft')]}"/>
+                                               attrs="{'readonly': [('state','!=','draft')]}"/>
                                         <field name="to_check"/>
                                     </group>
                                 </group>
@@ -1088,7 +1088,7 @@
                                 <group id="other_tab_entry_group">
                                     <group name="misc_group">
                                         <field name="auto_post"
-                                               attrs="{'invisible': [('move_type', '!=', 'entry')], 'readonly': ['|',('reversed_entry_id', '!=', False),('state','!=','draft')]}"/>
+                                               attrs="{'invisible': [('move_type', '!=', 'entry')], 'readonly': [('state','!=','draft')]}"/>
                                         <field name="reversed_entry_id"
                                                attrs="{'invisible': [('move_type', '!=', 'entry')]}"/>
                                         <field name="to_check"


### PR DESCRIPTION
The aim of this commit is to allow user to post a reversed entry even
when the date for the reversed has been set in the future.

before this commit:
if the move is generated using the reverse entry button and a date in
the future, the reverse entry is created with auto_post True and is
readonly in the view resulting in the user being unable to post the
move himself.

after this commit:
auto_post can be manually set to false and the user can post the move
himself.

task: #2522640

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
