### PR TITLE
[14.0] #69619 hr_holiday allocated/taken compensatory hours must remains same after week config changes

### DIFF
--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -11,3 +11,4 @@ from . import test_change_department
 from . import test_leave_requests
 from . import test_out_of_office
 from . import test_company_leave
+from . import test_hr_employee_week_change

--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -315,7 +315,7 @@ class TestCompanyLeave(SavepointCase):
         })
         company_leave._compute_date_from_to()
 
-        count = 734
+        count = 987
         with self.assertQueryCount(__system__=count, admin=count):
             # Original query count: 1987
             # Without tracking/activity context keys: 5154

--- a/addons/hr_holidays/tests/test_hr_employee_week_change.py
+++ b/addons/hr_holidays/tests/test_hr_employee_week_change.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import timedelta, date
+from odoo import tests
+from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
+from odoo.tests.common import Form
+
+
+@tests.tagged("post_install", "-at_install")
+class TestHrHolidaysChangingEmployeeWeek(TestHrHolidaysCommon):
+    def setUp(self):
+        super().setUp()
+        self.week_40_hour_per_week = self.env.ref("resource.resource_calendar_std")
+        self.week_35_hour_per_week = self.env.ref("resource.resource_calendar_std_35h")
+        self.compensatory_leave_type = self.env.ref("hr_holidays.holiday_status_comp")
+        self.assertEqual(
+            self.employee_emp.resource_calendar_id.id,
+            self.week_40_hour_per_week.id,
+            f"Expected default calendar to be 40h/week (found: {self.employee_emp.resource_calendar_id})",
+        )
+        self.alloc = (
+            self.env["hr.leave.allocation"]
+            .with_user(self.user_hrmanager.id)
+            .with_context(tracking_disable=True)
+            .create(
+                {
+                    "name": "Compensatory allocation for employee",
+                    "employee_id": self.employee_emp.id,
+                    "holiday_status_id": self.compensatory_leave_type.id,
+                    "allocation_type": "regular",
+                    "holiday_type": "employee",
+                    "number_of_days": 5,
+                    # 'number_of_hours_display': 40,
+                }
+            )
+        )
+        self.alloc.action_approve()
+        self.alloc = self.alloc.with_user(self.user_employee.id)
+        today = date.today()
+        next_monday = today + timedelta(days=-today.weekday(), weeks=1)
+        leave_form = Form(
+            self.env["hr.leave"].with_user(self.user_hrmanager),
+            view="hr_holidays.hr_leave_view_form_manager",
+        )
+        leave_form.employee_id = self.employee_emp
+        leave_form.holiday_status_id = self.compensatory_leave_type
+        leave_form.request_date_from = next_monday
+        leave_form.request_date_to = next_monday
+        self.compensatory_day = leave_form.save()
+        self.compensatory_day.action_approve()
+        self.compensatory_day = self.compensatory_day.with_user(self.user_employee.id)
+
+        self.assertEqual(self.alloc.number_of_hours_display, 40)
+        self.assertEqual(self.alloc.hours_per_day, 8)
+        self.assertEqual(self.alloc.max_leaves, 40)
+        self.assertEqual(self.alloc.leaves_taken, 8)
+        self.assertEqual(self.compensatory_day.number_of_hours_display, 8)
+        self.assertEqual(self.compensatory_day.duration_display, "8 hours")
+        self.assertEqual(self.compensatory_day.hours_per_day, 8)
+
+        # avoid getting upset with computed field cached
+        self.alloc.refresh()
+        self.compensatory_day.refresh()
+
+    def test_change_employee_week_keep_same_alloc_number_of_hours_display(self):
+        """Acquired approved compensatory hours shouldn't change even
+        employee contract change moving from 40 hours to 35 hours"""
+        self.employee_emp.resource_calendar_id = self.week_35_hour_per_week
+        self.assertEqual(self.alloc.number_of_hours_display, 40)
+
+    def test_change_employee_week_keep_same_max_leaves(self):
+        """Acquired approved compensatory hours shouldn't change even
+        employee contract change moving from 40 hours to 35 hours"""
+        self.employee_emp.resource_calendar_id = self.week_35_hour_per_week
+        self.assertEqual(self.alloc.max_leaves, 40)
+
+    def test_change_employee_week_keep_same_leaves_taken(self):
+        """Acquired approved compensatory hours shouldn't change even
+        employee contract change moving from 40 hours to 35 hours"""
+        self.employee_emp.resource_calendar_id = self.week_35_hour_per_week
+        self.assertEqual(self.alloc.leaves_taken, 8)
+
+    def test_change_employee_week_keep_same_number_of_hours_display(self):
+        """Acquired approved compensatory hours shouldn't change even
+        employee contract change moving from 40 hours to 35 hours"""
+        self.employee_emp.resource_calendar_id = self.week_35_hour_per_week
+        self.assertEqual(self.compensatory_day.number_of_hours_display, 8)
+
+    def test_change_employee_week_keep_same_duration_display(self):
+        """Acquired approved compensatory hours shouldn't change even
+        employee contract change moving from 40 hours to 35 hours"""
+        self.employee_emp.resource_calendar_id = self.week_35_hour_per_week
+        self.assertEqual(self.compensatory_day.duration_display, "8 hours")
+        self.env.add_to_compute(
+            self.compensatory_day._fields["duration_display"], self.compensatory_day
+        )
+        self.compensatory_day.recompute()
+        self.assertEqual(self.compensatory_day.duration_display, "8 hours")
+
+    def test_change_employee_week_hours_keep_same_number_of_hours_display(self):
+        """Acquired approved compensatory hours shouldn't change even
+        employee contract changing hours on hour earlier on monday on 40 hours/week"""
+        self.employee_emp.resource_calendar_id.attendance_ids[0].hour_from -= 1
+        self.employee_emp.resource_calendar_id.attendance_ids[0].hour_to -= 1
+        self.assertEqual(self.compensatory_day.number_of_hours_display, 8)
+
+    def test_change_employee_week_keep_hours_same_duration_display(self):
+        """Acquired approved compensatory hours shouldn't change even
+        employee contract changing hours on hour earlier on monday on 40 hours/week"""
+        self.employee_emp.resource_calendar_id.attendance_ids[0].hour_from -= 1
+        self.employee_emp.resource_calendar_id.attendance_ids[0].hour_to -= 1
+        self.assertEqual(self.compensatory_day.duration_display, "8 hours")
+        self.env.add_to_compute(
+            self.compensatory_day._fields["duration_display"], self.compensatory_day
+        )
+        self.compensatory_day.recompute()
+        self.assertEqual(self.compensatory_day.duration_display, "8 hours")

--- a/doc/cla/individual/petrus-v.md
+++ b/doc/cla/individual/petrus-v.md
@@ -1,0 +1,11 @@
+France, 2021-03-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Pierre Verkest pierreverkest84@gmail.com https://github.com/petrus-v


### PR DESCRIPTION
Updating hr employee works week changes amount of allocated and takens hours
on compensatory hr leave type.

This commit add unit test that prove the issue

Description of the issue/feature this PR addresses:

At the time writing this are unit test to reproduce https://github.com/odoo/odoo/issues/68619 issue. While moving employee works week configuration (changing from 40h to 35h a week or changing days time)  it changes amount approved allocated / taken hours

I'll try to suggest a fix, could you please to get in touch if you read that message before I've implemented it? to agree how to fix that to get a chance to be merge.

# Current behavior before PR:

Amount approved allocated / taken hours changes while changing employee works week configuration.

# Desired behavior after PR is merged:

Amount approved allocated / taken hours still the same after employee works week changes.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr (cherry picked from other open unmerged PR)
