### PR TITLE
[FIX][OPW] models: Include archived records on filtered_domain method

### DIFF
--- a/doc/cla/corporate/vauxoo.md
+++ b/doc/cla/corporate/vauxoo.md
@@ -50,3 +50,4 @@ Deivis Laya deivis@vauxoo.com https://github.com/deivislaya
 Yennifer Santiago yennifer@vauxoo.com https://github.com/ysantiago
 Alejandro Santillan asantillan@vauxoo.com https://github.com/R4Alex
 Williams Estrada williams@vauxoo.com https://github.com/WR-96
+Francisco J. Luna fluna@vauxoo.com https://github.com/frahikLV

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3352,7 +3352,7 @@ Fields:
 
     def _filter_access_rules_python(self, operation):
         dom = self.env['ir.rule']._compute_domain(self._name, operation)
-        return self.sudo().filtered_domain(dom or [])
+        return self.sudo().with_context(active_test=False).filtered_domain(dom or [])
 
     def unlink(self):
         """ unlink()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Solving issue https://github.com/odoo/odoo/issues/81271

* Modify mrp.bom record_rule "mrp_bom multi-company" from
```
['|', ('company_id', 'in', company_ids), ('company_id','=',False)]
```

to 

```
['|', ('company_id', 'child_of', company_ids), ('company_id','=',False)]
``` 

* Archive one mrp.bom record
*  Try to unarchive, the following error will show:

![image](https://user-images.githubusercontent.com/47753811/145699522-87adfb6a-6133-495b-a924-604509678261.png)


Current behavior before PR:

When the ORM check if the user has access vía _filter_access_rules_python method, this call filtered_domain, and because the access rule contains a child_of, a search is performed, however, by default, the searches omit records with active = False, for that reason the context active_test=False must be included.

Desired behavior after PR is merged:

If the filtered_domain doesn't have an explicit domain excluding active records, these should be included in the returned records.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
