### PR TITLE
[IMP] mail: rename rtc layout menu model

### DIFF
--- a/addons/mail/static/src/components/rtc_layout_menu/rtc_layout_menu.js
+++ b/addons/mail/static/src/components/rtc_layout_menu/rtc_layout_menu.js
@@ -12,7 +12,7 @@ export class RtcLayoutMenu extends Component {
      */
     setup() {
         super.setup();
-        useComponentToModel({ fieldName: 'component', modelName: 'mail.rtc_layout_menu', propNameAsRecordLocalId: 'localId' });
+        useComponentToModel({ fieldName: 'component', modelName: 'RtcLayoutMenu', propNameAsRecordLocalId: 'localId' });
     }
 
     //--------------------------------------------------------------------------
@@ -20,10 +20,10 @@ export class RtcLayoutMenu extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.rtc_layout_menu}
+     * @returns {RtcLayoutMenu}
      */
     get layoutMenu() {
-        return this.messaging && this.messaging.models['mail.rtc_layout_menu'].get(this.props.localId);
+        return this.messaging && this.messaging.models['RtcLayoutMenu'].get(this.props.localId);
     }
 
 }

--- a/addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js
+++ b/addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js
@@ -373,7 +373,7 @@ registerModel({
         /**
          * The model for the menu to control the layout of the viewer.
          */
-        rtcLayoutMenu: one2one('mail.rtc_layout_menu', {
+        rtcLayoutMenu: one2one('RtcLayoutMenu', {
             inverse: 'callViewer',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/rtc_layout_menu/rtc_layout_menu.js
+++ b/addons/mail/static/src/models/rtc_layout_menu/rtc_layout_menu.js
@@ -5,7 +5,7 @@ import { attr, one2one } from '@mail/model/model_field';
 import { clear } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.rtc_layout_menu',
+    name: 'RtcLayoutMenu',
     identifyingFields: ['callViewer'],
     lifecycleHooks: {
         _created() {


### PR DESCRIPTION
Rename javascript model `mail.rtc_layout_menu` to `RtcLayoutMenu` in order to distinguish javascript models from python models.

Part of task-2701674.