### PR TITLE
[IMP] hr_fleet,hr_recruitment: use work location

### DIFF
--- a/addons/hr_fleet/__manifest__.py
+++ b/addons/hr_fleet/__manifest__.py
@@ -13,6 +13,7 @@
         'views/employee_views.xml',
         'views/fleet_vehicle_views.xml',
         'views/fleet_vehicle_cost_views.xml',
+        'views/hr_work_location_views.xml',
         'wizard/hr_departure_wizard_views.xml',
     ],
     'demo': [

--- a/addons/hr_fleet/models/__init__.py
+++ b/addons/hr_fleet/models/__init__.py
@@ -8,3 +8,4 @@ from . import fleet_vehicle
 from . import fleet_vehicle_log_contract
 from . import fleet_vehicle_log_services
 from . import fleet_vehicle_odometer
+from . import hr_work_location

--- a/addons/hr_fleet/models/fleet_vehicle.py
+++ b/addons/hr_fleet/models/fleet_vehicle.py
@@ -21,6 +21,14 @@ class FleetVehicle(models.Model):
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
         tracking=True,
     )
+    work_location_id = fields.Many2one(related='driver_employee_id.work_location_id')
+    manager_id = fields.Many2one(compute='_compute_manager_id', store=True, readonly=False)
+
+    @api.depends('driver_employee_id', 'work_location_id.fleet_manager_id')
+    def _compute_manager_id(self):
+        for vehicle in self:
+            if vehicle.driver_employee_id:
+                vehicle.manager_id = vehicle.work_location_id.fleet_manager_id
 
     @api.depends('driver_id')
     def _compute_driver_employee_id(self):

--- a/addons/hr_fleet/models/hr_work_location.py
+++ b/addons/hr_fleet/models/hr_work_location.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class WorkLocation(models.Model):
+    _inherit = "hr.work.location"
+
+    def _domain_fleet_manager_id(self):
+        fleet_users = self.env.ref('fleet.fleet_group_user')
+        domain = str(('id', 'in', fleet_users.users.ids))
+        return f"[('company_ids', '=', company_id), {domain}]"
+
+    fleet_manager_id = fields.Many2one('res.users', string='Default Fleet Manager', domain=_domain_fleet_manager_id)

--- a/addons/hr_fleet/views/fleet_vehicle_views.xml
+++ b/addons/hr_fleet/views/fleet_vehicle_views.xml
@@ -29,6 +29,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='driver_id']" position="after">
                 <field name="driver_employee_id" invisible="1"/>
+                <field name="work_location_id" invisible="1"/>
                 <field name="mobility_card" readonly="1"/>
             </xpath>
             <xpath expr="//field[@name='future_driver_id']" position="after">

--- a/addons/hr_fleet/views/hr_work_location_views.xml
+++ b/addons/hr_fleet/views/hr_work_location_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="hr_fleet_hr_work_location_tree_view_inherit" model="ir.ui.view">
+            <field name="model">hr.work.location</field>
+            <field name="inherit_id" ref="hr.hr_work_location_tree_view" />
+            <field name="arch" type="xml">
+                <field name="company_id" position="before">
+                    <field name="fleet_manager_id" />
+                </field>
+            </field>
+        </record>
+
+        <record id="hr_work_location_form_view_inherit" model="ir.ui.view">
+            <field name="model">hr.work.location</field>
+            <field name="inherit_id" ref="hr.hr_work_location_form_view" />
+            <field name="arch" type="xml">
+                <field name="company_id" position="after">
+                    <field name="fleet_manager_id" />
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -137,6 +137,7 @@ class Applicant(models.Model):
     date_last_stage_update = fields.Datetime("Last Stage Update", index=True, default=fields.Datetime.now)
     priority = fields.Selection(AVAILABLE_PRIORITIES, "Appreciation", default='0')
     job_id = fields.Many2one('hr.job', "Applied Job", domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", tracking=True)
+    work_location_id = fields.Many2one(related='job_id.work_location_id', store=True)
     salary_proposed_extra = fields.Char("Proposed Salary Extra", help="Salary Proposed by the Organisation, extra advantages", tracking=True)
     salary_expected_extra = fields.Char("Expected Salary Extra", help="Salary Expected by Applicant, extra advantages", tracking=True)
     salary_proposed = fields.Float("Proposed Salary", group_operator="avg", help="Salary Proposed by the Organisation", tracking=True)
@@ -572,8 +573,8 @@ class Applicant(models.Model):
                     'default_job_title': applicant.job_id.name,
                     'default_address_home_id': address_id,
                     'default_department_id': applicant.department_id.id or False,
-                    'default_address_id': applicant.company_id and applicant.company_id.partner_id
-                            and applicant.company_id.partner_id.id or False,
+                    'default_address_id': applicant.job_id.address_id.id or False,
+                    'default_work_location_id': applicant.job_id.work_location_id.id or False,
                     'default_work_email': applicant.department_id and applicant.department_id.company_id
                             and applicant.department_id.company_id.email or False,
                     'default_work_phone': applicant.department_id.company_id.phone,

--- a/addons/hr_recruitment/views/hr_recruitment_views.xml
+++ b/addons/hr_recruitment/views/hr_recruitment_views.xml
@@ -47,6 +47,7 @@
                 <field name="availability" optional="hide"/>
                 <field name="department_id" invisible="context.get('invisible_department', True)" readonly="1"/>
                 <field name="company_id" groups="base.group_multi_company" readonly="1" optional="hide"/>
+                <field name="work_location_id" optional="hide"/>
             </tree>
         </field>
     </record>
@@ -134,6 +135,7 @@
                     </group>
                     <group string="Job">
                         <field name="job_id"/>
+                        <field name="work_location_id"/>
                         <field name="department_id"/>
                         <field name="company_id" groups="base.group_multi_company" options='{"no_open":True}' />
                     </group>
@@ -200,6 +202,7 @@
                     filter_domain="['|', '|', ('name', 'ilike', self), ('partner_name', 'ilike', self), ('email_from', 'ilike', self)]"/>
                 <field string="Email" name="email_from" filter_domain="[('email_from', 'ilike', self)]"/>
                 <field name="job_id"/>
+                <field name="work_location_id"/>
                 <field name="department_id" operator="child_of"/>
                 <field name="user_id"/>
                 <field name="stage_id" domain="[]"/>
@@ -479,7 +482,8 @@
         <field name="inherit_id" ref="hr.view_hr_job_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='department_id']" position="after">
-                <field name="address_id" context="{'show_address': 1}" domain= "[('is_company', '=', True )]" options="{'always_reload': True}"/>
+                <field name="address_id" context="{'show_address': 1}" options="{'always_reload': True}"/>
+                <field name="work_location_id" context="{'default_address_id': address_id}"/>
                 <label for="alias_name" string="Email Alias" attrs="{'invisible': [('alias_domain', '=', False)]}" help="Define a specific contact address for this job position. If you keep it empty, the default email address will be used which is in human resources settings"/>
                 <div name="alias_def" attrs="{'invisible': [('alias_domain', '=', False)]}">
                     <field name="alias_id" class="oe_read_only" string="Email Alias" required="0"/>


### PR DESCRIPTION
The work location model was added in #63192, this commit makes use of it
in the Fleet and Recruitment applications.

An employee created from a job application gets the work location set on
the job.

When ordering a new car, the fleet manager will be set to the default
fleet manager of that work location.

TaskID: 2704398

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
