### PR TITLE
[FIX] l10_ch: Adapt css only for 'l10n_ch_qr' report

### DIFF
--- a/addons/l10n_ch/report/swissqr_report.xml
+++ b/addons/l10n_ch/report/swissqr_report.xml
@@ -22,6 +22,8 @@
         <template id="l10n_ch_swissqr_template">
             <t t-set="o" t-value="o.with_context(lang=lang)"/>
             <t t-call="web.external_layout">
+                <!-- add class to body tag -->
+                <script>document.body.className += " l10n_ch_qr";</script>
                 <!-- add default margin for header (matching A4 European margin) -->
                 <t t-set="report_header_style">padding-top:6.2mm; padding-left:8.2mm; padding-right:8.2mm;</t>
 

--- a/addons/l10n_ch/static/src/scss/report_swissqr.scss
+++ b/addons/l10n_ch/static/src/scss/report_swissqr.scss
@@ -1,21 +1,21 @@
-body {
-    padding: 0!important;
+body.l10n_ch_qr {
+    padding: 0;
 
     /* Disable custom bakground */
     .o_report_layout_background {
         background: none;
         min-height: 0;
     }
+}
 
-    .swissqr_title {
-        position: absolute;
-        padding: 15px;
-        padding-top: 200px;
-    }
+.swissqr_title {
+    position: absolute;
+    padding: 15px;
+    padding-top: 150px;
+}
 
-    .swissqr_content {
-        position: relative;
-    }
+.swissqr_content {
+    position: relative;
 
     .swissqr_receipt {
         position: absolute;


### PR DESCRIPTION
Issue:

  Padding impacting all reports since css file imported in common
  report assets.

Solution:

  part revert of commit: https://github.com/odoo/odoo/commit/69a1289eca79272efe7e53f8b3ad70de6df3d96a

opw-2686597