### PR TITLE
[FIX] website_form: fix from redirection to an anchor in the same page

### DIFF
--- a/addons/website_form/static/src/snippets/s_website_form/000.js
+++ b/addons/website_form/static/src/snippets/s_website_form/000.js
@@ -193,6 +193,7 @@ odoo.define('website_form.s_website_form', function (require) {
                     }
                     switch (successMode) {
                         case 'redirect':
+                            successPage = successPage.startsWith("/#") ? successPage.slice(1) : successPage;
                             if (successPage.charAt(0) === "#") {
                                 dom.scrollTo($(successPage)[0], {
                                     duration: 500,


### PR DESCRIPTION
Before this commit, when the redirection of a form was an anchor and
that anchor link came from the anchor option, the scroll animation
was not triggered.

task-2172312

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
