### PR TITLE
[IMP] sale: Let user decide if partial payment confirms quotation

### DIFF
--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -38,6 +38,7 @@ This module contains all the common features of Sales Management and eCommerce.
         'views/crm_team_views.xml',
         'views/mail_activity_views.xml',
         'views/payment_templates.xml',
+        'views/payment_portal_templates.xml',
         'views/payment_views.xml',
         'views/product_packaging_views.xml',
         'views/product_views.xml',

--- a/addons/sale/static/src/js/payment_form.js
+++ b/addons/sale/static/src/js/payment_form.js
@@ -26,6 +26,8 @@ odoo.define('sale.payment_form', require => {
                 ...transactionRouteParams,
                 'sale_order_id': this.txContext.saleOrderId
                     ? parseInt(this.txContext.saleOrderId) : undefined,
+                'confirm_order': this.txContext.confirmOrder !== undefined
+                    ? this.txContext.confirmOrder : null,
             };
         },
 

--- a/addons/sale/views/payment_portal_templates.xml
+++ b/addons/sale/views/payment_portal_templates.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="payment_pay_inherit" inherit_id="payment.pay">
+        <xpath expr="//div[@t-if='partner_is_different']" position="after">
+            <t t-if="confirm_order and confirm_order == 'True'">
+                <div class="alert alert-info">
+                    <b>This payment will confirm the quotation.</b>
+                </div>
+            </t>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/sale/views/payment_templates.xml
+++ b/addons/sale/views/payment_templates.xml
@@ -5,6 +5,7 @@
     <template id="payment_checkout_inherit" inherit_id="payment.checkout">
         <xpath expr="//form[@name='o_payment_checkout']" position="attributes">
             <attribute name="t-att-data-sale-order-id">sale_order_id</attribute>
+            <attribute name="t-att-data-confirm-order">confirm_order</attribute>
         </xpath>
     </template>
 
@@ -14,5 +15,4 @@
             <attribute name="t-att-data-sale-order-id">sale_order_id</attribute>
         </xpath>
     </template>
-
 </odoo>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -310,6 +310,12 @@
                         Your order is not in a state to be rejected.
                     </div>
 
+                    <t t-if="sale_order.state in ['draft', 'sent', 'sale'] and sale_order.amount_paid() > 0">
+                        <div class="alert alert-info alert-dismissible">
+                            <t t-out="sale_order.amount_paid_msg"/>
+                        </div>
+                    </t>
+
                     <t t-if="sale_order.transaction_ids">
                         <t t-call="payment.transaction_status">
                             <t t-set="tx" t-value="sale_order.get_portal_last_transaction()"/>

--- a/addons/sale/wizard/payment_link_wizard.py
+++ b/addons/sale/wizard/payment_link_wizard.py
@@ -3,12 +3,39 @@
 
 from werkzeug import urls
 
-from odoo import api, models
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.addons.payment import utils as payment_utils
 
 
 class PaymentLinkWizard(models.TransientModel):
     _inherit = 'payment.link.wizard'
     _description = 'Generate Sales Payment Link'
+
+    confirm_order = fields.Boolean(
+        help="This payment will confirm the order.",
+        compute="_compute_confirm_order",
+        inverse="_inverse_confirm_order"
+    )
+    amount_paid = fields.Monetary(
+        currency_field='currency_id',
+        help="Amount partially paid on this order.",
+        string="Already Paid."
+    )
+    override_confirm = fields.Integer(compute="_compute_override_confirm")
+
+    # This field inherits the state of the current sale order to decide if the order can be
+    # confirmed or not (e.g. a cancelled order cannot be confirmed).
+    order_state = fields.Selection([
+        ('draft', 'Quotation'),
+        ('sent', 'Quotation Sent'),
+        ('sale', 'Sales Order'),
+        ('done', 'Locked'),
+        ('cancel', 'Cancelled'),
+    ],
+        default='draft',
+        help="Inherits the state of the SO from which this payment link is derived."
+    )
 
     @api.model
     def default_get(self, fields):
@@ -17,12 +44,60 @@ class PaymentLinkWizard(models.TransientModel):
             record = self.env[res['res_model']].browse(res['res_id'])
             res.update({
                 'description': record.name,
-                'amount': record.amount_total - sum(record.invoice_ids.filtered(lambda x: x.state != 'cancel').mapped('amount_total')),
+                'amount': (record.amount_total
+                           - sum(record.invoice_ids.filtered(lambda x: x.state != 'cancel')
+                                 .mapped('amount_total'))
+                           - record.amount_paid()),
+                'amount_paid': record.amount_paid(),
                 'currency_id': record.currency_id.id,
                 'partner_id': record.partner_id.id,
-                'amount_max': record.amount_total
+                'amount_max': record.amount_total,
+                'order_state': record.state,
             })
         return res
+
+    @api.depends('amount')
+    def _compute_override_confirm(self):
+        for payment_link in self:
+            payment_link.override_confirm = payment_link.currency_id.compare_amounts(
+                payment_link.amount_max - payment_link.amount_paid, payment_link.amount)
+
+    @api.onchange('amount')
+    def _onchange_amount(self):
+        for payment_link in self:
+            amount_to_be_paid = payment_link.amount_max - payment_link.amount_paid
+            if payment_link.amount > amount_to_be_paid:
+                raise ValidationError(
+                    f"Please set an amount smaller than {amount_to_be_paid}."
+                )
+
+    @api.depends('amount')
+    def _compute_confirm_order(self):
+        for payment_link in self:
+            payment_link.confirm_order = (
+                    payment_link.amount == payment_link.amount_max - payment_link.amount_paid
+            )
+
+    def _inverse_confirm_order(self):
+        for payment_link in self:
+            payment_link.amount = (
+                payment_link.amount
+                if payment_link.amount else payment_link.amount_to_be_paid
+            )
+
+    @api.depends('amount', 'description', 'partner_id', 'currency_id', 'payment_acquirer_selection',
+                 'confirm_order')
+    def _compute_values(self):
+        for payment_link in self:
+            if payment_link.res_model != 'sale.order':
+                super()._compute_values()
+            else:
+                payment_link.access_token = payment_utils.generate_access_token(
+                    payment_link.partner_id.id, payment_link.amount, payment_link.currency_id.id,
+                    payment_link.confirm_order
+                )
+        # must be called after token generation, obvsly - the link needs an up-to-date token
+        self._generate_link()
 
     def _get_payment_acquirer_available(self, res_model, res_id, **kwargs):
         """ Select and return the acquirers matching the criteria.
@@ -48,6 +123,7 @@ class PaymentLinkWizard(models.TransientModel):
                                     f'&amount={payment_link.amount}' \
                                     f'&sale_order_id={payment_link.res_id}' \
                                     f'{"&acquirer_id=" + str(payment_link.payment_acquirer_selection) if payment_link.payment_acquirer_selection != "all" else "" }' \
+                                    f'&confirm_order={payment_link.confirm_order}'\
                                     f'&access_token={payment_link.access_token}'
                 # Order-related fields are retrieved in the controller
             else:

--- a/addons/sale/wizard/payment_link_wizard_views.xml
+++ b/addons/sale/wizard/payment_link_wizard_views.xml
@@ -11,4 +11,27 @@
         <field name="binding_view_types">form</field>
     </record>
 
+    <record id="sale_link_wizard_view_form" model="ir.ui.view">
+        <field name="name">payment.link.wizard.form</field>
+        <field name="model">payment.link.wizard</field>
+        <field name="inherit_id" ref="payment.payment_link_wizard_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='amount']" position="after">
+                <field name="order_state" invisible="1"/>
+                <field name="override_confirm" invisible="1"/>
+                <field name="amount_paid" readonly="1"
+                       attrs="{
+                            'invisible': [
+                                '|', ('res_model', '!=', 'sale.order'),
+                                '!', ('amount_paid', '>', '0')]}"/>
+                <field name="confirm_order"
+                       attrs="{
+                           'invisible': [
+                               '|', ('res_model', '!=', 'sale.order'),
+                               '!', ('order_state', 'in', ['draft', 'sent'])
+                           ],
+                           'readonly': [('override_confirm', '=', 0)]}"/>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
When creating payment links for customer, the user can now decide
if partial payment will confirm or not the quotation.

If the customer decide to pay in several payments the user might
want to confirm the quotation from the first partial payment,
now it can be done

Task - 2672713

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
