### PR TITLE
[FIX] mass_mailing: allow changing color of columns

### DIFF
--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -944,9 +944,9 @@
 
     <div data-selector=".o_layout, .note-editable > div:not(.o_layout),
         .note-editable .oe_structure > div:not(:has(> .o_mail_snippet_general)),
-        .note-editable .oe_structure > div > .o_mail_snippet_general,
-        .note-editable .oe_structure > div > .o_mail_snippet_general .o_cc,
-        .note-editable .oe_structure > div > .o_mail_snippet_general .btn:not(.btn-link),
+        .note-editable .oe_structure > div.o_mail_snippet_general,
+        .note-editable .oe_structure > div.o_mail_snippet_general .o_cc,
+        .note-editable .oe_structure > div.o_mail_snippet_general .btn:not(.btn-link),
         td, td.o_mail_no_colorpicker div:first-child, th"
         data-exclude=".o_mail_no_colorpicker, .o_mail_no_options">
         <we-colorpicker string="Background Color"


### PR DESCRIPTION
Prior to this commit, it was impossible to change the background color of many columns (eg.: Big boxes). This was because the selector for the option had likely not been adapted along with the snippet structure.

task-2711618

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
