### PR TITLE
[IMP] mail: rename welcome view model

### DIFF
--- a/addons/mail/static/src/components/welcome_view/welcome_view.js
+++ b/addons/mail/static/src/components/welcome_view/welcome_view.js
@@ -11,15 +11,15 @@ export class WelcomeView extends owl.Component {
      */
     setup() {
         super.setup();
-        useRefToModel({ fieldName: 'guestNameInputRef', modelName: 'mail.welcome_view', propNameAsRecordLocalId: 'localId', refName: 'guestNameInput' });
-        useUpdateToModel({ methodName: 'onComponentUpdate', modelName: 'mail.welcome_view', propNameAsRecordLocalId: 'localId' });
+        useRefToModel({ fieldName: 'guestNameInputRef', modelName: 'WelcomeView', propNameAsRecordLocalId: 'localId', refName: 'guestNameInput' });
+        useUpdateToModel({ methodName: 'onComponentUpdate', modelName: 'WelcomeView', propNameAsRecordLocalId: 'localId' });
     }
 
     /**
-     * @returns {mail.welcome_view}
+     * @returns {WelcomeView}
      */
     get welcomeView() {
-        return this.messaging && this.messaging.models['mail.welcome_view'].get(this.props.localId);
+        return this.messaging && this.messaging.models['WelcomeView'].get(this.props.localId);
     }
 
 }

--- a/addons/mail/static/src/models/discuss_public_view/discuss_public_view.js
+++ b/addons/mail/static/src/models/discuss_public_view/discuss_public_view.js
@@ -86,7 +86,7 @@ registerModel({
         /**
          * States the welcome view linked to this discuss public view.
          */
-        welcomeView: one2one('mail.welcome_view', {
+        welcomeView: one2one('WelcomeView', {
             inverse: 'discussPublicView',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/welcome_view/welcome_view.js
+++ b/addons/mail/static/src/models/welcome_view/welcome_view.js
@@ -10,7 +10,7 @@ const getNextGuestNameInputId = (function () {
 })();
 
 registerModel({
-    name: 'mail.welcome_view',
+    name: 'WelcomeView',
     identifyingFields: ['messaging'],
     lifecycleHooks: {
         _created() {


### PR DESCRIPTION
Rename javascript model `mail.welcome_view` to `WelcomeView` in order to distinguish javascript models from python models.

Part of task-2701674.