### PR TITLE
15.0 fix my profile edit wbr

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -73,8 +73,13 @@ HR_WRITABLE_FIELDS = [
 class User(models.Model):
     _inherit = ['res.users']
 
+    def _employee_ids_domain(self):
+        # employee_ids is considered a safe field and as such will be fetched as sudo.
+        # So try to enforce the security rules on the field to make sure we do not load employees outside of active companies
+        return [('company_id', 'in', self.env.company.ids + self.env.context.get('allowed_company_ids', []))]
+
     # note: a user can only be linked to one employee per company (see sql constraint in ´hr.employee´)
-    employee_ids = fields.One2many('hr.employee', 'user_id', string='Related employee')
+    employee_ids = fields.One2many('hr.employee', 'user_id', string='Related employee', domain=_employee_ids_domain)
     employee_id = fields.Many2one('hr.employee', string="Company employee",
         compute='_compute_company_employee', search='_search_company_employee', store=False)
 

--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -29,7 +29,7 @@
     <record id="hr_employee_comp_rule" model="ir.rule">
         <field name="name">Employee multi company rule</field>
         <field name="model_id" ref="model_hr_employee"/>
-        <field name="domain_force">['|', '|',('company_id','=',False),('company_id', 'in', company_ids),('user_id', '=', user.id)]</field>
+        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
     </record>
 
     <record id="hr_dept_comp_rule" model="ir.rule">


### PR DESCRIPTION
Before this commit users were not able to edit their settings if they
had a linked employee for a company that was not currently active for
them.
This is due to the fact that since the employee_ids field is considered
`safe` to read/write by your own user the fields were loaded in sudo and
thus bypassed the security rules that were meant to prevent that issue.
The security rule is now enforced as a domain on the `employee_ids`.