### PR TITLE
[FIX] hr_holidays: display the kind of leave for the time off types

### DIFF
--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -54,6 +54,7 @@
                                 'invisible': [('leave_validation_type', 'in', ['no_validation', 'manager']), '|', ('requires_allocation', '=', 'no'), ('allocation_validation_type', '=', 'officer')]}"/>
                             <field name="request_unit" widget="radio-inline"/>
                             <field name="support_document" string="Allow To Join Supporting Document" />
+                            <field name="time_type" required="1"/>
                             <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                         <group name="allocation_validation" id="allocation_requests">


### PR DESCRIPTION
Since 15.0, we work with accrual plans and in the conditions,
an accrual plan level can be based on "worked time" or not.

However, the user can't decide which time off type is considered
as a worked time or not.

For example: a time off type for a training can be considered as
worked time or not in the accrual plan level to grant a time off.
If the employee has one month of training with 2 days of annual time off
granted via the accrual plan based on worked time. The one month training should
grant 2 days of annual time off at the end of the month. If the time off type is set to
leave instead, it will not grant any time off at the end of the month

This commit allows the user to select if the time off type is considered
as worked time or not for the calculation of the time off granted in the accrual plan

task-2693319

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
