### PR TITLE
[IMP] mail: rename rtc model

### DIFF
--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -354,7 +354,7 @@ registerModel({
         ringingThreads: one2many('mail.thread', {
             inverse: 'messagingAsRingingThread',
         }),
-        rtc: one2one('mail.rtc', {
+        rtc: one2one('Rtc', {
             default: insertAndReplace(),
             isCausal: true,
             readonly: true,

--- a/addons/mail/static/src/models/rtc/rtc.js
+++ b/addons/mail/static/src/models/rtc/rtc.js
@@ -23,7 +23,7 @@ const getRTCPeerNotificationNextTemporaryId = (function () {
 })();
 
 registerModel({
-    name: 'mail.rtc',
+    name: 'Rtc',
     identifyingFields: ['messaging'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/rtc_session/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session/rtc_session.js
@@ -405,7 +405,7 @@ registerModel({
          * sessions from other channels with the same partner (sessions opened from different
          * tabs or devices).
          */
-        rtc: one2one('mail.rtc', {
+        rtc: one2one('Rtc', {
             inverse: 'currentRtcSession',
         }),
         /**

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -2320,7 +2320,7 @@ registerModel({
         /**
          * If set, the current thread is the thread that hosts the current RTC call.
          */
-        rtc: one2one('mail.rtc', {
+        rtc: one2one('Rtc', {
             inverse: 'channel',
         }),
         /**


### PR DESCRIPTION
Rename javascript model `mail.rtc` to `Rtc` in order to distinguish javascript models from python models.

Part of task-2701674.
