### PR TITLE
[IMP] mail: rename media preview model

### DIFF
--- a/addons/mail/static/src/components/media_preview/media_preview.js
+++ b/addons/mail/static/src/components/media_preview/media_preview.js
@@ -10,15 +10,15 @@ export class MediaPreview extends owl.Component {
      */
     setup() {
         super.setup();
-        useRefToModel({ fieldName: 'audioRef', modelName: 'mail.media_preview', propNameAsRecordLocalId: 'localId', refName: 'audio' });
-        useRefToModel({ fieldName: 'videoRef', modelName: 'mail.media_preview', propNameAsRecordLocalId: 'localId', refName: 'video' });
+        useRefToModel({ fieldName: 'audioRef', modelName: 'MediaPreview', propNameAsRecordLocalId: 'localId', refName: 'audio' });
+        useRefToModel({ fieldName: 'videoRef', modelName: 'MediaPreview', propNameAsRecordLocalId: 'localId', refName: 'video' });
     }
 
     /**
-     * @returns {mail.media_preview}
+     * @returns {MediaPreview}
      */
     get mediaPreview() {
-        return this.messaging && this.messaging.models['mail.media_preview'].get(this.props.localId);
+        return this.messaging && this.messaging.models['MediaPreview'].get(this.props.localId);
     }
 }
 

--- a/addons/mail/static/src/models/media_preview/media_preview.js
+++ b/addons/mail/static/src/models/media_preview/media_preview.js
@@ -4,7 +4,7 @@ import { attr } from '@mail/model/model_field';
 import { registerModel } from '@mail/model/model_core';
 
 registerModel({
-    name: 'mail.media_preview',
+    name: 'MediaPreview',
     identifyingFields: ['messaging'],
     lifecycleHooks: {
         _created() {
@@ -37,7 +37,7 @@ registerModel({
             if (!this.audioStream) {
                 return;
             }
-            this.messaging.models['mail.media_preview'].stopTracksOnMediaStream(this.audioStream);
+            this.messaging.models['MediaPreview'].stopTracksOnMediaStream(this.audioStream);
             this.update({ audioStream: null });
         },
         /**
@@ -48,7 +48,7 @@ registerModel({
             if (!this.videoStream) {
                 return;
             }
-            this.messaging.models['mail.media_preview'].stopTracksOnMediaStream(this.videoStream);
+            this.messaging.models['MediaPreview'].stopTracksOnMediaStream(this.videoStream);
             this.update({ videoStream: null });
         },
         /**

--- a/addons/mail/static/src/models/welcome_view/welcome_view.js
+++ b/addons/mail/static/src/models/welcome_view/welcome_view.js
@@ -190,7 +190,7 @@ registerModel({
         /**
          * States the media preview embedded in this welcome view.
          */
-        mediaPreview: one2one('mail.media_preview', {
+        mediaPreview: one2one('MediaPreview', {
             compute: '_computeMediaPreview',
             isCausal: true,
             readonly: true,


### PR DESCRIPTION
Rename javascript model `mail.media_preview` to `MediaPreview` in order to distinguish javascript models from python models.

Part of task-2701674.
