### PR TITLE
[IMP] hr_holidays: 'My Department' filter now includes child departme…

### DIFF
--- a/addons/hr/data/hr_demo.xml
+++ b/addons/hr/data/hr_demo.xml
@@ -12,6 +12,16 @@
           <field name="name">Research &amp; Development</field>
       </record>
 
+      <record id="dep_rd_be" model="hr.department">
+          <field name="name">R&amp;D Belgium</field>
+          <field name="parent_id" ref="dep_rd"/>
+      </record>
+
+      <record id="dep_rd_ltp" model="hr.department">
+          <field name="name">Long Term Projects</field>
+          <field name="parent_id" ref="dep_rd_be"/>
+      </record>
+
       <record id="dep_ps" model="hr.department">
           <field name="name">Professional Services</field>
       </record>
@@ -189,7 +199,7 @@ If you have development competencies, we can propose you specific traineeships</
 
       <record id="employee_mit" model="hr.employee">
           <field name="name">Anita Oliver</field>
-          <field name="department_id" ref="dep_rd"/>
+          <field name="department_id" ref="dep_rd_be"/>
           <field name="parent_id" ref="employee_al"/>
           <field name="job_id" ref="hr.job_developer"/>
           <field name="job_title">Experienced Developer</field>
@@ -333,7 +343,7 @@ If you have development competencies, we can propose you specific traineeships</
 
       <record id="employee_jve" model="hr.employee">
           <field name="name">Paul Williams</field>
-          <field name="department_id" ref="dep_management"/>
+          <field name="department_id" ref="dep_rd_ltp"/>
           <field name="job_id" ref="hr.job_developer"/>
           <field name="job_title">Experienced Developer</field>
           <field name="work_location_id" ref="work_location_1"/>

--- a/addons/hr_holidays/report/hr_leave_report_calendar.xml
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.xml
@@ -37,7 +37,9 @@
                 <field name="department_id"/>
                 <field name="job_id"/>
                 <filter name="my_team" string="My Team" domain="['|', ('employee_id.user_id', '=', uid), ('employee_id.parent_id.user_id', '=', uid)]"/>
-                <filter string="My Department" name="department" domain="['|', ('department_id.member_ids.user_id', '=', uid), ('employee_id.user_id', '=', uid)]" help="My Department"/>
+                <filter string="My Department" name="department"
+                        domain="[('employee_id.member_of_department', '=', True)]"
+                        help="My Department"/>
                 <separator/>
                 <filter string="Off Today" name="off_today" domain="[('start_datetime', '&lt;=', context_today().strftime('%Y-%m-%d')), ('stop_datetime', '&gt;=', context_today().strftime('%Y-%m-%d'))]" help="My Department"/>
                 <separator/>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -51,7 +51,9 @@
                 <separator/>
                 <filter string="My Time Off" name="my_leaves" domain="[('employee_id.user_id', '=', uid)]"/>
                 <filter string="My Team" name="my_team" domain="['|', ('employee_id.leave_manager_id', '=', uid), ('employee_id.user_id', '=', uid)]" help="Time off of people you are manager of"/>
-                <filter string="My Department" name="department" domain="['|', ('department_id.member_ids.user_id', '=', uid), ('employee_id.user_id', '=', uid)]" help="My Department"/>
+                <filter string="My Department" name="department"
+                        domain="[('employee_id.member_of_department', '=', True)]"
+                        help="My Department"/>
                 <separator/>
                 <filter string="Active Employee" name="active_employee" domain="[('active_employee','=',True)]"/>
                 <separator/>


### PR DESCRIPTION
…nts.

The "My department" filter in the "Time Off" overview menu is changed to also include the leaves of employees from child departments (all the way to the bottom of the hierarchy).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
