### PR TITLE
[IMP] mail: rename test models (test hobby)

### DIFF
--- a/addons/mail/static/src/model/tests/test_models.js
+++ b/addons/mail/static/src/model/tests/test_models.js
@@ -30,10 +30,10 @@ registerModel({
         address: one2one('TestAddress', {
             inverse: 'contact',
         }),
-        favorite: one2one('test.hobby', {
+        favorite: one2one('TestHobby', {
             default: insertAndReplace({ description: 'football' }),
         }),
-        hobbies: one2many('test.hobby', {
+        hobbies: one2many('TestHobby', {
             default: insertAndReplace([
                 { description: 'hiking' },
                 { description: 'fishing' },
@@ -46,7 +46,7 @@ registerModel({
 });
 
 registerModel({
-    name: 'test.hobby',
+    name: 'TestHobby',
     identifyingFields: ['description'],
     fields: {
         description: attr({


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/80562
Omission of 'test.hobby' in the renaming of test models.

Task-2701674
