### PR TITLE
[IMP] mail: rename attachment viewer model

### DIFF
--- a/addons/mail/static/src/components/attachment_viewer/attachment_viewer.js
+++ b/addons/mail/static/src/components/attachment_viewer/attachment_viewer.js
@@ -80,10 +80,10 @@ export class AttachmentViewer extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.attachment_viewer}
+     * @returns {AttachmentViewer}
      */
     get attachmentViewer() {
-        return this.messaging && this.messaging.models['mail.attachment_viewer'].get(this.props.localId);
+        return this.messaging && this.messaging.models['AttachmentViewer'].get(this.props.localId);
     }
 
     /**

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -299,7 +299,7 @@ registerModel({
         attachmentLists: many2many('mail.attachment_list', {
             inverse: 'attachments',
         }),
-        attachmentViewer: many2many('mail.attachment_viewer', {
+        attachmentViewer: many2many('AttachmentViewer', {
             inverse: 'attachments',
         }),
         checksum: attr(),

--- a/addons/mail/static/src/models/attachment_list/attachment_list.js
+++ b/addons/mail/static/src/models/attachment_list/attachment_list.js
@@ -83,7 +83,7 @@ registerModel({
         /**
          * Determines the attachment viewers displaying this attachment list (if any).
          */
-        attachmentViewer: one2many('mail.attachment_viewer', {
+        attachmentViewer: one2many('AttachmentViewer', {
             inverse: 'attachmentList',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/attachment_viewer/attachment_viewer.js
+++ b/addons/mail/static/src/models/attachment_viewer/attachment_viewer.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { attr, many2many, many2one, one2one } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.attachment_viewer',
+    name: 'AttachmentViewer',
     identifyingFields: ['attachmentList'],
     recordMethods: {
         /**

--- a/addons/mail/static/src/models/dialog/dialog.js
+++ b/addons/mail/static/src/models/dialog/dialog.js
@@ -31,7 +31,7 @@ registerModel({
         },
     },
     fields: {
-        attachmentViewer: one2one('mail.attachment_viewer', {
+        attachmentViewer: one2one('AttachmentViewer', {
             isCausal: true,
             inverse: 'dialog',
             readonly: true,


### PR DESCRIPTION
Rename javascript model `mail.attachment_viewer` to `AttachmentViewer` in order to distinguish javascript models from python models.

Part of task-2701674.