### PR TITLE
[IMP] hr_holidays, mail, sms, snailmail: rename thread viewer model

### DIFF
--- a/addons/hr_holidays/static/src/components/thread_view/tests/thread_view_tests.js
+++ b/addons/hr_holidays/static/src/components/thread_view/tests/thread_view_tests.js
@@ -50,7 +50,7 @@ QUnit.test('out of office message on direct chat with out of office partner', as
         id: 20,
         model: 'mail.channel'
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),

--- a/addons/mail/static/src/components/message/tests/message_tests.js
+++ b/addons/mail/static/src/components/message/tests/message_tests.js
@@ -134,7 +134,7 @@ QUnit.test('Notification Sent', async function (assert) {
         id: 11,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -233,7 +233,7 @@ QUnit.test('Notification Error', async function (assert) {
         id: 11,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -289,7 +289,7 @@ QUnit.test("'channel_fetch' notification received is correctly handled", async f
         id: 11,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -354,7 +354,7 @@ QUnit.test("'channel_seen' notification received is correctly handled", async fu
         id: 11,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -418,7 +418,7 @@ QUnit.test("'channel_fetch' notification then 'channel_seen' received  are corre
         id: 11,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -501,7 +501,7 @@ QUnit.test('do not show messaging seen indicator if not authored by me', async f
         ]),
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -542,7 +542,7 @@ QUnit.test('do not show messaging seen indicator if before last seen by all mess
         }),
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -620,7 +620,7 @@ QUnit.test('only show messaging seen indicator if authored by me, after last see
         }),
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -921,7 +921,7 @@ QUnit.test('open chat with author on avatar click should be disabled when curren
     });
     const correspondent = this.messaging.models['mail.partner'].insert({ id: 10 });
     const thread = await correspondent.getChat();
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -1564,7 +1564,7 @@ QUnit.test('message should not be considered as "clicked" after clicking on noti
         notification_type: 'email',
     });
     const { createThreadViewComponent } = await this.start();
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({

--- a/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
+++ b/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
@@ -58,7 +58,7 @@ QUnit.test('dragover files on thread with composer', async function (assert) {
         id: 100,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -107,7 +107,7 @@ QUnit.test('message list desc order', async function (assert) {
         id: 100,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         order: 'desc',
@@ -206,7 +206,7 @@ QUnit.test('message list asc order', async function (assert) {
         id: 100,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -316,7 +316,7 @@ QUnit.test('mark channel as fetched when a new message is loaded and as seen whe
         id: 100,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -386,7 +386,7 @@ QUnit.test('mark channel as fetched and seen when a new message is loaded if com
         id: 100,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -440,7 +440,7 @@ QUnit.test('show message subject when subject is not the same as the thread name
         id: 100,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -484,7 +484,7 @@ QUnit.test('do not show message subject when subject is the same as the thread n
         id: 100,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: [['link', thread]],
@@ -521,7 +521,7 @@ QUnit.test('[technical] new messages separator on posting message', async functi
         id: 20,
         model: 'mail.channel'
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -592,7 +592,7 @@ QUnit.test('new messages separator on receiving new message [REQUIRE FOCUS]', as
         id: 20,
         model: 'mail.channel'
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -686,7 +686,7 @@ QUnit.test('new messages separator on posting message', async function (assert) 
         id: 20,
         model: 'mail.channel'
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -743,7 +743,7 @@ QUnit.test('basic rendering of canceled notification', async function (assert) {
         res_partner_id: 12,
     });
     const { createThreadViewComponent } = await this.start();
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({
@@ -838,7 +838,7 @@ QUnit.test('should scroll to bottom on receiving new message if the list is init
         id: 20,
         model: 'mail.channel'
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -911,7 +911,7 @@ QUnit.test('should not scroll on receiving new message if the list is initially 
         id: 20,
         model: 'mail.channel'
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -987,7 +987,7 @@ QUnit.test("delete all attachments of message without content should no longer d
         }
     );
     const { createThreadViewComponent } = await this.start();
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({ id: 11, model: 'mail.channel' }),
@@ -1047,7 +1047,7 @@ QUnit.test('delete all attachments of a message with some text content should st
         },
     );
     const { createThreadViewComponent } = await this.start();
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({ id: 11, model: 'mail.channel' }),
@@ -1114,7 +1114,7 @@ QUnit.test('delete all attachments of a message with tracking fields should stil
         old_value: "Old name",
     });
     const { createThreadViewComponent } = await this.start();
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({ id: 11, model: 'mail.channel' }),
@@ -1169,7 +1169,7 @@ QUnit.test('Post a message containing an email address followed by a mention on 
         id: 11,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -1213,7 +1213,7 @@ QUnit.test(`Mention a partner with special character (e.g. apostrophe ')`, async
         id: 11,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -1262,7 +1262,7 @@ QUnit.test('mention 2 different partners that have the same name', async functio
         id: 11,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -1315,7 +1315,7 @@ QUnit.test('mention a channel with space in the name', async function (assert) {
         id: 7,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -1360,7 +1360,7 @@ QUnit.test('mention a channel with "&" in the name', async function (assert) {
         id: 7,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -1405,7 +1405,7 @@ QUnit.test('mention a channel on a second line when the first line contains #', 
         id: 7,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -1450,7 +1450,7 @@ QUnit.test('mention a channel when replacing the space after the mention by anot
         id: 7,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -1511,7 +1511,7 @@ QUnit.test('mention 2 different channels that have the same name', async functio
         id: 11,
         model: 'mail.channel',
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -1557,7 +1557,7 @@ QUnit.test('show empty placeholder when thread contains no message', async funct
 
     this.data['mail.channel'].records.push({ id: 11 });
     const { createThreadViewComponent } = await this.start();
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({
@@ -1603,7 +1603,7 @@ QUnit.test('show empty placeholder when thread contains only empty messages', as
         },
     );
     const { createThreadViewComponent } = await this.start();
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({
@@ -1654,7 +1654,7 @@ QUnit.test('message with subtype should be displayed (and not considered as empt
         },
     );
     const { createThreadViewComponent } = await this.start();
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({
@@ -1712,7 +1712,7 @@ QUnit.test('[technical] message list with a full page of empty messages should s
         });
     }
     const { createThreadViewComponent } = await this.start();
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({
@@ -1775,7 +1775,7 @@ QUnit.test('first unseen message should be directly preceded by the new message 
         id: 20,
         model: 'mail.channel'
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -1830,7 +1830,7 @@ QUnit.test('composer should be focused automatically after clicking on the send 
         id: 20,
         model: 'mail.channel'
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -1869,7 +1869,7 @@ QUnit.test('failure on loading messages should display error', async function (a
         id: 20,
         model: 'mail.channel'
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -1904,7 +1904,7 @@ QUnit.test('failure on loading messages should prompt retry button', async funct
         id: 20,
         model: 'mail.channel'
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -1953,7 +1953,7 @@ QUnit.test('failure on loading more messages should not alter message list displ
         id: 20,
         model: 'mail.channel'
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -2005,7 +2005,7 @@ QUnit.test('failure on loading more messages should display error and prompt ret
         id: 20,
         model: 'mail.channel'
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -2066,7 +2066,7 @@ QUnit.test('Retry loading more messages on failed load more messages should load
         id: 20,
         model: 'mail.channel'
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -2117,7 +2117,7 @@ QUnit.test("highlight the message mentioning the current user inside the channel
         id: 20,
         model: 'mail.channel'
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),
@@ -2158,7 +2158,7 @@ QUnit.test("not highlighting the message if not mentioning the current user insi
         id: 20,
         model: 'mail.channel'
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: link(thread),

--- a/addons/mail/static/src/models/chat_window/chat_window.js
+++ b/addons/mail/static/src/models/chat_window/chat_window.js
@@ -288,7 +288,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.thread_viewer}
+         * @returns {ThreadViewer}
          */
         _computeThreadViewer() {
             return insertAndReplace({
@@ -474,9 +474,9 @@ registerModel({
             related: 'threadViewer.threadView',
         }),
         /**
-         * Determines the `mail.thread_viewer` managing the display of `this.thread`.
+         * Determines the `ThreadViewer` managing the display of `this.thread`.
          */
-        threadViewer: one2one('mail.thread_viewer', {
+        threadViewer: one2one('ThreadViewer', {
             compute: '_computeThreadViewer',
             inverse: 'chatWindow',
             isCausal: true,

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -185,7 +185,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.thread_viewer}
+         * @returns {ThreadViewer}
          */
         _computeThreadViewer() {
             return insertAndReplace({
@@ -394,9 +394,9 @@ registerModel({
             related: 'threadViewer.threadView',
         }),
         /**
-         * Determines the `mail.thread_viewer` managing the display of `this.thread`.
+         * Determines the `ThreadViewer` managing the display of `this.thread`.
          */
-        threadViewer: one2one('mail.thread_viewer', {
+        threadViewer: one2one('ThreadViewer', {
             compute: '_computeThreadViewer',
             inverse: 'chatter',
             isCausal: true,

--- a/addons/mail/static/src/models/discuss/discuss.js
+++ b/addons/mail/static/src/models/discuss/discuss.js
@@ -298,7 +298,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.thread_viewer}
+         * @returns {ThreadViewer}
          */
         _computeThreadViewer() {
             return insertAndReplace({
@@ -412,9 +412,9 @@ registerModel({
             related: 'threadViewer.threadView',
         }),
         /**
-         * Determines the `mail.thread_viewer` managing the display of `this.thread`.
+         * Determines the `ThreadViewer` managing the display of `this.thread`.
          */
-        threadViewer: one2one('mail.thread_viewer', {
+        threadViewer: one2one('ThreadViewer', {
             compute: '_computeThreadViewer',
             inverse: 'discuss',
             isCausal: true,

--- a/addons/mail/static/src/models/discuss_public_view/discuss_public_view.js
+++ b/addons/mail/static/src/models/discuss_public_view/discuss_public_view.js
@@ -79,7 +79,7 @@ registerModel({
         /**
          * States the thread viewer linked to this discuss public view.
          */
-        threadViewer: one2one('mail.thread_viewer', {
+        threadViewer: one2one('ThreadViewer', {
             inverse: 'discussPublicView',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/thread_view/tests/thread_viewer_qunit_tests.js
+++ b/addons/mail/static/src/models/thread_view/tests/thread_viewer_qunit_tests.js
@@ -5,13 +5,13 @@ import { one2one } from '@mail/model/model_field';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/thread_view/thread_viewer';
 
-addFields('mail.thread_viewer', {
+addFields('ThreadViewer', {
     qunitTest: one2one('mail.qunit_test', {
         inverse: 'threadViewer',
         readonly: true,
     }),
 });
 
-patchIdentifyingFields('mail.thread_viewer', identifyingFields => {
+patchIdentifyingFields('ThreadViewer', identifyingFields => {
     identifyingFields[0].push('qunitTest');
 });

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -469,9 +469,9 @@ registerModel({
             related: 'threadViewer.threadCacheInitialScrollPositions',
         }),
         /**
-         * Determines the `mail.thread_viewer` currently managing `this`.
+         * Determines the `ThreadViewer` currently managing `this`.
          */
-        threadViewer: one2one('mail.thread_viewer', {
+        threadViewer: one2one('ThreadViewer', {
             inverse: 'threadView',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/thread_view/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_view/thread_viewer.js
@@ -5,7 +5,7 @@ import { attr, many2one, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.thread_viewer',
+    name: 'ThreadViewer',
     identifyingFields: [['chatter', 'chatWindow', 'discuss', 'discussPublicView']],
     recordMethods: {
         /**
@@ -52,7 +52,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {mail.thread_viewer|undefined}
+         * @returns {ThreadViewer|undefined}
          */
         _computeThreadView() {
             return this.hasThreadView ? insertAndReplace() : clear();

--- a/addons/mail/static/tests/qunit_test.js
+++ b/addons/mail/static/tests/qunit_test.js
@@ -18,7 +18,7 @@ registerModel({
             inverse: 'qunitTest',
             isCausal: true,
         }),
-        threadViewer: one2one('mail.thread_viewer', {
+        threadViewer: one2one('ThreadViewer', {
             inverse: 'qunitTest',
             isCausal: true,
         }),

--- a/addons/sms/static/src/components/message/tests/message_tests.js
+++ b/addons/sms/static/src/components/message/tests/message_tests.js
@@ -53,7 +53,7 @@ QUnit.test('Notification Sent', async function (assert) {
         res_partner_id: 12,
     });
     const { createThreadViewComponent } = await this.start();
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({
@@ -150,7 +150,7 @@ QUnit.test('Notification Error', async function (assert) {
         res_partner_id: 12,
     });
     const { createThreadViewComponent } = await this.start({ env: { bus } });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({

--- a/addons/snailmail/static/src/components/message/tests/message_tests.js
+++ b/addons/snailmail/static/src/components/message/tests/message_tests.js
@@ -52,7 +52,7 @@ QUnit.test('Sent', async function (assert) {
         res_partner_id: 12,
     });
     const { createThreadViewComponent } = await this.start();
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({
@@ -128,7 +128,7 @@ QUnit.test('Canceled', async function (assert) {
         res_partner_id: 12,
     });
     const { createThreadViewComponent } = await this.start();
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({
@@ -204,7 +204,7 @@ QUnit.test('Pending', async function (assert) {
         res_partner_id: 12,
     });
     const { createThreadViewComponent } = await this.start();
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({
@@ -288,7 +288,7 @@ QUnit.test('No Price Available', async function (assert) {
             return this._super(...arguments);
         },
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({
@@ -380,7 +380,7 @@ QUnit.test('Credit Error', async function (assert) {
             return this._super(...arguments);
         },
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({
@@ -477,7 +477,7 @@ QUnit.test('Trial Error', async function (assert) {
             return this._super(...arguments);
         },
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({
@@ -581,7 +581,7 @@ QUnit.test('Format Error', async function (assert) {
         res_partner_id: 12,
     });
     const { createThreadViewComponent } = await this.start({ env: { bus } });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({
@@ -659,7 +659,7 @@ QUnit.test('Missing Required Fields', async function (assert) {
     const { createThreadViewComponent } = await this.start({
         env: { bus },
     });
-    const threadViewer = this.messaging.models['mail.thread_viewer'].create({
+    const threadViewer = this.messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         thread: insert({ id: 20, model: 'res.partner' }),


### PR DESCRIPTION
Rename javascript model `mail.thread_viewer` to `ThreadViewer` in order to distinguish javascript models from python models.

Part of task-2701674.