### PR TITLE
[IMP] im_livechat, mail: rename discuss model

### DIFF
--- a/addons/im_livechat/static/src/models/discuss/discuss.js
+++ b/addons/im_livechat/static/src/models/discuss/discuss.js
@@ -5,7 +5,7 @@ import { one2one } from '@mail/model/model_field';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/discuss/discuss';
 
-patchRecordMethods('mail.discuss', {
+patchRecordMethods('Discuss', {
     /**
      * @override
      */
@@ -17,7 +17,7 @@ patchRecordMethods('mail.discuss', {
     },
 });
 
-addFields('mail.discuss', {
+addFields('Discuss', {
     /**
      * Discuss sidebar category for `livechat` channel threads.
      */

--- a/addons/im_livechat/static/src/models/discuss_sidebar_category/discuss_sidebar_category.js
+++ b/addons/im_livechat/static/src/models/discuss_sidebar_category/discuss_sidebar_category.js
@@ -6,7 +6,7 @@ import { one2one } from '@mail/model/model_field';
 import '@mail/models/discuss_sidebar_category/discuss_sidebar_category';
 
 addFields('mail.discuss_sidebar_category', {
-    discussAsLivechat: one2one('mail.discuss', {
+    discussAsLivechat: one2one('Discuss', {
         inverse: 'categoryLivechat',
         readonly: true,
     }),

--- a/addons/mail/static/src/components/discuss/discuss.js
+++ b/addons/mail/static/src/components/discuss/discuss.js
@@ -72,7 +72,7 @@ export class Discuss extends Component {
     }
 
     /**
-     * @returns {mail.discuss}
+     * @returns {Discuss}
      */
     get discuss() {
         return this.messaging && this.messaging.discuss;

--- a/addons/mail/static/src/components/discuss_mobile_mailbox_selection/discuss_mobile_mailbox_selection.js
+++ b/addons/mail/static/src/components/discuss_mobile_mailbox_selection/discuss_mobile_mailbox_selection.js
@@ -39,7 +39,7 @@ export class DiscussMobileMailboxSelection extends Component {
     }
 
     /**
-     * @returns {mail.discuss}
+     * @returns {Discuss}
      */
     get discuss() {
         return this.messaging && this.messaging.discuss;

--- a/addons/mail/static/src/components/discuss_sidebar/discuss_sidebar.js
+++ b/addons/mail/static/src/components/discuss_sidebar/discuss_sidebar.js
@@ -15,7 +15,7 @@ export class DiscussSidebar extends Component {
     setup() {
         super.setup();
         useUpdate({ func: () => this._update() });
-        useRefToModel({ fieldName: 'startAMeetingButtonRef', modelName: 'mail.discuss', propNameAsRecordLocalId: 'localId', refName: 'startAMeetingButton' });
+        useRefToModel({ fieldName: 'startAMeetingButtonRef', modelName: 'Discuss', propNameAsRecordLocalId: 'localId', refName: 'startAMeetingButton' });
         /**
          * Reference of the quick search input. Useful to filter channels and
          * chats based on this input content.
@@ -28,10 +28,10 @@ export class DiscussSidebar extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.discuss}
+     * @returns {Discuss}
      */
     get discuss() {
-        return this.messaging && this.messaging.models['mail.discuss'].get(this.props.localId);
+        return this.messaging && this.messaging.models['Discuss'].get(this.props.localId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/models/discuss/discuss.js
+++ b/addons/mail/static/src/models/discuss/discuss.js
@@ -5,7 +5,7 @@ import { attr, many2one, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace, link, unlink } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.discuss',
+    name: 'Discuss',
     identifyingFields: ['messaging'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/discuss_sidebar_category/discuss_sidebar_category.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category/discuss_sidebar_category.js
@@ -233,11 +233,11 @@ registerModel({
             readonly: true,
             sum: 'categoryItems.categoryCounterContribution',
         }),
-        discussAsChannel: one2one('mail.discuss', {
+        discussAsChannel: one2one('Discuss', {
             inverse: 'categoryChannel',
             readonly: true,
         }),
-        discussAsChat: one2one('mail.discuss', {
+        discussAsChat: one2one('Discuss', {
             inverse: 'categoryChat',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -256,7 +256,7 @@ registerModel({
         disableAnimation: attr({
             default: false,
         }),
-        discuss: one2one('mail.discuss', {
+        discuss: one2one('Discuss', {
             default: insertAndReplace(),
             isCausal: true,
             readonly: true,

--- a/addons/mail/static/src/models/thread_view/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_view/thread_viewer.js
@@ -73,7 +73,7 @@ registerModel({
         compact: attr({
             default: false,
         }),
-        discuss: one2one('mail.discuss', {
+        discuss: one2one('Discuss', {
             inverse: 'threadViewer',
             readonly: true,
         }),


### PR DESCRIPTION
Rename javascript model `mail.discuss` to `Discuss` in order to distinguish javascript models from python models.

Part of task-2701674.