### PR TITLE
[IMP] website_livechat: rename visitor model

### DIFF
--- a/addons/website_livechat/static/src/components/visitor_banner/visitor_banner.js
+++ b/addons/website_livechat/static/src/components/visitor_banner/visitor_banner.js
@@ -11,10 +11,10 @@ class VisitorBanner extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {website_livechat.visitor}
+     * @returns {Visitor}
      */
     get visitor() {
-        return this.messaging && this.messaging.models['website_livechat.visitor'].get(this.props.visitorLocalId);
+        return this.messaging && this.messaging.models['Visitor'].get(this.props.visitorLocalId);
     }
 
 }

--- a/addons/website_livechat/static/src/models/thread/thread.js
+++ b/addons/website_livechat/static/src/models/thread/thread.js
@@ -14,7 +14,7 @@ patchModelMethods('mail.thread', {
         const data2 = this._super(data);
         if ('visitor' in data) {
             if (data.visitor) {
-                data2.visitor = insert(this.messaging.models['website_livechat.visitor'].convertData(data.visitor));
+                data2.visitor = insert(this.messaging.models['Visitor'].convertData(data.visitor));
             } else {
                 data2.visitor = unlink();
             }
@@ -27,7 +27,7 @@ addFields('mail.thread', {
     /**
      * Visitor connected to the livechat.
      */
-    visitor: many2one('website_livechat.visitor', {
+    visitor: many2one('Visitor', {
         inverse: 'threads',
     }),
 });

--- a/addons/website_livechat/static/src/models/visitor/visitor.js
+++ b/addons/website_livechat/static/src/models/visitor/visitor.js
@@ -5,7 +5,7 @@ import { attr, many2one, one2many } from '@mail/model/model_field';
 import { insert, link, unlink } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'website_livechat.visitor',
+    name: 'Visitor',
     identifyingFields: ['id'],
     modelMethods: {
         convertData(data) {


### PR DESCRIPTION
Rename javascript model `website_livechat.visitor` to `Visitor` in order to distinguish javascript models from python models.

Part of task-2701674.