### PR TITLE
[IMP] mail: rename popover view model

### DIFF
--- a/addons/mail/static/src/components/popover_view/popover_view.js
+++ b/addons/mail/static/src/components/popover_view/popover_view.js
@@ -14,7 +14,7 @@ export class PopoverView extends Component {
      */
     setup() {
         super.setup();
-        useComponentToModel({ fieldName: 'component', modelName: 'mail.popover_view', propNameAsRecordLocalId: 'popoverViewLocalId' });
+        useComponentToModel({ fieldName: 'component', modelName: 'PopoverView', propNameAsRecordLocalId: 'popoverViewLocalId' });
         usePosition(
             () => this.popoverView && this.popoverView.anchorRef && this.popoverView.anchorRef.el,
             {
@@ -29,10 +29,10 @@ export class PopoverView extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.popover_view|undefined}
+     * @returns {PopoverView|undefined}
      */
     get popoverView() {
-        return this.messaging && this.messaging.models['mail.popover_view'].get(this.props.popoverViewLocalId);
+        return this.messaging && this.messaging.models['PopoverView'].get(this.props.popoverViewLocalId);
     }
 
 }

--- a/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
@@ -210,7 +210,7 @@ registerModel({
         inviteButtonText: attr({
             compute: '_computeInviteButtonText',
         }),
-        popoverView: one2one('mail.popover_view', {
+        popoverView: one2one('PopoverView', {
             inverse: 'channelInvitationForm',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/popover_view/popover_view.js
+++ b/addons/mail/static/src/models/popover_view/popover_view.js
@@ -5,7 +5,7 @@ import { attr, one2one } from '@mail/model/model_field';
 import { clear } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.popover_view',
+    name: 'PopoverView',
     identifyingFields: ['threadViewTopbarOwner', 'channelInvitationForm'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
+++ b/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
@@ -591,7 +591,7 @@ registerModel({
          * If set, this is the record of invite button popover that is currently
          * open in the topbar.
          */
-        invitePopoverView: one2one('mail.popover_view', {
+        invitePopoverView: one2one('PopoverView', {
             isCausal: true,
             inverse: 'threadViewTopbarOwner',
         }),


### PR DESCRIPTION
Rename javascript model `mail.popover_view` to `PopoverView` in order to distinguish javascript models from python models.

Part of task-2701674.