### PR TITLE
[IMP] mail: rename device model

### DIFF
--- a/addons/mail/static/src/models/device/device.js
+++ b/addons/mail/static/src/models/device/device.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.device',
+    name: 'Device',
     identifyingFields: ['messaging'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -240,7 +240,7 @@ registerModel({
         currentGuest: one2one('mail.guest'),
         currentPartner: one2one('mail.partner'),
         currentUser: one2one('mail.user'),
-        device: one2one('mail.device', {
+        device: one2one('Device', {
             default: insertAndReplace(),
             isCausal: true,
             readonly: true,


### PR DESCRIPTION
Rename javascript model `mail.device` to `Device` in order to distinguish javascript models from python models.

Part of task-2701674.