### PR TITLE
[FIX] mass_mailing, web_editor: fix some mail editor issues

### DIFF
--- a/addons/mass_mailing/views/snippets/s_cover.xml
+++ b/addons/mass_mailing/views/snippets/s_cover.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template id="s_cover" name="Cover">
         <div class="s_cover o_mail_snippet_general" data-snippet="s_cover">
-            <img src="/web/image/mass_mailing.s_default_image_block_banner" alt="Cover image" class="img-fluid w-100"/>
+            <img src="/web/image/mass_mailing.s_default_image_block_banner" alt="Cover image" class="img-fluid w-100 mx-auto"/>
         </div>
     </template>
 </odoo>

--- a/addons/mass_mailing/views/snippets/s_media_list.xml
+++ b/addons/mass_mailing/views/snippets/s_media_list.xml
@@ -5,7 +5,7 @@
     <div class="s_media_list pt32 pb32 o_cc o_cc2 o_mail_snippet_general" data-vcss="001" data-snippet="s_media_list">
         <div class="container">
             <div class="row s_nb_column_fixed s_col_no_bgcolor">
-                <div class="col-lg-12 s_media_list_item pt16 pb16" data-name="Media item">
+                <div class="col-lg-12 s_media_list_item pt16 pb16 pl-0 pr-0" data-name="Media item">
                     <div class="row s_col_no_resize s_col_no_bgcolor no-gutters align-items-center o_cc o_cc1">
                         <div class="col-lg-4 align-self-stretch s_media_list_img_wrapper">
                             <img src="/web/image/mass_mailing.s_media_list_default_image_1" class="s_media_list_img h-100 w-100" alt=""/>
@@ -17,7 +17,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-lg-12 s_media_list_item pt16 pb16" data-name="Media item">
+                <div class="col-lg-12 s_media_list_item pt16 pb16 pl-0 pr-0" data-name="Media item">
                     <div class="row s_col_no_resize s_col_no_bgcolor no-gutters align-items-center o_cc o_cc1">
                         <div class="col-lg-4 align-self-stretch s_media_list_img_wrapper">
                             <img src="/web/image/mass_mailing.s_media_list_default_image_2" class="s_media_list_img h-100 w-100" alt=""/>
@@ -28,7 +28,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-lg-12 s_media_list_item pt16 pb16" data-name="Media item">
+                <div class="col-lg-12 s_media_list_item pt16 pb16 pl-0 pr-0" data-name="Media item">
                     <div class="row s_col_no_resize s_col_no_bgcolor no-gutters align-items-center o_cc o_cc1">
                         <div class="col-lg-4 align-self-stretch s_media_list_img_wrapper">
                             <img src="/web/image/mass_mailing.s_media_list_default_image_3" class="s_media_list_img h-100 w-100" alt=""/>

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -254,8 +254,7 @@
             <div class="row">
                 <div class="col-lg">
                     <p class="o_mail_no_margin o_mail_footer_copy">
-                        <span class="fa fa-copyright" role="img" aria-label="Copyright" title="Copyright"/>
-                        <t t-esc="datetime.datetime.now().year"/> All Rights Reserved
+                        © <t t-esc="datetime.datetime.now().year"/> All Rights Reserved
                     </p>
                 </div>
             </div>
@@ -277,7 +276,7 @@
                 </div>
                 <div class="col-lg" align="right">
                     <div class="o_mail_footer_social pb16"><t t-call="mass_mailing.social_links"/></div>
-                    <p class="o_mail_footer_copy"><span class="fa fa-copyright" role="img" aria-label="Copyright" title="Copyright"/> <t t-esc="datetime.datetime.now().year"/> All Rights Reserved</p>
+                    <p class="o_mail_footer_copy">© <t t-esc="datetime.datetime.now().year"/> All Rights Reserved</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- The footer templates were using a font awesome icon for the copyright sign, while it has a unicode equivalent, which is easier to edit and lighter.
- When the cover snippet's image is in full width, we don't notice it's not centered. But reduce its width and it appears at the left of its container. There is no reasonable scenario in which this would be what we expect so this commit centers that image by default.
- A horizontal padding was applied to each media list item, making it impossible to make the media list items full width. Full width media list items can always be reduced by adding padding in the editor, but the converse is not true. For this reason, this commit applies horizontal padding 0 to each media list item in the snippet template.

task-2679885

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
