### PR TITLE
[FIX] hr_timesheet: archive/unarchive ir.rule for project sharing

### DIFF
--- a/addons/hr_timesheet/models/project_collaborator.py
+++ b/addons/hr_timesheet/models/project_collaborator.py
@@ -18,4 +18,4 @@ class ProjectCollaborator(models.Model):
         # ir.rule
         timesheet_portal_ir_rule = self.env.ref('hr_timesheet.timesheet_line_rule_portal_user').sudo()
         if timesheet_portal_ir_rule.active != active:
-            access_timesheet_portal.write({'active': active})
+            timesheet_portal_ir_rule.write({'active': active})


### PR DESCRIPTION
Before this commit, the ir.rule called `timesheet_line_rule_portal_user`
is added just for the project sharing and have to be unarchived when at
least an external collaborator is added into a project. But this rule is
never unarchived.

This commit archives/unarchives the ir rule when the condition is
satisfied.

part of task-2648955

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
