### PR TITLE
[FIX] sale: Payment had wrong sales team

### DIFF
--- a/addons/sale/wizard/__init__.py
+++ b/addons/sale/wizard/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import account_payment_register
 from . import payment_acquirer_onboarding_wizard
 from . import sale_make_invoice_advance
 from . import sale_order_cancel

--- a/addons/sale/wizard/account_payment_register.py
+++ b/addons/sale/wizard/account_payment_register.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models
+
+
+class AccountPaymentRegister(models.TransientModel):
+    _inherit = 'account.payment.register'
+
+    def _create_payment_vals_from_wizard(self):
+        vals = super()._create_payment_vals_from_wizard()
+        # Make sure the account move linked to generated payment
+        # belongs to the expected sales team
+        # team_id field on account.payment comes from the `_inherits` on account.move model
+        vals.update({'team_id': self.line_ids.move_id[0].team_id.id})
+        return vals


### PR DESCRIPTION
Current behavior :
When creating payment from invoice, the payment had the wrong sales team id

Steps to reproduce :
- Create atleast 2 invoices with different sales team and same partner
- Register payments for every invoice
- Go in payments list view
- Filter on partner and group by sales team
- All the payments are grouped in the same sales team

opw-2681041

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
