### PR TITLE
[FIX] ORM: round onchange values before computations

### DIFF
--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -942,7 +942,20 @@ class DecimalPrecisionTestModel(models.Model):
     float = fields.Float()
     float_2 = fields.Float(digits=(16, 2))
     float_4 = fields.Float(digits=(16, 4))
+    float_string = fields.Float(digits='New API Precision')
 
+    computed_float = fields.Float(compute="_compute_float")
+    computed_float_2 = fields.Float(digits=(16, 2), compute="_compute_float")
+    computed_float_4 = fields.Float(digits=(16, 4), compute="_compute_float")
+    computed_float_string = fields.Float(digits='New API Precision', compute="_compute_float")
+
+    @api.depends("float", "float_2", "float_4", "float_string")
+    def _compute_float(self):
+        for rec in self:
+            rec.computed_float = self.float * 1.33333
+            rec.computed_float_2 = self.float_2 * 1.33333
+            rec.computed_float_4 = self.float_4 * 1.33333
+            rec.computed_float_string = self.float_string * 1.33333
 
 class ModelA(models.Model):
     _name = 'test_new_api.model_a'

--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -900,3 +900,26 @@ class TestComputeOnchange(common.TransactionCase):
             {'name': 'foo', 'count': 1},
             {'name': 'bar', 'count': 1},
         ])
+
+    def test_onchange_decimal_precision(self):
+        """Performing onchange on float fields wich is used in other
+        computed field should be rounded before computation. Otherwise
+        there is inconsistency state before and after saving data
+        as after saving data the float value is rounded result
+        wouldn't be the same.
+        """
+        with Form(self.env["decimal.precision.test"]) as form:
+            form.float = 1.123456789
+            form.float_2 = 1.123456789
+            form.float_4 = 1.123456789
+            form.float_string = 1.123456789
+            unsaved_computed_float = form.computed_float
+            unsaved_computed_float_2 = form.computed_float_2
+            unsaved_computed_float_4 = form.computed_float_4
+            unsaved_computed_float_string = form.computed_float_string
+            rec = form.save()
+
+        self.assertEqual(unsaved_computed_float, rec.computed_float)
+        self.assertEqual(unsaved_computed_float_2, rec.computed_float_2)
+        self.assertEqual(unsaved_computed_float_4, rec.computed_float_4)
+        self.assertEqual(unsaved_computed_float_string, rec.computed_float_string)

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -61,6 +61,7 @@ from .tools.func import frame_codeinfo
 from .tools.misc import CountingStream, clean_context, DEFAULT_SERVER_DATETIME_FORMAT, DEFAULT_SERVER_DATE_FORMAT, get_lang
 from .tools.translate import _
 from .tools import date_utils
+from .tools import float_round
 from .tools import populate
 from .tools import unique
 from .tools.lru import LRU
@@ -6019,6 +6020,14 @@ Fields:
                 ))
 
         if onchange in ("1", "true"):
+            # before calling on change ensure float are properly rounded
+            # as expected in configuration
+            field = self._fields[field_name]
+            if field.type == 'float' and field._digits:
+                self[field_name] = float_round(
+                    self[field_name],
+                    precision_digits=field.get_digits(self.env)[1]
+                )
             for method in self._onchange_methods.get(field_name, ()):
                 method_res = method(self)
                 process(method_res)


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:

On change price unit do not round the unit price before compute new price, while after saving the unit price is rounded this make inconsistency price in the mean time when users try to set unit price with greater significant digits than configured.

That frustrate end user that do not understand why the price is not the same before and after saving. This is specially true while using formula in price unit cell trying to get round price.

This happen in domains where price are used to given in a small unit of measure with 4 or 5 significant digits with huge quantities.

# Current behaviour before PR:

Reproduced on versions 14.0 and 15.0 (not on v13.0)

- on a sale order line set new unit price with more significant digits than allowed for price (in the video 382.23 -> 382.2333) *this happens often while we are using formula in the cell to compute unit price.*
- have a look to the line price (7644.67)
- save the order and have a look to the line price changed (7644.60) 

https://user-images.githubusercontent.com/4328507/146388091-2b27af57-e77d-475c-8422-dd7e018276c6.mp4

# Desired behaviour after PR is merged:

On a sale order line setting a new unit price with more significant digits than allowed should:
 - round the unit price
 - recompute the line amount with the rounded unit price
 - ensure that sale order price display before and after saving that change should remain the same


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
