### PR TITLE
[IMP] mail, *: rename messaging initializer model

### DIFF
--- a/addons/crm_livechat/static/src/models/messaging_initializer/messaging_initializer.js
+++ b/addons/crm_livechat/static/src/models/messaging_initializer/messaging_initializer.js
@@ -5,7 +5,7 @@ import { insert } from '@mail/model/model_field_command';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/messaging_initializer/messaging_initializer';
 
-patchRecordMethods('mail.messaging_initializer', {
+patchRecordMethods('MessagingInitializer', {
     /**
      * @override
      */

--- a/addons/im_livechat/static/src/models/messaging_initializer/messaging_initializer.js
+++ b/addons/im_livechat/static/src/models/messaging_initializer/messaging_initializer.js
@@ -5,7 +5,7 @@ import { insert, insertAndReplace } from '@mail/model/model_field_command';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/messaging_initializer/messaging_initializer';
 
-patchRecordMethods('mail.messaging_initializer', {
+patchRecordMethods('MessagingInitializer', {
     /**
      * @override
      * @param {Object} resUsersSettings

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -281,7 +281,7 @@ registerModel({
             required: true,
             readonly: true,
         }),
-        initializer: one2one('mail.messaging_initializer', {
+        initializer: one2one('MessagingInitializer', {
             default: insertAndReplace(),
             isCausal: true,
             readonly: true,

--- a/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
@@ -5,7 +5,7 @@ import { executeGracefully } from '@mail/utils/utils';
 import { link, insert, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.messaging_initializer',
+    name: 'MessagingInitializer',
     identifyingFields: ['messaging'],
     recordMethods: {
         /**

--- a/addons/mail_bot/static/src/models/messaging_initializer/messaging_initializer.js
+++ b/addons/mail_bot/static/src/models/messaging_initializer/messaging_initializer.js
@@ -4,7 +4,7 @@ import { addRecordMethods, patchRecordMethods } from '@mail/model/model_core';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/messaging_initializer/messaging_initializer';
 
-addRecordMethods('mail.messaging_initializer', {
+addRecordMethods('MessagingInitializer', {
     /**
      * @private
      */
@@ -20,7 +20,7 @@ addRecordMethods('mail.messaging_initializer', {
     },
 });
 
-patchRecordMethods('mail.messaging_initializer', {
+patchRecordMethods('MessagingInitializer', {
     /**
      * @override
      */


### PR DESCRIPTION
Rename javascript model `mail.messaging_initializer` to `MessagingInitializer` in order to distinguish javascript models from python models.

Part of task-2701674.
\* = crm_livechat, im_livechat, mail_bot
Enterprise: https://github.com/odoo/enterprise/pull/22889