### PR TITLE
[IMP] master: rename rtc controller model

### DIFF
--- a/addons/mail/static/src/components/rtc_controller/rtc_controller.js
+++ b/addons/mail/static/src/components/rtc_controller/rtc_controller.js
@@ -11,10 +11,10 @@ export class RtcController extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.rtc_controller}
+     * @returns {RtcController}
      */
     get rtcController() {
-        return this.messaging && this.messaging.models['mail.rtc_controller'].get(this.props.localId);
+        return this.messaging && this.messaging.models['RtcController'].get(this.props.localId);
     }
 
 }

--- a/addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js
+++ b/addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js
@@ -363,7 +363,7 @@ registerModel({
         /**
          * The model for the controller (buttons).
          */
-        rtcController: one2one('mail.rtc_controller', {
+        rtcController: one2one('RtcController', {
             default: insertAndReplace(),
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/rtc_controller/rtc_controller.js
+++ b/addons/mail/static/src/models/rtc_controller/rtc_controller.js
@@ -5,7 +5,7 @@ import { attr, one2one } from '@mail/model/model_field';
 import { insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.rtc_controller',
+    name: 'RtcController',
     identifyingFields: ['callViewer'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/rtc_option_list/rtc_option_list.js
+++ b/addons/mail/static/src/models/rtc_option_list/rtc_option_list.js
@@ -70,7 +70,7 @@ registerModel({
          * States the OWL component of this option list.
          */
         component: attr(),
-        rtcController: one2one('mail.rtc_controller', {
+        rtcController: one2one('RtcController', {
             inverse: 'rtcOptionList',
             readonly: true,
             required: true,


### PR DESCRIPTION
Rename javascript model `mail.rtc_controller` to `RtcController` in order to distinguish javascript models from python models.

Part of task-2701674.
