### PR TITLE
[IMP] mail: rename mail template model

### DIFF
--- a/addons/mail/static/src/components/mail_template/mail_template.js
+++ b/addons/mail/static/src/components/mail_template/mail_template.js
@@ -18,10 +18,10 @@ export class MailTemplate extends Component {
     }
 
     /**
-     * @returns {mail.mail_template}
+     * @returns {MailTemplate}
      */
     get mailTemplate() {
-        return this.messaging && this.messaging.models['mail.mail_template'].get(this.props.mailTemplateLocalId);
+        return this.messaging && this.messaging.models['MailTemplate'].get(this.props.mailTemplateLocalId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/models/activity/activity.js
+++ b/addons/mail/static/src/models/activity/activity.js
@@ -261,7 +261,7 @@ registerModel({
             compute: '_computeIsCurrentPartnerAssignee',
             default: false,
         }),
-        mailTemplates: many2many('mail.mail_template', {
+        mailTemplates: many2many('MailTemplate', {
             inverse: 'activities',
         }),
         /**

--- a/addons/mail/static/src/models/mail_template/mail_template.js
+++ b/addons/mail/static/src/models/mail_template/mail_template.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { attr, many2many } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.mail_template',
+    name: 'MailTemplate',
     identifyingFields: ['id'],
     recordMethods: {
         /**


### PR DESCRIPTION
Rename javascript model `mail.mail_template` to `MailTemplate` in order to distinguish javascript models from python models.

Part of task-2701674.