### PR TITLE
[FIX] point_of_sale: assign SML with correct SN

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -3,6 +3,7 @@
 import logging
 from datetime import timedelta
 from functools import partial
+from itertools import groupby
 
 import psycopg2
 import pytz
@@ -1084,6 +1085,15 @@ class PosOrderLine(models.Model):
             if pickings_to_confirm:
                 # Trigger the Scheduler for Pickings
                 pickings_to_confirm.action_confirm()
+                tracked_lines = order.lines.filtered(lambda l: l.product_id.tracking != 'none')
+                lines_by_tracked_product = groupby(sorted(tracked_lines, key=lambda l: l.product_id.id), key=lambda l: l.product_id.id)
+                mls_to_unlink = self.env['stock.move.line']
+                for product, lines in lines_by_tracked_product:
+                    lines = self.env['pos.order.line'].concat(*lines)
+                    moves = pickings_to_confirm.move_lines.filtered(lambda m: m.product_id in tracked_lines.product_id)
+                    mls_to_unlink |= moves.move_line_ids
+                    moves._add_mls_related_to_order(lines, are_qties_done=False)
+                mls_to_unlink.unlink()
         return True
 
     def _is_product_storable_fifo_avco(self):

--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -88,76 +88,11 @@ class StockPicking(models.Model):
         lines_by_product = groupby(sorted(lines, key=lambda l: l.product_id.id), key=lambda l: l.product_id.id)
         for product, lines in lines_by_product:
             order_lines = self.env['pos.order.line'].concat(*lines)
-            first_line = order_lines[0]
             current_move = self.env['stock.move'].create(
-                self._prepare_stock_move_vals(first_line, order_lines)
+                self._prepare_stock_move_vals(order_lines[0], order_lines)
             )
             confirmed_moves = current_move._action_confirm()
-            for move in confirmed_moves:
-                if first_line.product_id == move.product_id and first_line.product_id.tracking != 'none':
-                    if self.picking_type_id.use_existing_lots or self.picking_type_id.use_create_lots:
-                        for line in order_lines:
-                            sum_of_lots = 0
-                            for lot in line.pack_lot_ids.filtered(lambda l: l.lot_name):
-                                if line.product_id.tracking == 'serial':
-                                    qty = 1
-                                else:
-                                    qty = abs(line.qty)
-                                ml_vals = move._prepare_move_line_vals()
-                                ml_vals.update({'qty_done':qty})
-                                if self.picking_type_id.use_existing_lots:
-                                    existing_lot = self.env['stock.production.lot'].search([
-                                        ('company_id', '=', self.company_id.id),
-                                        ('product_id', '=', line.product_id.id),
-                                        ('name', '=', lot.lot_name)
-                                    ])
-                                    if not existing_lot and self.picking_type_id.use_create_lots:
-                                        existing_lot = self.env['stock.production.lot'].create({
-                                            'company_id': self.company_id.id,
-                                            'product_id': line.product_id.id,
-                                            'name': lot.lot_name,
-                                        })
-                                    quant = existing_lot.quant_ids.filtered(lambda q: q.quantity > 0.0 and q.location_id.parent_path.startswith(move.location_id.parent_path))[-1:]
-                                    ml_vals.update({
-                                        'lot_id': existing_lot.id,
-                                        'location_id': quant.location_id.id or move.location_id.id
-                                    })
-                                else:
-                                    ml_vals.update({
-                                        'lot_name': lot.lot_name,
-                                    })
-                                self.env['stock.move.line'].create(ml_vals)
-                                sum_of_lots += qty
-                            if abs(line.qty) != sum_of_lots:
-                                difference_qty = abs(line.qty) - sum_of_lots
-                                ml_vals = current_move._prepare_move_line_vals()
-                                if line.product_id.tracking == 'serial':
-                                    ml_vals.update({'qty_done': 1})
-                                    for i in range(int(difference_qty)):
-                                        self.env['stock.move.line'].create(ml_vals)
-                                else:
-                                    ml_vals.update({'qty_done': difference_qty})
-                                    self.env['stock.move.line'].create(ml_vals)
-                    else:
-                        move._action_assign()
-                        for move_line in move.move_line_ids:
-                            move_line.qty_done = move_line.product_uom_qty
-                        if float_compare(move.product_uom_qty, move.quantity_done, precision_rounding=move.product_uom.rounding) > 0:
-                            remaining_qty = move.product_uom_qty - move.quantity_done
-                            ml_vals = move._prepare_move_line_vals()
-                            ml_vals.update({'qty_done':remaining_qty})
-                            self.env['stock.move.line'].create(ml_vals)
-
-                else:
-                    move._action_assign()
-                    for move_line in move.move_line_ids:
-                        move_line.qty_done = move_line.product_uom_qty
-                    if float_compare(move.product_uom_qty, move.quantity_done, precision_rounding=move.product_uom.rounding) > 0:
-                        remaining_qty = move.product_uom_qty - move.quantity_done
-                        ml_vals = move._prepare_move_line_vals()
-                        ml_vals.update({'qty_done':remaining_qty})
-                        self.env['stock.move.line'].create(ml_vals)
-                    move.quantity_done = move.product_uom_qty
+            confirmed_moves._add_mls_related_to_order(order_lines)
 
     def _send_confirmation_email(self):
         # Avoid sending Mail/SMS for POS deliveries
@@ -181,3 +116,74 @@ class StockMove(models.Model):
     def _key_assign_picking(self):
         keys = super(StockMove, self)._key_assign_picking()
         return keys + (self.group_id.pos_order_id,)
+
+    def _add_mls_related_to_order(self, related_order_lines):
+        for move in self:
+            if related_order_lines[0].product_id == move.product_id and related_order_lines[0].product_id.tracking != 'none':
+                if self.picking_type_id.use_existing_lots or self.picking_type_id.use_create_lots:
+                    for line in related_order_lines:
+                        sum_of_lots = 0
+                        for lot in line.pack_lot_ids.filtered(lambda l: l.lot_name):
+                            if line.product_id.tracking == 'serial':
+                                qty = 1
+                            else:
+                                qty = abs(line.qty)
+                            ml_vals = move._prepare_move_line_vals()
+                            ml_vals.update({'qty_done': qty})
+                            if self.picking_type_id.use_existing_lots:
+                                existing_lot = self.env['stock.production.lot'].search([
+                                    ('company_id', '=', self.company_id.id),
+                                    ('product_id', '=', line.product_id.id),
+                                    ('name', '=', lot.lot_name)
+                                ])
+                                if not existing_lot and self.picking_type_id.use_create_lots:
+                                    existing_lot = self.env['stock.production.lot'].create({
+                                        'company_id': self.company_id.id,
+                                        'product_id': line.product_id.id,
+                                        'name': lot.lot_name,
+                                    })
+                                quant = existing_lot.quant_ids.filtered(
+                                    lambda q: q.quantity > 0.0 and q.location_id.parent_path.startswith(
+                                        move.location_id.parent_path))[-1:]
+                                ml_vals.update({
+                                    'lot_id': existing_lot.id,
+                                    'location_id': quant.location_id.id or move.location_id.id
+                                })
+                            else:
+                                ml_vals.update({
+                                    'lot_name': lot.lot_name,
+                                })
+                            self.env['stock.move.line'].create(ml_vals)
+                            sum_of_lots += qty
+                        if abs(line.qty) != sum_of_lots:
+                            difference_qty = abs(line.qty) - sum_of_lots
+                            ml_vals = self[0]._prepare_move_line_vals()
+                            if line.product_id.tracking == 'serial':
+                                ml_vals.update({'qty_done': 1})
+                                for i in range(int(difference_qty)):
+                                    self.env['stock.move.line'].create(ml_vals)
+                            else:
+                                ml_vals.update({'qty_done': difference_qty})
+                                self.env['stock.move.line'].create(ml_vals)
+                else:
+                    move._action_assign()
+                    for move_line in move.move_line_ids:
+                        move_line.qty_done = move_line.product_uom_qty
+                    if float_compare(move.product_uom_qty, move.quantity_done,
+                                     precision_rounding=move.product_uom.rounding) > 0:
+                        remaining_qty = move.product_uom_qty - move.quantity_done
+                        ml_vals = move._prepare_move_line_vals()
+                        ml_vals.update({'qty_done': remaining_qty})
+                        self.env['stock.move.line'].create(ml_vals)
+
+            else:
+                move._action_assign()
+                for move_line in move.move_line_ids:
+                    move_line.qty_done = move_line.product_uom_qty
+                if float_compare(move.product_uom_qty, move.quantity_done,
+                                 precision_rounding=move.product_uom.rounding) > 0:
+                    remaining_qty = move.product_uom_qty - move.quantity_done
+                    ml_vals = move._prepare_move_line_vals()
+                    ml_vals.update({'qty_done': remaining_qty})
+                    self.env['stock.move.line'].create(ml_vals)
+                move.quantity_done = move.product_uom_qty

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -1012,3 +1012,77 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         # check the difference line
         diff_line = pos_session.move_id.line_ids.filtered(lambda line: line.name == 'Difference at closing PoS session')
         self.assertAlmostEqual(diff_line.credit, 5.0, msg="Missing amount of 5.0")
+
+    def test_order_and_ship_later(self):
+        """ In case the product is tracked and the "Ship Later" feature is enabled, this test ensures
+        that the lots defined on the POS order are the same that the ones on the SMLs of the associated
+        picking"""
+        self.env['stock.picking.type'].search([('code', '=', 'outgoing')]).write({
+            'use_create_lots': True,
+            'use_existing_lots': True,
+        })
+
+        tracked_product = self.env['product.product'].create({
+            'name': 'SuperProduct Tracked',
+            'type': 'product',
+            'tracking': 'lot',
+            'available_in_pos': True,
+        })
+
+        lot01, lot02 = self.env['stock.production.lot'].create([{
+            'name': name,
+            'product_id': tracked_product.id,
+            'company_id': self.env.company.id,
+        } for name in ['Lot01', 'Lot02']])
+        stock_location = self.company_data['default_warehouse'].lot_stock_id
+        self.env['stock.quant']._update_available_quantity(tracked_product, stock_location, 10, lot_id=lot01)
+        self.env['stock.quant']._update_available_quantity(tracked_product, stock_location, 10, lot_id=lot02)
+
+        self.pos_config.ship_later = True
+        self.pos_config.open_session_cb()
+
+        # Create a POS order with:
+        #   1 x Lot01
+        #   1 x Lot02
+        #   1 x Lot03 (-> nonexistent lot!)
+        pos_order = self.PosOrder.create({
+            'company_id': self.env.company.id,
+            'session_id': self.pos_config.current_session_id.id,
+            'pricelist_id': self.partner1.property_product_pricelist.id,
+            'partner_id': self.partner1.id,
+            'lines': [(0, 0, {
+                'name': "OL/0001",
+                'product_id': tracked_product.id,
+                'price_unit': 5,
+                'discount': 0.0,
+                'qty': 1.0,
+                'tax_ids': [(6, 0, [])],
+                'price_subtotal': 5,
+                'price_subtotal_incl': 5,
+                'pack_lot_ids': [[0, 0, {'lot_name': lot_name}]],
+            }) for lot_name in [lot01.name, lot02.name, 'Lot03']],
+            'amount_tax': 10,
+            'amount_total': 10,
+            'amount_paid': 0,
+            'amount_return': 0,
+            'to_ship': True,
+        })
+
+        context_make_payment = {
+            "active_ids": [pos_order.id],
+            "active_id": pos_order.id,
+        }
+        pos_make_payment = self.PosMakePayment.with_context(context_make_payment).create({
+            'amount': 10,
+        })
+        pos_make_payment.with_context(active_id=pos_order.id).check()
+
+        picking = pos_order.picking_ids
+        picking_mls = picking.move_line_ids
+        lot01_ml = picking_mls.filtered(lambda ml: ml.lot_id == lot01)
+        lot02_ml = picking_mls.filtered(lambda ml: ml.lot_id == lot02)
+        lot03_ml = picking_mls - lot01_ml - lot02_ml
+        self.assertEqual(lot01_ml.product_qty, 1)
+        self.assertEqual(lot02_ml.product_qty, 1)
+        self.assertEqual(lot03_ml.product_qty, 1)
+        self.assertEqual(lot03_ml.lot_id.name, "Lot03")


### PR DESCRIPTION
In case the product is tracked and the "Ship Later" feature is enabled,
the lots defined on the POS order are not the same that the ones on the
SMLs of the associated picking

To reproduce the issue:
(Use demo data)
1. Create a product P:
    - Type: Storable
    - Tracked by lots
    - Available in POS
2. Update P's quantity:
    - 2 x Lot01
    - 2 x Lot02
3. Edit the existing POS:
    - Enable the "Ship Later" feature
4. Start a POS session
5. Add some products:
    - 1 x P (Lot01)
    - 1 x P (Lot02)
6. Process the order with the option "Ship Later" selected
7. Open the associated delivery order

Error: The reserved lots are incorrect: 2 x Lot01 instead of 1 x Lot01 +
1 x Lot02

When creating such a POS order, if the feature "Ship Later" is used, a
method creates a procurement for each POS order line thanks to
`_launch_stock_rule_from_pos_order_lines`
https://github.com/odoo/odoo/blob/72d6431eb26654b697fc0379f4b6d7e305bb79fc/addons/point_of_sale/models/pos_order.py#L677-L680
Then, these procurements are managed by the standard process, which does
not consider the defined lots. This is the reason why it simply uses the
available quantity in the first lot.

OPW-2704352