### PR TITLE
[IMP] mail: rename channel invitation form model

### DIFF
--- a/addons/mail/static/src/components/channel_invitation_form/channel_invitation_form.js
+++ b/addons/mail/static/src/components/channel_invitation_form/channel_invitation_form.js
@@ -14,9 +14,9 @@ export class ChannelInvitationForm extends Component {
      */
     setup() {
         super.setup();
-        useComponentToModel({ fieldName: 'component', modelName: 'mail.channel_invitation_form', propNameAsRecordLocalId: 'localId' });
-        useRefToModel({ fieldName: 'searchInputRef', modelName: 'mail.channel_invitation_form', propNameAsRecordLocalId: 'localId', refName: 'searchInput' });
-        useUpdateToModel({ methodName: 'onComponentUpdate', modelName: 'mail.channel_invitation_form', propNameAsRecordLocalId: 'localId' });
+        useComponentToModel({ fieldName: 'component', modelName: 'ChannelInvitationForm', propNameAsRecordLocalId: 'localId' });
+        useRefToModel({ fieldName: 'searchInputRef', modelName: 'ChannelInvitationForm', propNameAsRecordLocalId: 'localId', refName: 'searchInput' });
+        useUpdateToModel({ methodName: 'onComponentUpdate', modelName: 'ChannelInvitationForm', propNameAsRecordLocalId: 'localId' });
     }
 
     //--------------------------------------------------------------------------
@@ -24,7 +24,7 @@ export class ChannelInvitationForm extends Component {
     //--------------------------------------------------------------------------
 
     get channelInvitationForm() {
-        return this.messaging && this.messaging.models['mail.channel_invitation_form'].get(this.props.localId);
+        return this.messaging && this.messaging.models['ChannelInvitationForm'].get(this.props.localId);
     }
 
 }

--- a/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace, link, replace, unlink, unlinkAll } from '@mail
 import { cleanSearchTerm } from '@mail/utils/utils';
 
 registerModel({
-    name: 'mail.channel_invitation_form',
+    name: 'ChannelInvitationForm',
     identifyingFields: [['chatWindow', 'threadView']],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/chat_window/chat_window.js
+++ b/addons/mail/static/src/models/chat_window/chat_window.js
@@ -375,7 +375,7 @@ registerModel({
          * Determines the channel invitation form displayed by this chat window
          * (if any). Only makes sense if hasInviteFeature is true.
          */
-        channelInvitationForm: one2one('mail.channel_invitation_form', {
+        channelInvitationForm: one2one('ChannelInvitationForm', {
             inverse: 'chatWindow',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/popover_view/popover_view.js
+++ b/addons/mail/static/src/models/popover_view/popover_view.js
@@ -67,7 +67,7 @@ registerModel({
         /**
          * The record that represents the content inside the popover view.
          */
-        channelInvitationForm: one2one('mail.channel_invitation_form', {
+        channelInvitationForm: one2one('ChannelInvitationForm', {
             inverse: 'popoverView',
             isCausal: true,
             readonly: true,

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -290,7 +290,7 @@ registerModel({
          * States which channel invitation form is operating this thread view.
          * Only applies if this thread is a channel.
          */
-        channelInvitationForm: one2one('mail.channel_invitation_form', {
+        channelInvitationForm: one2one('ChannelInvitationForm', {
             inverse: 'threadView',
             isCausal: true,
         }),


### PR DESCRIPTION
Rename javascript model `mail.channel_invitation_form` to `ChannelInvitationForm` in order to distinguish javascript models from python models.

Part of task-2701674.