### PR TITLE
[IMP] mail: rename message action list model

### DIFF
--- a/addons/mail/static/src/components/delete_message_confirm_dialog/delete_message_confirm_dialog.js
+++ b/addons/mail/static/src/components/delete_message_confirm_dialog/delete_message_confirm_dialog.js
@@ -18,10 +18,10 @@ export class DeleteMessageConfirmDialog extends Component {
     }
 
     /**
-     * @returns {mail.message_action_list}
+     * @returns {MessageActionList}
      */
     get messageActionList() {
-        return this.messaging && this.messaging.models['mail.message_action_list'].get(this.props.messageActionListLocalId);
+        return this.messaging && this.messaging.models['MessageActionList'].get(this.props.messageActionListLocalId);
     }
 }
 

--- a/addons/mail/static/src/components/message_action_list/message_action_list.js
+++ b/addons/mail/static/src/components/message_action_list/message_action_list.js
@@ -12,15 +12,15 @@ export class MessageActionList extends Component {
      */
     setup() {
         super.setup();
-        useRefToModel({ fieldName: 'reactionPopoverRef', modelName: 'mail.message_action_list', propNameAsRecordLocalId: 'messageActionListLocalId', refName: 'reactionPopover' });
+        useRefToModel({ fieldName: 'reactionPopoverRef', modelName: 'MessageActionList', propNameAsRecordLocalId: 'messageActionListLocalId', refName: 'reactionPopover' });
         this.ADD_A_REACTION = this.env._t("Add a Reaction");
     }
 
     /**
-     * @returns {mail.message}
+     * @returns {MessageActionList}
      */
     get messageActionList() {
-        return this.messaging && this.messaging.models['mail.message_action_list'].get(this.props.messageActionListLocalId);
+        return this.messaging && this.messaging.models['MessageActionList'].get(this.props.messageActionListLocalId);
     }
 
 }

--- a/addons/mail/static/src/models/message_action_list/message_action_list.js
+++ b/addons/mail/static/src/models/message_action_list/message_action_list.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace, replace } from '@mail/model/model_field_comman
 import { markEventHandled } from '@mail/utils/utils';
 
 registerModel({
-    name: 'mail.message_action_list',
+    name: 'MessageActionList',
     identifyingFields: ['messageView'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/message_view/message_view.js
+++ b/addons/mail/static/src/models/message_view/message_view.js
@@ -148,7 +148,7 @@ registerModel({
         /**
          * Determines the message action list of this message view (if any).
          */
-        messageActionList: one2one('mail.message_action_list', {
+        messageActionList: one2one('MessageActionList', {
             compute: '_computeMessageActionList',
             inverse: 'messageView',
             isCausal: true,
@@ -158,7 +158,7 @@ registerModel({
          * States the message action list that is displaying this message view
          * in its delete confirmation view.
          */
-        messageActionListWithDelete: one2one('mail.message_action_list', {
+        messageActionListWithDelete: one2one('MessageActionList', {
             inverse: 'messageViewForDelete',
             isCausal: true,
             readonly: true,


### PR DESCRIPTION
Rename javascript model `mail.message_action_list` to `MessageActionList` inorder to distinguish javascript models from python models.

Part of task-2701674.