### PR TITLE
[IMP] mail: rename rtc session model

### DIFF
--- a/addons/mail/static/src/components/rtc_video/rtc_video.js
+++ b/addons/mail/static/src/components/rtc_video/rtc_video.js
@@ -21,10 +21,10 @@ export class RtcVideo extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.thread|undefined}
+     * @returns {RtcSession|undefined}
      */
     get rtcSession() {
-        return this.messaging.models["mail.rtc_session"].get(
+        return this.messaging.models['RtcSession'].get(
             this.props.rtcSessionLocalId
         );
     }

--- a/addons/mail/static/src/models/guest/guest.js
+++ b/addons/mail/static/src/models/guest/guest.js
@@ -43,7 +43,7 @@ registerModel({
             readonly: true,
         }),
         name: attr(),
-        rtcSessions: one2many('mail.rtc_session', {
+        rtcSessions: one2many('RtcSession', {
             inverse: 'guest',
         }),
         volumeSetting: one2one('mail.volume_setting', {

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -144,7 +144,7 @@ registerModel({
          * @param {String} sessionId
          */
         toggleFocusedRtcSession(sessionId) {
-            const rtcSession = this.messaging.models['mail.rtc_session'].findFromIdentifyingData({
+            const rtcSession = this.messaging.models['RtcSession'].findFromIdentifyingData({
                 id: sessionId,
             });
             const focusedSessionId = this.focusedRtcSession && this.focusedRtcSession.id;
@@ -264,7 +264,7 @@ registerModel({
             isCausal: true,
             readonly: true,
         }),
-        focusedRtcSession: one2one('mail.rtc_session'),
+        focusedRtcSession: one2one('RtcSession'),
         /**
          * Mailbox History.
          */

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -106,7 +106,7 @@ registerModel({
                         case 'mail.message/insert':
                             return this.messaging.models['mail.message'].insert(message.payload);
                         case 'mail.channel.rtc.session/insert':
-                            return this.messaging.models['mail.rtc_session'].insert(message.payload);
+                            return this.messaging.models['RtcSession'].insert(message.payload);
                         case 'res.users.settings/changed':
                             return this._handleNotificationResUsersSettings(message.payload);
                         case 'mail.channel.rtc.session/peer_notification':

--- a/addons/mail/static/src/models/partner/partner.js
+++ b/addons/mail/static/src/models/partner/partner.js
@@ -450,7 +450,7 @@ registerModel({
             inverse: 'partner',
             isCausal: true,
         }),
-        rtcSessions: one2many('mail.rtc_session', {
+        rtcSessions: one2many('RtcSession', {
             inverse: 'partner',
         }),
         user: one2one('mail.user', {

--- a/addons/mail/static/src/models/rtc/rtc.js
+++ b/addons/mail/static/src/models/rtc/rtc.js
@@ -101,7 +101,7 @@ registerModel({
         /**
          * Removes and disconnects all the peerConnections that are not current members of the call.
          *
-         * @param {mail.rtc_session[]} currentSessions list of sessions of this call.
+         * @param {RtcSession[]} currentSessions list of sessions of this call.
          */
         async filterCallees(currentSessions) {
             const currentSessionsTokens = new Set(currentSessions.map(session => session.peerToken));
@@ -143,7 +143,7 @@ registerModel({
          */
         async handleNotification(sender, content) {
             const { event, channelId, payload } = JSON.parse(content);
-            const rtcSession = this.messaging.models['mail.rtc_session'].findFromIdentifyingData({ id: sender });
+            const rtcSession = this.messaging.models['RtcSession'].findFromIdentifyingData({ id: sender });
             if (!rtcSession || rtcSession.channel !== this.channel) {
                 // does handle notifications targeting a different session
                 return;
@@ -177,7 +177,7 @@ registerModel({
         },
         /**
          * @param {Object} param0
-         * @param {string} param0.currentSessionId the Id of the 'mail.rtc_session'
+         * @param {string} param0.currentSessionId the Id of the 'RtcSession'
                   of the current partner for the current call
          * @param {Array<Object>} [param0.iceServers]
          * @param {boolean} [param0.startWithAudio]
@@ -598,7 +598,7 @@ registerModel({
         },
         /**
          * @private
-         * @param {mail.rtc_session} rtcSession
+         * @param {RtcSession} rtcSession
          * @param {Object} param1
          * @param {String} param1.type 'audio' or 'video'
          * @param {Object} param1.state
@@ -724,7 +724,7 @@ registerModel({
          * @param {String} token
          */
         _removePeer(token) {
-            const rtcSession = this.messaging.models['mail.rtc_session'].findFromIdentifyingData({ id: token });
+            const rtcSession = this.messaging.models['RtcSession'].findFromIdentifyingData({ id: token });
             if (rtcSession) {
                 rtcSession.reset();
             }
@@ -898,14 +898,14 @@ registerModel({
             }
         },
         /**
-         * Updates the mail.rtc_session associated to the token with a new track.
+         * Updates the RtcSession associated to the token with a new track.
          *
          * @private
          * @param {Track} [track]
          * @param {String} token the token of video
          */
         _updateExternalSessionTrack(track, token) {
-            const rtcSession = this.messaging.models['mail.rtc_session'].findFromIdentifyingData({ id: token });
+            const rtcSession = this.messaging.models['RtcSession'].findFromIdentifyingData({ id: token });
             if (!rtcSession) {
                 return;
             }
@@ -1092,7 +1092,7 @@ registerModel({
          */
         async _onICEConnectionStateChange(connectionState, token) {
             this._addLogEntry(token, `ICE connection state changed: ${connectionState}`, { state: connectionState });
-            const rtcSession = this.messaging.models['mail.rtc_session'].findFromIdentifyingData({ id: token });
+            const rtcSession = this.messaging.models['RtcSession'].findFromIdentifyingData({ id: token });
             if (!rtcSession) {
                 return;
             }
@@ -1170,7 +1170,7 @@ registerModel({
         /**
          * String, peerToken of the current session used to identify him during the peer-to-peer transactions.
          */
-        currentRtcSession: one2one('mail.rtc_session', {
+        currentRtcSession: one2one('RtcSession', {
             inverse: 'rtc',
         }),
         /**

--- a/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
+++ b/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
@@ -183,6 +183,6 @@ registerModel({
         /**
          * If set, this card represents a rtcSession.
          */
-        rtcSession: many2one('mail.rtc_session'),
+        rtcSession: many2one('RtcSession'),
     },
 });

--- a/addons/mail/static/src/models/rtc_session/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session/rtc_session.js
@@ -7,7 +7,7 @@ import { attr, many2one, one2one, one2many } from '@mail/model/model_field';
 import { clear } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.rtc_session',
+    name: 'RtcSession',
     identifyingFields: ['id'],
     lifecycleHooks: {
         _created() {
@@ -134,7 +134,7 @@ registerModel({
             this.updateAndBroadcast({
                 isDeaf: !this.isDeaf,
             });
-            for (const session of this.messaging.models['mail.rtc_session'].all()) {
+            for (const session of this.messaging.models['RtcSession'].all()) {
                 if (!session.audioElement) {
                     continue;
                 }

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -2327,10 +2327,10 @@ registerModel({
          * The session that invited the current user, it is only set when the
          * invitation is still pending.
          */
-        rtcInvitingSession: many2one('mail.rtc_session', {
+        rtcInvitingSession: many2one('RtcSession', {
             inverse: 'calledChannels',
         }),
-        rtcSessions: one2many('mail.rtc_session', {
+        rtcSessions: one2many('RtcSession', {
             inverse: 'channel',
             isCausal: true,
         }),


### PR DESCRIPTION
Rename javascript model `mail.rtc_session` to `RtcSession` in order to distinguish javascript models from python models.

Part of task-2701674.