### PR TITLE
[IMP] mail: rename rtc option list model

### DIFF
--- a/addons/mail/static/src/components/rtc_option_list/rtc_option_list.js
+++ b/addons/mail/static/src/components/rtc_option_list/rtc_option_list.js
@@ -12,7 +12,7 @@ export class RtcOptionList extends Component {
      */
     setup() {
         super.setup();
-        useComponentToModel({ fieldName: 'component', modelName: 'mail.rtc_option_list', propNameAsRecordLocalId: 'localId' });
+        useComponentToModel({ fieldName: 'component', modelName: 'RtcOptionList', propNameAsRecordLocalId: 'localId' });
     }
 
     //--------------------------------------------------------------------------
@@ -20,10 +20,10 @@ export class RtcOptionList extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.rtc_option_list}
+     * @returns {RtcOptionList}
      */
     get rtcOptionList() {
-        return this.messaging && this.messaging.models['mail.rtc_option_list'].get(this.props.localId);
+        return this.messaging && this.messaging.models['RtcOptionList'].get(this.props.localId);
     }
 
 }

--- a/addons/mail/static/src/models/rtc_controller/rtc_controller.js
+++ b/addons/mail/static/src/models/rtc_controller/rtc_controller.js
@@ -88,7 +88,7 @@ registerModel({
         isSmall: attr({
             compute: '_computeIsSmall',
         }),
-        rtcOptionList: one2one('mail.rtc_option_list', {
+        rtcOptionList: one2one('RtcOptionList', {
             default: insertAndReplace(),
             inverse: 'rtcController',
             isCausal: true,

--- a/addons/mail/static/src/models/rtc_option_list/rtc_option_list.js
+++ b/addons/mail/static/src/models/rtc_option_list/rtc_option_list.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { attr, one2one } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.rtc_option_list',
+    name: 'RtcOptionList',
     identifyingFields: ['rtcController'],
     lifecycleHooks: {
         _created() {


### PR DESCRIPTION
Rename javascript model `mail.rtc_option_list` to `RtcOptionList` in order to distinguish javascript models from python models.

Part of task-2701674.