### PR TITLE
[IMP] mail, sms, snailmail: rename message model

### DIFF
--- a/addons/mail/static/src/components/attachment_image/tests/attachment_image_tests.js
+++ b/addons/mail/static/src/components/attachment_image/tests/attachment_image_tests.js
@@ -39,7 +39,7 @@ QUnit.test('auto layout with image', async function (assert) {
         mimetype: 'image/png',
         name: "test.png",
     });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         attachments: link(attachment),
         author: link(this.messaging.currentPartner),
         body: "<p>Test</p>",

--- a/addons/mail/static/src/components/attachment_list/tests/attachment_list_tests.js
+++ b/addons/mail/static/src/components/attachment_list/tests/attachment_list_tests.js
@@ -41,7 +41,7 @@ QUnit.test('simplest layout', async function (assert) {
         mimetype: 'text/plain',
         name: "test.txt",
     });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         attachments: link(attachment),
         author: link(this.messaging.currentPartner),
         body: "<p>Test</p>",
@@ -113,7 +113,7 @@ QUnit.test('simplest layout + editable', async function (assert) {
         mimetype: 'text/plain',
         name: "test.txt",
     });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         attachments: link(attachment),
         author: link(this.messaging.currentPartner),
         body: "<p>Test</p>",
@@ -169,7 +169,7 @@ QUnit.test('layout with card details and filename and extension', async function
         mimetype: 'text/plain',
         name: "test.txt",
     });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         attachments: link(attachment),
         author: link(this.messaging.currentPartner),
         body: "<p>Test</p>",
@@ -201,7 +201,7 @@ QUnit.test('view attachment', async function (assert) {
         mimetype: 'image/png',
         name: "test.png",
     });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         attachments: link(attachment),
         author: link(this.messaging.currentPartner),
         body: "<p>Test</p>",
@@ -237,7 +237,7 @@ QUnit.test('close attachment viewer', async function (assert) {
         mimetype: 'image/png',
         name: "test.png",
     });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         attachments: link(attachment),
         author: link(this.messaging.currentPartner),
         body: "<p>Test</p>",
@@ -286,7 +286,7 @@ QUnit.test('clicking on the delete attachment button multiple times should do th
         mimetype: 'text/plain',
         name: "test.txt",
     });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         attachments: link(attachment),
         author: link(this.messaging.currentPartner),
         body: "<p>Test</p>",
@@ -328,7 +328,7 @@ QUnit.test('[technical] does not crash when the viewer is closed before image lo
         mimetype: 'image/png',
         name: "test.png",
     });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         attachments: link(attachment),
         author: link(this.messaging.currentPartner),
         body: "<p>Test</p>",
@@ -362,7 +362,7 @@ QUnit.test('plain text file is viewable', async function (assert) {
         mimetype: 'text/plain',
         name: "test.txt",
     });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         attachments: link(attachment),
         author: link(this.messaging.currentPartner),
         body: "<p>Test</p>",
@@ -387,7 +387,7 @@ QUnit.test('HTML file is viewable', async function (assert) {
         mimetype: 'text/html',
         name: "test.html",
     });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         attachments: link(attachment),
         author: link(this.messaging.currentPartner),
         body: "<p>Test</p>",
@@ -411,7 +411,7 @@ QUnit.test('ODT file is not viewable', async function (assert) {
         mimetype: 'application/vnd.oasis.opendocument.text',
         name: "test.odt",
     });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         attachments: link(attachment),
         author: link(this.messaging.currentPartner),
         body: "<p>Test</p>",
@@ -435,7 +435,7 @@ QUnit.test('DOCX file is not viewable', async function (assert) {
         mimetype: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         name: "test.docx",
     });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         attachments: link(attachment),
         author: link(this.messaging.currentPartner),
         body: "<p>Test</p>",

--- a/addons/mail/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_tests.js
@@ -1143,7 +1143,7 @@ QUnit.test('load single message from channel initially', async function (assert)
         document.querySelectorAll(`
             .o_Discuss_thread
             .o_MessageList_message[data-message-local-id="${
-                this.messaging.models['mail.message'].findFromIdentifyingData({ id: 100 }).localId
+                this.messaging.models['Message'].findFromIdentifyingData({ id: 100 }).localId
             }"]
         `).length,
         1,
@@ -1201,7 +1201,7 @@ QUnit.test('basic rendering of message', async function (assert) {
         .o_Discuss_thread
         .o_ThreadView_messageList
         .o_MessageList_message[data-message-local-id="${
-            this.messaging.models['mail.message'].findFromIdentifyingData({ id: 100 }).localId
+            this.messaging.models['Message'].findFromIdentifyingData({ id: 100 }).localId
         }"]
     `);
     assert.strictEqual(
@@ -1333,14 +1333,14 @@ QUnit.test('basic rendering of squashed message', async function (assert) {
         .o_Discuss_thread
         .o_ThreadView_messageList
         .o_MessageList_message[data-message-local-id="${
-            this.messaging.models['mail.message'].findFromIdentifyingData({ id: 100 }).localId
+            this.messaging.models['Message'].findFromIdentifyingData({ id: 100 }).localId
         }"]
     `);
     const message2 = document.querySelector(`
         .o_Discuss_thread
         .o_ThreadView_messageList
         .o_MessageList_message[data-message-local-id="${
-            this.messaging.models['mail.message'].findFromIdentifyingData({ id: 101 }).localId
+            this.messaging.models['Message'].findFromIdentifyingData({ id: 101 }).localId
         }"]
     `);
     assert.notOk(
@@ -1466,14 +1466,14 @@ QUnit.test('inbox messages are never squashed', async function (assert) {
         .o_Discuss_thread
         .o_ThreadView_messageList
         .o_MessageList_message[data-message-local-id="${
-            this.messaging.models['mail.message'].findFromIdentifyingData({ id: 100 }).localId
+            this.messaging.models['Message'].findFromIdentifyingData({ id: 100 }).localId
         }"]
     `);
     const message2 = document.querySelector(`
         .o_Discuss_thread
         .o_ThreadView_messageList
         .o_MessageList_message[data-message-local-id="${
-            this.messaging.models['mail.message'].findFromIdentifyingData({ id: 101 }).localId
+            this.messaging.models['Message'].findFromIdentifyingData({ id: 101 }).localId
         }"]
     `);
     assert.notOk(
@@ -2110,7 +2110,7 @@ QUnit.test('redirect to author (open chat)', async function (assert) {
     const msg1 = document.querySelector(`
         .o_Discuss_thread
         .o_Message[data-message-local-id="${
-            this.messaging.models['mail.message'].findFromIdentifyingData({ id: 100 }).localId
+            this.messaging.models['Message'].findFromIdentifyingData({ id: 100 }).localId
         }"]
     `);
     assert.strictEqual(
@@ -2799,7 +2799,7 @@ QUnit.test('post a simple message', async function (assert) {
     const message = document.querySelector(`.o_Message`);
     assert.strictEqual(
         message.dataset.messageLocalId,
-        this.messaging.models['mail.message'].findFromIdentifyingData({ id: postedMessageId }).localId,
+        this.messaging.models['Message'].findFromIdentifyingData({ id: postedMessageId }).localId,
         "new message in thread should be linked to newly created message from message post"
     );
     assert.strictEqual(
@@ -3106,7 +3106,7 @@ QUnit.test('receive new needaction messages', async function (assert) {
     );
     assert.strictEqual(
         document.querySelector(`.o_Discuss_thread .o_Message`).dataset.messageLocalId,
-        this.messaging.models['mail.message'].findFromIdentifyingData({ id: 100 }).localId,
+        this.messaging.models['Message'].findFromIdentifyingData({ id: 100 }).localId,
         "should display newly received needaction message"
     );
 
@@ -3142,7 +3142,7 @@ QUnit.test('receive new needaction messages', async function (assert) {
         document.querySelector(`
             .o_Discuss_thread
             .o_Message[data-message-local-id="${
-                this.messaging.models['mail.message'].findFromIdentifyingData({ id: 100 }).localId
+                this.messaging.models['Message'].findFromIdentifyingData({ id: 100 }).localId
             }"]
         `),
         "should still display 1st needaction message"
@@ -3151,7 +3151,7 @@ QUnit.test('receive new needaction messages', async function (assert) {
         document.querySelector(`
             .o_Discuss_thread
             .o_Message[data-message-local-id="${
-                this.messaging.models['mail.message'].findFromIdentifyingData({ id: 101 }).localId
+                this.messaging.models['Message'].findFromIdentifyingData({ id: 101 }).localId
             }"]
         `),
         "should display 2nd needaction message"
@@ -3227,7 +3227,7 @@ QUnit.test('reply to message from inbox (message linked to document)', async fun
     );
     assert.strictEqual(
         document.querySelector('.o_Message').dataset.messageLocalId,
-        this.messaging.models['mail.message'].findFromIdentifyingData({ id: 100 }).localId,
+        this.messaging.models['Message'].findFromIdentifyingData({ id: 100 }).localId,
         "should display message with ID 100"
     );
     assert.strictEqual(
@@ -3277,7 +3277,7 @@ QUnit.test('reply to message from inbox (message linked to document)', async fun
     );
     assert.strictEqual(
         document.querySelector('.o_Message').dataset.messageLocalId,
-        this.messaging.models['mail.message'].findFromIdentifyingData({ id: 100 }).localId,
+        this.messaging.models['Message'].findFromIdentifyingData({ id: 100 }).localId,
         "should still display message with ID 100 after posting reply"
     );
     assert.notOk(
@@ -3486,7 +3486,7 @@ QUnit.test('mark a single message as read should only move this message to "Hist
     await afterNextRender(() =>
         document.querySelector(`
             .o_Message[data-message-local-id="${
-                this.messaging.models['mail.message'].findFromIdentifyingData({ id: 1 }).localId
+                this.messaging.models['Message'].findFromIdentifyingData({ id: 1 }).localId
             }"]
         `).click()
     );
@@ -3494,7 +3494,7 @@ QUnit.test('mark a single message as read should only move this message to "Hist
     await afterNextRender(() =>
         document.querySelector(`
             .o_Message[data-message-local-id="${
-                this.messaging.models['mail.message'].findFromIdentifyingData({ id: 1 }).localId
+                this.messaging.models['Message'].findFromIdentifyingData({ id: 1 }).localId
             }"] .o_MessageActionList_actionMarkRead
         `).click()
     );
@@ -3506,7 +3506,7 @@ QUnit.test('mark a single message as read should only move this message to "Hist
     assert.containsOnce(
         document.body,
         `.o_Message[data-message-local-id="${
-            this.messaging.models['mail.message'].findFromIdentifyingData({ id: 2 }).localId
+            this.messaging.models['Message'].findFromIdentifyingData({ id: 2 }).localId
         }"]`,
         "message still in inbox should be the one not marked as read"
     );
@@ -3535,7 +3535,7 @@ QUnit.test('mark a single message as read should only move this message to "Hist
     assert.containsOnce(
         document.body,
         `.o_Message[data-message-local-id="${
-            this.messaging.models['mail.message'].findFromIdentifyingData({ id: 1 }).localId
+            this.messaging.models['Message'].findFromIdentifyingData({ id: 1 }).localId
         }"]`,
         "message moved in history should be the one marked as read"
     );

--- a/addons/mail/static/src/components/message/tests/message_tests.js
+++ b/addons/mail/static/src/components/message/tests/message_tests.js
@@ -39,7 +39,7 @@ QUnit.test('basic rendering', async function (assert) {
     assert.expect(12);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         author: insert({ id: 7, display_name: "Demo User" }),
         body: "<p>Test</p>",
         date: moment(),
@@ -54,7 +54,7 @@ QUnit.test('basic rendering', async function (assert) {
     const messageEl = document.querySelector('.o_Message');
     assert.strictEqual(
         messageEl.dataset.messageLocalId,
-        this.messaging.models['mail.message'].findFromIdentifyingData({ id: 100 }).localId,
+        this.messaging.models['Message'].findFromIdentifyingData({ id: 100 }).localId,
         "message component should be linked to message store model"
     );
     assert.strictEqual(
@@ -294,7 +294,7 @@ QUnit.test("'channel_fetch' notification received is correctly handled", async f
         qunitTest: insertAndReplace(),
         thread: link(thread),
     });
-    this.messaging.models['mail.message'].create({
+    this.messaging.models['Message'].create({
         author: link(currentPartner),
         body: "<p>Test</p>",
         id: 100,
@@ -359,7 +359,7 @@ QUnit.test("'channel_seen' notification received is correctly handled", async fu
         qunitTest: insertAndReplace(),
         thread: link(thread),
     });
-    this.messaging.models['mail.message'].create({
+    this.messaging.models['Message'].create({
         author: link(currentPartner),
         body: "<p>Test</p>",
         id: 100,
@@ -423,7 +423,7 @@ QUnit.test("'channel_fetch' notification then 'channel_seen' received  are corre
         qunitTest: insertAndReplace(),
         thread: link(thread),
     });
-    this.messaging.models['mail.message'].create({
+    this.messaging.models['Message'].create({
         author: link(currentPartner),
         body: "<p>Test</p>",
         id: 100,
@@ -506,7 +506,7 @@ QUnit.test('do not show messaging seen indicator if not authored by me', async f
         qunitTest: insertAndReplace(),
         thread: link(thread),
     });
-    this.messaging.models['mail.message'].insert({
+    this.messaging.models['Message'].insert({
         author: link(author),
         body: "<p>Test</p>",
         id: 100,
@@ -547,13 +547,13 @@ QUnit.test('do not show messaging seen indicator if before last seen by all mess
         qunitTest: insertAndReplace(),
         thread: link(thread),
     });
-    const lastSeenMessage = this.messaging.models['mail.message'].create({
+    const lastSeenMessage = this.messaging.models['Message'].create({
         author: link(currentPartner),
         body: "<p>You already saw me</p>",
         id: 100,
         originThread: link(thread),
     });
-    this.messaging.models['mail.message'].insert({
+    this.messaging.models['Message'].insert({
         author: link(currentPartner),
         body: "<p>Test</p>",
         id: 99,
@@ -625,7 +625,7 @@ QUnit.test('only show messaging seen indicator if authored by me, after last see
         qunitTest: insertAndReplace(),
         thread: link(thread),
     });
-    this.messaging.models['mail.message'].insert({
+    this.messaging.models['Message'].insert({
         author: link(currentPartner),
         body: "<p>Test</p>",
         id: 100,
@@ -655,7 +655,7 @@ QUnit.test('allow attachment delete on authored message', async function (assert
     assert.expect(5);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         attachments: insertAndReplace({
             filename: "BLAH.jpg",
             id: 10,
@@ -705,7 +705,7 @@ QUnit.test('prevent attachment delete on non-authored message', async function (
     assert.expect(2);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         attachments: insertAndReplace({
             filename: "BLAH.jpg",
             id: 10,
@@ -734,7 +734,7 @@ QUnit.test('subtype description should be displayed if it is different than body
     assert.expect(2);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         body: "<p>Hello</p>",
         id: 100,
         subtype_description: 'Bonjour',
@@ -756,7 +756,7 @@ QUnit.test('subtype description should not be displayed if it is similar to body
     assert.expect(2);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         body: "<p>Hello</p>",
         id: 100,
         subtype_description: 'hello',
@@ -797,7 +797,7 @@ QUnit.test('data-oe-id & data-oe-model link redirection on click', async functio
         assert.step('do-action:openFormView_some.model_250');
     });
     const { createMessageComponent } = await this.start({ env: { bus } });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         body: `<p><a href="#" data-oe-id="250" data-oe-model="some.model">some.model_250</a></p>`,
         id: 100,
     });
@@ -828,7 +828,7 @@ QUnit.test('chat with author should be opened after clicking on his avatar', asy
     const { createMessageComponent } = await this.start({
         hasChatWindow: true,
     });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         author: insert({ id: 10 }),
         id: 10,
     });
@@ -867,7 +867,7 @@ QUnit.test('chat with author should be opened after clicking on his im status ic
     const { createMessageComponent } = await this.start({
         hasChatWindow: true,
     });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         author: insert({ id: 10, im_status: 'online' }),
         id: 10,
     });
@@ -951,7 +951,7 @@ QUnit.test('basic rendering of tracking value (float type)', async function (ass
     assert.expect(8);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Total",
@@ -1008,7 +1008,7 @@ QUnit.test('rendering of tracked field of type integer: from non-0 to 0', async 
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Total",
@@ -1030,7 +1030,7 @@ QUnit.test('rendering of tracked field of type integer: from 0 to non-0', async 
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Total",
@@ -1052,7 +1052,7 @@ QUnit.test('rendering of tracked field of type float: from non-0 to 0', async fu
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Total",
@@ -1074,7 +1074,7 @@ QUnit.test('rendering of tracked field of type float: from 0 to non-0', async fu
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Total",
@@ -1096,7 +1096,7 @@ QUnit.test('rendering of tracked field of type monetary: from non-0 to 0', async
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Total",
@@ -1118,7 +1118,7 @@ QUnit.test('rendering of tracked field of type monetary: from 0 to non-0', async
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Total",
@@ -1140,7 +1140,7 @@ QUnit.test('rendering of tracked field of type boolean: from true to false', asy
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Is Ready",
@@ -1162,7 +1162,7 @@ QUnit.test('rendering of tracked field of type boolean: from false to true', asy
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Is Ready",
@@ -1184,7 +1184,7 @@ QUnit.test('rendering of tracked field of type char: from a string to empty stri
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Name",
@@ -1206,7 +1206,7 @@ QUnit.test('rendering of tracked field of type char: from empty string to a stri
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Name",
@@ -1228,7 +1228,7 @@ QUnit.test('rendering of tracked field of type date: from no date to a set date'
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Deadline",
@@ -1250,7 +1250,7 @@ QUnit.test('rendering of tracked field of type date: from a set date to no date'
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Deadline",
@@ -1272,7 +1272,7 @@ QUnit.test('rendering of tracked field of type datetime: from no date and time t
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Deadline",
@@ -1294,7 +1294,7 @@ QUnit.test('rendering of tracked field of type datetime: from a set date and tim
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Deadline",
@@ -1316,7 +1316,7 @@ QUnit.test('rendering of tracked field of type text: from some text to empty', a
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Name",
@@ -1338,7 +1338,7 @@ QUnit.test('rendering of tracked field of type text: from empty to some text', a
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Name",
@@ -1360,7 +1360,7 @@ QUnit.test('rendering of tracked field of type selection: from a selection to no
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "State",
@@ -1382,7 +1382,7 @@ QUnit.test('rendering of tracked field of type selection: from no selection to a
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "State",
@@ -1404,7 +1404,7 @@ QUnit.test('rendering of tracked field of type many2one: from having a related r
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Author",
@@ -1426,7 +1426,7 @@ QUnit.test('rendering of tracked field of type many2one: from no related record 
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Author",
@@ -1454,7 +1454,7 @@ QUnit.test('basic rendering of tracking value (monetary type)', async function (
             },
         },
     });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         id: 11,
         tracking_value_ids: [{
             changed_field: "Revenue",
@@ -1513,7 +1513,7 @@ QUnit.test('message should not be considered as "clicked" after clicking on its 
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         author: [['insert', { id: 7, display_name: "Demo User" }]],
         body: "<p>Test</p>",
         id: 100,
@@ -1532,7 +1532,7 @@ QUnit.test('message should not be considered as "clicked" after clicking on its 
     assert.expect(1);
 
     const { createMessageComponent } = await this.start();
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         author: [['insert', { id: 7, display_name: "Demo User" }]],
         body: "<p>Test</p>",
         id: 100,

--- a/addons/mail/static/src/components/message_author_prefix/message_author_prefix.js
+++ b/addons/mail/static/src/components/message_author_prefix/message_author_prefix.js
@@ -11,10 +11,10 @@ export class MessageAuthorPrefix extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.message}
+     * @returns {Message}
      */
     get message() {
-        return this.messaging && this.messaging.models['mail.message'].get(this.props.messageLocalId);
+        return this.messaging && this.messaging.models['Message'].get(this.props.messageLocalId);
     }
 
     /**

--- a/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator.js
+++ b/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator.js
@@ -73,10 +73,10 @@ export class MessageSeenIndicator extends Component {
     }
 
     /**
-     * @returns {mail.message}
+     * @returns {Message}
      */
     get message() {
-        return this.messaging && this.messaging.models['mail.message'].get(this.props.messageLocalId);
+        return this.messaging && this.messaging.models['Message'].get(this.props.messageLocalId);
     }
 
     /**

--- a/addons/mail/static/src/components/message_seen_indicator/tests/message_seen_indicator_tests.js
+++ b/addons/mail/static/src/components/message_seen_indicator/tests/message_seen_indicator_tests.js
@@ -59,7 +59,7 @@ QUnit.test('rendering when just one has received the message', async function (a
             message: insertAndReplace({ id: 100 }),
         }),
     });
-    const message = this.messaging.models['mail.message'].insert({
+    const message = this.messaging.models['Message'].insert({
         author: insert({ id: this.messaging.currentPartner.id, display_name: "Demo User" }),
         body: "<p>Test</p>",
         id: 100,
@@ -104,7 +104,7 @@ QUnit.test('rendering when everyone have received the message', async function (
             message: insertAndReplace({ id: 100 }),
         }),
     });
-    const message = this.messaging.models['mail.message'].insert({
+    const message = this.messaging.models['Message'].insert({
         author: insert({ id: this.messaging.currentPartner.id, display_name: "Demo User" }),
         body: "<p>Test</p>",
         id: 100,
@@ -150,7 +150,7 @@ QUnit.test('rendering when just one has seen the message', async function (asser
             message: insertAndReplace({ id: 100 }),
         }),
     });
-    const message = this.messaging.models['mail.message'].insert({
+    const message = this.messaging.models['Message'].insert({
         author: insert({ id: this.messaging.currentPartner.id, display_name: "Demo User" }),
         body: "<p>Test</p>",
         id: 100,
@@ -196,7 +196,7 @@ QUnit.test('rendering when just one has seen & received the message', async func
             message: insertAndReplace({ id: 100 }),
         }),
     });
-    const message = this.messaging.models['mail.message'].insert({
+    const message = this.messaging.models['Message'].insert({
         author: insert({ id: this.messaging.currentPartner.id, display_name: "Demo User" }),
         body: "<p>Test</p>",
         id: 100,
@@ -244,7 +244,7 @@ QUnit.test('rendering when just everyone has seen the message', async function (
             message: insertAndReplace({ id: 100 }),
         }),
     });
-    const message = this.messaging.models['mail.message'].insert({
+    const message = this.messaging.models['Message'].insert({
         author: insert({ id: this.messaging.currentPartner.id, display_name: "Demo User" }),
         body: "<p>Test</p>",
         id: 100,

--- a/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.js
+++ b/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.js
@@ -87,7 +87,7 @@ export class ThreadNeedactionPreview extends Component {
      * @param {MouseEvent} ev
      */
     _onClickMarkAsRead(ev) {
-        this.messaging.models['mail.message'].markAllAsRead([
+        this.messaging.models['Message'].markAllAsRead([
             ['model', '=', this.thread.model],
             ['res_id', '=', this.thread.id],
         ]);

--- a/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
+++ b/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
@@ -648,7 +648,7 @@ QUnit.test('new messages separator on receiving new message [REQUIRE FOCUS]', as
     assert.containsOnce(
         document.body,
         `.o_MessageList_separatorNewMessages ~ .o_Message[data-message-local-id="${
-            this.messaging.models['mail.message'].findFromIdentifyingData({ id: 2 }).localId
+            this.messaging.models['Message'].findFromIdentifyingData({ id: 2 }).localId
         }"]`,
         "'new messages' separator should be shown above new message received"
     );
@@ -1815,7 +1815,7 @@ QUnit.test('first unseen message should be directly preceded by the new message 
     assert.containsOnce(
         document.body,
         `.o_Message[data-message-local-id="${
-            this.messaging.models['mail.message'].find(m => m.isTransient).localId
+            this.messaging.models['Message'].find(m => m.isTransient).localId
         }"] + .o_MessageList_separatorNewMessages`,
         "separator should be shown just after transient message"
     );

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -391,7 +391,7 @@ registerModel({
         mediaType: attr({
             compute: '_computeMediaType',
         }),
-        messages: many2many('mail.message', {
+        messages: many2many('Message', {
             inverse: 'attachments',
         }),
         mimetype: attr({

--- a/addons/mail/static/src/models/attachment_list/attachment_list.js
+++ b/addons/mail/static/src/models/attachment_list/attachment_list.js
@@ -107,7 +107,7 @@ registerModel({
         imageAttachments: many2many('mail.attachment', {
             compute: '_computeImageAttachments',
         }),
-        message: many2one('mail.message', {
+        message: many2one('Message', {
             related: 'messageView.message'
         }),
         /**

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -224,7 +224,7 @@ registerModel({
                 }
             } else if (!this.thread || !this.thread.isTemporary) {
                 const currentPartner = this.messaging.currentPartner;
-                const message = this.messaging.models['mail.message'].create({
+                const message = this.messaging.models['Message'].create({
                     author: link(currentPartner),
                     body: this.env._t("Creating a new record..."),
                     id: getMessageNextTemporaryId(),

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -293,8 +293,8 @@ registerModel({
                 if (!this.messaging) {
                     return;
                 }
-                const message = this.messaging.models['mail.message'].insert(
-                    this.messaging.models['mail.message'].convertData(messageData)
+                const message = this.messaging.models['Message'].insert(
+                    this.messaging.models['Message'].convertData(messageData)
                 );
                 for (const threadView of message.originThread.threadViews) {
                     // Reset auto scroll to be able to see the newly posted message.

--- a/addons/mail/static/src/models/guest/guest.js
+++ b/addons/mail/static/src/models/guest/guest.js
@@ -32,7 +32,7 @@ registerModel({
         },
     },
     fields: {
-        authoredMessages: one2many('mail.message', {
+        authoredMessages: one2many('Message', {
             inverse: 'guestAuthor',
         }),
         avatarUrl: attr({

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -11,7 +11,7 @@ import { session } from '@web/session';
 import { str_to_datetime } from 'web.time';
 
 registerModel({
-    name: 'mail.message',
+    name: 'Message',
     identifyingFields: ['id'],
     modelMethods: {
         /**
@@ -148,7 +148,7 @@ registerModel({
          *
          * @see MessagingNotificationHandler:_handleNotificationPartnerMarkAsRead()
          *
-         * @param {mail.message[]} messages
+         * @param {Message[]} messages
          */
         async markAsRead(messages) {
             await this.env.services.rpc({
@@ -162,15 +162,15 @@ registerModel({
          *
          * @param {string} route
          * @param {Object} params
-         * @returns {mail.message[]}
+         * @returns {Message[]}
          */
         async performRpcMessageFetch(route, params) {
             const messagesData = await this.env.services.rpc({ route, params }, { shadow: true });
             if (!this.messaging) {
                 return;
             }
-            const messages = this.messaging.models['mail.message'].insert(messagesData.map(
-                messageData => this.messaging.models['mail.message'].convertData(messageData)
+            const messages = this.messaging.models['Message'].insert(messagesData.map(
+                messageData => this.messaging.models['Message'].convertData(messageData)
             ));
             // compute seen indicators (if applicable)
             for (const message of messages) {
@@ -287,7 +287,7 @@ registerModel({
             if (!this.messaging) {
                 return;
             }
-            this.messaging.models['mail.message'].insert(messageData);
+            this.messaging.models['Message'].insert(messageData);
         },
         /**
          * @returns {string|FieldCommand}
@@ -725,7 +725,7 @@ registerModel({
          * (parent_id in python) that should be ignored for the purpose of this
          * feature.
          */
-        parentMessage: many2one('mail.message'),
+        parentMessage: many2one('Message'),
         /**
          * This value is meant to be based on field body which is
          * returned by the server (and has been sanitized before stored into db).

--- a/addons/mail/static/src/models/message/tests/message_tests.js
+++ b/addons/mail/static/src/models/message/tests/message_tests.js
@@ -35,14 +35,14 @@ QUnit.test('create', async function (assert) {
         model: 'mail.channel',
     }));
     assert.notOk(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
-    assert.notOk(this.messaging.models['mail.message'].findFromIdentifyingData({ id: 4000 }));
+    assert.notOk(this.messaging.models['Message'].findFromIdentifyingData({ id: 4000 }));
 
     const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'mail.channel',
         name: "General",
     });
-    const message = this.messaging.models['mail.message'].create({
+    const message = this.messaging.models['Message'].create({
         attachments: insertAndReplace({
             filename: "test.txt",
             id: 750,
@@ -64,10 +64,10 @@ QUnit.test('create', async function (assert) {
         model: 'mail.channel',
     }));
     assert.ok(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
-    assert.ok(this.messaging.models['mail.message'].findFromIdentifyingData({ id: 4000 }));
+    assert.ok(this.messaging.models['Message'].findFromIdentifyingData({ id: 4000 }));
 
     assert.ok(message);
-    assert.strictEqual(this.messaging.models['mail.message'].findFromIdentifyingData({ id: 4000 }), message);
+    assert.strictEqual(this.messaging.models['Message'].findFromIdentifyingData({ id: 4000 }), message);
     assert.strictEqual(message.body, "<p>Test</p>");
     assert.ok(message.date instanceof moment);
     assert.strictEqual(
@@ -113,70 +113,70 @@ QUnit.test('create', async function (assert) {
 QUnit.test('message without body should be considered empty', async function (assert) {
     assert.expect(1);
     await this.start();
-    const message = this.messaging.models['mail.message'].create({ id: 11 });
+    const message = this.messaging.models['Message'].create({ id: 11 });
     assert.ok(message.isEmpty);
 });
 
 QUnit.test('message with body "" should be considered empty', async function (assert) {
     assert.expect(1);
     await this.start();
-    const message = this.messaging.models['mail.message'].create({ body: "", id: 11 });
+    const message = this.messaging.models['Message'].create({ body: "", id: 11 });
     assert.ok(message.isEmpty);
 });
 
 QUnit.test('message with body "<p></p>" should be considered empty', async function (assert) {
     assert.expect(1);
     await this.start();
-    const message = this.messaging.models['mail.message'].create({ body: "<p></p>", id: 11 });
+    const message = this.messaging.models['Message'].create({ body: "<p></p>", id: 11 });
     assert.ok(message.isEmpty);
 });
 
 QUnit.test('message with body "<p><br></p>" should be considered empty', async function (assert) {
     assert.expect(1);
     await this.start();
-    const message = this.messaging.models['mail.message'].create({ body: "<p><br></p>", id: 11 });
+    const message = this.messaging.models['Message'].create({ body: "<p><br></p>", id: 11 });
     assert.ok(message.isEmpty);
 });
 
 QUnit.test('message with body "<p><br/></p>" should be considered empty', async function (assert) {
     assert.expect(1);
     await this.start();
-    const message = this.messaging.models['mail.message'].create({ body: "<p><br/></p>", id: 11 });
+    const message = this.messaging.models['Message'].create({ body: "<p><br/></p>", id: 11 });
     assert.ok(message.isEmpty);
 });
 
 QUnit.test(String.raw`message with body "<p>\n</p>" should be considered empty`, async function (assert) {
     assert.expect(1);
     await this.start();
-    const message = this.messaging.models['mail.message'].create({ body: "<p>\n</p>", id: 11 });
+    const message = this.messaging.models['Message'].create({ body: "<p>\n</p>", id: 11 });
     assert.ok(message.isEmpty);
 });
 
 QUnit.test(String.raw`message with body "<p>\r\n\r\n</p>" should be considered empty`, async function (assert) {
     assert.expect(1);
     await this.start();
-    const message = this.messaging.models['mail.message'].create({ body: "<p>\r\n\r\n</p>", id: 11 });
+    const message = this.messaging.models['Message'].create({ body: "<p>\r\n\r\n</p>", id: 11 });
     assert.ok(message.isEmpty);
 });
 
 QUnit.test('message with body "<p>   </p>  " should be considered empty', async function (assert) {
     assert.expect(1);
     await this.start();
-    const message = this.messaging.models['mail.message'].create({ body: "<p>   </p>  ", id: 11 });
+    const message = this.messaging.models['Message'].create({ body: "<p>   </p>  ", id: 11 });
     assert.ok(message.isEmpty);
 });
 
 QUnit.test(`message with body "<img src=''>" should not be considered empty`, async function (assert) {
     assert.expect(1);
     await this.start();
-    const message = this.messaging.models['mail.message'].create({ body: "<img src=''>", id: 11 });
+    const message = this.messaging.models['Message'].create({ body: "<img src=''>", id: 11 });
     assert.notOk(message.isEmpty);
 });
 
 QUnit.test('message with body "test" should not be considered empty', async function (assert) {
     assert.expect(1);
     await this.start();
-    const message = this.messaging.models['mail.message'].create({ body: "test", id: 11 });
+    const message = this.messaging.models['Message'].create({ body: "test", id: 11 });
     assert.notOk(message.isEmpty);
 });
 

--- a/addons/mail/static/src/models/message_action_list/message_action_list.js
+++ b/addons/mail/static/src/models/message_action_list/message_action_list.js
@@ -176,7 +176,7 @@ registerModel({
         /**
          * States the message on which this action message list operates.
          */
-        message: many2one('mail.message', {
+        message: many2one('Message', {
             related: 'messageView.message',
         }),
         /**

--- a/addons/mail/static/src/models/message_reaction_group/message_reaction_group.js
+++ b/addons/mail/static/src/models/message_reaction_group/message_reaction_group.js
@@ -88,7 +88,7 @@ registerModel({
             compute: '_computeHasUserReacted',
             default: false,
         }),
-        message: many2one('mail.message', {
+        message: many2one('Message', {
             compute: '_computeMessage',
             inverse: 'messageReactionGroups',
             readonly: true,

--- a/addons/mail/static/src/models/message_seen_indicator/message_seen_indicator.js
+++ b/addons/mail/static/src/models/message_seen_indicator/message_seen_indicator.js
@@ -225,7 +225,7 @@ registerModel({
         /**
          * The message concerned by this seen indicator.
          */
-        message: many2one('mail.message', {
+        message: many2one('Message', {
             inverse: 'messageSeenIndicators',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/message_view/message_view.js
+++ b/addons/mail/static/src/models/message_view/message_view.js
@@ -166,7 +166,7 @@ registerModel({
         /**
          * Determines the message that is displayed by this message view.
          */
-        message: many2one('mail.message', {
+        message: many2one('Message', {
             inverse: 'messageViews',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
@@ -201,8 +201,8 @@ registerModel({
          */
         async _initMailFailures(mailFailuresData) {
             await executeGracefully(mailFailuresData.map(messageData => () => {
-                const message = this.messaging.models['mail.message'].insert(
-                    this.messaging.models['mail.message'].convertData(messageData)
+                const message = this.messaging.models['Message'].insert(
+                    this.messaging.models['Message'].convertData(messageData)
                 );
                 // implicit: failures are sent by the server at initialization
                 // only if the current partner is author of the message

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -104,7 +104,7 @@ registerModel({
                         case 'mail.guest/insert':
                             return this.messaging.models['Guest'].insert(message.payload);
                         case 'mail.message/insert':
-                            return this.messaging.models['mail.message'].insert(message.payload);
+                            return this.messaging.models['Message'].insert(message.payload);
                         case 'mail.channel.rtc.session/insert':
                             return this.messaging.models['RtcSession'].insert(message.payload);
                         case 'res.users.settings/changed':
@@ -228,7 +228,7 @@ registerModel({
             if (!channel && this.messaging.isCurrentUserGuest) {
                 return; // guests should not receive messages for channels they don't know, and they can't make the channel_info RPC
             }
-            const convertedData = this.messaging.models['mail.message'].convertData(messageData);
+            const convertedData = this.messaging.models['Message'].convertData(messageData);
 
             // Fetch missing info from channel before going further. Inserting
             // a channel with incomplete info can lead to issues. This is in
@@ -244,7 +244,7 @@ registerModel({
                 channel.pin();
             }
 
-            const message = this.messaging.models['mail.message'].insert(convertedData);
+            const message = this.messaging.models['Message'].insert(convertedData);
             this._notifyThreadViewsMessageReceived(message);
 
             // If the current partner is author, do nothing else.
@@ -302,7 +302,7 @@ registerModel({
                 // knowledge of the channel
                 return;
             }
-            const lastMessage = this.messaging.models['mail.message'].insert({ id: last_message_id });
+            const lastMessage = this.messaging.models['Message'].insert({ id: last_message_id });
             // restrict computation of seen indicator for "non-channel" channels
             // for performance reasons
             const shouldComputeSeenIndicators = channel.channel_type !== 'channel';
@@ -408,8 +408,8 @@ registerModel({
          * @param {Object} data
          */
         _handleNotificationNeedaction(data) {
-            const message = this.messaging.models['mail.message'].insert(
-                this.messaging.models['mail.message'].convertData(data)
+            const message = this.messaging.models['Message'].insert(
+                this.messaging.models['Message'].convertData(data)
             );
             this.messaging.inbox.update({ counter: increment() });
             const originThread = message.originThread;
@@ -490,7 +490,7 @@ registerModel({
          */
         _handleNotificationMessageDelete({ message_ids }) {
             for (const id of message_ids) {
-                const message = this.messaging.models['mail.message'].findFromIdentifyingData({ id });
+                const message = this.messaging.models['Message'].findFromIdentifyingData({ id });
                 if (message) {
                     message.delete();
                 }
@@ -502,8 +502,8 @@ registerModel({
          */
         _handleNotificationPartnerMessageNotificationUpdate({ elements }) {
             for (const messageData of elements) {
-                const message = this.messaging.models['mail.message'].insert(
-                    this.messaging.models['mail.message'].convertData(messageData)
+                const message = this.messaging.models['Message'].insert(
+                    this.messaging.models['Message'].convertData(messageData)
                 );
                 // implicit: failures are sent by the server as notification
                 // only if the current partner is author of the message
@@ -525,7 +525,7 @@ registerModel({
                 // Furthermore, server should not send back all message_ids marked as read
                 // but something like last read message_id or something like that.
                 // (just imagine you mark 1000 messages as read ... )
-                const message = this.messaging.models['mail.message'].findFromIdentifyingData({ id: message_id });
+                const message = this.messaging.models['Message'].findFromIdentifyingData({ id: message_id });
                 if (!message) {
                     continue;
                 }
@@ -563,7 +563,7 @@ registerModel({
         _handleNotificationPartnerToggleStar({ message_ids = [], starred }) {
             const starredMailbox = this.messaging.starred;
             for (const messageId of message_ids) {
-                const message = this.messaging.models['mail.message'].findFromIdentifyingData({
+                const message = this.messaging.models['Message'].findFromIdentifyingData({
                     id: messageId,
                 });
                 if (!message) {
@@ -584,13 +584,13 @@ registerModel({
          * @param {Object} data
          */
         _handleNotificationPartnerTransientMessage(data) {
-            const convertedData = this.messaging.models['mail.message'].convertData(data);
-            const lastMessageId = this.messaging.models['mail.message'].all().reduce(
+            const convertedData = this.messaging.models['Message'].convertData(data);
+            const lastMessageId = this.messaging.models['Message'].all().reduce(
                 (lastMessageId, message) => Math.max(lastMessageId, message.id),
                 0
             );
             const partnerRoot = this.messaging.partnerRoot;
-            const message = this.messaging.models['mail.message'].create(Object.assign(convertedData, {
+            const message = this.messaging.models['Message'].create(Object.assign(convertedData, {
                 author: link(partnerRoot),
                 id: lastMessageId + 0.01,
                 isTransient: true,
@@ -664,7 +664,7 @@ registerModel({
          * @private
          * @param {Object} param0
          * @param {Thread} param0.channel
-         * @param {mail.message} param0.message
+         * @param {Message} param0.message
          */
         _notifyNewChannelMessageWhileOutOfFocus({ channel, message }) {
             const author = message.author;
@@ -714,7 +714,7 @@ registerModel({
          * This can allow them adjust their scroll position if applicable.
          *
          * @private
-         * @param {mail.message}
+         * @param {Message}
          */
         _notifyThreadViewsMessageReceived(message) {
             for (const thread of message.threads) {

--- a/addons/mail/static/src/models/notification/notification.js
+++ b/addons/mail/static/src/models/notification/notification.js
@@ -140,7 +140,7 @@ registerModel({
         isFromCurrentUser: attr({
             compute: '_computeIsFromCurrentUser',
         }),
-        message: many2one('mail.message', {
+        message: many2one('Message', {
             inverse: 'notifications',
         }),
         notificationGroup: many2one('NotificationGroup', {

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -187,7 +187,7 @@ registerModel({
                 data2.lastInterestDateTime = str_to_datetime(data.last_interest_dt);
             }
             if ('last_message' in data && data.last_message) {
-                const messageData = this.messaging.models['mail.message'].convertData({
+                const messageData = this.messaging.models['Message'].convertData({
                     id: data.last_message.id,
                     model: data2.model,
                     res_id: data2.id,
@@ -195,7 +195,7 @@ registerModel({
                 data2.serverLastMessage = insert(messageData);
             }
             if ('last_message_id' in data && data.last_message_id) {
-                const messageData = this.messaging.models['mail.message'].convertData({
+                const messageData = this.messaging.models['Message'].convertData({
                     id: data.last_message_id,
                     model: data2.model,
                     res_id: data2.id,
@@ -393,8 +393,8 @@ registerModel({
                 method: 'channel_fetch_preview',
                 args: [channelIds],
             }, { shadow: true });
-            this.messaging.models['mail.message'].insert(channelPreviews.filter(p => p.last_message).map(
-                channelPreview => this.messaging.models['mail.message'].convertData(channelPreview.last_message)
+            this.messaging.models['Message'].insert(channelPreviews.filter(p => p.last_message).map(
+                channelPreview => this.messaging.models['Message'].convertData(channelPreview.last_message)
             ));
         },
         /**
@@ -840,7 +840,7 @@ registerModel({
         /**
          * Mark the specified conversation as read/seen.
          *
-         * @param {mail.message} message the message to be considered as last seen.
+         * @param {Message} message the message to be considered as last seen.
          */
         async markAsSeen(message) {
             if (this.messaging.currentGuest) {
@@ -869,7 +869,7 @@ registerModel({
          */
         async markNeedactionMessagesAsOriginThreadAsRead() {
             await this.async(() =>
-                this.messaging.models['mail.message'].markAsRead(this.needactionMessagesAsOriginThread)
+                this.messaging.models['Message'].markAsRead(this.needactionMessagesAsOriginThread)
             );
         },
         /**
@@ -1405,7 +1405,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.message}
+         * @returns {Message}
          */
         _computeLastCurrentPartnerMessageSeenByEveryone() {
             const otherPartnerSeenInfos =
@@ -1440,7 +1440,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.message|undefined}
+         * @returns {Message|undefined}
          */
         _computeLastMessage() {
             const {
@@ -1454,7 +1454,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.message|undefined}
+         * @returns {Message|undefined}
          */
         _computeLastNonTransientMessage() {
             const {
@@ -1503,7 +1503,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.message|undefined}
+         * @returns {Message|undefined}
          */
         _computeLastNeedactionMessageAsOriginThread() {
             const orderedNeedactionMessagesAsOriginThread = this.needactionMessagesAsOriginThread.sort(
@@ -1577,14 +1577,14 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.message[]}
+         * @returns {Message[]}
          */
         _computeNeedactionMessagesAsOriginThread() {
             return replace(this.messagesAsOriginThread.filter(message => message.isNeedaction));
         },
         /**
          * @private
-         * @returns {mail.message|undefined}
+         * @returns {Message|undefined}
          */
         _computeMessageAfterNewMessageSeparator() {
             if (this.model !== 'mail.channel') {
@@ -1621,14 +1621,14 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.message[]}
+         * @returns {Message[]}
          */
         _computeOrderedMessages() {
             return replace(this.messages.sort((m1, m2) => m1.id < m2.id ? -1 : 1));
         },
         /**
          * @private
-         * @returns {mail.message[]}
+         * @returns {Message[]}
          */
         _computeOrderedNonTransientMessages() {
             return replace(this.orderedMessages.filter(m => !m.isTransient));
@@ -2132,25 +2132,25 @@ registerModel({
          * pinning, and new message posted. It is contained as a Date object.
          */
         lastInterestDateTime: attr(),
-        lastCurrentPartnerMessageSeenByEveryone: many2one('mail.message', {
+        lastCurrentPartnerMessageSeenByEveryone: many2one('Message', {
             compute: '_computeLastCurrentPartnerMessageSeenByEveryone',
         }),
         /**
          * Last message of the thread, could be a transient one.
          */
-        lastMessage: many2one('mail.message', {
+        lastMessage: many2one('Message', {
             compute: '_computeLastMessage',
         }),
         /**
          * States the last known needaction message having this thread as origin.
          */
-        lastNeedactionMessageAsOriginThread: many2one('mail.message', {
+        lastNeedactionMessageAsOriginThread: many2one('Message', {
             compute: '_computeLastNeedactionMessageAsOriginThread',
         }),
         /**
          * Last non-transient message.
          */
-        lastNonTransientMessage: many2one('mail.message', {
+        lastNonTransientMessage: many2one('Message', {
             compute: '_computeLastNonTransientMessage',
         }),
         /**
@@ -2194,7 +2194,7 @@ registerModel({
          * Determines the message before which the "new message" separator must
          * be positioned, if any.
          */
-        messageAfterNewMessageSeparator: many2one('mail.message', {
+        messageAfterNewMessageSeparator: many2one('Message', {
             compute: '_computeMessageAfterNewMessageSeparator',
         }),
         message_needaction_counter: attr({
@@ -2205,14 +2205,14 @@ registerModel({
          * Note that this field is automatically computed by inverse
          * computed field.
          */
-        messages: many2many('mail.message', {
+        messages: many2many('Message', {
             inverse: 'threads',
             readonly: true,
         }),
         /**
          * All messages that have been originally posted in this thread.
          */
-        messagesAsOriginThread: one2many('mail.message', {
+        messagesAsOriginThread: one2many('Message', {
             inverse: 'originThread',
             isCausal: true,
         }),
@@ -2243,7 +2243,7 @@ registerModel({
         /**
          * States all known needaction messages having this thread as origin.
          */
-        needactionMessagesAsOriginThread: many2many('mail.message', {
+        needactionMessagesAsOriginThread: many2many('Message', {
             compute: '_computeNeedactionMessagesAsOriginThread',
         }),
         /**
@@ -2261,14 +2261,14 @@ registerModel({
         /**
          * All messages ordered like they are displayed.
          */
-        orderedMessages: many2many('mail.message', {
+        orderedMessages: many2many('Message', {
             compute: '_computeOrderedMessages',
         }),
         /**
          * All messages ordered like they are displayed. This field does not
          * contain transient messages which are not "real" records.
          */
-        orderedNonTransientMessages: many2many('mail.message', {
+        orderedNonTransientMessages: many2many('Message', {
             compute: '_computeOrderedNonTransientMessages',
         }),
         /**
@@ -2353,7 +2353,7 @@ registerModel({
          *
          * @see localMessageUnreadCounter
          */
-        serverLastMessage: many2one('mail.message'),
+        serverLastMessage: many2one('Message'),
         /**
          * Message unread counter coming from server.
          *

--- a/addons/mail/static/src/models/thread_cache/thread_cache.js
+++ b/addons/mail/static/src/models/thread_cache/thread_cache.js
@@ -42,7 +42,7 @@ registerModel({
             this.update({ isLoadingMore: false });
         },
         /**
-         * @returns {mail.message[]|undefined}
+         * @returns {Message[]|undefined}
          */
         async loadNewMessages() {
             if (this.isLoading) {
@@ -64,7 +64,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.message[]}
+         * @returns {Message[]}
          */
         _computeFetchedMessages() {
             if (!this.thread) {
@@ -80,7 +80,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.message|undefined}
+         * @returns {Message|undefined}
          */
         _computeLastFetchedMessage() {
             const {
@@ -94,7 +94,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.message|undefined}
+         * @returns {Message|undefined}
          */
         _computeLastMessage() {
             const {
@@ -108,7 +108,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.message[]}
+         * @returns {Message[]}
          */
         _computeMessages() {
             if (!this.thread) {
@@ -126,14 +126,14 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.message[]}
+         * @returns {Message[]}
          */
         _computeOrderedFetchedMessages() {
             return replace(this.fetchedMessages.sort((m1, m2) => m1.id < m2.id ? -1 : 1));
         },
         /**
          * @private
-         * @returns {mail.message[]}
+         * @returns {Message[]}
          */
         _computeOrderedMessages() {
             return replace(this.messages.sort((m1, m2) => m1.id < m2.id ? -1 : 1));
@@ -141,7 +141,7 @@ registerModel({
         /**
          *
          * @private
-         * @returns {mail.message[]}
+         * @returns {Message[]}
          */
         _computeOrderedNonEmptyMessages() {
             return replace(this.orderedMessages.filter(message => !message.isEmpty));
@@ -195,14 +195,14 @@ registerModel({
          * @param {integer} [param0.limit=30]
          * @param {integer} [param0.maxId]
          * @param {integer} [param0.minId]
-         * @returns {mail.message[]}
+         * @returns {Message[]}
          * @throws {Error} when failed to load messages
          */
         async _loadMessages({ limit = 30, maxId, minId } = {}) {
             this.update({ isLoading: true });
             let messages;
             try {
-                messages = await this.messaging.models['mail.message'].performRpcMessageFetch(this.thread.fetchMessagesUrl, {
+                messages = await this.messaging.models['Message'].performRpcMessageFetch(this.thread.fetchMessagesUrl, {
                     ...this.thread.fetchMessagesParams,
                     limit,
                     'max_id': maxId,
@@ -276,7 +276,7 @@ registerModel({
                 // ignore the request
                 return;
             }
-            this.messaging.models['mail.message'].markAllAsRead([
+            this.messaging.models['Message'].markAllAsRead([
                 ['model', '=', this.thread.model],
                 ['res_id', '=', this.thread.id],
             ]);
@@ -314,7 +314,7 @@ registerModel({
          * to manage "holes" in message list, while still allowing to display
          * new messages on main cache of thread in real-time.
          */
-        fetchedMessages: many2many('mail.message', {
+        fetchedMessages: many2many('Message', {
             compute: '_computeFetchedMessages',
         }),
         /**
@@ -367,16 +367,16 @@ registerModel({
          * cache (@see lastMessage field for that). @see fetchedMessages field
          * for a deeper explanation about "fetched" messages.
          */
-        lastFetchedMessage: many2one('mail.message', {
+        lastFetchedMessage: many2one('Message', {
             compute: '_computeLastFetchedMessage',
         }),
-        lastMessage: many2one('mail.message', {
+        lastMessage: many2one('Message', {
             compute: '_computeLastMessage',
         }),
         /**
          * List of messages linked to this cache.
          */
-        messages: many2many('mail.message', {
+        messages: many2many('Message', {
             compute: '_computeMessages',
         }),
         /**
@@ -386,19 +386,19 @@ registerModel({
          * cache (@see orderedMessages field for that). @see fetchedMessages
          * field for deeper explanation about "fetched" messages.
          */
-        orderedFetchedMessages: many2many('mail.message', {
+        orderedFetchedMessages: many2many('Message', {
             compute: '_computeOrderedFetchedMessages',
         }),
         /**
          * Ordered list of messages linked to this cache.
          */
-        orderedMessages: many2many('mail.message', {
+        orderedMessages: many2many('Message', {
             compute: '_computeOrderedMessages',
         }),
         /**
          * List of ordered non empty messages linked to this cache.
          */
-        orderedNonEmptyMessages: many2many('mail.message', {
+        orderedNonEmptyMessages: many2many('Message', {
             compute: '_computeOrderedNonEmptyMessages',
         }),
         thread: one2one('Thread', {

--- a/addons/mail/static/src/models/thread_partner_seen_info/thread_partner_seen_info.js
+++ b/addons/mail/static/src/models/thread_partner_seen_info/thread_partner_seen_info.js
@@ -7,8 +7,8 @@ registerModel({
     name: 'ThreadPartnerSeenInfo',
     identifyingFields: ['thread', 'partner'],
     fields: {
-        lastFetchedMessage: many2one('mail.message'),
-        lastSeenMessage: many2one('mail.message'),
+        lastFetchedMessage: many2one('Message'),
+        lastSeenMessage: many2one('Message'),
         /**
          * Partner that this seen info is related to.
          */

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -37,7 +37,7 @@ registerModel({
             });
         },
         /**
-         * @param {mail.message} message
+         * @param {Message} message
          */
         handleVisibleMessage(message) {
             if (!this.lastVisibleMessage || this.lastVisibleMessage.id < message.id) {
@@ -226,8 +226,8 @@ registerModel({
             this.update({ isLoading: false, isPreparingLoading: false });
         },
         /**
-         * @param {mail.message} prevMessage
-         * @param {mail.message} message
+         * @param {Message} prevMessage
+         * @param {Message} message
          * @returns {boolean}
          */
         _shouldMessageBeSquashed(prevMessage, message) {
@@ -393,15 +393,15 @@ registerModel({
         /**
          * Last message in the context of the currently displayed thread cache.
          */
-        lastMessage: many2one('mail.message', {
+        lastMessage: many2one('Message', {
             related: 'thread.lastMessage',
         }),
         /**
          * Most recent message in this ThreadView that has been shown to the
          * current partner in the currently displayed thread cache.
          */
-        lastVisibleMessage: many2one('mail.message'),
-        messages: many2many('mail.message', {
+        lastVisibleMessage: many2one('Message'),
+        messages: many2many('Message', {
             related: 'threadCache.messages',
         }),
         /**

--- a/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
+++ b/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
@@ -53,7 +53,7 @@ registerModel({
          * @param {MouseEvent} ev
          */
         onClickInboxMarkAllAsRead(ev) {
-            this.messaging.models['mail.message'].markAllAsRead();
+            this.messaging.models['Message'].markAllAsRead();
         },
         /**
          * Handles click on the "invite" button.
@@ -129,7 +129,7 @@ registerModel({
          * @param {MouseEvent} ev
          */
         onClickUnstarAll(ev) {
-            this.messaging.models['mail.message'].unstarAll();
+            this.messaging.models['Message'].unstarAll();
         },
         /**
          * Handles click on the guest name.

--- a/addons/sms/static/src/models/message/message.js
+++ b/addons/sms/static/src/models/message/message.js
@@ -4,7 +4,7 @@ import { patchRecordMethods } from '@mail/model/model_core';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/message/message';
 
-patchRecordMethods('mail.message', {
+patchRecordMethods('Message', {
     /**
      * @override
      */

--- a/addons/snailmail/static/src/components/snailmail_error_dialog/snailmail_error_dialog.js
+++ b/addons/snailmail/static/src/components/snailmail_error_dialog/snailmail_error_dialog.js
@@ -24,10 +24,10 @@ class SnailmailErrorDialog extends Component {
     }
 
     /**
-     * @returns {mail.message}
+     * @returns {Message}
      */
     get message() {
-        return this.messaging && this.messaging.models['mail.message'].get(this.props.messageLocalId);
+        return this.messaging && this.messaging.models['Message'].get(this.props.messageLocalId);
     }
 
     /**

--- a/addons/snailmail/static/src/components/snailmail_notification_popover/snailmail_notification_popover.js
+++ b/addons/snailmail/static/src/components/snailmail_notification_popover/snailmail_notification_popover.js
@@ -39,10 +39,10 @@ class SnailmailNotificationPopover extends Component {
     }
 
     /**
-     * @returns {mail.message}
+     * @returns {Message}
      */
     get message() {
-        return this.messaging && this.messaging.models['mail.message'].get(this.props.messageLocalId);
+        return this.messaging && this.messaging.models['Message'].get(this.props.messageLocalId);
     }
 
     /**

--- a/addons/snailmail/static/src/models/message/message.js
+++ b/addons/snailmail/static/src/models/message/message.js
@@ -4,7 +4,7 @@ import { addRecordMethods } from '@mail/model/model_core';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/message/message';
 
-addRecordMethods('mail.message', {
+addRecordMethods('Message', {
     /**
      * Cancels the 'snailmail.letter' corresponding to this message.
      *


### PR DESCRIPTION
Rename javascript model `mail.message` to `Message` in order to distinguish javascript models from python models.

Part of task-2701674.
Enterprise: https://github.com/odoo/enterprise/pull/22883