### PR TITLE
[IMP] mail, snailmail: rename notification model

### DIFF
--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -96,7 +96,7 @@ registerModel({
             }
             if ('notifications' in data) {
                 data2.notifications = insert(data.notifications.map(notificationData =>
-                    this.messaging.models['mail.notification'].convertData(notificationData)
+                    this.messaging.models['Notification'].convertData(notificationData)
                 ));
             }
             if ('parentMessage' in data) {
@@ -578,7 +578,7 @@ registerModel({
             compute: '_computeDateFromNow',
         }),
         email_from: attr(),
-        failureNotifications: one2many('mail.notification', {
+        failureNotifications: one2many('Notification', {
             compute: '_computeFailureNotifications',
         }),
         guestAuthor: many2one('mail.guest', {
@@ -709,7 +709,7 @@ registerModel({
             inverse: 'message',
             isCausal: true,
         }),
-        notifications: one2many('mail.notification', {
+        notifications: one2many('Notification', {
             inverse: 'message',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/notification/notification.js
+++ b/addons/mail/static/src/models/notification/notification.js
@@ -5,7 +5,7 @@ import { attr, many2one } from '@mail/model/model_field';
 import { clear, insert, insertAndReplace, unlinkAll } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.notification',
+    name: 'Notification',
     identifyingFields: ['id'],
     modelMethods: {
         /**

--- a/addons/mail/static/src/models/notification_group/notification_group.js
+++ b/addons/mail/static/src/models/notification_group/notification_group.js
@@ -124,7 +124,7 @@ registerModel({
         notification_type: attr({
             readonly: true,
         }),
-        notifications: one2many('mail.notification', {
+        notifications: one2many('Notification', {
             inverse: 'notificationGroup',
         }),
         res_id: attr({

--- a/addons/snailmail/static/src/components/snailmail_error_dialog/snailmail_error_dialog.js
+++ b/addons/snailmail/static/src/components/snailmail_error_dialog/snailmail_error_dialog.js
@@ -31,7 +31,7 @@ class SnailmailErrorDialog extends Component {
     }
 
     /**
-     * @returns {mail.notification}
+     * @returns {Notification}
      */
     get notification() {
         // Messages from snailmail are considered to have at most one notification.

--- a/addons/snailmail/static/src/components/snailmail_notification_popover/snailmail_notification_popover.js
+++ b/addons/snailmail/static/src/components/snailmail_notification_popover/snailmail_notification_popover.js
@@ -46,7 +46,7 @@ class SnailmailNotificationPopover extends Component {
     }
 
     /**
-     * @returns {mail.notification}
+     * @returns {Notification}
      */
     get notification() {
         // Messages from snailmail are considered to have at most one notification.


### PR DESCRIPTION
Rename javascript model `mail.notification` to `Notification` in order to distinguish javascript models from python models.

Part of task-2701674.