### PR TITLE
[IMP] mail: rename thread view model

### DIFF
--- a/addons/mail/static/src/components/message/message.js
+++ b/addons/mail/static/src/components/message/message.js
@@ -260,7 +260,7 @@ export class Message extends Component {
     }
 
     /**
-     * @returns {mail.thread_view}
+     * @returns {ThreadView}
      */
     get threadView() {
         return this.messageView && this.messageView.threadView;

--- a/addons/mail/static/src/components/message_list/message_list.js
+++ b/addons/mail/static/src/components/message_list/message_list.js
@@ -159,10 +159,10 @@ export class MessageList extends Component {
     }
 
     /**
-     * @returns {mail.thread_view}
+     * @returns {ThreadView}
      */
     get threadView() {
-        return this.messaging && this.messaging.models['mail.thread_view'].get(this.props.threadViewLocalId);
+        return this.messaging && this.messaging.models['ThreadView'].get(this.props.threadViewLocalId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/components/thread_view/thread_view.js
+++ b/addons/mail/static/src/components/thread_view/thread_view.js
@@ -58,10 +58,10 @@ export class ThreadView extends Component {
     }
 
     /**
-     * @returns {mail.thread_view}
+     * @returns {ThreadView}
      */
     get threadView() {
-        return this.messaging && this.messaging.models['mail.thread_view'].get(this.props.threadViewLocalId);
+        return this.messaging && this.messaging.models['ThreadView'].get(this.props.threadViewLocalId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
@@ -251,7 +251,7 @@ registerModel({
         /**
          * States the thread view on which this list operates (if any).
          */
-        threadView: one2one('mail.thread_view', {
+        threadView: one2one('ThreadView', {
             inverse: 'channelInvitationForm',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/chat_window/chat_window.js
+++ b/addons/mail/static/src/models/chat_window/chat_window.js
@@ -468,9 +468,9 @@ registerModel({
             readonly: true,
         }),
         /**
-         * States the `mail.thread_view` displaying `this.thread`.
+         * States the `ThreadView` displaying `this.thread`.
          */
-        threadView: one2one('mail.thread_view', {
+        threadView: one2one('ThreadView', {
             related: 'threadViewer.threadView',
         }),
         /**

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -388,9 +388,9 @@ registerModel({
          */
         threadRef: attr(),
         /**
-         * States the `mail.thread_view` displaying `this.thread`.
+         * States the `ThreadView` displaying `this.thread`.
          */
-        threadView: one2one('mail.thread_view', {
+        threadView: one2one('ThreadView', {
             related: 'threadViewer.threadView',
         }),
         /**

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -969,7 +969,7 @@ registerModel({
         /**
          * States the thread view on which this composer allows editing (if any).
          */
-        threadView: one2one('mail.thread_view', {
+        threadView: one2one('ThreadView', {
             inverse: 'composerView',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/discuss/discuss.js
+++ b/addons/mail/static/src/models/discuss/discuss.js
@@ -406,9 +406,9 @@ registerModel({
             compute: '_computeThread',
         }),
         /**
-         * States the `mail.thread_view` displaying `this.thread`.
+         * States the `ThreadView` displaying `this.thread`.
          */
-        threadView: one2one('mail.thread_view', {
+        threadView: one2one('ThreadView', {
             related: 'threadViewer.threadView',
         }),
         /**

--- a/addons/mail/static/src/models/discuss_public_view/discuss_public_view.js
+++ b/addons/mail/static/src/models/discuss_public_view/discuss_public_view.js
@@ -72,7 +72,7 @@ registerModel({
         /**
          * States the thread view linked to this discuss public view.
          */
-        threadView: one2one('mail.thread_view', {
+        threadView: one2one('ThreadView', {
             readonly: true,
             related: 'threadViewer.threadView',
         }),

--- a/addons/mail/static/src/models/message_view/message_view.js
+++ b/addons/mail/static/src/models/message_view/message_view.js
@@ -184,7 +184,7 @@ registerModel({
         /**
          * States the thread view that is displaying this messages (if any).
          */
-        threadView: many2one('mail.thread_view', {
+        threadView: many2one('ThreadView', {
             inverse: 'messageViews',
             readonly: true,
         }),

--- a/addons/mail/static/src/models/messaging/tests/messaging_tests.js
+++ b/addons/mail/static/src/models/messaging/tests/messaging_tests.js
@@ -97,7 +97,7 @@ QUnit.test('openChat: open new chat for user', async function (assert) {
         thread.public === 'private'
     );
     assert.ok(chat, 'a chat should exist with the target partner');
-    assert.strictEqual(chat.threadViews.length, 1, 'the chat should be displayed in a `mail.thread_view`');
+    assert.strictEqual(chat.threadViews.length, 1, 'the chat should be displayed in a `ThreadView`');
 });
 
 QUnit.test('openChat: open existing chat for user', async function (assert) {
@@ -120,12 +120,12 @@ QUnit.test('openChat: open existing chat for user', async function (assert) {
         thread.public === 'private'
     );
     assert.ok(existingChat, 'a chat should initially exist with the target partner');
-    assert.strictEqual(existingChat.threadViews.length, 0, 'the chat should not be displayed in a `mail.thread_view`');
+    assert.strictEqual(existingChat.threadViews.length, 0, 'the chat should not be displayed in a `ThreadView`');
 
     await this.messaging.openChat({ partnerId: 14 });
     assert.ok(existingChat, 'a chat should still exist with the target partner');
     assert.strictEqual(existingChat.id, 10, 'the chat should be the existing chat');
-    assert.strictEqual(existingChat.threadViews.length, 1, 'the chat should now be displayed in a `mail.thread_view`');
+    assert.strictEqual(existingChat.threadViews.length, 1, 'the chat should now be displayed in a `ThreadView`');
 });
 
 });

--- a/addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js
+++ b/addons/mail/static/src/models/rtc_call_viewer/rtc_call_viewer.js
@@ -392,7 +392,7 @@ registerModel({
         /**
          * ThreadView on which the call viewer is attached.
          */
-        threadView: one2one('mail.thread_view', {
+        threadView: one2one('ThreadView', {
             inverse: 'rtcCallViewer',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -2402,7 +2402,7 @@ registerModel({
         textInputSelectionDirectionBackup: attr({
             default: "none",
         }),
-        threadViews: one2many('mail.thread_view', {
+        threadViews: one2many('ThreadView', {
             inverse: 'thread',
         }),
         /**

--- a/addons/mail/static/src/models/thread_cache/thread_cache.js
+++ b/addons/mail/static/src/models/thread_cache/thread_cache.js
@@ -407,9 +407,9 @@ registerModel({
             required: true,
         }),
         /**
-         * States the 'mail.thread_view' that are currently displaying `this`.
+         * States the 'ThreadView' that are currently displaying `this`.
          */
-        threadViews: one2many('mail.thread_view', {
+        threadViews: one2many('ThreadView', {
             inverse: 'threadCache',
         }),
     },

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -7,7 +7,7 @@ import { clear, insertAndReplace, link, replace, unlink, update } from '@mail/mo
 import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
-    name: 'mail.thread_view',
+    name: 'ThreadView',
     identifyingFields: ['threadViewer'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/thread_view/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_view/thread_viewer.js
@@ -142,9 +142,9 @@ registerModel({
             default: {},
         }),
         /**
-         * States the `mail.thread_view` currently displayed and managed by `this`.
+         * States the `ThreadView` currently displayed and managed by `this`.
          */
-        threadView: one2one('mail.thread_view', {
+        threadView: one2one('ThreadView', {
             compute: '_computeThreadView',
             inverse: 'threadViewer',
             isCausal: true,

--- a/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
+++ b/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
@@ -674,7 +674,7 @@ registerModel({
         /**
          * States the thread view managing this top bar.
          */
-        threadView: one2one('mail.thread_view', {
+        threadView: one2one('ThreadView', {
             inverse: 'topbar',
             readonly: true,
             required: true,


### PR DESCRIPTION
Rename javascript model mail.thread_view to ThreadView
in order to distinguish javascript model from python model.

Task-2701674
