### PR TITLE
[FIX] stock_inventory : allow to inventory disabled product

### DIFF
--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -236,7 +236,7 @@ class Inventory(models.Model):
     def _get_inventory_lines_values(self):
         # TDE CLEANME: is sql really necessary ? I don't think so
         locations = self.env['stock.location'].search([('id', 'child_of', [self.location_id.id])])
-        domain = ' location_id in %s AND quantity != 0 AND active = TRUE'
+        domain = ' location_id in %s AND quantity != 0'
         args = (tuple(locations.ids),)
 
         vals = []


### PR DESCRIPTION
Step to reproduce : 
- create a product ; 
- make out moves to have negative quantity;
- archive the product ; 

- make a full inventory ; 
- the inventory doesn't contains the disabled product
- confirm the inventory

If the user enable the product, the quantity will be bad.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
