### PR TITLE
[IMP] mail: rename qunit test model

### DIFF
--- a/addons/mail/static/src/models/composer_view/tests/composer_view_qunit_tests.js
+++ b/addons/mail/static/src/models/composer_view/tests/composer_view_qunit_tests.js
@@ -16,7 +16,7 @@ patchRecordMethods('ComposerView', {
 });
 
 addFields('ComposerView', {
-    qunitTest: one2one('mail.qunit_test', {
+    qunitTest: one2one('QUnitTest', {
         inverse: 'composerView',
         readonly: true,
     }),

--- a/addons/mail/static/src/models/message_view/tests/message_view_qunit_tests.js
+++ b/addons/mail/static/src/models/message_view/tests/message_view_qunit_tests.js
@@ -6,7 +6,7 @@ import { one2one } from '@mail/model/model_field';
 import '@mail/models/message_view/message_view';
 
 addFields('MessageView', {
-    qunitTest: one2one('mail.qunit_test', {
+    qunitTest: one2one('QUnitTest', {
         inverse: 'messageView',
         readonly: true,
     }),

--- a/addons/mail/static/src/models/thread_view/tests/thread_viewer_qunit_tests.js
+++ b/addons/mail/static/src/models/thread_view/tests/thread_viewer_qunit_tests.js
@@ -6,7 +6,7 @@ import { one2one } from '@mail/model/model_field';
 import '@mail/models/thread_view/thread_viewer';
 
 addFields('ThreadViewer', {
-    qunitTest: one2one('mail.qunit_test', {
+    qunitTest: one2one('QUnitTest', {
         inverse: 'threadViewer',
         readonly: true,
     }),

--- a/addons/mail/static/tests/qunit_test.js
+++ b/addons/mail/static/tests/qunit_test.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { one2one } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.qunit_test',
+    name: 'QUnitTest',
     identifyingFields: [], // singleton acceptable (only one test at a time)
     fields: {
         composer: one2one('Composer', {


### PR DESCRIPTION
Rename javascript model `mail.qunit_test` to `QUnitTest` in order to distinguish javascript models from python models.

Part of task-2701674.