### PR TITLE
[13.0][FIX] wrong assignments of tax accounts in l10n_jp

### DIFF
--- a/addons/l10n_jp/data/account_tax_template_data.xml
+++ b/addons/l10n_jp/data/account_tax_template_data.xml
@@ -240,7 +240,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('A11807'),
+                'account_id': ref('A11809'),
                 'plus_report_line_ids': [ref('l10n_jp.tax_report_to_pay_temp_pmt_susp_cons_8')],
             }),
         ]"/>
@@ -253,7 +253,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('A11807'),
+                'account_id': ref('A11809'),
                 'minus_report_line_ids': [ref('l10n_jp.tax_report_to_pay_temp_pmt_susp_cons_8')],
             }),
         ]"/>
@@ -278,7 +278,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('A11807'),
+                'account_id': ref('A11809'),
                 'plus_report_line_ids': [ref('l10n_jp.tax_report_to_pay_temp_pmt_susp_cons_10')],
             }),
         ]"/>
@@ -291,7 +291,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('A11807'),
+                'account_id': ref('A11809'),
                 'minus_report_line_ids': [ref('l10n_jp.tax_report_to_pay_temp_pmt_susp_cons_10')],
             }),
         ]"/>
@@ -316,7 +316,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('A11807'),
+                'account_id': ref('A11809'),
                 'plus_report_line_ids': [ref('l10n_jp.tax_report_to_pay_temp_pmt_susp_cons_8')],
             }),
         ]"/>
@@ -329,7 +329,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('A11807'),
+                'account_id': ref('A11809'),
                 'minus_report_line_ids': [ref('l10n_jp.tax_report_to_pay_temp_pmt_susp_cons_8')],
             }),
         ]"/>
@@ -354,7 +354,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('A11807'),
+                'account_id': ref('A11809'),
                 'plus_report_line_ids': [ref('l10n_jp.tax_report_to_pay_temp_pmt_susp_cons_10')],
             }),
         ]"/>
@@ -367,7 +367,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('A11807'),
+                'account_id': ref('A11809'),
                 'minus_report_line_ids': [ref('l10n_jp.tax_report_to_pay_temp_pmt_susp_cons_10')],
             }),
         ]"/>


### PR DESCRIPTION
This PR is related to https://github.com/odoo/odoo/pull/21822. It was fixed, but I got the same issue in 13.0 and later versions again.

Description of the issue/feature this PR addresses:

   Fixes the wrong assignments of tax accounts in taxes

Current behavior before PR:

  Wrong accounts are proposed for taxes.

Desired behavior after PR is merged:

  Correct accounts are proposed for taxes.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

@qrtl