### PR TITLE
[IMP] survey: improve technical tooltips for few fields

### DIFF
--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -149,11 +149,11 @@ class SurveyQuestion(models.Model):
     triggering_question_id = fields.Many2one(
         'survey.question', string="Triggering Question", copy=False, compute="_compute_triggering_question_id",
         store=True, readonly=False, help="Question containing the triggering answer to display the current question.",
-        domain="""[('survey_id', '=', survey_id),
-                 '&', ('question_type', 'in', ['simple_choice', 'multiple_choice']),
-                 '|',
-                     ('sequence', '<', sequence),
-                     '&', ('sequence', '=', sequence), ('id', '<', id)]""")
+        domain="[('survey_id', '=', survey_id), \
+                 '&', ('question_type', 'in', ['simple_choice', 'multiple_choice']), \
+                 '|', \
+                     ('sequence', '<', sequence), \
+                     '&', ('sequence', '=', sequence), ('id', '<', id)]")
     triggering_answer_id = fields.Many2one(
         'survey.question.answer', string="Triggering Answer", copy=False, compute="_compute_triggering_answer_id",
         store=True, readonly=False, help="Answer that will trigger the display of the current question.",

--- a/addons/survey/wizard/survey_invite.py
+++ b/addons/survey/wizard/survey_invite.py
@@ -41,11 +41,11 @@ class SurveyInvite(models.TransientModel):
     # recipients
     partner_ids = fields.Many2many(
         'res.partner', 'survey_invite_partner_ids', 'invite_id', 'partner_id', string='Recipients',
-        domain="""[
-            '|', (survey_users_can_signup, '=', 1),
-            '|', (not survey_users_login_required, '=', 1),
-                 ('user_ids', '!=', False),
-        ]"""
+        domain="[ \
+            '|', (survey_users_can_signup, '=', 1), \
+            '|', (not survey_users_login_required, '=', 1), \
+                 ('user_ids', '!=', False), \
+        ]"
     )
     existing_partner_ids = fields.Many2many(
         'res.partner', compute='_compute_existing_partner_ids', readonly=True, store=False)


### PR DESCRIPTION
PURPOSE
Improve the  technical tooltips of domain in triggering_question_id of survey.question and in partner_ids of survey.invite

SPECIFICATION
Current:
A weird domain with '\n' is visible in UI of survey for triggering_question_id, partner_ids.
To BE:
Remove '\n' from the domain and improve the domain UI view.

TaskId-2704057

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr