### PR TITLE
[IMP] mail, website_livechat: rename country model

### DIFF
--- a/addons/mail/static/src/models/country/country.js
+++ b/addons/mail/static/src/models/country/country.js
@@ -5,7 +5,7 @@ import { attr } from '@mail/model/model_field';
 import { clear } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.country',
+    name: 'Country',
     identifyingFields: ['id'],
     recordMethods: {
         /**

--- a/addons/mail/static/src/models/partner/partner.js
+++ b/addons/mail/static/src/models/partner/partner.js
@@ -409,7 +409,7 @@ registerModel({
         avatarUrl: attr({
             compute: '_computeAvatarUrl',
         }),
-        country: many2one('mail.country'),
+        country: many2one('Country'),
         display_name: attr({
             compute: '_computeDisplayName',
             default: "",

--- a/addons/website_livechat/static/src/models/visitor/visitor.js
+++ b/addons/website_livechat/static/src/models/visitor/visitor.js
@@ -61,7 +61,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.country}
+         * @returns {Country}
          */
         _computeCountry() {
             if (this.partner && this.partner.country) {
@@ -93,7 +93,7 @@ registerModel({
         /**
          * Country of the visitor.
          */
-        country: many2one('mail.country', {
+        country: many2one('Country', {
             compute: '_computeCountry',
         }),
         /**


### PR DESCRIPTION
Rename javascript model `mail.country` to `Country` in order to distinguish javascript models from python models.

Part of task-2701674.