### PR TITLE
[IMP] mail, *: rename partner model

### DIFF
--- a/addons/hr/static/src/models/employee/employee.js
+++ b/addons/hr/static/src/models/employee/employee.js
@@ -161,7 +161,7 @@ registerModel({
         /**
          * Partner related to this employee.
          */
-        partner: one2one('mail.partner', {
+        partner: one2one('Partner', {
             inverse: 'employee',
             related: 'user.partner',
         }),

--- a/addons/hr/static/src/models/partner/partner.js
+++ b/addons/hr/static/src/models/partner/partner.js
@@ -5,7 +5,7 @@ import { attr, one2one } from '@mail/model/model_field';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/partner/partner';
 
-addRecordMethods('mail.partner', {
+addRecordMethods('Partner', {
     /**
      * Checks whether this partner has a related employee and links them if
      * applicable.
@@ -20,7 +20,7 @@ addRecordMethods('mail.partner', {
     },
 });
 
-patchRecordMethods('mail.partner', {
+patchRecordMethods('Partner', {
     /**
      * When a partner is an employee, its employee profile contains more useful
      * information to know who he is than its partner profile.
@@ -40,7 +40,7 @@ patchRecordMethods('mail.partner', {
     },
 });
 
-addFields('mail.partner', {
+addFields('Partner', {
     /**
      * Employee related to this partner. It is computed through
      * the inverse relation and should be considered read-only.

--- a/addons/hr_holidays/static/src/components/partner_im_status_icon/tests/partner_im_status_icon_tests.js
+++ b/addons/hr_holidays/static/src/components/partner_im_status_icon/tests/partner_im_status_icon_tests.js
@@ -38,7 +38,7 @@ QUnit.test('on leave & online', async function (assert) {
     assert.expect(2);
 
     await this.start();
-    const partner = this.messaging.models['mail.partner'].create({
+    const partner = this.messaging.models['Partner'].create({
         id: 7,
         name: "Demo User",
         im_status: 'leave_online',
@@ -60,7 +60,7 @@ QUnit.test('on leave & away', async function (assert) {
     assert.expect(2);
 
     await this.start();
-    const partner = this.messaging.models['mail.partner'].create({
+    const partner = this.messaging.models['Partner'].create({
         id: 7,
         name: "Demo User",
         im_status: 'leave_away',
@@ -82,7 +82,7 @@ QUnit.test('on leave & offline', async function (assert) {
     assert.expect(2);
 
     await this.start();
-    const partner = this.messaging.models['mail.partner'].create({
+    const partner = this.messaging.models['Partner'].create({
         id: 7,
         name: "Demo User",
         im_status: 'leave_offline',

--- a/addons/hr_holidays/static/src/models/partner/partner.js
+++ b/addons/hr_holidays/static/src/models/partner/partner.js
@@ -8,7 +8,7 @@ import '@mail/models/partner/partner';
 
 import { str_to_date } from 'web.time';
 
-patchModelMethods('mail.partner', {
+patchModelMethods('Partner', {
     /**
      * @override
      */
@@ -21,7 +21,7 @@ patchModelMethods('mail.partner', {
     },
 });
 
-addRecordMethods('mail.partner', {
+addRecordMethods('Partner', {
     /**
      * @private
      */
@@ -44,7 +44,7 @@ addRecordMethods('mail.partner', {
     },
 });
 
-patchRecordMethods('mail.partner', {
+patchRecordMethods('Partner', {
     /**
      * @override
      */
@@ -56,7 +56,7 @@ patchRecordMethods('mail.partner', {
     },
 });
 
-addFields('mail.partner', {
+addFields('Partner', {
     /**
      * Date of end of the out of office period of the partner as string.
      * String is expected to use Odoo's date string format

--- a/addons/im_livechat/static/src/models/partner/partner.js
+++ b/addons/im_livechat/static/src/models/partner/partner.js
@@ -6,7 +6,7 @@ import '@mail/models/partner/partner';
 
 let nextPublicId = -1;
 
-addModelMethods('mail.partner', {
+addModelMethods('Partner', {
     getNextPublicId() {
         const id = nextPublicId;
         nextPublicId -= 1;

--- a/addons/im_livechat/static/src/models/thread/thread.js
+++ b/addons/im_livechat/static/src/models/thread/thread.js
@@ -34,16 +34,16 @@ patchModelMethods('Thread', {
                  * easier to handle one temporary partner per channel.
                  */
                 data2.members.push(unlink(this.messaging.publicPartners));
-                const partner = this.messaging.models['mail.partner'].create(
+                const partner = this.messaging.models['Partner'].create(
                     Object.assign(
-                        this.messaging.models['mail.partner'].convertData(data.livechat_visitor),
-                        { id: this.messaging.models['mail.partner'].getNextPublicId() }
+                        this.messaging.models['Partner'].convertData(data.livechat_visitor),
+                        { id: this.messaging.models['Partner'].getNextPublicId() }
                     )
                 );
                 data2.members.push(link(partner));
                 data2.correspondent = link(partner);
             } else {
-                const partnerData = this.messaging.models['mail.partner'].convertData(data.livechat_visitor);
+                const partnerData = this.messaging.models['Partner'].convertData(data.livechat_visitor);
                 data2.members.push(insert(partnerData));
                 data2.correspondent = insert(partnerData);
             }

--- a/addons/mail/static/src/components/chat_window/chat_window.js
+++ b/addons/mail/static/src/components/chat_window/chat_window.js
@@ -160,7 +160,7 @@ export class ChatWindow extends Component {
      * @param {function} res
      */
     _onAutocompleteSource(req, res) {
-        this.messaging.models['mail.partner'].imSearch({
+        this.messaging.models['Partner'].imSearch({
             callback: (partners) => {
                 const suggestions = partners.map(partner => {
                     return {

--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
@@ -40,7 +40,7 @@ export class ComposerSuggestion extends Component {
     }
 
     get isPartner() {
-        return this.props.modelName === "mail.partner";
+        return this.props.modelName === "Partner";
     }
 
     get record() {

--- a/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_partner_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_partner_tests.js
@@ -31,14 +31,14 @@ QUnit.test('partner mention suggestion displayed', async function (assert) {
         id: 20,
         model: 'mail.channel',
     });
-    const partner = this.messaging.models['mail.partner'].create({
+    const partner = this.messaging.models['Partner'].create({
         id: 7,
         im_status: 'online',
         name: "Demo User",
     });
     await createComposerSuggestionComponent(thread.composer, {
         isActive: true,
-        modelName: 'mail.partner',
+        modelName: 'Partner',
         recordLocalId: partner.localId,
     });
 
@@ -58,7 +58,7 @@ QUnit.test('partner mention suggestion correct data', async function (assert) {
         id: 20,
         model: 'mail.channel',
     });
-    const partner = this.messaging.models['mail.partner'].create({
+    const partner = this.messaging.models['Partner'].create({
         email: "demo_user@odoo.com",
         id: 7,
         im_status: 'online',
@@ -66,7 +66,7 @@ QUnit.test('partner mention suggestion correct data', async function (assert) {
     });
     await createComposerSuggestionComponent(thread.composer, {
         isActive: true,
-        modelName: 'mail.partner',
+        modelName: 'Partner',
         recordLocalId: partner.localId,
     });
 
@@ -111,14 +111,14 @@ QUnit.test('partner mention suggestion active', async function (assert) {
         id: 20,
         model: 'mail.channel',
     });
-    const partner = this.messaging.models['mail.partner'].create({
+    const partner = this.messaging.models['Partner'].create({
         id: 7,
         im_status: 'online',
         name: "Demo User",
     });
     await createComposerSuggestionComponent(thread.composer, {
         isActive: true,
-        modelName: 'mail.partner',
+        modelName: 'Partner',
         recordLocalId: partner.localId,
     });
 

--- a/addons/mail/static/src/components/message/tests/message_tests.js
+++ b/addons/mail/static/src/components/message/tests/message_tests.js
@@ -281,7 +281,7 @@ QUnit.test("'channel_fetch' notification received is correctly handled", async f
         members: [this.data.currentPartnerId, 11],
     });
     const { createThreadViewComponent } = await this.start();
-    const currentPartner = this.messaging.models['mail.partner'].insert({
+    const currentPartner = this.messaging.models['Partner'].insert({
         id: this.messaging.currentPartner.id,
         display_name: "Demo User",
     });
@@ -346,7 +346,7 @@ QUnit.test("'channel_seen' notification received is correctly handled", async fu
         members: [this.data.currentPartnerId, 11],
     });
     const { createThreadViewComponent } = await this.start();
-    const currentPartner = this.messaging.models['mail.partner'].insert({
+    const currentPartner = this.messaging.models['Partner'].insert({
         id: this.messaging.currentPartner.id,
         display_name: "Demo User",
     });
@@ -410,7 +410,7 @@ QUnit.test("'channel_fetch' notification then 'channel_seen' received  are corre
         members: [this.data.currentPartnerId, 11],
     });
     const { createThreadViewComponent } = await this.start();
-    const currentPartner = this.messaging.models['mail.partner'].insert({
+    const currentPartner = this.messaging.models['Partner'].insert({
         id: this.messaging.currentPartner.id,
         display_name: "Demo User",
     });
@@ -482,7 +482,7 @@ QUnit.test('do not show messaging seen indicator if not authored by me', async f
     assert.expect(2);
 
     const { createThreadViewComponent } = await this.start();
-    const author = this.messaging.models['mail.partner'].create({
+    const author = this.messaging.models['Partner'].create({
         id: 100,
         display_name: "Demo User"
     });
@@ -530,7 +530,7 @@ QUnit.test('do not show messaging seen indicator if before last seen by all mess
     assert.expect(3);
 
     await this.start();
-    const currentPartner = this.messaging.models['mail.partner'].insert({
+    const currentPartner = this.messaging.models['Partner'].insert({
         id: this.messaging.currentPartner.id,
         display_name: "Demo User",
     });
@@ -597,7 +597,7 @@ QUnit.test('only show messaging seen indicator if authored by me, after last see
     assert.expect(3);
 
     const { createThreadViewComponent } = await this.start();
-    const currentPartner = this.messaging.models['mail.partner'].insert({
+    const currentPartner = this.messaging.models['Partner'].insert({
         id: this.messaging.currentPartner.id,
         display_name: "Demo User"
     });
@@ -919,7 +919,7 @@ QUnit.test('open chat with author on avatar click should be disabled when curren
     const { createThreadViewComponent } = await this.start({
         hasChatWindow: true,
     });
-    const correspondent = this.messaging.models['mail.partner'].insert({ id: 10 });
+    const correspondent = this.messaging.models['Partner'].insert({ id: 10 });
     const thread = await correspondent.getChat();
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,

--- a/addons/mail/static/src/components/messaging_menu/messaging_menu.js
+++ b/addons/mail/static/src/components/messaging_menu/messaging_menu.js
@@ -155,7 +155,7 @@ export class MessagingMenu extends Component {
      */
     _onMobileNewMessageInputSource(req, res) {
         const value = _.escape(req.term);
-        this.messaging.models['mail.partner'].imSearch({
+        this.messaging.models['Partner'].imSearch({
             callback: partners => {
                 const suggestions = partners.map(partner => {
                     return {

--- a/addons/mail/static/src/components/partner_im_status_icon/partner_im_status_icon.js
+++ b/addons/mail/static/src/components/partner_im_status_icon/partner_im_status_icon.js
@@ -11,10 +11,10 @@ export class PartnerImStatusIcon extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.partner}
+     * @returns {Partner}
      */
     get partner() {
-        return this.messaging && this.messaging.models['mail.partner'].get(this.props.partnerLocalId);
+        return this.messaging && this.messaging.models['Partner'].get(this.props.partnerLocalId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/components/partner_im_status_icon/tests/partner_im_status_icon_tests.js
+++ b/addons/mail/static/src/components/partner_im_status_icon/tests/partner_im_status_icon_tests.js
@@ -39,7 +39,7 @@ QUnit.test('initially online', async function (assert) {
     assert.expect(3);
 
     await this.start();
-    const partner = this.messaging.models['mail.partner'].create({
+    const partner = this.messaging.models['Partner'].create({
         id: 7,
         name: "Demo User",
         im_status: 'online',
@@ -66,7 +66,7 @@ QUnit.test('initially offline', async function (assert) {
     assert.expect(1);
 
     await this.start();
-    const partner = this.messaging.models['mail.partner'].create({
+    const partner = this.messaging.models['Partner'].create({
         id: 7,
         name: "Demo User",
         im_status: 'offline',
@@ -83,7 +83,7 @@ QUnit.test('initially away', async function (assert) {
     assert.expect(1);
 
     await this.start();
-    const partner = this.messaging.models['mail.partner'].create({
+    const partner = this.messaging.models['Partner'].create({
         id: 7,
         name: "Demo User",
         im_status: 'away',
@@ -100,7 +100,7 @@ QUnit.test('change icon on change partner im_status', async function (assert) {
     assert.expect(4);
 
     await this.start();
-    const partner = this.messaging.models['mail.partner'].create({
+    const partner = this.messaging.models['Partner'].create({
         id: 7,
         name: "Demo User",
         im_status: 'online',

--- a/addons/mail/static/src/models/activity/activity.js
+++ b/addons/mail/static/src/models/activity/activity.js
@@ -280,7 +280,7 @@ registerModel({
          * Also, be useful when the assigned user is different from the
          * "source" or "requesting" partner.
          */
-        requestingPartner: many2one('mail.partner'),
+        requestingPartner: many2one('Partner'),
         state: attr(),
         summary: attr(),
         /**

--- a/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
@@ -59,7 +59,7 @@ registerModel({
             this.delete();
         },
         /**
-         * @param {mail.partner} partner
+         * @param {Partner} partner
          * @param {MouseEvent} ev
          */
         onClickSelectablePartner(partner, ev) {
@@ -70,7 +70,7 @@ registerModel({
             this.update({ selectedPartners: link(partner) });
         },
         /**
-         * @param {mail.partner} partner
+         * @param {Partner} partner
          * @param {MouseEvent} ev
          */
         onClickSelectedPartner(partner, ev) {
@@ -87,7 +87,7 @@ registerModel({
             }
         },
         /**
-         * @param {mail.partner} partner
+         * @param {Partner} partner
          * @param {InputEvent} ev
          */
         onInputPartnerCheckbox(partner, ev) {
@@ -136,7 +136,7 @@ registerModel({
                 }
                 this.update({
                     searchResultCount: count,
-                    selectablePartners: insertAndReplace(partnersData.map(partnerData => this.messaging.models['mail.partner'].convertData(partnerData))),
+                    selectablePartners: insertAndReplace(partnersData.map(partnerData => this.messaging.models['Partner'].convertData(partnerData))),
                 });
             } finally {
                 if (this.exists()) {
@@ -235,11 +235,11 @@ registerModel({
          * States all partners that are potential choices according to this
          * search term.
          */
-        selectablePartners: many2many('mail.partner'),
+        selectablePartners: many2many('Partner'),
         /**
          * Determines all partners that are currently selected.
          */
-        selectedPartners: many2many('mail.partner'),
+        selectedPartners: many2many('Partner'),
         /**
          * States the thread on which this list operates (if any).
          */

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -43,7 +43,7 @@ registerModel({
          * and removes them if not.
          *
          * @private
-         * @returns {mail.partner[]}
+         * @returns {Partner[]}
          */
         _computeMentionedPartners() {
             const unmentionedPartners = [];
@@ -68,7 +68,7 @@ registerModel({
          * and removes them if not.
          *
          * @private
-         * @returns {mail.partner[]}
+         * @returns {Partner[]}
          */
         _computeMentionedChannels() {
             const unmentionedChannels = [];
@@ -90,7 +90,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.partner[]}
+         * @returns {Partner[]}
          */
         _computeRecipients() {
             const recipients = [...this.mentionedPartners];
@@ -169,7 +169,7 @@ registerModel({
         mentionedChannels: many2many('Thread', {
             compute: '_computeMentionedChannels',
         }),
-        mentionedPartners: many2many('mail.partner', {
+        mentionedPartners: many2many('Partner', {
             compute: '_computeMentionedPartners',
         }),
         messageViewInEditing: one2one('MessageView', {
@@ -177,11 +177,11 @@ registerModel({
             readonly: true,
         }),
         /**
-         * Determines the extra `mail.partner` (on top of existing followers)
+         * Determines the extra `Partner` (on top of existing followers)
          * that will receive the message being composed by `this`, and that will
          * also be added as follower of `this.activeThread`.
          */
-        recipients: many2many('mail.partner', {
+        recipients: many2many('Partner', {
             compute: '_computeRecipients',
         }),
         textInputContent: attr({

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -145,7 +145,7 @@ registerModel({
                 case 'Thread':
                     Object.assign(updateData, { mentionedChannels: link(this.activeSuggestedRecord) });
                     break;
-                case 'mail.partner':
+                case 'Partner':
                     Object.assign(updateData, { mentionedPartners: link(this.activeSuggestedRecord) });
                     break;
             }
@@ -570,7 +570,7 @@ registerModel({
         _computeSuggestionModelName() {
             switch (this.suggestionDelimiter) {
                 case '@':
-                    return 'mail.partner';
+                    return 'Partner';
                 case ':':
                     return 'mail.canned_response';
                 case '/':

--- a/addons/mail/static/src/models/discuss/discuss.js
+++ b/addons/mail/static/src/models/discuss/discuss.js
@@ -114,7 +114,7 @@ registerModel({
          */
         handleAddChatAutocompleteSource(req, res) {
             const value = owl.utils.escape(req.term);
-            this.messaging.models['mail.partner'].imSearch({
+            this.messaging.models['Partner'].imSearch({
                 callback: partners => {
                     const suggestions = partners.map(partner => {
                         return {

--- a/addons/mail/static/src/models/follower/follower.js
+++ b/addons/mail/static/src/models/follower/follower.js
@@ -37,7 +37,7 @@ registerModel({
                 }
             }
             if (data.partner) {
-                data2.partner = insertAndReplace(this.models['mail.partner'].convertData(data.partner));
+                data2.partner = insertAndReplace(this.models['Partner'].convertData(data.partner));
             }
             return data2;
         },
@@ -155,7 +155,7 @@ registerModel({
         isEditable: attr({
             default: false,
         }),
-        partner: many2one('mail.partner', {
+        partner: many2one('Partner', {
             required: true,
         }),
         selectedSubtypes: many2many('mail.follower_subtype'),

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -538,7 +538,7 @@ registerModel({
         attachments: many2many('mail.attachment', {
             inverse: 'messages',
         }),
-        author: many2one('mail.partner'),
+        author: many2one('Partner'),
         /**
          * This value is meant to be returned by the server
          * (and has been sanitized before stored into db).

--- a/addons/mail/static/src/models/message/tests/message_tests.js
+++ b/addons/mail/static/src/models/message/tests/message_tests.js
@@ -29,7 +29,7 @@ QUnit.test('create', async function (assert) {
     assert.expect(31);
 
     await this.start();
-    assert.notOk(this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 5 }));
+    assert.notOk(this.messaging.models['Partner'].findFromIdentifyingData({ id: 5 }));
     assert.notOk(this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
@@ -58,7 +58,7 @@ QUnit.test('create', async function (assert) {
         originThread: link(thread),
     });
 
-    assert.ok(this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 5 }));
+    assert.ok(this.messaging.models['Partner'].findFromIdentifyingData({ id: 5 }));
     assert.ok(this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
@@ -104,7 +104,7 @@ QUnit.test('create', async function (assert) {
     assert.strictEqual(channel.model, 'mail.channel');
     assert.strictEqual(channel.id, 100);
     assert.strictEqual(channel.name, "General");
-    const partner = this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 5 });
+    const partner = this.messaging.models['Partner'].findFromIdentifyingData({ id: 5 });
     assert.ok(partner);
     assert.strictEqual(partner.display_name, "Demo");
     assert.strictEqual(partner.id, 5);

--- a/addons/mail/static/src/models/message_reaction_group/message_reaction_group.js
+++ b/addons/mail/static/src/models/message_reaction_group/message_reaction_group.js
@@ -101,7 +101,7 @@ registerModel({
         /**
          * States the partners that have used this reaction on this message.
          */
-        partners: many2many('mail.partner'),
+        partners: many2many('Partner'),
         summary: attr({
             compute: '_computeSummary',
         }),

--- a/addons/mail/static/src/models/message_seen_indicator/message_seen_indicator.js
+++ b/addons/mail/static/src/models/message_seen_indicator/message_seen_indicator.js
@@ -145,7 +145,7 @@ registerModel({
          * Manually called as not always called when necessary
          *
          * @private
-         * @returns {mail.partner[]}
+         * @returns {Partner[]}
          * @see computeFetchedValues
          * @see computeSeenValues
          */
@@ -175,7 +175,7 @@ registerModel({
          * Manually called as not always called when necessary
          *
          * @private
-         * @returns {mail.partner[]}
+         * @returns {Partner[]}
          * @see computeSeenValues
          */
         _computePartnersThatHaveSeen() {
@@ -230,10 +230,10 @@ registerModel({
             readonly: true,
             required: true,
         }),
-        partnersThatHaveFetched: many2many('mail.partner', {
+        partnersThatHaveFetched: many2many('Partner', {
             compute: '_computePartnersThatHaveFetched',
         }),
-        partnersThatHaveSeen: many2many('mail.partner', {
+        partnersThatHaveSeen: many2many('Partner', {
             compute: '_computePartnersThatHaveSeen',
         }),
         /**

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -53,7 +53,7 @@ registerModel({
                 return user.getChat();
             }
             if (partnerId) {
-                const partner = this.messaging.models['mail.partner'].insert({ id: partnerId });
+                const partner = this.messaging.models['Partner'].insert({ id: partnerId });
                 return partner.getChat();
             }
         },
@@ -106,7 +106,7 @@ registerModel({
          */
         async openProfile({ id, model }) {
             if (model === 'res.partner') {
-                const partner = this.messaging.models['mail.partner'].insert({ id });
+                const partner = this.messaging.models['Partner'].insert({ id });
                 return partner.openProfile();
             }
             if (model === 'res.users') {
@@ -241,7 +241,7 @@ registerModel({
         commands: one2many('ChannelCommand'),
         companyName: attr(),
         currentGuest: one2one('Guest'),
-        currentPartner: one2one('mail.partner'),
+        currentPartner: one2one('Partner'),
         currentUser: one2one('mail.user'),
         device: one2one('Device', {
             default: insertAndReplace(),
@@ -341,12 +341,12 @@ registerModel({
         outOfFocusUnreadMessageCounter: attr({
             default: 0,
         }),
-        partnerRoot: many2one('mail.partner'),
+        partnerRoot: many2one('Partner'),
         /**
          * Determines which partners should be considered the public partners,
          * which are special partners notably used in livechat.
          */
-        publicPartners: many2many('mail.partner'),
+        publicPartners: many2many('Partner'),
         /**
          * Threads for which the current partner has a pending invitation.
          * It is computed from the inverse relation for performance reasons.

--- a/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
@@ -44,7 +44,7 @@ registerModel({
                 discuss.openInitThread();
             }
             if (this.messaging.autofetchPartnerImStatus) {
-                this.messaging.models['mail.partner'].startLoopFetchImStatus();
+                this.messaging.models['Partner'].startLoopFetchImStatus();
             }
         },
         /**
@@ -285,7 +285,7 @@ registerModel({
                 this.messaging.update({ currentGuest: insert(currentGuest) });
             }
             if (current_partner) {
-                const partnerData = this.messaging.models['mail.partner'].convertData(current_partner);
+                const partnerData = this.messaging.models['Partner'].convertData(current_partner);
                 partnerData.user = insert({ id: currentUserId });
                 this.messaging.update({
                     currentPartner: insert(partnerData),
@@ -293,9 +293,9 @@ registerModel({
                 });
             }
             this.messaging.update({
-                partnerRoot: insert(this.messaging.models['mail.partner'].convertData(partner_root)),
+                partnerRoot: insert(this.messaging.models['Partner'].convertData(partner_root)),
                 publicPartners: insert(public_partners.map(
-                    publicPartner => this.messaging.models['mail.partner'].convertData(publicPartner)
+                    publicPartner => this.messaging.models['Partner'].convertData(publicPartner)
                 )),
             });
         },

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -346,7 +346,7 @@ registerModel({
             if (!channel) {
                 return;
             }
-            const partner = this.messaging.models['mail.partner'].insert({
+            const partner = this.messaging.models['Partner'].insert({
                 id: partner_id,
                 name: partner_name,
             });

--- a/addons/mail/static/src/models/notification/notification.js
+++ b/addons/mail/static/src/models/notification/notification.js
@@ -149,6 +149,6 @@ registerModel({
         }),
         notification_status: attr(),
         notification_type: attr(),
-        partner: many2one('mail.partner'),
+        partner: many2one('Partner'),
     },
 });

--- a/addons/mail/static/src/models/partner/partner.js
+++ b/addons/mail/static/src/models/partner/partner.js
@@ -6,7 +6,7 @@ import { insert, link, unlinkAll } from '@mail/model/model_field_command';
 import { cleanSearchTerm } from '@mail/utils/utils';
 
 registerModel({
-    name: 'mail.partner',
+    name: 'Partner',
     identifyingFields: ['id'],
     modelMethods: {
         /**
@@ -93,8 +93,8 @@ registerModel({
                 },
                 { shadow: true },
             );
-            const partners = this.messaging.models['mail.partner'].insert(suggestedPartners.map(data =>
-                this.messaging.models['mail.partner'].convertData(data)
+            const partners = this.messaging.models['Partner'].insert(suggestedPartners.map(data =>
+                this.messaging.models['Partner'].convertData(data)
             ));
             if (isNonPublicChannel) {
                 thread.update({ members: link(partners) });
@@ -220,7 +220,7 @@ registerModel({
          * @param {Object} [options={}]
          * @param {Thread} [options.thread] prioritize and/or restrict
          *  result in the context of given thread
-         * @returns {[mail.partner[], mail.partner[]]}
+         * @returns {[Partner[], Partner[]]}
          */
         searchSuggestions(searchTerm, { thread } = {}) {
             let partners;
@@ -233,7 +233,7 @@ registerModel({
                 // mentioned partner.
                 partners = thread.members;
             } else {
-                partners = this.messaging.models['mail.partner'].all();
+                partners = this.messaging.models['Partner'].all();
             }
             const cleanedSearchTerm = cleanSearchTerm(searchTerm);
             const mainSuggestionList = [];

--- a/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
+++ b/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
@@ -132,7 +132,7 @@ registerModel({
         /**
          * If set, this card represents an invitation of this partner to this call.
          */
-        invitedPartner: many2one('mail.partner'),
+        invitedPartner: many2one('Partner'),
         /**
          * States whether this card is representing a person with a pending
          * invitation.

--- a/addons/mail/static/src/models/rtc_session/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session/rtc_session.js
@@ -389,7 +389,7 @@ registerModel({
          * has open sessions in multiple channels, but only one session per
          * channel is allowed.
          */
-        partner: many2one('mail.partner', {
+        partner: many2one('Partner', {
             inverse: 'rtcSessions',
         }),
         /**

--- a/addons/mail/static/src/models/suggested_recipient_info/suggested_recipient_info.js
+++ b/addons/mail/static/src/models/suggested_recipient_info/suggested_recipient_info.js
@@ -63,9 +63,9 @@ registerModel({
             compute: '_computeName',
         }),
         /**
-         * Determines the optional `mail.partner` associated to `this`.
+         * Determines the optional `Partner` associated to `this`.
          */
-        partner: many2one('mail.partner'),
+        partner: many2one('Partner'),
         /**
          * Determines why `this` is a suggestion for `this.thread`. It serves as
          * visual clue when displaying `this`.

--- a/addons/mail/static/src/models/thread/tests/thread_tests.js
+++ b/addons/mail/static/src/models/thread/tests/thread_tests.js
@@ -45,8 +45,8 @@ QUnit.test('create (channel)', async function (assert) {
     assert.expect(23);
 
     await this.start();
-    assert.notOk(this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 9 }));
-    assert.notOk(this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 10 }));
+    assert.notOk(this.messaging.models['Partner'].findFromIdentifyingData({ id: 9 }));
+    assert.notOk(this.messaging.models['Partner'].findFromIdentifyingData({ id: 10 }));
     assert.notOk(this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
@@ -71,14 +71,14 @@ QUnit.test('create (channel)', async function (assert) {
         serverMessageUnreadCounter: 5,
     });
     assert.ok(thread);
-    assert.ok(this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 9 }));
-    assert.ok(this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 10 }));
+    assert.ok(this.messaging.models['Partner'].findFromIdentifyingData({ id: 9 }));
+    assert.ok(this.messaging.models['Partner'].findFromIdentifyingData({ id: 10 }));
     assert.ok(this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
     }));
-    const partner9 = this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 9 });
-    const partner10 = this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 10 });
+    const partner9 = this.messaging.models['Partner'].findFromIdentifyingData({ id: 9 });
+    const partner10 = this.messaging.models['Partner'].findFromIdentifyingData({ id: 10 });
     assert.strictEqual(thread, this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
@@ -104,7 +104,7 @@ QUnit.test('create (chat)', async function (assert) {
     assert.expect(15);
 
     await this.start();
-    assert.notOk(this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 5 }));
+    assert.notOk(this.messaging.models['Partner'].findFromIdentifyingData({ id: 5 }));
     assert.notOk(this.messaging.models['Thread'].findFromIdentifyingData({
         id: 200,
         model: 'mail.channel',
@@ -126,8 +126,8 @@ QUnit.test('create (chat)', async function (assert) {
         id: 200,
         model: 'mail.channel',
     }));
-    assert.ok(this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 5 }));
-    const partner = this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 5 });
+    assert.ok(this.messaging.models['Partner'].findFromIdentifyingData({ id: 5 }));
+    const partner = this.messaging.models['Partner'].findFromIdentifyingData({ id: 5 });
     assert.strictEqual(channel, this.messaging.models['Thread'].findFromIdentifyingData({
         id: 200,
         model: 'mail.channel',

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -231,7 +231,7 @@ registerModel({
                     data2.members = [unlinkAll()];
                 } else {
                     data2.members = [insertAndReplace(data.members.map(memberData =>
-                        this.messaging.models['mail.partner'].convertData(memberData)
+                        this.messaging.models['Partner'].convertData(memberData)
                     ))];
                 }
             }
@@ -908,7 +908,7 @@ registerModel({
          * Handles click on the avatar of the given member in the member list of
          * this channel.
          *
-         * @param {mail.partner} member
+         * @param {Partner} member
          */
         onClickMemberAvatar(member) {
             member.openChat();
@@ -917,7 +917,7 @@ registerModel({
          * Handles click on the name of the given member in the member list of
          * this channel.
          *
-         * @param {mail.partner} member
+         * @param {Partner} member
          */
         onClickMemberName(member) {
             member.openProfile();
@@ -1057,7 +1057,7 @@ registerModel({
          * Called to refresh a registered other member partner that is typing
          * something.
          *
-         * @param {mail.partner} partner
+         * @param {Partner} partner
          */
         refreshOtherMemberTypingMember(partner) {
             this._otherMembersLongTypingTimers.get(partner).reset();
@@ -1087,7 +1087,7 @@ registerModel({
          * Called to register a new other member partner that is typing
          * something.
          *
-         * @param {mail.partner} partner
+         * @param {Partner} partner
          */
         registerOtherMemberTypingMember(partner) {
             const timer = new Timer(
@@ -1189,7 +1189,7 @@ registerModel({
          * Called to unregister an other member partner that is no longer typing
          * something.
          *
-         * @param {mail.partner} partner
+         * @param {Partner} partner
          */
         unregisterOtherMemberTypingMember(partner) {
             this._otherMembersLongTypingTimers.get(partner).clear();
@@ -1240,7 +1240,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.partner}
+         * @returns {Partner}
          */
         _computeCorrespondent() {
             if (this.channel_type === 'channel') {
@@ -1607,14 +1607,14 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.partner[]}
+         * @returns {Partner[]}
          */
         _computeOrderedOfflineMembers() {
             return replace(this._sortMembers(this.members.filter(member => !member.isOnline)));
         },
         /**
          * @private
-         * @returns {mail.partner[]}
+         * @returns {Partner[]}
          */
         _computeOrderedOnlineMembers() {
             return replace(this._sortMembers(this.members.filter(member => member.isOnline)));
@@ -1635,7 +1635,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.partner[]}
+         * @returns {Partner[]}
          */
         _computeOrderedOtherTypingMembers() {
             return replace(this.orderedTypingMembers.filter(
@@ -1644,13 +1644,13 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.partner[]}
+         * @returns {Partner[]}
          */
         _computeOrderedTypingMembers() {
             return [[
                 'replace',
                 this.orderedTypingMemberLocalIds
-                    .map(localId => this.messaging.models['mail.partner'].get(localId))
+                    .map(localId => this.messaging.models['Partner'].get(localId))
                     .filter(member => !!member),
             ]];
         },
@@ -1836,8 +1836,8 @@ registerModel({
         },
         /**
          * @private
-         * @param {mail.partner[]} members
-         * @returns {mail.partner[]}
+         * @param {Partner[]} members
+         * @returns {Partner[]}
          */
         _sortMembers(members) {
             return [...members].sort((a, b) => {
@@ -1893,7 +1893,7 @@ registerModel({
         },
         /**
          * @private
-         * @param {mail.partner} partner
+         * @param {Partner} partner
          */
         async _onOtherMemberLongTypingTimeout(partner) {
             if (!this.typingMembers.includes(partner)) {
@@ -1956,7 +1956,7 @@ registerModel({
             isCausal: true,
             readonly: true,
         }),
-        correspondent: many2one('mail.partner', {
+        correspondent: many2one('Partner', {
             compute: '_computeCorrespondent',
         }),
         counter: attr({
@@ -1993,7 +1993,7 @@ registerModel({
         fetchMessagesUrl: attr({
             compute: '_computeFetchMessagesUrl',
         }),
-        followersPartner: many2many('mail.partner', {
+        followersPartner: many2many('Partner', {
             related: 'followers.partner',
         }),
         followers: one2many('mail.follower', {
@@ -2060,7 +2060,7 @@ registerModel({
         /**
          * List of partners that have been invited to the RTC call of this channel.
          */
-        invitedPartners: many2many('mail.partner'),
+        invitedPartners: many2many('Partner'),
         /**
          * Determines whether this description can be changed.
          * Only makes sense for channels.
@@ -2177,7 +2177,7 @@ registerModel({
          * Only makes sense if this thread is a channel.
          */
         memberCount: attr(),
-        members: many2many('mail.partner', {
+        members: many2many('Partner', {
             inverse: 'memberThreads',
         }),
         /**
@@ -2189,7 +2189,7 @@ registerModel({
          * Determines the last mentioned partners of the last composer related
          * to this thread. Useful to sync the composer when re-creating it.
          */
-        mentionedPartnersBackup: many2many('mail.partner'),
+        mentionedPartnersBackup: many2many('Partner'),
         /**
          * Determines the message before which the "new message" separator must
          * be positioned, if any.
@@ -2249,13 +2249,13 @@ registerModel({
         /**
          * All offline members ordered like they are displayed.
          */
-        orderedOfflineMembers: many2many('mail.partner', {
+        orderedOfflineMembers: many2many('Partner', {
             compute: '_computeOrderedOfflineMembers',
         }),
         /**
          * All online members ordered like they are displayed.
          */
-        orderedOnlineMembers: many2many('mail.partner', {
+        orderedOnlineMembers: many2many('Partner', {
             compute: '_computeOrderedOnlineMembers',
         }),
         /**
@@ -2274,7 +2274,7 @@ registerModel({
         /**
          * Ordered typing members on this thread, excluding the current partner.
          */
-        orderedOtherTypingMembers: many2many('mail.partner', {
+        orderedOtherTypingMembers: many2many('Partner', {
             compute: '_computeOrderedOtherTypingMembers',
         }),
         /**
@@ -2282,7 +2282,7 @@ registerModel({
          * is currently typing for the longest time. This list includes current
          * partner as typer.
          */
-        orderedTypingMembers: many2many('mail.partner', {
+        orderedTypingMembers: many2many('Partner', {
             compute: '_computeOrderedTypingMembers',
         }),
         /**
@@ -2416,7 +2416,7 @@ registerModel({
          * Members that are currently typing something in the composer of this
          * thread, including current partner.
          */
-        typingMembers: many2many('mail.partner'),
+        typingMembers: many2many('Partner'),
         /**
          * Text that represents the status on this thread about typing members.
          */

--- a/addons/mail/static/src/models/thread_partner_seen_info/thread_partner_seen_info.js
+++ b/addons/mail/static/src/models/thread_partner_seen_info/thread_partner_seen_info.js
@@ -12,7 +12,7 @@ registerModel({
         /**
          * Partner that this seen info is related to.
          */
-        partner: many2one('mail.partner', {
+        partner: many2one('Partner', {
             inverse: 'partnerSeenInfos',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/user/user.js
+++ b/addons/mail/static/src/models/user/user.js
@@ -187,7 +187,7 @@ registerModel({
         nameOrDisplayName: attr({
             compute: '_computeNameOrDisplayName',
         }),
-        partner: one2one('mail.partner', {
+        partner: one2one('Partner', {
             inverse: 'user',
         }),
         /**

--- a/addons/mail/static/src/models/volume_setting/volume_setting.js
+++ b/addons/mail/static/src/models/volume_setting/volume_setting.js
@@ -35,7 +35,7 @@ registerModel({
             readonly: true,
             required: true,
         }),
-        partner: one2one('mail.partner', {
+        partner: one2one('Partner', {
             inverse: 'volumeSetting',
         }),
         userSetting: many2one('mail.user_setting', {

--- a/addons/mail/static/src/webclient/commands/mail_providers.js
+++ b/addons/mail/static/src/webclient/commands/mail_providers.js
@@ -24,7 +24,7 @@ commandProviderRegistry.add("partner", {
     async provide(newEnv, options) {
         const messaging = await Component.env.services.messaging.get();
         const suggestions = [];
-        await messaging.models['mail.partner'].imSearch({
+        await messaging.models['Partner'].imSearch({
             callback(partners) {
                 partners.forEach((partner) => {
                     suggestions.push({

--- a/addons/website_livechat/static/src/models/visitor/visitor.js
+++ b/addons/website_livechat/static/src/models/visitor/visitor.js
@@ -125,7 +125,7 @@ registerModel({
         /**
          * Partner linked to this visitor, if any.
          */
-        partner: many2one('mail.partner'),
+        partner: many2one('Partner'),
         /**
          * Threads with this visitor as member
          */


### PR DESCRIPTION
Rename javascript model `mail.partner` to `Partner` in order to distinguish javascript models from python models.

Part of task-2701674.
 \* = hr, hr_holidays, im_livechat, website_livechat