### PR TITLE
[FIX]link_tracker: Re allow creation

### DIFF
--- a/addons/link_tracker/views/link_tracker_views.xml
+++ b/addons/link_tracker/views/link_tracker_views.xml
@@ -26,7 +26,7 @@
             <field name="name">link.tracker.view.form</field>
             <field name="model">link.tracker</field>
             <field name="arch" type="xml">
-                <form string="Website Link" duplicate="0" create="0">
+                <form string="Website Link" duplicate="0">
                     <sheet>
                         <div class="oe_button_box" name="button_box">
                             <button type="object" icon="fa-sign-out" name="action_visit_page"
@@ -58,7 +58,7 @@
             <field name="name">link.tracker.view.tree</field>
             <field name="model">link.tracker</field>
             <field name="arch" type="xml">
-                <tree string="Links" sample="1" create="0">
+                <tree string="Links" sample="1">
                     <field name="create_date"/>
                     <field name="title"/>
                     <field name="label"/>


### PR DESCRIPTION
PURPOSE

Since v14 (with commit[1]), we prevented users from creating 'link.tracker'
and 'link.tracker.click' records.

This is not ideal because creation of the link trackers should be allowed
whenever needed (for example to add it in a button somewhere, ...) unlike
'link.tracker.click', which is a technical model and so the records should
always be created by system.

SPECIFICATION

This PR partially reverts commit[1] and allows users to create the
'link.tracker' records if user is having enough access rights.

commit[1] - odoo@d430822

Task Id- 2712107

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
