### PR TITLE
[IMP] project_sms: send sms at stage change of project and task

### DIFF
--- a/addons/project_sms/__init__.py
+++ b/addons/project_sms/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/project_sms/__manifest__.py
+++ b/addons/project_sms/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "Project - SMS",
+    'summary': 'Send text messages when project/task stage move',
+    'description': "Send text messages when project/task stage move",
+    'category': 'Hidden',
+    'version': '1.0',
+    'depends': ['project', 'sms'],
+    'data': [
+        'views/project_stage_views.xml',
+        'views/project_task_type_views.xml',
+        'security/ir.model.access.csv',
+        'security/project_sms_security.xml',
+    ],
+    'application': False,
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/project_sms/models/__init__.py
+++ b/addons/project_sms/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import project_task_type
+from . import project_task
+from . import project_stage
+from . import project

--- a/addons/project_sms/models/project.py
+++ b/addons/project_sms/models/project.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class ProjectProject(models.Model):
+    _inherit = "project.project"
+
+    def _send_sms(self):
+        for project in self:
+            if project.partner_id and project.stage_id and project.stage_id.sms_template_id:
+                project._message_sms_with_template(template=project.stage_id.sms_template_id, partner_ids=project.partner_id.ids)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        projects = super().create(vals_list)
+        projects._send_sms()
+        return projects
+
+    def write(self, vals):
+        res = super().write(vals)
+        if 'stage_id' in vals:
+            self._send_sms()
+        return res

--- a/addons/project_sms/models/project_stage.py
+++ b/addons/project_sms/models/project_stage.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ProjectProjectStage(models.Model):
+    _inherit = 'project.project.stage'
+
+    sms_template_id = fields.Many2one('sms.template', string="SMS Template",
+        domain=[('model', '=', 'project.project')], help="Template used to render SMS reminder content.")

--- a/addons/project_sms/models/project_task.py
+++ b/addons/project_sms/models/project_task.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class ProjectTask(models.Model):
+    _inherit = "project.task"
+
+    def _send_sms(self):
+        for task in self:
+            if task.partner_id and task.stage_id and task.stage_id.sms_template_id:
+                task._message_sms_with_template(template=task.stage_id.sms_template_id, partner_ids=task.partner_id.ids)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        tasks = super().create(vals_list)
+        tasks._send_sms()
+        return tasks
+
+    def write(self, vals):
+        res = super().write(vals)
+        if 'stage_id' in vals:
+            self._send_sms()
+        return res

--- a/addons/project_sms/models/project_task_type.py
+++ b/addons/project_sms/models/project_task_type.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ProjectTaskType(models.Model):
+    _inherit = "project.task.type"
+
+    sms_template_id = fields.Many2one('sms.template', string="SMS Template",
+        domain=[('model', '=', 'project.task')], help="Template used to render SMS reminder content.")

--- a/addons/project_sms/security/ir.model.access.csv
+++ b/addons/project_sms/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sms_template_project_manager,access.sms.template.project.manager,sms.model_sms_template,project.group_project_manager,1,1,1,1

--- a/addons/project_sms/security/project_sms_security.xml
+++ b/addons/project_sms/security/project_sms_security.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="ir_rule_sms_template_project_manager" model="ir.rule">
+        <field name="name">SMS Template: project manager CUD on project/task</field>
+        <field name="model_id" ref="sms.model_sms_template"/>
+        <field name="groups" eval="[(4, ref('project.group_project_manager'))]"/>
+        <field name="domain_force">[('model_id.model', 'in', ('project.task.type', 'project.project.stage'))]</field>
+        <field name="perm_read" eval="False"/>
+    </record>
+</odoo>

--- a/addons/project_sms/views/project_stage_views.xml
+++ b/addons/project_sms/views/project_stage_views.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="project_project_stage_view_tree_inherit_project_sms" model="ir.ui.view">
+        <field name="name">project.project.stage.view.tree.inherit.project.sms</field>
+        <field name="model">project.project.stage</field>
+        <field name="inherit_id" ref="project.project_project_stage_view_tree"/>
+        <field name="arch" type="xml">
+            <field name="mail_template_id" position="after">
+                <field name="sms_template_id" optional="hide" context="{'default_model': 'project.project'}"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="project_project_stage_view_form_inherit_project_sms" model="ir.ui.view">
+        <field name="name">project.project.stage.view.form.inherit.project.sms</field>
+        <field name="model">project.project.stage</field>
+        <field name="inherit_id" ref="project.project_project_stage_view_form"/>
+        <field name="arch" type="xml">
+            <field name="mail_template_id" position="after">
+                <field name="sms_template_id" context="{'default_model': 'project.project'}" options="{'no_quick_create': True}"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="project_project_stage_view_search_inherit_project_sms" model="ir.ui.view">
+        <field name="name">project.project.stage.view.search.inherit.project.sms</field>
+        <field name="model">project.project.stage</field>
+        <field name="inherit_id" ref="project.project_project_stage_view_search"/>
+        <field name="arch" type="xml">
+            <field name="mail_template_id" position="after">
+                <field name="sms_template_id" domain="[('model', '=', 'project.project')]"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/project_sms/views/project_task_type_views.xml
+++ b/addons/project_sms/views/project_task_type_views.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="task_type_edit_view_form_inherit_project_sms" model="ir.ui.view">
+        <field name="name">project.task.type.view.form.inherit.project.sms</field>
+        <field name="model">project.task.type</field>
+        <field name="inherit_id" ref="project.task_type_edit"/>
+        <field name="arch" type="xml">
+            <field name="rating_template_id" position="after">
+                <field name="sms_template_id" context="{'default_model': 'project.task'}" options="{'no_quick_create': True}"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="task_type_edit_view_tree_inherit_project_sms" model="ir.ui.view">
+        <field name="name">project.task.type.view.tree.inherit.project.sms</field>
+        <field name="model">project.task.type</field>
+        <field name="inherit_id" ref="project.task_type_tree"/>
+        <field name="arch" type="xml">
+            <field name="mail_template_id" position="after">
+                <field name="sms_template_id" optional="hide"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="task_type_search_view_search_inherit_project_sms" model="ir.ui.view">
+        <field name="name">project.task.type.view.search.inherit.project.sms</field>
+        <field name="model">project.task.type</field>
+        <field name="inherit_id" ref="project.task_type_search"/>
+        <field name="arch" type="xml">
+            <field name="rating_template_id" position="after">
+                <field name="sms_template_id" domain="[('model', '=', 'project.task')]"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
The purpose of this commit is to include SMS templates. Templates allow people to
customize the content of sent SMS. When the project/task stage changes, the user will
be notified and there will be a track in the chatter.

- add this field on the right of the 'email template' one in list view.
optional and hidden by default.
- add it below the 'name' quick search in the search view.

task-2683575