### PR TITLE
[IMP] mail: rename rtc call participant card model

### DIFF
--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.js
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.js
@@ -23,7 +23,7 @@ export class RtcCallParticipantCard extends Component {
      * @returns {mail.thread|undefined}
      */
     get callParticipantCard() {
-        return this.messaging.models['mail.rtc_call_participant_card'].get(this.props.callParticipantCardLocalId);
+        return this.messaging.models['RtcCallParticipantCard'].get(this.props.callParticipantCardLocalId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
+++ b/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
@@ -5,7 +5,7 @@ import { attr, many2one, one2one } from '@mail/model/model_field';
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
 registerModel({
-    name: 'mail.rtc_call_participant_card',
+    name: 'RtcCallParticipantCard',
     identifyingFields: ['relationalId'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js
+++ b/addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js
@@ -356,7 +356,7 @@ registerModel({
         /**
          * If set, the card to be displayed as the "main/spotlight" card.
          */
-        mainParticipantCard: one2one('mail.rtc_call_participant_card', {
+        mainParticipantCard: one2one('RtcCallParticipantCard', {
             compute: '_computeMainParticipantCard',
             inverse: 'rtcCallViewerOfMainCard',
         }),
@@ -400,7 +400,7 @@ registerModel({
         /**
          * List of all participant cards (can either be invitations or rtcSessions).
          */
-        tileParticipantCards: one2many('mail.rtc_call_participant_card', {
+        tileParticipantCards: one2many('RtcCallParticipantCard', {
             compute: '_computeTileParticipantCards',
             inverse: 'rtcCallViewerOfTile',
         }),


### PR DESCRIPTION
Rename javascript model `mail.rtc_call_participant_card` to `RtcCallParticipantCard` in order to distinguish javascript models from python models.

Part of task-2701674.