### PR TITLE
focusing dropdown item makes item transparent

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown.scss
+++ b/addons/web/static/src/core/dropdown/dropdown.scss
@@ -3,6 +3,7 @@
 .dropdown-menu {
   .dropdown-toggle:focus, .dropdown-item:focus {
     background-color: transparent;
+    color: $dropdown-link-color;
   }
   .dropdown-toggle.focus, .dropdown-item.focus {
     background-color: $dropdown-link-hover-bg;


### PR DESCRIPTION
PURPOSE
Dropdown item should not disappear when focusing on dropdown item.

Example: Go to Website Events -> Open any Event -> Community tab -> open Languages dropdown and then click on any dropdown item, you will see item text disappear when we click on it.

SPEC
When focusing over dropdown item dropdown item color should remain black by default in standard dropdown component.

TASK 2711542



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
