### PR TITLE
[IMP] mail: rename dialog model

### DIFF
--- a/addons/mail/static/src/components/dialog/dialog.js
+++ b/addons/mail/static/src/components/dialog/dialog.js
@@ -37,10 +37,10 @@ export class Dialog extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.dialog}
+     * @returns {Dialog}
      */
     get dialog() {
-        return this.messaging && this.messaging.models['mail.dialog'].get(this.props.dialogLocalId);
+        return this.messaging && this.messaging.models['Dialog'].get(this.props.dialogLocalId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/models/attachment_viewer/attachment_viewer.js
+++ b/addons/mail/static/src/models/attachment_viewer/attachment_viewer.js
@@ -11,7 +11,7 @@ registerModel({
          * Close the attachment viewer by closing its linked dialog.
          */
         close() {
-            const dialog = this.messaging.models['mail.dialog'].find(dialog => dialog.record === this);
+            const dialog = this.messaging.models['Dialog'].find(dialog => dialog.record === this);
             if (dialog) {
                 dialog.delete();
             }
@@ -51,7 +51,7 @@ registerModel({
         /**
          * Determines the dialog displaying this attachment viewer.
          */
-        dialog: one2one('mail.dialog', {
+        dialog: one2one('Dialog', {
             inverse: 'attachmentViewer',
             isCausal: true,
             readonly: true,

--- a/addons/mail/static/src/models/dialog/dialog.js
+++ b/addons/mail/static/src/models/dialog/dialog.js
@@ -5,7 +5,7 @@ import { attr, many2one, one2one } from '@mail/model/model_field';
 import { clear, replace } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.dialog',
+    name: 'Dialog',
     identifyingFields: ['manager', ['attachmentViewer', 'followerSubtypeList']],
     recordMethods: {
         /**

--- a/addons/mail/static/src/models/dialog_manager/dialog_manager.js
+++ b/addons/mail/static/src/models/dialog_manager/dialog_manager.js
@@ -8,7 +8,7 @@ registerModel({
     identifyingFields: ['messaging'],
     fields: {
         // FIXME: dependent on implementation that uses insert order in relations!!
-        dialogs: one2many('mail.dialog', {
+        dialogs: one2many('Dialog', {
             inverse: 'manager',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/follower_subtype_list/follower_subtype_list.js
+++ b/addons/mail/static/src/models/follower_subtype_list/follower_subtype_list.js
@@ -10,7 +10,7 @@ registerModel({
         /**
          * States the dialog displaying this follower subtype list.
          */
-        dialog: one2one('mail.dialog', {
+        dialog: one2one('Dialog', {
             inverse: 'followerSubtypeList',
             isCausal: true,
             readonly: true,


### PR DESCRIPTION
Rename javascript model `mail.dialog` to `Dialog` in order to distinguish javascript models from python models.

Part of task-2701674.