### PR TITLE
[IMP] mail: rename discuss public view model

### DIFF
--- a/addons/mail/static/src/components/discuss_public_view/discuss_public_view.js
+++ b/addons/mail/static/src/components/discuss_public_view/discuss_public_view.js
@@ -7,10 +7,10 @@ const { Component } = owl;
 class DiscussPublicView extends Component {
 
     /**
-     * @returns {mail.discuss_public_view}
+     * @returns {DiscussPublicView}
      */
      get discussPublicView() {
-        return this.messaging && this.messaging.models['mail.discuss_public_view'].get(this.props.localId);
+        return this.messaging && this.messaging.models['DiscussPublicView'].get(this.props.localId);
     }
 }
 

--- a/addons/mail/static/src/models/discuss_public_view/discuss_public_view.js
+++ b/addons/mail/static/src/models/discuss_public_view/discuss_public_view.js
@@ -5,7 +5,7 @@ import { registerModel } from '@mail/model/model_core';
 import { clear, insertAndReplace, link } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.discuss_public_view',
+    name: 'DiscussPublicView',
     identifyingFields: ['messaging'],
     recordMethods: {
         /**

--- a/addons/mail/static/src/models/thread_view/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_view/thread_viewer.js
@@ -77,7 +77,7 @@ registerModel({
             inverse: 'threadViewer',
             readonly: true,
         }),
-        discussPublicView: one2one('mail.discuss_public_view', {
+        discussPublicView: one2one('DiscussPublicView', {
             inverse: 'threadViewer',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/welcome_view/welcome_view.js
+++ b/addons/mail/static/src/models/welcome_view/welcome_view.js
@@ -143,7 +143,7 @@ registerModel({
         /**
          * States discuss public view on which this welcome view is displayed.
          */
-        discussPublicView: one2one('mail.discuss_public_view', {
+        discussPublicView: one2one('DiscussPublicView', {
             inverse: 'welcomeView',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/public/discuss_public_boot.js
+++ b/addons/mail/static/src/public/discuss_public_boot.js
@@ -71,7 +71,7 @@ async function createAndMountDiscussPublicView() {
     const dialogManagerComponent = new DialogManager(null, {});
     await dialogManagerComponent.mount(document.body);
     messaging.models['mail.thread'].insert(messaging.models['mail.thread'].convertData(data.channelData));
-    const discussPublicView = messaging.models['mail.discuss_public_view'].create(data.discussPublicViewData);
+    const discussPublicView = messaging.models['DiscussPublicView'].create(data.discussPublicViewData);
     if (discussPublicView.shouldDisplayWelcomeViewInitially) {
         discussPublicView.switchToWelcomeView();
     } else {


### PR DESCRIPTION
Rename javascript model `mail.discuss_public_view` to `DiscussPublicView` inorder to distinguish javascript models from python models.

Part of task-2701674.