### PR TITLE
[IMP] mail: rename rtc peer notification model

### DIFF
--- a/addons/mail/static/src/models/rtc/rtc.js
+++ b/addons/mail/static/src/models/rtc/rtc.js
@@ -1212,7 +1212,7 @@ registerModel({
         logs: attr({
             default: {},
         }),
-        peerNotificationsToSend: one2many('mail.rtc_peer_notification', {
+        peerNotificationsToSend: one2many('RtcPeerNotification', {
             isCausal: true,
         }),
         /**

--- a/addons/mail/static/src/models/rtc_peer_notification/rtc_peer_notification.js
+++ b/addons/mail/static/src/models/rtc_peer_notification/rtc_peer_notification.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.rtc_peer_notification',
+    name: 'RtcPeerNotification',
     identifyingFields: ['id'],
     fields: {
         channelId: attr({


### PR DESCRIPTION
Rename javascript model `mail.rtc_peer_notification` to `RtcPeerNotification` in order to distinguish javascript models from python models.

Part of task-2701674.