### PR TITLE
[FIX] stock_account:make cogs multi_company safe

### DIFF
--- a/addons/sale_stock/tests/test_anglosaxon_account.py
+++ b/addons/sale_stock/tests/test_anglosaxon_account.py
@@ -9,6 +9,7 @@ class TestAngloSaxonAccounting(AccountTestInvoicingCommon):
     def setUpClass(cls):
         super().setUpClass()
         (cls.company_data['company'] + cls.company_data_2['company']).write({'anglo_saxon_accounting': True})
+        # fifo and real_time will be only set for company_A as product.category is company dependant
         product_category = cls.env['product.category'].create({
             'name': 'a random storable product category',
             'property_cost_method': 'fifo',
@@ -18,11 +19,6 @@ class TestAngloSaxonAccounting(AccountTestInvoicingCommon):
             'name': 'storable product a',
             'type': 'product',
             'categ_id': product_category.id,
-        })
-        # Those values are company dependent and need to be explicitly set for both companies
-        product_category.with_context(force_company=cls.company_data_2['company'].id).write({
-            'property_cost_method': 'fifo',
-            'property_valuation': 'real_time',
         })
 
     def test_cogs_should_use_price_from_the_right_company(self):


### PR DESCRIPTION
## Goal:
The aim of this commit is to make the cogs generation multi-company
safe.

## Context:

Considering the situation in which company A has set a product P with
a real time valuation and company B didn't set the real time valuation
or has set it to manual;
Considering the user has selected both company in the switcher;
The user post an invoice for the product P.

## Before this commit:
There isn't any cogs created for the invoice which is wrong.

## After this commit:
Whatever the selected companies are, the cost selected will always be from
the company that created the invoice.

task: #2713607

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
