### PR TITLE
[FIX] web: missing context during resequence

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -1017,6 +1017,7 @@ var BasicModel = AbstractModel.extend({
         var params = {
             model: modelName,
             ids: resIDs,
+            context: data.getContext(),
         };
         if (options.offset) {
             params.offset = options.offset;
@@ -1040,6 +1041,7 @@ var BasicModel = AbstractModel.extend({
                     model: modelName,
                     method: 'read',
                     args: [resIDs, [field]],
+                    context: data.getContext(),
                 }).then(function (records) {
                     if (data.data.length) {
                         var dataType = self.localData[data.data[0]].type;

--- a/addons/web/static/tests/views/basic_model_tests.js
+++ b/addons/web/static/tests/views/basic_model_tests.js
@@ -65,6 +65,41 @@ odoo.define('web.basic_model_tests', function (require) {
     }, function () {
         QUnit.module('BasicModel');
 
+        QUnit.test('context is given when using a resequence', async function (assert) {
+            assert.expect(2);
+            delete this.params["res_id"];
+            this.data.product.fields.sequence = {string: "Sequence", type: "integer"};
+
+            const model = createModel({
+                Model: BasicModel,
+                data: this.data,
+                mockRPC: function (route, args) {
+                    if (route === '/web/dataset/resequence') {
+                        assert.deepEqual(args.context, { active_field: 2 },
+                            "context should be correct after a resequence");
+                    }
+                    else if (args.method === "read") {
+                        assert.deepEqual(args.kwargs.context, { active_field: 2 },
+                            "context should be correct after a 'read' RPC");
+                    }
+                    return this._super.apply(this, arguments);
+                },
+            });
+            const params = _.extend(this.params, {
+                context: { active_field: 2 },
+                groupedBy: ['product_id'],
+                fieldNames: ['foo'],
+            });
+    
+            model.load(params)
+                .then(function (stateID) {
+                    return model.resequence('product', [41, 37], stateID);
+                })
+                .then(function () {
+                    model.destroy();
+                });
+        });
+
         QUnit.test('can process x2many commands', async function (assert) {
             assert.expect(5);
 

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -5448,6 +5448,7 @@ QUnit.module('Views', {
                 if (route === '/web/dataset/resequence') {
                     if (moves === 0) {
                         assert.deepEqual(args, {
+                            context: {},
                             model: "foo",
                             ids: [4, 3],
                             offset: 13,
@@ -5456,6 +5457,7 @@ QUnit.module('Views', {
                     }
                     if (moves === 1) {
                         assert.deepEqual(args, {
+                            context: {},
                             model: "foo",
                             ids: [4, 2],
                             offset: 12,
@@ -5464,6 +5466,7 @@ QUnit.module('Views', {
                     }
                     if (moves === 2) {
                         assert.deepEqual(args, {
+                            context: {},
                             model: "foo",
                             ids: [2, 4],
                             offset: 12,
@@ -5472,6 +5475,7 @@ QUnit.module('Views', {
                     }
                     if (moves === 3) {
                         assert.deepEqual(args, {
+                            context: {},
                             model: "foo",
                             ids: [4, 2],
                             offset: 12,


### PR DESCRIPTION
Problem 1: The context was not passed when calling the resequence function.
Problem 2: Also, the subsequent read operation did not pass the full
context, but only the context of the user, not the context of the action.
A test has been added for the basic model to check that the context is properly
given after a resequence.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
