### PR TITLE
[FIX] account: Validate invoice with archived bank account

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -12055,6 +12055,14 @@ msgid "The payment's currency."
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/account_move.py:0
+#, python-format
+msgid ""
+"The recipient bank account link to this invoice is archived.\n"
+"So you cannot confirm the invoice."
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,help:account.field_account_reconcile_model__match_partner_category_ids
 #: model:ir.model.fields,help:account.field_account_reconcile_model_template__match_partner_category_ids
 msgid ""

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2594,6 +2594,8 @@ class AccountMove(models.Model):
         if not self.env.su and not self.env.user.has_group('account.group_account_invoice'):
             raise AccessError(_("You don't have the access rights to post an invoice."))
         for move in to_post:
+            if move.partner_bank_id and not move.partner_bank_id.active:
+                raise UserError(_("The recipient bank account link to this invoice is archived.\nSo you cannot confirm the invoice."))
             if move.state == 'posted':
                 raise UserError(_('The entry %s (id %s) is already posted.') % (move.name, move.id))
             if not move.line_ids.filtered(lambda line: not line.display_type):


### PR DESCRIPTION
### Step to reproduce:
- create an invoice with an archived recipient bank account
- confirm the invoice
- it's possible to confirm the invoice

### Current Behavior:
The invoice can be confirmed, even if the recipient bank account link to the invoice is archived. But it doesn't make sense to confirm an invoice with an archived account number.

### Behavior after the PR:
The user will be blocked with a "user error" to prevent him to confirm the invoice if the recipient bank account is archived.

opw-2704605

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
