### PR TITLE
[IMP] mail: rename sound effect model

### DIFF
--- a/addons/mail/static/src/models/sound_effect/sound_effect.js
+++ b/addons/mail/static/src/models/sound_effect/sound_effect.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.sound_effect',
+    name: 'SoundEffect',
     identifyingFields: ['path', 'filename'],
     recordMethods: {
         /**

--- a/addons/mail/static/src/models/sound_effects/sound_effects.js
+++ b/addons/mail/static/src/models/sound_effects/sound_effects.js
@@ -8,31 +8,31 @@ registerModel({
     name: 'mail.sound_effects',
     identifyingFields: ['messaging'],
     fields: {
-        channelJoin: one2one('mail.sound_effect', {
+        channelJoin: one2one('SoundEffect', {
             default: insertAndReplace({ filename: 'channel_01_in' }),
             isCausal: true,
         }),
-        channelLeave: one2one('mail.sound_effect', {
+        channelLeave: one2one('SoundEffect', {
             default: insertAndReplace({ filename: 'channel_04_out' }),
             isCausal: true,
         }),
-        incomingCall: one2one('mail.sound_effect', {
+        incomingCall: one2one('SoundEffect', {
             default: insertAndReplace({ filename: 'call_02_in_' }),
             isCausal: true,
         }),
-        memberLeave: one2one('mail.sound_effect', {
+        memberLeave: one2one('SoundEffect', {
             default: insertAndReplace({ filename: 'channel_01_out' }),
             isCausal: true,
         }),
-        newMessage: one2one('mail.sound_effect', {
+        newMessage: one2one('SoundEffect', {
             default: insertAndReplace({ filename: 'dm_02' }),
             isCausal: true,
         }),
-        pushToTalk: one2one('mail.sound_effect', {
+        pushToTalk: one2one('SoundEffect', {
             default: insertAndReplace({ filename: 'dm_01' }),
             isCausal: true,
         }),
-        screenSharing: one2one('mail.sound_effect', {
+        screenSharing: one2one('SoundEffect', {
             default: insertAndReplace({ filename: 'share_02' }),
             isCausal: true,
         }),


### PR DESCRIPTION
Rename javascript model `mail.sound_effect` to `SoundEffect` in order to distinguish javascript models from python models.

Part of task-2701674.