### PR TITLE
[FIX] stock_account: right aml with manual valuation

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -230,7 +230,7 @@ class AccountMoveLine(models.Model):
             and self.move_id.is_purchase_document():
             fiscal_position = self.move_id.fiscal_position_id
             accounts = self.product_id.product_tmpl_id.get_product_accounts(fiscal_pos=fiscal_position)
-            if accounts['stock_input']:
+            if accounts['stock_input'] and self.product_id.valuation == 'real_time':
                 return accounts['stock_input']
         return super(AccountMoveLine, self)._get_computed_account()
 


### PR DESCRIPTION
Steps to reproduce:

- Create a Product Category with manual valuation
- Create a product in this category
- Make a purchase order for the product, confirm and receive it
- Create the bill from the PO

Issue:

There is an account move line for the Stock Interim Account
instead of the Expense Account

opw-2599948

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
