### PR TITLE
[IMP] im_livechat, mail: rename chat window model

### DIFF
--- a/addons/im_livechat/static/src/models/chat_window/chat_window.js
+++ b/addons/im_livechat/static/src/models/chat_window/chat_window.js
@@ -4,7 +4,7 @@ import { patchRecordMethods } from '@mail/model/model_core';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/chat_window/chat_window';
 
-patchRecordMethods('mail.chat_window', {
+patchRecordMethods('ChatWindow', {
     /**
      * @override
      */

--- a/addons/mail/static/src/components/chat_window/chat_window.js
+++ b/addons/mail/static/src/components/chat_window/chat_window.js
@@ -43,10 +43,10 @@ export class ChatWindow extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.chat_window}
+     * @returns {ChatWindow}
      */
     get chatWindow() {
-        return this.messaging && this.messaging.models['mail.chat_window'].get(this.props.chatWindowLocalId);
+        return this.messaging && this.messaging.models['ChatWindow'].get(this.props.chatWindowLocalId);
     }
 
     /**

--- a/addons/mail/static/src/components/chat_window_header/chat_window_header.js
+++ b/addons/mail/static/src/components/chat_window_header/chat_window_header.js
@@ -15,10 +15,10 @@ export class ChatWindowHeader extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.chat_window}
+     * @returns {ChatWindow}
      */
     get chatWindow() {
-        return this.messaging && this.messaging.models['mail.chat_window'].get(this.props.chatWindowLocalId);
+        return this.messaging && this.messaging.models['ChatWindow'].get(this.props.chatWindowLocalId);
     }
 
     /**

--- a/addons/mail/static/src/components/chat_window_hidden_menu/chat_window_hidden_menu.js
+++ b/addons/mail/static/src/components/chat_window_hidden_menu/chat_window_hidden_menu.js
@@ -111,7 +111,7 @@ export class ChatWindowHiddenMenu extends Component {
     /**
      * @private
      * @param {Object} detail
-     * @param {mail.chat_window} detail.chatWindow
+     * @param {ChatWindow} detail.chatWindow
      */
     _onClickedChatWindow(detail) {
         const chatWindow = detail.chatWindow;

--- a/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
@@ -178,7 +178,7 @@ registerModel({
         },
     },
     fields: {
-        chatWindow: one2one('mail.chat_window', {
+        chatWindow: one2one('ChatWindow', {
             inverse: 'channelInvitationForm',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/chat_window/chat_window.js
+++ b/addons/mail/static/src/models/chat_window/chat_window.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace, link, unlink } from '@mail/model/model_field_c
 import { markEventHandled } from '@mail/utils/utils';
 
 registerModel({
-    name: 'mail.chat_window',
+    name: 'ChatWindow',
     identifyingFields: ['manager', ['thread', 'managerAsNewMessage']],
     lifecycleHooks: {
         _created() {
@@ -336,7 +336,7 @@ registerModel({
          * @private
          * @param {Object} [param0={}]
          * @param {boolean} [param0.reverse=false]
-         * @returns {mail.chat_window|undefined}
+         * @returns {ChatWindow|undefined}
          */
         _getNextVisibleUnfoldedChatWindow({ reverse = false } = {}) {
             const orderedVisible = this.manager.allOrderedVisible;

--- a/addons/mail/static/src/models/chat_window_manager/chat_window_manager.js
+++ b/addons/mail/static/src/models/chat_window_manager/chat_window_manager.js
@@ -109,7 +109,7 @@ registerModel({
                 chatWindow.thread === thread
             );
             if (!chatWindow) {
-                chatWindow = this.messaging.models['mail.chat_window'].create({
+                chatWindow = this.messaging.models['ChatWindow'].create({
                     isFolded,
                     manager: link(this),
                     thread: link(thread),
@@ -136,7 +136,7 @@ registerModel({
          * Shift provided chat window to previous visible index, which swap visible order of this
          * chat window and the preceding visible one
          *
-         * @param {mail.chat_window} chatWindow
+         * @param {ChatWindow} chatWindow
          */
         shiftPrev(chatWindow) {
             const chatWindows = this.allOrdered;
@@ -156,7 +156,7 @@ registerModel({
          * Shift provided chat window to next visible index, which swap visible order of this
          * chat window and the following visible one.
          *
-         * @param {mail.chat_window} chatWindow
+         * @param {ChatWindow} chatWindow
          */
         shiftNext(chatWindow) {
             const chatWindows = this.allOrdered;
@@ -173,8 +173,8 @@ registerModel({
             chatWindow.focus();
         },
         /**
-         * @param {mail.chat_window} chatWindow1
-         * @param {mail.chat_window} chatWindow2
+         * @param {ChatWindow} chatWindow1
+         * @param {ChatWindow} chatWindow2
          */
         swap(chatWindow1, chatWindow2) {
             const ordered = this.allOrdered;
@@ -190,27 +190,27 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.chat_window[]}
+         * @returns {ChatWindow[]}
          */
         _computeAllOrdered() {
             return link(this.chatWindows);
         },
         /**
          * @private
-         * @returns {mail.chat_window[]}
+         * @returns {ChatWindow[]}
          */
         _computeAllOrderedHidden() {
             return replace(this.visual.hidden.chatWindowLocalIds.map(chatWindowLocalId =>
-                this.messaging.models['mail.chat_window'].get(chatWindowLocalId)
+                this.messaging.models['ChatWindow'].get(chatWindowLocalId)
             ));
         },
         /**
          * @private
-         * @returns {mail.chat_window[]}
+         * @returns {ChatWindow[]}
          */
         _computeAllOrderedVisible() {
             return replace(this.visual.visible.map(({ chatWindowLocalId }) =>
-                this.messaging.models['mail.chat_window'].get(chatWindowLocalId)
+                this.messaging.models['ChatWindow'].get(chatWindowLocalId)
             ));
         },
         /**
@@ -229,7 +229,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.chat_window|undefined}
+         * @returns {ChatWindow|undefined}
          */
         _computeLastVisible() {
             const { length: l, [l - 1]: lastVisible } = this.allOrderedVisible;
@@ -327,16 +327,16 @@ registerModel({
         /**
          * List of ordered chat windows.
          */
-        allOrdered: one2many('mail.chat_window', {
+        allOrdered: one2many('ChatWindow', {
             compute: '_computeAllOrdered',
         }),
-        allOrderedHidden: one2many('mail.chat_window', {
+        allOrderedHidden: one2many('ChatWindow', {
             compute: '_computeAllOrderedHidden',
         }),
-        allOrderedVisible: one2many('mail.chat_window', {
+        allOrderedVisible: one2many('ChatWindow', {
             compute: '_computeAllOrderedVisible',
         }),
-        chatWindows: one2many('mail.chat_window', {
+        chatWindows: one2many('ChatWindow', {
             inverse: 'manager',
             isCausal: true,
         }),
@@ -349,10 +349,10 @@ registerModel({
         isHiddenMenuOpen: attr({
             default: false,
         }),
-        lastVisible: many2one('mail.chat_window', {
+        lastVisible: many2one('ChatWindow', {
             compute: '_computeLastVisible',
         }),
-        newMessageChatWindow: one2one('mail.chat_window', {
+        newMessageChatWindow: one2one('ChatWindow', {
             inverse: 'managerAsNewMessage',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1943,7 +1943,7 @@ registerModel({
         /**
          * States the chat window related to this thread (if any).
          */
-        chatWindow: one2one('mail.chat_window', {
+        chatWindow: one2one('ChatWindow', {
             inverse: 'thread',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/thread_view/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_view/thread_viewer.js
@@ -63,7 +63,7 @@ registerModel({
             inverse: 'threadViewer',
             readonly: true,
         }),
-        chatWindow: one2one('mail.chat_window', {
+        chatWindow: one2one('ChatWindow', {
             inverse: 'threadViewer',
             readonly: true,
         }),


### PR DESCRIPTION
Rename javascript model `mail.chat_window` to `ChatWindow` in order to distinguish javascript models from python models.

Part of task-2701674.