### PR TITLE
[FIX] sale,account,web: fix alignment 'Total' and Address on reports in RTL language

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -122,8 +122,8 @@
                     </table>
 
                     <div class="clearfix">
-                        <div id="total" class="row">
-                            <div t-attf-class="#{'col-6' if report_type != 'html' else 'col-sm-7 col-md-6'} ml-auto">
+                        <div id="total" class="row justify-content-end">
+                            <div t-attf-class="#{'col-6' if report_type != 'html' else 'col-sm-7 col-md-6'}">
                                 <table class="table table-sm" style="page-break-inside: avoid;">
 
                                     <!--Tax totals-->

--- a/addons/sale/report/sale_report_templates.xml
+++ b/addons/sale/report/sale_report_templates.xml
@@ -141,8 +141,8 @@
             </table>
 
             <div class="clearfix" name="so_total_summary">
-                <div id="total" class="row" name="total">
-                    <div t-attf-class="#{'col-4' if report_type != 'html' else 'col-sm-7 col-md-5'} ml-auto">
+                <div id="total" class="row justify-content-end" name="total">
+                    <div t-attf-class="#{'col-4' if report_type != 'html' else 'col-sm-7 col-md-5'}">
                         <table class="table table-sm">
                             <!-- Tax totals -->
                             <t t-set="tax_totals" t-value="json.loads(doc.tax_totals_json)"/>

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -291,9 +291,9 @@
     <!-- External layouts styles -->
 
     <template id="address_layout">
-        <t t-set="colclass" t-value="('col-sm-5' if report_type == 'html' else 'col-5') + ' ml-auto'"/>
+        <t t-set="colclass" t-value="('col-sm-5' if report_type == 'html' else 'col-5')"/>
         <t t-if="address">
-            <div class="address row">
+            <div class="address row justify-content-end">
                 <t t-if="information_block">
                     <t t-set="colclass" t-value="'col-5 offset-1'"/>
                     <div name="information_block" class="col-6">


### PR DESCRIPTION
### Current behavior
'Total' and Address blocks are not properly aligned on RTL language's reports

### Expected behavior
'Total' and Address blocks should be left aligned on RTL language's reports

### Steps to reproduce
- Install Sales and Invoicing
- Create a Quotation 
- Choose/Set a client with a RTL language (e.g. Hebrew)
- Try to print the quotation
- Create an invoice
- Try to print the invoice

### Examples
#### Quotation
[v14_quotation.pdf](https://github.com/odoo/odoo/files/7784339/v14_quotation.pdf)
[v15_quotation.pdf](https://github.com/odoo/odoo/files/7784341/v15_quotation.pdf)
[v15_fixed_quotation.pdf](https://github.com/odoo/odoo/files/7784340/v15_fixed_quotation.pdf)

#### Invoice
[v14_invoice.pdf](https://github.com/odoo/odoo/files/7784343/v14_invoice.pdf)
[v15_invoice.pdf](https://github.com/odoo/odoo/files/7784344/v15_invoice.pdf)
[v15_fixed_invoice.pdf](https://github.com/odoo/odoo/files/7784342/v15_fixed_invoice.pdf)

OPW-2704477
