### PR TITLE
[FIX] unit price calculation BoM in different UoM

### DIFF
--- a/addons/sale_mrp/models/sale_mrp.py
+++ b/addons/sale_mrp/models/sale_mrp.py
@@ -67,7 +67,7 @@ class SaleOrderLine(models.Model):
                         order_line.qty_delivered = 0.0
 
     def _get_bom_component_qty(self, bom):
-        bom_quantity = self.product_uom._compute_quantity(1, bom.product_uom_id)
+        bom_quantity = self.product_id.uom_id._compute_quantity(1, bom.product_uom_id)
         boms, lines = bom.explode(self.product_id, bom_quantity)
         components = {}
         for line, line_data in lines:

--- a/addons/sale_mrp/models/sale_mrp.py
+++ b/addons/sale_mrp/models/sale_mrp.py
@@ -67,7 +67,7 @@ class SaleOrderLine(models.Model):
                         order_line.qty_delivered = 0.0
 
     def _get_bom_component_qty(self, bom):
-        bom_quantity = self.product_id.uom_id._compute_quantity(1, bom.product_uom_id)
+        bom_quantity = self.product_id.uom_id._compute_quantity(1, bom.product_uom_id, rounding_method='HALF-UP')
         boms, lines = bom.explode(self.product_id, bom_quantity)
         components = {}
         for line, line_data in lines:


### PR DESCRIPTION
Fix for task 2620026.

_get_bom_component_qty function is only referred to once in the whole odoo app,
which is on addons/sale_mrp/models/account_move.py#22.

The result returned from this function is used as a multiplier to quantity
to convert into the expected UoM. However, the quantity being referred to on
_stock_account_get_anglo_saxon_price_unit (qty_invoiced, qty_to_invoice), are
already converted into the SO Line's product's default UoM. In this function,
it however tries to convert 1 from SO Line's UoM to BoM's UOM.

With this, if Product UoM=x, SO Line UoM=y, BOM UoM=x, in the function _stock_account_get_anglo_saxon_price_unit,
the quantities will be multiplied by the same factor twice, resulting to the incorrect computation of price_unit to follow.

--

Description of the issue/feature this PR addresses:
More detail on error and its demonstration can be found in this [task](https://www.odoo.com/web#id=2620026&cids=5&menu_id=4720&action=333&active_id=3622&model=project.task&view_type=form).

--
Current behavior before PR:
Incorrect price_unit calculation due to BoM prod_qty_invoiced and prod_qty_to_invoice is incorrect on addons/sale_mrp/models/account_move.py/#27-28 after multiplying by incorrect factor. Error will occur if product has BoM and SO Line has different UoM from product's default UoM and its corresponding BoM's UoM.

--
Desired behavior after PR is merged:
price_unit calculation fixed.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
