### PR TITLE
[IMP] mail: rename canned response model

### DIFF
--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
@@ -28,7 +28,7 @@ export class ComposerSuggestion extends Component {
     }
 
     get isCannedResponse() {
-        return this.props.modelName === "mail.canned_response";
+        return this.props.modelName === "CannedResponse";
     }
 
     get isChannel() {

--- a/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_canned_response_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_canned_response_tests.js
@@ -31,14 +31,14 @@ QUnit.test('canned response suggestion displayed', async function (assert) {
         id: 20,
         model: 'mail.channel',
     });
-    const cannedResponse = this.messaging.models['mail.canned_response'].create({
+    const cannedResponse = this.messaging.models['CannedResponse'].create({
         id: 7,
         source: 'hello',
         substitution: "Hello, how are you?",
     });
     await createComposerSuggestionComponent(thread.composer, {
         isActive: true,
-        modelName: 'mail.canned_response',
+        modelName: 'CannedResponse',
         recordLocalId: cannedResponse.localId,
     });
 
@@ -58,14 +58,14 @@ QUnit.test('canned response suggestion correct data', async function (assert) {
         id: 20,
         model: 'mail.channel',
     });
-    const cannedResponse = this.messaging.models['mail.canned_response'].create({
+    const cannedResponse = this.messaging.models['CannedResponse'].create({
         id: 7,
         source: 'hello',
         substitution: "Hello, how are you?",
     });
     await createComposerSuggestionComponent(thread.composer, {
         isActive: true,
-        modelName: 'mail.canned_response',
+        modelName: 'CannedResponse',
         recordLocalId: cannedResponse.localId,
     });
 
@@ -105,14 +105,14 @@ QUnit.test('canned response suggestion active', async function (assert) {
         id: 20,
         model: 'mail.channel',
     });
-    const cannedResponse = this.messaging.models['mail.canned_response'].create({
+    const cannedResponse = this.messaging.models['CannedResponse'].create({
         id: 7,
         source: 'hello',
         substitution: "Hello, how are you?",
     });
     await createComposerSuggestionComponent(thread.composer, {
         isActive: true,
-        modelName: 'mail.canned_response',
+        modelName: 'CannedResponse',
         recordLocalId: cannedResponse.localId,
     });
 

--- a/addons/mail/static/src/models/canned_response/canned_response.js
+++ b/addons/mail/static/src/models/canned_response/canned_response.js
@@ -5,7 +5,7 @@ import { attr } from '@mail/model/model_field';
 import { cleanSearchTerm } from '@mail/utils/utils';
 
 registerModel({
-    name: 'mail.canned_response',
+    name: 'CannedResponse',
     identifyingFields: ['id'],
     modelMethods: {
         /**
@@ -59,7 +59,7 @@ registerModel({
          * @param {Object} [options={}]
          * @param {Thread} [options.thread] prioritize and/or restrict
          *  result in the context of given thread
-         * @returns {[mail.canned_response[], mail.canned_response[]]}
+         * @returns {[CannedResponse[], CannedResponse[]]}
          */
         searchSuggestions(searchTerm, { thread } = {}) {
             const cleanedSearchTerm = cleanSearchTerm(searchTerm);

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -572,7 +572,7 @@ registerModel({
                 case '@':
                     return 'mail.partner';
                 case ':':
-                    return 'mail.canned_response';
+                    return 'CannedResponse';
                 case '/':
                     return 'ChannelCommand';
                 case '#':

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -232,7 +232,7 @@ registerModel({
         autofetchPartnerImStatus: attr({
             default: true,
         }),
-        cannedResponses: one2many('mail.canned_response'),
+        cannedResponses: one2many('CannedResponse'),
         chatWindowManager: one2one('ChatWindowManager', {
             default: insertAndReplace(),
             isCausal: true,


### PR DESCRIPTION
Rename javascript model `mail.canned_response` to `CannedResponse` in order to distinguish javascript models from python models.
