### PR TITLE
[FIX] mass_mailing: flag blockquote and highlight as inner snippets

### DIFF
--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -927,7 +927,7 @@
         t-att-data-selector="so_snippet_addition_selector"
         data-drop-in=":not(p).oe_structure:not(.oe_structure_solo), :not(.o_mega_menu):not(p)[data-oe-type=html], :not(p).oe_structure.oe_structure_solo:not(:has(> section, > div))"/>
 
-    <t t-set="so_content_addition_selector" t-translation="off">.s_blockquote, .s_mail_alert, .s_rating, .s_hr, .s_text_highlight</t>
+    <t t-set="so_content_addition_selector" t-translation="off">.s_mail_blockquote, .s_mail_alert, .s_rating, .s_hr, .s_mail_text_highlight</t>
     <div id="so_content_addition"
         t-att-data-selector="so_content_addition_selector"
         t-attf-data-drop-near="p, h1, h2, h3, ul, ol, .row > div > img, #{so_content_addition_selector}"


### PR DESCRIPTION
The wrong classes were declared for the s_blockquote and s_text_highlight snippets in the selector of so_content_addition. As a result, these snippets could not be inserted inside other snippets.

task-2711645

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
