### PR TITLE
[IMP] mail: rename attachment image model

### DIFF
--- a/addons/mail/static/src/components/attachment_image/attachment_image.js
+++ b/addons/mail/static/src/components/attachment_image/attachment_image.js
@@ -11,7 +11,7 @@ export class AttachmentImage extends Component {
      */
     setup() {
         super.setup();
-        useComponentToModel({ fieldName: 'component', modelName: 'mail.attachment_image', propNameAsRecordLocalId: 'attachmentImageLocalId' });
+        useComponentToModel({ fieldName: 'component', modelName: 'AttachmentImage', propNameAsRecordLocalId: 'attachmentImageLocalId' });
     }
 
     //--------------------------------------------------------------------------
@@ -19,10 +19,10 @@ export class AttachmentImage extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.attachment_image}
+     * @returns {AttachmentImage}
      */
     get attachmentImage() {
-        return this.messaging && this.messaging.models['mail.attachment_image'].get(this.props.attachmentImageLocalId);
+        return this.messaging && this.messaging.models['AttachmentImage'].get(this.props.attachmentImageLocalId);
     }
 
 }

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -289,7 +289,7 @@ registerModel({
         /**
          * States the attachment images that are displaying this attachment.
          */
-        attachmentImages: one2many('mail.attachment_image', {
+        attachmentImages: one2many('AttachmentImage', {
             inverse: 'attachment',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/attachment_image/attachment_image.js
+++ b/addons/mail/static/src/models/attachment_image/attachment_image.js
@@ -5,7 +5,7 @@ import { attr, many2one } from '@mail/model/model_field';
 import { clear, insert, insertAndReplace, replace } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.attachment_image',
+    name: 'AttachmentImage',
     identifyingFields: ['attachmentList', 'attachment'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/attachment_list/attachment_list.js
+++ b/addons/mail/static/src/models/attachment_list/attachment_list.js
@@ -75,7 +75,7 @@ registerModel({
         /**
          * States the attachment images that are displaying this imageAttachments.
          */
-        attachmentImages: one2many('mail.attachment_image', {
+        attachmentImages: one2many('AttachmentImage', {
             compute: '_computeAttachmentImages',
             inverse: 'attachmentList',
             isCausal: true,


### PR DESCRIPTION
Rename javascript model `mail.attachment_image` to `AttachmentImage` in order to distinguish javascript models from python models.

Part of task-2701674.
