### PR TITLE
[FIX] web: ActionService: send user context to /web/action/run

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1063,7 +1063,7 @@ function makeActionManager(env) {
     async function _executeServerAction(action, options) {
         const runProm = env.services.rpc("/web/action/run", {
             action_id: action.id,
-            context: action.context || {},
+            context: makeContext([env.services.user.context, action.context]),
         });
         let nextAction = await keepLast.add(runProm);
         nextAction = nextAction || { type: "ir.actions.act_window_close" };

--- a/addons/web/static/tests/webclient/actions/server_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/server_action_tests.js
@@ -66,4 +66,25 @@ QUnit.module("ActionManager", (hooks) => {
             "close handler",
         ]);
     });
+
+    QUnit.test("send correct context when executing a server action", async function (assert) {
+        assert.expect(1);
+
+        serverData.actions[2].context = { someKey: 44 };
+        const mockRPC = async (route, args) => {
+            if (route === "/web/action/run") {
+                assert.deepEqual(args.context, {
+                    // user context
+                    lang: "en",
+                    tz: "taht",
+                    uid: 7,
+                    // action context
+                    someKey: 44,
+                });
+                return Promise.resolve(1); // execute action 1
+            }
+        };
+        const webClient = await createWebClient({ serverData, mockRPC });
+        await doAction(webClient, 2);
+    });
 });


### PR DESCRIPTION
Since commit [1], the user context wasn't put in the context
sent when executing a server action (only the context of the
action sent). This commit fixes the issue.

[1] https://github.com/odoo/odoo/commit/7354d1686915ec21437fc677f15a6c5409106492