### PR TITLE
[IMP] mail: rename composer model

### DIFF
--- a/addons/mail/static/src/components/file_uploader/file_uploader.js
+++ b/addons/mail/static/src/components/file_uploader/file_uploader.js
@@ -63,7 +63,7 @@ export class FileUploader extends Component {
     /**
      * @private
      * @param {Object} param0
-     * @param {mail.composer} param0.composer
+     * @param {Composer} param0.composer
      * @param {File} param0.file
      * @param {Thread} param0.thread
      * @returns {FormData}
@@ -81,7 +81,7 @@ export class FileUploader extends Component {
     /**
      * @private
      * @param {Object} param0
-     * @param {mail.composer} param0.composer
+     * @param {Composer} param0.composer
      * @param {FileList|Array} param0.files
      * @param {Thread} param0.thread
      * @returns {Promise}
@@ -138,7 +138,7 @@ export class FileUploader extends Component {
      * @private
      * @param {Object} param0
      * @param {Object} attachmentData
-     * @param {mail.composer} param0.composer
+     * @param {Composer} param0.composer
      * @param {Thread} param0.thread
      */
     _onAttachmentUploaded({ attachmentData, composer, thread }) {

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -306,7 +306,7 @@ registerModel({
         /**
          * States on which composer this attachment is currently being created.
          */
-        composer: many2one('mail.composer', {
+        composer: many2one('Composer', {
             inverse: 'attachments',
         }),
         defaultSource: attr({

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -5,7 +5,7 @@ import { attr, many2many, many2one, one2many, one2one } from '@mail/model/model_
 import { clear, replace, unlink } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.composer',
+    name: 'Composer',
     identifyingFields: [['thread', 'messageViewInEditing']],
     recordMethods: {
         /**

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -869,7 +869,7 @@ registerModel({
         /**
          * States the composer state that is displayed by this composer view.
          */
-        composer: many2one('mail.composer', {
+        composer: many2one('Composer', {
             compute: '_computeComposer',
             inverse: 'composerViews',
             required: true,

--- a/addons/mail/static/src/models/message_view/message_view.js
+++ b/addons/mail/static/src/models/message_view/message_view.js
@@ -119,7 +119,7 @@ registerModel({
          * States the component displaying this message view (if any).
          */
         component: attr(),
-        composerForEditing: one2one('mail.composer', {
+        composerForEditing: one2one('Composer', {
             inverse: 'messageViewInEditing',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1950,7 +1950,7 @@ registerModel({
         /**
          * Determines the composer state of this thread.
          */
-        composer: one2one('mail.composer', {
+        composer: one2one('Composer', {
             compute: '_computeComposer',
             inverse: 'thread',
             isCausal: true,

--- a/addons/mail/static/tests/qunit_test.js
+++ b/addons/mail/static/tests/qunit_test.js
@@ -7,7 +7,7 @@ registerModel({
     name: 'mail.qunit_test',
     identifyingFields: [], // singleton acceptable (only one test at a time)
     fields: {
-        composer: one2one('mail.composer', {
+        composer: one2one('Composer', {
             isCausal: true,
         }),
         composerView: one2one('ComposerView', {


### PR DESCRIPTION
Rename javascript model `mail.composer` to `Composer` in order to distinguish javascript models from python models.

Part of task-2701674.