### PR TITLE
[IMP] mail: rename rtc call viewer model

### DIFF
--- a/addons/mail/static/src/components/rtc_call_viewer/rtc_call_viewer.js
+++ b/addons/mail/static/src/components/rtc_call_viewer/rtc_call_viewer.js
@@ -35,10 +35,10 @@ export class RtcCallViewer extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.rtc_call_viewer}
+     * @returns {RtcCallViewer}
      */
     get rtcCallViewer() {
-        return this.messaging.models['mail.rtc_call_viewer'].get(this.props.localId);
+        return this.messaging.models['RtcCallViewer'].get(this.props.localId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
+++ b/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
@@ -171,13 +171,13 @@ registerModel({
         /**
          * The callViewer for which this card is the spotlight.
          */
-        rtcCallViewerOfMainCard: one2one('mail.rtc_call_viewer', {
+        rtcCallViewerOfMainCard: one2one('RtcCallViewer', {
             inverse: 'mainParticipantCard',
         }),
         /**
          * The callViewer for which this card is one of the tiles.
          */
-        rtcCallViewerOfTile: many2one('mail.rtc_call_viewer', {
+        rtcCallViewerOfTile: many2one('RtcCallViewer', {
             inverse: 'tileParticipantCards',
         }),
         /**

--- a/addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js
+++ b/addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js
@@ -10,7 +10,7 @@ import { clear, insert, insertAndReplace, link, unlink } from '@mail/model/model
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
 registerModel({
-    name: 'mail.rtc_call_viewer',
+    name: 'RtcCallViewer',
     identifyingFields: ['threadView'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/rtc_controller/rtc_controller.js
+++ b/addons/mail/static/src/models/rtc_controller/rtc_controller.js
@@ -80,7 +80,7 @@ registerModel({
         },
     },
     fields: {
-        callViewer: one2one('mail.rtc_call_viewer', {
+        callViewer: one2one('RtcCallViewer', {
             inverse: 'rtcController',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/rtc_layout_menu/rtc_layout_menu.js
+++ b/addons/mail/static/src/models/rtc_layout_menu/rtc_layout_menu.js
@@ -48,7 +48,7 @@ registerModel({
     },
     fields: {
         component: attr(),
-        callViewer: one2one('mail.rtc_call_viewer', {
+        callViewer: one2one('RtcCallViewer', {
             inverse: 'rtcLayoutMenu',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -426,7 +426,7 @@ registerModel({
         /**
          * Determines the Rtc call viewer of this thread.
          */
-        rtcCallViewer: one2one('mail.rtc_call_viewer', {
+        rtcCallViewer: one2one('RtcCallViewer', {
             compute: '_computeRtcCallViewer',
             inverse: 'threadView',
             isCausal: true,


### PR DESCRIPTION
Rename javascript model `mail.rtc_call_viewer` to `RtcCallViewer` in order to distinguish javascript models from python models.

Part of task-2701674.