### PR TITLE
SQL checker update: support f-strings and make a little stricter

### DIFF
--- a/addons/sale/report/report_all_channels_sales.py
+++ b/addons/sale/report/report_all_channels_sales.py
@@ -59,7 +59,7 @@ class PosSaleReport(models.Model):
     def _from(self):
         return """(%s)""" % (self._so())
 
-    def get_main_request(self):
+    def _get_main_request(self):
         request = """
             CREATE or REPLACE VIEW %s AS
                 SELECT id AS id,
@@ -84,4 +84,4 @@ class PosSaleReport(models.Model):
 
     def init(self):
         tools.drop_view_if_exists(self.env.cr, self._table)
-        self.env.cr.execute(self.get_main_request())
+        self.env.cr.execute(self._get_main_request())

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1410,9 +1410,12 @@ class Website(models.Model):
             snippet_occurences.append(match.group())
 
         # As well as every snippet dropped in html fields
-        snippet_regex = f'<([^>]*data-snippet="{snippet_id}"[^>]*)>'
-        snippet_dropped = 'UNION '.join(f'SELECT REGEXP_MATCHES({column}, \'{snippet_regex}\') FROM {table} ' for table, column in html_fields)
-        self.env.cr.execute(snippet_dropped)
+        self.env.cr.execute(sql.SQL(" UNION ").join(
+            sql.SQL('SELECT regexp_matches({}, %(snippet_regex)s) FROM {}').format(
+                sql.Identifier(column),
+                sql.Identifier(table)
+            ) for table, column in html_fields
+        ), {'snippet_regex': f'<([^>]*data-snippet="{snippet_id}"[^>]*)>'})
         results = self.env.cr.fetchall()
         for r in results:
             snippet_occurences.append(r[0][0])

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -985,7 +985,6 @@ actual arch.
         return arch
 
     def _apply_groups(self, node, name_manager, node_info):
-        #pylint: disable=unused-argument
         """ Apply group restrictions: elements with a 'groups' attribute should
         be made invisible to people who are not members.
         """

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -20,6 +20,7 @@ import pytz
 from lxml import etree
 from lxml.builder import E
 from passlib.context import CryptContext
+from psycopg2 import sql
 
 from odoo import api, fields, models, tools, SUPERUSER_ID, _, Command
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
@@ -1677,8 +1678,8 @@ class APIKeys(models.Model):
     create_date = fields.Datetime("Creation Date", readonly=True)
 
     def init(self):
-        # pylint: disable=sql-injection
-        self.env.cr.execute("""
+        table = sql.Identifier(self._table)
+        self.env.cr.execute(sql.SQL("""
         CREATE TABLE IF NOT EXISTS {table} (
             id serial primary key,
             name varchar not null,
@@ -1688,17 +1689,17 @@ class APIKeys(models.Model):
             key varchar not null,
             create_date timestamp without time zone DEFAULT (now() at time zone 'utc')
         )
-        """.format(table=self._table, index_size=INDEX_SIZE))
+        """).format(table=table, index_size=sql.Literal(INDEX_SIZE)))
 
         index_name = self._table + "_user_id_index_idx"
         if len(index_name) > 63:
             # unique determinist index name
             index_name = self._table[:50] + "_idx_" + sha256(self._table.encode()).hexdigest()[:8]
-        self.env.cr.execute("""
+        self.env.cr.execute(sql.SQL("""
         CREATE INDEX IF NOT EXISTS {index_name} ON {table} (user_id, index);
-        """.format(
-            table=self._table,
-            index_name=index_name
+        """).format(
+            table=table,
+            index_name=sql.Identifier(index_name)
         ))
 
     @check_identity

--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -481,7 +481,7 @@ class MergePartnerAutomatic(models.TransientModel):
         model_mapping = self._compute_models()
 
         # group partner query
-        self._cr.execute(query)
+        self._cr.execute(query) # pylint: disable=sql-injection
 
         counter = 0
         for min_id, aggr_ids in self._cr.fetchall():

--- a/odoo/addons/test_lint/tests/__init__.py
+++ b/odoo/addons/test_lint/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_markers
 from . import test_onchange_domains
 from . import test_pofile
 from . import test_pylint
+from . import test_checkers

--- a/odoo/addons/test_lint/tests/test_checkers.py
+++ b/odoo/addons/test_lint/tests/test_checkers.py
@@ -1,0 +1,91 @@
+import json
+import os
+import tempfile
+import unittest
+from subprocess import run, PIPE
+from textwrap import dedent
+
+from odoo import tools
+from odoo.tests.common import TransactionCase
+
+try:
+    import pylint
+except ImportError:
+    pylint = None
+try:
+    pylint_bin = tools.which('pylint')
+except IOError:
+    pylint_bin = None
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+@unittest.skipUnless(pylint and pylint_bin, "testing lints requires pylint")
+class TestSqlLint(TransactionCase):
+    def check(self, testtext):
+        with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8', delete=False) as f:
+            self.addCleanup(os.remove, f.name)
+            f.write(dedent(testtext).strip())
+
+        result = run(
+            [pylint_bin,
+             f'--rcfile={os.devnull}',
+             '--load-plugins=_odoo_checker_sql_injection',
+             '--disable=all',
+             '--enable=sql-injection',
+             '--output-format=json',
+             f.name,
+            ],
+            check=False,
+            stdout=PIPE, encoding='utf-8',
+            env={
+                **os.environ,
+                'PYTHONPATH': HERE+os.pathsep+os.environ.get('PYTHONPATH', ''),
+            }
+        )
+        return result.returncode, json.loads(result.stdout)
+
+    def test_printf(self):
+        r, [err] = self.check("""
+        def do_the_thing(cr, name):
+            cr.execute('select %s from thing' % name)
+        """)
+        self.assertTrue(r, "should have noticed the injection")
+        self.assertEqual(err['line'], 2, err)
+
+        r, errs = self.check("""
+        def do_the_thing(self):
+            self.env.cr.execute("select thing from %s" % self._table)
+        """)
+        self.assertFalse(r, f"underscore-attributes are allowed\n{errs}")
+
+        r, errs = self.check("""
+        def do_the_thing(self):
+            query = "select thing from %s"
+            self.env.cr.execute(query % self._table)
+        """)
+        self.assertFalse(r, f"underscore-attributes are allowed\n{errs}")
+
+    def test_fstring(self):
+        r, [err] = self.check("""
+        def do_the_thing(cr, name):
+            cr.execute(f'select {name} from thing')
+        """)
+        self.assertTrue(r, "should have noticed the injection")
+        self.assertEqual(err['line'], 2, err)
+
+        r, errs = self.check("""
+        def do_the_thing(cr, name):
+            cr.execute(f'select name from thing')
+        """)
+        self.assertFalse(r, f"unnecessary fstring should be innocuous\n{errs}")
+
+        r, errs = self.check("""
+        def do_the_thing(cr, name, value):
+            cr.execute(f'select {name} from thing where field = %s', [value])
+        """)
+        self.assertFalse(r, f"probably has a good reason for the extra arg\n{errs}")
+
+        r, errs = self.check("""
+        def do_the_thing(self):
+            self.env.cr.execute(f'select name from {self._table}')
+        """)
+        self.assertFalse(r, f'underscore-attributes are allowable\n{errs}')

--- a/odoo/modules/db.py
+++ b/odoo/modules/db.py
@@ -29,7 +29,7 @@ def initialize(cr):
         raise IOError(m)
 
     with odoo.tools.misc.file_open(f) as base_sql_file:
-        cr.execute(base_sql_file.read())
+        cr.execute(base_sql_file.read())  # pylint: disable=sql-injection
 
     for i in odoo.modules.get_modules():
         mod_path = odoo.modules.get_module_path(i)

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -759,7 +759,7 @@ def convert_file(cr, module, filename, idref, mode='update', noupdate=False, kin
             raise ValueError("Can't load unknown file type %s.", filename)
 
 def convert_sql_import(cr, fp):
-    cr.execute(fp.read())
+    cr.execute(fp.read()) # pylint: disable=sql-injection
 
 def convert_csv_import(cr, module, fname, csvcontent, idref=None, mode='init',
         noupdate=False):


### PR DESCRIPTION
`f-strings` were not handled and would go through unflagged even when used incorrectly (though no such use was present). 

Also makes the checker stricter going forwards: before this update the checker would "fail open", unknown nodes would be considered valid (hence f-strings being allowed). This was changed to fail closed, unknown nodes should now be considered invalid. This surfaces a few cases which previously weren't visible, but all are innocuous.

Also expand the resolution of variables: it would only work for the `arg0` of `cr.execute`, it now also works for the LHS (format string) of `%`, which allows e.g.
```python
query = """a
very
long
query
"""
cr.execute(query % self._table)
```
which occurs in a pair of locations.