### PR TITLE
[IMP] mail: rename rtc configuration menu model

### DIFF
--- a/addons/mail/static/src/models/rtc_configuration_menu/rtc_configuration_menu.js
+++ b/addons/mail/static/src/models/rtc_configuration_menu/rtc_configuration_menu.js
@@ -6,7 +6,7 @@ import { registerModel } from '@mail/model/model_core';
 import { attr, one2one } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.rtc_configuration_menu',
+    name: 'RtcConfigurationMenu',
     identifyingFields: ['userSetting'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/user_setting/user_setting.js
+++ b/addons/mail/static/src/models/user_setting/user_setting.js
@@ -251,7 +251,7 @@ registerModel({
         /**
          * Model for the component with the controls for RTC related settings.
          */
-        rtcConfigurationMenu: one2one('mail.rtc_configuration_menu', {
+        rtcConfigurationMenu: one2one('RtcConfigurationMenu', {
             default: insertAndReplace(),
             inverse: 'userSetting',
             isCausal: true,


### PR DESCRIPTION
Rename javascript model `mail.rtc_configuration_menu` to `RtcConfigurationMenu` in order to distinguish javascript models from python models.

Part of task-2701674.