### PR TITLE
fix: in mrp_production._check_sn_uniqueness, add domain filter on pro…

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1799,6 +1799,7 @@ class MrpProduction(models.Model):
 
                 # Check presence of same sn in previous productions
                 duplicates = self.env['stock.move.line'].search_count(domain + [
+                    ('production_id', '!=', False),
                     ('location_id.usage', '=', 'production')
                 ])
                 if duplicates:
@@ -1841,6 +1842,7 @@ class MrpProduction(models.Model):
 
                 # Check presence of same sn in previous productions
                 duplicates = self.env['stock.move.line'].search_count(domain + [
+                    ('production_id', '!=', False),
                     ('location_dest_id.usage', '=', 'production')
                 ])
                 if duplicates:

--- a/doc/cla/individual/toelen.md
+++ b/doc/cla/individual/toelen.md
@@ -1,0 +1,11 @@
+Belgium, 2021-12-16
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Leen Toelen toelen@gmail.com https://github.com/toelen


### PR DESCRIPTION
When re-using a serial that has previously been used in an mrp_production, the check_sn_uniqueness has false positives on stock move lines that are created on production locations but not from an mrp_production.

Description of the issue/feature this PR addresses:

Current behavior before PR:

`_check_sn_uniqueness` misfires on stock move lines from inventory adjustments
Desired behavior after PR is merged:

`_check_sn_uniqueness` only raises an error when a stock move lines is really from production ordere

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
