### PR TITLE
[FIX] l10n_gcc_invoice : Address cropped

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -516,7 +516,7 @@
         <div t-attf-class="article o_report_layout_standard o_company_#{company.id}_layout"
              t-att-data-oe-model="o and o._name" t-att-data-oe-id="o and o.id"
              t-att-data-oe-lang="o and o.env.context.get('lang')">
-            <div class="pt-5">
+            <div style="padding-top:80px">
                 <t t-set="address">
                     <address t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}' class="mb-0"/>
                     <p t-if="o.partner_id.vat">


### PR DESCRIPTION
Current behavior:
The address is cropped in the invoice report

Steps to reproduce:
1/ Install "Saudi Arabia - Accounting " (l10n_sa) and "K.S.A - Invoice" (l10n_sa_invoice)
2/ A company called "SA company" should appear, click on it
3/ In the company informations, fill all the lines in the address (street 1, street 2, etc) and the VAT if not set
4/ Create an invoice and print the invoice as pdf => you will have an invoice with a QR and the name of the

opw-2703128

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
