### PR TITLE
[FIX] base: generating wrong view res.users.groups for base.view_users_form

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1017,7 +1017,7 @@ class GroupsImplied(models.Model):
     trans_implied_ids = fields.Many2many('res.groups', string='Transitively inherits',
         compute='_compute_trans_implied')
 
-    @api.depends('implied_ids.trans_implied_ids')
+    @api.depends('implied_ids')
     def _compute_trans_implied(self):
         # Compute the transitive closure recursively. Note that the performance
         # is good, because the record cache behaves as a memo (the field is


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- _compute_trans_implied is depends on implied_ids.trans_implied_ids only, which it won't recompute again when implied_ids updated. So when generating the groups view from get_groups_by_application, it will generate a wrong view when len(trans_implied_ids) doesn't add up to len(gs).

Current behavior before PR:
- Same as the screenshot below, some of the permission groups views are not deplaying correctly.
![2021-12-17_17-27](https://user-images.githubusercontent.com/85471608/146521824-0735a86a-9cae-487d-9e2f-5e2300e64e8c.png)

Desired behavior after PR is merged:
- It should allow user to edit it.

- I think we need to discuss more on this PR. Since I haven't checked deep enough to know why sometimes the groups will display under human resources, sometimes it doesn't. However this compute method fix could allow user to edit the permission again like the screenshot below. 
![2021-12-17_17-39](https://user-images.githubusercontent.com/85471608/146523691-87e3b105-4439-4ecf-bf15-eeb5934a310c.png)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
