### PR TITLE
[FIX] sale_stock: correctly display lot's quantities on invoice

### DIFF
--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -92,7 +92,7 @@ class AccountMove(models.Model):
                 continue
             lot_values.append({
                 'product_name': lot_id.product_id.display_name,
-                'quantity': qty,
+                'quantity': self.env['ir.qweb.field.float'].value_to_html(qty, {'precision': self.env['decimal.precision'].precision_get('Product Unit of Measure')}),
                 'uom_name': lot_id.product_uom_id.name,
                 'lot_name': lot_id.name,
                 # The lot id is needed by localizations to inherit the method and add custom fields on the invoice's report.


### PR DESCRIPTION
### Current behavior
Quantity displayed on 'Detailed operations' block for a product lot isn't correctly displayed on the invoice sometimes.

### Steps to reproduce
- Install Sales and Stock
- Enable 'Units of Measure' in Settings
- Enable debug mode then go to Users and enable 'Display Serial & Lot Number on Invoices' for current user (i.e. Mitchell Admin)
- Create a new product
  - Tracking set to 'By Lots'
  - UoM set to 'g'
- Create a quotation with the previously created product and set the quantity to 3.07
- Confirm the quotation, go to the Delivery and confirm it too
- Go back to the SO and create the invoice, then go to the invoice and confirm it
- Print the invoice

### Example
[invoice_before_fix.pdf](https://github.com/odoo/odoo/files/7704188/invoice_before_fix.pdf)
[invoice_after_fix.pdf](https://github.com/odoo/odoo/files/7704189/invoice_after_fix.pdf)

OPW-2704307