### PR TITLE
[IMP] mail: rename chatter model

### DIFF
--- a/addons/mail/static/src/components/attachment_box/tests/attachment_box_tests.js
+++ b/addons/mail/static/src/components/attachment_box/tests/attachment_box_tests.js
@@ -23,7 +23,7 @@ QUnit.module('attachment_box_tests.js', {
         beforeEach(this);
 
         this.createAttachmentBoxComponent = async (thread, otherProps) => {
-            const chatter = this.messaging.models['mail.chatter'].insert({
+            const chatter = this.messaging.models['Chatter'].insert({
                 id: 1,
                 isAttachmentBoxVisibleInitially: true,
                 threadId: thread.id,

--- a/addons/mail/static/src/components/chatter/chatter.js
+++ b/addons/mail/static/src/components/chatter/chatter.js
@@ -15,7 +15,7 @@ export class Chatter extends Component {
     setup() {
         super.setup();
         useUpdate({ func: () => this._update() });
-        useRefToModel({ fieldName: 'threadRef', modelName: 'mail.chatter', propNameAsRecordLocalId: 'chatterLocalId', refName: 'thread' });
+        useRefToModel({ fieldName: 'threadRef', modelName: 'Chatter', propNameAsRecordLocalId: 'chatterLocalId', refName: 'thread' });
         /**
          * Reference of the scroll Panel (Real scroll element). Useful to pass the Scroll element to
          * child component to handle proper scrollable element.
@@ -29,10 +29,10 @@ export class Chatter extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.chatter}
+     * @returns {Chatter}
      */
     get chatter() {
-        return this.messaging && this.messaging.models['mail.chatter'].get(this.props.chatterLocalId);
+        return this.messaging && this.messaging.models['Chatter'].get(this.props.chatterLocalId);
     }
 
     /**

--- a/addons/mail/static/src/components/chatter/tests/chatter_suggested_recipient_tests.js
+++ b/addons/mail/static/src/components/chatter/tests/chatter_suggested_recipient_tests.js
@@ -50,7 +50,7 @@ QUnit.test("suggest recipient on 'Send message' composer", async function (asser
         partner_ids: [100],
     });
     await this.start ();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 10,
         threadModel: 'res.fake',
@@ -80,7 +80,7 @@ QUnit.test("with 3 or less suggested recipients: no 'show more' button", async f
         partner_ids: [100],
     });
     await this.start ();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 10,
         threadModel: 'res.fake',
@@ -109,7 +109,7 @@ QUnit.test("display reason for suggested recipient on mouse over", async functio
         partner_ids: [100],
     });
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 10,
         threadModel: 'res.fake',
@@ -134,7 +134,7 @@ QUnit.test("suggested recipient without partner are unchecked by default", async
         email_cc: "john@test.be",
     });
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 10,
         threadModel: 'res.fake',
@@ -163,7 +163,7 @@ QUnit.test("suggested recipient with partner are checked by default", async func
         partner_ids: [100],
     });
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 10,
         threadModel: 'res.fake',
@@ -207,7 +207,7 @@ QUnit.test("more than 3 suggested recipients: display only 3 and 'show more' but
         partner_ids: [100, 1000, 1001, 1002],
     });
     await this.start ();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 10,
         threadModel: 'res.fake',
@@ -252,7 +252,7 @@ QUnit.test("more than 3 suggested recipients: show all of them on click 'show mo
         partner_ids: [100, 1000, 1001, 1002],
     });
     await this.start ();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 10,
         threadModel: 'res.fake',
@@ -301,7 +301,7 @@ QUnit.test("more than 3 suggested recipients -> click 'show more' -> 'show less'
         partner_ids: [100, 1000, 1001, 1002],
     });
     await this.start ();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 10,
         threadModel: 'res.fake',
@@ -349,7 +349,7 @@ QUnit.test("suggested recipients list display 3 suggested recipient and 'show mo
         partner_ids: [100, 1000, 1001, 1002],
     });
     await this.start ();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 10,
         threadModel: 'res.fake',
@@ -402,7 +402,7 @@ QUnit.test("suggested recipients should not be notified when posting an internal
             return this._super(...arguments);
         },
     });
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 10,
         threadModel: 'res.fake',

--- a/addons/mail/static/src/components/chatter/tests/chatter_tests.js
+++ b/addons/mail/static/src/components/chatter/tests/chatter_tests.js
@@ -49,7 +49,7 @@ QUnit.test('base rendering when chatter has no attachment', async function (asse
         });
     }
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -94,7 +94,7 @@ QUnit.test('base rendering when chatter has no record', async function (assert) 
     assert.expect(10);
 
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadModel: 'res.partner',
     });
@@ -173,7 +173,7 @@ QUnit.test('base rendering when chatter has attachments', async function (assert
         }
     );
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -215,7 +215,7 @@ QUnit.test('show attachment box', async function (assert) {
         }
     );
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -262,7 +262,7 @@ QUnit.test('composer show/hide on log note/send message [REQUIRE FOCUS]', async 
 
     this.data['res.partner'].records.push({ id: 100 });
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -356,7 +356,7 @@ QUnit.test('should display subject when subject is not the same as the thread na
         model: 'res.partner',
         name: "voyageur",
     });
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -391,7 +391,7 @@ QUnit.test('should not display subject when subject is the same as the thread na
         model: 'res.partner',
         name: "Salutations, voyageur",
     });
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -416,7 +416,7 @@ QUnit.test('should not display user notification messages in chatter', async fun
         res_id: 100,
     });
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -435,7 +435,7 @@ QUnit.test('post message with "CTRL-Enter" keyboard shortcut', async function (a
 
     this.data['res.partner'].records.push({ id: 100 });
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -470,7 +470,7 @@ QUnit.test('post message with "META-Enter" keyboard shortcut', async function (a
 
     this.data['res.partner'].records.push({ id: 100 });
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -508,7 +508,7 @@ QUnit.test('do not post message with "Enter" keyboard shortcut', async function 
 
     this.data['res.partner'].records.push({ id: 100 });
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',

--- a/addons/mail/static/src/components/chatter_container/chatter_container.js
+++ b/addons/mail/static/src/components/chatter_container/chatter_container.js
@@ -65,7 +65,7 @@ export class ChatterContainer extends Component {
         if (values.threadId === undefined) {
             values.threadId = clear();
         }
-        this.chatter = messaging.models['mail.chatter'].insert(values);
+        this.chatter = messaging.models['Chatter'].insert(values);
         this.chatter.refresh();
         this.render();
     }

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.js
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.js
@@ -12,7 +12,7 @@ export class ChatterTopbar extends Component {
      */
     setup() {
         super.setup();
-        useComponentToModel({ fieldName: 'componentChatterTopbar', modelName: 'mail.chatter', propNameAsRecordLocalId: 'chatterLocalId' });
+        useComponentToModel({ fieldName: 'componentChatterTopbar', modelName: 'Chatter', propNameAsRecordLocalId: 'chatterLocalId' });
     }
 
     //--------------------------------------------------------------------------
@@ -20,10 +20,10 @@ export class ChatterTopbar extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.chatter}
+     * @returns {Chatter}
      */
     get chatter() {
-        return this.messaging && this.messaging.models['mail.chatter'].get(this.props.chatterLocalId);
+        return this.messaging && this.messaging.models['Chatter'].get(this.props.chatterLocalId);
     }
 
 }

--- a/addons/mail/static/src/components/chatter_topbar/tests/chatter_topbar_tests.js
+++ b/addons/mail/static/src/components/chatter_topbar/tests/chatter_topbar_tests.js
@@ -44,7 +44,7 @@ QUnit.test('base rendering', async function (assert) {
 
     this.data['res.partner'].records.push({ id: 100 });
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -97,7 +97,7 @@ QUnit.test('base disabled rendering', async function (assert) {
     assert.expect(8);
 
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadModel: 'res.partner',
     });
@@ -154,7 +154,7 @@ QUnit.test('attachment loading is delayed', async function (assert) {
             return this._super(...arguments);
         }
     });
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -197,7 +197,7 @@ QUnit.test('attachment counter while loading attachments', async function (asser
             return this._super(...arguments);
         }
     });
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -240,7 +240,7 @@ QUnit.test('attachment counter transition when attachments become loaded)', asyn
             return _super();
         },
     });
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -291,7 +291,7 @@ QUnit.test('attachment counter without attachments', async function (assert) {
 
     this.data['res.partner'].records.push({ id: 100 });
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -339,7 +339,7 @@ QUnit.test('attachment counter with attachments', async function (assert) {
         }
     );
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -373,7 +373,7 @@ QUnit.test('composer state conserved when clicking on another topbar button', as
 
     this.data['res.partner'].records.push({ id: 100 });
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -454,7 +454,7 @@ QUnit.test('rendering with multiple partner followers', async function (assert) 
             res_model: 'res.partner',
         },
     );
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         followerIds: [1, 2],
         threadId: 100,
@@ -510,7 +510,7 @@ QUnit.test('log note/send message switching', async function (assert) {
 
     this.data['res.partner'].records.push({ id: 100 });
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -571,7 +571,7 @@ QUnit.test('log note toggling', async function (assert) {
 
     this.data['res.partner'].records.push({ id: 100 });
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',
@@ -612,7 +612,7 @@ QUnit.test('send message toggling', async function (assert) {
 
     this.data['res.partner'].records.push({ id: 100 });
     await this.start();
-    const chatter = this.messaging.models['mail.chatter'].create({
+    const chatter = this.messaging.models['Chatter'].create({
         id: 11,
         threadId: 100,
         threadModel: 'res.partner',

--- a/addons/mail/static/src/models/activity_box_view/activity_box_view.js
+++ b/addons/mail/static/src/models/activity_box_view/activity_box_view.js
@@ -21,7 +21,7 @@ registerModel({
         },
     },
     fields: {
-        chatter: one2one('mail.chatter', {
+        chatter: one2one('Chatter', {
             inverse: 'activityBoxView',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/attachment_box_view/attachment_box_view.js
+++ b/addons/mail/static/src/models/attachment_box_view/attachment_box_view.js
@@ -36,7 +36,7 @@ registerModel({
         },
     },
     fields: {
-        chatter: one2one('mail.chatter', {
+        chatter: one2one('Chatter', {
             inverse: 'attachmentBoxView',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/attachment_list/attachment_list.js
+++ b/addons/mail/static/src/models/attachment_list/attachment_list.js
@@ -90,7 +90,7 @@ registerModel({
         /**
          * Link with a chatter to handle attachments.
          */
-        chatter: one2one('mail.chatter', {
+        chatter: one2one('Chatter', {
             inverse: 'attachmentList',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -22,7 +22,7 @@ const getMessageNextTemporaryId = (function () {
 })();
 
 registerModel({
-    name: 'mail.chatter',
+    name: 'Chatter',
     identifyingFields: ['id'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -862,7 +862,7 @@ registerModel({
         /**
          * States the chatter which this composer allows editing (if any).
          */
-        chatter: one2one('mail.chatter', {
+        chatter: one2one('Chatter', {
             inverse: 'composerView',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/thread_view/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_view/thread_viewer.js
@@ -59,7 +59,7 @@ registerModel({
         },
     },
     fields: {
-        chatter: one2one('mail.chatter', {
+        chatter: one2one('Chatter', {
             inverse: 'threadViewer',
             readonly: true,
         }),


### PR DESCRIPTION
Rename javascript model `mail.chatter` to `Chatter` in order to distinguish javascript models from python models.

Part of task-2701674.
Enterprise: https://github.com/odoo/enterprise/pull/22863