### PR TITLE
[FIX] core: use EXISTS in domain conditions like (m2m, '=', False)

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -440,8 +440,14 @@ class TestExpression(TransactionCase):
 
         # test many2many operator with False
         partners = self._search(Partner, [('category_id', '=', False)])
+        self.assertTrue(partners)
         for partner in partners:
             self.assertFalse(partner.category_id)
+
+        partners = self._search(Partner, [('category_id', '!=', False)])
+        self.assertTrue(partners)
+        for partner in partners:
+            self.assertTrue(partner.category_id)
 
         # filtering on nonexistent value across x2many should return nothing
         partners = self._search(Partner, [('child_ids.city', '=', 'foo')])


### PR DESCRIPTION
Consider the domain [('tag_ids', '=', False)] with a many2many field.
It is currently translated in SQL as

    "model".id NOT IN (
        SELECT "model_id"
        FROM "model_tag_rel"
        WHERE "model_id" IS NOT NULL
    )

PostgreSQL does not handle well this "NOT IN" expression when the relation table is large, and uses some very inefficient query plan in that case.  This commit changes the above expression to a "NOT EXISTS" expression (as below), which is executed with a much more efficient query plan, even with large tables.

    NOT EXISTS (
        SELECT 1
        FROM "model_tag_rel"
        WHERE "model_tag_rel"."model_id" = "model".id
    )

This change was motivated by a use-case with 2.7M account moves, 11M account move lines and a relation table `account_move_line_account_tax_rel` with 2.3M lines. The query was timing out (15 minutes), and it now takes 15 seconds.
