### PR TITLE
[IMP] mail: rename sound effects model

### DIFF
--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -359,7 +359,7 @@ registerModel({
             isCausal: true,
             readonly: true,
         }),
-        soundEffects: one2one('mail.sound_effects', {
+        soundEffects: one2one('SoundEffects', {
             default: insertAndReplace(),
             isCausal: true,
             readonly: true,

--- a/addons/mail/static/src/models/sound_effects/sound_effects.js
+++ b/addons/mail/static/src/models/sound_effects/sound_effects.js
@@ -5,7 +5,7 @@ import { one2one } from '@mail/model/model_field';
 import { insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.sound_effects',
+    name: 'SoundEffects',
     identifyingFields: ['messaging'],
     fields: {
         channelJoin: one2one('mail.sound_effect', {


### PR DESCRIPTION
Rename javascript model `mail.sound_effects` to `SoundEffects` in order to distinguish javascript models from python models.

Part of task-2701674.