### PR TITLE
[FIX] mrp_account: ignore returned SM in price computations

### DIFF
--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -3,6 +3,7 @@
 
 from odoo import api, models, _
 from odoo.exceptions import UserError
+from odoo.tools import groupby
 
 
 class ProductTemplate(models.Model):
@@ -47,20 +48,17 @@ class ProductProduct(models.Model):
         bom = self.env['mrp.bom']._bom_find(product=self, company_id=stock_moves.company_id.id, bom_type='phantom')
         if not bom:
             return super()._compute_average_price(qty_invoiced, qty_to_invoice, stock_moves)
+        value = 0
         dummy, bom_lines = bom.explode(self, 1)
         bom_lines = {line: data for line, data in bom_lines}
-        value = 0
-        for move in stock_moves:
-            if move.state == 'cancel':
+        for bom_line, moves_list in groupby(stock_moves.filtered(lambda sm: sm.state != 'cancel'), lambda sm: sm.bom_line_id):
+            if bom_line not in bom_lines:
+                for move in moves_list:
+                    value += move.product_qty * move.product_id._compute_average_price(qty_invoiced * move.product_qty, qty_to_invoice * move.product_qty, move)
                 continue
-            bom_line = move.bom_line_id
-            if bom_line in bom_lines:
-                bom_line_data = bom_lines[bom_line]
-                line_qty = bom_line.product_uom_id._compute_quantity(bom_line_data['qty'], bom_line.product_id.uom_id)
-            else:
-                # bom was altered (i.e. bom line removed) after being used
-                line_qty = move.product_qty
-            value += line_qty * move.product_id._compute_average_price(qty_invoiced * line_qty, qty_to_invoice * line_qty, move)
+            line_qty = bom_line.product_uom_id._compute_quantity(bom_line.product_qty, bom_line.product_id.uom_id)
+            moves = self.env['stock.move'].concat(*moves_list)
+            value += line_qty * bom_line.product_id._compute_average_price(qty_invoiced * line_qty, qty_to_invoice * line_qty, moves)
         return value
 
     def _compute_bom_price(self, bom, boms_to_recompute=False):


### PR DESCRIPTION
When returning a kit, the margin of the related SO decreases

To reproduce the issue:
(Need sale_management)
1. In Settings, enable "Margins"
2. Create a Product Category PC:
    - Costing Method: FIFO
3. Create two products P_kit, P_compo:
    - Both:
        - Type: Storable
        - Category: PC
    - P_compo:
        - Cost: 10
4. Update P_compo quantity: 1
5. Create a BoM:
    - Product: P_kit
    - Type: Kit
    - Components: 1 x P_compo
6. Update P_kit's cost
7. Create and confirm a SO with 1 x P_kit, unit price = $100
    - Note that the margin is correct: $90
8. Process the related picking
9. Create a return R
10. Go back to the SO

Error: the margin is now $80

When computing the cost of the kit, the move linked to R are considered.
Therefore, the cost becomes $20 and thus the margin becomes $80

OPW-2679473