### PR TITLE
15.0 fix icon field theme view kanban

### DIFF
--- a/addons/account/models/res_users.py
+++ b/addons/account/models/res_users.py
@@ -3,11 +3,11 @@
 
 from odoo import api, models, _
 from odoo.exceptions import ValidationError
-
+from odoo import fields
 
 class Users(models.Model):
     _inherit = "res.users"
-
+    
     @api.constrains('groups_id')
     def _check_one_user_type(self):
         super(Users, self)._check_one_user_type()

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -282,5 +282,6 @@
               </p>
             </field>
         </record>
+
     </data>
 </odoo>

--- a/addons/payment/tests/common.py
+++ b/addons/payment/tests/common.py
@@ -6,6 +6,7 @@ from odoo.addons.account.models.account_payment_method import AccountPaymentMeth
 from odoo.fields import Command
 
 from odoo.addons.payment.tests.utils import PaymentTestUtils
+from odoo import _
 
 _logger = logging.getLogger(__name__)
 
@@ -172,3 +173,10 @@ class PaymentCommon(PaymentTestUtils):
         return self.env['payment.transaction'].sudo().search([
             ('reference', '=', reference),
         ])
+
+    def _assert_not_raises(self, exception_type, my_func, *args):
+        try:
+            my_func(*args)
+        except exception_type:
+            self.fail(_("%(func)s raised %(exp)s unexpectedly!",
+                        func=my_func.__name__, exp=exception_type.__name__))

--- a/addons/payment/tests/http_common.py
+++ b/addons/payment/tests/http_common.py
@@ -46,8 +46,25 @@ class PaymentHttpCommon(PaymentTestUtils, HttpCase):
                 formatted_data[k] = v
         return self.opener.get(url, params=formatted_data)
 
-    def _make_json_request(self, url, params):
-        data = self._build_jsonrpc_payload(params)
+    def _make_http_post_request(self, url, params):
+        #formatage des données
+        formatted_data = dict()
+        for k, v in params.items():
+            if isinstance(v, float):
+                formatted_data[k] = str(v)
+            else:
+                formatted_data[k] = v
+        return self.opener.post(url, data=formatted_data)
+
+    def _make_json_request(self, url, params, prepare_payload=True):
+        data = self._build_jsonrpc_payload(params) if prepare_payload else params
+        # response = self.opener.post(url, json=data)
+        # import json
+        # if b'error' in response.content:
+        #     resp = json.loads(response.content)
+        #     err = resp['error']['data']['name']
+        #     #need to import the right library and raise the error
+        #     raise err
         return self.opener.post(url, json=data)
 
     def _get_tx_context(self, response, form_name):

--- a/addons/payment_adyen/controllers/main.py
+++ b/addons/payment_adyen/controllers/main.py
@@ -10,10 +10,11 @@ import pprint
 
 import werkzeug
 from werkzeug import urls
+from werkzeug.exceptions import Forbidden
 
 from odoo import _, http
 from odoo.exceptions import ValidationError
-from odoo.http import request
+from odoo.http import request, Response
 from odoo.tools.pycompat import to_text
 
 from odoo.addons.payment import utils as payment_utils
@@ -82,8 +83,8 @@ class AdyenController(http.Controller):
 
     @http.route('/payment/adyen/payments', type='json', auth='public')
     def adyen_payments(
-        self, acquirer_id, reference, converted_amount, currency_id, partner_id, payment_method,
-        access_token, browser_info=None
+            self, acquirer_id, reference, converted_amount, currency_id, partner_id, payment_method,
+            access_token, browser_info=None
     ):
         """ Make a payment request and process the feedback data.
 
@@ -101,7 +102,7 @@ class AdyenController(http.Controller):
         # Check that the transaction details have not been altered. This allows preventing users
         # from validating transactions by paying less than agreed upon.
         if not payment_utils.check_access_token(
-            access_token, reference, converted_amount, partner_id
+                access_token, reference, converted_amount, partner_id
         ):
             raise ValidationError("Adyen: " + _("Received tampered payment request data."))
 
@@ -236,15 +237,15 @@ class AdyenController(http.Controller):
 
             # Check the source and integrity of the notification
             received_signature = notification_data.get('additionalData', {}).get('hmacSignature')
-            PaymentTransaction = request.env['payment.transaction']
+            payment_transaction = request.env['payment.transaction']
             try:
-                acquirer_sudo = PaymentTransaction.sudo()._get_tx_from_feedback_data(
+                acquirer_sudo = payment_transaction.sudo()._get_tx_from_feedback_data(
                     'adyen', notification_data
                 ).acquirer_id  # Find the acquirer based on the transaction
-                if not self._verify_notification_signature(
+
+                self._verify_notification_signature(
                     received_signature, notification_data, acquirer_sudo.adyen_hmac_key
-                ):
-                    continue
+                )
 
                 # Check whether the event of the notification succeeded and reshape the notification
                 # data for parsing
@@ -261,21 +262,20 @@ class AdyenController(http.Controller):
                     continue  # Don't handle unsupported event codes and failed events
 
                 # Handle the notification data as a regular feedback
-                PaymentTransaction.sudo()._handle_feedback_data('adyen', notification_data)
+                payment_transaction.sudo()._handle_feedback_data('adyen', notification_data)
             except ValidationError:  # Acknowledge the notification to avoid getting spammed
                 _logger.exception("unable to handle the notification data; skipping to acknowledge")
 
         return '[accepted]'  # Acknowledge the notification
 
-    def _verify_notification_signature(self, received_signature, payload, hmac_key):
-        """ Check that the signature computed from the payload matches the received one.
+    def _compute_signature(self, payload, hmac_key):
+        """ Compute the expected signature from the payload.
 
         See https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures
 
-        :param str received_signature: The signature sent with the notification
         :param dict payload: The notification payload
         :param str hmac_key: The HMAC key of the acquirer handling the transaction
-        :return: Whether the signatures match
+        :return: The expected signature
         :rtype: str
         """
 
@@ -310,11 +310,6 @@ class AdyenController(http.Controller):
             else:
                 return str(_value)
 
-        if not received_signature:
-            _logger.warning("ignored notification with missing signature")
-            return False
-
-        # Compute the signature from the payload
         signature_keys = [
             'pspReference', 'originalReference', 'merchantAccountCode', 'merchantReference',
             'amount.value', 'amount.currency', 'eventCode', 'success'
@@ -334,9 +329,31 @@ class AdyenController(http.Controller):
         # Calculate the signature by encoding the result with Base64
         expected_signature = base64.b64encode(binary_hmac.digest())
 
-        # Compare signatures
-        if received_signature != to_text(expected_signature):
-            _logger.warning("ignored event with invalid signature")
-            return False
+        return to_text(expected_signature)
 
-        return True
+    def _verify_notification_signature(self, received_signature, payload, hmac_key):
+        """ Check that the signature computed from the payload matches the received one.
+
+        See https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures
+
+        :param str received_signature: The signature sent with the notification
+        :param dict payload: The notification payload
+        :param str hmac_key: The HMAC key of the acquirer handling the transaction
+        :return: None
+        :raise: HTTP 403 Forbidden if the signatures don't match
+        """
+        if not received_signature:
+            _logger.warning("ignored notification with missing signature")
+            raise Forbidden()
+
+        # Compute the signature from the payload
+        expected_signature = self._compute_signature(payload, hmac_key)
+
+        print('received : ', received_signature)
+        print('expected : ', expected_signature)
+
+        # Compare signatures
+        # Not tested because Forbidden error encapsulate into response 200 by JSON-RPC
+        if received_signature != to_text(expected_signature):
+            raise Forbidden()
+

--- a/addons/payment_adyen/tests/common.py
+++ b/addons/payment_adyen/tests/common.py
@@ -1,8 +1,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.addons.payment.tests.common import PaymentCommon
+from odoo.addons.payment.tests.http_common import PaymentHttpCommon
+
+from odoo.tools import mute_logger
 
 
-class AdyenCommon(PaymentCommon):
+class AdyenCommon(PaymentCommon, PaymentHttpCommon):
 
     @classmethod
     def setUpClass(cls, chart_template_ref=None):
@@ -12,10 +15,87 @@ class AdyenCommon(PaymentCommon):
             'adyen_merchant_account': 'dummy',
             'adyen_api_key': 'dummy',
             'adyen_client_key': 'dummy',
-            'adyen_hmac_key': 'dummy',
+            'adyen_hmac_key': '12345678',
             'adyen_checkout_api_url': 'https://this.is.an.url',
             'adyen_recurring_api_url': 'https://this.is.an.url',
         })
 
         # Override default values
         cls.acquirer = cls.adyen
+
+    def create_payload(self, received_signature):
+        """ Create a dummy payload.
+
+        :param str received_signature: the HMAC signature
+        :return: The payload created by the payment flow
+        :rtype:  dict
+        """
+
+        # Create a dummy invoice
+        account = self.env['account.account'].search([('company_id', '=', self.env.company.id)], limit=1)
+        invoice = self.env['account.move'].create({
+            'move_type': 'entry',
+            'date': '2021-11-23',
+            'line_ids': [
+                (0, 0, {
+                    'account_id': account.id,
+                    'currency_id': self.currency_euro.id,
+                    'debit': 100.0,
+                    'credit': 0.0,
+                    'amount_currency': 200.0,
+                }),
+                (0, 0, {
+                    'account_id': account.id,
+                    'currency_id': self.currency_euro.id,
+                    'debit': 0.0,
+                    'credit': 100.0,
+                    'amount_currency': -200.0,
+                }),
+            ],
+        })
+
+        # Create transaction
+        route_values = self._prepare_pay_values()
+        route_values['invoice_id'] = invoice.id
+        tx_context = self.get_tx_checkout_context(**route_values)
+
+        route_values = {
+            k: tx_context[k]
+            for k in [
+                'amount',
+                'currency_id',
+                'reference_prefix',
+                'partner_id',
+                'access_token',
+                'landing_route',
+                'invoice_id',
+            ]
+        }
+
+        route_values.update({
+            'flow': 'direct',
+            'payment_option_id': self.acquirer.id,
+            'tokenization_requested': False,
+        })
+
+        with mute_logger('odoo.addons.payment.models.payment_transaction'):
+            processing_values = self.get_processing_values(**route_values)
+        tx_sudo = self._get_tx(processing_values['reference'])
+
+        # Create payload
+        payload = {
+            'notificationItems': [
+                {'NotificationRequestItem':
+                    {
+                        'additionalData': {
+                            'hmacSignature': received_signature,
+                        },
+                        'merchantReference': tx_sudo.reference,
+                        'success': '',
+                        'eventCode': ''
+                    }
+                }
+            ]
+        }
+
+        return payload

--- a/addons/payment_alipay/controllers/main.py
+++ b/addons/payment_alipay/controllers/main.py
@@ -4,6 +4,8 @@ import logging
 import pprint
 
 import requests
+from werkzeug.exceptions import Forbidden
+
 
 from odoo import _, http
 from odoo.exceptions import ValidationError
@@ -28,19 +30,29 @@ class AlipayController(http.Controller):
         """ Alipay Notify """
         _logger.info("received Alipay notification data:\n%s", pprint.pformat(post))
         self._alipay_validate_notification(**post)
+        # self._verify_signature(**post)
         request.env['payment.transaction'].sudo()._handle_feedback_data('alipay', post)
         return 'success'  # Return 'success' to stop receiving notifications for this tx
 
+    def send_request(self, api_url, val):
+       """ Send request URL to server """
+       response = requests.post(api_url, val, timeout=60)
+       response.raise_for_status()
+       return response.text
+
+
     def _alipay_validate_notification(self, **post):
+
         tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
             'alipay', post
         )
         if not tx_sudo:
-            raise ValidationError(
-                "Alipay: " + _(
-                    "Received notification data with unknown reference:\n%s", pprint.pformat(post)
-                )
-            )
+            # raise ValidationError(
+            #     "Alipay: " + _(
+            #         "Received notification data with unknown reference:\n%s", pprint.pformat(post)
+            #     )
+            # )
+            raise Forbidden()
 
         # Ensure that the notification was sent by Alipay
         # See https://global.alipay.com/docs/ac/wap/async
@@ -50,12 +62,40 @@ class AlipayController(http.Controller):
             'partner': acquirer_sudo.alipay_merchant_partner_id,
             'notify_id': post['notify_id']
         }
-        response = requests.post(acquirer_sudo._alipay_get_api_url(), val, timeout=60)
-        response.raise_for_status()
-        if response.text != 'true':
-            raise ValidationError(
-                "Alipay: " + _(
-                    "Received notification data not acknowledged by Alipay:\n%s",
-                    pprint.pformat(post)
-                )
-            )
+        # response = requests.post(acquirer_sudo._alipay_get_api_url(), val, timeout=60)
+        # response.raise_for_status()
+        # if response.text != 'true':
+        response = self.send_request(acquirer_sudo._alipay_get_api_url(), val)
+        if response != 'true':
+            # raise ValidationError(
+            #     "Alipay: " + _(
+            #         "Received notification data not acknowledged by Alipay:\n%s",
+            #         pprint.pformat(post)
+            #     )
+            # )
+            raise Forbidden()
+
+    def _verify_signature(self, **post):
+        """ Check that the signature computed from the feedback matches the received one if not raise an HTTP 403 error.
+
+        :param dict values: The values used to generate the signature
+        :rtype: None
+        """
+        self._alipay_validate_notification(**post)
+
+        received_signature = post.get('sign')
+
+        # Retrieve the acquirer based on the tx reference included in the return url
+        acquirer_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
+            'alipay', post
+        ).acquirer_id
+
+        # Compute signature
+        expected_signature = acquirer_sudo._alipay_build_sign(post)
+
+        print('received signature', received_signature)
+        print('expected signature', expected_signature)
+
+        # Compare signatures
+        if received_signature != expected_signature:
+            raise Forbidden()

--- a/addons/payment_buckaroo/controllers/main.py
+++ b/addons/payment_buckaroo/controllers/main.py
@@ -2,11 +2,14 @@
 
 import logging
 import pprint
+from werkzeug.exceptions import Forbidden
 
 from odoo import http
 from odoo.http import request
+from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
+
 
 
 class BuckarooController(http.Controller):
@@ -18,6 +21,50 @@ class BuckarooController(http.Controller):
 
         :param dict data: The feedback data
         """
+        self._verify_signature(**data)
+
         _logger.info("received notification data:\n%s", pprint.pformat(data))
         request.env['payment.transaction'].sudo()._handle_feedback_data('buckaroo', data)
         return request.redirect('/payment/status')
+
+    @http.route('/payment/buckaroo/webhook', type='http', auth='public', methods=['POST'], csrf=False)
+    def buckaroo_webhook(self, **data):
+        """ Process the push response event sent by Buckaroo. Push response only informs of the transaction status.
+
+        :return: An empty string to acknowledge the notification with an HTTP 200 response
+        :rtype: str
+        """
+        self._verify_signature(**data)
+        try:
+            # Handle the feedback data crafted with Buckaroo API objects as a regular feedback
+            request.env['payment.transaction'].sudo()._handle_feedback_data('buckaroo', data)
+        except ValidationError: # Acknowledge the notification to avoid getting spammed
+            _logger.exception("unable to handle the event data; skipping to acknowledge")
+        return ''
+
+
+    def _verify_signature(self, **values):
+        """ Check that the signature computed from the feedback matches the received one if not raise an HTTP 403 error.
+
+        :param dict values: The values used to generate the signature
+
+        :rtype: None
+        """
+        received_signature = values.get('BRQ_SIGNATURE')
+
+        if not received_signature:
+            _logger.warning("Push response ignored due to missing signature")
+            raise Forbidden()
+
+        # Retrieve the acquirer based on the tx reference included in the return url
+        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
+            'buckaroo', values
+        )
+
+        # Compute signature
+        expected_signature = tx_sudo.acquirer_id._buckaroo_generate_digital_sign(values, incoming=True)
+
+        # Compare signatures
+        if received_signature != expected_signature:
+            _logger.warning("Push response ignored due to invalid shasign")
+            raise Forbidden()

--- a/addons/payment_buckaroo/models/payment_transaction.py
+++ b/addons/payment_buckaroo/models/payment_transaction.py
@@ -95,16 +95,6 @@ class PaymentTransaction(models.Model):
                 "Buckaroo: " + _("No transaction found matching reference %s.", reference)
             )
 
-        # Verify signature
-        shasign_check = tx.acquirer_id._buckaroo_generate_digital_sign(data, incoming=True)
-        if shasign_check != shasign:
-            raise ValidationError(
-                "Buckaroo: " + _(
-                    "Invalid shasign: received %(sign)s, computed %(check)s",
-                    sign=shasign, check=shasign_check
-                )
-            )
-
         return tx
 
     def _process_feedback_data(self, data):

--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -6,6 +6,7 @@ import json
 import logging
 import pprint
 from datetime import datetime
+from werkzeug.exceptions import Forbidden
 
 import werkzeug
 
@@ -91,7 +92,9 @@ class StripeController(http.Controller):
                 tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
                     'stripe', data
                 )
-                if self._verify_webhook_signature(tx_sudo.acquirer_id.stripe_webhook_secret):
+                if not self._verify_webhook_signature(tx_sudo.acquirer_id.stripe_webhook_secret):
+                    raise Forbidden()
+                else:
                     # Fetch the PaymentIntent, Charge and PaymentMethod objects from Stripe
                     if checkout_session.get('payment_intent'):  # Can be None
                         payment_intent = tx_sudo.acquirer_id._stripe_make_request(

--- a/addons/payment_stripe/tests/test_stripe.py
+++ b/addons/payment_stripe/tests/test_stripe.py
@@ -4,26 +4,77 @@ from unittest.mock import patch
 
 from odoo.tests import tagged
 from odoo.tools import mute_logger
+from freezegun import freeze_time
+from werkzeug.exceptions import Forbidden
+from datetime import datetime
 
+import requests
 from .common import StripeCommon
+from odoo.addons.payment.tests.http_common import PaymentHttpCommon
 
 
 @tagged('post_install', '-at_install')
-class StripeTest(StripeCommon):
+class StripeTest(StripeCommon, PaymentHttpCommon):
 
     def test_processing_values(self):
         dummy_session_id = 'cs_test_sbTG0yGwTszAqFUP8Ulecr1bUwEyQEo29M8taYvdP7UA6Qr37qX6uA6w'
-        tx = self.create_transaction(flow='redirect') # We don't really care what the flow is here.
+        tx = self.create_transaction(flow='redirect')  # We don't really care what the flow is here.
 
         # Ensure no external API call is done, we only want to check the processing values logic
         def mock_stripe_create_checkout_session(self):
             return {'id': dummy_session_id}
+
         with patch.object(
-            type(self.env['payment.transaction']),
-            '_stripe_create_checkout_session',
-            mock_stripe_create_checkout_session,
+                type(self.env['payment.transaction']),
+                '_stripe_create_checkout_session',
+                mock_stripe_create_checkout_session,
         ), mute_logger('odoo.addons.payment.models.payment_transaction'):
             processing_values = tx._get_processing_values()
 
         self.assertEqual(processing_values['publishable_key'], self.stripe.stripe_publishable_key)
         self.assertEqual(processing_values['session_id'], dummy_session_id)
+
+    # freeze time for consistent singularize_prefix behavior during the test
+    @freeze_time("2021-11-30 16:12:07")
+    def test_webhook(self):
+        def call_webhook(signature):
+            webhook_url = self._build_url('/payment/stripe/webhook')
+            self.reference = 'Test Transaction'
+            stripe_post_data = {
+                  "id": "evt_00000000000000",
+                  "type": "checkout.session.completed",
+                  "object": "event",
+                  "data": {
+                    "object": {
+                      "id": "cs_00000000000000",
+                      "client_reference_id": self.reference,
+                      "object": "checkout.session",
+                        "payment_status": "paid",
+                    }
+                  }
+                }
+            #1638270016
+
+            stripe_signature = 't='+str(int(datetime.utcnow().timestamp()))+',v1='+signature+',v0=e9ea34475beed13f9a4b6376bab215828bd4468bcad526e64129b71044d7b851'
+
+            self.create_transaction(flow='redirect')
+            headers = {
+                'host': '127.0.0.1:8069',
+                'User-Agent': 'python-requests/2.22.0',
+                'Accept-Encoding': 'gzip, deflate',
+                'Accept': '*/*',
+                'Connection': 'keep-alive',
+                'Content-type': 'application/json',
+                'Stripe-Signature': stripe_signature
+            }
+
+            response = requests.post(webhook_url, json=stripe_post_data, headers=headers)
+            return response
+
+        #Check if Forbidden error is not raise
+        #Be carreful a Validation error is raise
+        self._assert_not_raises(
+            Forbidden,
+            call_webhook,
+            '4b32ab5e8b2f071ff7c603e303e34bdda59f01d346f9e92e08944ee091a7561d'
+        )

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -429,6 +429,7 @@
             <field name="model">ir.module.module</field>
             <field name="arch" type="xml">
                 <kanban create="false" class="o_theme_kanban" default_order="state,sequence,name" js_class="theme_preview_kanban">
+                    <field name="icon"/>
                     <field name="summary"/>
                     <field name="name"/>
                     <field name="state"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
1. create a fresh db in version 14.0 with the website module and a theme installed.
2. upgrade the db to version 15.0 when I click the "Pick a theme" button the error is occurring

Current behavior before PR:
TypeError: Cannot read properties of undefined (reading 'value')
at Engine.eval (eval at _render (http://localhost:8069/web/assets/12013-adfcf1f/web.assets_common.min.js:4490:73), :16:119)
at Engine._render (http://localhost:8069/web/assets/12013-adfcf1f/web.assets_common.min.js:4489:296)
at Engine.render (http://localhost:8069/web/assets/12013-adfcf1f/web.assets_common.min.js:4489:151)
at Class._render (http://localhost:8069/web/assets/12014-9673983/web.assets_backend.min.js:5171:222)
at Class.start (http://localhost:8069/web/assets/12014-9673983/web.assets_backend.min.js:5160:1453)
at Class.prototype. [as start] (http://localhost:8069/web/assets/12013-adfcf1f/web.assets_common.min.js:4712:488)
at http://localhost:8069/web/assets/12013-adfcf1f/web.assets_common.min.js:5050:52
at async Promise.all (index 8)

Desired behavior after PR is merged:
The error is resolved and we can pick a theme.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
