### PR TITLE
[IMP] mail: cleanup '_htmlEscape' usage

### DIFF
--- a/addons/mail/static/src/js/emojis_mixin.js
+++ b/addons/mail/static/src/js/emojis_mixin.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { escape } from '@web/core/utils/strings';
 import emojis from '@mail/js/emojis';
 
 /**
@@ -49,24 +50,11 @@ export default {
      * @param {String} message a text message to format
      */
     _formatText: function (message) {
-        message = this._htmlEscape(message);
+        message = escape(message);
         message = this._wrapEmojis(message);
         message = message.replace(/(?:\r\n|\r|\n)/g, '<br>');
 
         return message;
-    },
-
-    /**
-     * Adapted from qweb2.js#html_escape to avoid formatting '&'
-     *
-     * @param {String} s
-     * @private
-     */
-    _htmlEscape: function (s) {
-        if (s == null) {
-            return '';
-        }
-        return String(s).replace(/</g, '&lt;').replace(/>/g, '&gt;');
     },
 
     /**


### PR DESCRIPTION
We instead use the standard owl.utils.escape.
This allows having less custom implementations of escaping and rely on existing
tools.

Task-2622893

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
