### PR TITLE
[FIX] hr_timesheet: use correct field type for timesheet_count

### DIFF
--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -38,7 +38,7 @@ class Project(models.Model):
     )
 
     timesheet_ids = fields.One2many('account.analytic.line', 'project_id', 'Associated Timesheets')
-    timesheet_count = fields.Boolean(compute="_compute_timesheet_count")
+    timesheet_count = fields.Integer(compute="_compute_timesheet_count")
     timesheet_encode_uom_id = fields.Many2one('uom.uom', related='company_id.timesheet_encode_uom_id')
     total_timesheet_time = fields.Integer(
         compute='_compute_total_timesheet_time',


### PR DESCRIPTION
This commit fixes #80080 where a bad field type has been used.
Fortunatelly the field is only used in conditions where it is
checked as being Truthy.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
