### PR TITLE
[IMP] im_livechat, mail: rename discuss sidebar category item model

### DIFF
--- a/addons/im_livechat/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
+++ b/addons/im_livechat/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
@@ -4,7 +4,7 @@ import { patchRecordMethods } from '@mail/model/model_core';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/discuss_sidebar_category_item/discuss_sidebar_category_item';
 
-patchRecordMethods('mail.discuss_sidebar_category_item', {
+patchRecordMethods('DiscussSidebarCategoryItem', {
     /**
      * @override
      */

--- a/addons/mail/static/src/components/discuss_sidebar_category_item/discuss_sidebar_category_item.js
+++ b/addons/mail/static/src/components/discuss_sidebar_category_item/discuss_sidebar_category_item.js
@@ -11,10 +11,10 @@ export class DiscussSidebarCategoryItem extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.discuss_sidebar_category_item}
+     * @returns {DiscussSidebarCategoryItem}
      */
     get categoryItem() {
-        return this.messaging.models['mail.discuss_sidebar_category_item'].get(this.props.categoryItemLocalId);
+        return this.messaging.models['DiscussSidebarCategoryItem'].get(this.props.categoryItemLocalId);
     }
 }
 

--- a/addons/mail/static/src/models/discuss_sidebar_category/discuss_sidebar_category.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category/discuss_sidebar_category.js
@@ -61,7 +61,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.discuss_sidebar_category_item | undefined}
+         * @returns {DiscussSidebarCategoryItem|undefined}
          */
         _computeActiveItem() {
             const thread = this.messaging.discuss.thread;
@@ -203,7 +203,7 @@ registerModel({
          * The category item which is active and belongs
          * to the category.
          */
-        activeItem: one2one('mail.discuss_sidebar_category_item', {
+        activeItem: one2one('DiscussSidebarCategoryItem', {
             compute: '_computeActiveItem',
         }),
         /**
@@ -219,7 +219,7 @@ registerModel({
          * Determines the discuss sidebar category items that are displayed by
          * this discuss sidebar category.
          */
-        categoryItems: one2many('mail.discuss_sidebar_category_item', {
+        categoryItems: one2many('DiscussSidebarCategoryItem', {
             inverse: 'category',
             isCausal: true,
             sort: '_sortDefinitionCategoryItems',
@@ -245,7 +245,7 @@ registerModel({
          * Determines the filtered and sorted discuss sidebar category items
          * that are displayed by this discuss sidebar category.
          */
-        filteredCategoryItems: one2many('mail.discuss_sidebar_category_item', {
+        filteredCategoryItems: one2many('DiscussSidebarCategoryItem', {
             compute: '_computeFilteredCategoryItems',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
@@ -7,7 +7,7 @@ import { clear, link } from '@mail/model/model_field_command';
 import Dialog from 'web.Dialog';
 
 registerModel({
-    name: 'mail.discuss_sidebar_category_item',
+    name: 'DiscussSidebarCategoryItem',
     identifyingFields: ['category', 'channel'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1978,7 +1978,7 @@ registerModel({
          * Determines the discuss sidebar category item that displays this
          * thread (if any). Only applies to channels.
          */
-        discussSidebarCategoryItem: one2one('mail.discuss_sidebar_category_item', {
+        discussSidebarCategoryItem: one2one('DiscussSidebarCategoryItem', {
             compute: '_computeDiscussSidebarCategoryItem',
             inverse: 'channel',
             isCausal: true,


### PR DESCRIPTION
Rename javascript model `mail.discuss_sidebar_category_item` to `DiscussSidebarCategoryItem` in order to distinguish javascript models from python models.

Part of task-2701674.