### PR TITLE
[IMP] mail: rename message reaction group model

### DIFF
--- a/addons/mail/static/src/components/message_reaction_group/message_reaction_group.js
+++ b/addons/mail/static/src/components/message_reaction_group/message_reaction_group.js
@@ -6,7 +6,7 @@ import { registerMessagingComponent } from '@mail/utils/messaging_component';
 export class MessageReactionGroup extends Component {
 
     get messageReactionGroup() {
-        return this.messaging.models['mail.message_reaction_group'].get(this.props.messageReactionGroupLocalId);
+        return this.messaging.models['MessageReactionGroup'].get(this.props.messageReactionGroupLocalId);
     }
 
 }

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -693,7 +693,7 @@ registerModel({
          * Groups of reactions per content allowing to know the number of
          * reactions for each.
          */
-        messageReactionGroups: one2many('mail.message_reaction_group', {
+        messageReactionGroups: one2many('MessageReactionGroup', {
             inverse: 'message',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/message_reaction_group/message_reaction_group.js
+++ b/addons/mail/static/src/models/message_reaction_group/message_reaction_group.js
@@ -6,7 +6,7 @@ import { insertAndReplace } from '@mail/model/model_field_command';
 import { markEventHandled } from '@mail/utils/utils';
 
 registerModel({
-    name: 'mail.message_reaction_group',
+    name: 'MessageReactionGroup',
     identifyingFields: ['message', 'content'],
     lifecycleHooks: {
         _created() {


### PR DESCRIPTION
Rename javascript model `mail.message_reaction_group` to `MessageReactionGroup` in order to distinguish javascript models from python models.

Part of task-2701674.
