### PR TITLE
[IMP] mail: rename thread cache model

### DIFF
--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1932,7 +1932,7 @@ registerModel({
          * It only makes sense for channels.
          */
         avatarCacheKey: attr(),
-        cache: one2one('mail.thread_cache', {
+        cache: one2one('ThreadCache', {
             default: insertAndReplace(),
             inverse: 'thread',
             isCausal: true,

--- a/addons/mail/static/src/models/thread_cache/thread_cache.js
+++ b/addons/mail/static/src/models/thread_cache/thread_cache.js
@@ -6,7 +6,7 @@ import { link, replace, unlink, unlinkAll } from '@mail/model/model_field_comman
 import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
-    name: 'mail.thread_cache',
+    name: 'ThreadCache',
     identifyingFields: ['thread'],
     recordMethods: {
         async loadMoreMessages() {

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -441,9 +441,9 @@ registerModel({
             related: 'threadViewer.thread',
         }),
         /**
-         * States the `mail.thread_cache` currently displayed by `this`.
+         * States the `ThreadCache` currently displayed by `this`.
          */
-        threadCache: many2one('mail.thread_cache', {
+        threadCache: many2one('ThreadCache', {
             inverse: 'threadViews',
             readonly: true,
             related: 'threadViewer.threadCache',

--- a/addons/mail/static/src/models/thread_view/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_view/thread_viewer.js
@@ -10,7 +10,7 @@ registerModel({
     recordMethods: {
         /**
          * @param {integer} scrollHeight
-         * @param {mail.thread_cache} threadCache
+         * @param {ThreadCache} threadCache
          */
         saveThreadCacheScrollHeightAsInitial(scrollHeight, threadCache) {
             threadCache = threadCache || this.threadCache;
@@ -31,7 +31,7 @@ registerModel({
         },
         /**
          * @param {integer} scrollTop
-         * @param {mail.thread_cache} threadCache
+         * @param {ThreadCache} threadCache
          */
         saveThreadCacheScrollPositionsAsInitial(scrollTop, threadCache) {
             threadCache = threadCache || this.threadCache;
@@ -117,9 +117,9 @@ registerModel({
          */
         thread: many2one('mail.thread'),
         /**
-         * States the `mail.thread_cache` that should be displayed by `this`.
+         * States the `ThreadCache` that should be displayed by `this`.
          */
-        threadCache: many2one('mail.thread_cache', {
+        threadCache: many2one('ThreadCache', {
             related: 'thread.cache',
         }),
         /**


### PR DESCRIPTION
Rename javascript model `mail.thread_cache` to `ThreadCache` in order to distinguish javascript models from python models.

Part of task-2701674.