### PR TITLE
[IMP] mail: rename thread view topbar model

### DIFF
--- a/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.js
+++ b/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.js
@@ -13,11 +13,11 @@ export class ThreadViewTopbar extends Component {
      */
     setup() {
         super.setup();
-        useRefToModel({ fieldName: 'guestNameInputRef', modelName: 'mail.thread_view_topbar', propNameAsRecordLocalId: 'localId', refName: 'guestNameInput' });
-        useRefToModel({ fieldName: 'inviteButtonRef', modelName: 'mail.thread_view_topbar', propNameAsRecordLocalId: 'localId', refName: 'inviteButton' });
-        useRefToModel({ fieldName: 'threadNameInputRef', modelName: 'mail.thread_view_topbar', propNameAsRecordLocalId: 'localId', refName: 'threadNameInput' });
-        useRefToModel({ fieldName: 'threadDescriptionInputRef', modelName: 'mail.thread_view_topbar', propNameAsRecordLocalId: 'localId', refName: 'threadDescriptionInput' });
-        useUpdateToModel({ methodName: 'onComponentUpdate', modelName: 'mail.thread_view_topbar', propNameAsRecordLocalId: 'localId' });
+        useRefToModel({ fieldName: 'guestNameInputRef', modelName: 'ThreadViewTopbar', propNameAsRecordLocalId: 'localId', refName: 'guestNameInput' });
+        useRefToModel({ fieldName: 'inviteButtonRef', modelName: 'ThreadViewTopbar', propNameAsRecordLocalId: 'localId', refName: 'inviteButton' });
+        useRefToModel({ fieldName: 'threadNameInputRef', modelName: 'ThreadViewTopbar', propNameAsRecordLocalId: 'localId', refName: 'threadNameInput' });
+        useRefToModel({ fieldName: 'threadDescriptionInputRef', modelName: 'ThreadViewTopbar', propNameAsRecordLocalId: 'localId', refName: 'threadDescriptionInput' });
+        useUpdateToModel({ methodName: 'onComponentUpdate', modelName: 'ThreadViewTopbar', propNameAsRecordLocalId: 'localId' });
     }
 
     //--------------------------------------------------------------------------
@@ -25,10 +25,10 @@ export class ThreadViewTopbar extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.thread_view_topbar}
+     * @returns {ThreadViewTopbar}
      */
     get threadViewTopbar() {
-        return this.messaging && this.messaging.models['mail.thread_view_topbar'].get(this.props.localId);
+        return this.messaging && this.messaging.models['ThreadViewTopbar'].get(this.props.localId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/models/popover_view/popover_view.js
+++ b/addons/mail/static/src/models/popover_view/popover_view.js
@@ -88,7 +88,7 @@ registerModel({
         /**
          * If set, this popover view is owned by a thread view topbar record.
          */
-        threadViewTopbarOwner: one2one('mail.thread_view_topbar', {
+        threadViewTopbarOwner: one2one('ThreadViewTopbar', {
             inverse: 'invitePopoverView',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -479,7 +479,7 @@ registerModel({
         /**
          * Determines the top bar of this thread view, if any.
          */
-        topbar: one2one('mail.thread_view_topbar', {
+        topbar: one2one('ThreadViewTopbar', {
             compute: '_computeTopbar',
             inverse: 'threadView',
             isCausal: true,

--- a/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
+++ b/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
@@ -5,7 +5,7 @@ import { attr, many2one, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.thread_view_topbar',
+    name: 'ThreadViewTopbar',
     identifyingFields: ['threadView'],
     lifecycleHooks: {
         _created() {


### PR DESCRIPTION
Rename javascript model `mail.thread_view_topbar` to `ThreadViewTopbar` in order to distinguish javascript models from python models.

Part of task-2701674.
