### PR TITLE
[FIX] mrp: Remove name field defined twice in workorder tree view

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -61,7 +61,6 @@
                 <field name="company_id" invisible="1"/>
                 <field name="is_produced" invisible="1"/>
                 <field name="is_user_working" invisible="1"/>
-                <field name="name" invisible="1"/>
                 <field name="product_uom_id" invisible="1" readonly="0"/>
                 <field name="production_state" invisible="1"/>
                 <field name="production_bom_id" invisible="1"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In mrp_production_workorder_tree_editable_view the name field is defined twice, once invisible.

Current behavior before PR:
This makes inheritance more difficult than it needs to be.

Desired behavior after PR is merged:
After this commit, the first invisible name field is removed, leaving it defined only once.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
