### PR TITLE
[FIX] mass_mailing: ensure mailing demo has a body_arch field

### DIFF
--- a/addons/mass_mailing/data/mass_mailing_demo.xml
+++ b/addons/mass_mailing/data/mass_mailing_demo.xml
@@ -85,7 +85,7 @@
             <field name="mailing_domain" eval="[('parent_id', '=', ref('base.res_partner_4'))]"/>
             <field name="reply_to_mode">new</field>
             <field name="reply_to">Info &lt;info@yourcompany.example.com&gt;</field>
-            <field name="body_html" type="html">
+            <field name="body_arch" type="html">
 <div class="o_layout o_default_theme oe_unremovable oe_unmovable" data-name="Mailing">
     <div class="container o_mail_wrapper oe_unremovable oe_unmovable" style="border-collapse:collapse;">
         <div class="row">


### PR DESCRIPTION
mass_mailing used to show the body_html but now shows the body_arch field instead (and body_html only in debug mode). As a result, one demo that had only defined body_html showed an empty field. This moves the body_html of that demo into its body_arch.

task-2710460

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
