### PR TITLE
[IMP] mail: rename user setting model

### DIFF
--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -368,7 +368,7 @@ registerModel({
          * Mailbox Starred.
          */
         starred: one2one('Thread'),
-        userSetting: one2one('mail.user_setting', {
+        userSetting: one2one('UserSetting', {
             isCausal: true,
         }),
     },

--- a/addons/mail/static/src/models/rtc_configuration_menu/rtc_configuration_menu.js
+++ b/addons/mail/static/src/models/rtc_configuration_menu/rtc_configuration_menu.js
@@ -84,7 +84,7 @@ registerModel({
         isRegisteringKey: attr({
             default: false,
         }),
-        userSetting: one2one('mail.user_setting', {
+        userSetting: one2one('UserSetting', {
             inverse: 'rtcConfigurationMenu',
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/user_setting/user_setting.js
+++ b/addons/mail/static/src/models/user_setting/user_setting.js
@@ -7,7 +7,7 @@ import { attr, one2one, one2many } from '@mail/model/model_field';
 import { insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
-    name: 'mail.user_setting',
+    name: 'UserSetting',
     identifyingFields: ['id'],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/volume_setting/volume_setting.js
+++ b/addons/mail/static/src/models/volume_setting/volume_setting.js
@@ -38,7 +38,7 @@ registerModel({
         partner: one2one('Partner', {
             inverse: 'volumeSetting',
         }),
-        userSetting: many2one('mail.user_setting', {
+        userSetting: many2one('UserSetting', {
             inverse: 'volumeSettings',
             required: true,
         }),


### PR DESCRIPTION
Rename javascript model mail.user_setting to UserSetting
in order to distinguish javascript model from python model.

Task-2701674
