### PR TITLE
[IMP] mail: rename message in reply to view model

### DIFF
--- a/addons/mail/static/src/components/message_in_reply_to_view/message_in_reply_to_view.js
+++ b/addons/mail/static/src/components/message_in_reply_to_view/message_in_reply_to_view.js
@@ -6,10 +6,10 @@ const { Component } = owl;
 
 export class MessageInReplyToView extends Component {
     /**
-     * @returns {mail.message_in_reply_to_view}
+     * @returns {MessageInReplyToView}
      */
     get messageInReplyToView() {
-        return this.messaging && this.messaging.models['mail.message_in_reply_to_view'].get(this.props.messageInReplyToViewLocalId);
+        return this.messaging && this.messaging.models['MessageInReplyToView'].get(this.props.messageInReplyToViewLocalId);
     }
 }
 

--- a/addons/mail/static/src/models/message_in_reply_to_view/message_in_reply_to_view.js
+++ b/addons/mail/static/src/models/message_in_reply_to_view/message_in_reply_to_view.js
@@ -6,7 +6,7 @@ import { replace } from '@mail/model/model_field_command';
 import { markEventHandled } from '@mail/utils/utils';
 
 registerModel({
-    name: 'mail.message_in_reply_to_view',
+    name: 'MessageInReplyToView',
     identifyingFields: ['messageView'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/message_view/message_view.js
+++ b/addons/mail/static/src/models/message_view/message_view.js
@@ -175,7 +175,7 @@ registerModel({
          * States the message in reply to view that displays the message of
          * which this message is a reply to (if any).
          */
-        messageInReplyToView: one2one('mail.message_in_reply_to_view', {
+        messageInReplyToView: one2one('MessageInReplyToView', {
             compute: '_computeMessageInReplyToView',
             inverse: 'messageView',
             isCausal: true,


### PR DESCRIPTION
Rename javascript model `mail.message_in_reply_to_view` to `MessageInReplyToView` in order to distinguish javascript models from python models.

Part of task-2701674.