### PR TITLE
[IMP] mail: rename messaging menu model

### DIFF
--- a/addons/mail/static/src/components/messaging_menu/messaging_menu.js
+++ b/addons/mail/static/src/components/messaging_menu/messaging_menu.js
@@ -41,10 +41,10 @@ export class MessagingMenu extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.messaging_menu}
+     * @returns {MessagingMenu}
      */
     get messagingMenu() {
-        return this.messaging && this.messaging.models['mail.messaging_menu'].get(this.props.localId);
+        return this.messaging && this.messaging.models['MessagingMenu'].get(this.props.localId);
     }
 
     /**

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -328,7 +328,7 @@ registerModel({
             readonly: true,
             required: true,
         }),
-        messagingMenu: one2one('mail.messaging_menu', {
+        messagingMenu: one2one('MessagingMenu', {
             default: insertAndReplace(),
             isCausal: true,
             readonly: true,

--- a/addons/mail/static/src/models/messaging_menu/messaging_menu.js
+++ b/addons/mail/static/src/models/messaging_menu/messaging_menu.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { attr, one2many } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.messaging_menu',
+    name: 'MessagingMenu',
     identifyingFields: ['messaging'],
     recordMethods: {
         /**

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -2228,7 +2228,7 @@ registerModel({
             inverse: 'ringingThreads',
             readonly: true,
         }),
-        messagingMenuAsPinnedAndUnreadChannel: many2one('mail.messaging_menu', {
+        messagingMenuAsPinnedAndUnreadChannel: many2one('MessagingMenu', {
             compute: '_computeMessagingMenuAsPinnedAndUnreadChannel',
             inverse: 'pinnedAndUnreadChannels',
             readonly: true,


### PR DESCRIPTION
Rename javascript model `mail.messaging_menu` to `MessagingMenu` in order to distinguish javascript models from python models.

Part of task-2701674.