### PR TITLE
[FIX] mail: ignore followers generating AccessError

### DIFF
--- a/addons/mail/controllers/main.py
+++ b/addons/mail/controllers/main.py
@@ -138,18 +138,21 @@ class MailController(http.Controller):
         for follower in follower_recs:
             if follower.partner_id == request.env.user.partner_id:
                 follower_id = follower.id
-            followers.append({
-                'id': follower.id,
-                'partner_id': follower.partner_id.id,
-                'channel_id': follower.channel_id.id,
-                'name': follower.name,
-                'display_name': follower.display_name,
-                'email': follower.email,
-                'is_active': follower.is_active,
-                # When editing the followers, the "pencil" icon that leads to the edition of subtypes
-                # should be always be displayed and not only when "debug" mode is activated.
-                'is_editable': True
-            })
+            try:
+                followers.append({
+                    'id': follower.id,
+                    'partner_id': follower.partner_id.id,
+                    'channel_id': follower.channel_id.id,
+                    'name': follower.name,
+                    'display_name': follower.display_name,
+                    'email': follower.email,
+                    'is_active': follower.is_active,
+                    # When editing the followers, the "pencil" icon that leads to the edition of subtypes
+                    # should be always be displayed and not only when "debug" mode is activated.
+                    'is_editable': True
+                })
+            except AccessError:
+                _logger.warning('follower with id %s cannot be displayed for security access restriction.', follower.id)
         return {
             'followers': followers,
             'subtypes': self.read_subscription_data(follower_id) if follower_id else None


### PR DESCRIPTION
How to reproduce:

- Create a private channel with user U1
- Follow a contact C with the private channel
- Login with user U2 that is not part of the private channel
- Open contact C

Bug:

If you try to open a contact who is followed by a private channel,
an error will be generated for every user that are not members of the
private channel.

opw: 2690903

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
