### PR TITLE
[MERGE][REF] event{,_sale}: unstore seats and add revenues reporting

### DIFF
--- a/addons/event/__manifest__.py
+++ b/addons/event/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Events Organization',
-    'version': '1.6',
+    'version': '1.7',
     'website': 'https://www.odoo.com/app/events',
     'category': 'Marketing/Events',
     'summary': 'Trainings, Conferences, Meetings, Exhibitions, Registrations',

--- a/addons/event/data/event_registration_demo.xml
+++ b/addons/event/data/event_registration_demo.xml
@@ -2,16 +2,19 @@
 <odoo><data>
     <!-- Design fair -->
     <record id="event_registration_0_0" model="event.registration">
+        <field name="create_date" eval="DateTime.now() - relativedelta(days=2)"/>
         <field name="event_id" ref="event.event_0"/>
         <field name="event_ticket_id" ref="event.event_0_ticket_1"/>
         <field name="partner_id" ref="base.res_partner_address_1"/>
     </record>
     <record id="event_registration_0_1" model="event.registration">
+        <field name="create_date" eval="DateTime.now() - relativedelta(days=2)"/>
         <field name="event_id" ref="event.event_0"/>
         <field name="event_ticket_id" ref="event.event_0_ticket_1"/>
         <field name="partner_id" ref="base.res_partner_address_2"/>
     </record>
     <record id="event_registration_0_2" model="event.registration">
+        <field name="create_date" eval="DateTime.now() - relativedelta(days=2)"/>
         <field name="event_id" ref="event.event_0"/>
         <field name="event_ticket_id" ref="event.event_0_ticket_0"/>
         <field name="name">Tucker Carlson</field>
@@ -51,16 +54,19 @@
 
     <!-- Conference for architects -->
     <record id="event_registration_2_0" model="event.registration">
+        <field name="create_date" eval="DateTime.now() - relativedelta(days=0.5)"/>
         <field name="event_id" ref="event.event_2"/>
         <field name="event_ticket_id" ref="event.event_2_ticket_1"/>
         <field name="partner_id" ref="base.res_partner_address_1"/>
     </record>
     <record id="event_registration_2_1" model="event.registration">
+        <field name="create_date" eval="DateTime.now() - relativedelta(days=0.5)"/>
         <field name="event_id" ref="event.event_2"/>
         <field name="event_ticket_id" ref="event.event_2_ticket_1"/>
         <field name="partner_id" ref="base.res_partner_address_2"/>
     </record>
     <record id="event_registration_2_2" model="event.registration">
+        <field name="create_date" eval="DateTime.now() - relativedelta(days=0.5)"/>
         <field name="event_id" ref="event.event_2"/>
         <field name="event_ticket_id" ref="event.event_2_ticket_2"/>
         <field name="name">Piers Morgan</field>
@@ -68,11 +74,13 @@
         <field name="partner_id" eval="False"/>
     </record>
     <record id="event_registration_2_3" model="event.registration">
+        <field name="create_date" eval="DateTime.now() - relativedelta(days=1)"/>
         <field name="event_id" ref="event.event_2"/>
         <field name="event_ticket_id" ref="event.event_2_ticket_1"/>
         <field name="partner_id" ref="base.res_partner_address_3"/>
     </record>
     <record id="event_registration_2_4" model="event.registration">
+        <field name="create_date" eval="DateTime.now() - relativedelta(days=1)"/>
         <field name="event_id" ref="event.event_2"/>
         <field name="event_ticket_id" ref="event.event_2_ticket_1"/>
         <field name="partner_id" ref="base.res_partner_address_4"/>
@@ -110,16 +118,19 @@
 
     <!-- Business Workshop -->
     <record id="event_registration_4_0" model="event.registration">
+        <field name="create_date" eval="DateTime.now() - relativedelta(days=8)"/>
         <field name="event_id" ref="event.event_4"/>
         <field name="event_ticket_id" ref="event.event_4_ticket_0"/>
         <field name="partner_id" ref="base.res_partner_address_7"/>
     </record>
     <record id="event_registration_4_1" model="event.registration">
+        <field name="create_date" eval="DateTime.now() - relativedelta(days=7)"/>
         <field name="event_id" ref="event.event_4"/>
         <field name="event_ticket_id" ref="event.event_4_ticket_0"/>
         <field name="partner_id" ref="base.res_partner_address_13"/>
     </record>
     <record id="event_registration_4_2" model="event.registration">
+        <field name="create_date" eval="DateTime.now() - relativedelta(days=7)"/>
         <field name="event_id" ref="event.event_4"/>
         <field name="event_ticket_id" ref="event.event_4_ticket_0"/>
         <field name="partner_id" ref="base.res_partner_address_14"/>

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -8,6 +8,7 @@ from odoo import _, api, Command, fields, models
 from odoo.addons.base.models.res_partner import _tz_get
 from odoo.tools import format_datetime, is_html_empty
 from odoo.exceptions import ValidationError
+from odoo.tools.misc import formatLang
 from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
@@ -56,7 +57,7 @@ class EventType(models.Model):
     # registration
     has_seats_limitation = fields.Boolean('Limited Seats')
     seats_max = fields.Integer(
-        'Maximum Registrations', compute='_compute_default_registration',
+        'Maximum Registrations', compute='_compute_seats_max',
         readonly=False, store=True,
         help="It will select this default maximum value when you choose this event")
     auto_confirm = fields.Boolean(
@@ -74,7 +75,7 @@ class EventType(models.Model):
         help="This information will be printed on your tickets.")
 
     @api.depends('has_seats_limitation')
-    def _compute_default_registration(self):
+    def _compute_seats_max(self):
         for template in self:
             if not template.has_seats_limitation:
                 template.seats_max = 0
@@ -140,19 +141,19 @@ class EventEvent(models.Model):
                                    precompute=True, readonly=False, store=True)
     seats_reserved = fields.Integer(
         string='Number of Registrations',
-        store=True, readonly=True, compute='_compute_seats')
+        store=False, readonly=True, compute='_compute_seats')
     seats_available = fields.Integer(
         string='Available Seats',
-        store=True, readonly=True, compute='_compute_seats')
+        store=False, readonly=True, compute='_compute_seats')
     seats_unconfirmed = fields.Integer(
         string='Unconfirmed Registrations',
-        store=True, readonly=True, compute='_compute_seats')
+        store=False, readonly=True, compute='_compute_seats')
     seats_used = fields.Integer(
         string='Number of Attendees',
-        store=True, readonly=True, compute='_compute_seats')
+        store=False, readonly=True, compute='_compute_seats')
     seats_expected = fields.Integer(
         string='Number of Expected Attendees',
-        compute_sudo=True, readonly=True, compute='_compute_seats_expected')
+        store=False, readonly=True, compute='_compute_seats')
     # Registration fields
     auto_confirm = fields.Boolean(
         string='Autoconfirmation', compute='_compute_auto_confirm', readonly=False, store=True,
@@ -239,15 +240,12 @@ class EventEvent(models.Model):
             for event_id, state, num in res:
                 results[event_id][state_field[state]] = num
 
-        # compute seats_available
+        # compute seats_available and expected
         for event in self:
             event.update(results.get(event._origin.id or event.id, base_vals))
             if event.seats_max > 0:
                 event.seats_available = event.seats_max - (event.seats_reserved + event.seats_used)
 
-    @api.depends('seats_unconfirmed', 'seats_reserved', 'seats_used')
-    def _compute_seats_expected(self):
-        for event in self:
             event.seats_expected = event.seats_unconfirmed + event.seats_reserved + event.seats_used
 
     @api.depends('date_tz', 'start_sale_datetime')
@@ -261,7 +259,8 @@ class EventEvent(models.Model):
             else:
                 event.event_registrations_started = True
 
-    @api.depends('date_tz', 'event_registrations_started', 'date_end', 'seats_available', 'seats_limited', 'event_ticket_ids.sale_available')
+    @api.depends('date_tz', 'event_registrations_started', 'date_end', 'seats_available', 'seats_limited', 'seats_max',
+                 'event_ticket_ids.sale_available')
     def _compute_event_registrations_open(self):
         """ Compute whether people may take registrations for this event
 
@@ -277,7 +276,7 @@ class EventEvent(models.Model):
             date_end_tz = event.date_end.astimezone(pytz.timezone(event.date_tz or 'UTC')) if event.date_end else False
             event.event_registrations_open = event.event_registrations_started and \
                 (date_end_tz >= current_datetime if date_end_tz else True) and \
-                (not event.seats_limited or event.seats_available) and \
+                (not event.seats_limited or not event.seats_max or event.seats_available) and \
                 (not event.event_ticket_ids or any(ticket.sale_available for ticket in event.event_ticket_ids))
 
     @api.depends('event_ticket_ids.start_sale_datetime')
@@ -288,17 +287,19 @@ class EventEvent(models.Model):
             start_dates = [ticket.start_sale_datetime for ticket in event.event_ticket_ids if not ticket.is_expired]
             event.start_sale_datetime = min(start_dates) if start_dates and all(start_dates) else False
 
-    @api.depends('event_ticket_ids.sale_available')
+    @api.depends('event_ticket_ids.sale_available', 'seats_available', 'seats_limited')
     def _compute_event_registrations_sold_out(self):
+        """Note that max seats limits for events and sum of limits for all its tickets may not be
+        equal to enable flexibility.
+        E.g. max 20 seats for ticket A, 20 seats for ticket B
+            * With max 20 seats for the event
+            * Without limit set on the event (=40, but the customer didn't explicitly write 40)
+        """
         for event in self:
-            if event.seats_limited and not event.seats_available:
-                event.event_registrations_sold_out = True
-            elif event.event_ticket_ids:
-                event.event_registrations_sold_out = not any(
-                    ticket.seats_available > 0 if ticket.seats_limited else True for ticket in event.event_ticket_ids
-                )
-            else:
-                event.event_registrations_sold_out = False
+            event.event_registrations_sold_out = (
+                (event.seats_limited and event.seats_max and not event.seats_available)
+                or (event.event_ticket_ids and all(ticket.is_sold_out for ticket in event.event_ticket_ids))
+            )
 
     @api.depends('date_tz', 'date_begin')
     def _compute_date_begin_tz(self):
@@ -511,13 +512,17 @@ class EventEvent(models.Model):
             else:
                 event.address_inline = event.address_id.name or ''
 
-    @api.constrains('seats_max', 'seats_available', 'seats_limited')
-    def _check_seats_limit(self):
+    @api.constrains('seats_max', 'seats_limited', 'registration_ids')
+    def _check_seats_availability(self, minimal_availability=0):
+        sold_out_events = []
         for event in self:
-            if event.seats_limited and event.seats_max and event.seats_available < 0:
-                raise ValidationError(_('No more available seats for %s. '
-                                        'Raise the limit or remove some other confirmed registrations first.',
-                                        event.name))
+            if event.seats_limited and event.seats_max and event.seats_available < minimal_availability:
+                sold_out_events.append(
+                    (_('- "%(event_name)s": Missing %(nb_too_many)i seats.',
+                        event_name=event.name, nb_too_many=-event.seats_available)))
+        if sold_out_events:
+            raise ValidationError(_('There are not enough seats available for:')
+                                  + '\n%s\n' % '\n'.join(sold_out_events))
 
     @api.constrains('date_begin', 'date_end')
     def _check_closing_date(self):
@@ -545,6 +550,26 @@ class EventEvent(models.Model):
         res = super(EventEvent, self).write(vals)
         if vals.get('organizer_id'):
             self.message_subscribe([vals['organizer_id']])
+        return res
+
+    def name_get(self):
+        """Adds ticket seats availability if requested by context."""
+        if not self.env.context.get('name_with_seats_availability'):
+            return super().name_get()
+        res = []
+        for event in self:
+            # event or its tickets are sold out
+            if event.event_registrations_sold_out:
+                name = _('%(event_name)s (Sold out)', event_name=event.name)
+            elif event.seats_limited and event.seats_max:
+                name = _(
+                    '%(event_name)s (%(count)s seats remaining)',
+                    event_name=event.name,
+                    count=formatLang(self.env, event.seats_available, digits=0),
+                )
+            else:
+                name = event.name
+            res.append((event.id, name))
         return res
 
     @api.returns('self', lambda value: value.id)

--- a/addons/event/models/event_ticket.py
+++ b/addons/event/models/event_ticket.py
@@ -3,6 +3,7 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, UserError
+from odoo.tools.misc import formatLang
 
 
 class EventTemplateTicket(models.Model):
@@ -63,14 +64,19 @@ class EventTicket(models.Model):
     # sale
     start_sale_datetime = fields.Datetime(string="Registration Start")
     end_sale_datetime = fields.Datetime(string="Registration End")
+    is_launched = fields.Boolean(string='Are sales launched', compute='_compute_is_launched')
     is_expired = fields.Boolean(string='Is Expired', compute='_compute_is_expired')
-    sale_available = fields.Boolean(string='Is Available', compute='_compute_sale_available', compute_sudo=True)
+    sale_available = fields.Boolean(
+        string='Is Available', compute='_compute_sale_available', compute_sudo=True,
+        help='Whether it is possible to sell these tickets')
     registration_ids = fields.One2many('event.registration', 'event_ticket_id', string='Registrations')
     # seats
-    seats_reserved = fields.Integer(string='Reserved Seats', compute='_compute_seats', store=True)
-    seats_available = fields.Integer(string='Available Seats', compute='_compute_seats', store=True)
-    seats_unconfirmed = fields.Integer(string='Unconfirmed Seats', compute='_compute_seats', store=True)
-    seats_used = fields.Integer(string='Used Seats', compute='_compute_seats', store=True)
+    seats_reserved = fields.Integer(string='Reserved Seats', compute='_compute_seats', store=False)
+    seats_available = fields.Integer(string='Available Seats', compute='_compute_seats', store=False)
+    seats_unconfirmed = fields.Integer(string='Unconfirmed Seats', compute='_compute_seats', store=False)
+    seats_used = fields.Integer(string='Used Seats', compute='_compute_seats', store=False)
+    is_sold_out = fields.Boolean(
+        'Sold Out', compute='_compute_is_sold_out', help='Whether seats are not available for this ticket.')
 
     @api.depends('end_sale_datetime', 'event_id.date_tz')
     def _compute_is_expired(self):
@@ -83,13 +89,22 @@ class EventTicket(models.Model):
             else:
                 ticket.is_expired = False
 
+    @api.depends('start_sale_datetime', 'event_id.date_tz')
+    def _compute_is_launched(self):
+        now = fields.Datetime.now()
+        for ticket in self:
+            if not ticket.start_sale_datetime:
+                ticket.is_launched = True
+            else:
+                ticket = ticket._set_tz_context()
+                current_datetime = fields.Datetime.context_timestamp(ticket, now)
+                start_sale_datetime = fields.Datetime.context_timestamp(ticket, ticket.start_sale_datetime)
+                ticket.is_launched = start_sale_datetime <= current_datetime
+
     @api.depends('is_expired', 'start_sale_datetime', 'event_id.date_tz', 'seats_available', 'seats_max')
     def _compute_sale_available(self):
         for ticket in self:
-            if not ticket.is_launched() or ticket.is_expired or (ticket.seats_max and ticket.seats_available <= 0):
-                ticket.sale_available = False
-            else:
-                ticket.sale_available = True
+            ticket.sale_available = ticket.is_launched and not ticket.is_expired and not ticket.is_sold_out
 
     @api.depends('seats_max', 'registration_ids.state', 'registration_ids.active')
     def _compute_seats(self):
@@ -121,20 +136,48 @@ class EventTicket(models.Model):
             if ticket.seats_max > 0:
                 ticket.seats_available = ticket.seats_max - (ticket.seats_reserved + ticket.seats_used)
 
+    @api.depends('seats_limited', 'seats_available')
+    def _compute_is_sold_out(self):
+        for ticket in self:
+            ticket.is_sold_out = ticket.seats_limited and not ticket.seats_available
+
     @api.constrains('start_sale_datetime', 'end_sale_datetime')
     def _constrains_dates_coherency(self):
         for ticket in self:
             if ticket.start_sale_datetime and ticket.end_sale_datetime and ticket.start_sale_datetime > ticket.end_sale_datetime:
-                raise UserError(_('The stop date cannot be earlier than the start date.'))
+                raise UserError(_('The stop date cannot be earlier than the start date. '
+                                  'Please check ticket %(ticket_name)s', ticket_name=ticket.name))
 
-    @api.constrains('seats_available', 'seats_max')
-    def _constrains_seats_available(self):
-        for record in self:
-            if record.seats_max and record.seats_available < 0:
-                raise ValidationError(
-                    _('No more available seats for the ticket %s (%s). '
-                      'Raise the limit or remove some other confirmed registrations first.',
-                      record.name, record.event_id.name))
+    @api.constrains('registration_ids', 'seats_max')
+    def _check_seats_availability(self, minimal_availability=0):
+        sold_out_tickets = []
+        for ticket in self:
+            if ticket.seats_max and ticket.seats_available < minimal_availability:
+                sold_out_tickets.append((_(
+                    '- the ticket "%(ticket_name)s" (%(event_name)s): Missing %(nb_too_many)i seats.',
+                    ticket_name=ticket.name, event_name=ticket.event_id.name, nb_too_many=-ticket.seats_available)))
+        if sold_out_tickets:
+            raise ValidationError(_('There are not enough seats available for:')
+                                  + '\n%s\n' % '\n'.join(sold_out_tickets))
+
+    def name_get(self):
+        """Adds ticket seats availability if requested by context."""
+        if not self.env.context.get('name_with_seats_availability'):
+            return super().name_get()
+        res = []
+        for ticket in self:
+            if not ticket.seats_max:
+                name = ticket.name
+            elif not ticket.seats_available:
+                name = _('%(ticket_name)s (Sold out)', ticket_name=ticket.name)
+            else:
+                name = _(
+                    '%(ticket_name)s (%(count)s seats remaining)',
+                    ticket_name=ticket.name,
+                    count=formatLang(self.env, ticket.seats_available, digits=0),
+                )
+            res.append((ticket.id, name))
+        return res
 
     def _get_ticket_multiline_description(self):
         """ Compute a multiline description of this ticket. It is used when ticket
@@ -145,17 +188,6 @@ class EventTicket(models.Model):
     def _set_tz_context(self):
         self.ensure_one()
         return self.with_context(tz=self.event_id.date_tz or 'UTC')
-
-    def is_launched(self):
-        # TDE FIXME: in master, make a computed field, easier to use
-        self.ensure_one()
-        if self.start_sale_datetime:
-            ticket = self._set_tz_context()
-            current_datetime = fields.Datetime.context_timestamp(ticket, fields.Datetime.now())
-            start_sale_datetime = fields.Datetime.context_timestamp(ticket, ticket.start_sale_datetime)
-            return start_sale_datetime <= current_datetime
-        else:
-            return True
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_if_registrations(self):

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -285,41 +285,7 @@
         </field>
     </record>
 
-    <record id="event_event_view_pivot" model="ir.ui.view" >
-        <field name="name">event.event.view.pivot</field>
-        <field name="model">event.event</field>
-        <field name="arch" type="xml">
-            <pivot string="Event" sample="1">
-                <field name="name" type="row"/>
-                <field name="seats_reserved" type="measure"/>
-            </pivot>
-        </field>
-    </record>
-
-    <record id="event_event_view_graph" model="ir.ui.view" >
-        <field name="name">event.event.view.graph</field>
-        <field name="model">event.event</field>
-        <field name="arch" type="xml">
-            <graph string="Events" sample="1">
-                <field name="name"/>
-                <field name="seats_available" type="measure"/>
-            </graph>
-        </field>
-    </record>
-
     <!-- EVENT.EVENT VIEWS -->
-    <record id="event_event_action_pivot" model="ir.actions.act_window" >
-        <field name="name">Events Analysis</field>
-        <field name="res_model">event.event</field>
-        <field name="view_mode">pivot,graph</field>
-        <field name="help" type="html">
-            <p class="o_view_nocontent_smiling_face">
-                No Event data yet!
-            </p><p>
-                Use this report to compare or aggregate event performances.
-            </p>
-        </field>
-    </record>
 
     <record model="ir.actions.act_window" id="action_event_view">
        <field name="name">Events</field>
@@ -340,10 +306,4 @@
         <field name="action" ref="event.action_event_view"/>
     </record>
 
-    <menuitem name="Events"
-        id="event_event_menu_pivot_report"
-        action="event_event_action_pivot"
-        sequence="3"
-        parent="event.menu_reporting_events"
-        groups="event.group_event_user"/>
 </data></odoo>

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -66,14 +66,11 @@
                             <field name="mobile" class="o_force_ltr" widget="phone"/>
                         </group>
                         <group string="Event Information" name="event">
-                            <field class="o_text_overflow" name="event_id" attrs="{'readonly': [('state', '!=', 'draft')]}" options="{'no_create': True}"/>
-                            <field name="event_ticket_id"
-                                domain="[
-                                    ('event_id', '=', event_id),
-                                    '|', ('seats_limited', '=', False), ('seats_available', '>', 0)
-                                ]"
-                                attrs="{'invisible': [('event_id', '=', False)]}"
-                                options="{'no_open': True, 'no_create': True}"/>
+                            <field class="o_text_overflow" name="event_id" attrs="{'readonly': [('state', '!=', 'draft')]}"
+                                   context="{'name_with_seats_availability': True}" options="{'no_create': True}"/>
+                            <field name="event_ticket_id" attrs="{'invisible': [('event_id', '=', False)]}"
+                                   context="{'name_with_seats_availability': True}" options="{'no_open': True, 'no_create': True}"
+                                   domain="[('event_id', '=', event_id)]"/>
                             <field name="partner_id"/>
                             <field name="create_date" string="Registration Date" groups="base.group_no_one"/>
                             <field name="date_closed" groups="base.group_no_one"/>
@@ -282,7 +279,7 @@
         <field name="name">Attendees</field>
         <field name="view_mode">tree,kanban,form,calendar,graph</field>
         <field name="domain">[('event_id', '=', active_id)]</field>
-        <field name="context">{'default_event_id': active_id}</field>
+        <field name="context">{'default_event_id': active_id, 'name_with_seats_availability': True}</field>
         <field name="search_view_id" ref="event_registration_view_search_event_specific"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">

--- a/addons/event_sale/__init__.py
+++ b/addons/event_sale/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
+from . import report
 from . import wizard

--- a/addons/event_sale/__manifest__.py
+++ b/addons/event_sale/__manifest__.py
@@ -27,12 +27,18 @@ this event.
         'data/event_sale_data.xml',
         'data/mail_data.xml',
         'report/event_event_templates.xml',
+        'report/event_sale_report_views.xml',
         'security/ir.model.access.csv',
+        'security/ir_rule.xml',
         'security/event_security.xml',
         'wizard/event_edit_registration.xml',
         'wizard/event_configurator_views.xml',
     ],
-    'demo': ['data/event_demo.xml'],
+    'demo': [
+        'data/event_sale_demo.xml',
+        'data/event_demo.xml',  # needs event_sale_demo
+        'data/event_registration_demo.xml',  # needs event_sale_demo
+    ],
     'installable': True,
     'auto_install': True,
     'assets': {

--- a/addons/event_sale/data/event_demo.xml
+++ b/addons/event_sale/data/event_demo.xml
@@ -6,35 +6,35 @@
         <field name="price">0</field>
     </record>
     <record id="event.event_0_ticket_1" model="event.event.ticket">
-        <field name="product_id" ref="product_product_event"/>
+        <field name="product_id" ref="product_product_event_standard"/>
         <field name="price">1000.0</field>
     </record>
     <record id="event.event_0_ticket_2" model="event.event.ticket">
-        <field name="product_id" ref="product_product_event"/>
+        <field name="product_id" ref="product_product_event_vip"/>
         <field name="price">1500.0</field>
     </record>
 
     <record id="event.event_2_ticket_1" model="event.event.ticket">
-        <field name="product_id" ref="product_product_event"/>
+        <field name="product_id" ref="product_product_event_standard"/>
         <field name="price">1000.0</field>
     </record>
     <record id="event.event_2_ticket_2" model="event.event.ticket">
-        <field name="product_id" ref="product_product_event"/>
+        <field name="product_id" ref="product_product_event_vip"/>
         <field name="price">1500.0</field>
     </record>
 
     <record id="event.event_4_ticket_0" model="event.event.ticket">
-        <field name="product_id" ref="product_product_event"/>
+        <field name="product_id" ref="product_product_event_standard"/>
         <field name="price">99.0</field>
     </record>
 
     <record id="event.event_7_ticket_1" model="event.event.ticket">
-        <field name="product_id" ref="product_product_event"/>
+        <field name="product_id" ref="product_product_event_standard"/>
         <field name="price">0.0</field>
     </record>
     <record id="event.event_7_ticket_2" model="event.event.ticket">
-        <field name="product_id" ref="product_product_event"/>
-        <field name="price">1000.0</field>
+        <field name="product_id" ref="product_product_event_vip"/>
+        <field name="price">0.0</field>
     </record>
 
 </odoo>

--- a/addons/event_sale/data/event_registration_demo.xml
+++ b/addons/event_sale/data/event_registration_demo.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<odoo><data>
+    <!-- Design fair -->
+    <record id="event.event_registration_0_0" model="event.registration">
+        <field name="sale_order_id" ref="event_sale.event_0_sale_order_0"/>
+        <field name="sale_order_line_id" ref="event_sale.event_0_sale_order_0_line_0"/>
+    </record>
+    <record id="event.event_registration_0_1" model="event.registration">
+        <field name="sale_order_id" ref="event_sale.event_0_sale_order_0"/>
+        <field name="sale_order_line_id" ref="event_sale.event_0_sale_order_0_line_0"/>
+    </record>
+    <record id="event.event_registration_0_2" model="event.registration">
+        <field name="sale_order_id" ref="event_sale.event_0_sale_order_0"/>
+        <field name="sale_order_line_id" ref="event_sale.event_0_sale_order_0_line_1"/>
+    </record>
+
+    <!-- Conference for architects -->
+    <record id="event.event_registration_2_0" model="event.registration">
+        <field name="sale_order_id" ref="event_sale.event_2_sale_order_0"/>
+        <field name="sale_order_line_id" ref="event_sale.event_2_sale_order_0_line_0"/>
+    </record>
+    <record id="event.event_registration_2_1" model="event.registration">
+        <field name="sale_order_id" ref="event_sale.event_2_sale_order_0"/>
+        <field name="sale_order_line_id" ref="event_sale.event_2_sale_order_0_line_0"/>
+    </record>
+    <record id="event.event_registration_2_2" model="event.registration">
+        <field name="sale_order_id" ref="event_sale.event_2_sale_order_0"/>
+        <field name="sale_order_line_id" ref="event_sale.event_2_sale_order_0_line_1"/>
+    </record>
+    <record id="event.event_registration_2_3" model="event.registration">
+        <field name="sale_order_id" ref="event_sale.event_2_sale_order_1"/>
+        <field name="sale_order_line_id" ref="event_sale.event_2_sale_order_1_line_0"/>
+    </record>
+    <record id="event.event_registration_2_4" model="event.registration">
+        <field name="sale_order_id" ref="event_sale.event_2_sale_order_1"/>
+        <field name="sale_order_line_id" ref="event_sale.event_2_sale_order_1_line_0"/>
+    </record>
+
+    <!-- Business Workshop -->
+    <record id="event.event_registration_4_0" model="event.registration">
+        <field name="sale_order_id" ref="event_sale.event_4_sale_order_0"/>
+        <field name="sale_order_line_id" ref="event_sale.event_4_sale_order_0_line_0"/>
+    </record>
+    <record id="event.event_registration_4_1" model="event.registration">
+        <field name="sale_order_id" ref="event_sale.event_4_sale_order_1"/>
+        <field name="sale_order_line_id" ref="event_sale.event_4_sale_order_1_line_0"/>
+    </record>
+    <record id="event.event_registration_4_2" model="event.registration">
+        <field name="sale_order_id" ref="event_sale.event_4_sale_order_2"/>
+        <field name="sale_order_line_id" ref="event_sale.event_4_sale_order_2_line_0"/>
+    </record>
+
+    <!-- OpenWood Collection Online Reveal: Gemini (all) -->
+    <record id="event.event_registration_7_0" model="event.registration">
+        <field name="sale_order_id" ref="event_sale.event_7_sale_order_0"/>
+        <field name="sale_order_line_id" ref="event_sale.event_7_sale_order_0_line_0"/>
+    </record>
+    <record id="event.event_registration_7_1" model="event.registration">
+        <field name="sale_order_id" ref="event_sale.event_7_sale_order_1"/>
+        <field name="sale_order_line_id" ref="event_sale.event_7_sale_order_1_line_0"/>
+    </record>
+    <record id="event.event_registration_7_2" model="event.registration">
+        <field name="sale_order_id" ref="event_sale.event_7_sale_order_0"/>
+        <field name="sale_order_line_id" ref="event_sale.event_7_sale_order_0_line_1"/>
+    </record>
+    <record id="event.event_registration_7_3" model="event.registration">
+        <field name="sale_order_id" ref="event_sale.event_7_sale_order_1"/>
+        <field name="sale_order_line_id" ref="event_sale.event_7_sale_order_1_line_1"/>
+    </record>
+</data></odoo>

--- a/addons/event_sale/data/event_sale_demo.xml
+++ b/addons/event_sale/data/event_sale_demo.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo><data>
+    <!-- ****** Products ****** -->
+    <record id="product_product_event_standard" model="product.product">
+        <field name="list_price">30.0</field>
+        <field name="standard_price">10.0</field>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
+        <field name="name">Event Registration - Standard</field>
+        <field name="description_sale" eval="False"/>
+        <field name="invoice_policy">order</field>
+        <field name="categ_id" ref="event_sale.product_category_events"/>
+        <field name="detailed_type">event</field>
+    </record>
+
+    <record id="product_product_event_vip" model="product.product">
+        <field name="list_price">100.0</field>
+        <field name="standard_price">50.0</field>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
+        <field name="name">Event Registration - VIP</field>
+        <field name="description_sale" eval="False"/>
+        <field name="invoice_policy">order</field>
+        <field name="categ_id" ref="event_sale.product_category_events"/>
+        <field name="detailed_type">event</field>
+    </record>
+
+    <!-- ****** Registrations ****** -->
+    <!-- Design fair -->
+    <record id="event_0_sale_order_0" model="sale.order">
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="partner_id" ref="base.res_partner_address_1"/>
+        <field name="pricelist_id" ref="product.list0"/>
+        <field name="date_order" eval="DateTime.now() - relativedelta(days=2)"/>
+        <field name="state">sale</field>
+    </record>
+    <record id="event_0_sale_order_0_line_0" model="sale.order.line">
+        <field name="order_id" ref="event_0_sale_order_0"/>
+        <field name="name">Event Registration - Standard</field>
+        <field name="product_id" ref="event_sale.product_product_event_standard"/>
+        <field name="price_unit">1000</field>
+        <field name="product_uom_qty">2</field>
+        <field name="event_id" ref="event.event_0"/>
+        <field name="event_ticket_id" ref="event.event_0_ticket_1"/>
+    </record>
+    <record id="event_0_sale_order_0_line_1" model="sale.order.line">
+        <field name="order_id" ref="event_0_sale_order_0"/>
+        <field name="name">Event Registration</field>
+        <field name="product_id" ref="event_sale.product_product_event"/>
+        <field name="price_unit">0</field>
+        <field name="product_uom_qty">1</field>
+        <field name="event_id" ref="event.event_0"/>
+        <field name="event_ticket_id" ref="event.event_0_ticket_0"/>
+    </record>
+
+    <!-- Conference for architects -->
+    <record id="event_2_sale_order_0" model="sale.order">
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="partner_id" ref="base.res_partner_address_2"/>
+        <field name="pricelist_id" ref="product.list0"/>
+        <field name="date_order" eval="DateTime.now() - relativedelta(days=0.5)"/>
+        <field name="state">sale</field>
+    </record>
+    <record id="event_2_sale_order_0_line_0" model="sale.order.line">
+        <field name="order_id" ref="event_2_sale_order_0"/>
+        <field name="name">Event Registration - Standard</field>
+        <field name="product_id" ref="event_sale.product_product_event_standard"/>
+        <field name="price_unit">1000</field>
+        <field name="product_uom_qty">2</field>
+        <field name="event_id" ref="event.event_2"/>
+        <field name="event_ticket_id" ref="event.event_2_ticket_1"/>
+    </record>
+    <record id="event_2_sale_order_0_line_1" model="sale.order.line">
+        <field name="order_id" ref="event_2_sale_order_0"/>
+        <field name="name">Event Registration - VIP</field>
+        <field name="product_id" ref="event_sale.product_product_event_vip"/>
+        <field name="price_unit">1500</field>
+        <field name="product_uom_qty">1</field>
+        <field name="event_id" ref="event.event_2"/>
+        <field name="event_ticket_id" ref="event.event_2_ticket_2"/>
+    </record>
+
+    <record id="event_2_sale_order_1" model="sale.order">
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="partner_id" ref="base.res_partner_address_3"/>
+        <field name="pricelist_id" ref="product.list0"/>
+        <field name="date_order" eval="DateTime.now() - relativedelta(days=1)"/>
+        <field name="state">sale</field>
+    </record>
+    <record id="event_2_sale_order_1_line_0" model="sale.order.line">
+        <field name="order_id" ref="event_2_sale_order_1"/>
+        <field name="name">Event Registration - Standard</field>
+        <field name="product_id" ref="event_sale.product_product_event_standard"/>
+        <field name="price_unit">1000</field>
+        <field name="product_uom_qty">2</field>
+        <field name="event_id" ref="event.event_2"/>
+        <field name="event_ticket_id" ref="event.event_2_ticket_1"/>
+    </record>
+
+    <!-- Business Workshop -->
+    <record id="event_4_sale_order_0" model="sale.order">
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="partner_id" ref="base.res_partner_address_7"/>
+        <field name="pricelist_id" ref="product.list0"/>
+        <field name="date_order" eval="DateTime.now() - relativedelta(days=8)"/>
+        <field name="state">sale</field>
+    </record>
+    <record id="event_4_sale_order_0_line_0" model="sale.order.line">
+        <field name="order_id" ref="event_4_sale_order_0"/>
+        <field name="name">Event Registration - Standard</field>
+        <field name="product_id" ref="event_sale.product_product_event_standard"/>
+        <field name="price_unit">499</field>
+        <field name="product_uom_qty">1</field>
+        <field name="event_id" ref="event.event_4"/>
+        <field name="event_ticket_id" ref="event.event_4_ticket_0"/>
+    </record>
+
+    <record id="event_4_sale_order_1" model="sale.order">
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="partner_id" ref="base.res_partner_address_13"/>
+        <field name="pricelist_id" ref="product.list0"/>
+        <field name="date_order" eval="DateTime.now() - relativedelta(days=7)"/>
+        <field name="state">sale</field>
+    </record>
+    <record id="event_4_sale_order_1_line_0" model="sale.order.line">
+        <field name="order_id" ref="event_4_sale_order_1"/>
+        <field name="name">Event Registration - Standard</field>
+        <field name="product_id" ref="event_sale.product_product_event_standard"/>
+        <field name="price_unit">499</field>
+        <field name="product_uom_qty">1</field>
+        <field name="event_id" ref="event.event_4"/>
+        <field name="event_ticket_id" ref="event.event_4_ticket_0"/>
+    </record>
+
+    <record id="event_4_sale_order_2" model="sale.order">
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="partner_id" ref="base.res_partner_address_14"/>
+        <field name="pricelist_id" ref="product.list0"/>
+        <field name="date_order" eval="DateTime.now() - relativedelta(days=7)"/>
+        <field name="state">sale</field>
+    </record>
+    <record id="event_4_sale_order_2_line_0" model="sale.order.line">
+        <field name="order_id" ref="event_4_sale_order_2"/>
+        <field name="name">Event Registration - Standard</field>
+        <field name="product_id" ref="event_sale.product_product_event_standard"/>
+        <field name="price_unit">499</field>
+        <field name="product_uom_qty">1</field>
+        <field name="event_id" ref="event.event_4"/>
+        <field name="event_ticket_id" ref="event.event_4_ticket_0"/>
+    </record>
+
+    <!-- OpenWood Collection Online Reveal: Gemini (all) -->
+    <record id="event_7_sale_order_0" model="sale.order">
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="partner_id" ref="base.res_partner_address_5"/>
+        <field name="pricelist_id" ref="product.list0"/>
+        <field name="state">sale</field>
+    </record>
+    <record id="event_7_sale_order_0_line_0" model="sale.order.line">
+        <field name="order_id" ref="event_7_sale_order_0"/>
+        <field name="name">Event Registration - Standard</field>
+        <field name="product_id" ref="event_sale.product_product_event_standard"/>
+        <field name="price_unit">0</field>
+        <field name="product_uom_qty">1</field>
+        <field name="event_id" ref="event.event_7"/>
+        <field name="event_ticket_id" ref="event.event_7_ticket_1"/>
+    </record>
+    <record id="event_7_sale_order_0_line_1" model="sale.order.line">
+        <field name="order_id" ref="event_7_sale_order_0"/>
+        <field name="name">Event Registration - VIP</field>
+        <field name="product_id" ref="event_sale.product_product_event_vip"/>
+        <field name="price_unit">0</field>
+        <field name="product_uom_qty">1</field>
+        <field name="event_id" ref="event.event_7"/>
+        <field name="event_ticket_id" ref="event.event_7_ticket_2"/>
+    </record>
+
+    <record id="event_7_sale_order_1" model="sale.order">
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="partner_id" ref="base.res_partner_address_25"/>
+        <field name="pricelist_id" ref="product.list0"/>
+        <field name="state">sale</field>
+    </record>
+    <record id="event_7_sale_order_1_line_0" model="sale.order.line">
+        <field name="order_id" ref="event_7_sale_order_1"/>
+        <field name="name">Event Registration - Standard</field>
+        <field name="product_id" ref="event_sale.product_product_event_standard"/>
+        <field name="price_unit">0</field>
+        <field name="product_uom_qty">1</field>
+        <field name="event_id" ref="event.event_7"/>
+        <field name="event_ticket_id" ref="event.event_7_ticket_1"/>
+    </record>
+    <record id="event_7_sale_order_1_line_1" model="sale.order.line">
+        <field name="order_id" ref="event_7_sale_order_1"/>
+        <field name="name">Event Registration - VIP</field>
+        <field name="product_id" ref="event_sale.product_product_event_vip"/>
+        <field name="price_unit">0</field>
+        <field name="product_uom_qty">1</field>
+        <field name="event_id" ref="event.event_7"/>
+        <field name="event_ticket_id" ref="event.event_7_ticket_2"/>
+    </record>
+</data></odoo>

--- a/addons/event_sale/report/__init__.py
+++ b/addons/event_sale/report/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import controllers
-from . import models
-from . import report
+from . import event_sale_report

--- a/addons/event_sale/report/event_sale_report.py
+++ b/addons/event_sale/report/event_sale_report.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, tools
+
+
+class EventSaleReport(models.Model):
+    """Event Registrations-based sales report, allowing to analyze sales and number of seats
+    by event (type), ticket, etc. Each opened record will also give access to all this information."""
+    _name = 'event.sale.report'
+    _description = 'Event Sales Report'
+    _auto = False
+    _rec_name = 'sale_order_line_id'
+
+    event_type_id = fields.Many2one('event.type', string='Event Type', readonly=True)
+    event_id = fields.Many2one('event.event', string='Event', readonly=True)
+    event_date_begin = fields.Date(string='Event Start Date', readonly=True)
+    event_date_end = fields.Date(string='Event End Date', readonly=True)
+    event_ticket_id = fields.Many2one('event.event.ticket', string='Event Ticket', readonly=True)
+    event_ticket_price = fields.Float(string='Ticket price', readonly=True)
+    event_registration_create_date = fields.Date(string='Registration Date', readonly=True)
+    event_registration_state = fields.Selection([
+        ('draft', 'Unconfirmed'), ('cancel', 'Cancelled'),
+        ('open', 'Confirmed'), ('done', 'Attended')],
+        string='Registration Status', readonly=True)
+    active = fields.Boolean('Is registration active (not archived)?')
+    event_registration_id = fields.Many2one('event.registration', readonly=True)
+    event_registration_name = fields.Char('Attendee Name', readonly=True)
+
+    product_id = fields.Many2one('product.product', string='Product', readonly=True)
+    sale_order_id = fields.Many2one('sale.order', readonly=True)
+    sale_order_date = fields.Datetime('Order Date', readonly=True)
+    sale_order_partner_id = fields.Many2one('res.partner', string='Customer', readonly=True)
+    sale_order_state = fields.Selection([
+        ('draft', 'Quotation'),
+        ('sent', 'Quotation Sent'),
+        ('sale', 'Sales Order'),
+        ('done', 'Locked'),
+        ('cancel', 'Cancelled'),
+        ], string='Sale Order Status', readonly=True)
+    sale_order_user_id = fields.Many2one('res.users', string='Salesperson', readonly=True)
+    sale_order_line_id = fields.Many2one('sale.order.line', readonly=True)
+    sale_price = fields.Float('Revenues', readonly=True)
+    sale_price_untaxed = fields.Float('Untaxed Revenues', readonly=True)
+    invoice_partner_id = fields.Many2one('res.partner', string='Invoice Address', readonly=True)
+    is_paid = fields.Boolean('Is Paid', readonly=True)
+    payment_status = fields.Selection(string="Payment Status", selection=[
+            ('to_pay', 'Not Paid'),
+            ('paid', 'Paid'),
+            ('free', 'Free'),
+        ])
+    company_id = fields.Many2one('res.company', string='Company', readonly=True)
+
+    def init(self):
+        tools.drop_view_if_exists(self._cr, self._table)
+        self._cr.execute('CREATE OR REPLACE VIEW %s AS (%s);' % (self._table, self._query()))
+
+    def _query(self, with_=None, select=None, join=None, group_by=None):
+        return "\n".join([
+            self._with_clause(*(with_ or [])),
+            self._select_clause(*(select or [])),
+            self._from_clause(*(join or [])),
+            self._group_by_clause(*(group_by or []))
+        ])
+
+    def _with_clause(self, *with_):
+        # Extra clauses formatted as `cte1 AS (SELECT ...)`, `cte2 AS (SELECT ...)`...
+        return """
+WITH 
+    """ + ',\n    '.join(with_) if with_ else ''
+
+    def _select_clause(self, *select):
+        # Extra clauses formatted as `cte1.column1 AS new_column1`, `table1.column2 AS new_column2`...
+        return """
+SELECT
+    ROW_NUMBER() OVER (ORDER BY event_registration.id) AS id,
+    
+    event_registration.id AS event_registration_id,
+    event_registration.company_id AS company_id,
+    event_registration.event_id AS event_id,
+    event_registration.event_ticket_id AS event_ticket_id,
+    event_registration.create_date AS event_registration_create_date,
+    event_registration.name AS event_registration_name,
+    event_registration.state AS event_registration_state, 
+    event_registration.active AS active,
+    event_registration.sale_order_id AS sale_order_id,
+    event_registration.sale_order_line_id AS sale_order_line_id,
+    event_registration.is_paid AS is_paid,
+    
+    event_event.event_type_id AS event_type_id,
+    event_event.date_begin AS event_date_begin,
+    event_event.date_end AS event_date_end,
+
+    event_event_ticket.price AS event_ticket_price,
+
+    sale_order.date_order AS sale_order_date,
+    sale_order.partner_invoice_id AS invoice_partner_id,
+    sale_order.partner_id AS sale_order_partner_id,
+    sale_order.state AS sale_order_state,
+    sale_order.user_id AS sale_order_user_id,
+    
+    sale_order_line.product_id AS product_id,
+    sale_order_line.price_total
+        / CASE COALESCE(sale_order.currency_rate, 0) WHEN 0 THEN 1.0 ELSE sale_order.currency_rate END
+        / sale_order_line.product_uom_qty AS sale_price,
+    sale_order_line.price_subtotal
+        / CASE COALESCE(sale_order.currency_rate, 0) WHEN 0 THEN 1.0 ELSE sale_order.currency_rate END
+        / sale_order_line.product_uom_qty AS sale_price_untaxed,
+    CASE
+        WHEN sale_order_line.price_total = 0 THEN 'free'
+        WHEN event_registration.is_paid THEN 'paid'
+        ELSE 'to_pay'
+    END payment_status""" + (',\n    ' + ',\n    '.join(select) if select else '')
+
+    def _from_clause(self, *join_):
+        # Extra clauses formatted as `column1`, `column2`...
+        return """
+FROM event_registration
+LEFT JOIN event_event ON event_event.id = event_registration.event_id
+LEFT JOIN event_event_ticket ON event_event_ticket.id = event_registration.event_ticket_id
+LEFT JOIN sale_order ON sale_order.id = event_registration.sale_order_id
+LEFT JOIN sale_order_line ON sale_order_line.id = event_registration.sale_order_line_id
+""" + ('\n'.join(join_) + '\n' if join_ else '')
+
+    def _group_by_clause(self, *group_by):
+        # Extra clauses formatted like `column1`, `column2`...
+        return """
+GROUP BY
+    """ + ',\n    '.join(group_by) if group_by else ''

--- a/addons/event_sale/report/event_sale_report_views.xml
+++ b/addons/event_sale/report/event_sale_report_views.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="event_sale_report_view_graph" model="ir.ui.view">
+        <field name="name">event.sale.report.view.graph</field>
+        <field name="model">event.sale.report</field>
+        <field name="arch" type="xml">
+            <graph string="Revenues" sample="1" type="line">
+                <field name="sale_price" type="measure"/>
+                <field name="event_registration_create_date" interval="day"/>
+                <field name="event_ticket_price" type="measure" invisible="True"/>
+            </graph>
+        </field>
+    </record>
+
+    <record id="event_sale_report_view_form" model="ir.ui.view">
+        <field name="name">event.sale.report.view.form</field>
+        <field name="model">event.sale.report</field>
+        <field name="arch" type="xml">
+            <form string="Registration revenues" edit="false" create="false">
+                <sheet>
+                    <group col="2">
+                        <group string="Event">
+                            <field name="event_type_id"/>
+                            <field name="event_id"/>
+                            <field name="event_date_begin"/>
+                        </group>
+                        <group string="Registration">
+                            <field name="event_registration_id"/>
+                            <field name="event_registration_name"/>
+                            <field name="event_registration_create_date"/>
+                            <field name="event_ticket_id"/>
+                            <field name="event_registration_state"/>
+                        </group>
+                    </group>
+                    <group col="2">
+                        <group string="Sale Order">
+                            <field name="sale_order_partner_id"/>
+                            <field name="sale_order_id"/>
+                            <field name="product_id"/>
+                        </group>
+                        <group string="Revenues">
+                            <field name="event_ticket_price"/>
+                            <field name="sale_price_untaxed"/>
+                            <field name="sale_price"/>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="event_sale_report_view_pivot" model="ir.ui.view">
+        <field name="name">event.sale.report.view.pivot</field>
+        <field name="model">event.sale.report</field>
+        <field name="arch" type="xml">
+            <pivot string="Revenues" sample="1">
+                <field name="sale_price_untaxed" type="measure"/>
+                <field name="sale_price" type="measure"/>
+                <field name="event_id" type="row"/>
+                <field name="product_id" type="row"/>
+                <field name="event_ticket_price" invisible="True"/>
+            </pivot>
+        </field>
+    </record>
+
+    <record id="event_sale_report_view_tree" model="ir.ui.view">
+        <field name="name">event.sale.report.view.tree</field>
+        <field name="model">event.sale.report</field>
+        <field name="arch" type="xml">
+            <tree string="Revenues" edit="false" create="false">
+                <field name="event_id"/>
+                <field name="event_ticket_id"/>
+                <field name="product_id" optional="hide"/>
+                <field name="event_ticket_price"/>
+                <field name="sale_price_untaxed" optional="hide"/>
+                <field name="sale_price" optional="hide"/>
+                <field name="event_registration_state" optional="hide"/>
+                <field name="sale_order_partner_id"/>
+                <field name="invoice_partner_id" optional="hide"/>
+                <field name="event_registration_name" optional="hide"/>
+                <field name="sale_order_state" widget="badge"
+                       decoration-success="sale_order_state == 'sale' or sale_order_state == 'done'"
+                       decoration-info="sale_order_state == 'draft' or sale_order_state == 'sent'"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="event_sale_report_view_search" model="ir.ui.view">
+        <field name="name">event.sale.report.view.search</field>
+        <field name="model">event.sale.report</field>
+        <field name="arch" type="xml">
+            <search string="Event Sales Analysis">
+                <field name="event_id"/>
+                <field name="event_registration_name" string="Participant"/>
+                <field name="sale_order_partner_id" string="Booked by"/>
+                <field name="company_id"/>
+                <filter string="Non-free tickets" name="priced_tickets" domain="[('event_ticket_price', '!=', 0)]"/>
+                <separator/>
+                <filter string="Free" name="free" domain="[('payment_status', '=', 'free')]"/>
+                <filter string="Pending payment" name="payment_pending" domain="[('payment_status', '=', 'to_pay')]"/>
+                <filter string="Paid" name="is_paid" domain="[('payment_status', '=', 'paid')]"/>
+                <separator/>
+                <filter string="Registration Date" name="event_registration_create_date" date="event_registration_create_date" default_period="this_year"/>
+                <separator/>
+                <filter string="Upcoming/Running" name="upcoming" help="Upcoming events from today"
+                        domain="[('event_date_end', '&gt;=', datetime.datetime.combine(context_today(), datetime.time(0,0,0)))]"/>
+                <filter string="Past Events" name="past" help="Events that have ended"
+                        domain="[('event_date_end', '&lt;', datetime.datetime.combine(context_today(), datetime.time(0,0,0)))]"/>
+                <filter string="Event Start Date" name="event_date_start" date="event_date_begin" default_period="this_year"/>
+                <filter string="Event End Date" name="event_date_end" date="event_date_end"/>
+                <group expand="0" string="Group By">
+                    <filter string="Event Type" name="group_by_event_type_id" context="{'group_by': 'event_type_id' }"/>
+                    <filter string="Event" name="group_by_event_id" context="{'group_by': 'event_id' }"/>
+                    <separator/>
+                    <filter string="Product" name="group_by_product_id" context="{'group_by': 'product_id'}"/>
+                    <filter string="Ticket" name="group_by_ticket_id" context="{'group_by': 'event_ticket_id'}"/>
+                    <separator/>
+                    <filter string="Registration Status" name="group_by_registration_state"
+                            context="{'group_by': 'event_registration_state'}"/>
+                    <filter string="Sale Order Status" name="group_by_sale_order_state"
+                            context="{'group_by': 'sale_order_state'}"/>
+                    <filter string="Customer" name="group_by_customer" context="{'group_by': 'sale_order_partner_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="event_sale_report_action" model="ir.actions.act_window">
+        <field name="name">Revenues</field>
+        <field name="res_model">event.sale.report</field>
+        <field name="view_mode">graph,pivot</field>
+        <field name="context">{
+            'search_default_priced_tickets': 1,
+            'search_default_event_date_start': 1,
+            'pivot_measures': ['__count__', 'sale_price_untaxed', 'sale_price'],
+        }</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No Event Revenues yet!
+            </p><p>
+                Come back once tickets have been sold to overview your sales income.
+            </p>
+        </field>
+    </record>
+
+    <menuitem name="Revenues"
+        id="menu_action_show_revenues"
+        action="event_sale_report_action"
+        sequence="5"
+        parent="event.menu_reporting_events"
+        groups="event.group_event_user"/>
+</odoo>

--- a/addons/event_sale/security/ir.model.access.csv
+++ b/addons/event_sale/security/ir.model.access.csv
@@ -4,3 +4,4 @@ access_product_product_event_manager,product.product.event.manager,product.model
 access_registration_editor,access.registration.editor,model_registration_editor,sales_team.group_sale_salesman,1,1,1,0
 access_registration_editor_line,access.registration.editor.line,model_registration_editor_line,sales_team.group_sale_salesman,1,1,1,1
 access_event_event_configurator,access.event.event.configurator,model_event_event_configurator,sales_team.group_sale_salesman,1,1,1,0
+access_event_sale_report_manager,access.event.sale.report.manager,model_event_sale_report,event.group_event_manager,1,1,1,1

--- a/addons/event_sale/security/ir_rule.xml
+++ b/addons/event_sale/security/ir_rule.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <!-- Multi - Company Rules -->
+    <record id="event_sale_report_comp_rule" model="ir.rule">
+        <field name="name">Event Sales Report multi-company</field>
+        <field name="model_id" ref="model_event_sale_report"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+    </record>
+
+</odoo>

--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -146,6 +146,8 @@ class TestEventSale(TestEventSaleCommon):
             'email': 'manual.email.2@test.example.com',
             'mobile': '+32456222222',
         })
+
+        self.assertFalse(editor.seats_available_insufficient)
         editor.action_make_registration()
 
         # check editor correctly created new registrations with information coming from it or SO as fallback
@@ -191,6 +193,135 @@ class TestEventSale(TestEventSaleCommon):
 
         self.assertEqual(editor_action['type'], 'ir.actions.act_window')
         self.assertEqual(editor_action['res_model'], 'registration.editor')
+
+    @users('user_sales_salesman')
+    def test_event_sale_free_confirm(self):
+        """Check that even with the event's `no_confirm`, free registrations are immediately
+        confirmed if the seats are available.
+        """
+        TICKET_COUNT = 3
+        customer_so = self.customer_so.with_user(self.env.user)
+        ticket = self.event_0.event_ticket_ids[0]
+
+        # Limiting seats
+        self.event_0.write({
+            "auto_confirm": False,
+            "seats_limited": True,
+            "seats_max": 5
+        })
+
+        customer_so.write({
+            'order_line': [
+                (0, 0, {
+                    'event_id': self.event_0.id,
+                    'event_ticket_id': ticket.id,
+                    'product_id': ticket.product_id.id,
+                    'product_uom_qty': TICKET_COUNT,
+                    'price_unit': 0,
+                })
+            ]
+        })
+
+        editor = self.env['registration.editor'].with_context({
+            'default_sale_order_id': customer_so.id
+        }).create({})
+
+        self.assertFalse(editor.seats_available_insufficient)
+
+        editor.action_make_registration()
+        self.assertEqual(len(self.event_0.registration_ids), TICKET_COUNT)
+        self.assertTrue(all(reg.state == "open" for reg in self.event_0.registration_ids))
+
+    @users('user_sales_salesman')
+    def test_event_sale_free_full_event_no_confirm(self):
+        """Check that even free registrations are not immediately confirmed if there are not
+        enough seats available for the event.
+        """
+        TICKET_COUNT = 3
+        customer_so = self.customer_so.with_user(self.env.user)
+        ticket = self.event_0.event_ticket_ids[0]
+
+        # Limiting event seats
+        self.event_0.write({
+            "auto_confirm": False,
+            "seats_limited": True,
+            "seats_max": 2
+        })
+
+        # adding too many tickets to SO in two different lines
+        customer_so.write({
+            'order_line': [
+                (0, 0, {
+                    'event_id': self.event_0.id,
+                    'event_ticket_id': ticket.id,
+                    'product_id': ticket.product_id.id,
+                    'product_uom_qty': TICKET_COUNT - 1,
+                    'price_unit': 0,
+                }),
+                (0, 0, {
+                    'event_id': self.event_0.id,
+                    'event_ticket_id': ticket.id,
+                    'product_id': ticket.product_id.id,
+                    'product_uom_qty': 1,
+                    'price_unit': 0,
+                })
+            ]
+        })
+
+        editor = self.env['registration.editor'].with_context({
+            'default_sale_order_id': customer_so.id
+        }).create({})
+
+        self.assertTrue(editor.seats_available_insufficient)
+
+        editor.action_make_registration()
+        self.assertEqual(len(self.event_0.registration_ids), TICKET_COUNT)
+        self.assertTrue(all(reg.state == "draft" for reg in self.event_0.registration_ids))
+
+    @users('user_sales_salesman')
+    def test_event_sale_free_full_ticket_no_confirm(self):
+        """Check that even free registrations are not immediately confirmed if there are not enough
+        seats available for the requested tickets.
+        """
+        TICKET_COUNT = 3
+        customer_so = self.customer_so.with_user(self.env.user)
+        ticket = self.event_0.event_ticket_ids[0]
+
+        self.event_0.write({"auto_confirm": False})
+        # Limiting ticket seats
+        ticket.write({
+            "seats_limited": True,
+            "seats_max": 2,
+        })
+        # adding too many tickets to SO in two different lines
+        customer_so.write({
+            'order_line': [
+                (0, 0, {
+                    'event_id': self.event_0.id,
+                    'event_ticket_id': ticket.id,
+                    'product_id': ticket.product_id.id,
+                    'product_uom_qty': TICKET_COUNT - 1,
+                    'price_unit': 0,
+                }),
+                (0, 0, {
+                    'event_id': self.event_0.id,
+                    'event_ticket_id': ticket.id,
+                    'product_id': ticket.product_id.id,
+                    'product_uom_qty': 1,
+                    'price_unit': 0,
+                })
+            ]
+        })
+
+        editor = self.env['registration.editor'].with_context({
+            'default_sale_order_id': customer_so.id
+        }).create({})
+
+        self.assertTrue(editor.seats_available_insufficient)
+
+        editor.action_make_registration()
+        self.assertEqual(len(self.event_0.registration_ids), TICKET_COUNT)
+        self.assertTrue(all(reg.state == "draft" for reg in self.event_0.registration_ids))
 
     def test_ticket_price_with_pricelist_and_tax(self):
         self.env.user.partner_id.country_id = False

--- a/addons/event_sale/views/sale_order_views.xml
+++ b/addons/event_sale/views/sale_order_views.xml
@@ -25,9 +25,8 @@
                 <field
                     name="event_ticket_id"
                     domain="[
-                        ('event_id', '=', event_id),
-                        ('product_id','=',product_id),
-                        '|', ('seats_limited', '=', False), ('seats_available', '>', 0), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)
+                        ('event_id', '=', event_id), ('product_id','=',product_id),
+                         '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)
                     ]"
                     attrs="{
                         'invisible': ['|', ('event_ok', '=', False), ('event_id', '=', False)],

--- a/addons/event_sale/wizard/event_configurator.py
+++ b/addons/event_sale/wizard/event_configurator.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields
+from odoo import _, api, models, fields
+from odoo.exceptions import ValidationError
 
 
 class EventConfigurator(models.TransientModel):
@@ -11,3 +12,13 @@ class EventConfigurator(models.TransientModel):
     product_id = fields.Many2one('product.product', string="Product", readonly=True)
     event_id = fields.Many2one('event.event', string="Event")
     event_ticket_id = fields.Many2one('event.event.ticket', string="Event Ticket")
+
+    @api.constrains('event_id', 'event_ticket_id')
+    def check_event_id(self):
+        error_messages = []
+        for record in self:
+            if record.event_id.id != record.event_ticket_id.event_id.id:
+                error_messages.append(
+                    _('Invalid ticket choice "%(ticket_name)s" for event "%(event_name)s".'))
+        if error_messages:
+            raise ValidationError('\n'.join(error_messages))

--- a/addons/event_sale/wizard/event_configurator_views.xml
+++ b/addons/event_sale/wizard/event_configurator_views.xml
@@ -13,19 +13,17 @@
                             ('date_end','&gt;=',time.strftime('%Y-%m-%d 00:00:00'))
                         ]"
                         required="1"
+                        context="{'name_with_seats_availability': True}"
                         options="{'no_open': True, 'no_create': True}"
                     />
                     <field
                         name="event_ticket_id"
-                        domain="[
-                            ('event_id', '=', event_id),
-                            ('product_id','=',product_id),
-                            '|', ('seats_limited', '=', False), ('seats_available', '>', 0)
-                        ]"
+                        domain="[('event_id', '=', event_id), ('product_id', '=', product_id)]"
                         attrs="{
                             'invisible': [('event_id', '=', False)],
                             'required': [('event_id', '!=', False)],
                         }"
+                        context="{'name_with_seats_availability': True}"
                         options="{'no_open': True, 'no_create': True}"
                     />
                     <field name="product_id" invisible="1"/>
@@ -43,6 +41,7 @@
         <field name="res_model">event.event.configurator</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
+        <field name="context">{'name_with_seats_availability': True}</field>
         <field name="view_id" ref="event_configurator_view_form"/>
     </record>
 </odoo>

--- a/addons/event_sale/wizard/event_edit_registration.xml
+++ b/addons/event_sale/wizard/event_edit_registration.xml
@@ -6,23 +6,31 @@
             <field name="model">registration.editor</field>
             <field name="arch" type="xml">
                 <form string="Registration">
-                    <p>Before confirming <field name="sale_order_id" readonly="1" class="oe_inline"/>
-                    please give details about the registrations</p>
-                    <field name="event_registration_ids">
-                        <tree string="Registration" editable="top" create="false" delete="false">
-                            <field name="event_id" readonly='1' force_save="1"/>
-                            <field name="registration_id" readonly='1' force_save="1"/>
-                            <field name="event_ticket_id" domain="[('event_id', '=', event_id)]" readonly='1' force_save="1"/>
-                            <field name="name"/>
-                            <field name="email"/>
-                            <field name="mobile" class="o_force_ltr"/>
-                            <field name="phone" class="o_force_ltr"/>
-                            <field name="sale_order_line_id" invisible="1"/>
-                        </tree>
-                    </field>
+                    <field name="seats_available_insufficient" invisible="1"/>
+                    <div class="alert alert-warning m-0" role="alert" attrs="{'invisible': [('seats_available_insufficient', '=', False)]}">
+                        <p class="my-0">
+                            <span>Not enough seats available. All registrations were created as "Unconfirmed" and can be updated later on.</span>
+                        </p>
+                    </div>
+                    <sheet>
+                        <p>Before updating the linked registrations of <field name="sale_order_id" readonly="1" class="oe_inline"/>
+                        please give attendee details.</p>
+                        <field name="event_registration_ids">
+                            <tree string="Registration" editable="top" create="false" delete="false">
+                                <field name="event_id" readonly='1' force_save="1"/>
+                                <field name="registration_id" readonly='1' force_save="1"/>
+                                <field name="event_ticket_id" domain="[('event_id', '=', event_id)]" readonly='1' force_save="1"/>
+                                <field name="name"/>
+                                <field name="email"/>
+                                <field name="mobile" class="o_force_ltr"/>
+                                <field name="phone" class="o_force_ltr"/>
+                                <field name="sale_order_line_id" invisible="1"/>
+                            </tree>
+                        </field>
+                    </sheet>
                     <footer>
-                        <button string="Confirm" name="action_make_registration" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="z"/>
+                        <button string="Create/Update registrations" name="action_make_registration" type="object" class="btn-primary" data-hotkey="q"/>
+                        <button string="Skip" class="btn-secondary" special="cancel" data-hotkey="z"/>
                     </footer>
                 </form>
             </field>

--- a/addons/test_event_full/tests/test_performance.py
+++ b/addons/test_event_full/tests/test_performance.py
@@ -36,7 +36,7 @@ class TestEventPerformance(EventPerformanceCase):
         batch_size = 20
 
         # simple without type involved
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=343):  # 337 (sometimes +6)
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=342):  # 336 (sometimes +6)
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = [
                 dict(self.event_base_vals,
@@ -107,7 +107,7 @@ class TestEventPerformance(EventPerformanceCase):
         has_social = 'social_menu' in self.env['event.event']  # otherwise view may crash in enterprise
 
         # no type, no website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=234):  # tef only: 184 - com runbot: 184
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=229):  # tef only: 179? - com runbot: 179
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.event']) as event_form:
                 event_form.name = 'Test Event'
@@ -159,7 +159,7 @@ class TestEventPerformance(EventPerformanceCase):
     def test_event_create_single_notype(self):
         """ Test a single event creation """
         # simple without type involved
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=39):  # 33 (sometimes +6)
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=38):  # 32 (sometimes +6)
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = dict(
                 self.event_base_vals,
@@ -249,7 +249,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=245):  # tef only: 201 - com runbot 240 - ent runbot 245
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=240):  # tef only: 197? - com runbot 236
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = [
                 dict(reg_data,
@@ -321,7 +321,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """ Test a single registration creation using Form """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=142):  # tef only: 124 - com runbot 126
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=138):  # tef only: 120? - com runbot 122
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.registration'].with_context(event_lead_rule_skip=True)) as reg_form:
                 reg_form.event_id = event

--- a/addons/test_event_full/tests/test_performance.py
+++ b/addons/test_event_full/tests/test_performance.py
@@ -52,7 +52,7 @@ class TestEventPerformance(EventPerformanceCase):
         batch_size = 20
 
         # simple without type involved + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5484):  # tef only: 5069 (5065) - com runbot: 5059 - ent runbot 5484
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5483):  # tef only: 5068? (5064?) - com runbot: 5058 - ent runbot 5483
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = [
                 dict(self.event_base_vals,
@@ -125,7 +125,7 @@ class TestEventPerformance(EventPerformanceCase):
         has_social = 'social_menu' in self.env['event.event']  # otherwise view may crash in enterprise
 
         # no type, website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=691):  # tef only: 637 - com runbot: 587 - ent runbot: 691
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=692):  # tef only: 638? - com runbot: 588 - ent runbot: 692
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.event']) as event_form:
                 event_form.name = 'Test Event'
@@ -172,7 +172,7 @@ class TestEventPerformance(EventPerformanceCase):
     def test_event_create_single_notype_website(self):
         """ Test a single event creation """
         # simple without type involved + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=373):  # tef only: 358 (353) - com runbot: 284 - ent runbot 373
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=372):  # tef only: 347? (342?) - com runbot: 346 - ent runbot 372
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = dict(
                 self.event_base_vals,
@@ -225,7 +225,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=716):  # tef only: 674 - com runbot 713 - ent runbot 716
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=714):  # tef only: 672? - com runbot 711 - ent runbot 714
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = [
                 dict(reg_data,
@@ -271,7 +271,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         form like) """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=727):  # tef only: 685 - com runbot 724 - ent runbot: 727
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=725):  # tef only: 683? - com runbot 722 - ent runbot: 725
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = [
                 dict(reg_data,
@@ -292,7 +292,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """ Test a single registration creation using Form """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=227):  # tef only: 210 - com runbot: 213 - ent runbot: 227
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=225):  # tef only: 208? - com runbot: 211 - ent runbot: 225
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.registration']) as reg_form:
                 reg_form.event_id = event
@@ -308,7 +308,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """ Test a single registration creation using Form """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=229):  # tef only: 213 - com runbot: 214 - ent runbot: 229
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=227):  # tef only: 211? - com runbot: 212 - ent runbot: 227
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.registration']) as reg_form:
                 reg_form.event_id = event
@@ -335,7 +335,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # simple customer data
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=139):  # tef only: 135 - com runbot: 137 - ent runbot: 139
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=138):  # tef only: 133? - com runbot: 135 - ent runbot: 138
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = dict(
                 self.customer_data[0],
@@ -349,7 +349,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # partner-based customer
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=145):  # tef only: 143 - com runbot: 144 - ent runbot: 145
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=143):  # tef only: 141? - com runbot: 142 - ent runbot: 143
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = {
                 'event_id': event.id,
@@ -364,7 +364,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # partner-based customer
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=147):  # tef only: 56 - com runbot: 58 - ent runbot: 147
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=56):  # tef only: 54? - com runbot: 54 - ent runbot: 56
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = {
                 'event_id': event.id,
@@ -379,7 +379,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # website customer data
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=147):  # tef only: 142 - com runbot: 143 - ent runbot: 147
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=145):  # tef only: 140? - com runbot: 141 - ent runbot: 145
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = dict(
                 self.website_customer_data[0],
@@ -436,7 +436,7 @@ class TestOnlineEventPerformance(EventPerformanceCase, UtilPerf):
         # website customer data
         with freeze_time(self.reference_now):
             self.authenticate(None, None)
-            with self.assertQueryCount(default=31):
+            with self.assertQueryCount(default=31):  # tef only: 29? - com runbot: 29 - ent runbot: 31
                 self._test_url_open('/event/%i' % self.test_event.id)
 
     @warmup

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -120,7 +120,7 @@
     <div t-if="toast_message" class="o_wevent_register_toaster d-none" t-att-data-message="toast_message"/>
     <div t-if="not event.event_registrations_open" class="bg-white mb-5">
         <div class="alert alert-info mb-0 d-flex justify-content-between align-items-center" role="status">
-            <t t-if="not event.event_registrations_started">
+            <t t-if="not event.event_registrations_started and not event.event_registrations_sold_out">
                 <div class="col-md-8 d-flex">
                     <em class="mr-2">Ticket Sales starting on
                         <span class="" t-out="event.start_sale_datetime"
@@ -204,7 +204,7 @@
                                     </t>
                                 </select>
                                 <div t-else="" class="text-danger">
-                                    <span t-if="not ticket.sale_available and not ticket.is_expired and ticket.is_launched()" >Sold Out</span>
+                                    <span t-if="not ticket.sale_available and not ticket.is_expired and ticket.is_launched" >Sold Out</span>
                                     <span t-if="ticket.is_expired">Expired</span>
                                 </div>
                             </div>

--- a/addons/website_event_sale/__manifest__.py
+++ b/addons/website_event_sale/__manifest__.py
@@ -11,6 +11,7 @@ Sell event tickets through eCommerce app.
     'depends': ['website_event', 'event_sale', 'website_sale'],
     'data': [
         'data/event_data.xml',
+        'report/event_sale_report_views.xml',
         'views/event_event_views.xml',
         'views/website_event_templates.xml',
         'views/website_sale_templates.xml',

--- a/addons/website_event_sale/report/__init__.py
+++ b/addons/website_event_sale/report/__init__.py
@@ -1,0 +1,1 @@
+from . import event_sale_report

--- a/addons/website_event_sale/report/event_sale_report.py
+++ b/addons/website_event_sale/report/event_sale_report.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class EventSaleReport(models.Model):
+    _inherit = 'event.sale.report'
+
+    is_published = fields.Boolean('Published Events', readonly=True)
+
+    def _select_clause(self, *select):
+        return super()._select_clause('event_event.is_published as is_published', *select)

--- a/addons/website_event_sale/report/event_sale_report_views.xml
+++ b/addons/website_event_sale/report/event_sale_report_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="event_sale_report_view_search" model="ir.ui.view">
+        <field name="name">event.sale.report.view.search.inherit.website</field>
+        <field name="model">event.sale.report</field>
+        <field name="inherit_id" ref="event_sale.event_sale_report_view_search"/>
+        <field name="arch" type="xml">
+            <xpath expr="//search" position="inside">
+                <filter string="Published Events" name="is_published" domain="[('is_published', '=', True)]"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR tackles event registrations in two ways:

1. In order to reduce the concurrent writes on the database occurring when many users book at the same time, this unstores seats availability on events and tickets.

2. To provide better tools to analyse revenues specifically generated from events, we add an event sales report (+ a dashboard with Enterprise).

Task-2654816
Task-2679881
See odoo/upgrade#3118
See odoo/enterprise#24472