### PR TITLE
[FIX] mass_mailing, website: prevent merge lines in s_numbers snippet

### DIFF
--- a/addons/mass_mailing/views/snippets/s_numbers.xml
+++ b/addons/mass_mailing/views/snippets/s_numbers.xml
@@ -5,15 +5,15 @@
             <div class="container">
                 <div class="row">
                     <div class="text-center pt24 pb24 col-lg-4" valign="top">
-                        <span class="s_number display-4 o_default_snippet_text">12</span>
+                        <span class="s_number display-4 o_default_snippet_text">12</span><br/>
                         <h6 class="o_default_snippet_text">Useful options</h6>
                     </div>
                     <div class="text-center pt24 pb24 col-lg-4" valign="top">
-                        <span class="s_number display-4 o_default_snippet_text">45</span>
+                        <span class="s_number display-4 o_default_snippet_text">45</span><br/>
                         <h6 class="">Beautiful snippets</h6>
                     </div>
                     <div class="text-center pt24 pb24 col-lg-4" valign="top">
-                        <span class="s_number display-4 o_default_snippet_text">8</span>
+                        <span class="s_number display-4 o_default_snippet_text">8</span><br/>
                         <h6 class="o_default_snippet_text">Amazing pages</h6>
                     </div>
                 </div>

--- a/addons/website/views/snippets/s_numbers.xml
+++ b/addons/website/views/snippets/s_numbers.xml
@@ -6,19 +6,19 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-3 text-center pt24 pb24">
-                    <span class="s_number display-4">12</span>
+                    <span class="s_number display-4">12</span><br/>
                     <h6>Useful options</h6>
                 </div>
                 <div class="col-lg-3 text-center pt24 pb24">
-                    <span class="s_number display-4">45</span>
+                    <span class="s_number display-4">45</span><br/>
                     <h6>Beautiful snippets</h6>
                 </div>
                 <div class="col-lg-3 text-center pt24 pb24">
-                    <span class="s_number display-4">8</span>
+                    <span class="s_number display-4">8</span><br/>
                     <h6>Amazing pages</h6>
                 </div>
                 <div class="col-lg-3 text-center pt24 pb24">
-                    <span class="s_number display-4">37</span>
+                    <span class="s_number display-4">37</span><br/>
                     <h6>Outstanding images</h6>
                 </div>
             </div>


### PR DESCRIPTION
When double clicking a number in the numbers snippet, then typing a new number, the number line would be merge with the text underneath. This prevents that by adding a line break in between so they aren't considered the same line by the editor (an inline with a block as sibling is a tricky case for edition).

task-2711644

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
