### PR TITLE
[IMP] mail: rename follower subtype model

### DIFF
--- a/addons/mail/static/src/components/follower_subtype/follower_subtype.js
+++ b/addons/mail/static/src/components/follower_subtype/follower_subtype.js
@@ -18,10 +18,10 @@ export class FollowerSubtype extends Component {
     }
 
     /**
-     * @returns {mail.follower_subtype}
+     * @returns {FollowerSubtype}
      */
     get followerSubtype() {
-        return this.messaging && this.messaging.models['mail.follower_subtype'].get(this.props.followerSubtypeLocalId);
+        return this.messaging && this.messaging.models['FollowerSubtype'].get(this.props.followerSubtypeLocalId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/components/follower_subtype/tests/follower_subtype_tests.js
+++ b/addons/mail/static/src/components/follower_subtype/tests/follower_subtype_tests.js
@@ -59,7 +59,7 @@ QUnit.test('simplest layout of a followed subtype', async function (assert) {
         isActive: true,
         isEditable: true,
     });
-    const followerSubtype = this.messaging.models['mail.follower_subtype'].create({
+    const followerSubtype = this.messaging.models['FollowerSubtype'].create({
         id: 1,
         isDefault: true,
         isInternal: false,
@@ -119,7 +119,7 @@ QUnit.test('simplest layout of a not followed subtype', async function (assert) 
         isActive: true,
         isEditable: true,
     });
-    const followerSubtype = this.messaging.models['mail.follower_subtype'].create({
+    const followerSubtype = this.messaging.models['FollowerSubtype'].create({
         id: 1,
         isDefault: true,
         isInternal: false,
@@ -176,7 +176,7 @@ QUnit.test('toggle follower subtype checkbox', async function (assert) {
         isActive: true,
         isEditable: true,
     });
-    const followerSubtype = this.messaging.models['mail.follower_subtype'].create({
+    const followerSubtype = this.messaging.models['FollowerSubtype'].create({
         id: 1,
         isDefault: true,
         isInternal: false,

--- a/addons/mail/static/src/models/follower/follower.js
+++ b/addons/mail/static/src/models/follower/follower.js
@@ -71,7 +71,7 @@ registerModel({
             followedThread.fetchAndUpdateSuggestedRecipients();
         },
         /**
-         * @param {mail.follower_subtype} subtype
+         * @param {FollowerSubtype} subtype
          */
         selectSubtype(subtype) {
             if (!this.selectedSubtypes.includes(subtype)) {
@@ -88,8 +88,8 @@ registerModel({
             }));
             this.update({ subtypes: unlinkAll() });
             for (const data of subtypesData) {
-                const subtype = this.messaging.models['mail.follower_subtype'].insert(
-                    this.messaging.models['mail.follower_subtype'].convertData(data)
+                const subtype = this.messaging.models['FollowerSubtype'].insert(
+                    this.messaging.models['FollowerSubtype'].convertData(data)
                 );
                 this.update({ subtypes: link(subtype) });
                 if (data.followed) {
@@ -107,7 +107,7 @@ registerModel({
             });
         },
         /**
-         * @param {mail.follower_subtype} subtype
+         * @param {FollowerSubtype} subtype
          */
         unselectSubtype(subtype) {
             if (this.selectedSubtypes.includes(subtype)) {
@@ -158,11 +158,11 @@ registerModel({
         partner: many2one('mail.partner', {
             required: true,
         }),
-        selectedSubtypes: many2many('mail.follower_subtype'),
+        selectedSubtypes: many2many('FollowerSubtype'),
         subtypeList: one2many('mail.follower_subtype_list', {
             inverse: 'follower',
             isCausal: true,
         }),
-        subtypes: many2many('mail.follower_subtype'),
+        subtypes: many2many('FollowerSubtype'),
     },
 });

--- a/addons/mail/static/src/models/follower_subtype/follower_subtype.js
+++ b/addons/mail/static/src/models/follower_subtype/follower_subtype.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.follower_subtype',
+    name: 'FollowerSubtype',
     identifyingFields: ['id'],
     modelMethods: {
         /**


### PR DESCRIPTION
Rename javascript model `mail.follower_subtype` to `FollowerSubtype` in order to distinguish javascript models from python models.

Part of task-2701674.