### PR TITLE
[IMP] mail: rename message view model

### DIFF
--- a/addons/mail/static/src/components/message/message.js
+++ b/addons/mail/static/src/components/message/message.js
@@ -22,7 +22,7 @@ export class Message extends Component {
      */
     setup() {
         super.setup();
-        useComponentToModel({ fieldName: 'component', modelName: 'mail.message_view', propNameAsRecordLocalId: 'messageViewLocalId' });
+        useComponentToModel({ fieldName: 'component', modelName: 'MessageView', propNameAsRecordLocalId: 'messageViewLocalId' });
         this.state = useState({
             /**
              * Determine whether the message is hovered. When message is hovered
@@ -216,10 +216,10 @@ export class Message extends Component {
     }
 
     /**
-     * @returns {mail.message_view}
+     * @returns {MessageView}
      */
     get messageView() {
-        return this.messaging && this.messaging.models['mail.message_view'].get(this.props.messageViewLocalId);
+        return this.messaging && this.messaging.models['MessageView'].get(this.props.messageViewLocalId);
     }
     /**
      * @returns {string}

--- a/addons/mail/static/src/components/message_list/message_list.js
+++ b/addons/mail/static/src/components/message_list/message_list.js
@@ -264,7 +264,7 @@ export class MessageList extends Component {
      * Scrolls to a given message view and briefly highlights it.
      *
      * @private
-     * @param {mail.message_view} messageView
+     * @param {MessageView} messageView
      */
     _highlightMessageView(messageView) {
         if (messageView.exists() && messageView.component && messageView.component.el) {

--- a/addons/mail/static/src/components/notification_popover/notification_popover.js
+++ b/addons/mail/static/src/components/notification_popover/notification_popover.js
@@ -7,10 +7,10 @@ const { Component } = owl;
 export class NotificationPopover extends Component {
 
     /**
-     * @returns {mail.message_view}
+     * @returns {MessageView}
      */
     get messageView() {
-        return this.messaging && this.messaging.models['mail.message_view'].get(this.props.messageViewLocalId);
+        return this.messaging && this.messaging.models['MessageView'].get(this.props.messageViewLocalId);
     }
 
 }

--- a/addons/mail/static/src/models/attachment_list/attachment_list.js
+++ b/addons/mail/static/src/models/attachment_list/attachment_list.js
@@ -113,7 +113,7 @@ registerModel({
         /**
          * Link with a message view to handle attachments.
          */
-        messageView: one2one('mail.message_view', {
+        messageView: one2one('MessageView', {
             inverse: 'attachmentList',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -172,7 +172,7 @@ registerModel({
         mentionedPartners: many2many('mail.partner', {
             compute: '_computeMentionedPartners',
         }),
-        messageViewInEditing: one2one('mail.message_view', {
+        messageViewInEditing: one2one('MessageView', {
             inverse: 'composerForEditing',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -917,7 +917,7 @@ registerModel({
         /**
          * States the message view on which this composer allows editing (if any).
          */
-        messageViewInEditing: one2one('mail.message_view', {
+        messageViewInEditing: one2one('MessageView', {
             inverse: 'composerViewInEditing',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -705,7 +705,7 @@ registerModel({
         /**
          * States the views that are displaying this message.
          */
-        messageViews: one2many('mail.message_view', {
+        messageViews: one2many('MessageView', {
             inverse: 'message',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/message_action_list/message_action_list.js
+++ b/addons/mail/static/src/models/message_action_list/message_action_list.js
@@ -146,7 +146,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.message_view}
+         * @returns {MessageView}
          */
         _computeMessageViewForDelete() {
             return this.message
@@ -182,7 +182,7 @@ registerModel({
         /**
          * States the message view that controls this message action list.
          */
-        messageView: one2one('mail.message_view', {
+        messageView: one2one('MessageView', {
             inverse: 'messageActionList',
             readonly: true,
             required: true,
@@ -191,7 +191,7 @@ registerModel({
          * Determines the message view that this message action list will use to
          * display this message in this delete confirmation dialog.
          */
-        messageViewForDelete: one2one('mail.message_view', {
+        messageViewForDelete: one2one('MessageView', {
             compute: '_computeMessageViewForDelete',
             inverse: 'messageActionListWithDelete',
             isCausal: true,

--- a/addons/mail/static/src/models/message_in_reply_to_view/message_in_reply_to_view.js
+++ b/addons/mail/static/src/models/message_in_reply_to_view/message_in_reply_to_view.js
@@ -26,7 +26,7 @@ registerModel({
             if (!threadView || !parentMessage) {
                 return;
             }
-            const parentMessageView = this.messaging.models['mail.message_view'].findFromIdentifyingData({
+            const parentMessageView = this.messaging.models['MessageView'].findFromIdentifyingData({
                 message: replace(parentMessage),
                 threadView: replace(threadView),
             });
@@ -37,7 +37,7 @@ registerModel({
         },
     },
     fields: {
-        messageView: one2one('mail.message_view', {
+        messageView: one2one('MessageView', {
             inverse: 'messageInReplyToView',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/message_view/message_view.js
+++ b/addons/mail/static/src/models/message_view/message_view.js
@@ -5,7 +5,7 @@ import { attr, many2one, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.message_view',
+    name: 'MessageView',
     identifyingFields: [['threadView', 'messageActionListWithDelete'], 'message'],
     recordMethods: {
         /**

--- a/addons/mail/static/src/models/message_view/tests/message_view_qunit_tests.js
+++ b/addons/mail/static/src/models/message_view/tests/message_view_qunit_tests.js
@@ -5,13 +5,13 @@ import { one2one } from '@mail/model/model_field';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/message_view/message_view';
 
-addFields('mail.message_view', {
+addFields('MessageView', {
     qunitTest: one2one('mail.qunit_test', {
         inverse: 'messageView',
         readonly: true,
     }),
 });
 
-patchIdentifyingFields('mail.message_view', identifyingFields => {
+patchIdentifyingFields('MessageView', identifyingFields => {
     identifyingFields[0].push('qunitTest');
 });

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -97,7 +97,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.message_view[]}
+         * @returns {MessageView[]}
          */
         _computeMessageViews() {
             if (!this.threadCache) {
@@ -407,7 +407,7 @@ registerModel({
         /**
          * States the message views used to display this messages.
          */
-        messageViews: one2many('mail.message_view', {
+        messageViews: one2many('MessageView', {
             compute: '_computeMessageViews',
             inverse: 'threadView',
             isCausal: true,
@@ -422,7 +422,7 @@ registerModel({
         /**
          * Determines the message that's currently being replied to.
          */
-        replyingToMessageView: many2one('mail.message_view'),
+        replyingToMessageView: many2one('MessageView'),
         /**
          * Determines the Rtc call viewer of this thread.
          */

--- a/addons/mail/static/src/utils/test_utils.js
+++ b/addons/mail/static/src/utils/test_utils.js
@@ -440,7 +440,7 @@ function getCreateComposerSuggestionComponent({ components, env, modelManager, w
 
 function getCreateMessageComponent({ components, env, modelManager, widget }) {
     return async function createMessageComponent(message) {
-        const messageView = modelManager.messaging.models['mail.message_view'].create({
+        const messageView = modelManager.messaging.models['MessageView'].create({
             message: replace(message),
             qunitTest: insertAndReplace(),
         });

--- a/addons/mail/static/tests/qunit_test.js
+++ b/addons/mail/static/tests/qunit_test.js
@@ -14,7 +14,7 @@ registerModel({
             inverse: 'qunitTest',
             isCausal: true,
         }),
-        messageView: one2one('mail.message_view', {
+        messageView: one2one('MessageView', {
             inverse: 'qunitTest',
             isCausal: true,
         }),


### PR DESCRIPTION
Rename javascript model `mail.message_view` to `MessageView` in order to distinguish javascript models from python models.

Part of task-2701674.