### PR TITLE
[IMP] mail: rename follower subtype list model

### DIFF
--- a/addons/mail/static/src/components/follower_subtype_list/follower_subtype_list.js
+++ b/addons/mail/static/src/components/follower_subtype_list/follower_subtype_list.js
@@ -11,10 +11,10 @@ export class FollowerSubtypeList extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {mail.follower_subtype_list}
+     * @returns {FollowerSubtypeList}
      */
     get followerSubtypeList() {
-        return this.messaging && this.messaging.models['mail.follower_subtype_list'].get(this.props.localId);
+        return this.messaging && this.messaging.models['FollowerSubtypeList'].get(this.props.localId);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/models/dialog/dialog.js
+++ b/addons/mail/static/src/models/dialog/dialog.js
@@ -40,7 +40,7 @@ registerModel({
             compute: '_computeComponentName',
             required: true,
         }),
-        followerSubtypeList: one2one('mail.follower_subtype_list', {
+        followerSubtypeList: one2one('FollowerSubtypeList', {
             isCausal: true,
             inverse: 'dialog',
             readonly: true,

--- a/addons/mail/static/src/models/follower/follower.js
+++ b/addons/mail/static/src/models/follower/follower.js
@@ -159,7 +159,7 @@ registerModel({
             required: true,
         }),
         selectedSubtypes: many2many('FollowerSubtype'),
-        subtypeList: one2many('mail.follower_subtype_list', {
+        subtypeList: one2many('FollowerSubtypeList', {
             inverse: 'follower',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/follower_subtype_list/follower_subtype_list.js
+++ b/addons/mail/static/src/models/follower_subtype_list/follower_subtype_list.js
@@ -4,7 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { many2one, one2one } from '@mail/model/model_field';
 
 registerModel({
-    name: 'mail.follower_subtype_list',
+    name: 'FollowerSubtypeList',
     identifyingFields: ['follower'],
     fields: {
         /**


### PR DESCRIPTION
Rename javascript model mail.follower_subtype_list to FollowerSubtypeList
in order to distinguish javascript model from python model.

Task-2701674