### PR TITLE
[FIX] hr_timesheet: correctly compute is_internal_project

### DIFF
--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -60,7 +60,7 @@ class Project(models.Model):
     @api.depends('company_id')
     def _compute_is_internal_project(self):
         for project in self:
-            project.is_internal_project = bool(project.company_id.internal_project_id)
+            project.is_internal_project = project == project.company_id.internal_project_id
 
     @api.model
     def _search_is_internal_project(self, operator, value):


### PR DESCRIPTION
This commit fixes the way is_internal_project is computed.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
