### PR TITLE
[IMP] digest: fix tip description

### DIFF
--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -258,7 +258,7 @@ class Digest(models.Model):
             '|', ('group_id', 'in', user.groups_id.ids), ('group_id', '=', False)
         ], limit=tips_count)
         tip_descriptions = [
-            self.env['mail.render.mixin'].sudo()._render_template(tools.html_sanitize(tip.tip_description), 'digest.tip', tip.ids, post_process=True, engine="qweb")[tip.id]
+            tools.html_sanitize(self.env['mail.render.mixin'].sudo()._render_template(tip.tip_description, 'digest.tip', tip.ids, post_process=True, engine="qweb")[tip.id])
             for tip in tips
         ]
         if consumed:

--- a/addons/digest/models/digest_tip.py
+++ b/addons/digest/models/digest_tip.py
@@ -16,7 +16,7 @@ class DigestTip(models.Model):
     user_ids = fields.Many2many(
         'res.users', string='Recipients',
         help='Users having already received this tip')
-    tip_description = fields.Html('Tip description', translate=html_translate)
+    tip_description = fields.Html('Tip description', translate=html_translate, sanitize=False)
     group_id = fields.Many2one(
         'res.groups', string='Authorized Group',
         default=lambda self: self.env.ref('base.group_user'))


### PR DESCRIPTION
Current behavior before PR:

The digest tip description field value should be dynamically print in
the digest email.
While sending the digest emails, The tip description has improper because of
sanitizing.

Desired behavior after PR is merged:

With this, We remove the sanitized, set the html_sanitize of tip description field,
and set rendering after the QWEB template. So, all the conditions
and aliases are showing correctly. Replacing jinja with qweb template, 
we should use <t t-out="variable"/> to print the dynamic value so, remove 
the inline_template expression `{{` and `}}` and put the <t t-out="variable"/>.

PR #81465
Task-2704083


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
