### PR TITLE
[IMP] project,**: improve generic ux

### DIFF
--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -126,8 +126,8 @@
                         <group>
                             <group>
                                 <div class="o_td_label">
-                                    <label for="planned_hours" string="Initially Planned Hours" attrs="{'invisible': [('encode_uom_in_days', '=', True)]}"/>
-                                    <label for="planned_hours" string="Initially Planned Days" attrs="{'invisible': [('encode_uom_in_days', '=', False)]}"/>
+                                    <label for="planned_hours" string="Allocated Hours" attrs="{'invisible': [('encode_uom_in_days', '=', True)]}"/>
+                                    <label for="planned_hours" string="Allocated Days" attrs="{'invisible': [('encode_uom_in_days', '=', False)]}"/>
                                 </div>
                                 <field name="planned_hours" widget="timesheet_uom_no_toggle" nolabel="1"/>
                                 <div class="o_td_label" groups="project.group_subtask_project" attrs="{'invisible': ['|', ('allow_subtasks', '=', False), ('subtask_count', '=', 0)]}">
@@ -331,11 +331,22 @@
             <field name="model">project.task</field>
             <field name="inherit_id" ref="project.view_task_search_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//filter[@name='my_tasks']" position='after'>
+                <xpath expr="//filter[@name='followed_by_me']" position='after'>
                     <filter string="My Team's Tasks" name="my_team_tasks" domain="[('user_ids.employee_parent_id.user_id', '=', uid)]"/>
                 </xpath>
                 <xpath expr="//filter[@name='late']" position='after'>
                     <filter string="Tasks in Overtime" name="overtime" domain="[('overtime', '&gt;', 0)]"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="view_task_search_form_hr_extended" model="ir.ui.view">
+            <field name="name">project.task.view.search.inherit.hr.timesheet</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="project.view_task_search_form_extended"/>
+            <field name="arch" type="xml">
+                <xpath expr="//filter[@name='my_favorite_projects']" position='after'>
+                    <filter string="My Team's Projects" name="my_teams_projects" domain="[('project_id.user_id.employee_parent_id.user_id', '=', uid)]"/>
                 </xpath>
             </field>
         </record>

--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -4,7 +4,7 @@
 
         <!-- Users -->
         <record id="base.user_demo" model="res.users">
-            <field name="groups_id" eval="[Command.link(ref('group_project_manager'))]"/>
+            <field name="groups_id" eval="[Command.link(ref('group_project_user'))]"/>
         </record>
 
         <!-- Groups : Add subtasks, recurring tasks and task dependencies by default -->

--- a/addons/project/models/res_config_settings.py
+++ b/addons/project/models/res_config_settings.py
@@ -14,6 +14,18 @@ class ResConfigSettings(models.TransientModel):
     group_project_stages = fields.Boolean("Project Stages", implied_group="project.group_project_stages")
     group_project_recurring_tasks = fields.Boolean("Recurring Tasks", implied_group="project.group_project_recurring_tasks")
     group_project_task_dependencies = fields.Boolean("Task Dependencies", implied_group="project.group_project_task_dependencies")
+    rating_status = fields.Selection(
+        [('stage', 'Rating when changing stage'),
+         ('periodic', 'Periodic rating')
+        ], 'Customer Ratings Status', default="stage", required=True, config_parameter='project.rating_status')
+    rating_status_period = fields.Selection([
+        ('daily', 'Daily'),
+        ('weekly', 'Weekly'),
+        ('bimonthly', 'Twice a Month'),
+        ('monthly', 'Once a Month'),
+        ('quarterly', 'Quarterly'),
+        ('yearly', 'Yearly')], 'Rating Frequency', required=True, default='monthly', config_parameter='project.rating_status_period')
+
 
     @api.model
     def _get_basic_project_domain(self):

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -25,13 +25,16 @@
                     <field name="parent_id"/>
                     <field name="rating_last_text"/>
                     <filter string="My Tasks" name="my_tasks" domain="[('user_ids', 'in', uid)]"/>
+                    <filter string="Followed Tasks" name="followed_by_me" domain="[('message_is_follower', '=', True)]"/>
                     <filter string="Unassigned" name="unassigned" domain="[('user_ids', '=', False)]"/>
                     <separator/>
-                    <filter string="Starred" name="starred" domain="[('priority', 'in', [0, 1])]"/>
+                    <filter string="Starred" name="starred" domain="[('priority', '=', 1)]"/>
+                    <filter string="Not Starred" name="not_starred" domain="[('priority', '=', 0)]"/>
+                    <separator/>
+                    <filter string="Open" name="open_tasks" domain="[('is_closed', '=', False)]"/>
+                    <filter string="Closed" name="closed_tasks" domain="[('is_closed', '!=', False)]"/>
                     <separator/>
                     <filter string="Late Tasks" name="late" domain="[('date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"/>
-                    <separator/>
-                    <filter string="Open Tasks" name="open_tasks" domain="[('is_closed', '=', False)]"/>
                     <separator/>
                     <filter name="rating_satisfied" string="Satisfied" domain="[('rating_avg', '&gt;=', 3.66)]" groups="project.group_project_rating"/>
                     <filter name="rating_okay" string="Okay" domain="[('rating_avg', '&lt;', 3.66), ('rating_avg', '&gt;=', 2.33)]" groups="project.group_project_rating"/>
@@ -73,7 +76,6 @@
                     <separator/>
                     <filter string="My Projects" name="my_projects" domain="[('project_id.user_id', '=', uid)]"/>
                     <filter string="My Favorite Projects" name="my_favorite_projects" domain="[('project_id.favorite_user_ids', 'in', [uid])]"/>
-                    <filter string="Followed Projects" name="my_followed_projects" domain="[('project_id.message_is_follower', '=', True)]"/>
                 </xpath>
             </field>
         </record>
@@ -123,6 +125,9 @@
             <field name="arch" type="xml">
                 <search string="Tasks Stages">
                    <field name="name" string="Name"/>
+                   <field name="project_ids" string="Project"/>
+                   <field name="mail_template_id"/>
+                   <field name="rating_template_id"/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                 </search>
             </field>
@@ -320,7 +325,8 @@
                             </div>
                         </button>
                         <field name="rating_avg" invisible="1"/>
-                        <button name="action_view_all_rating" type="object" attrs="{'invisible': [('rating_active', '=', False)]}" class="oe_stat_button" groups="project.group_project_rating">
+                        <field name="rating_count" invisible="1"/>
+                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', ('rating_active', '=', False), ('rating_count', '=', 0)]}" class="oe_stat_button" groups="project.group_project_rating">
                             <i class="fa fa-fw o_button_icon fa-smile-o text-success" attrs="{'invisible': [('rating_avg', '&lt;', 3.66)]}" title="Satisfied"/>
                             <i class="fa fa-fw o_button_icon fa-meh-o text-warning" attrs="{'invisible': ['|', ('rating_avg', '&lt;', 2.33), ('rating_avg', '&gt;=', 3.66)]}" title="Okay"/>
                             <i class="fa fa-fw o_button_icon fa-frown-o text-danger" attrs="{'invisible': [('rating_avg', '&gt;=', 2.33)]}" title="Dissatisfied"/>
@@ -505,6 +511,9 @@
                     <filter string="Unassigned" name="unassigned_projects" domain="[('user_id', '=', False)]"/>
                     <separator/>
                     <filter string="Late Milestones" name="late_milestones" domain="[('is_milestone_exceeded', '=', True)]"/>
+                    <separator/>
+                    <filter string="Open" name="open_project" domain="[('stage_id.fold', '=', False)]" groups="project.group_project_stages"/>
+                    <filter string="Closed" name="closed_project" domain="[('stage_id.fold', '=', True)]" groups="project.group_project_stages"/>
                     <separator/>
                     <filter string="Start Date" name="start_date" date="date_start"/>
                     <filter string="End Date" name="end_date" date="date"/>
@@ -827,8 +836,8 @@
                     <field name="rating_last_value" invisible="1"/>
                     <field name="rating_count" invisible="1"/>
                     <header>
-                        <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight"
-                            attrs="{'invisible' : &quot;[('user_ids', 'in', uid)]&quot;}" data-hotkey="q"/>
+                        <button name="action_assign_to_me" string="Assign to Me" type="object" attrs="{'invisible': &quot;['|', ('user_ids', 'in', uid), ('user_ids', '=', [])]&quot;}" data-hotkey="q"/>
+                        <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight" attrs="{'invisible' : &quot;['|', ('user_ids', 'in', uid), ('user_ids', '!=', [])]&quot;}" data-hotkey="q"/>
                         <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False), ('stage_id', '=', False)]}"/>
                     </header>
                     <div class="alert alert-info oe_edit_only mb-0" role="status" attrs="{'invisible': ['|', ('recurring_task', '=', False), ('recurrence_id', '=', False)]}">
@@ -1191,6 +1200,7 @@
                     <field name="allow_subtasks" invisible="1" />
                     <field name="sequence" invisible="1" readonly="1"/>
                     <field name="priority" widget="priority" optional="show" nolabel="1"/>
+                    <field name="id" optional="hide"/>
                     <field name="name" widget="name_with_subtask_count"/>
                     <field name="child_text" invisible="1"/>
                     <field name="project_id" widget="project_private_task" optional="show" readonly="1"/>

--- a/addons/project/views/rating_views.xml
+++ b/addons/project/views/rating_views.xml
@@ -46,8 +46,8 @@
             <field name="rated_partner_id" position="attributes">
                 <attribute name="string">Assigned to</attribute>
             </field>
-            <field name="create_date" position="attributes">
-                <attribute name="readonly">1</attribute>
+            <field name="create_date" position="replace">
+                <field name="write_date" readonly="1" string="Submitted On"/>
             </field>
             <field name="feedback" position="attributes">
                 <attribute name="readonly">1</attribute>
@@ -55,7 +55,7 @@
             <div name="rating_image_container" position="replace">
                 <field name="rating_text" string="Rating" decoration-danger="rating_text == 'ko'" decoration-warning="rating_text == 'ok'" decoration-success="rating_text == 'top'" widget='badge'/>
             </div>
-            <field name="create_date" position="after">
+            <field name="write_date" position="after">
                 <field name="partner_id" position="move"/>
             </field>
             <xpath expr="//field[@name='is_internal']" position="attributes">
@@ -91,6 +91,18 @@
         </field>
     </record>
 
+    <record id="rating_rating_project_view_kanban" model="ir.ui.view">
+        <field name="name">rating.rating.kanban.project</field>
+        <field name="model">rating.rating</field>
+        <field name="inherit_id" ref="rating.rating_rating_view_kanban"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='create_date']" position="replace">
+                <field name="write_date"/>
+            </xpath>
+        </field>
+    </record>
+
     <record id="rating_rating_view_search_project" model="ir.ui.view">
         <field name="name">rating.rating.search.project</field>
         <field name="model">rating.rating</field>
@@ -117,6 +129,21 @@
                 <attribute name="string">Task</attribute>
             </xpath>
             <xpath expr="//filter[@name='responsible']" position="replace"></xpath>
+            <xpath expr="//filter[@name='filter_create_date']" position="replace">
+                <filter name="filter_write_date" string="Submitted On" date="write_date"/>
+            </xpath>
+            <xpath expr="//filter[@name='month']" position="attributes">
+                <attribute name="context">{'group_by':'write_date:month'}</attribute>
+            </xpath>
+            <xpath expr="//filter[@name='today']" position="attributes">
+                <attribute name="domain">[('write_date', '&gt;', (context_today() - datetime.timedelta(days=1)).strftime('%Y-%m-%d'))]</attribute>
+            </xpath>
+            <xpath expr="//filter[@name='last_7days']" position="attributes">
+                <attribute name="domain">[('write_date','&gt;', (context_today() - datetime.timedelta(days=7)).strftime('%Y-%m-%d'))]</attribute>
+            </xpath>
+            <xpath expr="//filter[@name='last_month']" position="attributes">
+                <attribute name="domain">[('write_date','&gt;', (context_today() - relativedelta(months=1)).strftime('%Y-%m-%d'))]</attribute>
+            </xpath>
         </field>
     </record>
 
@@ -137,7 +164,7 @@
         <field name="sequence" eval="5"/>
         <field name="view_mode">kanban</field>
         <field name="act_window_id" ref="rating_rating_action_view_project_rating"/>
-        <field name="view_id" ref="rating.rating_rating_view_kanban"/>
+        <field name="view_id" ref="rating_rating_project_view_kanban"/>
     </record>
 
     <record id="rating_rating_action_view_project_rating_tree" model="ir.actions.act_window.view">
@@ -187,7 +214,7 @@
         <field name="sequence" eval="5"/>
         <field name="view_mode">kanban</field>
         <field name="act_window_id" ref="rating_rating_action_task"/>
-        <field name="view_id" ref="rating.rating_rating_view_kanban"/>
+        <field name="view_id" ref="rating_rating_project_view_kanban"/>
     </record>
 
     <record id="rating_rating_action_task_tree" model="ir.actions.act_window.view">
@@ -241,7 +268,7 @@
         <field name="sequence" eval="5"/>
         <field name="view_mode">kanban</field>
         <field name="act_window_id" ref="rating_rating_action_project_report"/>
-        <field name="view_id" ref="rating.rating_rating_view_kanban"/>
+        <field name="view_id" ref="rating_rating_project_view_kanban"/>
     </record>
 
     <record id="rating_rating_action_project_report_tree" model="ir.actions.act_window.view">

--- a/addons/project/views/res_config_settings_views.xml
+++ b/addons/project/views/res_config_settings_views.xml
@@ -108,8 +108,17 @@
                                         Track customer satisfaction on tasks
                                     </div>
                                     <div class="content-group" attrs="{'invisible': [('group_project_rating', '=', False)]}">
-                                        <div class="mt8">
-                                            <button name="%(project.open_task_type_form)d" icon="fa-arrow-right" type="action" string="Set a Rating Email Template on Stages" class="btn-link"/>
+                                        <div class="mt16">
+                                            <field name="rating_status" widget="radio" />
+                                            <div attrs="{'required': [('rating_status', '=', 'periodic')], 'invisible': [('rating_status', '!=', 'periodic')]}">
+                                                <label for="rating_status_period"/>
+                                                <field name="rating_status_period"/>
+                                            </div>
+                                            <div class="content-group">
+                                                <div class="mt8">
+                                                    <button name="%(project.open_task_type_form_domain)d" context="{'project_id':id}" icon="fa-arrow-right" type="action" string="Set a Rating Email Template on Stages" class="btn-link"/>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -276,7 +276,9 @@ class Project(models.Model):
         action = self.env["ir.actions.actions"]._for_xml_id("hr_timesheet.timesheet_action_all")
         action.update({
             'context': {
-                'search_default_groupby_task': True,
+                'grid_range': 'week',
+                'search_default_groupby_timesheet_invoice_type': True,
+                'pivot_row_groupby': ['date:month'],
                 'default_project_id': self.id,
             },
             'domain': [('project_id', '=', self.id)],
@@ -284,7 +286,7 @@ class Project(models.Model):
             'views': [
                 [self.env.ref('hr_timesheet.timesheet_view_tree_user').id, 'tree'],
                 [self.env.ref('hr_timesheet.view_kanban_account_analytic_line').id, 'kanban'],
-                [self.env.ref('hr_timesheet.view_hr_timesheet_line_pivot').id, 'pivot'],
+                [self.env.ref('sale_timesheet.view_hr_timesheet_line_pivot_billing_rate').id, 'pivot'],
                 [self.env.ref('hr_timesheet.view_hr_timesheet_line_graph_all').id, 'graph'],
                 [self.env.ref('hr_timesheet.timesheet_view_form_user').id, 'form'],
             ],

--- a/addons/sale_timesheet/tests/test_sale_service.py
+++ b/addons/sale_timesheet/tests/test_sale_service.py
@@ -41,7 +41,7 @@ class TestSaleService(TestCommonSaleTimesheet):
 
         # check task creation
         project = self.project_global
-        task = project.task_ids.filtered(lambda t: t.name == '%s: %s' % (self.sale_order.name, self.product_delivery_timesheet2.name))
+        task = project.task_ids.filtered(lambda t: t.name == '%s - %s' % (self.sale_order.name, self.product_delivery_timesheet2.name))
         self.assertTrue(task, 'Sale Service: task is not created, or it badly named')
         self.assertEqual(task.partner_id, self.sale_order.partner_id, 'Sale Service: customer should be the same on task and on SO')
         self.assertEqual(task.email_from, self.sale_order.partner_id.email, 'Sale Service: Task Email should be the same as the SO customer Email')

--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -663,6 +663,7 @@ var FieldDateRange = InputField.extend({
      */
     init: function () {
         this._super.apply(this, arguments);
+        this.formatType = this.nodeOptions.format_type || this.formatType;
         this.isDateField = this.formatType === 'date';
         this.dateRangePickerOptions = _.defaults(
             {},

--- a/addons/web/static/tests/legacy/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/basic_fields_tests.js
@@ -3665,6 +3665,66 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.test("Datetime field with option format type is 'date'", async function (assert) {
+        assert.expect(2);
+
+        this.data.partner.fields.datetime_end = {string: 'Datetime End', type: 'datetime'};
+        this.data.partner.records[0].datetime_end = '2017-03-13 00:00:00';
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `<form>
+                    <field name="datetime" widget="daterange" options="{'related_end_date': 'datetime_end', 'format_type': 'date'}"/>'
+                    <field name="datetime_end" widget="daterange" options="{'related_start_date': 'datetime', 'format_type': 'date'}"/>'
+                </form>`,
+            res_id: 1,
+            session: {
+                getTZOffset() {
+                    return 330;
+                },
+            },
+        });
+
+        assert.strictEqual(form.el.querySelector('.o_field_date_range[name="datetime"]').innerText, '02/08/2017',
+            "the start date should only show date when option formatType is Date");
+        assert.strictEqual(form.el.querySelector('.o_field_date_range[name="datetime_end"]').innerText, '03/13/2017',
+            "the end date should only show date when option formatType is Date");
+
+        form.destroy();
+    });
+
+    QUnit.test("Date field with option format type is 'datetime'", async function (assert) {
+        assert.expect(2);
+
+        this.data.partner.fields.date_end = {string: 'Date End', type: 'date'};
+        this.data.partner.records[0].date_end = '2017-03-13';
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `<form>
+                    <field name="date" widget="daterange" options="{'related_end_date': 'date_end', 'format_type': 'datetime'}"/>
+                    <field name="date_end" widget="daterange" options="{'related_start_date': 'date', 'format_type': 'datetime'}"/>
+                </form>`,
+            res_id: 1,
+            session: {
+                getTZOffset() {
+                    return 330;
+                },
+            },
+        });
+
+        assert.strictEqual(form.el.querySelector('.o_field_date_range[name="date"]').innerText, '02/03/2017 05:30:00',
+            "the start date should show date with time when option format_type is datatime");
+        assert.strictEqual(form.el.querySelector('.o_field_date_range[name="date_end"]').innerText, '03/13/2017 05:30:00',
+            "the end date should show date with time when option format_type is datatime");
+
+        form.destroy();
+    });
+
     QUnit.test('Date field without quickedit [REQUIRE FOCUS]', async function (assert) {
         assert.expect(19);
 


### PR DESCRIPTION
 ** = hr_timesheet,rating,sale_timesheet,sale_project

Purpose of this commit to improve generic UX of project app.

So, In this commit done the following  point:
- change the label for 'planned_hours' field in project task form view.
- change demo user access right to project user instead project admin.
- display the rating_status and rating_status_period fields under the 'customer
ratings' feature in the settings.
- add documents stat btn in project and task form view.
- add stat btn in right-side panel view of project update.
- add 'project_id', 'mail_template_id', 'rating_template_id' fields in project
 task search view.
-add open and closed filter in project search view.
- display 'assign to me' button secondary when user set on task.
- add tooltip for 'date_deadline' field in project form view.
- replace create_date field with write_date in rating views.
- change context of billable time stat button action.
- improve search view of project task.
- hide rating stat btn when satisfaction is 0%.
- change name of task created when SO confirmation.
- change name of project create when SO confirmed when there is only one SO
 line contain service_tracking is 'only_project'.
- add id field in tree view of project task as option hide

Web 

-add formatType option in node option which convert actual formatType
to given formatType in option and add test case for that feature.

task-2710539

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
