### PR TITLE
[IMP] mail: rename locale model

### DIFF
--- a/addons/mail/static/src/models/locale/locale.js
+++ b/addons/mail/static/src/models/locale/locale.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.locale',
+    name: 'Locale',
     identifyingFields: ['messaging'],
     recordMethods: {
         /**

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -308,7 +308,7 @@ registerModel({
         isQUnitTest: attr({
             default: false,
         }),
-        locale: one2one('mail.locale', {
+        locale: one2one('Locale', {
             default: insertAndReplace(),
             isCausal: true,
             readonly: true,


### PR DESCRIPTION
Rename javascript model `mail.locale` to `Locale` in order to distinguish javascript models from python models.

Part of task-2701674.