### PR TITLE
[FIX] website: remove countdown flicker when loading

### DIFF
--- a/addons/website/static/src/snippets/s_countdown/000.js
+++ b/addons/website/static/src/snippets/s_countdown/000.js
@@ -1,13 +1,10 @@
 odoo.define('website.s_countdown', function (require) {
 'use strict';
 
-const {ColorpickerWidget} = require('web.Colorpicker');
 const core = require('web.core');
 const publicWidget = require('web.public.widget');
-const weUtils = require('web_editor.utils');
 
 const qweb = core.qweb;
-const _t = core._t;
 
 const CountdownWidget = publicWidget.Widget.extend({
     selector: '.s_countdown',
@@ -21,32 +18,15 @@ const CountdownWidget = publicWidget.Widget.extend({
     start: function () {
         this.$wrapper = this.$('.s_countdown_canvas_wrapper');
         this.$wrapper.addClass('d-flex justify-content-center');
-        this.$textWrapper = this.$wrapper.find('.s_countdown_text_wrapper');
         this.hereBeforeTimerEnds = false;
         this.endAction = this.el.dataset.endAction;
         this.endTime = parseInt(this.el.dataset.endTime);
-        this.size = parseInt(this.el.dataset.size);
         this.display = this.el.dataset.display;
 
-        this.layout = this.el.dataset.layout;
-        this.layoutBackground = this.el.dataset.layoutBackground;
-        this.progressBarStyle = this.el.dataset.progressBarStyle;
-        this.progressBarWeight = this.el.dataset.progressBarWeight;
-
-        this.textColor = this._ensureCssColor(this.el.dataset.textColor);
-        this.layoutBackgroundColor = this._ensureCssColor(this.el.dataset.layoutBackgroundColor);
-        this.progressBarColor = this._ensureCssColor(this.el.dataset.progressBarColor);
-
         this.onlyOneUnit = this.display === 'd';
-        this.width = parseInt(this.size);
-        if (this.layout === 'boxes') {
-            this.width /= 1.75;
-        }
-        this._initTimeDiff();
 
-        this._render();
-
-        this.setInterval = setInterval(this._render.bind(this), 1000);
+        this._update();
+        this.setInterval = setInterval(this._update.bind(this), 1000);
         return this._super(...arguments);
     },
     /**
@@ -55,9 +35,8 @@ const CountdownWidget = publicWidget.Widget.extend({
     destroy: function () {
         this.$('.s_countdown_end_redirect_message').remove();
         this.$('.s_countdown_end_message').addClass('d-none');
-        this.$('.s_countdown_text').remove();
+        this.$('span.s_countdown_text').empty();
         this.$('.s_countdown_canvas_wrapper').removeClass('d-none');
-        this.$('.s_countdown_canvas_flex').remove();
 
         clearInterval(this.setInterval);
         this._super(...arguments);
@@ -67,20 +46,6 @@ const CountdownWidget = publicWidget.Widget.extend({
     // Private
     //--------------------------------------------------------------------------
 
-    /**
-     * Ensures the color is an actual css color. In case of a color variable,
-     * the color will be mapped to hexa.
-     *
-     * @private
-     * @param {string} color
-     * @returns {string}
-     */
-    _ensureCssColor: function (color) {
-        if (ColorpickerWidget.isCSSColor(color)) {
-            return color;
-        }
-        return weUtils.getCSSVariableValue(color) || this.defaultColor;
-    },
     /**
      * Gets the time difference in seconds between now and countdown due date.
      *
@@ -117,130 +82,30 @@ const CountdownWidget = publicWidget.Widget.extend({
         }
     },
     /**
-     * Initializes the `diff` object. It will contains every visible time unit
-     * which will each contain its related canvas, total step, label..
+     * Updates the remaining time shown by the countdown.
      *
      * @private
      */
-    _initTimeDiff: function () {
-        const delta = this._getDelta();
-        this.diff = [];
-        if (this._isUnitVisible('d') && !(this.onlyOneUnit && delta < 86400)) {
-            this.diff.push({
-                canvas: $('<div class="s_countdown_canvas_flex"><canvas class="w-100"/></div>').appendTo(this.$wrapper)[0],
-                // There is no logical number of unit (total) on which day units
-                //  can be compared against, so we use an arbitrary number.
-                total: 15,
-                label: _t("Days"),
-                nbSeconds: 86400,
-            });
-        }
-        if (this._isUnitVisible('h') || (this.onlyOneUnit && delta < 86400 && delta > 3600)) {
-            this.diff.push({
-                canvas: $('<div class="s_countdown_canvas_flex"><canvas class="w-100"/></div>').appendTo(this.$wrapper)[0],
-                total: 24,
-                label: _t("Hours"),
-                nbSeconds: 3600,
-            });
-        }
-        if (this._isUnitVisible('m') || (this.onlyOneUnit && delta < 3600 && delta > 60)) {
-            this.diff.push({
-                canvas: $('<div class="s_countdown_canvas_flex"><canvas class="w-100"/></div>').appendTo(this.$wrapper)[0],
-                total: 60,
-                label: _t("Minutes"),
-                nbSeconds: 60,
-            });
-        }
-        if (this._isUnitVisible('s') || (this.onlyOneUnit && delta < 60)) {
-            this.diff.push({
-                canvas: $('<div class="s_countdown_canvas_flex"><canvas class="w-100"/></div>').appendTo(this.$wrapper)[0],
-                total: 60,
-                label: _t("Seconds"),
-                nbSeconds: 1,
-            });
-        }
-    },
-    /**
-     * Returns weither or not the countdown should be displayed for the given
-     * unit (days, sec..).
-     *
-     * @private
-     * @param {string} unit - either 'd', 'm', 'h', or 's'
-     * @returns {boolean}
-     */
-    _isUnitVisible: function (unit) {
-        return this.display.includes(unit);
-    },
-    /**
-     * Draws the whole countdown, including one countdown for each time unit.
-     *
-     * @private
-     */
-    _render: function () {
+    _update: function () {
+        let timeDelta = this._getDelta();
+        let data = [];
 
-        // If only one unit mode, restart widget on unit change to populate diff
-        if (this.onlyOneUnit && this._getDelta() < this.diff[0].nbSeconds) {
-            this.$('.s_countdown_canvas_flex').remove();
-            this._initTimeDiff();
+        for (const unit of this.display) {
+            const period = {'d': 86400, 'h': 3600, 'm': 60, 's': 1}[unit];
+            data.push(Math.floor(timeDelta / period));
+            timeDelta %= period;
         }
-        this._updateTimeDiff();
 
+        this.isFinished = timeDelta < 0;
         const hideCountdown = this.isFinished && !this.editableMode && this.$el.hasClass('hide-countdown');
-        if (this.layout === 'text') {
-            this.$('.s_countdown_canvas_flex').addClass('d-none');
-            if (!this.$textWrapper.length) {
-                // The creation of the text wrapper here instead of the option
-                // is kept for compatibility.
-                // TODO migrate?
-                this.$textWrapper = $('<span/>').attr({
-                    class: 's_countdown_text_wrapper d-none',
-                });
-                this.$textWrapper.text(_t("Countdown ends in"));
-                this.$textWrapper.appendTo(this.$wrapper);
-            }
-
-            if (!this.$textWrapper.find('.s_countdown_text').length) {
-                $('<span/>').attr({
-                    class: 's_countdown_text ml-1',
-                }).appendTo(this.$textWrapper);
-            }
-
-            this.$textWrapper.toggleClass('d-none', hideCountdown);
-
-            const countdownText = this.diff.map(e => e.nb + ' ' + e.label).join(', ');
-            this.$('.s_countdown_text').text(countdownText.toLowerCase());
-        } else {
-            // Kept for compatibility (the text wrapper for the text layout is
-            // not created by the option but here for old snippets)
-            // TODO migrate?
-            this.$textWrapper.remove();
-
-            for (const val of this.diff) {
-                const canvas = val.canvas.querySelector('canvas');
-                const ctx = canvas.getContext("2d");
-                ctx.canvas.width = this.width;
-                ctx.canvas.height = this.size;
-                this._clearCanvas(ctx);
-
-                $(canvas).toggleClass('d-none', hideCountdown);
-                if (hideCountdown) {
-                    continue;
-                }
-
-                // Draw canvas elements
-                if (this.layoutBackground !== 'none') {
-                    this._drawBgShape(ctx, this.layoutBackground === 'plain');
-                }
-                this._drawText(canvas, val.nb, val.label, this.layoutBackground === 'plain');
-                if (this.progressBarStyle === 'surrounded') {
-                    this._drawProgressBarBg(ctx, this.progressBarWeight === 'thin');
-                }
-                if (this.progressBarStyle !== 'none') {
-                    this._drawProgressBar(ctx, val.nb, val.total, this.progressBarWeight === 'thin');
-                }
-                this.$('.s_countdown_canvas_flex').toggleClass('mx-1', this.layout === 'boxes');
-            }
-        }
+        const counterSelector = 'text[y="50"], span.o_not_editable';
+        this.$wrapper[0].querySelectorAll(counterSelector).forEach((el, i) => {
+            el.textContent = data[i];
+        });
+        this.$wrapper[0].querySelectorAll('[pathLength]').forEach((el, i) => {
+            const max = parseInt(el.getAttribute('pathLength'));
+            el.setAttribute('stroke-dasharray', `${data[i]} ${max - data[i]}`);
+        });
 
         if (this.isFinished) {
             const $container = this.$('> .container, > .container-fluid, > .o_container_small');
@@ -250,185 +115,6 @@ const CountdownWidget = publicWidget.Widget.extend({
                 this._handleEndCountdownAction();
             }
         }
-    },
-    /**
-     * Updates the remaining units into the `diff` object.
-     *
-     * @private
-     */
-    _updateTimeDiff: function () {
-        let delta = this._getDelta();
-        this.isFinished = delta < 0;
-        if (this.isFinished) {
-            for (const unitData of this.diff) {
-                  unitData.nb = 0;
-            }
-            return;
-        }
-
-        this.hereBeforeTimerEnds = true;
-        for (const unitData of this.diff) {
-              unitData.nb = Math.floor(delta / unitData.nbSeconds);
-              delta -= unitData.nb * unitData.nbSeconds;
-        }
-    },
-
-    //--------------------------------------------------------------------------
-    // Canvas drawing methods
-    //--------------------------------------------------------------------------
-
-    /**
-     * Erases the canvas.
-     *
-     * @private
-     * @param {RenderingContext} ctx - Context of the canvas
-     */
-    _clearCanvas: function (ctx) {
-        ctx.clearRect(0, 0, this.size, this.size);
-    },
-    /**
-     * Draws a text into the canvas.
-     *
-     * @private
-     * @param {HTMLCanvasElement} canvas
-     * @param {string} textNb - text to display in the center of the canvas, in big
-     * @param {string} textUnit - text to display bellow `textNb` in small
-     * @param {boolean} full - if true, the shape will be drawn up to the progressbar
-     */
-    _drawText: function (canvas, textNb, textUnit, full = false) {
-        const ctx = canvas.getContext("2d");
-        const nbSize = this.size / 4;
-        ctx.font = `${nbSize}px Arial`;
-        ctx.fillStyle = this.textColor;
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.fillText(textNb, canvas.width / 2, canvas.height / 2);
-
-        const unitSize = this.size / 12;
-        ctx.font = `${unitSize}px Arial`;
-        ctx.fillText(textUnit, canvas.width / 2, canvas.height / 2 + nbSize / 1.5, this.width);
-
-        if (this.layout === 'boxes' && this.layoutBackground !== 'none' && this.progressBarStyle === 'none') {
-            let barWidth = this.size / (this.progressBarWeight === 'thin' ? 31 : 10);
-            if (full) {
-                barWidth = 0;
-            }
-            ctx.beginPath();
-            ctx.moveTo(barWidth, this.size / 2);
-            ctx.lineTo(this.width - barWidth, this.size / 2);
-            ctx.stroke();
-        }
-    },
-    /**
-     * Draws a plain shape into the canvas.
-     *
-     * @private
-     * @param {RenderingContext} ctx - Context of the canvas
-     * @param {boolean} full - if true, the shape will be drawn up to the progressbar
-     */
-    _drawBgShape: function (ctx, full = false) {
-        ctx.fillStyle = this.layoutBackgroundColor;
-        ctx.beginPath();
-        if (this.layout === 'circle') {
-            let rayon = this.size / 2;
-            if (this.progressBarWeight === 'thin') {
-                rayon -= full ? this.size / 29 : this.size / 15;
-            } else {
-                rayon -= full ? 0 : this.size / 10;
-            }
-            ctx.arc(this.size / 2, this.size / 2, rayon, 0, Math.PI * 2);
-            ctx.fill();
-        } else if (this.layout === 'boxes') {
-            let barWidth = this.size / (this.progressBarWeight === 'thin' ? 31 : 10);
-            if (full) {
-                barWidth = 0;
-            }
-
-            ctx.fillStyle = this.layoutBackgroundColor;
-            ctx.rect(barWidth, barWidth, this.width - barWidth * 2, this.size - barWidth * 2);
-            ctx.fill();
-
-            const gradient = ctx.createLinearGradient(0, this.width, 0, 0);
-            gradient.addColorStop(0, '#ffffff24');
-            gradient.addColorStop(1, this.layoutBackgroundColor);
-            ctx.fillStyle = gradient;
-            ctx.rect(barWidth, barWidth, this.width - barWidth * 2, this.size - barWidth * 2);
-            ctx.fill();
-            $(ctx.canvas).css({'border-radius': '8px'});
-        }
-    },
-    /**
-     * Draws a progress bar around the countdown shape.
-     *
-     * @private
-     * @param {RenderingContext} ctx - Context of the canvas
-     * @param {string} nbUnit - how many unit should fill progress bar
-     * @param {string} totalUnit - number of unit to do a complete progress bar
-     * @param {boolean} thinLine - if true, the progress bar will be thiner
-     */
-    _drawProgressBar: function (ctx, nbUnit, totalUnit, thinLine) {
-        ctx.strokeStyle = this.progressBarColor;
-        ctx.lineWidth = thinLine ? this.size / 35 : this.size / 10;
-        if (this.layout === 'circle') {
-            ctx.beginPath();
-            ctx.arc(this.size / 2, this.size / 2, this.size / 2 - this.size / 20, Math.PI / -2, (Math.PI * 2) * (nbUnit / totalUnit) + (Math.PI / -2));
-            ctx.stroke();
-        } else if (this.layout === 'boxes') {
-            ctx.lineWidth *= 2;
-            let pc = nbUnit / totalUnit * 100;
-
-            // Lines: Top(x1,y1,x2,y2) Right(x1,y1,x2,y2) Bottom(x1,y1,x2,y2) Left(x1,y1,x2,y2)
-            const linesCoordFuncs = [
-                (linePc) => [0 + ctx.lineWidth / 2, 0, (this.width - ctx.lineWidth / 2) * linePc / 25 + ctx.lineWidth / 2, 0],
-                (linePc) => [this.width, 0 + ctx.lineWidth / 2, this.width, (this.size - ctx.lineWidth / 2) * linePc / 25 + ctx.lineWidth / 2],
-                (linePc) => [this.width - ((this.width - ctx.lineWidth / 2) * linePc / 25) - ctx.lineWidth / 2, this.size, this.width - ctx.lineWidth / 2, this.size],
-                (linePc) => [0, this.size - ((this.size - ctx.lineWidth / 2) * linePc / 25) - ctx.lineWidth / 2, 0, this.size - ctx.lineWidth / 2],
-            ];
-            while (pc > 0 && linesCoordFuncs.length) {
-                const linePc = Math.min(pc, 25);
-                const lineCoord = (linesCoordFuncs.shift())(linePc);
-                ctx.beginPath();
-                ctx.moveTo(lineCoord[0], lineCoord[1]);
-                ctx.lineTo(lineCoord[2], lineCoord[3]);
-                ctx.stroke();
-                pc -= linePc;
-            }
-        }
-    },
-    /**
-     * Draws a full lighter background progressbar around the shape.
-     *
-     * @private
-     * @param {RenderingContext} ctx - Context of the canvas
-     * @param {boolean} thinLine - if true, the progress bar will be thiner
-     */
-    _drawProgressBarBg: function (ctx, thinLine) {
-        ctx.strokeStyle = this.progressBarColor;
-        ctx.globalAlpha = 0.2;
-        ctx.lineWidth = thinLine ? this.size / 35 : this.size / 10;
-        if (this.layout === 'circle') {
-            ctx.beginPath();
-            ctx.arc(this.size / 2, this.size / 2, this.size / 2 - this.size / 20, 0, Math.PI * 2);
-            ctx.stroke();
-        } else if (this.layout === 'boxes') {
-            ctx.lineWidth *= 2;
-
-            // Lines: Top(x1,y1,x2,y2) Right(x1,y1,x2,y2) Bottom(x1,y1,x2,y2) Left(x1,y1,x2,y2)
-            const points = [
-                [0 + ctx.lineWidth / 2, 0, this.width, 0],
-                [this.width, 0 + ctx.lineWidth / 2, this.width, this.size],
-                [0, this.size, this.width - ctx.lineWidth / 2, this.size],
-                [0, 0, 0, this.size - ctx.lineWidth / 2],
-            ];
-            while (points.length) {
-                const point = points.shift();
-                ctx.beginPath();
-                ctx.moveTo(point[0], point[1]);
-                ctx.lineTo(point[2], point[3]);
-                ctx.stroke();
-            }
-        }
-        ctx.globalAlpha = 1;
     },
 });
 

--- a/addons/website/static/src/snippets/s_countdown/000.js
+++ b/addons/website/static/src/snippets/s_countdown/000.js
@@ -21,6 +21,7 @@ const CountdownWidget = publicWidget.Widget.extend({
     start: function () {
         this.$wrapper = this.$('.s_countdown_canvas_wrapper');
         this.$wrapper.addClass('d-flex justify-content-center');
+        this.$textWrapper = this.$wrapper.find('.s_countdown_text_wrapper');
         this.hereBeforeTimerEnds = false;
         this.endAction = this.el.dataset.endAction;
         this.endTime = parseInt(this.el.dataset.endTime);
@@ -54,7 +55,7 @@ const CountdownWidget = publicWidget.Widget.extend({
     destroy: function () {
         this.$('.s_countdown_end_redirect_message').remove();
         this.$('.s_countdown_end_message').addClass('d-none');
-        this.$('.s_countdown_text_wrapper').remove();
+        this.$('.s_countdown_text').remove();
         this.$('.s_countdown_canvas_wrapper').removeClass('d-none');
         this.$('.s_countdown_canvas_flex').remove();
 
@@ -187,15 +188,21 @@ const CountdownWidget = publicWidget.Widget.extend({
         const hideCountdown = this.isFinished && !this.editableMode && this.$el.hasClass('hide-countdown');
         if (this.layout === 'text') {
             this.$('.s_countdown_canvas_flex').addClass('d-none');
-            if (!this.$textWrapper) {
+            if (!this.$textWrapper.length) {
+                // The creation of the text wrapper here instead of the option
+                // is kept for compatibility.
+                // TODO migrate?
                 this.$textWrapper = $('<span/>').attr({
                     class: 's_countdown_text_wrapper d-none',
                 });
                 this.$textWrapper.text(_t("Countdown ends in"));
-                this.$textWrapper.append($('<span/>').attr({
-                    class: 's_countdown_text ml-1',
-                }));
                 this.$textWrapper.appendTo(this.$wrapper);
+            }
+
+            if (!this.$textWrapper.find('.s_countdown_text').length) {
+                $('<span/>').attr({
+                    class: 's_countdown_text ml-1',
+                }).appendTo(this.$textWrapper);
             }
 
             this.$textWrapper.toggleClass('d-none', hideCountdown);
@@ -203,6 +210,11 @@ const CountdownWidget = publicWidget.Widget.extend({
             const countdownText = this.diff.map(e => e.nb + ' ' + e.label).join(', ');
             this.$('.s_countdown_text').text(countdownText.toLowerCase());
         } else {
+            // Kept for compatibility (the text wrapper for the text layout is
+            // not created by the option but here for old snippets)
+            // TODO migrate?
+            this.$textWrapper.remove();
+
             for (const val of this.diff) {
                 const canvas = val.canvas.querySelector('canvas');
                 const ctx = canvas.getContext("2d");
@@ -231,7 +243,9 @@ const CountdownWidget = publicWidget.Widget.extend({
         }
 
         if (this.isFinished) {
+            const $container = this.$('> .container, > .container-fluid, > .o_container_small');
             clearInterval(this.setInterval);
+            $container.toggleClass('d-none', hideCountdown);
             if (!this.editableMode) {
                 this._handleEndCountdownAction();
             }

--- a/addons/website/static/src/snippets/s_countdown/000.xml
+++ b/addons/website/static/src/snippets/s_countdown/000.xml
@@ -25,40 +25,33 @@
     </t>
     <t t-name="website.s_countdown.graphics">
         <t t-set="width" t-value="layout === 'boxes' ? 57 : 100" />
-        <t t-set="circles" t-value="layout === 'circle' ? display.split('') : []" />
-        <t t-set="boxes" t-value="layout === 'boxes' ? display.split('') : []" />
-        <svg t-if="layout !== 'text'" height="175" class="o_not_editable"
-            t-attf-viewBox="0 0 #{4 * width} 100">
-            <g class="s_countdown_background text-400" fill="currentColor" >
-                <circle t-foreach="circles" t-as="unit" r="43.5"
-                    t-att-cx="unit_index * width + 50" cy="50" />
-                <rect t-foreach="boxes" t-as="unit" width="57" height="100" rx="5"
-                    t-att-x="unit_index * width" y="0" />
-            </g>
-            <g class="s_countdown_surround text-o-color-1" fill="none"
-                stroke="currentColor" stroke-width="3" >
-                <circle t-foreach="circles" t-as="unit" opacity="0.2" r="45"
-                    t-att-cx="unit_index * width + 50" cy="50" />
-                <rect t-foreach="boxes" t-as="unit" rx="3.5" opacity="0.2"
-                    t-att-x="unit_index * width + 5" y="5" width="47" height="90" />
-            </g>
-            <g class="s_countdown_progress text-o-color-1" fill="none"
-                stroke="currentColor" stroke-width="3" >
-                <circle t-foreach="circles" t-as="unit"
-                    t-att-cx="unit_index * width + 50" cy="50" r="45"
+        <svg t-foreach="layout !== 'text' ? display.split('') : []" t-as="unit"
+            class="o_not_editable" t-attf-viewBox="0 0 #{width} 100" height="175">
+            <t t-if="layout === 'circle'">
+                <circle class="text-400" cx="50" cy="50" r="43.5" fill="currentColor" />
+                <circle class="text-o-color-1" cx="50" cy="50" r="45"
+                    fill="none" stroke="currentColor" stroke-width="3" opacity="0.2" />
+                <circle class="text-o-color-1" cx="50" cy="50" r="45"
+                    fill="none" stroke="currentColor" stroke-width="3"
                     t-att-pathLength="sizes[unit]" t-att-stroke-dashoffset="sizes[unit]/4" />
-                <rect t-foreach="boxes" t-as="unit" rx="3.5"
-                    t-att-x="unit_index * width + 5" y="5" width="47" height="90"
+            </t>
+            <t t-if="layout === 'boxes'">
+                <rect class="text-400" fill="currentColor"
+                    x="3.5" y="3.5" width="50" height="93" rx="5" />
+                <rect class="text-o-color-1" fill="none" opacity="0.2"
+                    x="5" y="5" width="47" height="90" rx="3.5"
+                    stroke="currentColor" stroke-width="3" />
+                <rect class="text-o-color-1" fill="none" x="5" y="5"
+                    width="47" height="90" rx="3.5" stroke="currentColor" stroke-width="3"
                     t-att-pathLength="sizes[unit]" />
-            </g>
-            <g class="s_countdown_text text-o-color-1" fill="currentColor">
-                <text t-foreach="display.split('')" t-as="unit"
-                    t-att-x="(unit_index + 0.5) * width" y="50" font-size="25"
+            </t>
+            <t t-if="layout !== 'text'">
+                <text class="text-o-color-1" fill="currentColor" x="50%" y="50" font-size="25"
                     font-family="Arial" text-anchor="middle" dominant-baseline="middle"/>
-                <text t-foreach="display.split('')" t-as="unit" t-out="names[unit]"
-                    t-att-x="(unit_index + 0.5) * width" y="67" font-size="8"
-                    font-family="Arial" text-anchor="middle" dominant-baseline="middle"/>
-            </g>
+                <text class="text-o-color-1" fill="currentColor" x="50%" y="67" font-size="8"
+                    font-family="Arial" text-anchor="middle" dominant-baseline="middle"
+                    t-out="names[unit]"/>
+            </t>
         </svg>
         <span t-if="layout === 'text'">
             Countdown ends in:

--- a/addons/website/static/src/snippets/s_countdown/000.xml
+++ b/addons/website/static/src/snippets/s_countdown/000.xml
@@ -24,16 +24,14 @@
         </div>
     </t>
     <t t-name="website.s_countdown.graphics">
-        <t t-set="width" t-value="layout === 'boxes' ? 57 : 100" />
-        <svg t-foreach="layout !== 'text' ? display.split('') : []" t-as="unit"
-            class="o_not_editable" t-attf-viewBox="0 0 #{width} 100" height="175">
+        <svg t-if="layout !== 'text'" class="o_not_editable"
+            t-attf-viewBox="0 0 #{layout === 'boxes' ? 57 : 100} 100" height="175">
             <t t-if="layout === 'circle'">
                 <circle class="text-400" cx="50" cy="50" r="43.5" fill="currentColor" />
                 <circle class="text-o-color-1" cx="50" cy="50" r="45"
                     fill="none" stroke="currentColor" stroke-width="3" opacity="0.2" />
-                <circle class="text-o-color-1" cx="50" cy="50" r="45"
-                    fill="none" stroke="currentColor" stroke-width="3"
-                    t-att-pathLength="sizes[unit]" t-att-stroke-dashoffset="sizes[unit]/4" />
+                <circle class="s_countdown_progress text-o-color-1" cx="50" cy="50" r="45"
+                    fill="none" stroke="currentColor" stroke-width="3"/>
             </t>
             <t t-if="layout === 'boxes'">
                 <rect class="text-400" fill="currentColor"
@@ -41,24 +39,22 @@
                 <rect class="text-o-color-1" fill="none" opacity="0.2"
                     x="5" y="5" width="47" height="90" rx="3.5"
                     stroke="currentColor" stroke-width="3" />
-                <rect class="text-o-color-1" fill="none" x="5" y="5"
-                    width="47" height="90" rx="3.5" stroke="currentColor" stroke-width="3"
-                    t-att-pathLength="sizes[unit]" />
+                <rect class="s_countdown_progress text-o-color-1" fill="none" x="5" y="5"
+                    width="47" height="90" rx="3.5" stroke="currentColor" stroke-width="3"/>
             </t>
             <t t-if="layout !== 'text'">
-                <text class="text-o-color-1" fill="currentColor" x="50%" y="50" font-size="25"
-                    font-family="Arial" text-anchor="middle" dominant-baseline="middle"/>
-                <text class="text-o-color-1" fill="currentColor" x="50%" y="67" font-size="8"
-                    font-family="Arial" text-anchor="middle" dominant-baseline="middle"
-                    t-out="names[unit]"/>
+                <text class="s_countdown_value text-o-color-1" fill="currentColor" x="50%" y="50"
+                    font-size="25" font-family="Arial" text-anchor="middle" dominant-baseline="middle"/>
+                <text class="s_countdown_label text-o-color-1" fill="currentColor" x="50%" y="67"
+                    font-size="8" font-family="Arial" text-anchor="middle" dominant-baseline="middle"/>
             </t>
         </svg>
-        <span t-if="layout === 'text'">
+        <t t-if="layout === 'text'">
             Countdown ends in:
-            <t t-foreach="display.split('')" t-as="unit">
-                <span class="o_not_editable"/>
-                <t t-out="names[unit].toString().toLowerCase() + (unit_last ? '' : ', ')" />
-            </t>
-        </span>
+            <span class="ml-1">
+                <span class="s_countdown_value o_not_editable"/>
+                <span class="s_countdown_label"/>
+            </span>
+        </t>
     </t>
 </templates>

--- a/addons/website/static/src/snippets/s_countdown/000.xml
+++ b/addons/website/static/src/snippets/s_countdown/000.xml
@@ -23,4 +23,49 @@
             </div>
         </div>
     </t>
+    <t t-name="website.s_countdown.graphics">
+        <t t-set="width" t-value="layout === 'boxes' ? 57 : 100" />
+        <t t-set="circles" t-value="layout === 'circle' ? display.split('') : []" />
+        <t t-set="boxes" t-value="layout === 'boxes' ? display.split('') : []" />
+        <svg t-if="layout !== 'text'" height="175" class="o_not_editable"
+            t-attf-viewBox="0 0 #{4 * width} 100">
+            <g class="s_countdown_background text-400" fill="currentColor" >
+                <circle t-foreach="circles" t-as="unit" r="43.5"
+                    t-att-cx="unit_index * width + 50" cy="50" />
+                <rect t-foreach="boxes" t-as="unit" width="57" height="100" rx="5"
+                    t-att-x="unit_index * width" y="0" />
+            </g>
+            <g class="s_countdown_surround text-o-color-1" fill="none"
+                stroke="currentColor" stroke-width="3" >
+                <circle t-foreach="circles" t-as="unit" opacity="0.2" r="45"
+                    t-att-cx="unit_index * width + 50" cy="50" />
+                <rect t-foreach="boxes" t-as="unit" rx="3.5" opacity="0.2"
+                    t-att-x="unit_index * width + 5" y="5" width="47" height="90" />
+            </g>
+            <g class="s_countdown_progress text-o-color-1" fill="none"
+                stroke="currentColor" stroke-width="3" >
+                <circle t-foreach="circles" t-as="unit"
+                    t-att-cx="unit_index * width + 50" cy="50" r="45"
+                    t-att-pathLength="sizes[unit]" t-att-stroke-dashoffset="sizes[unit]/4" />
+                <rect t-foreach="boxes" t-as="unit" rx="3.5"
+                    t-att-x="unit_index * width + 5" y="5" width="47" height="90"
+                    t-att-pathLength="sizes[unit]" />
+            </g>
+            <g class="s_countdown_text text-o-color-1" fill="currentColor">
+                <text t-foreach="display.split('')" t-as="unit"
+                    t-att-x="(unit_index + 0.5) * width" y="50" font-size="25"
+                    font-family="Arial" text-anchor="middle" dominant-baseline="middle"/>
+                <text t-foreach="display.split('')" t-as="unit" t-out="names[unit]"
+                    t-att-x="(unit_index + 0.5) * width" y="67" font-size="8"
+                    font-family="Arial" text-anchor="middle" dominant-baseline="middle"/>
+            </g>
+        </svg>
+        <span t-if="layout === 'text'">
+            Countdown ends in:
+            <t t-foreach="display.split('')" t-as="unit">
+                <span class="o_not_editable"/>
+                <t t-out="names[unit].toString().toLowerCase() + (unit_last ? '' : ', ')" />
+            </t>
+        </span>
+    </t>
 </templates>

--- a/addons/website/static/src/snippets/s_countdown/options.js
+++ b/addons/website/static/src/snippets/s_countdown/options.js
@@ -13,6 +13,12 @@ options.registry.countdown = options.Class.extend({
     }),
 
     /**
+     * @override
+     */
+    onBuilt() {
+        this._updateMinHeight();
+    },
+    /**
      * Remove any preview classes, if present.
      *
      * @override
@@ -75,6 +81,16 @@ options.registry.countdown = options.Class.extend({
                 break;
         }
         this.$target[0].dataset.layout = widgetValue;
+        this._updateMinHeight();
+    },
+    /**
+    * Changes the countdown size.
+    *
+    * @see this.selectClass for parameters
+    */
+    size: function (previewMode, widgetValue, params) {
+        this.$target[0].dataset.size = widgetValue;
+        this._updateMinHeight();
     },
 
     //--------------------------------------------------------------------------
@@ -116,6 +132,7 @@ options.registry.countdown = options.Class.extend({
         switch (methodName) {
             case 'endAction':
             case 'layout':
+            case 'size':
                 return this.$target[0].dataset[methodName];
 
             case 'selectDataAttribute': {
@@ -129,6 +146,13 @@ options.registry.countdown = options.Class.extend({
             }
         }
         return this._super(...arguments);
+    },
+    /**
+     * @private
+     */
+    _updateMinHeight: function () {
+        const height = this.$target[0].dataset.layout === 'text' ? '' : `${this.$target[0].dataset.size}px`;
+        this.$target.find('.s_countdown_canvas_wrapper').css('min-height', height);
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website/static/src/snippets/s_countdown/options.js
+++ b/addons/website/static/src/snippets/s_countdown/options.js
@@ -68,16 +68,13 @@ options.registry.countdown = options.Class.extend({
         this.$target[0].dataset.layout = widgetValue;
         this._render();
 
-        switch (widgetValue) {
-            case 'circle':
-                this.selectDataAttribute(false, 'surrounded', {attributeName: 'progressBarStyle'});
-                this.selectDataAttribute(false, 'thin', {attributeName: 'progressBarWeight'});
-                this.selectDataAttribute(false, 'none', {attributeName: 'layoutBackground'});
-                break;
-            case 'boxes':
-                this.selectDataAttribute(false, 'none', {attributeName: 'progressBarStyle'});
-                this.selectDataAttribute(false, 'plain', {attributeName: 'layoutBackground'});
-                break;
+        if (widgetValue === 'circle') {
+            this._update('progressBarStyle', 'surrounded');
+            this._update('progressBarWeight', 'thin');
+            this._update('layoutBackground', 'none');
+        } else if (widgetValue === 'boxes') {
+            this._update('progressBarStyle', 'none');
+            this._update('layoutBackground', 'plain');
         }
     },
     /**
@@ -164,9 +161,11 @@ options.registry.countdown = options.Class.extend({
      * @private
      * @param {string} attributeName - The attribute that was changed
      */
-    _update: function (attributeName) {
-        const value = this.$target[0].dataset[attributeName];
+    _update: function (attributeName, value = undefined) {
         let offset = 0;
+
+        value = value || this.$target[0].dataset[attributeName];
+        this.$target[0].dataset[attributeName] = value;
 
         if (attributeName === 'display') {
             this._render();
@@ -179,6 +178,9 @@ options.registry.countdown = options.Class.extend({
         } else if (attributeName === 'progressBarStyle') {
             this.$target.find('.s_countdown_surround').toggleClass('d-none', value !== 'surrounded');
             this.$target.find('.s_countdown_progress').toggleClass('d-none', value === 'none');
+            if (value === "none" && this.$target[0].dataset.layoutBackground === 'inner') {
+                this.selectDataAttribute(false, 'plain', {attributeName: 'layoutBackground'});
+            }
         } else if (attributeName === 'layoutBackground') {
             const stroke = this.$target[0].dataset.progressBarWeight === 'thin' ? 3 : 10;
             offset = (value === 'inner' ? -1 : 1) * stroke / 2;

--- a/addons/website/static/src/snippets/s_countdown/options.js
+++ b/addons/website/static/src/snippets/s_countdown/options.js
@@ -8,7 +8,6 @@ const {ColorpickerWidget} = require('web.Colorpicker');
 const weUtils = require('web_editor.utils');
 
 const qweb = core.qweb;
-const _t = core._t;
 
 options.registry.countdown = options.Class.extend({
     xmlDependencies: ['/website/static/src/snippets/s_countdown/000.xml'],
@@ -147,13 +146,19 @@ options.registry.countdown = options.Class.extend({
      */
     _render: function () {
         const $wrapper = this.$target.find('.s_countdown_canvas_wrapper');
-        const svg = qweb.render(`website.s_countdown.graphics`, Object.assign({
-            names: {'s': _t('Seconds'), 'm': _t('Minutes'), 'h': _('Hours'), 'd': _('Days')},
-            sizes: {'s': 60, 'm': 60, 'h': 60, 'd': 15},
-        }, this.$target[0].dataset));
 
-        $wrapper.empty();
-        $wrapper.append(svg);
+        if (this.currentLayout !== this.$target[0].dataset.layout) {
+            const svg = qweb.render(`website.s_countdown.graphics`, this.$target[0].dataset);
+            $wrapper.empty();
+            $wrapper.append(svg);
+            this.currentLayout = this.$target[0].dataset.layout;
+        }
+
+        const display = this.$target[0].dataset.display;
+        $wrapper.find(`> :nth-child(${display.length}) ~ *`).remove();
+        for (let i = $wrapper[0].childElementCount; i < display.length; i++) {
+            $wrapper.append($wrapper[0].firstElementChild.cloneNode(true));
+        }
     },
     /**
      * Updates the countdown to reflect changes to an attribute.
@@ -177,7 +182,7 @@ options.registry.countdown = options.Class.extend({
             });
         } else if (attributeName === 'progressBarStyle') {
             this.$target.find('svg [opacity]').toggleClass('d-none', value !== 'surrounded');
-            this.$target.find('svg [pathLength]').toggleClass('d-none', value === 'none');
+            this.$target.find('.s_countdown_progress').toggleClass('d-none', value === 'none');
             if (value === "none" && this.$target[0].dataset.layoutBackground === 'inner') {
                 this.selectDataAttribute('layoutBackground', 'plain');
             }

--- a/addons/website/static/src/snippets/s_countdown/options.js
+++ b/addons/website/static/src/snippets/s_countdown/options.js
@@ -172,27 +172,27 @@ options.registry.countdown = options.Class.extend({
         } else if (attributeName === 'progressBarWeight') {
             const stroke = value === 'thin' ? 3 : 10;
             offset = (this.$target[0].dataset.layoutBackground === 'inner' ? -1 : 1) * stroke / 2;
-            this.$target[0].querySelectorAll('g[stroke] > :not(text)').forEach(el => {
+            this.$target[0].querySelectorAll('[stroke]:not(text)').forEach(el => {
                 el.setAttribute('stroke-width', stroke);
             });
         } else if (attributeName === 'progressBarStyle') {
-            this.$target.find('.s_countdown_surround').toggleClass('d-none', value !== 'surrounded');
-            this.$target.find('.s_countdown_progress').toggleClass('d-none', value === 'none');
+            this.$target.find('svg [opacity]').toggleClass('d-none', value !== 'surrounded');
+            this.$target.find('svg [pathLength]').toggleClass('d-none', value === 'none');
             if (value === "none" && this.$target[0].dataset.layoutBackground === 'inner') {
-                this.selectDataAttribute(false, 'plain', {attributeName: 'layoutBackground'});
+                this.selectDataAttribute('layoutBackground', 'plain');
             }
         } else if (attributeName === 'layoutBackground') {
             const stroke = this.$target[0].dataset.progressBarWeight === 'thin' ? 3 : 10;
             offset = (value === 'inner' ? -1 : 1) * stroke / 2;
-            this.$target.find('.s_countdown_background').toggleClass('d-none', value === 'none');
+            this.$target.find('svg :not(text):not([stroke])').toggleClass('d-none', value === 'none');
         }
 
         if (offset) {
-            this.$target[0].querySelectorAll('.s_countdown_background circle').forEach(el => {
+            this.$target[0].querySelectorAll('svg circle:first-child').forEach(el => {
                 el.setAttribute('r', 45 + offset);
             });
-            this.$target[0].querySelectorAll('.s_countdown_background rect').forEach((el, index) => {
-                el.setAttribute('x', 57 * index + 5 - offset);
+            this.$target[0].querySelectorAll('svg rect:first-child').forEach(el => {
+                el.setAttribute('x', 5 - offset);
                 el.setAttribute('y', 5 - offset);
                 el.setAttribute('width', 47 + 2 * offset);
                 el.setAttribute('height', 90 + 2 * offset);

--- a/addons/website/static/tests/tours/snippet_countdown.js
+++ b/addons/website/static/tests/tours/snippet_countdown.js
@@ -8,6 +8,14 @@ tour.register('snippet_countdown', {
     url: '/?enable_editor=1',
 }, [
     wTourUtils.dragNDrop({id: 's_countdown', name: 'Countdown'}),
+    {
+        trigger: '.s_countdown .s_countdown_canvas_wrapper:has(canvas)',
+        run: function () {
+            if (this.$anchor.css('min-height') !== '175px') {
+                console.error("The min-height property on the canvas wrapper wasn't set");
+            }
+        },
+    },
     wTourUtils.clickOnSnippet({id: 's_countdown', name: 'Countdown'}),
     wTourUtils.changeOption('countdown', 'we-select:has([data-end-action]) we-toggler', 'end action'),
     wTourUtils.changeOption('countdown', 'we-button[data-end-action="message"]', 'end action'),

--- a/addons/website/views/snippets/s_countdown.xml
+++ b/addons/website/views/snippets/s_countdown.xml
@@ -41,7 +41,7 @@
                 <we-button data-select-data-attribute="hm">H - M</we-button>
                 <we-button data-select-data-attribute="hms">H - M - S</we-button>
             </we-select>
-            <we-colorpicker string="Text Color" data-apply-to="svg .s_countdown_text"
+            <we-colorpicker string="Text Color" data-apply-to="svg text"
                 data-select-style="" data-css-property="color" data-color-prefix="text-" />
             <we-select string="Layout">
                 <we-button data-layout="circle" data-name="circle_layout_opt">Circle</we-button>
@@ -54,7 +54,7 @@
                 <we-button data-select-data-attribute="plain">Plain</we-button>
                 <we-button data-select-data-attribute="none" data-name="no_background_layout_opt">None</we-button>
             </we-select>
-            <we-colorpicker string="Layout Background Color" data-apply-to="svg .s_countdown_background"
+            <we-colorpicker string="Layout Background Color" data-apply-to="svg :not([stroke]):not(text)"
                 data-select-style="" data-css-property="color" data-color-prefix="text-" data-dependencies="!no_background_layout_opt" />
             <we-select string="Progress Bar Style" data-attribute-name="progressBarStyle" data-dependencies="circle_layout_opt, boxes_layout_opt">
                 <we-button data-select-data-attribute="surrounded">Surrounded</we-button>
@@ -65,7 +65,7 @@
                 <we-button data-select-data-attribute="thin">Thin</we-button>
                 <we-button data-select-data-attribute="thick">Thick</we-button>
             </we-select>
-            <we-colorpicker string="Progress Bar Color" data-apply-to="svg .s_countdown_progress, svg .s_countdown_surround"
+            <we-colorpicker string="Progress Bar Color" data-apply-to="svg [stroke]"
                 data-select-style="" data-css-property="color" data-color-prefix="text-" data-dependencies="!no_progressbar_style_opt" />
         </div>
     </xpath>

--- a/addons/website/views/snippets/s_countdown.xml
+++ b/addons/website/views/snippets/s_countdown.xml
@@ -3,11 +3,10 @@
 
 <template id="s_countdown" name="Countdown">
     <section class="s_countdown pt48 pb48"
-        data-display="dhms" data-end-action="nothing" data-size="175"
+        data-display="dhms" data-end-action="nothing"
         t-att-data-end-time="datetime.datetime.now().timestamp() + 228307"
         data-layout="circle" data-layout-background="none"
-        data-progress-bar-style="surrounded" data-progress-bar-weight="thin"
-        data-text-color="o-color-1" data-layout-background-color="400" data-progress-bar-color="o-color-1">
+        data-progress-bar-style="surrounded" data-progress-bar-weight="thin">
         <div class="container">
             <div class="s_countdown_canvas_wrapper text-center"/>
         </div>
@@ -30,17 +29,20 @@
                 </we-button>
             </we-row>
             <we-urlpicker string="URL" data-dependencies="redirect_end_action_opt" data-select-data-attribute="" placeholder="e.g. /my-awesome-page" data-attribute-name="redirectUrl"/>
-            <we-select string="Size">
-                <we-button data-size="80">Small</we-button>
-                <we-button data-size="120">Medium</we-button>
-                <we-button data-size="175">Large</we-button>
+            <we-select string="Size" data-attribute-name="height" data-apply-to="svg">
+                <we-button data-select-attribute="80">Small</we-button>
+                <we-button data-select-attribute="120">Medium</we-button>
+                <we-button data-select-attribute="175">Large</we-button>
             </we-select>
             <we-select string="Display" data-attribute-name="display">
                 <we-button data-select-data-attribute="d">D</we-button>
                 <we-button data-select-data-attribute="dhm">D - H - M</we-button>
                 <we-button data-select-data-attribute="dhms">D - H - M - S</we-button>
+                <we-button data-select-data-attribute="hm">H - M</we-button>
+                <we-button data-select-data-attribute="hms">H - M - S</we-button>
             </we-select>
-            <we-colorpicker string="Text Color" data-attribute-name="textColor" data-select-data-attribute=""/>
+            <we-colorpicker string="Text Color" data-apply-to="svg .s_countdown_text"
+                data-select-style="" data-css-property="color" data-color-prefix="text-" />
             <we-select string="Layout">
                 <we-button data-layout="circle" data-name="circle_layout_opt">Circle</we-button>
                 <we-button data-layout="boxes" data-name="boxes_layout_opt">Boxes</we-button>
@@ -48,11 +50,12 @@
                 <we-button data-layout="text">Text Inline</we-button>
             </we-select>
             <we-select string="Layout Background" data-attribute-name="layoutBackground" data-dependencies="circle_layout_opt, boxes_layout_opt">
-                <we-button data-select-data-attribute="inner">Inner</we-button>
+                <we-button data-select-data-attribute="inner" data-dependencies="!no_progressbar_style_opt">Inner</we-button>
                 <we-button data-select-data-attribute="plain">Plain</we-button>
                 <we-button data-select-data-attribute="none" data-name="no_background_layout_opt">None</we-button>
             </we-select>
-            <we-colorpicker string="Layout Background Color" data-dependencies="!no_background_layout_opt" data-attribute-name="layoutBackgroundColor" data-select-data-attribute=""/>
+            <we-colorpicker string="Layout Background Color" data-apply-to="svg .s_countdown_background"
+                data-select-style="" data-css-property="color" data-color-prefix="text-" data-dependencies="!no_background_layout_opt" />
             <we-select string="Progress Bar Style" data-attribute-name="progressBarStyle" data-dependencies="circle_layout_opt, boxes_layout_opt">
                 <we-button data-select-data-attribute="surrounded">Surrounded</we-button>
                 <we-button data-select-data-attribute="disappear">Disappearing</we-button>
@@ -62,7 +65,8 @@
                 <we-button data-select-data-attribute="thin">Thin</we-button>
                 <we-button data-select-data-attribute="thick">Thick</we-button>
             </we-select>
-            <we-colorpicker string="Progress Bar Color" data-dependencies="!no_progressbar_style_opt" data-attribute-name="progressBarColor" data-select-data-attribute=""/>
+            <we-colorpicker string="Progress Bar Color" data-apply-to="svg .s_countdown_progress, svg .s_countdown_surround"
+                data-select-style="" data-css-property="color" data-color-prefix="text-" data-dependencies="!no_progressbar_style_opt" />
         </div>
     </xpath>
 </template>

--- a/addons/website/views/snippets/s_countdown.xml
+++ b/addons/website/views/snippets/s_countdown.xml
@@ -30,10 +30,10 @@
                 </we-button>
             </we-row>
             <we-urlpicker string="URL" data-dependencies="redirect_end_action_opt" data-select-data-attribute="" placeholder="e.g. /my-awesome-page" data-attribute-name="redirectUrl"/>
-            <we-select string="Size" data-attribute-name="size">
-                <we-button data-select-data-attribute="80">Small</we-button>
-                <we-button data-select-data-attribute="120">Medium</we-button>
-                <we-button data-select-data-attribute="175">Large</we-button>
+            <we-select string="Size">
+                <we-button data-size="80">Small</we-button>
+                <we-button data-size="120">Medium</we-button>
+                <we-button data-size="175">Large</we-button>
             </we-select>
             <we-select string="Display" data-attribute-name="display">
                 <we-button data-select-data-attribute="d">D</we-button>


### PR DESCRIPTION
When loading a page with a countdown snippet (with a layout other than
text), the page will jump after starting the countdown widget. This
happens because the canvases containing the countdowns are added
by the javascript widget controlling the snippet. The same thing
happens for text layouts because the wrapper is empty before the widget
starts.

For canvas based layouts, simply setting the same height on the
container containing the canvases solves the problem in most cases (the
exception being small page widths causing the canvases to wrap around).

For text layouts, the problem is mitigated by leaving a prefix in the
DOM after the widget is destroyed.

task-2717526