### PR TITLE
[FIX] mass_mailing, web_editor: fix some mail editor issues

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -46,6 +46,7 @@ import {
     YOUTUBE_URL_GET_VIDEO_ID,
     unwrapContents,
     peek,
+    rightPos,
 } from './utils/utils.js';
 import { editorCommands } from './commands/commands.js';
 import { Powerbox } from './powerbox/Powerbox.js';
@@ -2138,7 +2139,21 @@ export class OdooEditor extends EventTarget {
                 this.historyRollback();
                 ev.preventDefault();
                 if (this._applyCommand('oEnter') === UNBREAKABLE_ROLLBACK_CODE) {
-                    this._applyCommand('oShiftEnter');
+                    const brs = this._applyCommand('oShiftEnter');
+                    const anchor = brs[0].parentElement;
+                    if (anchor.nodeName === 'A') {
+                        if (brs.includes(anchor.firstChild)) {
+                            brs.forEach(br => anchor.before(br));
+                            setSelection(...rightPos(brs[brs.length - 1]));
+                            this.sanitize();
+                            this.historyStep();
+                        } else if (brs.includes(anchor.lastChild)) {
+                            brs.forEach(br => anchor.after(br));
+                            setSelection(...rightPos(brs[0]));
+                            this.sanitize();
+                            this.historyStep();
+                        }
+                    }
                 }
             } else if (['insertText', 'insertCompositionText'].includes(ev.inputType)) {
                 // insertCompositionText, courtesy of Samsung keyboard.

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/shiftEnter.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/shiftEnter.js
@@ -12,7 +12,7 @@ import {
 } from '../utils/utils.js';
 
 Text.prototype.oShiftEnter = function (offset) {
-    this.parentElement.oShiftEnter(splitTextNode(this, offset));
+    return this.parentElement.oShiftEnter(splitTextNode(this, offset));
 };
 
 HTMLElement.prototype.oShiftEnter = function (offset) {
@@ -39,4 +39,6 @@ HTMLElement.prototype.oShiftEnter = function (offset) {
             break;
         }
     }
+
+    return brEls;
 };

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/collab.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/collab.test.js
@@ -139,7 +139,7 @@ const testMultiEditor = spec => {
                 clientInfo.editor.onExternalHistorySteps(missingSteps.concat([step]));
             },
         });
-        clientInfo.editor.keyboardType = 'PHYSICAL_KEYBOARD';
+        clientInfo.editor.keyboardType = 'PHYSICAL';
         const selection = selections[clientInfo.clientId];
         if (selection) {
             setTestSelection(selection, iframeDocument);

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -2248,6 +2248,31 @@ X[]
                         contentAfter: '<p><b>abc</b></p><p>[]<br></p>',
                     });
                 });
+                it.only('should insert line breaks outside the edges of an anchor', async () => {
+                    const pressEnter = editor => {
+                        editor.document.execCommand('insertParagraph');
+                    }
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div>ab<a>[]cd</a></div>',
+                        stepFunction: pressEnter,
+                        contentAfter: '<div>ab<br><a>[]cd</a></div>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div><a>a[]b</a></div>',
+                        stepFunction: pressEnter,
+                        contentAfter: '<div><a>a<br>[]b</a></div>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div><a>ab[]</a></div>',
+                        stepFunction: pressEnter,
+                        contentAfter: '<div><a>ab</a><br>[]<br></div>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div><a>ab[]</a>cd</div>',
+                        stepFunction: pressEnter,
+                        contentAfter: '<div><a>ab</a><br>[]cd</div>',
+                    });
+                });
             });
             describe('With attributes', () => {
                 it('should insert an empty paragraph before a paragraph with a span with a class', async () => {

--- a/addons/web_editor/static/lib/odoo-editor/test/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/utils.js
@@ -296,9 +296,10 @@ export async function testEditor(Editor = OdooEditor, spec) {
     const selection = parseTextualSelection(testNode);
 
     const editor = new Editor(testNode, { toSanitize: false });
-    editor.keyboardType = 'PHYSICAL_KEYBOARD';
+    editor.keyboardType = 'PHYSICAL';
     if (selection) {
         setTestSelection(selection);
+        editor._recordHistorySelection();
     } else {
         document.getSelection().removeAllRanges();
     }

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -460,9 +460,14 @@ var SnippetEditor = Widget.extend({
         // first, destroying the related editors and not calling onBlur... to
         // check if this has always been like this or not and this should be
         // unit tested.
-        const parent = this.$target[0].parentElement;
+        let parent = this.$target[0].parentElement;
         const nextSibling = this.$target[0].nextElementSibling;
         const previousSibling = this.$target[0].previousElementSibling;
+        if ($(parent).is('.o_editable:not(body)')) {
+            // If we target the editable, we want to reset the selection to the
+            // body. If the editable has options, we do not want to show them.
+            parent = $(parent).closest('body');
+        }
         this.trigger_up('activate_snippet', {
             $snippet: $(previousSibling || nextSibling || parent)
         });
@@ -1293,7 +1298,7 @@ var SnippetsMenu = Widget.extend({
             if (!$target.closest('we-button, we-toggler, we-select, .o_we_color_preview').length) {
                 this._closeWidgets();
             }
-            if (!$target.closest('body > *').length) {
+            if (!$target.closest('body > *').length || $target.is('#iframe_target')) {
                 return;
             }
             if ($target.closest(this._notActivableElementsSelector).length) {


### PR DESCRIPTION
- The snippet selection was lost on every action in mass mailing. The code that prevents that was checking if the target of a click was the body element but for mass mailing we needed to be a little bit more restrictive since the editable area is not the body itself and we want to actually prevent changing the snippet selection when the target is the iframe target as well. Since the mailing itself has a options, the sidebar is actually never empty and therefore removing a snippet doesn't bring us back to the block tab. Since therefore also ensures that we actually do.
- When pressing enter at the edge of an anchor that is a child of an unbreakable element, we inserted line breaks in the anchor itself, which is unexpected. This inserts the anchors after/before it instead.

task-2679885

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
