### PR TITLE
[IMP] im_livechat, mail: rename discuss sidebar category model

### DIFF
--- a/addons/im_livechat/static/src/models/discuss/discuss.js
+++ b/addons/im_livechat/static/src/models/discuss/discuss.js
@@ -21,7 +21,7 @@ addFields('Discuss', {
     /**
      * Discuss sidebar category for `livechat` channel threads.
      */
-    categoryLivechat: one2one('mail.discuss_sidebar_category', {
+    categoryLivechat: one2one('DiscussSidebarCategory', {
         inverse: 'discussAsLivechat',
         isCausal: true,
     }),

--- a/addons/im_livechat/static/src/models/discuss_sidebar_category/discuss_sidebar_category.js
+++ b/addons/im_livechat/static/src/models/discuss_sidebar_category/discuss_sidebar_category.js
@@ -5,13 +5,13 @@ import { one2one } from '@mail/model/model_field';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/discuss_sidebar_category/discuss_sidebar_category';
 
-addFields('mail.discuss_sidebar_category', {
+addFields('DiscussSidebarCategory', {
     discussAsLivechat: one2one('Discuss', {
         inverse: 'categoryLivechat',
         readonly: true,
     }),
 });
 
-patchIdentifyingFields('mail.discuss_sidebar_category', identifyingFields => {
+patchIdentifyingFields('DiscussSidebarCategory', identifyingFields => {
     identifyingFields[0].push('discussAsLivechat');
 });

--- a/addons/mail/static/src/components/discuss_sidebar_category/discuss_sidebar_category.js
+++ b/addons/mail/static/src/components/discuss_sidebar_category/discuss_sidebar_category.js
@@ -11,10 +11,10 @@ export class DiscussSidebarCategory extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.discuss_sidebar_category}
+     * @returns {DiscussSidebarCategory}
      */
     get category() {
-        return this.messaging.models['mail.discuss_sidebar_category'].get(this.props.categoryLocalId);
+        return this.messaging.models['DiscussSidebarCategory'].get(this.props.categoryLocalId);
     }
 }
 

--- a/addons/mail/static/src/models/discuss/discuss.js
+++ b/addons/mail/static/src/models/discuss/discuss.js
@@ -329,14 +329,14 @@ registerModel({
         /**
          * Discuss sidebar category for `channel` type channel threads.
          */
-        categoryChannel: one2one('mail.discuss_sidebar_category', {
+        categoryChannel: one2one('DiscussSidebarCategory', {
             inverse: 'discussAsChannel',
             isCausal: true,
         }),
         /**
          * Discuss sidebar category for `chat` type channel threads.
          */
-        categoryChat: one2one('mail.discuss_sidebar_category', {
+        categoryChat: one2one('DiscussSidebarCategory', {
             inverse: 'discussAsChat',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/discuss_sidebar_category/discuss_sidebar_category.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category/discuss_sidebar_category.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace, replace } from '@mail/model/model_field_comman
 import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
-    name: 'mail.discuss_sidebar_category',
+    name: 'DiscussSidebarCategory',
     identifyingFields: [['discussAsChannel', 'discussAsChat']],
     lifecycleHooks: {
         _created() {
@@ -46,7 +46,7 @@ registerModel({
          */
         async close() {
             this.update({ isPendingOpen: false });
-            await this.messaging.models['mail.discuss_sidebar_category'].performRpcSetResUsersSettings({
+            await this.messaging.models['DiscussSidebarCategory'].performRpcSetResUsersSettings({
                 [this.serverStateKey]: false,
             });
         },
@@ -55,7 +55,7 @@ registerModel({
          */
         async open() {
             this.update({ isPendingOpen: true });
-            await this.messaging.models['mail.discuss_sidebar_category'].performRpcSetResUsersSettings({
+            await this.messaging.models['DiscussSidebarCategory'].performRpcSetResUsersSettings({
                 [this.serverStateKey]: true,
             });
         },

--- a/addons/mail/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
@@ -217,7 +217,7 @@ registerModel({
         /**
          * Determines the discuss sidebar category displaying this item.
          */
-        category: many2one('mail.discuss_sidebar_category', {
+        category: many2one('DiscussSidebarCategory', {
             inverse: 'categoryItems',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1727,7 +1727,7 @@ registerModel({
          * type.
          *
          * @private
-         * @returns {mail.discuss_sidebar_category}
+         * @returns {DiscussSidebarCategory}
          */
         _getDiscussSidebarCategory() {
             switch (this.channel_type) {


### PR DESCRIPTION
Rename javascript model `mail.discuss_sidebar_category` to `DiscussSidebarCategory` in order to distinguish javascript models from python models.

Part of task-2701674.