### PR TITLE
[IMP] hr, mail, snailmail: rename messaging model

### DIFF
--- a/addons/hr/static/src/models/messaging/messaging.js
+++ b/addons/hr/static/src/models/messaging/messaging.js
@@ -4,7 +4,7 @@ import { patchRecordMethods } from '@mail/model/model_core';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/messaging/messaging';
 
-patchRecordMethods('mail.messaging', {
+patchRecordMethods('Messaging', {
     /**
      * @override
      * @param {integer} [param0.employeeId]

--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -143,7 +143,7 @@ export class ModelManager {
         /**
          * Create the messaging singleton record.
          */
-        const messaging = this.models['mail.messaging'].insert(values);
+        const messaging = this.models['Messaging'].insert(values);
         Object.assign(odoo.__DEBUG__, { messaging });
         this.messagingCreatedPromise.resolve();
         await this.messaging.start();
@@ -302,7 +302,7 @@ export class ModelManager {
      * be considered the main entry point to the messaging system for outside
      * code.
      *
-     * @returns {mail.messaging}
+     * @returns {Messaging}
      **/
     async getMessaging() {
         await this.messagingCreatedPromise;
@@ -329,15 +329,15 @@ export class ModelManager {
     /**
      * Returns the messaging singleton associated to this model manager.
      *
-     * @returns {mail.messaging|undefined}
+     * @returns {Messaging|undefined}
      */
     get messaging() {
-        if (!this.models['mail.messaging']) {
+        if (!this.models['Messaging']) {
             return undefined;
         }
         // Use "findFromIdentifyingData" specifically to ensure the record still
         // exists and to ensure listeners are properly notified of this access.
-        return this.models['mail.messaging'].findFromIdentifyingData({});
+        return this.models['Messaging'].findFromIdentifyingData({});
     }
 
     /**

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -9,7 +9,7 @@ import { makeDeferred } from '@mail/utils/deferred/deferred';
 const { EventBus } = owl.core;
 
 registerModel({
-    name: 'mail.messaging',
+    name: 'Messaging',
     identifyingFields: [],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/model/model.js
+++ b/addons/mail/static/src/models/model/model.js
@@ -145,7 +145,7 @@ registerModel({
         /**
          * Returns the messaging singleton.
          *
-         * @returns {mail.messaging}
+         * @returns {Messaging}
          */
         messaging() {
             return this.modelManager.messaging;
@@ -258,7 +258,7 @@ registerModel({
          * States the messaging singleton. Automatically assigned by the model
          * manager at creation.
          */
-        messaging: many2one('mail.messaging', {
+        messaging: many2one('Messaging', {
             default: insertAndReplace(),
             inverse: 'allRecords',
             readonly: true,

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -2223,7 +2223,7 @@ registerModel({
             inverse: 'thread',
             isCausal: true,
         }),
-        messagingAsRingingThread: many2one('mail.messaging', {
+        messagingAsRingingThread: many2one('Messaging', {
             compute: '_computeMessagingAsRingingThread',
             inverse: 'ringingThreads',
             readonly: true,

--- a/addons/mail/static/src/services/messaging/messaging.js
+++ b/addons/mail/static/src/services/messaging/messaging.js
@@ -26,7 +26,7 @@ export const MessagingService = AbstractService.extend({
      * be considered the main entry point to the messaging system for outside
      * code.
      *
-     * @returns {mail.messaging}
+     * @returns {Messaging}
      **/
     async get() {
         return this.modelManager.getMessaging();

--- a/addons/snailmail/static/src/models/messaging/messaging.js
+++ b/addons/snailmail/static/src/models/messaging/messaging.js
@@ -5,7 +5,7 @@ import { attr } from '@mail/model/model_field';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/messaging/messaging';
 
-addRecordMethods('mail.messaging', {
+addRecordMethods('Messaging', {
     async fetchSnailmailCreditsUrl() {
         const snailmail_credits_url = await this.async(() => this.env.services.rpc({
             model: 'iap.account',
@@ -28,7 +28,7 @@ addRecordMethods('mail.messaging', {
     },
 });
 
-addFields('mail.messaging', {
+addFields('Messaging', {
     snailmail_credits_url: attr(),
     snailmail_credits_url_trial: attr(),
 });


### PR DESCRIPTION
Rename javascript model `mail.messaging` to `Messaging` in order to distinguish javascript models from python models.

Part of task-2701674.
