### PR TITLE
[FIX] hw_drivers: Add printer manually to IoT

### DIFF
--- a/addons/hw_drivers/iot_handlers/interfaces/PrinterInterface.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/PrinterInterface.py
@@ -20,18 +20,29 @@ class PrinterInterface(Interface):
         with cups_lock:
             printers = conn.getPrinters()
             devices = conn.getDevices()
-            for printer in printers:
-                path = printers.get(printer).get('device-uri', False)
-                if path and path in devices:
-                    devices.get(path).update({'supported': True}) # these printers are automatically supported
-        for path in devices:
-            if 'uuid=' in path:
-                identifier = sub('[^a-zA-Z0-9_]', '', path.split('uuid=')[1])
-            elif 'serial=' in path:
-                identifier = sub('[^a-zA-Z0-9_]', '', path.split('serial=')[1])
-            else:
-                identifier = sub('[^a-zA-Z0-9_]', '', path)
-            devices[path]['identifier'] = identifier
-            devices[path]['url'] = path
-            printer_devices[identifier] = devices[path]
+            for printer_name, printer in printers.items():
+                path = printer.get('device-uri', False)
+                if printer_name != self.get_identifier(path):
+                    printer.update({'supported': True}) # these printers are automatically supported
+                    device_class = 'network'
+                    if 'usb' in printer.get('device-uri'):
+                        device_class = 'direct'
+                    printer.update({'device-class': device_class})
+                    printer.update({'device-make-and-model': printer}) # give name setted in Cups
+                    printer.update({'device-id': ''})
+                    devices.update({printer_name: printer})
+        for path, device in devices.items():
+            identifier = self.get_identifier(path)
+            device.update({'identifier': identifier})
+            device.update({'url': path})
+            printer_devices.update({identifier: device})
         return printer_devices
+
+    def get_identifier(self, path):
+        if 'uuid=' in path:
+            identifier = sub('[^a-zA-Z0-9_]', '', path.split('uuid=')[1])
+        elif 'serial=' in path:
+            identifier = sub('[^a-zA-Z0-9_]', '', path.split('serial=')[1])
+        else:
+            identifier = sub('[^a-zA-Z0-9_]', '', path)
+        return identifier


### PR DESCRIPTION
Actually it is not possible to add manually a printer.

With this commit we loop into all printer recorded in cups to
check if a printer is not automatically added.
If a printer does not match with a identifier automaticcaly generated,
it is added to the list of usable printer.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
