### PR TITLE
[FIX] website: add the necessary field in the kanban view

### DIFF
--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -429,6 +429,7 @@
             <field name="model">ir.module.module</field>
             <field name="arch" type="xml">
                 <kanban create="false" class="o_theme_kanban" default_order="state,sequence,name" js_class="theme_preview_kanban">
+                    <field name="icon"/>
                     <field name="summary"/>
                     <field name="name"/>
                     <field name="state"/>


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
1. create a fresh db in version 14.0 with the website module and a theme installed.
2. upgrade the db to version 15.0 when I click the "Pick a theme" button the error is occurring

Current behavior before PR:
```
TypeError: Cannot read properties of undefined (reading 'value')
at Engine.eval (eval at _render (http://localhost:8069/web/assets/12013-adfcf1f/web.assets_common.min.js:4490:73), :16:119)
at Engine._render (http://localhost:8069/web/assets/12013-adfcf1f/web.assets_common.min.js:4489:296)
at Engine.render (http://localhost:8069/web/assets/12013-adfcf1f/web.assets_common.min.js:4489:151)
at Class._render (http://localhost:8069/web/assets/12014-9673983/web.assets_backend.min.js:5171:222)
at Class.start (http://localhost:8069/web/assets/12014-9673983/web.assets_backend.min.js:5160:1453)
at Class.prototype. [as start] (http://localhost:8069/web/assets/12013-adfcf1f/web.assets_common.min.js:4712:488)
at http://localhost:8069/web/assets/12013-adfcf1f/web.assets_common.min.js:5050:52
at async Promise.all (index 8)
```
Desired behavior after PR is merged:
The error is resolved and we can pick a theme.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
