### PR TITLE
[FIX] lunch: show only company locations

### DIFF
--- a/addons/lunch/controllers/main.py
+++ b/addons/lunch/controllers/main.py
@@ -75,11 +75,12 @@ class LunchController(http.Controller):
         self._check_user_impersonification(user_id)
         user = request.env['res.users'].browse(user_id) if user_id else request.env.user
 
+        company_ids = request.env.context.get('allowed_company_ids', request.env.company.ids)
         user_location = user.last_lunch_location_id
-        has_multi_company_access = not user_location.company_id or user_location.company_id.id in request._context.get('allowed_company_ids', request.env.company.ids)
+        has_multi_company_access = not user_location.company_id or user_location.company_id.id in company_ids
 
         if not user_location or not has_multi_company_access:
-            return request.env['lunch.location'].search([], limit=1).id
+            return request.env['lunch.location'].search([('company_id', 'in', [False] + company_ids)], limit=1).id
         return user_location.id
 
     def _make_infos(self, user, **kwargs):

--- a/addons/lunch/static/src/js/lunch_widget.js
+++ b/addons/lunch/static/src/js/lunch_widget.js
@@ -43,7 +43,10 @@ var LunchWidget = Widget.extend({
         this.locations = params.locations || [];
         this.userLocation = params.user_location[1] || '';
 
-        this.lunchLocationField = this._createMany2One('locations', 'lunch.location', this.userLocation);
+        const company_ids = [false].concat(session.user_context.allowed_company_ids || []);
+        this.lunchLocationField = this._createMany2One('locations', 'lunch.location', this.userLocation, () => [
+            ['company_id', 'in', company_ids]
+        ]);
 
         this.wallet = params.wallet || 0;
         this.raw_state = params.raw_state || 'new';
@@ -72,7 +75,10 @@ var LunchWidget = Widget.extend({
         } else {
             this.$('.o_lunch_user_field').text(this.username);
         }
-        this.lunchLocationField.appendTo(this.$('.o_lunch_location_field'));
+
+        if (this.userLocation) {
+            this.lunchLocationField.appendTo(this.$('.o_lunch_location_field'));
+        }
     },
 
     //--------------------------------------------------------------------------

--- a/addons/lunch/static/tests/lunch_kanban_tests.js
+++ b/addons/lunch/static/tests/lunch_kanban_tests.js
@@ -40,10 +40,11 @@ QUnit.module('LunchKanbanView', {
             'lunch.location': {
                 fields: {
                     name: {string: 'Name', type: 'char'},
+                    company_id: {string: 'Company', type: 'many2one', relation: 'res.company'},
                 },
                 records: [
-                    {id: 1, name: "Office 1"},
-                    {id: 2, name: "Office 2"},
+                    {id: 1, name: "Office 1", company_id: false},
+                    {id: 2, name: "Office 2", company_id: false},
                 ],
             },
             'res.users': {
@@ -57,6 +58,13 @@ QUnit.module('LunchKanbanView', {
                     {id: 3, name: "Jean-Luc Portal", groups_id: [PORTAL_GROUP_ID]},
                 ],
             },
+            'res.company': {
+                fields: {
+                    name: {string: 'Name', type: 'char'},
+                }, records: [
+                    {id: 1, name: "Dunder Trade Company"},
+                ]
+            }
         };
         this.regularInfos = {
             username: "Marc Demo",

--- a/addons/lunch/static/tests/lunch_list_tests.js
+++ b/addons/lunch/static/tests/lunch_list_tests.js
@@ -40,10 +40,11 @@ QUnit.module('LunchListView', {
             'lunch.location': {
                 fields: {
                     name: {string: 'Name', type: 'char'},
+                    company_id: {string: 'Company', type: 'many2one', relation: 'res.company'},
                 },
                 records: [
-                    {id: 1, name: "Office 1"},
-                    {id: 2, name: "Office 2"},
+                    {id: 1, name: "Office 1", company_id: false},
+                    {id: 2, name: "Office 2", company_id: false},
                 ],
             },
             'res.users': {
@@ -57,6 +58,13 @@ QUnit.module('LunchListView', {
                     {id: 3, name: "Jean-Luc Portal", groups_id: [PORTAL_GROUP_ID]},
                 ],
             },
+            'res.company': {
+                fields: {
+                    name: {string: 'Name', type: 'char'},
+                }, records: [
+                    {id: 1, name: "Dunder Trade Company"},
+                ]
+            }
         };
         this.regularInfos = {
             username: "Marc Demo",


### PR DESCRIPTION
All lunch locations were showing regardless of the company the user is
logged in.

Now only the lunch locations of the current company are showing.

TaskID: 2710417

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
