### PR TITLE
[IMP] mrp: make WO ready when all previous WOs cancelled

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1459,6 +1459,7 @@ class MrpProduction(models.Model):
                         new_moves_vals.append(move_vals[0])
                 new_moves = self.env['stock.move'].create(new_moves_vals)
             backorders |= backorder_mo
+            first_wo = self.env['mrp.workorder']
             for old_wo, wo in zip(production.workorder_ids, backorder_mo.workorder_ids):
                 wo.qty_produced = max(old_wo.qty_produced - old_wo.qty_producing, 0)
                 if wo.product_tracking == 'serial':
@@ -1467,6 +1468,9 @@ class MrpProduction(models.Model):
                     wo.qty_producing = wo.qty_remaining
                 if wo.qty_producing == 0:
                     wo.action_cancel()
+                if not first_wo and wo.state != 'cancel':
+                    first_wo = wo
+            first_wo.state = 'ready'
 
             # We need to adapt `duration_expected` on both the original workorders and their
             # backordered workorders. To do that, we use the original `duration_expected` and the


### PR DESCRIPTION
In case of backorder, it can happen that the first WO is already done in
the original MO, so it get cancelled in the backorder MO. In that case,
the second WO is actually the first WO available. In this case, we will
make the second WO's state "Ready". Similarly, if all previous WOs
cancelled, the first one available should be "Ready".

Task-2678388

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
