### PR TITLE
[FIX] survey: fix shortcut usage

### DIFF
--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -88,8 +88,13 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend({
      * @param {Event} event
      */
     _onKeyDown: function (event) {
-        // If user is answering a text input, do not handle keydown (can be forced by pressing CTRL)
-        if ((this.$("textarea").is(":focus") || this.$('input').is(':focus')) && !event.ctrlKey) {
+        var self = this;
+        var keyCode = event.keyCode;
+
+        // If user is answering a text input, do not handle keydown
+        // CTRL+enter will force submission
+        if ((this.$("textarea").is(":focus") || this.$('input').is(':focus')) &&
+            (!event.ctrlKey || keyCode !== 13)) {
             return;
         }
         // If in session mode and question already answered, do not handle keydown
@@ -97,8 +102,6 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend({
             return;
         }
 
-        var self = this;
-        var keyCode = event.keyCode;
         var letter = String.fromCharCode(keyCode).toUpperCase();
 
         // Handle Start / Next / Submit


### PR DESCRIPTION
Currently, we allow the user to press CTRL+Enter to force the submission of his
answer for that question when the focus is within a textarea.

However, we do not want to submit the question if CTRL+Arrow-right is pressed
(since you may use CTRL+arrows to navigate within your text).
In the same fashion, we don't want to select "option C" if you use CTRL+C to
copy some text in the textarea.

This commit fixes these use cases by only allowing the shortcut handling when
the focus is within a textarea when the pressed key is 'Enter' (code 13).

Task-2716078

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
