### PR TITLE
[15.0][FIX] Fix kitchen order black bar if ordered from smartphone

### DIFF
--- a/addons/point_of_sale/static/src/js/printers.js
+++ b/addons/point_of_sale/static/src/js/printers.js
@@ -105,6 +105,7 @@ var PrinterMixin = {
                     resolve(self.process_canvas(canvas));
                 },
                 letterRendering: self.htmlToImgLetterRendering,
+                width: 512
             })
         });
         return promise;

--- a/doc/cla/individual/rgon.md
+++ b/doc/cla/individual/rgon.md
@@ -1,0 +1,11 @@
+Spain, 2021-12-14
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Gonzalo Ruiz rgon@rgon.es https://github.com/rgon


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:
Point of Sale kitchen order tickets covered by black bar from mobile devices (fixes #81296)

## Current behavior before PR:
Tickets get printed with a black bar at the right covering the order lines. Only happens when ordering from (some) mobile devices in portrait (not landscape) mode.

## Desired behavior after PR is merged:
An order ticket gets printed with all the items clearly visible no matter the device it is issued from.



----
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
