### PR TITLE
[IMP] mail, *: rename messaging notification handler model

### DIFF
--- a/addons/im_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/im_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -4,7 +4,7 @@ import { patchRecordMethods } from '@mail/model/model_core';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/messaging_notification_handler/messaging_notification_handler';
 
-patchRecordMethods('mail.messaging_notification_handler', {
+patchRecordMethods('MessagingNotificationHandler', {
     /**
      * @override
      * @param {object} settings

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -146,7 +146,7 @@ registerModel({
          *
          * [[dbname, 'res.partner', partnerId], { type: 'mark_as_read' }]
          *
-         * @see mail.messaging_notification_handler:_handleNotificationPartnerMarkAsRead()
+         * @see MessagingNotificationHandler:_handleNotificationPartnerMarkAsRead()
          *
          * @param {mail.message[]} messages
          */

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -333,7 +333,7 @@ registerModel({
             isCausal: true,
             readonly: true,
         }),
-        notificationHandler: one2one('mail.messaging_notification_handler', {
+        notificationHandler: one2one('MessagingNotificationHandler', {
             default: insertAndReplace(),
             isCausal: true,
             readonly: true,

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -10,7 +10,7 @@ import { Markup } from 'web.utils';
 const PREVIEW_MSG_MAX_SIZE = 350; // optimal for native English speakers
 
 registerModel({
-    name: 'mail.messaging_notification_handler',
+    name: 'MessagingNotificationHandler',
     identifyingFields: ['messaging'],
     lifecycleHooks: {
         _willDelete() {

--- a/addons/website_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/website_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -4,7 +4,7 @@ import { patchRecordMethods } from '@mail/model/model_core';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/messaging_notification_handler/messaging_notification_handler';
 
-patchRecordMethods('mail.messaging_notification_handler', {
+patchRecordMethods('MessagingNotificationHandler', {
     /**
      * @override
      */


### PR DESCRIPTION
Rename javascript model `mail.messaging_notification_handler` to `MessagingNotificationHandler` in order to distinguish javascript models from python models.

Part of task-2701674.
\* = im_livechat, website_livechat