### PR TITLE
[IMP] survey: improve the survey question form view

### DIFF
--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -126,9 +126,11 @@
 
                                 <group attrs="{'invisible': ['|', ('scoring_type', '=', 'no_scoring'), ('question_type', 'not in', ['numerical_box', 'date', 'datetime'])]}">
                                     <label for="is_scored_question"/>
-                                    <field name="is_scored_question"/>
-                                    <field name="answer_score" nolabel="1" class="oe_inline" attrs="{'invisible': [('is_scored_question', '=', False)]}"/>
-                                    <span class="oe_inline" attrs="{'invisible': [('is_scored_question', '=', False)]}">Points</span>
+                                    <div name="survey_scored_question">
+                                        <field name="is_scored_question" nolabel="1"/>
+                                        <field name="answer_score" class="w-50 mx-2" attrs="{'invisible': [('is_scored_question', '=', False)]}" nolabel="1"/>
+                                        <span attrs="{'invisible': [('is_scored_question', '!=', True)]}">Points</span>
+                                    </div>
                                 </group>
                             </group>
                             <group attrs="{'invisible': [('question_type', 'not in', ['simple_choice', 'multiple_choice', 'matrix'])]}">


### PR DESCRIPTION
PURPOSE
To improve the UI of survey_question form.

Specification:
Current:
There is duplication of scored label and all fields are not inline.
To Be:
There is a single label, the integer and boolean are on the same line, we display the score only if the option is activated

Taskid-2704057

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
