### PR TITLE
update the translation of Billed Quantity

### DIFF
--- a/addons/purchase/i18n/zh_CN.po
+++ b/addons/purchase/i18n/zh_CN.po
@@ -730,7 +730,7 @@ msgstr "开单数量"
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.track_po_line_template
 msgid "Billed Quantity:"
-msgstr "宣传量："
+msgstr "开单数量："
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_order__invoice_status


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Wrong Translation
Current behavior before PR:
Billed Quantity translated to "宣传量"， it's wroing, should be "开单数量"
Desired behavior after PR is merged:

should be translated to "开单数量"


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
