### PR TITLE
[IMP] mail: properly pluralize x2many fields

### DIFF
--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -299,7 +299,7 @@ registerModel({
         attachmentLists: many2many('AttachmentList', {
             inverse: 'attachments',
         }),
-        attachmentViewer: many2many('AttachmentViewer', {
+        attachmentViewers: many2many('AttachmentViewer', {
             inverse: 'attachments',
         }),
         checksum: attr(),

--- a/addons/mail/static/src/models/attachment_list/attachment_list.js
+++ b/addons/mail/static/src/models/attachment_list/attachment_list.js
@@ -83,7 +83,7 @@ registerModel({
         /**
          * Determines the attachment viewers displaying this attachment list (if any).
          */
-        attachmentViewer: one2many('AttachmentViewer', {
+        attachmentViewers: one2many('AttachmentViewer', {
             inverse: 'attachmentList',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/attachment_viewer/attachment_viewer.js
+++ b/addons/mail/static/src/models/attachment_viewer/attachment_viewer.js
@@ -40,12 +40,12 @@ registerModel({
         }),
         attachment: many2one('mail.attachment'),
         attachmentList: many2one('AttachmentList', {
-            inverse: 'attachmentViewer',
+            inverse: 'attachmentViewers',
             readonly: true,
             required: true,
         }),
         attachments: many2many('mail.attachment', {
-            inverse: 'attachmentViewer',
+            inverse: 'attachmentViewers',
             related: 'attachmentList.viewableAttachments',
         }),
         /**


### PR DESCRIPTION
Go through all the x2many javascript models fields and make their name plural when needed.