### PR TITLE
Employee created from applicant is not provided Address field.

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -571,7 +571,7 @@ class Applicant(models.Model):
                     'default_name': applicant.partner_name or contact_name,
                     'default_job_id': applicant.job_id.id,
                     'default_job_title': applicant.job_id.name,
-                    'address_home_id': address_id,
+                    'default_address_home_id': address_id,
                     'default_department_id': applicant.department_id.id or False,
                     'default_address_id': applicant.company_id and applicant.company_id.partner_id
                             and applicant.company_id.partner_id.id or False,

--- a/doc/cla/individual/BayarkhuuBataa.md
+++ b/doc/cla/individual/BayarkhuuBataa.md
@@ -1,0 +1,11 @@
+Mongolia, 2021-12-12
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Bayarkhuu Bataa bbayarkhuu@gmail.com https://github.com/BayarkhuuBataa


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR: Employee created from applicant is not provided Address field.

Desired behavior after PR is merged: Employee created from applicant is provided Address field.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
