### PR TITLE
[FIX] core: load static files from mod w/o assets

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1320,8 +1320,7 @@ class Root(object):
                 manifest = get_manifest(module)
                 static_path = opj(addons_path, module, 'static')
                 if (manifest
-                        and manifest['installable']
-                        and manifest['assets']
+                        and (manifest['installable'] or manifest['assets'])
                         and os.path.isdir(static_path)):
                     statics[f'/{module}/static'] = static_path
 


### PR DESCRIPTION
Access /base/static/img/country_flags/fr.png, 404 file not found but it
exists.

The conditional was wrong. We should load static files when the addon is
instalkable OR that it contains assets.

Code before 2e29a93:

    expr = not manifest or (
        not manifest.get('installable', True)
        and 'asset' not in manifest
    )
    if expr:
        continue
    ...

Code after 2e29a93:

    expr = manifest and (manifest['installable'] or manifest['assets']
    if not expr:
        ...

Proof:

    a is manifest
    b is manifest.get('installable', True)
    c is 'asset' in manifest

    expr = not a or (not b and not c)
    not expr = not (not a or (not b and not c)
             = a and not(not b and not c)
             = a and (b or c)

Fine-tuning of 2e29a93