### PR TITLE
[FIX] sale: Importing SO with payment terms

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -477,6 +477,8 @@ class SaleOrder(models.Model):
             vals['partner_invoice_id'] = vals.setdefault('partner_invoice_id', addr['invoice'])
             vals['partner_shipping_id'] = vals.setdefault('partner_shipping_id', addr['delivery'])
             vals['pricelist_id'] = vals.setdefault('pricelist_id', partner.property_product_pricelist and partner.property_product_pricelist.id)
+            if self.env.context.get('import_file'):
+                vals['payment_term_id'] = vals.setdefault('payment_term_id', partner.property_payment_term_id.id)
         result = super(SaleOrder, self).create(vals)
         return result
 


### PR DESCRIPTION
Let's consider a partner P with a specific payment term PT and a specific pricelist PL
When importing SO with P (witout specifying PL and PT in the import file), PL is automatically populated
but not PT.

The property field PT should be populated as PL

opw:2706007