### PR TITLE
[IMP] mail: rename chat window manager model

### DIFF
--- a/addons/mail/static/src/models/chat_window/chat_window.js
+++ b/addons/mail/static/src/models/chat_window/chat_window.js
@@ -448,11 +448,11 @@ registerModel({
         isVisible: attr({
             compute: '_computeIsVisible',
         }),
-        manager: many2one('mail.chat_window_manager', {
+        manager: many2one('ChatWindowManager', {
             inverse: 'chatWindows',
             readonly: true,
         }),
-        managerAsNewMessage: one2one('mail.chat_window_manager', {
+        managerAsNewMessage: one2one('ChatWindowManager', {
             inverse: 'newMessageChatWindow',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/chat_window_manager/chat_window_manager.js
+++ b/addons/mail/static/src/models/chat_window_manager/chat_window_manager.js
@@ -47,7 +47,7 @@ const BASE_VISUAL = {
 };
 
 registerModel({
-    name: 'mail.chat_window_manager',
+    name: 'ChatWindowManager',
     identifyingFields: ['messaging'],
     recordMethods: {
         /**

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -230,7 +230,7 @@ registerModel({
             default: true,
         }),
         cannedResponses: one2many('mail.canned_response'),
-        chatWindowManager: one2one('mail.chat_window_manager', {
+        chatWindowManager: one2one('ChatWindowManager', {
             default: insertAndReplace(),
             isCausal: true,
             readonly: true,


### PR DESCRIPTION
Rename javascript model `mail.chat_window_manager` to `ChatWindowManager` in order to distinguish javascript models from python models.

Part of task-2701674.