### PR TITLE
[IMP] mail: rename thread partner seen info model

### DIFF
--- a/addons/mail/static/src/components/message/tests/message_tests.js
+++ b/addons/mail/static/src/components/message/tests/message_tests.js
@@ -559,7 +559,7 @@ QUnit.test('do not show messaging seen indicator if before last seen by all mess
         id: 99,
         originThread: link(thread),
     });
-    this.messaging.models['mail.thread_partner_seen_info'].insert([
+    this.messaging.models['ThreadPartnerSeenInfo'].insert([
         {
             lastSeenMessage: link(lastSeenMessage),
             partner: replace(this.messaging.currentPartner),

--- a/addons/mail/static/src/models/message_seen_indicator/message_seen_indicator.js
+++ b/addons/mail/static/src/models/message_seen_indicator/message_seen_indicator.js
@@ -157,7 +157,7 @@ registerModel({
                 .filter(partnerSeenInfo =>
                     /**
                      * Relation may not be set yet immediately
-                     * @see mail.thread_partner_seen_info:partnerId field
+                     * @see ThreadPartnerSeenInfo:partnerId field
                      * FIXME task-2278551
                      */
                     partnerSeenInfo.partner &&
@@ -186,7 +186,7 @@ registerModel({
                 .filter(partnerSeenInfo =>
                     /**
                      * Relation may not be set yet immediately
-                     * @see mail.thread_partner_seen_info:partnerId field
+                     * @see ThreadPartnerSeenInfo:partnerId field
                      * FIXME task-2278551
                      */
                     partnerSeenInfo.partner &&

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -166,7 +166,7 @@ registerModel({
                 // disabled on `channel` channels for performance reasons
                 return;
             }
-            this.messaging.models['mail.thread_partner_seen_info'].insert({
+            this.messaging.models['ThreadPartnerSeenInfo'].insert({
                 lastFetchedMessage: insert({ id: last_message_id }),
                 partner: insertAndReplace({ id: partner_id }),
                 thread: replace(channel),
@@ -307,7 +307,7 @@ registerModel({
             // for performance reasons
             const shouldComputeSeenIndicators = channel.channel_type !== 'channel';
             if (shouldComputeSeenIndicators) {
-                this.messaging.models['mail.thread_partner_seen_info'].insert({
+                this.messaging.models['ThreadPartnerSeenInfo'].insert({
                     lastSeenMessage: link(lastMessage),
                     partner: insertAndReplace({ id: partner_id }),
                     thread: replace(channel),

--- a/addons/mail/static/src/models/partner/partner.js
+++ b/addons/mail/static/src/models/partner/partner.js
@@ -446,7 +446,7 @@ registerModel({
         nameOrDisplayName: attr({
             compute: '_computeNameOrDisplayName',
         }),
-        partnerSeenInfos: one2many('mail.thread_partner_seen_info', {
+        partnerSeenInfos: one2many('ThreadPartnerSeenInfo', {
             inverse: 'partner',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -2306,7 +2306,7 @@ registerModel({
          * Contains the seen information for all members of the thread.
          * FIXME This field should be readonly once task-2336946 is done.
          */
-        partnerSeenInfos: one2many('mail.thread_partner_seen_info', {
+        partnerSeenInfos: one2many('ThreadPartnerSeenInfo', {
             inverse: 'thread',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/thread_partner_seen_info/thread_partner_seen_info.js
+++ b/addons/mail/static/src/models/thread_partner_seen_info/thread_partner_seen_info.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { many2one } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.thread_partner_seen_info',
+    name: 'ThreadPartnerSeenInfo',
     identifyingFields: ['thread', 'partner'],
     fields: {
         lastFetchedMessage: many2one('mail.message'),


### PR DESCRIPTION
Rename javascript model `mail.thread_partner_seen_info` to `ThreadPartnerSeenInfo` in order to distinguish javascript models from python models.

Part of task-2701674.