### PR TITLE
[IMP] mail: rename composer view model

### DIFF
--- a/addons/mail/static/src/components/composer/composer.js
+++ b/addons/mail/static/src/components/composer/composer.js
@@ -55,10 +55,10 @@ export class Composer extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.composer_view}
+     * @returns {ComposerView}
      */
     get composerView() {
-        return this.messaging && this.messaging.models['mail.composer_view'].get(this.props.composerViewLocalId);
+        return this.messaging && this.messaging.models['ComposerView'].get(this.props.composerViewLocalId);
     }
 
     /**

--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
@@ -21,10 +21,10 @@ export class ComposerSuggestion extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.composer_view}
+     * @returns {ComposerView}
      */
     get composerView() {
-        return this.messaging && this.messaging.models['mail.composer_view'].get(this.props.composerViewLocalId);
+        return this.messaging && this.messaging.models['ComposerView'].get(this.props.composerViewLocalId);
     }
 
     get isCannedResponse() {

--- a/addons/mail/static/src/components/composer_suggestion_list/composer_suggestion_list.js
+++ b/addons/mail/static/src/components/composer_suggestion_list/composer_suggestion_list.js
@@ -11,10 +11,10 @@ export class ComposerSuggestionList extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.composer_view}
+     * @returns {ComposerView}
      */
     get composerView() {
-        return this.messaging && this.messaging.models['mail.composer_view'].get(this.props.composerViewLocalId);
+        return this.messaging && this.messaging.models['ComposerView'].get(this.props.composerViewLocalId);
     }
 
 }

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.js
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.js
@@ -41,10 +41,10 @@ export class ComposerTextInput extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.composer_view}
+     * @returns {ComposerView}
      */
     get composerView() {
-        return this.messaging && this.messaging.models['mail.composer_view'].get(this.props.composerViewLocalId);
+        return this.messaging && this.messaging.models['ComposerView'].get(this.props.composerViewLocalId);
     }
 
     /**

--- a/addons/mail/static/src/components/file_uploader/file_uploader.js
+++ b/addons/mail/static/src/components/file_uploader/file_uploader.js
@@ -32,7 +32,7 @@ export class FileUploader extends Component {
     //--------------------------------------------------------------------------
 
     get composerView() {
-        return this.messaging.models['mail.composer_view'].get(this.props.composerViewLocalId);
+        return this.messaging.models['ComposerView'].get(this.props.composerViewLocalId);
     }
 
     /**

--- a/addons/mail/static/src/models/attachment_list/attachment_list.js
+++ b/addons/mail/static/src/models/attachment_list/attachment_list.js
@@ -97,7 +97,7 @@ registerModel({
         /**
          * Link with a composer view to handle attachments.
          */
-        composerView: one2one('mail.composer_view', {
+        composerView: one2one('ComposerView', {
             inverse: 'attachmentList',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -302,7 +302,7 @@ registerModel({
         /**
          * Determines the composer view used to post in this chatter (if any).
          */
-        composerView: one2one('mail.composer_view', {
+        composerView: one2one('ComposerView', {
             inverse: 'chatter',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -135,7 +135,7 @@ registerModel({
             compute: '_computeCanPostMessage',
             default: false,
         }),
-        composerViews: one2many('mail.composer_view', {
+        composerViews: one2many('ComposerView', {
             inverse: 'composer',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -8,7 +8,7 @@ import { OnChange } from '@mail/model/model_onchange';
 import { addLink, escapeAndCompactTextContent, parseAndTransform } from '@mail/js/utils';
 
 registerModel({
-    name: 'mail.composer_view',
+    name: 'ComposerView',
     identifyingFields: [['threadView', 'messageViewInEditing', 'chatter']],
     lifecycleHooks: {
         _willCreate() {

--- a/addons/mail/static/src/models/composer_view/tests/composer_view_qunit_tests.js
+++ b/addons/mail/static/src/models/composer_view/tests/composer_view_qunit_tests.js
@@ -6,7 +6,7 @@ import { replace } from '@mail/model/model_field_command';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/composer_view/composer_view';
 
-patchRecordMethods('mail.composer_view', {
+patchRecordMethods('ComposerView', {
     _computeComposer() {
         if (this.qunitTest && this.qunitTest.composer) {
             return replace(this.qunitTest.composer);
@@ -15,13 +15,13 @@ patchRecordMethods('mail.composer_view', {
     },
 });
 
-addFields('mail.composer_view', {
+addFields('ComposerView', {
     qunitTest: one2one('mail.qunit_test', {
         inverse: 'composerView',
         readonly: true,
     }),
 });
 
-patchIdentifyingFields('mail.composer_view', identifyingFields => {
+patchIdentifyingFields('ComposerView', identifyingFields => {
     identifyingFields[0].push('qunitTest');
 });

--- a/addons/mail/static/src/models/message_view/message_view.js
+++ b/addons/mail/static/src/models/message_view/message_view.js
@@ -126,7 +126,7 @@ registerModel({
         /**
         * Determines the composer that is used to edit this message (if any).
         */
-        composerViewInEditing: one2one('mail.composer_view', {
+        composerViewInEditing: one2one('ComposerView', {
             inverse: 'messageViewInEditing',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -315,7 +315,7 @@ registerModel({
         componentHintList: attr({
             default: [],
         }),
-        composerView: one2one('mail.composer_view', {
+        composerView: one2one('ComposerView', {
             compute: '_computeComposerView',
             inverse: 'threadView',
             isCausal: true,

--- a/addons/mail/static/src/utils/test_utils.js
+++ b/addons/mail/static/src/utils/test_utils.js
@@ -398,7 +398,7 @@ async function createRootMessagingComponent(self, componentName, { props = {}, t
 
 function getCreateComposerComponent({ components, env, modelManager, widget }) {
     return async function createComposerComponent(composer, props) {
-        const composerView = modelManager.messaging.models['mail.composer_view'].create({
+        const composerView = modelManager.messaging.models['ComposerView'].create({
             qunitTest: insertAndReplace({
                 composer: replace(composer),
             }),
@@ -412,7 +412,7 @@ function getCreateComposerComponent({ components, env, modelManager, widget }) {
 
 function getCreateComposerSuggestionComponent({ components, env, modelManager, widget }) {
     return async function createComposerSuggestionComponent(composer, props) {
-        const composerView = modelManager.messaging.models['mail.composer_view'].create({
+        const composerView = modelManager.messaging.models['ComposerView'].create({
             qunitTest: insertAndReplace({
                 composer: replace(composer),
             }),

--- a/addons/mail/static/tests/qunit_test.js
+++ b/addons/mail/static/tests/qunit_test.js
@@ -10,7 +10,7 @@ registerModel({
         composer: one2one('mail.composer', {
             isCausal: true,
         }),
-        composerView: one2one('mail.composer_view', {
+        composerView: one2one('ComposerView', {
             inverse: 'qunitTest',
             isCausal: true,
         }),


### PR DESCRIPTION
Rename javascript model `mail.composer_view` to `ComposerView` in order to distinguish javascript models from python models.

Part of task-2701674.