### PR TITLE
[14.0][LOC] l10n_ch: Add SCOR (iso) reference type for swiss qr invoices

### DIFF
--- a/addons/l10n_ch/models/account_invoice.py
+++ b/addons/l10n_ch/models/account_invoice.py
@@ -350,3 +350,11 @@ class AccountMove(models.Model):
             i -= 5
 
         return spaced_qrr_ref
+
+    @api.model
+    def space_scor_reference(self, iso11649_ref):
+        """ Makes the provided SCOR reference human-friendly, spacing its elements
+        by blocks of 5 from right to left.
+        """
+
+        return ' '.join(iso11649_ref[i:i + 4] for i in range(0, len(iso11649_ref), 4))

--- a/addons/l10n_ch/models/res_bank.py
+++ b/addons/l10n_ch/models/res_bank.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import re
+from stdnum.util import clean
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
@@ -191,6 +192,9 @@ class ResPartnerBank(models.Model):
             # _check_for_qr_code_errors ensures we can't have a QR-IBAN without a QR-reference here
             reference_type = 'QRR'
             reference = structured_communication
+        elif self._is_iso11649_reference(structured_communication):
+            reference_type = 'SCOR'
+            reference = structured_communication.replace(' ', '')
 
         currency = currency or self.currency_id or self.company_id.currency_id
 
@@ -287,6 +291,17 @@ class ResPartnerBank(models.Model):
                and len(reference) == 27 \
                and re.match('\d+$', reference) \
                and reference == mod10r(reference[:-1])
+
+    @api.model
+    def _is_iso11649_reference(self, reference):
+        """ Checks whether the given reference is a ISO11649 (SCOR) reference.
+        """
+        return reference \
+               and len(reference) >= 5 \
+               and len(reference) <= 25 \
+               and reference.startswith('RF') \
+               and int(''.join(str(int(x, 36)) for x in clean(reference[4:] + reference[:4], ' -.,/:').upper().strip())) % 97 == 1
+               # see https://github.com/arthurdejong/python-stdnum/blob/master/stdnum/iso11649.py
 
     def _eligible_for_qr_code(self, qr_method, debtor_partner, currency):
         if qr_method == 'ch_qr':

--- a/addons/l10n_ch/report/swissqr_report.xml
+++ b/addons/l10n_ch/report/swissqr_report.xml
@@ -29,6 +29,9 @@
 
                 <t t-set="formated_amount" t-value="'{:,.2f}'.format(o.amount_residual).replace(',','\xa0')"/>
 
+                <t t-set="is_qrr" t-value="o.partner_bank_id._is_qr_iban()"/>
+                <t t-set="is_scor" t-value="o.partner_bank_id._is_iso11649_reference(o.payment_reference)"/>
+
                 <div class="swissqr_page_title">
                     <h1>QR-bill for invoice <t t-esc="o.name"/></h1>
                 </div>
@@ -58,12 +61,20 @@
                                 <br/>
                             </div>
 
-                            <t t-if="o.partner_bank_id._is_qr_iban()">
+                            <t t-if="is_qrr or is_scor">
                                 <div class="swissqr_text title">
                                     <span>Reference</span>
                                 </div>
+                            </t>
+                            <t t-if="is_qrr">
                                 <div class="swissqr_text content">
                                     <span t-esc="o.space_qrr_reference(o.payment_reference)"/><br/>
+                                    <br/>
+                                </div>
+                            </t>
+                            <t t-if="is_scor">
+                                <div class="swissqr_text content">
+                                    <span t-esc="o.space_scor_reference(o.payment_reference)"/><br/>
                                     <br/>
                                 </div>
                             </t>
@@ -160,17 +171,25 @@
                                 <br/>
                             </div>
 
-                            <t t-if="o.partner_bank_id._is_qr_iban()">
+                            <t t-if="is_qrr or is_scor">
                                 <div class="swissqr_text title">
                                     <span class="title">Reference</span>
                                 </div>
+                            </t>
+                            <t t-if="is_qrr">
                                 <div class="swissqr_text content">
                                     <span t-esc="o.space_qrr_reference(o.payment_reference)"/><br/>
                                     <br/>
                                 </div>
                             </t>
+                            <t t-if="is_scor">
+                                <div class="swissqr_text content">
+                                    <span t-esc="o.space_scor_reference(o.payment_reference)"/><br/>
+                                    <br/>
+                                </div>
+                            </t>
 
-                            <t t-set="additional_info" t-value="(o.ref or o.name if o.partner_bank_id._is_qr_iban() else o.payment_reference or o.ref or o.name)"/>
+                            <t t-set="additional_info" t-value="(o.ref or o.name if is_qrr or is_scor else o.payment_reference or o.ref or o.name)"/>
                             <t t-if="additional_info">
                                 <div class="swissqr_text title">
                                     <span>Additional information</span>

--- a/doc/cla/individual/TeoGoddet.md
+++ b/doc/cla/individual/TeoGoddet.md
@@ -1,0 +1,9 @@
+Switzerland, 2021-12-11
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Téo Goddet teo.goddet@gmail.com https://github.com/TeoGoddet


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
According to https://www.paymentstandards.ch/en/shared/know-how/faq/qr.html
The following types can be used:

QR-bill with QR IBAN and QR reference
QR-bill with IBAN and creditor reference (ISO 11649)
QR-bill with IBAN without reference
The difference lies in the use of IBAN and references.

Current behavior before PR:
QR-bill with IBAN and creditor reference (ISO 11649) is not supported yet and downgraded as "without reference".

Desired behavior after PR is merged:
QR-bill with IBAN and creditor reference (ISO 11649) are included in the qr code if they are present.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
