### PR TITLE
[IMP] mail: rename dialog manager model

### DIFF
--- a/addons/mail/static/src/models/dialog/dialog.js
+++ b/addons/mail/static/src/models/dialog/dialog.js
@@ -45,14 +45,14 @@ registerModel({
             inverse: 'dialog',
             readonly: true,
         }),
-        manager: many2one('mail.dialog_manager', {
+        manager: many2one('DialogManager', {
             inverse: 'dialogs',
             readonly: true,
         }),
         /**
          * Content of dialog that is directly linked to a record that models
          * a UI component, such as AttachmentViewer. These records must be
-         * created from @see `mail.dialog_manager:open()`.
+         * created from @see `DialogManager:open()`.
          */
         record: one2one('mail.model', {
             compute: '_computeRecord',

--- a/addons/mail/static/src/models/dialog_manager/dialog_manager.js
+++ b/addons/mail/static/src/models/dialog_manager/dialog_manager.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { one2many } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.dialog_manager',
+    name: 'DialogManager',
     identifyingFields: ['messaging'],
     fields: {
         // FIXME: dependent on implementation that uses insert order in relations!!

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -245,7 +245,7 @@ registerModel({
             isCausal: true,
             readonly: true,
         }),
-        dialogManager: one2one('mail.dialog_manager', {
+        dialogManager: one2one('DialogManager', {
             default: insertAndReplace(),
             isCausal: true,
             readonly: true,


### PR DESCRIPTION
Rename javascript model `mail.dialog_manager` to `DialogManager` in order to distinguish javascript models from python models.

Part of task-2701674.