### PR TITLE
[FIX] mrp: Context irrelevant of hidden parameters for mrp

### DIFF
--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import fields, models, api
 
 
 class StockPickingType(models.Model):
@@ -49,6 +49,12 @@ class StockPickingType(models.Model):
 
     def get_mrp_stock_picking_action_picking_type(self):
         return self._get_action('mrp.mrp_production_action_picking_deshboard')
+
+    @api.onchange('code')
+    def _onchange_code(self):
+        if self.code == 'mrp_operation':
+            self.use_create_lots = True
+            self.use_existing_lots = True
 
 class StockPicking(models.Model):
     _inherit = 'stock.picking'


### PR DESCRIPTION
Step to reproduce:
- Inventory > Configuration > Operations Types > Manufacturing (or any other operation type with code 'mrp_operation')
- Change 'Type of Operation' to 'Receipt' (or any other but 'manufacturing')
- Uncheck box field 'Use Existing Lots/Serial Numbers'
- Change 'Type of Operation' back to 'Manufacturing'
- Set correct value for 'Default Source Location' (type Receipt changed the value to 'Vendor', need to fix it)

- Create a storable product with the route 'Manufacture' selected.
- Create a BoM for this product, with a component tracked by lot (Add quantity to component)
- Create a MO for the product > Confirm > Check Availability

Current Behaviour :
Quantity are reserved, but the lot_ids are not visible

Behaviour after PR :
Lot ids are shown no matter the hidden configuration of picking type

opw-2680370

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
