### PR TITLE
[IMP] mail: rename channel command model

### DIFF
--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
@@ -36,7 +36,7 @@ export class ComposerSuggestion extends Component {
     }
 
     get isCommand() {
-        return this.props.modelName === "mail.channel_command";
+        return this.props.modelName === "ChannelCommand";
     }
 
     get isPartner() {

--- a/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_command_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_command_tests.js
@@ -31,14 +31,14 @@ QUnit.test('command suggestion displayed', async function (assert) {
         id: 20,
         model: 'mail.channel',
     });
-    const command = this.messaging.models['mail.channel_command'].create({
+    const command = this.messaging.models['ChannelCommand'].create({
         methodName: '',
         name: 'whois',
         help: "Displays who it is",
     });
     await createComposerSuggestionComponent(thread.composer, {
         isActive: true,
-        modelName: 'mail.channel_command',
+        modelName: 'ChannelCommand',
         recordLocalId: command.localId,
     });
 
@@ -58,14 +58,14 @@ QUnit.test('command suggestion correct data', async function (assert) {
         id: 20,
         model: 'mail.channel',
     });
-    const command = this.messaging.models['mail.channel_command'].create({
+    const command = this.messaging.models['ChannelCommand'].create({
         methodName: '',
         name: 'whois',
         help: "Displays who it is",
     });
     await createComposerSuggestionComponent(thread.composer, {
         isActive: true,
-        modelName: 'mail.channel_command',
+        modelName: 'ChannelCommand',
         recordLocalId: command.localId,
     });
 
@@ -105,14 +105,14 @@ QUnit.test('command suggestion active', async function (assert) {
         id: 20,
         model: 'mail.channel',
     });
-    const command = this.messaging.models['mail.channel_command'].create({
+    const command = this.messaging.models['ChannelCommand'].create({
         methodName: '',
         name: 'whois',
         help: "Displays who it is",
     });
     await createComposerSuggestionComponent(thread.composer, {
         isActive: true,
-        modelName: 'mail.channel_command',
+        modelName: 'ChannelCommand',
         recordLocalId: command.localId,
     });
 

--- a/addons/mail/static/src/models/channel_command/channel_command.js
+++ b/addons/mail/static/src/models/channel_command/channel_command.js
@@ -5,7 +5,7 @@ import { attr } from '@mail/model/model_field';
 import { cleanSearchTerm } from '@mail/utils/utils';
 
 registerModel({
-    name: 'mail.channel_command',
+    name: 'ChannelCommand',
     identifyingFields: ['name'],
     modelMethods: {
         /**
@@ -66,7 +66,7 @@ registerModel({
          * @param {Object} [options={}]
          * @param {mail.thread} [options.thread] prioritize and/or restrict
          *  result in the context of given thread
-         * @returns {[mail.channel_command[], mail.channel_command[]]}
+         * @returns {[ChannelCommand[], ChannelCommand[]]}
          */
         searchSuggestions(searchTerm, { thread } = {}) {
             if (thread.model !== 'mail.channel') {

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -71,7 +71,7 @@ registerModel({
                 return; // not supported for guests
             }
             if (
-                this.suggestionModelName === 'mail.channel_command' ||
+                this.suggestionModelName === 'ChannelCommand' ||
                 this._getCommandFromText(this.composer.textInputContent)
             ) {
                 return;
@@ -574,7 +574,7 @@ registerModel({
                 case ':':
                     return 'mail.canned_response';
                 case '/':
-                    return 'mail.channel_command';
+                    return 'ChannelCommand';
                 case '#':
                     return 'mail.thread';
                 default:
@@ -691,7 +691,7 @@ registerModel({
         /**
          * @private
          * @param {string} content html content
-         * @returns {mail.channel_command|undefined} command, if any in the content
+         * @returns {ChannelCommand|undefined} command, if any in the content
          */
         _getCommandFromText(content) {
             if (content.startsWith('/')) {

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -235,7 +235,7 @@ registerModel({
             isCausal: true,
             readonly: true,
         }),
-        commands: one2many('mail.channel_command'),
+        commands: one2many('ChannelCommand'),
         companyName: attr(),
         currentGuest: one2one('mail.guest'),
         currentPartner: one2one('mail.partner'),


### PR DESCRIPTION
Rename javascript model `mail.channel_command` to `ChannelCommand` in order to distinguish javascript models from python models.

Part of task-2701674.