### PR TITLE
[FIX] hr: Cannot acces profile without right

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -104,7 +104,7 @@ class HrEmployeePrivate(models.Model):
         string='Tags')
     # misc
     notes = fields.Text('Notes', groups="hr.group_hr_user")
-    color = fields.Integer('Color Index', default=0, groups="hr.group_hr_user")
+    color = fields.Integer('Color Index', default=0)
     barcode = fields.Char(string="Badge ID", help="ID used for employee identification.", groups="hr.group_hr_user", copy=False)
     pin = fields.Char(string="PIN", groups="hr.group_hr_user", copy=False,
         help="PIN used to Check In/Out in Kiosk Mode (if enabled in Configuration).")


### PR DESCRIPTION
Current behavior:
When a user doesn't have any HR access right he cannot access his own profile

Steps to reproduce:
-Go to the demo user settings
-Remove all the right in the HR section
-Log into demo account
-Try to access My Profile

opw-2712593

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
