### PR TITLE
[IMP] mail: rename suggested recipient info model

### DIFF
--- a/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.js
+++ b/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.js
@@ -78,10 +78,10 @@ export class ComposerSuggestedRecipient extends Component {
     }
 
     /**
-     * @returns {mail.suggested_recipient_info}
+     * @returns {SuggestedRecipientInfo}
      */
     get suggestedRecipientInfo() {
-        return this.messaging && this.messaging.models['mail.suggested_recipient_info'].get(this.props.suggestedRecipientInfoLocalId);
+        return this.messaging && this.messaging.models['SuggestedRecipientInfo'].get(this.props.suggestedRecipientInfoLocalId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/models/suggested_recipient_info/suggested_recipient_info.js
+++ b/addons/mail/static/src/models/suggested_recipient_info/suggested_recipient_info.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { attr, many2one } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.suggested_recipient_info',
+    name: 'SuggestedRecipientInfo',
     identifyingFields: ['id'],
     recordMethods: {
         /**

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -2368,9 +2368,9 @@ registerModel({
             default: 0,
         }),
         /**
-         * Determines the `mail.suggested_recipient_info` concerning `this`.
+         * Determines the `SuggestedRecipientInfo` concerning `this`.
          */
-        suggestedRecipientInfoList: one2many('mail.suggested_recipient_info', {
+        suggestedRecipientInfoList: one2many('SuggestedRecipientInfo', {
             inverse: 'thread',
             isCausal: true,
         }),


### PR DESCRIPTION
Rename javascript model `mail.suggested_recipient_info` to `SuggestedRecipientInfo` in order to distinguish javascript models from python models.

Part of task-2701674.
