### PR TITLE
[FIX] payment: enable Wire Transfer as payment method

### DIFF
--- a/addons/payment/wizards/payment_acquirer_onboarding_wizard.py
+++ b/addons/payment/wizards/payment_acquirer_onboarding_wizard.py
@@ -142,8 +142,6 @@ class PaymentWizard(models.TransientModel):
                 if journal:
                     journal.name = self.journal_name
                     journal.bank_acc_number = self.acc_number
-                else:
-                    raise UserError(_("You have to set a journal for your payment acquirer %s.", self.manual_name))
 
             # delete wizard data immediately to get rid of residual credentials
             self.sudo().unlink()


### PR DESCRIPTION
Error raised when trying to add the Wire Transfer payment method in eCommerce

Steps to reproduce:
1. Install the eCommerce app
2. Open the Website app
3. Click on "Set payments" on the eCommerce Dashboard
4. Select "Custom payment instructions", fill in the fields and save

Solution:
Remove the piece of code that raised the error

OPW-2687671