### PR TITLE
[FIX] hr_holidays: fix accrual test

### DIFF
--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -536,6 +536,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
     def test_unused_accrual_lost(self):
         #1 accrual with 2 levels and level transition immediately
+        freezer = freeze_time('2021-09-01')
+        freezer.start()
         accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
             'name': 'Accrual Plan For Test',
             'level_ids': [(0, 0, {
@@ -558,6 +560,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         })
         allocation.action_confirm()
         allocation.action_validate()
+        freezer.stop()
 
         freezer = freeze_time('2022-01-01')
         freezer.start()
@@ -568,6 +571,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
     def test_unused_accrual_postponed(self):
         # 1 accrual with 2 levels and level transition after
         # This also tests retroactivity
+        freezer = freeze_time('2021-09-01')
+        freezer.start()
         accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
             'name': 'Accrual Plan For Test',
             'level_ids': [(0, 0, {
@@ -590,6 +595,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         })
         allocation.action_confirm()
         allocation.action_validate()
+        freezer.stop()
 
         freezer = freeze_time('2022-01-01')
         freezer.start()


### PR DESCRIPTION
The test `test_unused_accrual_postponed` was expecting at least 25
holidays to be accrued, but started failing around mid-December.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
