### PR TITLE
[FIX] base_import_module: fix existing assets import error

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -123,8 +123,10 @@ class IrModule(models.Model):
                 })
 
         # Look for existing assets
-        existing_assets = IrAsset.search([('name', 'in', [vals['name'] for vals in assets_vals])])
-        existing_assets = existing_assets.mapped(lambda r: (r.name, r))
+        existing_assets = {
+            asset.name: asset
+            for asset in IrAsset.search([('name', 'in', [vals['name'] for vals in assets_vals])])
+        }
         assets_to_create = []
 
         # Update existing assets and generate the list of new assets values


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- Existing assets cannot use zip method to import again since base_import_module is comparing str to tuple. So it will treat the assets as new assets and returned unique key error when trying to create it.

Current behavior before PR:

- Returning error when importing existing assets again using base_import_module

Desired behavior after PR is merged:

- It should updating the existing assets instead of trying to create it again.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
