### PR TITLE
[IMP] mail, sms, snailmail: rename notification group model

### DIFF
--- a/addons/mail/static/src/components/notification_group/notification_group.js
+++ b/addons/mail/static/src/components/notification_group/notification_group.js
@@ -24,10 +24,10 @@ export class NotificationGroup extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.notification_group}
+     * @returns {NotificationGroup}
      */
     get group() {
-        return this.messaging && this.messaging.models['mail.notification_group'].get(this.props.notificationGroupLocalId);
+        return this.messaging && this.messaging.models['NotificationGroup'].get(this.props.notificationGroupLocalId);
     }
 
     /**

--- a/addons/mail/static/src/components/notification_list/notification_list.js
+++ b/addons/mail/static/src/components/notification_list/notification_list.js
@@ -91,7 +91,7 @@ export class NotificationList extends Component {
             });
         let notifications = threadNeedactionNotifications.concat(threadNotifications);
         if (this.props.filter === 'all') {
-            notifications = Object.values(this.messaging.models['mail.notification_group'].all())
+            notifications = Object.values(this.messaging.models['NotificationGroup'].all())
                 .sort((group1, group2) => group1.sequence - group2.sequence)
                 .map(notificationGroup => {
                     return {

--- a/addons/mail/static/src/models/messaging_menu/messaging_menu.js
+++ b/addons/mail/static/src/models/messaging_menu/messaging_menu.js
@@ -41,7 +41,7 @@ registerModel({
             }
             const inboxCounter = this.messaging.inbox ? this.messaging.inbox.counter : 0;
             const unreadChannelsCounter = this.pinnedAndUnreadChannels.length;
-            const notificationGroupsCounter = this.messaging.models['mail.notification_group'].all().reduce(
+            const notificationGroupsCounter = this.messaging.models['NotificationGroup'].all().reduce(
                 (total, group) => total + group.notifications.length,
                 0
             );

--- a/addons/mail/static/src/models/notification/notification.js
+++ b/addons/mail/static/src/models/notification/notification.js
@@ -143,7 +143,7 @@ registerModel({
         message: many2one('mail.message', {
             inverse: 'notifications',
         }),
-        notificationGroup: many2one('mail.notification_group', {
+        notificationGroup: many2one('NotificationGroup', {
             compute: '_computeNotificationGroup',
             inverse: 'notifications',
         }),

--- a/addons/mail/static/src/models/notification_group/notification_group.js
+++ b/addons/mail/static/src/models/notification_group/notification_group.js
@@ -6,7 +6,7 @@ import { clear, insert, unlink } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
-    name: 'mail.notification_group',
+    name: 'NotificationGroup',
     identifyingFields: ['res_model', 'res_id', 'notification_type'],
     recordMethods: {
         /**

--- a/addons/sms/static/src/models/notification_group/notification_group.js
+++ b/addons/sms/static/src/models/notification_group/notification_group.js
@@ -4,7 +4,7 @@ import { patchRecordMethods } from '@mail/model/model_core';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/notification_group/notification_group';
 
-patchRecordMethods('mail.notification_group', {
+patchRecordMethods('NotificationGroup', {
     /**
      * @override
      */

--- a/addons/snailmail/static/src/models/notification_group/notification_group.js
+++ b/addons/snailmail/static/src/models/notification_group/notification_group.js
@@ -4,7 +4,7 @@ import { patchRecordMethods } from '@mail/model/model_core';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/notification_group/notification_group';
 
-patchRecordMethods('mail.notification_group', {
+patchRecordMethods('NotificationGroup', {
     /**
      * @override
      */


### PR DESCRIPTION
Rename javascript model `mail.notification_group` to `NotificationGroup` in order to distinguish javascript models from python models.

Part of task-2701674.