### PR TITLE
[IMP] mail: rename model model

### DIFF
--- a/addons/mail/static/src/model/model_core.js
+++ b/addons/mail/static/src/model/model_core.js
@@ -73,7 +73,7 @@ export function addLifecycleHooks(modelName, hooks) {
 /**
  * Adds the provided model getters to the model specified by the `modelName`.
  *
- * @deprecated Getters are only used in `mail.model` and are intended to
+ * @deprecated Getters are only used in `Model` and are intended to
  * provide fields such as `env` to all models by inheritance. The creation of
  * these fields will be directly in the model manager in the future.
  * Use fields instead.
@@ -150,7 +150,7 @@ export function addRecordMethods(modelName, recordMethods) {
 /**
  * Adds the provided record getters to the model specified by the `modelName`.
  *
- * @deprecated Getters are only used in `mail.model` and are intended to
+ * @deprecated Getters are only used in `Model` and are intended to
  * provide fields such as `env` to all records by inheritance. The creation of
  * these fields will be directly in the model manager in the future.
  * Use fields instead.

--- a/addons/mail/static/src/model/model_field.js
+++ b/addons/mail/static/src/model/model_field.js
@@ -196,7 +196,7 @@ export class ModelField {
      * default value. Relational fields are always unlinked before the default
      * is applied.
      *
-     * @param {mail.model} record
+     * @param {Model} record
      * @param {options} [options]
      * @returns {boolean} whether the value changed for the current field
      */
@@ -220,7 +220,7 @@ export class ModelField {
      * Compute method when this field is related.
      *
      * @private
-     * @param {mail.model} record
+     * @param {Model} record
      */
     computeRelated(record) {
         const [relationName, relatedFieldName] = this.related.split('.');
@@ -282,7 +282,7 @@ export class ModelField {
      * Decreases the field value by `amount`
      * for an attribute field holding number value,
      *
-     * @param {mail.model} record
+     * @param {Model} record
      * @param {number} amount
      */
     decrement(record, amount) {
@@ -294,7 +294,7 @@ export class ModelField {
      * Get the value associated to this field. Relations must convert record
      * local ids to records.
      *
-     * @param {mail.model} record
+     * @param {Model} record
      * @returns {any}
      */
     get(record) {
@@ -314,7 +314,7 @@ export class ModelField {
      * Increases the field value by `amount`
      * for an attribute field holding number value.
      *
-     * @param {mail.model} record
+     * @param {Model} record
      * @param {number} amount
      */
     increment(record, amount) {
@@ -325,7 +325,7 @@ export class ModelField {
     /**
      * Parses newVal for command(s) and executes them.
      *
-     * @param {mail.model} record
+     * @param {Model} record
      * @param {any} newVal
      * @param {Object} [options]
      * @param {boolean} [options.hasToUpdateInverse] whether updating the
@@ -419,7 +419,7 @@ export class ModelField {
      * Get the raw value associated to this field. For relations, this means
      * the local id or list of local ids of records in this relational field.
      *
-     * @param {mail.model} record
+     * @param {Model} record
      * @returns {any}
      */
     read(record) {
@@ -454,11 +454,11 @@ export class ModelField {
      * an iterable of records.
      *
      * @private
-     * @param {mail.model|mail.model[]} newValue
+     * @param {Model|Model[]} newValue
      * @param {Object} [param1={}]
      * @param {boolean} [param1.hasToVerify=true] whether the value has to be
      *  verified @see `_verifyRelationalValue`
-     * @returns {mail.model[]}
+     * @returns {Model[]}
      */
     _convertX2ManyValue(newValue, { hasToVerify = true } = {}) {
         if (typeof newValue[Symbol.iterator] === 'function') {
@@ -480,9 +480,9 @@ export class ModelField {
      * field based on the given data and the inverse relation value.
      *
      * @private
-     * @param {mail.model} record
+     * @param {Model} record
      * @param {Object|Object[]} data
-     * @returns {mail.model|mail.model[]}
+     * @returns {Model|Model[]}
      */
     _insertOtherRecord(record, data) {
         const OtherModel = record.models[this.to];
@@ -505,7 +505,7 @@ export class ModelField {
      *  Set a value for this attribute field
      *
      * @private
-     * @param {mail.model} record
+     * @param {Model} record
      * @param {any} newVal value to be written on the field value.
      * @returns {boolean} whether the value changed for the current field
      */
@@ -525,7 +525,7 @@ export class ModelField {
      * this field.
      *
      * @private
-     * @param {mail.model} record
+     * @param {Model} record
      * @param {Object|Object[]} data
      * @param {Object} [options]
      * @returns {boolean} whether the value changed for the current field
@@ -541,7 +541,7 @@ export class ModelField {
      * records, which themselves must replace value on this field.
      *
      * @private
-     * @param {mail.model} record
+     * @param {Model} record
      * @param {Object|Object[]} data
      * @param {Object} [options]
      * @returns {boolean} whether the value changed for the current field
@@ -557,7 +557,7 @@ export class ModelField {
      * records, which themselves must be unlinked from this field.
      *
      * @private
-     * @param {mail.model} record
+     * @param {Model} record
      * @param {Object|Object[]} data
      * @param {Object} [options]
      * @returns {boolean} whether the value changed for the current field
@@ -571,7 +571,7 @@ export class ModelField {
      * Set a 'link' operation on this relational field.
      *
      * @private
-     * @param {mail.model|mail.model[]} newValue
+     * @param {Model|Model[]} newValue
      * @param {Object} [options]
      * @returns {boolean} whether the value changed for the current field
      */
@@ -590,8 +590,8 @@ export class ModelField {
      * Handling of a `set` 'link' of a x2many relational field.
      *
      * @private
-     * @param {mail.model} record
-     * @param {mail.model|mail.model[]} newValue
+     * @param {Model} record
+     * @param {Model|Model[]} newValue
      * @param {Object} [param2={}]
      * @param {boolean} [param2.hasToUpdateInverse=true] whether updating the
      *  current field should also update its inverse field. Typically set to
@@ -629,8 +629,8 @@ export class ModelField {
      * Handling of a `set` 'link' of an x2one relational field.
      *
      * @private
-     * @param {mail.model} record
-     * @param {mail.model} recordToLink
+     * @param {Model} record
+     * @param {Model} recordToLink
      * @param {Object} [param2={}]
      * @param {boolean} [param2.hasToUpdateInverse=true] whether updating the
      *  current field should also update its inverse field. Typically set to
@@ -666,8 +666,8 @@ export class ModelField {
      * Set a 'replace' operation on this relational field.
      *
      * @private
-     * @param {mail.model} record
-     * @param {mail.model|mail.model[]} newValue
+     * @param {Model} record
+     * @param {Model|Model[]} newValue
      * @param {Object} [options]
      * @returns {boolean} whether the value changed for the current field
      */
@@ -731,8 +731,8 @@ export class ModelField {
      * Set an 'unlink' operation on this relational field.
      *
      * @private
-     * @param {mail.model} record
-     * @param {mail.model|mail.model[]} newValue
+     * @param {Model} record
+     * @param {Model|Model[]} newValue
      * @param {Object} [options]
      * @returns {boolean} whether the value changed for the current field
      */
@@ -751,8 +751,8 @@ export class ModelField {
      * Handling of a `set` 'unlink' of a x2many relational field.
      *
      * @private
-     * @param {mail.model} record
-     * @param {mail.model|mail.model[]} newValue
+     * @param {Model} record
+     * @param {Model|Model[]} newValue
      * @param {Object} [param2={}]
      * @param {boolean} [param2.hasToUpdateInverse=true] whether updating the
      *  current field should also update its inverse field. Typically set to
@@ -803,7 +803,7 @@ export class ModelField {
      * Handling of a `set` 'unlink' of a x2one relational field.
      *
      * @private
-     * @param {mail.model} record
+     * @param {Model} record
      * @param {Object} [param1={}]
      * @param {boolean} [param1.hasToUpdateInverse=true] whether updating the
      *  current field should also update its inverse field. Typically set to
@@ -848,7 +848,7 @@ export class ModelField {
      * and it must originates from relational `to` model (or its subclasses).
      *
      * @private
-     * @param {mail.model} record
+     * @param {Model} record
      * @throws {Error} if record does not satisfy related model
      */
     _verifyRelationalValue(record) {

--- a/addons/mail/static/src/model/model_field_command.js
+++ b/addons/mail/static/src/model/model_field_command.js
@@ -114,7 +114,7 @@ function insertAndReplace(data = {}) {
  * - Or add the record(s) given by `newValue` which are not in the currecnt field value
  * to the field value for an x2many field.
  *
- * @param {mail.model|mail.model[]} newValue - record or records array to be linked.
+ * @param {Model|Model[]} newValue - record or records array to be linked.
  * @returns {FieldCommand}
  */
 function link(newValue) {
@@ -130,7 +130,7 @@ function link(newValue) {
  * link the missing values, and then sort field value by the order they are given in `newValue`
  * for a x2many field.
  *
- * @param {mail.model|mail.model[]} newValue - record or records array to be replaced.
+ * @param {Model|Model[]} newValue - record or records array to be replaced.
  * @returns {FieldCommand}
  */
 function replace(newValue) {
@@ -155,7 +155,7 @@ function set(newValue) {
  * - or remove the record(s) given by `data` which are in the current field value
  *  for a x2many field.
  *
- * @param {mail.model|mail.model[]} [data] - record or records array to be unlinked.
+ * @param {Model|Model[]} [data] - record or records array to be unlinked.
  * `data` will be ignored if the field is x2one type.
  * @returns {FieldCommand}
  */

--- a/addons/mail/static/src/model/model_field_relation_set.js
+++ b/addons/mail/static/src/model/model_field_relation_set.js
@@ -11,7 +11,7 @@ import { followRelations } from '@mail/model/model_utils';
 export class RelationSet {
 
     /**
-     * @param {mail.model} record
+     * @param {Model} record
      * @param {ModelField} field
      */
     constructor(record, field) {

--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -157,9 +157,9 @@ export class ModelManager {
     /**
      * Returns all records of provided model that match provided criteria.
      *
-     * @param {mail.model} Model class
+     * @param {Model} Model class
      * @param {function} [filterFunc]
-     * @returns {mail.model[]} records matching criteria.
+     * @returns {Model[]} records matching criteria.
      */
     all(Model, filterFunc) {
         for (const listener of this._listeners) {
@@ -194,7 +194,7 @@ export class ModelManager {
      * existed. Note that relation are removed, which may delete more relations
      * if some of them are causal.
      *
-     * @param {mail.model} record
+     * @param {Model} record
      */
     delete(record) {
         this._delete(record);
@@ -204,8 +204,8 @@ export class ModelManager {
     /**
      * Returns whether the given record still exists.
      *
-     * @param {mail.model} Model class
-     * @param {mail.model} record
+     * @param {Model} Model class
+     * @param {Model} record
      * @returns {boolean}
      */
     exists(Model, record) {
@@ -217,9 +217,9 @@ export class ModelManager {
      * Get the record of provided model that has provided
      * criteria, if it exists.
      *
-     * @param {mail.model} Model class
+     * @param {Model} Model class
      * @param {function} findFunc
-     * @returns {mail.model|undefined} the record of model matching criteria, if
+     * @returns {Model|undefined} the record of model matching criteria, if
      *   exists.
      */
     find(Model, findFunc) {
@@ -230,9 +230,9 @@ export class ModelManager {
      * Gets the unique record of provided model that matches the given
      * identifying data, if it exists.
      *
-     * @param {mail.model} Model class
+     * @param {Model} Model class
      * @param {Object} data
-     * @returns {mail.model|undefined}
+     * @returns {Model|undefined}
      */
     findFromIdentifyingData(Model, data) {
         return this.get(Model, this._getRecordIndex(Model, data));
@@ -245,11 +245,11 @@ export class ModelManager {
      * id, if the resulting record is not an instance of this model, this getter
      * assumes the record does not exist.
      *
-     * @param {mail.model} Model class
+     * @param {Model} Model class
      * @param {string} localId
      * @param {Object} param2
      * @param {boolean} [param2.isCheckingInheritance=false]
-     * @returns {mail.model|undefined} record, if exists
+     * @returns {Model|undefined} record, if exists
      */
     get(Model, localId, { isCheckingInheritance = false } = {}) {
         if (!localId) {
@@ -284,7 +284,7 @@ export class ModelManager {
         if (!isCheckingInheritance) {
             return;
         }
-        // support for inherited models (eg. relation targeting `mail.model`)
+        // support for inherited models (eg. relation targeting `Model`)
         for (const SubModel of Object.values(this.models)) {
             if (!(SubModel.prototype instanceof Model)) {
                 continue;
@@ -315,10 +315,10 @@ export class ModelManager {
      * provided data. This method assumes that records are uniquely identifiable
      * per "unique find" criteria from data on Model.
      *
-     * @param {mail.model} Model class
+     * @param {Model} Model class
      * @param {Object|Object[]} data
      *  If data is an iterable, multiple records will be created/updated.
-     * @returns {mail.model|mail.model[]} created or updated record(s).
+     * @returns {Model|Model[]} created or updated record(s).
      */
     insert(Model, data) {
         const res = this._insert(Model, data);
@@ -393,7 +393,7 @@ export class ModelManager {
      * ones from `data`) and then indirect ones (i.e. compute/related fields
      * and "after updates").
      *
-     * @param {mail.model} record
+     * @param {Model} record
      * @param {Object} data
      * @returns {boolean} whether any value changed for the current record
      */
@@ -412,7 +412,7 @@ export class ModelManager {
      * given model.
      *
      * @private
-     * @param {mail.model} Model class
+     * @param {Model} Model class
      * @param {Object} [data={}]
      */
     _addDefaultData(Model, data = {}) {
@@ -433,7 +433,7 @@ export class ModelManager {
      * definition to the Model, then registers it in `this.models`.
      *
      * @private
-     * @param {mail.model} Model
+     * @param {Model} Model
      */
     _applyModelDefinition(Model) {
         const definition = registry.get(Model.name);
@@ -627,7 +627,7 @@ export class ModelManager {
                 if (inverseField.inverse !== fieldName) {
                     throw new Error(`The name of ${field} on ${Model} does not match with the name defined in its inverse ${inverseField} on ${RelatedModel}.`);
                 }
-                if (![Model.name, 'mail.model'].includes(inverseField.to)) {
+                if (![Model.name, 'Model'].includes(inverseField.to)) {
                     throw new Error(`${field} on ${Model} has its inverse ${inverseField} on ${RelatedModel} referring to an invalid model (model(${inverseField.to})).`);
                 }
                 if (
@@ -663,9 +663,9 @@ export class ModelManager {
 
     /**
      * @private
-     * @param {mail.model} Model class
+     * @param {Model} Model class
      * @param {string} localId
-     * @returns {mail.model}
+     * @returns {Model}
      */
     _create(Model, localId) {
         /**
@@ -747,7 +747,7 @@ export class ModelManager {
 
     /**
      * @private
-     * @param {mail.model} record
+     * @param {Model} record
      */
     _delete(record) {
         this._ensureNoLockingListener();
@@ -944,13 +944,13 @@ export class ModelManager {
     _generateModels() {
         // Create the model through a class to give it a meaningful name to be
         // displayed in stack traces and stuff.
-        const Model = { 'mail.model': class {} }['mail.model'];
+        const Model = { 'Model': class {} }['Model'];
         this._applyModelDefinition(Model);
-        // mail.model is generated separately and before the other models since
+        // Model is generated separately and before the other models since
         // it is the dependency of all of them.
-        const allModelNamesButMailModel = [...registry.keys()].filter(name => name !== 'mail.model');
+        const allModelNamesButMailModel = [...registry.keys()].filter(name => name !== 'Model');
         for (const modelName of allModelNamesButMailModel) {
-            const Model = { [modelName]: class extends this.models['mail.model'] {} }[modelName];
+            const Model = { [modelName]: class extends this.models['Model'] {} }[modelName];
             this._applyModelDefinition(Model);
         }
         /**
@@ -973,8 +973,8 @@ export class ModelManager {
     /**
      * Returns an index on the given model for the given data.
      *
-     * @param {mail.model} Model class
-     * @param {Object|mail.model} data insert data or record
+     * @param {Model} Model class
+     * @param {Object|Model} data insert data or record
      * @returns {string}
      */
     _getRecordIndex(Model, data) {
@@ -1026,9 +1026,9 @@ export class ModelManager {
 
     /**
      * @private
-     * @param {mail.model}
+     * @param {Model}
      * @param {Object|Object[]} [data={}]
-     * @returns {mail.model|mail.model[]}
+     * @returns {Model|Model[]}
      */
     _insert(Model, data = {}) {
         this._ensureNoLockingListener();
@@ -1051,7 +1051,7 @@ export class ModelManager {
 
     /**
      * @private
-     * @param {mail.model} Model class
+     * @param {Model} Model class
      * @param {ModelField} field
      * @returns {ModelField}
      */
@@ -1109,7 +1109,7 @@ export class ModelManager {
     /**
      * Marks the given field of the given record as changed.
      *
-     * @param {mail.model} record
+     * @param {Model} record
      * @param {ModelField} field
      */
     _markRecordFieldAsChanged(record, field) {
@@ -1288,7 +1288,7 @@ export class ModelManager {
 
     /**
      * @private
-     * @param {mail.model} record
+     * @param {Model} record
      * @param {Object} data
      * @param {Object} [options]
      * @param [options.allowWriteReadonly=false]

--- a/addons/mail/static/src/model/model_utils.js
+++ b/addons/mail/static/src/model/model_utils.js
@@ -5,7 +5,7 @@
  * the resulting value, or undefined if a relation can't be followed because it
  * is undefined.
  *
- * @param {mail.model} record
+ * @param {Model} record
  * @param {string} relatedPath field names, dot separated to follow relations
  * @returns {any}
  */

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -420,7 +420,7 @@ registerModel({
          * the active current record is no longer part of the suggestions.
          *
          * @private
-         * @returns {mail.model}
+         * @returns {Model}
          */
         _computeActiveSuggestedRecord() {
             if (
@@ -476,7 +476,7 @@ registerModel({
          * main list, which is a requirement for the navigation process.
          *
          * @private
-         * @returns {mail.model[]}
+         * @returns {Model[]}
          */
         _computeExtraSuggestedRecords() {
             if (this.suggestionDelimiterPosition === undefined) {
@@ -495,7 +495,7 @@ registerModel({
          * Clears the main suggested record on closing mentions.
          *
          * @private
-         * @returns {mail.model[]}
+         * @returns {Model[]}
          */
         _computeMainSuggestedRecords() {
             if (this.suggestionDelimiterPosition === undefined) {
@@ -847,7 +847,7 @@ registerModel({
          * is highlighted in the UI and it will be the selected record if the
          * suggestion is confirmed by the user.
          */
-        activeSuggestedRecord: many2one('mail.model', {
+        activeSuggestedRecord: many2one('Model', {
             compute: '_computeActiveSuggestedRecord',
         }),
         /**
@@ -884,7 +884,7 @@ registerModel({
          * process. 2 arbitrary lists can be provided and the second is defined
          * as "extra".
          */
-        extraSuggestedRecords: many2many('mail.model', {
+        extraSuggestedRecords: many2many('Model', {
             compute: '_computeExtraSuggestedRecords',
         }),
         hasFocus: attr({
@@ -911,7 +911,7 @@ registerModel({
          * process. 2 arbitrary lists can be provided and the first is defined
          * as "main".
          */
-        mainSuggestedRecords: many2many('mail.model', {
+        mainSuggestedRecords: many2many('Model', {
             compute: '_computeMainSuggestedRecords',
         }),
         /**

--- a/addons/mail/static/src/models/dialog/dialog.js
+++ b/addons/mail/static/src/models/dialog/dialog.js
@@ -54,7 +54,7 @@ registerModel({
          * a UI component, such as AttachmentViewer. These records must be
          * created from @see `mail.dialog_manager:open()`.
          */
-        record: one2one('mail.model', {
+        record: one2one('Model', {
             compute: '_computeRecord',
             isCausal: true,
             readonly: true,

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -221,7 +221,7 @@ registerModel({
          * Inverse of the messaging field present on all models. This field
          * therefore contains all existing records.
          */
-        allRecords: one2many('mail.model', {
+        allRecords: one2many('Model', {
             inverse: 'messaging',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/model/model.js
+++ b/addons/mail/static/src/models/model/model.js
@@ -16,7 +16,7 @@ registerModel({
      * Name of the model. Important to refer to appropriate model like in
      * relational fields. Name of models must be unique.
      */
-    name: 'mail.model',
+    name: 'Model',
      /**
      * Determines which fields are identifying fields for this model. Must be
      * overwritten in actual models. This should be a list of either field name
@@ -66,7 +66,7 @@ registerModel({
          * Returns all records of this model that match provided criteria.
          *
          * @param {function} [filterFunc]
-         * @returns {mail.model[]}
+         * @returns {Model[]}
          */
         all(filterFunc) {
             return this.modelManager.all(this, filterFunc);
@@ -81,7 +81,7 @@ registerModel({
          * Get the record that has provided criteria, if it exists.
          *
          * @param {function} findFunc
-         * @returns {mail.model|undefined}
+         * @returns {Model|undefined}
          */
         find(findFunc) {
             return this.modelManager.find(this, findFunc);
@@ -91,7 +91,7 @@ registerModel({
          * exists.
          *
          * @param {Object} data
-         * @returns {mail.model|undefined}
+         * @returns {Model|undefined}
          */
         findFromIdentifyingData(data) {
             return this.modelManager.findFromIdentifyingData(this, data);
@@ -106,7 +106,7 @@ registerModel({
          * @param {string} localId
          * @param {Object} param1
          * @param {boolean} [param1.isCheckingInheritance]
-         * @returns {mail.model|undefined}
+         * @returns {Model|undefined}
          */
         get(localId, { isCheckingInheritance } = {}) {
             return this.modelManager.get(this, localId, { isCheckingInheritance });
@@ -119,7 +119,7 @@ registerModel({
          *
          * @param {Object|Object[]} [data={}]
          *  If data is an iterable, multiple records will be created/updated.
-         * @returns {mail.model|mail.model[]} created or updated record(s).
+         * @returns {Model|Model[]} created or updated record(s).
          */
         insert(data = {}) {
             return this.modelManager.insert(this, data);


### PR DESCRIPTION
Rename javascript model `mail.model` to `Model` in order to distinguish javascript models from python models.

Part of task-2701674.