### PR TITLE
[FIX] hr_skills_slides: remove html tags from resume

### DIFF
--- a/addons/hr_skills_slides/models/slide_channel.py
+++ b/addons/hr_skills_slides/models/slide_channel.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models
+from odoo.tools import html2plaintext
 
 
 class SlideChannelPartner(models.Model):
@@ -19,7 +20,7 @@ class SlideChannelPartner(models.Model):
                 'name': channel.name,
                 'date_start': fields.Date.today(),
                 'date_end': fields.Date.today(),
-                'description': channel.description,
+                'description': html2plaintext(channel.description),
                 'line_type_id': line_type and line_type.id,
                 'display_type': 'course',
                 'channel_id': channel.id


### PR DESCRIPTION
PURPOSE
To remove the html tags from description of course in resume

Specification:
Current:
We are getting html tags in description of resume's ''Internal Training' section.

To be:
Remove html tags from it.


Taskid-2711308

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
