### PR TITLE
[IMP] mrp: cancel workorder in backorder when qty_remaining is 0

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1517,12 +1517,18 @@ class MrpProduction(models.Model):
         # So those move lines are duplicated.
         backorders.move_raw_ids.move_line_ids.filtered(lambda ml: ml.product_id.tracking == 'serial' and ml.product_qty == 0).unlink()
 
+        wo_to_cancel = self.env['mrp.workorder']
         for old_wo, wo in zip(self.workorder_ids, backorders.workorder_ids):
+            if old_wo.qty_remaining == 0:
+                wo_to_cancel += wo
+                continue
             wo.qty_produced = max(old_wo.qty_produced - old_wo.qty_producing, 0)
             if wo.product_tracking == 'serial':
                 wo.qty_producing = 1
             else:
                 wo.qty_producing = wo.qty_remaining
+        wo_to_cancel.action_cancel()
+
         return backorders
 
     def _split_productions(self, amounts=False, cancel_remaning_qty=False, set_consumed_qty=False):

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -2188,6 +2188,7 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(wo_1.state, 'ready')
 
         wo_1.button_start()
+        wo_1.qty_producing = 10
         self.assertEqual(mo.state, 'progress')
         wo_1.button_finish()
 
@@ -2215,9 +2216,7 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(mo_2.state, 'progress')
         wo_4, wo_5, wo_6 = mo_2.workorder_ids
 
-        self.assertEqual(wo_4.state, 'ready')
-        wo_4.button_start()
-        wo_4.button_finish()
+        self.assertEqual(wo_4.state, 'cancel')
 
         wo_5.button_start()
         self.assertEqual(mo_2.state, 'progress')


### PR DESCRIPTION
When user record the production with full quantity in a workorder, and
then reduce the the qty_to_produce in the MO or another WO, then close
it and create backorder. In the backorder, the WO that is already fully
done in previous MO will have the qty_remaining to be 0. In this commit,
we cancel the WO in that case.

Task-2678388

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
