### PR TITLE
[IMP] mail: rename volume setting model

### DIFF
--- a/addons/mail/static/src/models/guest/guest.js
+++ b/addons/mail/static/src/models/guest/guest.js
@@ -46,7 +46,7 @@ registerModel({
         rtcSessions: one2many('RtcSession', {
             inverse: 'guest',
         }),
-        volumeSetting: one2one('mail.volume_setting', {
+        volumeSetting: one2one('VolumeSetting', {
             inverse: 'guest',
         }),
     },

--- a/addons/mail/static/src/models/partner/partner.js
+++ b/addons/mail/static/src/models/partner/partner.js
@@ -456,7 +456,7 @@ registerModel({
         user: one2one('mail.user', {
             inverse: 'partner',
         }),
-        volumeSetting: one2one('mail.volume_setting', {
+        volumeSetting: one2one('VolumeSetting', {
             inverse: 'partner',
         }),
     },

--- a/addons/mail/static/src/models/user_setting/user_setting.js
+++ b/addons/mail/static/src/models/user_setting/user_setting.js
@@ -285,7 +285,7 @@ registerModel({
         /**
          * Models that represent the volume chosen by the user for each partner.
          */
-        volumeSettings: one2many('mail.volume_setting', {
+        volumeSettings: one2many('VolumeSetting', {
             inverse: 'userSetting',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/volume_setting/volume_setting.js
+++ b/addons/mail/static/src/models/volume_setting/volume_setting.js
@@ -5,7 +5,7 @@ import { attr, one2one, many2one } from '@mail/model/model_field';
 import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
-    name: 'mail.volume_setting',
+    name: 'VolumeSetting',
     identifyingFields: ['id'],
     recordMethods: {
         /**


### PR DESCRIPTION
Rename javascript model mail.volume_setting to VolumeSetting
in order to distinguish javascript model from python model.

Task-2701674
