### PR TITLE
[FIX] mail: include legacy_promise_error_handler on public bundle

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -101,6 +101,7 @@
             'web/static/src/legacy/js/services/data_manager.js',
             'web/static/src/legacy/js/services/session.js',
             'web/static/src/legacy/js/widgets/date_picker.js',
+            'web/static/src/legacy/legacy_promise_error_handler.js',
             'web/static/src/legacy/legacy_rpc_error_handler.js',
             'web/static/src/legacy/utils.js',
             'web/static/src/legacy/xml/base.xml',


### PR DESCRIPTION
Before this commit, `XmlHttpRequestError abort` could show up as client error
with an empty stack trace.

see task-2664831