### PR TITLE
[IMP] mail: rename follower model

### DIFF
--- a/addons/mail/static/src/components/follower/follower.js
+++ b/addons/mail/static/src/components/follower/follower.js
@@ -11,10 +11,10 @@ export class Follower extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.follower}
+     * @returns {Follower}
      */
     get follower() {
-        return this.messaging && this.messaging.models['mail.follower'].get(this.props.followerLocalId);
+        return this.messaging && this.messaging.models['Follower'].get(this.props.followerLocalId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/components/follower/tests/follower_tests.js
+++ b/addons/mail/static/src/components/follower/tests/follower_tests.js
@@ -48,7 +48,7 @@ QUnit.test('base rendering not editable', async function (assert) {
         id: 100,
         model: 'res.partner',
     });
-    const follower = await this.messaging.models['mail.follower'].create({
+    const follower = await this.messaging.models['Follower'].create({
         partner: insert({
             id: 1,
             name: "François Perusse",
@@ -94,7 +94,7 @@ QUnit.test('base rendering editable', async function (assert) {
         id: 100,
         model: 'res.partner',
     });
-    const follower = await this.messaging.models['mail.follower'].create({
+    const follower = await this.messaging.models['Follower'].create({
         partner: insert({
             id: 1,
             name: "François Perusse",
@@ -169,7 +169,7 @@ QUnit.test('click on partner follower details', async function (assert) {
         id: 100,
         model: 'res.partner',
     });
-    const follower = await this.messaging.models['mail.follower'].create({
+    const follower = await this.messaging.models['Follower'].create({
         followedThread: link(thread),
         id: 2,
         isActive: true,
@@ -275,7 +275,7 @@ QUnit.test('edit follower and close subtype dialog', async function (assert) {
         id: 100,
         model: 'res.partner',
     });
-    const follower = await this.messaging.models['mail.follower'].create({
+    const follower = await this.messaging.models['Follower'].create({
         followedThread: link(thread),
         id: 2,
         isActive: true,

--- a/addons/mail/static/src/components/follower_list_menu/tests/follower_list_menu_tests.js
+++ b/addons/mail/static/src/components/follower_list_menu/tests/follower_list_menu_tests.js
@@ -251,7 +251,7 @@ QUnit.test('click on remove follower', async function (assert) {
         id: 100,
         model: 'res.partner',
     });
-    await this.messaging.models['mail.follower'].create({
+    await this.messaging.models['Follower'].create({
         followedThread: link(thread),
         id: 2,
         isActive: true,

--- a/addons/mail/static/src/components/follower_subtype/follower_subtype.js
+++ b/addons/mail/static/src/components/follower_subtype/follower_subtype.js
@@ -11,10 +11,10 @@ export class FollowerSubtype extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.follower|undefined}
+     * @returns {Follower|undefined}
      */
     get follower() {
-        return this.messaging && this.messaging.models['mail.follower'].get(this.props.followerLocalId);
+        return this.messaging && this.messaging.models['Follower'].get(this.props.followerLocalId);
     }
 
     /**

--- a/addons/mail/static/src/components/follower_subtype/tests/follower_subtype_tests.js
+++ b/addons/mail/static/src/components/follower_subtype/tests/follower_subtype_tests.js
@@ -49,7 +49,7 @@ QUnit.test('simplest layout of a followed subtype', async function (assert) {
         id: 100,
         model: 'res.partner',
     });
-    const follower = this.messaging.models['mail.follower'].create({
+    const follower = this.messaging.models['Follower'].create({
         partner: insert({
             id: 1,
             name: "François Perusse",
@@ -109,7 +109,7 @@ QUnit.test('simplest layout of a not followed subtype', async function (assert) 
         id: 100,
         model: 'res.partner',
     });
-    const follower = this.messaging.models['mail.follower'].create({
+    const follower = this.messaging.models['Follower'].create({
         partner: insert({
             id: 1,
             name: "François Perusse",
@@ -166,7 +166,7 @@ QUnit.test('toggle follower subtype checkbox', async function (assert) {
         id: 100,
         model: 'res.partner',
     });
-    const follower = this.messaging.models['mail.follower'].create({
+    const follower = this.messaging.models['Follower'].create({
         partner: insert({
             id: 1,
             name: "François Perusse",

--- a/addons/mail/static/src/models/follower/follower.js
+++ b/addons/mail/static/src/models/follower/follower.js
@@ -5,7 +5,7 @@ import { attr, many2many, many2one, one2many } from '@mail/model/model_field';
 import { clear, insert, insertAndReplace, link, replace, unlink, unlinkAll } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.follower',
+    name: 'Follower',
     identifyingFields: ['id'],
     modelMethods: {
         /**

--- a/addons/mail/static/src/models/follower_subtype_list/follower_subtype_list.js
+++ b/addons/mail/static/src/models/follower_subtype_list/follower_subtype_list.js
@@ -15,7 +15,7 @@ registerModel({
             isCausal: true,
             readonly: true,
         }),
-        follower: many2one('mail.follower', {
+        follower: many2one('Follower', {
             inverse: 'subtypeList',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1038,7 +1038,7 @@ registerModel({
             if (followers.length > 0) {
                 this.update({
                     followers: insertAndReplace(followers.map(data =>
-                        this.messaging.models['mail.follower'].convertData(data))
+                        this.messaging.models['Follower'].convertData(data))
                     ),
                 });
             } else {
@@ -1996,7 +1996,7 @@ registerModel({
         followersPartner: many2many('mail.partner', {
             related: 'followers.partner',
         }),
-        followers: one2many('mail.follower', {
+        followers: one2many('Follower', {
             inverse: 'followedThread',
         }),
         /**


### PR DESCRIPTION
Rename javascript model `mail.follower` to `Follower` in order to distinguish javascript models from python models.

Part of task-2701674.