### PR TITLE
[FIX] mass_mailing,web_editor: no !important and target table


### DIFF
--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -866,7 +866,7 @@
         data-selector=".note-editable > div:not(.o_layout), .note-editable .oe_structure > div, td, th"
         data-exclude=".o_mail_no_resize, .o_mail_no_options"/>
 
-    <div data-selector=".note-editable > div:not(.o_layout), .note-editable .oe_structure > div, td, th"
+    <div data-selector=".note-editable > div:not(.o_layout)[style*=&quot;background-color&quot;], .note-editable .oe_structure > div[style*=&quot;background-color&quot;], table, td, th"
          data-exclude=".o_mail_no_colorpicker, .o_mail_no_options">
         <we-colorpicker string="Background Color"
             data-select-style="true"

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -273,6 +273,8 @@ function classToStyle($editable) {
         var $target = $(node);
         var css = getMatchedCSSRules(node);
         var style = $target.attr('style') || '';
+        // Outlook doesn't support inline !important
+        style = style.replace(/!important/g,'');
         _.each(css, function (v,k) {
             if (!(new RegExp('(^|;)\s*' + k).test(style))) {
                 style = k+':'+v+';'+style;


### PR DESCRIPTION
The tool to change background color in mass mailing will currently
target `<div/>` elements and set the property as !important.

On outlook software (or windows mail app) this seems to fail:

- background-color should be set on table / tr / td / th
- !important should not be used

In this fix we target table instead of div, and we remove the !important
declaration.

TODO: check if we should remove !important or only in mass mailing case.

opw-2641343
