### PR TITLE
[FIX] point_of_sale: fix runtime error

### DIFF
--- a/addons/point_of_sale/static/src/js/popups.js
+++ b/addons/point_of_sale/static/src/js/popups.js
@@ -174,10 +174,10 @@ var SelectionPopupWidget = PopupWidget.extend({
     show: function(options){
         var self = this;
         options = options || {};
-        this._super(options);
-
         this.list = options.list || [];
         this.is_selected = options.is_selected || function (item) { return false; };
+
+        this._super(options);
         this.renderElement();
     },
     click_item : function(event) {


### PR DESCRIPTION
**Steps to follow**

  - Enable pos pricelists
  - Enable 'Login with Employees' and 'Advanced Pricelists'
  - Open a session
  - Select a Cashier
  - Order a product
  - Select a pricelist
  - Confirm the order
  - Lock the session
  - Select a Cashier again

  -> A stacktrace appears

**Cause of the issue**

  The same popup is reused between the pricelist and employee selection
  -> The current order can be null

**Solution**

  Check if the order is null

opw-2649351