### PR TITLE
[IMP] mail: rename message seen indicator model

### DIFF
--- a/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator.js
+++ b/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator.js
@@ -80,13 +80,13 @@ export class MessageSeenIndicator extends Component {
     }
 
     /**
-     * @returns {mail.message_seen_indicator}
+     * @returns {MessageSeenIndicator}
      */
     get messageSeenIndicator() {
         if (!this.thread || this.thread.model !== 'mail.channel') {
             return undefined;
         }
-        return this.messaging.models['mail.message_seen_indicator'].findFromIdentifyingData({
+        return this.messaging.models['MessageSeenIndicator'].findFromIdentifyingData({
             message: this.message,
             thread: this.thread,
         });

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -180,7 +180,7 @@ registerModel({
                         // on `channel` channels for performance reasons
                         continue;
                     }
-                    this.messaging.models['mail.message_seen_indicator'].insert({
+                    this.messaging.models['MessageSeenIndicator'].insert({
                         thread: replace(thread),
                         message: replace(message),
                     });
@@ -698,7 +698,7 @@ registerModel({
             isCausal: true,
         }),
         message_type: attr(),
-        messageSeenIndicators: one2many('mail.message_seen_indicator', {
+        messageSeenIndicators: one2many('MessageSeenIndicator', {
             inverse: 'message',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/message_seen_indicator/message_seen_indicator.js
+++ b/addons/mail/static/src/models/message_seen_indicator/message_seen_indicator.js
@@ -5,7 +5,7 @@ import { attr, many2many, many2one } from '@mail/model/model_field';
 import { replace, unlinkAll } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.message_seen_indicator',
+    name: 'MessageSeenIndicator',
     identifyingFields: ['thread', 'message'],
     modelMethods: {
         /**
@@ -13,7 +13,7 @@ registerModel({
          */
         recomputeFetchedValues(channel = undefined) {
             const indicatorFindFunction = channel ? localIndicator => localIndicator.thread === channel : undefined;
-            const indicators = this.messaging.models['mail.message_seen_indicator'].all(indicatorFindFunction);
+            const indicators = this.messaging.models['MessageSeenIndicator'].all(indicatorFindFunction);
             for (const indicator of indicators) {
                 indicator.update({
                     hasEveryoneFetched: indicator._computeHasEveryoneFetched(),
@@ -27,7 +27,7 @@ registerModel({
          */
         recomputeSeenValues(channel = undefined) {
             const indicatorFindFunction = channel ? localIndicator => localIndicator.thread === channel : undefined;
-            const indicators = this.messaging.models['mail.message_seen_indicator'].all(indicatorFindFunction);
+            const indicators = this.messaging.models['MessageSeenIndicator'].all(indicatorFindFunction);
             for (const indicator of indicators) {
                 indicator.update({
                     hasEveryoneSeen: indicator._computeHasEveryoneSeen(),

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -171,12 +171,12 @@ registerModel({
                 partner: insertAndReplace({ id: partner_id }),
                 thread: replace(channel),
             });
-            this.messaging.models['mail.message_seen_indicator'].insert({
+            this.messaging.models['MessageSeenIndicator'].insert({
                 message: insertAndReplace({ id: last_message_id }),
                 thread: replace(channel),
             });
             // FIXME force the computing of message values (cf task-2261221)
-            this.messaging.models['mail.message_seen_indicator'].recomputeFetchedValues(channel);
+            this.messaging.models['MessageSeenIndicator'].recomputeFetchedValues(channel);
         },
         /**
          * @private
@@ -312,7 +312,7 @@ registerModel({
                     partner: insertAndReplace({ id: partner_id }),
                     thread: replace(channel),
                 });
-                this.messaging.models['mail.message_seen_indicator'].insert({
+                this.messaging.models['MessageSeenIndicator'].insert({
                     message: replace(lastMessage),
                     thread: replace(channel),
                 });
@@ -327,7 +327,7 @@ registerModel({
                 // FIXME force the computing of thread values (cf task-2261221)
                 this.messaging.models['mail.thread'].computeLastCurrentPartnerMessageSeenByEveryone(channel);
                 // FIXME force the computing of message values (cf task-2261221)
-                this.messaging.models['mail.message_seen_indicator'].recomputeSeenValues(channel);
+                this.messaging.models['MessageSeenIndicator'].recomputeSeenValues(channel);
             }
         },
         /**

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -2219,7 +2219,7 @@ registerModel({
         /**
          * Contains the message fetched/seen indicators for all messages of this thread.
          */
-        messageSeenIndicators: one2many('mail.message_seen_indicator', {
+        messageSeenIndicators: one2many('MessageSeenIndicator', {
             inverse: 'thread',
             isCausal: true,
         }),


### PR DESCRIPTION
Rename javascript model `mail.message_seen_indicator` to `MessageSeenIndicator` in order to distinguish javascript models from python models.

Part of task-2701674.
