### PR TITLE
[FIX] im_livechat: livechat visitor country displayed twice in backend

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -88,7 +88,6 @@ class LivechatController(http.Controller):
                 country_code = request.session.geoip.get('country_code', "")
                 country = request.env['res.country'].sudo().search([('code', '=', country_code)], limit=1) if country_code else None
                 if country:
-                    anonymous_name = "%s (%s)" % (anonymous_name, country.name)
                     country_id = country.id
 
         if previous_operator_id:

--- a/addons/website_livechat/models/im_livechat_channel.py
+++ b/addons/website_livechat/models/im_livechat_channel.py
@@ -12,8 +12,6 @@ class ImLivechatChannel(models.Model):
         visitor_sudo = self.env['website.visitor']._get_visitor_from_request()
         if visitor_sudo:
             mail_channel_vals['livechat_visitor_id'] = visitor_sudo.id
-            if not user_id:
-                mail_channel_vals['anonymous_name'] = visitor_sudo.display_name + (' (%s)' % visitor_sudo.country_id.name if visitor_sudo.country_id else '')
             # As chat requested by the visitor, delete the chat requested by an operator if any to avoid conflicts between two flows
             # TODO DBE : Move this into the proper method (open or init mail channel)
             chat_request_channel = self.env['mail.channel'].sudo().search([('livechat_visitor_id', '=', visitor_sudo.id), ('livechat_active', '=', True)])


### PR DESCRIPTION
**Current behavior before PR:**

At least if website_livechat is installed, the livechat visitor (website visitor)
country is displayed twice in channel name: once from the country inside the
name of "livechat_visitor" and once from the country of the actual
website_visitor.

**Desired behavior after PR is merged:**

Livechat visitor country will be displayed only once instead of twice

**LINKS:**
Task-2668051

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
