### PR TITLE
[IMP] mail: rename attachment list model

### DIFF
--- a/addons/mail/static/src/components/attachment_list/attachment_list.js
+++ b/addons/mail/static/src/components/attachment_list/attachment_list.js
@@ -7,10 +7,10 @@ const { Component } = owl;
 export class AttachmentList extends Component {
 
     /**
-     * @returns {mail.attachment_list}
+     * @returns {AttachmentList}
      */
     get attachmentList() {
-        return this.messaging && this.messaging.models['mail.attachment_list'].get(this.props.attachmentListLocalId);
+        return this.messaging && this.messaging.models['AttachmentList'].get(this.props.attachmentListLocalId);
     }
 
 }

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -296,7 +296,7 @@ registerModel({
         /**
          * States the attachment lists that are displaying this attachment.
          */
-        attachmentLists: many2many('mail.attachment_list', {
+        attachmentLists: many2many('AttachmentList', {
             inverse: 'attachments',
         }),
         attachmentViewer: many2many('mail.attachment_viewer', {

--- a/addons/mail/static/src/models/attachment_card/attachment_card.js
+++ b/addons/mail/static/src/models/attachment_card/attachment_card.js
@@ -73,7 +73,7 @@ registerModel({
         /**
          * States the attachmentList displaying this card.
          */
-        attachmentList: many2one('mail.attachment_list', {
+        attachmentList: many2one('AttachmentList', {
             inverse: 'attachmentCards',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/attachment_image/attachment_image.js
+++ b/addons/mail/static/src/models/attachment_image/attachment_image.js
@@ -115,7 +115,7 @@ registerModel({
         /**
          * States the attachmentList displaying this attachment image.
          */
-        attachmentList: many2one('mail.attachment_list', {
+        attachmentList: many2one('AttachmentList', {
             inverse: 'attachmentImages',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/attachment_list/attachment_list.js
+++ b/addons/mail/static/src/models/attachment_list/attachment_list.js
@@ -5,7 +5,7 @@ import { many2many, many2one, one2many, one2one } from '@mail/model/model_field'
 import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.attachment_list',
+    name: 'AttachmentList',
     identifyingFields: [['composerView', 'messageView', 'chatter']],
     recordMethods: {
         _computeAttachmentImages() {

--- a/addons/mail/static/src/models/attachment_viewer/attachment_viewer.js
+++ b/addons/mail/static/src/models/attachment_viewer/attachment_viewer.js
@@ -39,7 +39,7 @@ registerModel({
             default: 0,
         }),
         attachment: many2one('mail.attachment'),
-        attachmentList: many2one('mail.attachment_list', {
+        attachmentList: many2one('AttachmentList', {
             inverse: 'attachmentViewer',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -289,7 +289,7 @@ registerModel({
         /**
          * Determines the attachment list that will be used to display the attachments.
          */
-        attachmentList: one2one('mail.attachment_list', {
+        attachmentList: one2one('AttachmentList', {
             compute: '_computeAttachmentList',
             inverse: 'chatter',
             isCausal: true,

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -853,7 +853,7 @@ registerModel({
         /**
          * Determines the attachment list that will be used to display the attachments.
          */
-        attachmentList: one2one('mail.attachment_list', {
+        attachmentList: one2one('AttachmentList', {
             compute: '_computeAttachmentList',
             inverse: 'composerView',
             isCausal: true,

--- a/addons/mail/static/src/models/message_view/message_view.js
+++ b/addons/mail/static/src/models/message_view/message_view.js
@@ -109,7 +109,7 @@ registerModel({
          * Determines the attachment list displaying the attachments of this
          * message (if any).
          */
-        attachmentList: one2one('mail.attachment_list', {
+        attachmentList: one2one('AttachmentList', {
             compute: '_computeAttachmentList',
             inverse: 'messageView',
             isCausal: true,


### PR DESCRIPTION
Rename javascript model `mail.attachment_list` to `AttachmentList` in order to distinguish javascript models from python models.

Part of task-2701674.