### PR TITLE
[IMP] mail, *: rename thread model

### DIFF
--- a/addons/hr/static/src/models/employee/employee.js
+++ b/addons/hr/static/src/models/employee/employee.js
@@ -100,7 +100,7 @@ registerModel({
          *
          * If a chat is not appropriate, a notification is displayed instead.
          *
-         * @returns {mail.thread|undefined}
+         * @returns {Thread|undefined}
          */
         async getChat() {
             if (!this.user && !this.hasCheckedUser) {
@@ -122,8 +122,8 @@ registerModel({
          *
          * If a chat is not appropriate, a notification is displayed instead.
          *
-         * @param {Object} [options] forwarded to @see `mail.thread:open()`
-         * @returns {mail.thread|undefined}
+         * @param {Object} [options] forwarded to @see `Thread:open()`
+         * @returns {Thread|undefined}
          */
         async openChat(options) {
             const chat = await this.async(() => this.getChat());

--- a/addons/hr_holidays/static/src/components/thread_icon/tests/thread_icon_tests.js
+++ b/addons/hr_holidays/static/src/components/thread_icon/tests/thread_icon_tests.js
@@ -49,7 +49,7 @@ QUnit.test('thread icon of a chat when correspondent is on leave & online', asyn
         members: [this.data.currentPartnerId, 7],
     });
     await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -81,7 +81,7 @@ QUnit.test('thread icon of a chat when correspondent is on leave & away', async 
         members: [this.data.currentPartnerId, 7],
     });
     await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -113,7 +113,7 @@ QUnit.test('thread icon of a chat when correspondent is on leave & offline', asy
         members: [this.data.currentPartnerId, 7],
     });
     await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });

--- a/addons/hr_holidays/static/src/components/thread_view/tests/thread_view_tests.js
+++ b/addons/hr_holidays/static/src/components/thread_view/tests/thread_view_tests.js
@@ -46,7 +46,7 @@ QUnit.test('out of office message on direct chat with out of office partner', as
         members: [this.data.currentPartnerId, 11],
     }];
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel'
     });

--- a/addons/im_livechat/static/src/components/composer/tests/composer_tests.js
+++ b/addons/im_livechat/static/src/components/composer/tests/composer_tests.js
@@ -28,7 +28,7 @@ QUnit.test('livechat: no add attachment button', async function (assert) {
     assert.expect(2);
 
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         channel_type: 'livechat',
         id: 10,
         model: 'mail.channel',

--- a/addons/im_livechat/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/im_livechat/static/src/components/discuss/tests/discuss_tests.js
@@ -58,7 +58,7 @@ QUnit.test('livechat in the sidebar: basic rendering', async function (assert) {
     );
     const livechat = groupLivechat.querySelector(`
         .o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId
@@ -278,11 +278,11 @@ QUnit.test('livechats are sorted by last activity time in the sidebar: most rece
         },
     );
     await this.start();
-    const livechat11 = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const livechat11 = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 11,
         model: 'mail.channel',
     });
-    const livechat12 = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const livechat12 = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 12,
         model: 'mail.channel',
     });

--- a/addons/im_livechat/static/src/components/discuss_sidebar_category/tests/discuss_sidebar_category_tests.js
+++ b/addons/im_livechat/static/src/components/discuss_sidebar_category/tests/discuss_sidebar_category_tests.js
@@ -132,7 +132,7 @@ QUnit.test('livechat - states: close manually by clicking the title', async func
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId
@@ -149,7 +149,7 @@ QUnit.test('livechat - states: close manually by clicking the title', async func
     assert.containsNone(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId
@@ -177,7 +177,7 @@ QUnit.test('livechat - states: open manually by clicking the title', async funct
     assert.containsNone(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId
@@ -194,7 +194,7 @@ QUnit.test('livechat - states: open manually by clicking the title', async funct
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId
@@ -310,7 +310,7 @@ QUnit.test('livechat - states: close from the bus', async function (assert) {
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId
@@ -328,7 +328,7 @@ QUnit.test('livechat - states: close from the bus', async function (assert) {
     assert.containsNone(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId
@@ -356,7 +356,7 @@ QUnit.test('livechat - states: open from the bus', async function (assert) {
     assert.containsNone(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId
@@ -374,7 +374,7 @@ QUnit.test('livechat - states: open from the bus', async function (assert) {
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId
@@ -399,7 +399,7 @@ QUnit.test('livechat - states: category item should be invisible if the catgory 
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId
@@ -416,7 +416,7 @@ QUnit.test('livechat - states: category item should be invisible if the catgory 
     assert.containsNone(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId
@@ -440,7 +440,7 @@ QUnit.test('livechat - states: the active category item should be visble even if
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId
@@ -448,7 +448,7 @@ QUnit.test('livechat - states: the active category item should be visble even if
     );
 
     const livechat = document.querySelector(`.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-        this.messaging.models['mail.thread'].findFromIdentifyingData({
+        this.messaging.models['Thread'].findFromIdentifyingData({
             id: 11,
             model: 'mail.channel',
         }).localId
@@ -468,7 +468,7 @@ QUnit.test('livechat - states: the active category item should be visble even if
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId

--- a/addons/im_livechat/static/src/components/discuss_sidebar_category_item/tests/discuss_sidebar_category_item_tests.js
+++ b/addons/im_livechat/static/src/components/discuss_sidebar_category_item/tests/discuss_sidebar_category_item_tests.js
@@ -42,7 +42,7 @@ QUnit.test('livechat - avatar: should have a smiley face avatar for an anonymous
 
     const livechatItem = document.querySelector(`
         .o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId
@@ -77,7 +77,7 @@ QUnit.test('livechat - avatar: should have a partner profile picture for a livec
 
     const livechatItem = document.querySelector(`
         .o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId

--- a/addons/im_livechat/static/src/components/messaging_menu/tests/messaging_menu_tests.js
+++ b/addons/im_livechat/static/src/components/messaging_menu/tests/messaging_menu_tests.js
@@ -66,7 +66,7 @@ QUnit.test('livechats should be in "chat" filter', async function (assert) {
     assert.containsOnce(
         document.body,
         `.o_ThreadPreview[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId
@@ -85,7 +85,7 @@ QUnit.test('livechats should be in "chat" filter', async function (assert) {
     assert.containsOnce(
         document.body,
         `.o_ThreadPreview[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId

--- a/addons/im_livechat/static/src/components/notification_list/notification_list.js
+++ b/addons/im_livechat/static/src/components/notification_list/notification_list.js
@@ -20,7 +20,7 @@ patch(components.NotificationList.prototype, 'im_livechat/static/src/components/
      */
     _getThreads(props) {
         if (props.filter === 'livechat') {
-            return this.messaging.models['mail.thread'].all(thread =>
+            return this.messaging.models['Thread'].all(thread =>
                 thread.channel_type === 'livechat' &&
                 thread.isPinned &&
                 thread.model === 'mail.channel'

--- a/addons/im_livechat/static/src/components/thread_icon/tests/thread_icon_tests.js
+++ b/addons/im_livechat/static/src/components/thread_icon/tests/thread_icon_tests.js
@@ -46,7 +46,7 @@ QUnit.test('livechat: public website visitor is typing', async function (assert)
         members: [this.data.currentPartnerId, this.data.publicPartnerId],
     });
     await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });

--- a/addons/im_livechat/static/src/components/thread_textual_typing_status/tests/thread_textual_typing_status_tests.js
+++ b/addons/im_livechat/static/src/components/thread_textual_typing_status/tests/thread_textual_typing_status_tests.js
@@ -46,7 +46,7 @@ QUnit.test('receive visitor typing status "is typing"', async function (assert) 
         members: [this.data.currentPartnerId, this.data.publicPartnerId],
     });
     await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });

--- a/addons/im_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/im_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -22,7 +22,7 @@ patchRecordMethods('mail.messaging_notification_handler', {
      * @override
      */
     _handleNotificationChannelPartnerTypingStatus({ channel_id, is_typing, partner_id, partner_name }) {
-        const channel = this.messaging.models['mail.thread'].findFromIdentifyingData({
+        const channel = this.messaging.models['Thread'].findFromIdentifyingData({
             id: channel_id,
             model: 'mail.channel',
         });

--- a/addons/im_livechat/static/src/models/thread/thread.js
+++ b/addons/im_livechat/static/src/models/thread/thread.js
@@ -5,7 +5,7 @@ import { insert, link, unlink } from '@mail/model/model_field_command';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/thread/thread';
 
-patchModelMethods('mail.thread', {
+patchModelMethods('Thread', {
     /**
      * @override
      */
@@ -52,7 +52,7 @@ patchModelMethods('mail.thread', {
     },
 });
 
-patchRecordMethods('mail.thread', {
+patchRecordMethods('Thread', {
     /**
      * @override
      */

--- a/addons/mail/static/src/components/attachment_box/tests/attachment_box_tests.js
+++ b/addons/mail/static/src/components/attachment_box/tests/attachment_box_tests.js
@@ -57,7 +57,7 @@ QUnit.test('base empty rendering', async function (assert) {
 
     this.data['res.partner'].records.push({ id: 100 });
     await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });
@@ -110,7 +110,7 @@ QUnit.test('base non-empty rendering', async function (assert) {
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });
@@ -146,7 +146,7 @@ QUnit.test('attachment box: drop attachments', async function (assert) {
 
     this.data['res.partner'].records.push({ id: 100 });
     await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });
@@ -224,7 +224,7 @@ QUnit.test('view attachments', async function (assert) {
     await this.start({
         hasDialog: true,
     });
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         attachments: [
             insert({
                 id: 143,
@@ -299,7 +299,7 @@ QUnit.test('remove attachment should ask for confirmation', async function (asse
 
     this.data['res.partner'].records.push({ id: 100 });
     await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         attachments: insert({
             id: 143,
             mimetype: 'text/plain',

--- a/addons/mail/static/src/components/channel_member_list/channel_member_list.js
+++ b/addons/mail/static/src/components/channel_member_list/channel_member_list.js
@@ -7,10 +7,10 @@ const { Component } = owl;
 export class ChannelMemberList extends Component {
 
     /**
-     * @returns {mail.thread}
+     * @returns {Thread}
      */
     get channel() {
-        return this.messaging.models['mail.thread'].get(this.props.channelLocalId);
+        return this.messaging.models['Thread'].get(this.props.channelLocalId);
     }
 
 }

--- a/addons/mail/static/src/components/chat_window_manager/tests/chat_window_manager_tests.js
+++ b/addons/mail/static/src/components/chat_window_manager/tests/chat_window_manager_tests.js
@@ -479,7 +479,7 @@ QUnit.test('chat window: basic rendering', async function (assert) {
     const chatWindow = document.querySelector(`.o_ChatWindow`);
     assert.strictEqual(
         chatWindow.dataset.threadLocalId,
-        this.messaging.models['mail.thread'].findFromIdentifyingData({
+        this.messaging.models['Thread'].findFromIdentifyingData({
             id: 20,
             model: 'mail.channel',
         }).localId,
@@ -1094,7 +1094,7 @@ QUnit.test('open 2 different chat windows: enough screen width [REQUIRE FOCUS]',
         document.querySelector(`
             .o_MessagingMenu_dropdownMenu
             .o_NotificationList_preview[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 10,
                     model: 'mail.channel',
                 }).localId
@@ -1109,7 +1109,7 @@ QUnit.test('open 2 different chat windows: enough screen width [REQUIRE FOCUS]',
     assert.strictEqual(
         document.querySelectorAll(`
             .o_ChatWindow[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 10,
                     model: 'mail.channel',
                 }).localId
@@ -1121,7 +1121,7 @@ QUnit.test('open 2 different chat windows: enough screen width [REQUIRE FOCUS]',
     assert.ok(
         document.querySelector(`
             .o_ChatWindow[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 10,
                     model: 'mail.channel',
                 }).localId
@@ -1135,7 +1135,7 @@ QUnit.test('open 2 different chat windows: enough screen width [REQUIRE FOCUS]',
         document.querySelector(`
             .o_MessagingMenu_dropdownMenu
             .o_NotificationList_preview[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 20,
                     model: 'mail.channel',
                 }).localId
@@ -1150,7 +1150,7 @@ QUnit.test('open 2 different chat windows: enough screen width [REQUIRE FOCUS]',
     assert.strictEqual(
         document.querySelectorAll(`
             .o_ChatWindow[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 20,
                     model: 'mail.channel',
                 }).localId
@@ -1162,7 +1162,7 @@ QUnit.test('open 2 different chat windows: enough screen width [REQUIRE FOCUS]',
     assert.strictEqual(
         document.querySelectorAll(`
             .o_ChatWindow[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 10,
                     model: 'mail.channel',
                 }).localId
@@ -1174,7 +1174,7 @@ QUnit.test('open 2 different chat windows: enough screen width [REQUIRE FOCUS]',
     assert.ok(
         document.querySelector(`
             .o_ChatWindow[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 20,
                     model: 'mail.channel',
                 }).localId
@@ -1185,7 +1185,7 @@ QUnit.test('open 2 different chat windows: enough screen width [REQUIRE FOCUS]',
     assert.notOk(
         document.querySelector(`
             .o_ChatWindow[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 10,
                     model: 'mail.channel',
                 }).localId
@@ -1445,7 +1445,7 @@ QUnit.test('open 3 different chat windows: not enough screen width', async funct
         document.querySelector(`
             .o_MessagingMenu_dropdownMenu
             .o_NotificationList_preview[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 1,
                     model: 'mail.channel',
                 }).localId
@@ -1475,7 +1475,7 @@ QUnit.test('open 3 different chat windows: not enough screen width', async funct
         document.querySelector(`
             .o_MessagingMenu_dropdownMenu
             .o_NotificationList_preview[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 2,
                     model: 'mail.channel',
                 }).localId
@@ -1505,7 +1505,7 @@ QUnit.test('open 3 different chat windows: not enough screen width', async funct
         document.querySelector(`
             .o_MessagingMenu_dropdownMenu
             .o_NotificationList_preview[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 3,
                     model: 'mail.channel',
                 }).localId
@@ -1530,7 +1530,7 @@ QUnit.test('open 3 different chat windows: not enough screen width', async funct
     assert.strictEqual(
         document.querySelectorAll(`
             .o_ChatWindow[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 1,
                     model: 'mail.channel',
                 }).localId
@@ -1542,7 +1542,7 @@ QUnit.test('open 3 different chat windows: not enough screen width', async funct
     assert.strictEqual(
         document.querySelectorAll(`
             .o_ChatWindow[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 3,
                     model: 'mail.channel',
                 }).localId
@@ -1554,7 +1554,7 @@ QUnit.test('open 3 different chat windows: not enough screen width', async funct
     assert.ok(
         document.querySelector(`
             .o_ChatWindow[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 3,
                     model: 'mail.channel',
                 }).localId
@@ -1583,7 +1583,7 @@ QUnit.test('chat window: switch on TAB', async function (assert) {
         document.querySelector(`
             .o_MessagingMenu_dropdownMenu
             .o_NotificationList_preview[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 1,
                     model: 'mail.channel',
                 }).localId
@@ -1624,7 +1624,7 @@ QUnit.test('chat window: switch on TAB', async function (assert) {
         document.querySelector(`
             .o_MessagingMenu_dropdownMenu
             .o_NotificationList_preview[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 2,
                     model: 'mail.channel',
                 }).localId
@@ -2129,7 +2129,7 @@ QUnit.test('chat window does not fetch messages if hidden', async function (asse
     assert.containsNone(
         document.body,
         `.o_ChatWindow[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 12,
                 model: 'mail.channel',
             }).localId
@@ -2167,7 +2167,7 @@ QUnit.test('chat window does not fetch messages if hidden', async function (asse
     assert.containsOnce(
         document.body,
         `.o_ChatWindow[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 12,
                 model: 'mail.channel',
             }).localId

--- a/addons/mail/static/src/components/chatter/tests/chatter_tests.js
+++ b/addons/mail/static/src/components/chatter/tests/chatter_tests.js
@@ -77,7 +77,7 @@ QUnit.test('base rendering when chatter has no attachment', async function (asse
     );
     assert.strictEqual(
         document.querySelector(`.o_Chatter_thread`).dataset.threadLocalId,
-        this.messaging.models['mail.thread'].findFromIdentifyingData({
+        this.messaging.models['Thread'].findFromIdentifyingData({
             id: 100,
             model: 'res.partner',
         }).localId,
@@ -351,7 +351,7 @@ QUnit.test('should display subject when subject is not the same as the thread na
         subject: "Salutations, voyageur",
     });
     await this.start();
-    this.messaging.models['mail.thread'].create({
+    this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
         name: "voyageur",
@@ -386,7 +386,7 @@ QUnit.test('should not display subject when subject is the same as the thread na
         subject: "Salutations, voyageur",
     });
     await this.start();
-    this.messaging.models['mail.thread'].create({
+    this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
         name: "Salutations, voyageur",

--- a/addons/mail/static/src/components/composer/tests/composer_tests.js
+++ b/addons/mail/static/src/components/composer/tests/composer_tests.js
@@ -45,7 +45,7 @@ QUnit.test('composer text input: basic rendering when posting a message', async 
     assert.expect(5);
 
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         composer: insertAndReplace({ isLog: false }),
         id: 20,
         model: 'res.partner',
@@ -81,7 +81,7 @@ QUnit.test('composer text input: basic rendering when logging note', async funct
     assert.expect(5);
 
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         composer: insertAndReplace({ isLog: true }),
         id: 20,
         model: 'res.partner',
@@ -118,7 +118,7 @@ QUnit.test('composer text input: basic rendering when linked thread is a mail.ch
 
     this.data['mail.channel'].records.push({ id: 20 });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -153,7 +153,7 @@ QUnit.test('composer text input placeholder should contain channel name when thr
         name: 'General',
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -175,7 +175,7 @@ QUnit.test('composer text input placeholder should contain correspondent name wh
         members: [this.data.currentPartnerId, 7],
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -194,7 +194,7 @@ QUnit.test('add an emoji', async function (assert) {
         id: 20,
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -223,7 +223,7 @@ QUnit.test('add an emoji after some text', async function (assert) {
         id: 20,
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -260,7 +260,7 @@ QUnit.test('add emoji replaces (keyboard) text selection', async function (asser
         id: 20,
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -308,7 +308,7 @@ QUnit.test('display canned response suggestions on typing ":"', async function (
         id: 20,
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -347,7 +347,7 @@ QUnit.test('use a canned response', async function (assert) {
         id: 20,
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -399,7 +399,7 @@ QUnit.test('use a canned response some text', async function (assert) {
         id: 20,
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -459,7 +459,7 @@ QUnit.test('add an emoji after a canned response', async function (assert) {
         id: 20,
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -523,7 +523,7 @@ QUnit.test('display channel mention suggestions on typing "#"', async function (
     });
 
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 7,
         model: 'mail.channel',
     });
@@ -558,7 +558,7 @@ QUnit.test('mention a channel', async function (assert) {
         public: "groups",
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 7,
         model: 'mail.channel',
     });
@@ -606,7 +606,7 @@ QUnit.test('mention a channel after some text', async function (assert) {
         public: "groups",
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 7,
         model: 'mail.channel',
     });
@@ -662,7 +662,7 @@ QUnit.test('add an emoji after a channel mention', async function (assert) {
         public: "groups",
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 7,
         model: 'mail.channel',
     });
@@ -721,7 +721,7 @@ QUnit.test('display command suggestions on typing "/"', async function (assert) 
 
     this.data['mail.channel'].records.push({ channel_type: 'channel', id: 20 });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -759,7 +759,7 @@ QUnit.test('do not send typing notification on typing "/" command', async functi
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -788,7 +788,7 @@ QUnit.test('do not send typing notification on typing after selecting suggestion
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -821,7 +821,7 @@ QUnit.test('use a command for a specific channel type', async function (assert) 
 
     this.data['mail.channel'].records.push({ channel_type: 'channel', id: 20 });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -860,7 +860,7 @@ QUnit.test('command suggestion should only open if command is the first characte
 
     this.data['mail.channel'].records.push({ channel_type: 'channel', id: 20 });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -903,7 +903,7 @@ QUnit.test('add an emoji after a command', async function (assert) {
 
     this.data['mail.channel'].records.push({ channel_type: 'channel', id: 20 });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -973,7 +973,7 @@ QUnit.test('display partner mention suggestions on typing "@"', async function (
         id: 20,
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1015,7 +1015,7 @@ QUnit.test('mention a partner', async function (assert) {
         id: 20,
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1075,7 +1075,7 @@ QUnit.test('mention a partner after some text', async function (assert) {
         id: 20,
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1144,7 +1144,7 @@ QUnit.test('add an emoji after a partner mention', async function (assert) {
         id: 20,
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1215,7 +1215,7 @@ QUnit.test('composer: add an attachment', async function (assert) {
         id: 20,
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1249,7 +1249,7 @@ QUnit.test('composer: drop attachments', async function (assert) {
         id: 20,
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1316,7 +1316,7 @@ QUnit.test('composer: paste attachments', async function (assert) {
         id: 20,
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1358,7 +1358,7 @@ QUnit.test('composer text input cleared on message post', async function (assert
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1393,7 +1393,7 @@ QUnit.test('composer with thread typing notification status', async function (as
     // with a random unique id that will be referenced in the test
     this.data['mail.channel'].records.push({ id: 20 });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1425,7 +1425,7 @@ QUnit.test('current partner notify is typing to other thread members', async fun
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1457,7 +1457,7 @@ QUnit.test('current partner is typing should not translate on textual typing sta
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1496,7 +1496,7 @@ QUnit.test('current partner notify no longer is typing to thread members after 5
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1534,7 +1534,7 @@ QUnit.test('current partner notify is typing again to other members every 50s of
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1582,7 +1582,7 @@ QUnit.test('composer: send button is disabled if attachment upload is not finish
             return res;
         }
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1648,7 +1648,7 @@ QUnit.test('remove an attachment from composer does not need any confirmation', 
         id: 20,
     });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1701,7 +1701,7 @@ QUnit.test('remove an uploading attachment', async function (assert) {
             return res;
         }
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1758,7 +1758,7 @@ QUnit.test('remove an uploading attachment aborts upload', async function (asser
             return res;
         }
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1797,7 +1797,7 @@ QUnit.test("Show a default status in the recipient status text when the thread d
     assert.expect(1);
 
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         composer: insertAndReplace({ isLog: false }),
         id: 20,
         model: 'res.partner',
@@ -1814,7 +1814,7 @@ QUnit.test("Show a thread name in the recipient status text.", async function (a
     assert.expect(1);
 
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         name: "test name",
         composer: insertAndReplace({ isLog: false }),
         id: 20,
@@ -1840,7 +1840,7 @@ QUnit.test('send message only once when button send is clicked twice quickly', a
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1881,7 +1881,7 @@ QUnit.test('[technical] does not crash when an attachment is removed before its 
             return _super();
         },
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -1924,7 +1924,7 @@ QUnit.test('send button on mail.channel should have "Send" as label', async func
 
     this.data['mail.channel'].records.push({ id: 20 });
     const { createComposerComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });

--- a/addons/mail/static/src/components/composer_suggested_recipient_list/composer_suggested_recipient_list.js
+++ b/addons/mail/static/src/components/composer_suggested_recipient_list/composer_suggested_recipient_list.js
@@ -22,10 +22,10 @@ export class ComposerSuggestedRecipientList extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.thread}
+     * @returns {Thread}
      */
     get thread() {
-        return this.messaging && this.messaging.models['mail.thread'].get(this.props.threadLocalId);
+        return this.messaging && this.messaging.models['Thread'].get(this.props.threadLocalId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
@@ -32,7 +32,7 @@ export class ComposerSuggestion extends Component {
     }
 
     get isChannel() {
-        return this.props.modelName === "mail.thread";
+        return this.props.modelName === "Thread";
     }
 
     get isCommand() {

--- a/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_canned_response_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_canned_response_tests.js
@@ -27,7 +27,7 @@ QUnit.test('canned response suggestion displayed', async function (assert) {
 
     this.data['mail.channel'].records.push({ id: 20 });
     const { createComposerSuggestionComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -54,7 +54,7 @@ QUnit.test('canned response suggestion correct data', async function (assert) {
 
     this.data['mail.channel'].records.push({ id: 20 });
     const { createComposerSuggestionComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -101,7 +101,7 @@ QUnit.test('canned response suggestion active', async function (assert) {
 
     this.data['mail.channel'].records.push({ id: 20 });
     const { createComposerSuggestionComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });

--- a/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_channel_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_channel_tests.js
@@ -27,13 +27,13 @@ QUnit.test('channel mention suggestion displayed', async function (assert) {
 
     this.data['mail.channel'].records.push({ id: 20 });
     const { createComposerSuggestionComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
     await createComposerSuggestionComponent(thread.composer, {
         isActive: true,
-        modelName: 'mail.thread',
+        modelName: 'Thread',
         recordLocalId: thread.localId,
     });
 
@@ -52,13 +52,13 @@ QUnit.test('channel mention suggestion correct data', async function (assert) {
         name: "General",
     });
     const { createComposerSuggestionComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
     await createComposerSuggestionComponent(thread.composer, {
         isActive: true,
-        modelName: 'mail.thread',
+        modelName: 'Thread',
         recordLocalId: thread.localId,
     });
 
@@ -84,13 +84,13 @@ QUnit.test('channel mention suggestion active', async function (assert) {
 
     this.data['mail.channel'].records.push({ id: 20 });
     const { createComposerSuggestionComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
     await createComposerSuggestionComponent(thread.composer, {
         isActive: true,
-        modelName: 'mail.thread',
+        modelName: 'Thread',
         recordLocalId: thread.localId,
     });
 

--- a/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_command_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_command_tests.js
@@ -27,7 +27,7 @@ QUnit.test('command suggestion displayed', async function (assert) {
 
     this.data['mail.channel'].records.push({ id: 20 });
     const { createComposerSuggestionComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -54,7 +54,7 @@ QUnit.test('command suggestion correct data', async function (assert) {
 
     this.data['mail.channel'].records.push({ id: 20 });
     const { createComposerSuggestionComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -101,7 +101,7 @@ QUnit.test('command suggestion active', async function (assert) {
 
     this.data['mail.channel'].records.push({ id: 20 });
     const { createComposerSuggestionComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });

--- a/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_partner_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_partner_tests.js
@@ -27,7 +27,7 @@ QUnit.test('partner mention suggestion displayed', async function (assert) {
 
     this.data['mail.channel'].records.push({ id: 20 });
     const { createComposerSuggestionComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -54,7 +54,7 @@ QUnit.test('partner mention suggestion correct data', async function (assert) {
 
     this.data['mail.channel'].records.push({ id: 20 });
     const { createComposerSuggestionComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -107,7 +107,7 @@ QUnit.test('partner mention suggestion active', async function (assert) {
 
     this.data['mail.channel'].records.push({ id: 20 });
     const { createComposerSuggestionComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });

--- a/addons/mail/static/src/components/discuss/tests/discuss_pinned_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_pinned_tests.js
@@ -44,7 +44,7 @@ QUnit.test('sidebar: pinned channel 1: init with one pinned channel', async func
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 20,
                 model: 'mail.channel',
             }).localId
@@ -61,7 +61,7 @@ QUnit.test('sidebar: pinned channel 2: open pinned channel', async function (ass
     this.data['mail.channel'].records.push({ id: 20 });
     await this.start();
 
-    const threadGeneral = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const threadGeneral = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -99,7 +99,7 @@ QUnit.test('sidebar: pinned channel 3: open channel and leave it', async functio
         },
     });
 
-    const threadGeneral = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const threadGeneral = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -137,7 +137,7 @@ QUnit.test('sidebar: unpin channel from bus', async function (assert) {
     // with a random unique id that will be referenced in the test
     this.data['mail.channel'].records.push({ id: 20 });
     await this.start();
-    const threadGeneral = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const threadGeneral = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -205,7 +205,7 @@ QUnit.test('[technical] sidebar: channel group_based_subscription: mandatorily p
         is_pinned: false, // expected value for this test
     });
     await this.start();
-    const threadGeneral = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const threadGeneral = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });

--- a/addons/mail/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_tests.js
@@ -451,7 +451,7 @@ QUnit.test('sidebar: basic channel rendering', async function (assert) {
     `);
     assert.strictEqual(
         channel.dataset.threadLocalId,
-        this.messaging.models['mail.thread'].findFromIdentifyingData({
+        this.messaging.models['Thread'].findFromIdentifyingData({
             id: 20,
             model: 'mail.channel',
         }).localId,
@@ -579,7 +579,7 @@ QUnit.test('sidebar: public/private channel rendering', async function (assert) 
         document.querySelectorAll(`
             .o_DiscussSidebar_categoryChannel
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 100,
                     model: 'mail.channel',
                 }).localId
@@ -592,7 +592,7 @@ QUnit.test('sidebar: public/private channel rendering', async function (assert) 
         document.querySelectorAll(`
             .o_DiscussSidebar_categoryChannel
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 101,
                     model: 'mail.channel'
                 }).localId
@@ -604,7 +604,7 @@ QUnit.test('sidebar: public/private channel rendering', async function (assert) 
     const channel1 = document.querySelector(`
         .o_DiscussSidebar_categoryChannel
         .o_DiscussSidebarCategory_item[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 100,
                 model: 'mail.channel'
             }).localId
@@ -613,7 +613,7 @@ QUnit.test('sidebar: public/private channel rendering', async function (assert) 
     const channel2 = document.querySelector(`
         .o_DiscussSidebar_categoryChannel
         .o_DiscussSidebarCategory_item[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 101,
                 model: 'mail.channel'
             }).localId
@@ -652,7 +652,7 @@ QUnit.test('sidebar: basic chat rendering', async function (assert) {
     const chat = document.querySelector(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_item`);
     assert.strictEqual(
         chat.dataset.threadLocalId,
-        this.messaging.models['mail.thread'].findFromIdentifyingData({
+        this.messaging.models['Thread'].findFromIdentifyingData({
             id: 10,
             model: 'mail.channel'
         }).localId,
@@ -770,7 +770,7 @@ QUnit.test('sidebar: chat im_status rendering', async function (assert) {
         document.querySelectorAll(`
             .o_DiscussSidebar_categoryChat
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 11,
                     model: 'mail.channel',
                 }).localId
@@ -783,7 +783,7 @@ QUnit.test('sidebar: chat im_status rendering', async function (assert) {
         document.querySelectorAll(`
             .o_DiscussSidebar_categoryChat
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 12,
                     model: 'mail.channel',
                 }).localId
@@ -796,7 +796,7 @@ QUnit.test('sidebar: chat im_status rendering', async function (assert) {
         document.querySelectorAll(`
             .o_DiscussSidebar_categoryChat
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 13,
                     model: 'mail.channel',
                 }).localId
@@ -808,7 +808,7 @@ QUnit.test('sidebar: chat im_status rendering', async function (assert) {
     const chat1 = document.querySelector(`
         .o_DiscussSidebar_categoryChat
         .o_DiscussSidebarCategory_item[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
             }).localId
@@ -817,7 +817,7 @@ QUnit.test('sidebar: chat im_status rendering', async function (assert) {
     const chat2 = document.querySelector(`
         .o_DiscussSidebar_categoryChat
         .o_DiscussSidebarCategory_item[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 12,
                 model: 'mail.channel',
             }).localId
@@ -826,7 +826,7 @@ QUnit.test('sidebar: chat im_status rendering', async function (assert) {
     const chat3 = document.querySelector(`
         .o_DiscussSidebar_categoryChat
         .o_DiscussSidebarCategory_item[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 13,
                 model: 'mail.channel',
             }).localId
@@ -908,7 +908,7 @@ QUnit.test('default thread rendering', async function (assert) {
     assert.strictEqual(
         document.querySelectorAll(`
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 20,
                     model: 'mail.channel',
                 }).localId
@@ -998,7 +998,7 @@ QUnit.test('default thread rendering', async function (assert) {
     await afterNextRender(() =>
         document.querySelector(`
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 20,
                     model: 'mail.channel',
                 }).localId
@@ -1008,7 +1008,7 @@ QUnit.test('default thread rendering', async function (assert) {
     assert.ok(
         document.querySelector(`
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 20,
                     model: 'mail.channel',
                 }).localId
@@ -1166,7 +1166,7 @@ QUnit.test('open channel from active_id as channel id', async function (assert) 
         document.body,
         `
             .o_Discuss_thread[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({ id: 20, model: 'mail.channel' }).localId
+                this.messaging.models['Thread'].findFromIdentifyingData({ id: 20, model: 'mail.channel' }).localId
             }"]
         `,
         "should have channel with ID 20 open in Discuss when providing active_id 20"
@@ -1952,7 +1952,7 @@ QUnit.test('restore thread scroll position', async function (assert) {
             document.querySelector(`
                 .o_DiscussSidebar_categoryChannel
                 .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                    this.messaging.models['mail.thread'].findFromIdentifyingData({
+                    this.messaging.models['Thread'].findFromIdentifyingData({
                         id: 12,
                         model: 'mail.channel',
                     }).localId
@@ -1985,7 +1985,7 @@ QUnit.test('restore thread scroll position', async function (assert) {
             document.querySelector(`
                 .o_DiscussSidebar_categoryChannel
                 .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                    this.messaging.models['mail.thread'].findFromIdentifyingData({
+                    this.messaging.models['Thread'].findFromIdentifyingData({
                         id: 11,
                         model: 'mail.channel',
                     }).localId
@@ -2015,7 +2015,7 @@ QUnit.test('restore thread scroll position', async function (assert) {
             document.querySelector(`
                 .o_DiscussSidebar_categoryChannel
                 .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                    this.messaging.models['mail.thread'].findFromIdentifyingData({
+                    this.messaging.models['Thread'].findFromIdentifyingData({
                         id: 12,
                         model: 'mail.channel',
                     }).localId
@@ -2082,7 +2082,7 @@ QUnit.test('redirect to author (open chat)', async function (assert) {
         document.querySelector(`
             .o_DiscussSidebar_categoryChannel
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 1,
                     model: 'mail.channel',
                 }).localId
@@ -2094,7 +2094,7 @@ QUnit.test('redirect to author (open chat)', async function (assert) {
         document.querySelector(`
             .o_DiscussSidebar_categoryChat
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 10,
                     model: 'mail.channel',
                 }).localId
@@ -2130,7 +2130,7 @@ QUnit.test('redirect to author (open chat)', async function (assert) {
         document.querySelector(`
             .o_DiscussSidebar_categoryChannel
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 1,
                     model: 'mail.channel',
                 }).localId
@@ -2142,7 +2142,7 @@ QUnit.test('redirect to author (open chat)', async function (assert) {
         document.querySelector(`
             .o_DiscussSidebar_categoryChat
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 10,
                     model: 'mail.channel',
                 }).localId
@@ -2199,7 +2199,7 @@ QUnit.test('sidebar quick search', async function (assert) {
         document.querySelector(`
             .o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_item
         `).dataset.threadLocalId,
-        this.messaging.models['mail.thread'].findFromIdentifyingData({
+        this.messaging.models['Thread'].findFromIdentifyingData({
             id: 12,
             model: 'mail.channel',
         }).localId,
@@ -2269,7 +2269,7 @@ QUnit.test('basic top bar rendering', async function (assert) {
     await afterNextRender(() =>
         document.querySelector(`
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 20,
                     model: 'mail.channel',
                 }).localId
@@ -2340,7 +2340,7 @@ QUnit.test('inbox: mark all messages as read', async function (assert) {
     assert.strictEqual(
         document.querySelector(`
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 20,
                     model: 'mail.channel',
                 }).localId
@@ -2375,7 +2375,7 @@ QUnit.test('inbox: mark all messages as read', async function (assert) {
     assert.strictEqual(
         document.querySelectorAll(`
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 20,
                     model: 'mail.channel',
                 }).localId
@@ -2977,7 +2977,7 @@ QUnit.test('mark channel as seen on last message visible [REQUIRE FOCUS]', async
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategory_item[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 10,
                 model: 'mail.channel',
             }).localId
@@ -2987,7 +2987,7 @@ QUnit.test('mark channel as seen on last message visible [REQUIRE FOCUS]', async
     assert.hasClass(
         document.querySelector(`
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 10,
                     model: 'mail.channel',
                 }).localId
@@ -3002,7 +3002,7 @@ QUnit.test('mark channel as seen on last message visible [REQUIRE FOCUS]', async
         func: () => {
             document.querySelector(`
                 .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                    this.messaging.models['mail.thread'].findFromIdentifyingData({
+                    this.messaging.models['Thread'].findFromIdentifyingData({
                         id: 10,
                         model: 'mail.channel',
                     }).localId
@@ -3021,7 +3021,7 @@ QUnit.test('mark channel as seen on last message visible [REQUIRE FOCUS]', async
     assert.doesNotHaveClass(
         document.querySelector(`
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 10,
                     model: 'mail.channel',
                 }).localId
@@ -3954,7 +3954,7 @@ QUnit.test('mark channel as seen if last message is visible when switching chann
         func: () => {
             document.querySelector(`
                 .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                    this.messaging.models['mail.thread'].findFromIdentifyingData({
+                    this.messaging.models['Thread'].findFromIdentifyingData({
                         id: 10,
                         model: 'mail.channel',
                     }).localId
@@ -3973,7 +3973,7 @@ QUnit.test('mark channel as seen if last message is visible when switching chann
     assert.doesNotHaveClass(
         document.querySelector(`
             .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 10,
                     model: 'mail.channel',
                 }).localId

--- a/addons/mail/static/src/components/discuss_mobile_mailbox_selection/discuss_mobile_mailbox_selection.js
+++ b/addons/mail/static/src/components/discuss_mobile_mailbox_selection/discuss_mobile_mailbox_selection.js
@@ -11,13 +11,13 @@ export class DiscussMobileMailboxSelection extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.thread[]}
+     * @returns {Thread[]}
      */
     get orderedMailboxes() {
         if (!this.messaging) {
             return [];
         }
-        return this.messaging.models['mail.thread']
+        return this.messaging.models['Thread']
             .all(thread => thread.isPinned && thread.model === 'mail.box')
             .sort((mailbox1, mailbox2) => {
                 if (mailbox1 === this.messaging.inbox) {
@@ -57,7 +57,7 @@ export class DiscussMobileMailboxSelection extends Component {
      */
     _onClick(ev) {
         const { mailboxLocalId } = ev.currentTarget.dataset;
-        const mailbox = this.messaging.models['mail.thread'].get(mailboxLocalId);
+        const mailbox = this.messaging.models['Thread'].get(mailboxLocalId);
         if (!mailbox) {
             return;
         }

--- a/addons/mail/static/src/components/discuss_sidebar/discuss_sidebar.xml
+++ b/addons/mail/static/src/components/discuss_sidebar/discuss_sidebar.xml
@@ -15,7 +15,7 @@
                 <DiscussSidebarMailbox threadLocalId="messaging.history.localId"/>
             </div>
             <hr class="o_DiscussSidebar_separator"/>
-            <t t-if="messaging.models['mail.thread'].all(thread => thread.isPinned and thread.model === 'mail.channel').length > 19">
+            <t t-if="messaging.models['Thread'].all(thread => thread.isPinned and thread.model === 'mail.channel').length > 19">
                 <input class="o_DiscussSidebar_quickSearch" t-on-input="_onInputQuickSearch" placeholder="Quick search..." t-ref="quickSearchInput" t-esc="discuss.sidebarQuickSearchValue"/>
             </t>
             <DiscussSidebarCategory

--- a/addons/mail/static/src/components/discuss_sidebar_category/tests/discuss_sidebar_category_tests.js
+++ b/addons/mail/static/src/components/discuss_sidebar_category/tests/discuss_sidebar_category_tests.js
@@ -206,7 +206,7 @@ QUnit.test('channel - states: close manually by clicking the title', async funct
     assert.containsNone(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 20,
                 model: 'mail.channel',
             }).localId
@@ -231,7 +231,7 @@ QUnit.test('channel - states: open manually by clicking the title', async functi
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 20,
                 model: 'mail.channel',
             }).localId
@@ -335,7 +335,7 @@ QUnit.test('channel - states: close from the bus', async function (assert) {
     assert.containsNone(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 20,
                 model: 'mail.channel',
             }).localId
@@ -365,7 +365,7 @@ QUnit.test('channel - states: open from the bus', async function (assert) {
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 20,
                 model: 'mail.channel',
             }).localId
@@ -383,7 +383,7 @@ QUnit.test('channel - states: the active category item should be visble even if 
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 20,
                 model: 'mail.channel',
             }).localId
@@ -391,7 +391,7 @@ QUnit.test('channel - states: the active category item should be visble even if 
     );
 
     const channel = document.querySelector(`.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-        this.messaging.models['mail.thread'].findFromIdentifyingData({
+        this.messaging.models['Thread'].findFromIdentifyingData({
             id: 20,
             model: 'mail.channel',
         }).localId
@@ -408,7 +408,7 @@ QUnit.test('channel - states: the active category item should be visble even if 
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 20,
                 model: 'mail.channel',
             }).localId
@@ -425,7 +425,7 @@ QUnit.test('channel - states: the active category item should be visble even if 
     assert.containsNone(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 20,
                 model: 'mail.channel',
             }).localId
@@ -565,7 +565,7 @@ QUnit.test('chat - states: close manually by clicking the title', async function
     assert.containsNone(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 10,
                 model: 'mail.channel',
             }).localId
@@ -595,7 +595,7 @@ QUnit.test('chat - states: open manually by clicking the title', async function 
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 10,
                 model: 'mail.channel',
             }).localId
@@ -704,7 +704,7 @@ QUnit.test('chat - states: close from the bus', async function (assert) {
     assert.containsNone(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 10,
                 model: 'mail.channel',
             }).localId
@@ -739,7 +739,7 @@ QUnit.test('chat - states: open from the bus', async function (assert) {
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 10,
                 model: 'mail.channel',
             }).localId
@@ -762,7 +762,7 @@ QUnit.test('chat - states: the active category item should be visble even if the
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 10,
                 model: 'mail.channel',
             }).localId
@@ -770,7 +770,7 @@ QUnit.test('chat - states: the active category item should be visble even if the
     );
 
     const chat = document.querySelector(`.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-        this.messaging.models['mail.thread'].findFromIdentifyingData({
+        this.messaging.models['Thread'].findFromIdentifyingData({
             id: 10,
             model: 'mail.channel',
         }).localId
@@ -787,7 +787,7 @@ QUnit.test('chat - states: the active category item should be visble even if the
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 10,
                 model: 'mail.channel',
             }).localId
@@ -804,7 +804,7 @@ QUnit.test('chat - states: the active category item should be visble even if the
     assert.containsNone(
         document.body,
         `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 10,
                 model: 'mail.channel',
             }).localId

--- a/addons/mail/static/src/components/discuss_sidebar_category_item/tests/discuss_sidebar_category_item_tests.js
+++ b/addons/mail/static/src/components/discuss_sidebar_category_item/tests/discuss_sidebar_category_item_tests.js
@@ -43,7 +43,7 @@ QUnit.test('channel - avatar: should have correct avatar', async function (asser
 
     const channelItem = document.querySelector(`
         .o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 20,
                 model: 'mail.channel',
             }).localId
@@ -75,7 +75,7 @@ QUnit.test('channel - avatar: should update avatar url from bus', async function
 
     const channelItemAvatar = document.querySelector(`
         .o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 20,
                 model: 'mail.channel',
             }).localId
@@ -122,7 +122,7 @@ QUnit.test('chat - avatar: should have correct avatar', async function (assert) 
 
     const chatItem = document.querySelector(`
         .o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 10,
                 model: 'mail.channel',
             }).localId
@@ -157,11 +157,11 @@ QUnit.test('chat - sorting: should be sorted by last activity time', async funct
     });
     await this.start();
 
-    const chat10 = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const chat10 = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 10,
         model: 'mail.channel',
     });
-    const chat20 = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const chat20 = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });

--- a/addons/mail/static/src/components/discuss_sidebar_mailbox/discuss_sidebar_mailbox.js
+++ b/addons/mail/static/src/components/discuss_sidebar_mailbox/discuss_sidebar_mailbox.js
@@ -11,10 +11,10 @@ export class DiscussSidebarMailbox extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.thread}
+     * @returns {Thread}
      */
     get mailbox() {
-        return this.messaging.models['mail.thread'].get(this.props.threadLocalId);
+        return this.messaging.models['Thread'].get(this.props.threadLocalId);
     }
 
 }

--- a/addons/mail/static/src/components/file_uploader/file_uploader.js
+++ b/addons/mail/static/src/components/file_uploader/file_uploader.js
@@ -53,7 +53,7 @@ export class FileUploader extends Component {
     }
 
     get thread() {
-        return this.messaging.models['mail.thread'].get(this.props.threadLocalId);
+        return this.messaging.models['Thread'].get(this.props.threadLocalId);
     }
 
     //--------------------------------------------------------------------------
@@ -65,7 +65,7 @@ export class FileUploader extends Component {
      * @param {Object} param0
      * @param {mail.composer} param0.composer
      * @param {File} param0.file
-     * @param {mail.thread} param0.thread
+     * @param {Thread} param0.thread
      * @returns {FormData}
      */
     _createFormData({ composer, file, thread }) {
@@ -83,7 +83,7 @@ export class FileUploader extends Component {
      * @param {Object} param0
      * @param {mail.composer} param0.composer
      * @param {FileList|Array} param0.files
-     * @param {mail.thread} param0.thread
+     * @param {Thread} param0.thread
      * @returns {Promise}
      */
     async _performUpload({ composer, files, thread }) {
@@ -139,7 +139,7 @@ export class FileUploader extends Component {
      * @param {Object} param0
      * @param {Object} attachmentData
      * @param {mail.composer} param0.composer
-     * @param {mail.thread} param0.thread
+     * @param {Thread} param0.thread
      */
     _onAttachmentUploaded({ attachmentData, composer, thread }) {
         if (attachmentData.error || !attachmentData.id) {

--- a/addons/mail/static/src/components/follow_button/follow_button.js
+++ b/addons/mail/static/src/components/follow_button/follow_button.js
@@ -25,10 +25,10 @@ export class FollowButton extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @return {mail.thread}
+     * @return {Thread}
      */
     get thread() {
-        return this.messaging && this.messaging.models['mail.thread'].get(this.props.threadLocalId);
+        return this.messaging && this.messaging.models['Thread'].get(this.props.threadLocalId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/components/follow_button/tests/follow_button_tests.js
+++ b/addons/mail/static/src/components/follow_button/tests/follow_button_tests.js
@@ -40,7 +40,7 @@ QUnit.test('base rendering not editable', async function (assert) {
     assert.expect(3);
 
     await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });
@@ -65,7 +65,7 @@ QUnit.test('base rendering editable', async function (assert) {
     assert.expect(3);
 
     await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });
@@ -99,7 +99,7 @@ QUnit.test('hover following button', async function (assert) {
         res_model: 'res.partner',
     });
     await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });
@@ -176,7 +176,7 @@ QUnit.test('click on "follow" button', async function (assert) {
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });
@@ -231,7 +231,7 @@ QUnit.test('click on "unfollow" button', async function (assert) {
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });

--- a/addons/mail/static/src/components/follower/tests/follower_tests.js
+++ b/addons/mail/static/src/components/follower/tests/follower_tests.js
@@ -44,7 +44,7 @@ QUnit.test('base rendering not editable', async function (assert) {
 
     await this.start();
 
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });
@@ -90,7 +90,7 @@ QUnit.test('base rendering editable', async function (assert) {
     assert.expect(6);
 
     await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });
@@ -165,7 +165,7 @@ QUnit.test('click on partner follower details', async function (assert) {
     await this.start({
         env: { bus },
     });
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });
@@ -221,7 +221,7 @@ QUnit.test('click on edit follower', async function (assert) {
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });
@@ -271,7 +271,7 @@ QUnit.test('edit follower and close subtype dialog', async function (assert) {
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });

--- a/addons/mail/static/src/components/follower_list_menu/follower_list_menu.js
+++ b/addons/mail/static/src/components/follower_list_menu/follower_list_menu.js
@@ -38,10 +38,10 @@ export class FollowerListMenu extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @return {mail.thread}
+     * @return {Thread}
      */
     get thread() {
-        return this.messaging && this.messaging.models['mail.thread'].get(this.props.threadLocalId);
+        return this.messaging && this.messaging.models['Thread'].get(this.props.threadLocalId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/components/follower_list_menu/tests/follower_list_menu_tests.js
+++ b/addons/mail/static/src/components/follower_list_menu/tests/follower_list_menu_tests.js
@@ -43,7 +43,7 @@ QUnit.test('base rendering not editable', async function (assert) {
     assert.expect(5);
 
     await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });
@@ -80,7 +80,7 @@ QUnit.test('base rendering editable', async function (assert) {
     assert.expect(5);
 
     await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });
@@ -162,7 +162,7 @@ QUnit.test('click on "add followers" button', async function (assert) {
     await this.start({
         env: { bus },
     });
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });
@@ -247,7 +247,7 @@ QUnit.test('click on remove follower', async function (assert) {
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });

--- a/addons/mail/static/src/components/follower_subtype/tests/follower_subtype_tests.js
+++ b/addons/mail/static/src/components/follower_subtype/tests/follower_subtype_tests.js
@@ -45,7 +45,7 @@ QUnit.test('simplest layout of a followed subtype', async function (assert) {
 
     await this.start();
 
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });
@@ -105,7 +105,7 @@ QUnit.test('simplest layout of a not followed subtype', async function (assert) 
 
     await this.start();
 
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });
@@ -162,7 +162,7 @@ QUnit.test('toggle follower subtype checkbox', async function (assert) {
 
     await this.start();
 
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'res.partner',
     });

--- a/addons/mail/static/src/components/message/tests/message_tests.js
+++ b/addons/mail/static/src/components/message/tests/message_tests.js
@@ -130,7 +130,7 @@ QUnit.test('Notification Sent', async function (assert) {
         res_partner_id: 12,
     });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 11,
         model: 'mail.channel',
     });
@@ -229,7 +229,7 @@ QUnit.test('Notification Error', async function (assert) {
         res_partner_id: 12,
     });
     const { createThreadViewComponent } = await this.start({ env: { bus } });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 11,
         model: 'mail.channel',
     });
@@ -285,7 +285,7 @@ QUnit.test("'channel_fetch' notification received is correctly handled", async f
         id: this.messaging.currentPartner.id,
         display_name: "Demo User",
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 11,
         model: 'mail.channel',
     });
@@ -350,7 +350,7 @@ QUnit.test("'channel_seen' notification received is correctly handled", async fu
         id: this.messaging.currentPartner.id,
         display_name: "Demo User",
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 11,
         model: 'mail.channel',
     });
@@ -414,7 +414,7 @@ QUnit.test("'channel_fetch' notification then 'channel_seen' received  are corre
         id: this.messaging.currentPartner.id,
         display_name: "Demo User",
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 11,
         model: 'mail.channel',
     });
@@ -486,7 +486,7 @@ QUnit.test('do not show messaging seen indicator if not authored by me', async f
         id: 100,
         display_name: "Demo User"
     });
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         channel_type: 'chat',
         id: 11,
         partnerSeenInfos: insertAndReplace([
@@ -534,7 +534,7 @@ QUnit.test('do not show messaging seen indicator if before last seen by all mess
         id: this.messaging.currentPartner.id,
         display_name: "Demo User",
     });
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         channel_type: 'chat',
         id: 11,
         messageSeenIndicators: insertAndReplace({
@@ -601,7 +601,7 @@ QUnit.test('only show messaging seen indicator if authored by me, after last see
         id: this.messaging.currentPartner.id,
         display_name: "Demo User"
     });
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         channel_type: 'chat',
         id: 11,
         partnerSeenInfos: insertAndReplace([

--- a/addons/mail/static/src/components/message_author_prefix/message_author_prefix.js
+++ b/addons/mail/static/src/components/message_author_prefix/message_author_prefix.js
@@ -18,10 +18,10 @@ export class MessageAuthorPrefix extends Component {
     }
 
     /**
-     * @returns {mail.thread|undefined}
+     * @returns {Thread|undefined}
      */
     get thread() {
-        return this.messaging && this.messaging.models['mail.thread'].get(this.props.threadLocalId);
+        return this.messaging && this.messaging.models['Thread'].get(this.props.threadLocalId);
     }
 
 }

--- a/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator.js
+++ b/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator.js
@@ -93,10 +93,10 @@ export class MessageSeenIndicator extends Component {
     }
 
     /**
-     * @returns {mail.Thread}
+     * @returns {Thread}
      */
     get thread() {
-        return this.messaging && this.messaging.models['mail.thread'].get(this.props.threadLocalId);
+        return this.messaging && this.messaging.models['Thread'].get(this.props.threadLocalId);
     }
 }
 

--- a/addons/mail/static/src/components/message_seen_indicator/tests/message_seen_indicator_tests.js
+++ b/addons/mail/static/src/components/message_seen_indicator/tests/message_seen_indicator_tests.js
@@ -43,7 +43,7 @@ QUnit.test('rendering when just one has received the message', async function (a
     assert.expect(3);
 
     await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 1000,
         model: 'mail.channel',
         partnerSeenInfos: insertAndReplace([
@@ -87,7 +87,7 @@ QUnit.test('rendering when everyone have received the message', async function (
     assert.expect(3);
 
     await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 1000,
         model: 'mail.channel',
         partnerSeenInfos: insertAndReplace([
@@ -132,7 +132,7 @@ QUnit.test('rendering when just one has seen the message', async function (asser
     assert.expect(3);
 
     await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 1000,
         model: 'mail.channel',
         partnerSeenInfos: insertAndReplace([
@@ -179,7 +179,7 @@ QUnit.test('rendering when just one has seen & received the message', async func
     assert.expect(3);
 
     await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 1000,
         model: 'mail.channel',
         partnerSeenInfos: insertAndReplace([
@@ -225,7 +225,7 @@ QUnit.test('rendering when just everyone has seen the message', async function (
     assert.expect(3);
 
     await this.start();
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 1000,
         model: 'mail.channel',
         partnerSeenInfos: insertAndReplace([

--- a/addons/mail/static/src/components/messaging_menu/tests/messaging_menu_tests.js
+++ b/addons/mail/static/src/components/messaging_menu/tests/messaging_menu_tests.js
@@ -587,7 +587,7 @@ QUnit.test('filtered previews', async function (assert) {
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
             .o_ThreadPreview[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 10,
                     model: 'mail.channel',
                 }).localId
@@ -600,7 +600,7 @@ QUnit.test('filtered previews', async function (assert) {
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
             .o_ThreadPreview[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 20,
                     model: 'mail.channel',
                 }).localId
@@ -622,7 +622,7 @@ QUnit.test('filtered previews', async function (assert) {
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
             .o_ThreadPreview[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 10,
                     model: 'mail.channel',
                 }).localId
@@ -635,7 +635,7 @@ QUnit.test('filtered previews', async function (assert) {
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
             .o_ThreadPreview[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 20,
                     model: 'mail.channel',
                 }).localId
@@ -660,7 +660,7 @@ QUnit.test('filtered previews', async function (assert) {
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
             .o_ThreadPreview[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 10,
                     model: 'mail.channel',
                 }).localId
@@ -673,7 +673,7 @@ QUnit.test('filtered previews', async function (assert) {
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
             .o_ThreadPreview[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 20,
                     model: 'mail.channel',
                 }).localId
@@ -695,7 +695,7 @@ QUnit.test('filtered previews', async function (assert) {
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
             .o_ThreadPreview[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 10,
                     model: 'mail.channel',
                 }).localId
@@ -708,7 +708,7 @@ QUnit.test('filtered previews', async function (assert) {
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
             .o_ThreadPreview[data-thread-local-id="${
-                this.messaging.models['mail.thread'].findFromIdentifyingData({
+                this.messaging.models['Thread'].findFromIdentifyingData({
                     id: 20,
                     model: 'mail.channel',
                 }).localId
@@ -1038,7 +1038,7 @@ QUnit.test('Group chat should be displayed inside the chat section of the messag
     assert.strictEqual(
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
-            .o_ThreadPreview[data-thread-local-id="${this.messaging.models['mail.thread'].findFromIdentifyingData({
+            .o_ThreadPreview[data-thread-local-id="${this.messaging.models['Thread'].findFromIdentifyingData({
                 id: 11,
                 model: 'mail.channel',
              }).localId}"]`).length,

--- a/addons/mail/static/src/components/notification_list/notification_list.js
+++ b/addons/mail/static/src/components/notification_list/notification_list.js
@@ -34,7 +34,7 @@ export class NotificationList extends Component {
         let threadNeedactionNotifications = [];
         if (this.props.filter === 'all') {
             // threads with needactions
-            threadNeedactionNotifications = this.messaging.models['mail.thread']
+            threadNeedactionNotifications = this.messaging.models['Thread']
                 .all(t => t.model !== 'mail.box' && t.needactionMessagesAsOriginThread.length > 0)
                 .sort((t1, t2) => {
                     if (t1.needactionMessagesAsOriginThread.length > 0 && t2.needactionMessagesAsOriginThread.length === 0) {
@@ -124,18 +124,18 @@ export class NotificationList extends Component {
         const threads = this.notifications
             .filter(notification => notification.thread && notification.thread.exists())
             .map(notification => notification.thread);
-        this.messaging.models['mail.thread'].loadPreviews(threads);
+        this.messaging.models['Thread'].loadPreviews(threads);
     }
 
     /**
      * @private
      * @param {Object} props
      * @throws {Error} in case `props.filter` is not supported
-     * @returns {mail.thread[]}
+     * @returns {Thread[]}
      */
     _getThreads(props) {
         if (props.filter === 'mailbox') {
-            return this.messaging.models['mail.thread']
+            return this.messaging.models['Thread']
                 .all(thread => thread.isPinned && thread.model === 'mail.box')
                 .sort((mailbox1, mailbox2) => {
                     if (mailbox1 === this.messaging.inbox) {
@@ -155,7 +155,7 @@ export class NotificationList extends Component {
                     mailbox1Name < mailbox2Name ? -1 : 1;
                 });
         } else if (props.filter === 'channel') {
-            return this.messaging.models['mail.thread']
+            return this.messaging.models['Thread']
                 .all(thread =>
                     thread.channel_type === 'channel' &&
                     thread.isPinned &&
@@ -163,7 +163,7 @@ export class NotificationList extends Component {
                 )
                 .sort((c1, c2) => c1.displayName < c2.displayName ? -1 : 1);
         } else if (props.filter === 'chat') {
-            return this.messaging.models['mail.thread']
+            return this.messaging.models['Thread']
                 .all(thread =>
                     thread.isChatChannel &&
                     thread.isPinned &&
@@ -172,7 +172,7 @@ export class NotificationList extends Component {
                 .sort((c1, c2) => c1.displayName < c2.displayName ? -1 : 1);
         } else if (props.filter === 'all') {
             // "All" filter is for channels and chats
-            return this.messaging.models['mail.thread']
+            return this.messaging.models['Thread']
                 .all(thread => thread.isPinned && thread.model === 'mail.channel')
                 .sort((c1, c2) => c1.displayName < c2.displayName ? -1 : 1);
         } else {

--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.js
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.js
@@ -20,7 +20,7 @@ export class RtcCallParticipantCard extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.thread|undefined}
+     * @returns {Thread|undefined}
      */
     get callParticipantCard() {
         return this.messaging.models['mail.rtc_call_participant_card'].get(this.props.callParticipantCardLocalId);

--- a/addons/mail/static/src/components/rtc_invitation_card/rtc_invitation_card.js
+++ b/addons/mail/static/src/components/rtc_invitation_card/rtc_invitation_card.js
@@ -11,10 +11,10 @@ export class RtcInvitationCard extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.thread}
+     * @returns {Thread}
      */
     get thread() {
-        return this.messaging.models['mail.thread'].get(this.props.threadLocalId);
+        return this.messaging.models['Thread'].get(this.props.threadLocalId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/components/thread_icon/tests/thread_icon_tests.js
+++ b/addons/mail/static/src/components/thread_icon/tests/thread_icon_tests.js
@@ -50,7 +50,7 @@ QUnit.test('chat: correspondent is typing', async function (assert) {
         members: [this.data.currentPartnerId, 17],
     });
     await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });

--- a/addons/mail/static/src/components/thread_icon/thread_icon.js
+++ b/addons/mail/static/src/components/thread_icon/thread_icon.js
@@ -11,10 +11,10 @@ export class ThreadIcon extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.thread}
+     * @returns {Thread}
      */
     get thread() {
-        return this.messaging && this.messaging.models['mail.thread'].get(this.props.threadLocalId);
+        return this.messaging && this.messaging.models['Thread'].get(this.props.threadLocalId);
     }
 
 }

--- a/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.js
+++ b/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.js
@@ -56,10 +56,10 @@ export class ThreadNeedactionPreview extends Component {
     }
 
     /**
-     * @returns {mail.thread}
+     * @returns {Thread}
      */
     get thread() {
-        return this.messaging && this.messaging.models['mail.thread'].get(this.props.threadLocalId);
+        return this.messaging && this.messaging.models['Thread'].get(this.props.threadLocalId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/components/thread_preview/tests/thread_preview_tests.js
+++ b/addons/mail/static/src/components/thread_preview/tests/thread_preview_tests.js
@@ -56,7 +56,7 @@ QUnit.test('mark as read', async function (assert) {
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 11,
         model: 'mail.channel',
     });

--- a/addons/mail/static/src/components/thread_preview/thread_preview.js
+++ b/addons/mail/static/src/components/thread_preview/thread_preview.js
@@ -50,10 +50,10 @@ export class ThreadPreview extends Component {
     }
 
     /**
-     * @returns {mail.thread}
+     * @returns {Thread}
      */
     get thread() {
-        return this.messaging && this.messaging.models['mail.thread'].get(this.props.threadLocalId);
+        return this.messaging && this.messaging.models['Thread'].get(this.props.threadLocalId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/components/thread_textual_typing_status/tests/thread_textual_typing_status_tests.js
+++ b/addons/mail/static/src/components/thread_textual_typing_status/tests/thread_textual_typing_status_tests.js
@@ -45,7 +45,7 @@ QUnit.test('receive other member typing status "is typing"', async function (ass
         members: [this.data.currentPartnerId, 17],
     });
     await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -85,7 +85,7 @@ QUnit.test('receive other member typing status "is typing" then "no longer is ty
         members: [this.data.currentPartnerId, 17],
     });
     await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -145,7 +145,7 @@ QUnit.test('assume other member typing status becomes "no longer is typing" afte
     await this.start({
         hasTimeControl: true,
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -194,7 +194,7 @@ QUnit.test ('other member typing status "is typing" refreshes 60 seconds timer o
     await this.start({
         hasTimeControl: true,
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -264,7 +264,7 @@ QUnit.test('receive several other members typing status "is typing"', async func
         members: [this.data.currentPartnerId, 10, 11, 12],
     });
     await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });

--- a/addons/mail/static/src/components/thread_textual_typing_status/thread_textual_typing_status.js
+++ b/addons/mail/static/src/components/thread_textual_typing_status/thread_textual_typing_status.js
@@ -11,10 +11,10 @@ export class ThreadTextualTypingStatus extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.thread}
+     * @returns {Thread}
      */
     get thread() {
-        return this.messaging && this.messaging.models['mail.thread'].get(this.props.threadLocalId);
+        return this.messaging && this.messaging.models['Thread'].get(this.props.threadLocalId);
     }
 
 }

--- a/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
+++ b/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
@@ -54,7 +54,7 @@ QUnit.test('dragover files on thread with composer', async function (assert) {
         public: 'public',
     });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
     });
@@ -103,7 +103,7 @@ QUnit.test('message list desc order', async function (assert) {
         public: 'public',
     });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
     });
@@ -202,7 +202,7 @@ QUnit.test('message list asc order', async function (assert) {
         public: 'public',
     });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
     });
@@ -312,7 +312,7 @@ QUnit.test('mark channel as fetched when a new message is loaded and as seen whe
             return this._super(...arguments);
         }
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
     });
@@ -382,7 +382,7 @@ QUnit.test('mark channel as fetched and seen when a new message is loaded if com
             return this._super(...arguments);
         }
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
     });
@@ -436,7 +436,7 @@ QUnit.test('show message subject when subject is not the same as the thread name
         subject: "Salutations, voyageur",
     });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
     });
@@ -480,7 +480,7 @@ QUnit.test('do not show message subject when subject is the same as the thread n
         subject: "Salutations, voyageur",
     });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
     });
@@ -517,7 +517,7 @@ QUnit.test('[technical] new messages separator on posting message', async functi
         res_id: 20,
     });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel'
     });
@@ -588,7 +588,7 @@ QUnit.test('new messages separator on receiving new message [REQUIRE FOCUS]', as
         res_id: 20,
     });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel'
     });
@@ -682,7 +682,7 @@ QUnit.test('new messages separator on posting message', async function (assert) 
         name: "General",
     }];
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel'
     });
@@ -834,7 +834,7 @@ QUnit.test('should scroll to bottom on receiving new message if the list is init
         });
     }
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel'
     });
@@ -907,7 +907,7 @@ QUnit.test('should not scroll on receiving new message if the list is initially 
         });
     }
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel'
     });
@@ -1165,7 +1165,7 @@ QUnit.test('Post a message containing an email address followed by a mention on 
         name: "TestPartner",
     });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 11,
         model: 'mail.channel',
     });
@@ -1209,7 +1209,7 @@ QUnit.test(`Mention a partner with special character (e.g. apostrophe ')`, async
         name: "Pynya's spokesman",
     });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 11,
         model: 'mail.channel',
     });
@@ -1258,7 +1258,7 @@ QUnit.test('mention 2 different partners that have the same name', async functio
         },
     );
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 11,
         model: 'mail.channel',
     });
@@ -1311,7 +1311,7 @@ QUnit.test('mention a channel with space in the name', async function (assert) {
         name: "General good boy",
     });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 7,
         model: 'mail.channel',
     });
@@ -1356,7 +1356,7 @@ QUnit.test('mention a channel with "&" in the name', async function (assert) {
         name: "General & good",
     });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 7,
         model: 'mail.channel',
     });
@@ -1401,7 +1401,7 @@ QUnit.test('mention a channel on a second line when the first line contains #', 
         name: "General good",
     });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 7,
         model: 'mail.channel',
     });
@@ -1446,7 +1446,7 @@ QUnit.test('mention a channel when replacing the space after the mention by anot
         name: "General good",
     });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 7,
         model: 'mail.channel',
     });
@@ -1507,7 +1507,7 @@ QUnit.test('mention 2 different channels that have the same name', async functio
         },
     );
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 11,
         model: 'mail.channel',
     });
@@ -1771,7 +1771,7 @@ QUnit.test('first unseen message should be directly preceded by the new message 
         uuid: 'channel20uuid',
     }];
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel'
     });
@@ -1826,7 +1826,7 @@ QUnit.test('composer should be focused automatically after clicking on the send 
 
     this.data['mail.channel'].records.push({ id: 20 });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel'
     });
@@ -1865,7 +1865,7 @@ QUnit.test('failure on loading messages should display error', async function (a
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel'
     });
@@ -1900,7 +1900,7 @@ QUnit.test('failure on loading messages should prompt retry button', async funct
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel'
     });
@@ -1949,7 +1949,7 @@ QUnit.test('failure on loading more messages should not alter message list displ
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel'
     });
@@ -2001,7 +2001,7 @@ QUnit.test('failure on loading more messages should display error and prompt ret
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel'
     });
@@ -2062,7 +2062,7 @@ QUnit.test('Retry loading more messages on failed load more messages should load
             return this._super(...arguments);
         },
     });
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel'
     });
@@ -2113,7 +2113,7 @@ QUnit.test("highlight the message mentioning the current user inside the channel
         res_id: 20,
     });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel'
     });
@@ -2154,7 +2154,7 @@ QUnit.test("not highlighting the message if not mentioning the current user insi
         res_id: 20,
     });
     const { createThreadViewComponent } = await this.start();
-    const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const thread = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel'
     });

--- a/addons/mail/static/src/models/activity/activity.js
+++ b/addons/mail/static/src/models/activity/activity.js
@@ -287,7 +287,7 @@ registerModel({
          * Determines to which "thread" (using `mail.activity.mixin` on the
          * server) `this` belongs to.
          */
-        thread: many2one('mail.thread', {
+        thread: many2one('Thread', {
             inverse: 'activities',
         }),
         type: many2one('mail.activity_type', {

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -398,11 +398,11 @@ registerModel({
             default: '',
         }),
         name: attr(),
-        originThread: many2one('mail.thread', {
+        originThread: many2one('Thread', {
             inverse: 'originThreadAttachments',
         }),
         size: attr(),
-        threads: many2many('mail.thread', {
+        threads: many2many('Thread', {
             inverse: 'attachments',
         }),
         type: attr(),

--- a/addons/mail/static/src/models/canned_response/canned_response.js
+++ b/addons/mail/static/src/models/canned_response/canned_response.js
@@ -17,7 +17,7 @@ registerModel({
          *
          * @param {string} searchTerm
          * @param {Object} [options={}]
-         * @param {mail.thread} [options.thread] prioritize and/or restrict
+         * @param {Thread} [options.thread] prioritize and/or restrict
          *  result in the context of given thread
          */
         fetchSuggestions(searchTerm, { thread } = {}) {},
@@ -27,7 +27,7 @@ registerModel({
          *
          * @param {string} searchTerm
          * @param {Object} [options={}]
-         * @param {mail.thread} [options.thread] prioritize result in the
+         * @param {Thread} [options.thread] prioritize result in the
          *  context of given thread
          * @returns {function}
          */
@@ -57,7 +57,7 @@ registerModel({
          * @static
          * @param {string} searchTerm
          * @param {Object} [options={}]
-         * @param {mail.thread} [options.thread] prioritize and/or restrict
+         * @param {Thread} [options.thread] prioritize and/or restrict
          *  result in the context of given thread
          * @returns {[mail.canned_response[], mail.canned_response[]]}
          */

--- a/addons/mail/static/src/models/channel_command/channel_command.js
+++ b/addons/mail/static/src/models/channel_command/channel_command.js
@@ -17,7 +17,7 @@ registerModel({
          *
          * @param {string} searchTerm
          * @param {Object} [options={}]
-         * @param {mail.thread} [options.thread] prioritize and/or restrict
+         * @param {Thread} [options.thread] prioritize and/or restrict
          *  result in the context of given thread
          */
         fetchSuggestions(searchTerm, { thread } = {}) {},
@@ -27,7 +27,7 @@ registerModel({
          *
          * @param {string} searchTerm
          * @param {Object} [options={}]
-         * @param {mail.thread} [options.thread] prioritize result in the
+         * @param {Thread} [options.thread] prioritize result in the
          *  context of given thread
          * @returns {function}
          */
@@ -64,7 +64,7 @@ registerModel({
          *
          * @param {string} searchTerm
          * @param {Object} [options={}]
-         * @param {mail.thread} [options.thread] prioritize and/or restrict
+         * @param {Thread} [options.thread] prioritize and/or restrict
          *  result in the context of given thread
          * @returns {[mail.channel_command[], mail.channel_command[]]}
          */
@@ -90,7 +90,7 @@ registerModel({
          * Executes this command on the given `mail.channel`.
          *
          * @param {Object} param0
-         * @param {mail.thread} param0.channel
+         * @param {Thread} param0.channel
          * @param {Object} [param0.body='']
          */
         async execute({ channel, body = '' }) {

--- a/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
@@ -28,7 +28,7 @@ registerModel({
                     ...this.thread.members.map(member => member.id),
                     ...this.selectedPartners.map(partner => partner.id),
                 ])];
-                const channel = await this.messaging.models['mail.thread'].createGroupChat({ partners_to });
+                const channel = await this.messaging.models['Thread'].createGroupChat({ partners_to });
                 if (this.thread.rtc) {
                     /**
                      * if we were in a RTC call on the current thread, we move to the new group chat.
@@ -243,7 +243,7 @@ registerModel({
         /**
          * States the thread on which this list operates (if any).
          */
-        thread: many2one('mail.thread', {
+        thread: many2one('Thread', {
             compute: '_computeThread',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/chat_window/chat_window.js
+++ b/addons/mail/static/src/models/chat_window/chat_window.js
@@ -460,10 +460,10 @@ registerModel({
             compute: '_computeName',
         }),
         /**
-         * Determines the `mail.thread` that should be displayed by `this`.
-         * If no `mail.thread` is linked, `this` is considered "new message".
+         * Determines the `Thread` that should be displayed by `this`.
+         * If no `Thread` is linked, `this` is considered "new message".
          */
-        thread: one2one('mail.thread', {
+        thread: one2one('Thread', {
             inverse: 'chatWindow',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/chat_window_manager/chat_window_manager.js
+++ b/addons/mail/static/src/models/chat_window_manager/chat_window_manager.js
@@ -66,7 +66,7 @@ registerModel({
         /**
          * Closes all chat windows related to the given thread.
          *
-         * @param {mail.thread} thread
+         * @param {Thread} thread
          * @param {Object} [options]
          */
         closeThread(thread, options) {
@@ -86,7 +86,7 @@ registerModel({
             this.newMessageChatWindow.makeActive();
         },
         /**
-         * @param {mail.thread} thread
+         * @param {Thread} thread
          * @param {Object} [param1={}]
          * @param {boolean} [param1.focus] if set, set focus the chat window
          *   to open.

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -372,9 +372,9 @@ registerModel({
             default: false,
         }),
         /**
-         * Determines the `mail.thread` that should be displayed by `this`.
+         * Determines the `Thread` that should be displayed by `this`.
          */
-        thread: many2one('mail.thread'),
+        thread: many2one('Thread'),
         /**
          * Determines the id of the thread that will be displayed by `this`.
          */

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -10,7 +10,7 @@ registerModel({
     recordMethods: {
         /**
          * @private
-         * @returns {mail.thread}
+         * @returns {Thread}
          */
         _computeActiveThread() {
             if (this.messageViewInEditing && this.messageViewInEditing.message && this.messageViewInEditing.message.originThread) {
@@ -120,7 +120,7 @@ registerModel({
         },
     },
     fields: {
-        activeThread: many2one('mail.thread', {
+        activeThread: many2one('Thread', {
             compute: '_computeActiveThread',
             readonly: true,
             required: true,
@@ -166,7 +166,7 @@ registerModel({
          * Determines whether a post_message request is currently pending.
          */
         isPostingMessage: attr(),
-        mentionedChannels: many2many('mail.thread', {
+        mentionedChannels: many2many('Thread', {
             compute: '_computeMentionedChannels',
         }),
         mentionedPartners: many2many('mail.partner', {
@@ -199,7 +199,7 @@ registerModel({
         /**
          * States the thread which this composer represents the state (if any).
          */
-        thread: one2one('mail.thread', {
+        thread: one2one('Thread', {
             inverse: 'composer',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -142,7 +142,7 @@ registerModel({
             // the mention will appear in the target channel, or be notified to
             // the target partner.
             switch (this.activeSuggestedRecord.constructor.name) {
-                case 'mail.thread':
+                case 'Thread':
                     Object.assign(updateData, { mentionedChannels: link(this.activeSuggestedRecord) });
                     break;
                 case 'mail.partner':
@@ -576,7 +576,7 @@ registerModel({
                 case '/':
                     return 'mail.channel_command';
                 case '#':
-                    return 'mail.thread';
+                    return 'Thread';
                 default:
                     return clear();
             }

--- a/addons/mail/static/src/models/discuss/discuss.js
+++ b/addons/mail/static/src/models/discuss/discuss.js
@@ -43,14 +43,14 @@ registerModel({
             this.clearIsAddingItem();
             if (ui.item.special) {
                 const channel = await this.async(() =>
-                    this.messaging.models['mail.thread'].performRpcCreateChannel({
+                    this.messaging.models['Thread'].performRpcCreateChannel({
                         name,
                         privacy: ui.item.special,
                     })
                 );
                 channel.open();
             } else {
-                const channel = this.messaging.models['mail.thread'].insert({
+                const channel = this.messaging.models['Thread'].insert({
                     id: ui.item.id,
                     model: 'mail.channel',
                 });
@@ -68,7 +68,7 @@ registerModel({
          */
         async handleAddChannelAutocompleteSource(req, res) {
             this.update({ addingChannelValue: req.term });
-            const threads = await this.messaging.models['mail.thread'].searchChannelsToOpen({ limit: 10, searchTerm: req.term });
+            const threads = await this.messaging.models['Thread'].searchChannelsToOpen({ limit: 10, searchTerm: req.term });
             const items = threads.map((thread) => {
                 const escapedName = owl.utils.escape(thread.name);
                 return {
@@ -151,7 +151,7 @@ registerModel({
          * @param {MouseEvent} ev
          */
         async onClickStartAMeetingButton(ev) {
-            const meetingChannel = await this.messaging.models['mail.thread'].createGroupChat({
+            const meetingChannel = await this.messaging.models['Thread'].createGroupChat({
                 default_display_mode: 'video_full_screen',
                 partners_to: [this.messaging.currentPartner.id],
             });
@@ -171,7 +171,7 @@ registerModel({
             const [model, id] = typeof this.initActiveId === 'number'
                 ? ['mail.channel', this.initActiveId]
                 : this.initActiveId.split('_');
-            const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
+            const thread = this.messaging.models['Thread'].findFromIdentifyingData({
                 id: model !== 'mail.box' ? Number(id) : id,
                 model,
             });
@@ -186,7 +186,7 @@ registerModel({
         /**
          * Opens the given thread in Discuss, and opens Discuss if necessary.
          *
-         * @param {mail.thread} thread
+         * @param {Thread} thread
          * @param {Object} [param1={}]
          * @param {Boolean} [param1.focus]
          */
@@ -209,7 +209,7 @@ registerModel({
             }
         },
         /**
-         * @param {mail.thread} thread
+         * @param {Thread} thread
          * @returns {string}
          */
         threadToActiveId(thread) {
@@ -289,7 +289,7 @@ registerModel({
          * Only pinned threads are allowed in discuss.
          *
          * @private
-         * @returns {mail.thread|undefined}
+         * @returns {Thread|undefined}
          */
         _computeThread() {
             if (!this.thread || !this.thread.isPinned) {
@@ -400,9 +400,9 @@ registerModel({
          */
         startAMeetingButtonRef: attr(),
         /**
-         * Determines the `mail.thread` that should be displayed by `this`.
+         * Determines the `Thread` that should be displayed by `this`.
          */
-        thread: many2one('mail.thread', {
+        thread: many2one('Thread', {
             compute: '_computeThread',
         }),
         /**

--- a/addons/mail/static/src/models/discuss_public_view/discuss_public_view.js
+++ b/addons/mail/static/src/models/discuss_public_view/discuss_public_view.js
@@ -54,7 +54,7 @@ registerModel({
         /**
          * States the channel linked to this discuss public view.
          */
-        channel: one2one('mail.thread', {
+        channel: one2one('Thread', {
             readonly: true,
             required: true,
         }),

--- a/addons/mail/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
@@ -275,7 +275,7 @@ registerModel({
         /**
          * The related channel thread.
          */
-        channel: one2one('mail.thread', {
+        channel: one2one('Thread', {
             inverse: 'discussSidebarCategoryItem',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/follower/follower.js
+++ b/addons/mail/static/src/models/follower/follower.js
@@ -142,7 +142,7 @@ registerModel({
         },
     },
     fields: {
-        followedThread: many2one('mail.thread', {
+        followedThread: many2one('Thread', {
             inverse: 'followers',
         }),
         id: attr({

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -512,7 +512,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.thread[]}
+         * @returns {Thread[]}
          */
         _computeThreads() {
             const threads = [];
@@ -716,7 +716,7 @@ registerModel({
         /**
          * Origin thread of this message (if any).
          */
-        originThread: many2one('mail.thread', {
+        originThread: many2one('Thread', {
             inverse: 'messagesAsOriginThread',
         }),
         /**
@@ -742,7 +742,7 @@ registerModel({
         /**
          * All threads that this message is linked to. This field is read-only.
          */
-        threads: many2many('mail.thread', {
+        threads: many2many('Thread', {
             compute: '_computeThreads',
             inverse: 'messages',
         }),

--- a/addons/mail/static/src/models/message/tests/message_tests.js
+++ b/addons/mail/static/src/models/message/tests/message_tests.js
@@ -30,14 +30,14 @@ QUnit.test('create', async function (assert) {
 
     await this.start();
     assert.notOk(this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 5 }));
-    assert.notOk(this.messaging.models['mail.thread'].findFromIdentifyingData({
+    assert.notOk(this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
     }));
     assert.notOk(this.messaging.models['mail.attachment'].findFromIdentifyingData({ id: 750 }));
     assert.notOk(this.messaging.models['mail.message'].findFromIdentifyingData({ id: 4000 }));
 
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         id: 100,
         model: 'mail.channel',
         name: "General",
@@ -59,7 +59,7 @@ QUnit.test('create', async function (assert) {
     });
 
     assert.ok(this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 5 }));
-    assert.ok(this.messaging.models['mail.thread'].findFromIdentifyingData({
+    assert.ok(this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
     }));
@@ -75,12 +75,12 @@ QUnit.test('create', async function (assert) {
         "2019-05-05 10:00:00"
     );
     assert.strictEqual(message.id, 4000);
-    assert.strictEqual(message.originThread, this.messaging.models['mail.thread'].findFromIdentifyingData({
+    assert.strictEqual(message.originThread, this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
     }));
     assert.ok(
-        message.threads.includes(this.messaging.models['mail.thread'].findFromIdentifyingData({
+        message.threads.includes(this.messaging.models['Thread'].findFromIdentifyingData({
             id: 100,
             model: 'mail.channel',
         }))
@@ -96,7 +96,7 @@ QUnit.test('create', async function (assert) {
     assert.notOk(attachment.isUploading);
     assert.strictEqual(attachment.mimetype, 'text/plain');
     assert.strictEqual(attachment.name, "test.txt");
-    const channel = this.messaging.models['mail.thread'].findFromIdentifyingData({
+    const channel = this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
     });

--- a/addons/mail/static/src/models/message_seen_indicator/message_seen_indicator.js
+++ b/addons/mail/static/src/models/message_seen_indicator/message_seen_indicator.js
@@ -9,7 +9,7 @@ registerModel({
     identifyingFields: ['thread', 'message'],
     modelMethods: {
         /**
-         * @param {mail.thread} [channel] the concerned thread
+         * @param {Thread} [channel] the concerned thread
          */
         recomputeFetchedValues(channel = undefined) {
             const indicatorFindFunction = channel ? localIndicator => localIndicator.thread === channel : undefined;
@@ -23,7 +23,7 @@ registerModel({
             }
         },
         /**
-         * @param {mail.thread} [channel] the concerned thread
+         * @param {Thread} [channel] the concerned thread
          */
         recomputeSeenValues(channel = undefined) {
             const indicatorFindFunction = channel ? localIndicator => localIndicator.thread === channel : undefined;
@@ -239,7 +239,7 @@ registerModel({
         /**
          * The thread concerned by this seen indicator.
          */
-        thread: many2one('mail.thread', {
+        thread: many2one('Thread', {
             inverse: 'messageSeenIndicators',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -45,7 +45,7 @@ registerModel({
          * @param {integer} [param0.partnerId]
          * @param {integer} [param0.userId]
          * @param {Object} [options]
-         * @returns {mail.thread|undefined}
+         * @returns {Thread|undefined}
          */
         async getChat({ partnerId, userId }) {
             if (userId) {
@@ -63,8 +63,8 @@ registerModel({
          * If a chat is not appropriate, a notification is displayed instead.
          *
          * @param {Object} person forwarded to @see `getChat()`
-         * @param {Object} [options] forwarded to @see `mail.thread:open()`
-         * @returns {mail.thread|undefined}
+         * @param {Object} [options] forwarded to @see `Thread:open()`
+         * @returns {Thread|undefined}
          */
         async openChat(person, options) {
             const chat = await this.async(() => this.getChat(person));
@@ -114,10 +114,10 @@ registerModel({
                 return user.openProfile();
             }
             if (model === 'mail.channel') {
-                let channel = this.messaging.models['mail.thread'].findFromIdentifyingData({ id, model: 'mail.channel' });
+                let channel = this.messaging.models['Thread'].findFromIdentifyingData({ id, model: 'mail.channel' });
                 if (!channel) {
                     channel = (await this.async(() =>
-                        this.messaging.models['mail.thread'].performRpcChannelInfo({ ids: [id] })
+                        this.messaging.models['Thread'].performRpcChannelInfo({ ids: [id] })
                     ))[0];
                 }
                 if (!channel) {
@@ -268,11 +268,11 @@ registerModel({
         /**
          * Mailbox History.
          */
-        history: one2one('mail.thread'),
+        history: one2one('Thread'),
         /**
          * Mailbox Inbox.
          */
-        inbox: one2one('mail.thread'),
+        inbox: one2one('Thread'),
         /**
          * Promise that will be resolved when messaging is initialized.
          */
@@ -351,7 +351,7 @@ registerModel({
          * Threads for which the current partner has a pending invitation.
          * It is computed from the inverse relation for performance reasons.
          */
-        ringingThreads: one2many('mail.thread', {
+        ringingThreads: one2many('Thread', {
             inverse: 'messagingAsRingingThread',
         }),
         rtc: one2one('mail.rtc', {
@@ -367,7 +367,7 @@ registerModel({
         /**
          * Mailbox Starred.
          */
-        starred: one2one('mail.thread'),
+        starred: one2one('Thread'),
         userSetting: one2one('mail.user_setting', {
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/messaging/tests/messaging_tests.js
+++ b/addons/mail/static/src/models/messaging/tests/messaging_tests.js
@@ -79,7 +79,7 @@ QUnit.test('openChat: open new chat for user', async function (assert) {
     this.data['res.users'].records.push({ id: 11, partner_id: 14 });
     await this.start();
 
-    const existingChat = this.messaging.models['mail.thread'].find(thread =>
+    const existingChat = this.messaging.models['Thread'].find(thread =>
         thread.channel_type === 'chat' &&
         thread.correspondent &&
         thread.correspondent.id === 14 &&
@@ -89,7 +89,7 @@ QUnit.test('openChat: open new chat for user', async function (assert) {
     assert.notOk(existingChat, 'a chat should not exist with the target partner initially');
 
     await this.messaging.openChat({ partnerId: 14 });
-    const chat = this.messaging.models['mail.thread'].find(thread =>
+    const chat = this.messaging.models['Thread'].find(thread =>
         thread.channel_type === 'chat' &&
         thread.correspondent &&
         thread.correspondent.id === 14 &&
@@ -112,7 +112,7 @@ QUnit.test('openChat: open existing chat for user', async function (assert) {
         public: 'private',
     });
     await this.start();
-    const existingChat = this.messaging.models['mail.thread'].find(thread =>
+    const existingChat = this.messaging.models['Thread'].find(thread =>
         thread.channel_type === 'chat' &&
         thread.correspondent &&
         thread.correspondent.id === 14 &&

--- a/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
@@ -132,7 +132,7 @@ registerModel({
          */
         async _initChannels(channelsData) {
             return executeGracefully(channelsData.map(channelData => () => {
-                const convertedData = this.messaging.models['mail.thread'].convertData(channelData);
+                const convertedData = this.messaging.models['Thread'].convertData(channelData);
                 if (!convertedData.members) {
                     // channel_info does not return all members of channel for
                     // performance reasons, but code is expecting to know at
@@ -147,7 +147,7 @@ registerModel({
                         convertedData.guestMembers = link(this.messaging.currentGuest);
                     }
                 }
-                const channel = this.messaging.models['mail.thread'].insert(
+                const channel = this.messaging.models['Thread'].insert(
                     Object.assign({ model: 'mail.channel' }, convertedData)
                 );
                 // flux specific: channels received at init have to be

--- a/addons/mail/static/src/models/messaging_menu/messaging_menu.js
+++ b/addons/mail/static/src/models/messaging_menu/messaging_menu.js
@@ -80,7 +80,7 @@ registerModel({
         /**
          * States all the pinned channels that have unread messages.
          */
-         pinnedAndUnreadChannels: one2many('mail.thread', {
+         pinnedAndUnreadChannels: one2many('Thread', {
             inverse: 'messagingMenuAsPinnedAndUnreadChannel',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/messaging_menu/tests/messaging_menu_tests.js
+++ b/addons/mail/static/src/models/messaging_menu/tests/messaging_menu_tests.js
@@ -23,7 +23,7 @@ QUnit.test('messaging menu counter should ignore unread messages in channels tha
     assert.expect(1);
 
     await this.start();
-    this.messaging.models['mail.thread'].create({
+    this.messaging.models['Thread'].create({
         id: 31,
         isServerPinned: false,
         model: 'mail.channel',

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -98,7 +98,7 @@ registerModel({
                         case 'mail.channel/last_interest_dt_changed':
                             return this._handleNotificationChannelLastInterestDateTimeChanged(message.payload);
                         case 'mail.channel/legacy_insert':
-                            return this.messaging.models['mail.thread'].insert(this.messaging.models['mail.thread'].convertData({ model: 'mail.channel', ...message.payload }));
+                            return this.messaging.models['Thread'].insert(this.messaging.models['Thread'].convertData({ model: 'mail.channel', ...message.payload }));
                         case 'mail.channel/insert':
                             return this._handleNotificationChannelUpdate(message.payload);
                         case 'mail.guest/insert':
@@ -153,7 +153,7 @@ registerModel({
             last_message_id,
             partner_id,
         }) {
-            const channel = this.messaging.models['mail.thread'].findFromIdentifyingData({
+            const channel = this.messaging.models['Thread'].findFromIdentifyingData({
                 id: channelId,
                 model: 'mail.channel',
             });
@@ -181,11 +181,11 @@ registerModel({
         /**
          * @private
          * @param {Object} payload
-         * @param {mail.thread} payload.channel
+         * @param {Thread} payload.channel
          * @param {integer} payload.invited_by_user_id
          */
         _handleNotificationChannelJoined({ channel: channelData, invited_by_user_id: invitedByUserId }) {
-            const channel = this.messaging.models['mail.thread'].insert(this.messaging.models['mail.thread'].convertData(channelData));
+            const channel = this.messaging.models['Thread'].insert(this.messaging.models['Thread'].convertData(channelData));
             if (invitedByUserId !== this.messaging.currentUser.id) {
                 // Current user was invited by someone else.
                 this.env.services['notification'].notify({
@@ -204,7 +204,7 @@ registerModel({
          * @param {string} payload.last_interest_dt
          */
         _handleNotificationChannelLastInterestDateTimeChanged({ id, last_interest_dt }) {
-            const channel = this.messaging.models['mail.thread'].findFromIdentifyingData({
+            const channel = this.messaging.models['Thread'].findFromIdentifyingData({
                 id: id,
                 model: 'mail.channel',
             });
@@ -221,7 +221,7 @@ registerModel({
          * @param {Object} payload.messageData
          */
         async _handleNotificationChannelMessage({ id: channelId, message: messageData }) {
-            let channel = this.messaging.models['mail.thread'].findFromIdentifyingData({
+            let channel = this.messaging.models['Thread'].findFromIdentifyingData({
                 id: channelId,
                 model: 'mail.channel',
             });
@@ -237,7 +237,7 @@ registerModel({
             // features such as chat windows.
             if (!channel) {
                 channel = (await this.async(() =>
-                    this.messaging.models['mail.thread'].performRpcChannelInfo({ ids: [channelId] })
+                    this.messaging.models['Thread'].performRpcChannelInfo({ ids: [channelId] })
                 ))[0];
             }
             if (!channel.isPinned) {
@@ -293,7 +293,7 @@ registerModel({
             last_message_id,
             partner_id,
         }) {
-            const channel = this.messaging.models['mail.thread'].findFromIdentifyingData({
+            const channel = this.messaging.models['Thread'].findFromIdentifyingData({
                 id: channelId,
                 model: 'mail.channel',
             });
@@ -325,7 +325,7 @@ registerModel({
             }
             if (shouldComputeSeenIndicators) {
                 // FIXME force the computing of thread values (cf task-2261221)
-                this.messaging.models['mail.thread'].computeLastCurrentPartnerMessageSeenByEveryone(channel);
+                this.messaging.models['Thread'].computeLastCurrentPartnerMessageSeenByEveryone(channel);
                 // FIXME force the computing of message values (cf task-2261221)
                 this.messaging.models['mail.message_seen_indicator'].recomputeSeenValues(channel);
             }
@@ -339,7 +339,7 @@ registerModel({
          * @param {string} param1.partner_name
          */
         _handleNotificationChannelPartnerTypingStatus({ channel_id, is_typing, partner_id, partner_name }) {
-            const channel = this.messaging.models['mail.thread'].findFromIdentifyingData({
+            const channel = this.messaging.models['Thread'].findFromIdentifyingData({
                 id: channel_id,
                 model: 'mail.channel',
             });
@@ -374,7 +374,7 @@ registerModel({
          * @param {Object} channelData
          */
         _handleNotificationChannelUpdate(channelData) {
-            this.messaging.models['mail.thread'].insert({ model: 'mail.channel', ...channelData });
+            this.messaging.models['Thread'].insert({ model: 'mail.channel', ...channelData });
         },
         /**
          * @private
@@ -477,7 +477,7 @@ registerModel({
          * @param {Object} [data.rtcSessions]
          */
         async _handleNotificationRtcSessionUpdate({ id, rtcSessions }) {
-            const channel = this.messaging.models['mail.thread'].findFromIdentifyingData({ id, model: 'mail.channel' });
+            const channel = this.messaging.models['Thread'].findFromIdentifyingData({ id, model: 'mail.channel' });
             if (!channel) {
                 return;
             }
@@ -603,7 +603,7 @@ registerModel({
          * @param {integer} payload.id
          */
         _handleNotificationChannelLeave({ id }) {
-            const channel = this.messaging.models['mail.thread'].findFromIdentifyingData({
+            const channel = this.messaging.models['Thread'].findFromIdentifyingData({
                 id,
                 model: 'mail.channel',
             });
@@ -625,7 +625,7 @@ registerModel({
          * @param {integer} payload.id
          */
         _handleNotificationChannelUnpin({ id }) {
-            const channel = this.messaging.models['mail.thread'].findFromIdentifyingData({
+            const channel = this.messaging.models['Thread'].findFromIdentifyingData({
                 id,
                 model: 'mail.channel',
             });
@@ -663,7 +663,7 @@ registerModel({
         /**
          * @private
          * @param {Object} param0
-         * @param {mail.thread} param0.channel
+         * @param {Thread} param0.channel
          * @param {mail.message} param0.message
          */
         _notifyNewChannelMessageWhileOutOfFocus({ channel, message }) {

--- a/addons/mail/static/src/models/notification_group/notification_group.js
+++ b/addons/mail/static/src/models/notification_group/notification_group.js
@@ -39,7 +39,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.thread|undefined}
+         * @returns {Thread|undefined}
          */
         _computeThread() {
             const notificationsThreadIds = this.notifications
@@ -144,7 +144,7 @@ registerModel({
         /**
          * Related thread when the notification group concerns a single thread.
          */
-        thread: many2one('mail.thread', {
+        thread: many2one('Thread', {
             compute: '_computeThread',
         }),
     },

--- a/addons/mail/static/src/models/partner/partner.js
+++ b/addons/mail/static/src/models/partner/partner.js
@@ -76,7 +76,7 @@ registerModel({
          *
          * @param {string} searchTerm
          * @param {Object} [options={}]
-         * @param {mail.thread} [options.thread] prioritize and/or restrict
+         * @param {Thread} [options.thread] prioritize and/or restrict
          *  result in the context of given thread
          */
         async fetchSuggestions(searchTerm, { thread } = {}) {
@@ -106,7 +106,7 @@ registerModel({
          *
          * @param {string} searchTerm
          * @param {Object} [options={}]
-         * @param {mail.thread} [options.thread] prioritize result in the
+         * @param {Thread} [options.thread] prioritize result in the
          *  context of given thread
          * @returns {function}
          */
@@ -218,7 +218,7 @@ registerModel({
          *
          * @param {string} searchTerm
          * @param {Object} [options={}]
-         * @param {mail.thread} [options.thread] prioritize and/or restrict
+         * @param {Thread} [options.thread] prioritize and/or restrict
          *  result in the context of given thread
          * @returns {[mail.partner[], mail.partner[]]}
          */
@@ -320,7 +320,7 @@ registerModel({
          *
          * If a chat is not appropriate, a notification is displayed instead.
          *
-         * @returns {mail.thread|undefined}
+         * @returns {Thread|undefined}
          */
         async getChat() {
             if (!this.user && !this.hasCheckedUser) {
@@ -350,8 +350,8 @@ registerModel({
          *
          * If a chat is not appropriate, a notification is displayed instead.
          *
-         * @param {Object} [options] forwarded to @see `mail.thread:open()`
-         * @returns {mail.thread|undefined}
+         * @param {Object} [options] forwarded to @see `Thread:open()`
+         * @returns {Thread|undefined}
          */
         async openChat(options) {
             const chat = await this.async(() => this.getChat());
@@ -436,7 +436,7 @@ registerModel({
         isMuted: attr({
             default: false,
         }),
-        memberThreads: many2many('mail.thread', {
+        memberThreads: many2many('Thread', {
             inverse: 'members',
         }),
         model: attr({

--- a/addons/mail/static/src/models/rtc/rtc.js
+++ b/addons/mail/static/src/models/rtc/rtc.js
@@ -1164,7 +1164,7 @@ registerModel({
         /**
          * The channel that is hosting the current RTC call.
          */
-        channel: one2one('mail.thread', {
+        channel: one2one('Thread', {
             inverse: 'rtc',
         }),
         /**

--- a/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
+++ b/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
@@ -122,7 +122,7 @@ registerModel({
         /**
          * The channel of the call.
          */
-        channel: many2one('mail.thread', {
+        channel: many2one('Thread', {
             required: true,
         }),
         /**

--- a/addons/mail/static/src/models/rtc_session/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session/rtc_session.js
@@ -299,7 +299,7 @@ registerModel({
          * The mail.channel of the session, rtc sessions are part and managed by
          * mail.channel
          */
-        channel: many2one('mail.thread', {
+        channel: many2one('Thread', {
             inverse: 'rtcSessions',
         }),
         /**
@@ -324,7 +324,7 @@ registerModel({
          * this serves as an explicit inverse as it seems to confuse it with
          * other session-channel relations otherwise.
          */
-        calledChannels: one2many('mail.thread', {
+        calledChannels: one2many('Thread', {
             inverse: 'rtcInvitingSession',
         }),
         /**

--- a/addons/mail/static/src/models/suggested_recipient_info/suggested_recipient_info.js
+++ b/addons/mail/static/src/models/suggested_recipient_info/suggested_recipient_info.js
@@ -72,9 +72,9 @@ registerModel({
          */
         reason: attr(),
         /**
-         * Determines the `mail.thread` concerned by `this.`
+         * Determines the `Thread` concerned by `this.`
          */
-        thread: many2one('mail.thread', {
+        thread: many2one('Thread', {
             inverse: 'suggestedRecipientInfoList',
             required: true,
         }),

--- a/addons/mail/static/src/models/thread/tests/thread_tests.js
+++ b/addons/mail/static/src/models/thread/tests/thread_tests.js
@@ -47,12 +47,12 @@ QUnit.test('create (channel)', async function (assert) {
     await this.start();
     assert.notOk(this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 9 }));
     assert.notOk(this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 10 }));
-    assert.notOk(this.messaging.models['mail.thread'].findFromIdentifyingData({
+    assert.notOk(this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
     }));
 
-    const thread = this.messaging.models['mail.thread'].create({
+    const thread = this.messaging.models['Thread'].create({
         channel_type: 'channel',
         id: 100,
         members: insert([{
@@ -73,13 +73,13 @@ QUnit.test('create (channel)', async function (assert) {
     assert.ok(thread);
     assert.ok(this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 9 }));
     assert.ok(this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 10 }));
-    assert.ok(this.messaging.models['mail.thread'].findFromIdentifyingData({
+    assert.ok(this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
     }));
     const partner9 = this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 9 });
     const partner10 = this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 10 });
-    assert.strictEqual(thread, this.messaging.models['mail.thread'].findFromIdentifyingData({
+    assert.strictEqual(thread, this.messaging.models['Thread'].findFromIdentifyingData({
         id: 100,
         model: 'mail.channel',
     }));
@@ -105,12 +105,12 @@ QUnit.test('create (chat)', async function (assert) {
 
     await this.start();
     assert.notOk(this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 5 }));
-    assert.notOk(this.messaging.models['mail.thread'].findFromIdentifyingData({
+    assert.notOk(this.messaging.models['Thread'].findFromIdentifyingData({
         id: 200,
         model: 'mail.channel',
     }));
 
-    const channel = this.messaging.models['mail.thread'].create({
+    const channel = this.messaging.models['Thread'].create({
         channel_type: 'chat',
         id: 200,
         members: insert({
@@ -122,13 +122,13 @@ QUnit.test('create (chat)', async function (assert) {
         model: 'mail.channel',
     });
     assert.ok(channel);
-    assert.ok(this.messaging.models['mail.thread'].findFromIdentifyingData({
+    assert.ok(this.messaging.models['Thread'].findFromIdentifyingData({
         id: 200,
         model: 'mail.channel',
     }));
     assert.ok(this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 5 }));
     const partner = this.messaging.models['mail.partner'].findFromIdentifyingData({ id: 5 });
-    assert.strictEqual(channel, this.messaging.models['mail.thread'].findFromIdentifyingData({
+    assert.strictEqual(channel, this.messaging.models['Thread'].findFromIdentifyingData({
         id: 200,
         model: 'mail.channel',
     }));

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -20,7 +20,7 @@ const getSuggestedRecipientInfoNextTemporaryId = (function () {
 })();
 
 registerModel({
-    name: 'mail.thread',
+    name: 'Thread',
     identifyingFields: ['model', 'id'],
     lifecycleHooks: {
         _willCreate() {
@@ -127,10 +127,10 @@ registerModel({
     },
     modelMethods: {
         /**
-         * @param {mail.thread} [thread] the concerned thread
+         * @param {Thread} [thread] the concerned thread
          */
         computeLastCurrentPartnerMessageSeenByEveryone(thread = undefined) {
-            const threads = thread ? [thread] : this.messaging.models['mail.thread'].all();
+            const threads = thread ? [thread] : this.messaging.models['Thread'].all();
             threads.map(localThread => {
                 localThread.update({
                     lastCurrentPartnerMessageSeenByEveryone: localThread._computeLastCurrentPartnerMessageSeenByEveryone(),
@@ -285,7 +285,7 @@ registerModel({
          * @param {number[]} param0.partners_to Ids of the partners to add as channel
          * members.
          * @param {boolean|string} param0.default_display_mode
-         * @returns {mail.thread} The newly created group chat.
+         * @returns {Thread} The newly created group chat.
          */
         async createGroupChat({ default_display_mode, partners_to }) {
             const channelData = await this.env.services.rpc({
@@ -296,8 +296,8 @@ registerModel({
                     partners_to,
                 },
             });
-            return this.messaging.models['mail.thread'].insert(
-                this.messaging.models['mail.thread'].convertData(channelData)
+            return this.messaging.models['Thread'].insert(
+                this.messaging.models['Thread'].convertData(channelData)
             );
         },
         /**
@@ -307,7 +307,7 @@ registerModel({
          *
          * @param {string} searchTerm
          * @param {Object} [options={}]
-         * @param {mail.thread} [options.thread] prioritize and/or restrict
+         * @param {Thread} [options.thread] prioritize and/or restrict
          *  result in the context of given thread
          */
         async fetchSuggestions(searchTerm, { thread } = {}) {
@@ -319,10 +319,10 @@ registerModel({
                 },
                 { shadow: true },
             );
-            this.messaging.models['mail.thread'].insert(channelsData.map(channelData =>
+            this.messaging.models['Thread'].insert(channelsData.map(channelData =>
                 Object.assign(
                     { model: 'mail.channel' },
-                    this.messaging.models['mail.thread'].convertData(channelData),
+                    this.messaging.models['Thread'].convertData(channelData),
                 )
             ));
         },
@@ -332,7 +332,7 @@ registerModel({
          *
          * @param {string} searchTerm
          * @param {Object} [options={}]
-         * @param {mail.thread} [options.thread] prioritize result in the
+         * @param {Thread} [options.thread] prioritize result in the
          *  context of given thread
          * @returns {function}
          */
@@ -376,7 +376,7 @@ registerModel({
          * Load the previews of the specified threads. Basically, it fetches the
          * last messages, since they are used to display inline content of them.
          *
-         * @param {mail.thread[]} threads
+         * @param {Thread[]} threads
          */
         async loadPreviews(threads) {
             const channelIds = threads.reduce((list, thread) => {
@@ -418,7 +418,7 @@ registerModel({
          *
          * @param {Object} param0
          * @param {integer[]} param0.ids list of id of channels
-         * @returns {mail.thread[]}
+         * @returns {Thread[]}
          */
         async performRpcChannelInfo({ ids }) {
             const channelInfos = await this.env.services.rpc({
@@ -426,8 +426,8 @@ registerModel({
                 method: 'channel_info',
                 args: [ids],
             }, { shadow: true });
-            const channels = this.messaging.models['mail.thread'].insert(
-                channelInfos.map(channelInfo => this.messaging.models['mail.thread'].convertData(channelInfo))
+            const channels = this.messaging.models['Thread'].insert(
+                channelInfos.map(channelInfo => this.messaging.models['Thread'].convertData(channelInfo))
             );
             return channels;
         },
@@ -470,7 +470,7 @@ registerModel({
          * @param {Object} param0
          * @param {string} param0.name
          * @param {string} [param0.privacy]
-         * @returns {mail.thread} the created channel
+         * @returns {Thread} the created channel
          */
         async performRpcCreateChannel({ name, privacy }) {
             const device = this.messaging.device;
@@ -486,8 +486,8 @@ registerModel({
                     }),
                 },
             });
-            return this.messaging.models['mail.thread'].insert(
-                this.messaging.models['mail.thread'].convertData(data)
+            return this.messaging.models['Thread'].insert(
+                this.messaging.models['Thread'].convertData(data)
             );
         },
         /**
@@ -499,7 +499,7 @@ registerModel({
          * @param {Object} param0
          * @param {integer[]} param0.partnerIds
          * @param {boolean} [param0.pinForCurrentPartner]
-         * @returns {mail.thread|undefined} the created or existing chat
+         * @returns {Thread|undefined} the created or existing chat
          */
         async performRpcCreateChat({ partnerIds, pinForCurrentPartner }) {
             const device = this.messaging.device;
@@ -520,8 +520,8 @@ registerModel({
             if (!data) {
                 return;
             }
-            return this.messaging.models['mail.thread'].insert(
-                this.messaging.models['mail.thread'].convertData(data)
+            return this.messaging.models['Thread'].insert(
+                this.messaging.models['Thread'].convertData(data)
             );
         },
         /**
@@ -593,7 +593,7 @@ registerModel({
          *
          * @param {string} searchTerm
          * @param {Object} [options={}]
-         * @param {mail.thread} [options.thread] prioritize and/or restrict
+         * @param {Thread} [options.thread] prioritize and/or restrict
          *  result in the context of given thread
          * @returns {[mail.threads[], mail.threads[]]}
          */
@@ -607,7 +607,7 @@ registerModel({
                 // channel.
                 threads = [thread];
             } else {
-                threads = this.messaging.models['mail.thread'].all();
+                threads = this.messaging.models['Thread'].all();
             }
             const cleanedSearchTerm = cleanSearchTerm(searchTerm);
             return [threads.filter(thread =>
@@ -655,7 +655,7 @@ registerModel({
             if (this.isTemporary) {
                 return;
             }
-            return this.messaging.models['mail.thread'].performRpcMailGetSuggestedRecipients({
+            return this.messaging.models['Thread'].performRpcMailGetSuggestedRecipients({
                 model: this.model,
                 res_ids: [this.id],
             });
@@ -859,7 +859,7 @@ registerModel({
                 return;
             }
             this.update({ pendingSeenMessageId: message.id });
-            return this.messaging.models['mail.thread'].performRpcChannelSeen({
+            return this.messaging.models['Thread'].performRpcChannelSeen({
                 id: this.id,
                 lastMessageId: message.id,
             });
@@ -886,7 +886,7 @@ registerModel({
             if (!this.uuid) {
                 return;
             }
-            return this.messaging.models['mail.thread'].performRpcChannelFold(this.uuid, state);
+            return this.messaging.models['Thread'].performRpcChannelFold(this.uuid, state);
         },
         /**
          * Notify server to leave the current channel. Useful for cross-tab
@@ -899,7 +899,7 @@ registerModel({
                 await this.leave();
                 return;
             }
-            await this.messaging.models['mail.thread'].performRpcChannelPin({
+            await this.messaging.models['Thread'].performRpcChannelPin({
                 pinned: this.isPendingPinned,
                 uuid: this.uuid,
             });
@@ -1829,7 +1829,7 @@ registerModel({
                 options: {
                     on_close: async () => {
                        await this.async(() => this.refreshFollowers());
-                       this.env.bus.trigger('mail.thread:promptAddFollower-closed');
+                       this.env.bus.trigger('Thread:promptAddFollower-closed');
                     },
                 },
             });
@@ -2184,7 +2184,7 @@ registerModel({
          * Determines the last mentioned channels of the last composer related
          * to this thread. Useful to sync the composer when re-creating it.
          */
-        mentionedChannelsBackup: many2many('mail.thread'),
+        mentionedChannelsBackup: many2many('Thread'),
         /**
          * Determines the last mentioned partners of the last composer related
          * to this thread. Useful to sync the composer when re-creating it.

--- a/addons/mail/static/src/models/thread_cache/thread_cache.js
+++ b/addons/mail/static/src/models/thread_cache/thread_cache.js
@@ -401,7 +401,7 @@ registerModel({
         orderedNonEmptyMessages: many2many('mail.message', {
             compute: '_computeOrderedNonEmptyMessages',
         }),
-        thread: one2one('mail.thread', {
+        thread: one2one('Thread', {
             inverse: 'cache',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/thread_partner_seen_info/thread_partner_seen_info.js
+++ b/addons/mail/static/src/models/thread_partner_seen_info/thread_partner_seen_info.js
@@ -20,7 +20,7 @@ registerModel({
         /**
          * Thread (channel) that this seen info is related to.
          */
-        thread: many2one('mail.thread', {
+        thread: many2one('Thread', {
             inverse: 'partnerSeenInfos',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -433,9 +433,9 @@ registerModel({
             readonly: true,
         }),
         /**
-         * Determines the `mail.thread` currently displayed by `this`.
+         * Determines the `Thread` currently displayed by `this`.
          */
-        thread: many2one('mail.thread', {
+        thread: many2one('Thread', {
             inverse: 'threadViews',
             readonly: true,
             related: 'threadViewer.thread',

--- a/addons/mail/static/src/models/thread_view/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_view/thread_viewer.js
@@ -113,9 +113,9 @@ registerModel({
             default: 'asc',
         }),
         /**
-         * Determines the `mail.thread` that should be displayed by `this`.
+         * Determines the `Thread` that should be displayed by `this`.
          */
-        thread: many2one('mail.thread'),
+        thread: many2one('Thread'),
         /**
          * States the `mail.thread_cache` that should be displayed by `this`.
          */

--- a/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
+++ b/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
@@ -658,7 +658,7 @@ registerModel({
         /**
          * States the thread that is displayed by this top bar.
          */
-        thread: many2one('mail.thread', {
+        thread: many2one('Thread', {
             related: 'threadView.thread',
         }),
         /**

--- a/addons/mail/static/src/models/user/user.js
+++ b/addons/mail/static/src/models/user/user.js
@@ -70,7 +70,7 @@ registerModel({
          *
          * If a chat is not appropriate, a notification is displayed instead.
          *
-         * @returns {mail.thread|undefined}
+         * @returns {Thread|undefined}
          */
         async getChat() {
             if (!this.partner) {
@@ -88,7 +88,7 @@ registerModel({
                 return;
             }
             // in other cases a chat would be valid, find it or try to create it
-            let chat = this.messaging.models['mail.thread'].find(thread =>
+            let chat = this.messaging.models['Thread'].find(thread =>
                 thread.channel_type === 'chat' &&
                 thread.correspondent === this.partner &&
                 thread.model === 'mail.channel' &&
@@ -98,7 +98,7 @@ registerModel({
                 // if chat is not pinned then it has to be pinned client-side
                 // and server-side, which is a side effect of following rpc
                 chat = await this.async(() =>
-                    this.messaging.models['mail.thread'].performRpcCreateChat({
+                    this.messaging.models['Thread'].performRpcCreateChat({
                         partnerIds: [this.partner.id],
                     })
                 );
@@ -117,8 +117,8 @@ registerModel({
          *
          * If a chat is not appropriate, a notification is displayed instead.
          *
-         * @param {Object} [options] forwarded to @see `mail.thread:open()`
-         * @returns {mail.thread|undefined}
+         * @param {Object} [options] forwarded to @see `Thread:open()`
+         * @returns {Thread|undefined}
          */
         async openChat(options) {
             const chat = await this.async(() => this.getChat());

--- a/addons/mail/static/src/models/welcome_view/welcome_view.js
+++ b/addons/mail/static/src/models/welcome_view/welcome_view.js
@@ -136,7 +136,7 @@ registerModel({
          * States the channel to redirect to once the user clicks on the
          * 'joinButton'.
          */
-        channel: one2one('mail.thread', {
+        channel: one2one('Thread', {
             readonly: true,
             required: true,
         }),

--- a/addons/mail/static/src/public/discuss_public_boot.js
+++ b/addons/mail/static/src/public/discuss_public_boot.js
@@ -70,7 +70,7 @@ async function createAndMountDiscussPublicView() {
     const DialogManager = getMessagingComponent('DialogManager');
     const dialogManagerComponent = new DialogManager(null, {});
     await dialogManagerComponent.mount(document.body);
-    messaging.models['mail.thread'].insert(messaging.models['mail.thread'].convertData(data.channelData));
+    messaging.models['Thread'].insert(messaging.models['Thread'].convertData(data.channelData));
     const discussPublicView = messaging.models['DiscussPublicView'].create(data.discussPublicViewData);
     if (discussPublicView.shouldDisplayWelcomeViewInitially) {
         discussPublicView.switchToWelcomeView();

--- a/addons/mail/static/src/webclient/commands/mail_providers.js
+++ b/addons/mail/static/src/webclient/commands/mail_providers.js
@@ -50,7 +50,7 @@ commandProviderRegistry.add("channel", {
     namespace: "#",
     async provide(newEnv, options) {
         const messaging = await Component.env.services.messaging.get();
-        const channels = await messaging.models['mail.thread'].searchChannelsToOpen({
+        const channels = await messaging.models['Thread'].searchChannelsToOpen({
             limit: 10,
             searchTerm: options.searchValue,
         });

--- a/addons/mail/static/src/widgets/form_renderer/form_renderer.js
+++ b/addons/mail/static/src/widgets/form_renderer/form_renderer.js
@@ -37,7 +37,7 @@ FormRenderer.include({
         this.off('o_attachments_changed', this);
         this.off('o_chatter_rendered', this);
         this.off('o_message_posted', this);
-        owl.Component.env.bus.off('mail.thread:promptAddFollower-closed', this);
+        owl.Component.env.bus.off('Thread:promptAddFollower-closed', this);
     },
 
     //--------------------------------------------------------------------------
@@ -76,7 +76,7 @@ FormRenderer.include({
             this.on('o_attachments_changed', this, ev => this.trigger_up('reload', { keepChanges: true }));
         }
         if (this.chatterFields.hasRecordReloadOnFollowersUpdate) {
-            owl.Component.env.bus.on('mail.thread:promptAddFollower-closed', this, ev => this.trigger_up('reload', { keepChanges: true }));
+            owl.Component.env.bus.on('Thread:promptAddFollower-closed', this, ev => this.trigger_up('reload', { keepChanges: true }));
         }
     },
     /**
@@ -177,7 +177,7 @@ FormRenderer.include({
      * @param {OdooEvent} ev
      * @param {Object} ev.data
      * @param {mail.attachment[]} ev.data.attachments
-     * @param {mail.thread} ev.data.thread
+     * @param {Thread} ev.data.thread
      */
     _onChatterRendered(ev) {},
 });

--- a/addons/website_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/website_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -10,11 +10,11 @@ patchRecordMethods('mail.messaging_notification_handler', {
      */
     async _handleNotification(message) {
         if (message.type === 'website_livechat.send_chat_request') {
-            const convertedData = this.messaging.models['mail.thread'].convertData(
+            const convertedData = this.messaging.models['Thread'].convertData(
                 Object.assign({ model: 'mail.channel' }, message.payload)
             );
-            this.messaging.models['mail.thread'].insert(convertedData);
-            const channel = this.messaging.models['mail.thread'].findFromIdentifyingData({
+            this.messaging.models['Thread'].insert(convertedData);
+            const channel = this.messaging.models['Thread'].findFromIdentifyingData({
                 id: message.payload.id,
                 model: 'mail.channel',
             });

--- a/addons/website_livechat/static/src/models/thread/thread.js
+++ b/addons/website_livechat/static/src/models/thread/thread.js
@@ -6,7 +6,7 @@ import { insert, unlink } from '@mail/model/model_field_command';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/thread/thread';
 
-patchModelMethods('mail.thread', {
+patchModelMethods('Thread', {
     /**
      * @override
      */
@@ -23,7 +23,7 @@ patchModelMethods('mail.thread', {
     },
 });
 
-addFields('mail.thread', {
+addFields('Thread', {
     /**
      * Visitor connected to the livechat.
      */

--- a/addons/website_livechat/static/src/models/visitor/visitor.js
+++ b/addons/website_livechat/static/src/models/visitor/visitor.js
@@ -129,7 +129,7 @@ registerModel({
         /**
          * Threads with this visitor as member
          */
-        threads: one2many('mail.thread', {
+        threads: one2many('Thread', {
             inverse: 'visitor',
         }),
         /**


### PR DESCRIPTION
Rename javascript model `mail.thread` to `Thread` in order to distinguish javascript models from python models.

Part of task-2701674.
 \* = hr, hr_holidays, im_livechat, website_livechat
Enterprise: https://github.com/odoo/enterprise/pull/22910
