### PR TITLE
[FIX] mass_mailing: properly select text color based on background

### DIFF
--- a/addons/mass_mailing/data/mass_mailing_demo.xml
+++ b/addons/mass_mailing/data/mass_mailing_demo.xml
@@ -89,7 +89,7 @@
 <div class="o_layout o_default_theme oe_unremovable oe_unmovable" data-name="Mailing">
     <div class="container o_mail_wrapper oe_unremovable oe_unmovable" style="border-collapse:collapse;">
         <div class="row">
-            <div class="col o_mail_no_options o_mail_wrapper_td oe_structure" style="text-align:left;width:100%;">
+            <div class="col o_mail_no_options o_mail_wrapper_td bg-white oe_structure" style="text-align:left;width:100%;">
                 <div class="o_mail_block_header_logo" data-snippet="s_mail_block_header_logo">
                     <div class="o_mail_snippet_general" style="margin:0px auto 0px auto;background-color:rgb(255, 255, 255);max-width:600px;width:100%;">
                         <div class="container o_mail_table_styles o_mail_h_padding" style="padding:0 20px 0 20px;width:100%;border-collapse:separate;">

--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -275,7 +275,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
                 class: 'container o_mail_wrapper o_mail_regular oe_unremovable',
             });
             $newWrapperContent = $('<div/>', {
-                class: 'col o_mail_no_options o_mail_wrapper_td oe_structure o_editable'
+                class: 'col o_mail_no_options o_mail_wrapper_td bg-white oe_structure o_editable'
             });
             $new_wrapper.append($('<div class="row"/>').append($newWrapperContent));
         }

--- a/addons/mass_mailing/static/src/scss/themes/theme_default.scss
+++ b/addons/mass_mailing/static/src/scss/themes/theme_default.scss
@@ -72,7 +72,6 @@ div.col:not([align]) {
         }
 
         .o_mail_wrapper_td {
-            background-color: $o-mm-def-color-2;
             flex: none;
             padding-left: 0 !important;
             padding-right: 0 !important;


### PR DESCRIPTION
When changing a mailing's background color to black, the text of many snippets would change to white, even though the mailing's body was white. This was because said body was applied in css while the mailing's body was applied with a class that also set the text's color.
This fixes that issue by applying the white background on the body via such a class rather that via css.

task-2711643

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
