### PR TITLE
[FIX] test_lint: support fstrings in sql injection checker

### DIFF
--- a/addons/sale/report/report_all_channels_sales.py
+++ b/addons/sale/report/report_all_channels_sales.py
@@ -59,7 +59,7 @@ class PosSaleReport(models.Model):
     def _from(self):
         return """(%s)""" % (self._so())
 
-    def get_main_request(self):
+    def _get_main_request(self):
         request = """
             CREATE or REPLACE VIEW %s AS
                 SELECT id AS id,
@@ -84,4 +84,4 @@ class PosSaleReport(models.Model):
 
     def init(self):
         tools.drop_view_if_exists(self.env.cr, self._table)
-        self.env.cr.execute(self.get_main_request())
+        self.env.cr.execute(self._get_main_request())

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -811,7 +811,6 @@ actual arch.
         return dict(view_data, arch=etree.tostring(arch, encoding='unicode'))
 
     def _apply_groups(self, node, name_manager, node_info):
-        #pylint: disable=unused-argument
         """ Apply group restrictions: elements with a 'groups' attribute should
         be made invisible to people who are not members.
         """

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -21,6 +21,7 @@ import passlib.context
 import pytz
 from lxml import etree
 from lxml.builder import E
+from psycopg2 import sql
 
 from odoo import api, fields, models, tools, SUPERUSER_ID, _
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
@@ -1624,7 +1625,7 @@ class APIKeys(models.Model):
 
     def init(self):
         # pylint: disable=sql-injection
-        self.env.cr.execute("""
+        self.env.cr.execute(sql.SQL("""
         CREATE TABLE IF NOT EXISTS {table} (
             id serial primary key,
             name varchar not null,
@@ -1635,7 +1636,12 @@ class APIKeys(models.Model):
             create_date timestamp without time zone DEFAULT (now() at time zone 'utc')
         );
         CREATE INDEX IF NOT EXISTS res_users_apikeys_user_id_index_idx ON {table} (user_id, index);
-        """.format(table=self._table, index_size=INDEX_SIZE))
+        """).format(
+            table=sql.Identifier(self._table),
+            index_size=sql.Placeholder('index_size')
+        ), {
+            'index_size': INDEX_SIZE
+        })
 
     @check_identity
     def remove(self):

--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -481,7 +481,7 @@ class MergePartnerAutomatic(models.TransientModel):
         model_mapping = self._compute_models()
 
         # group partner query
-        self._cr.execute(query)
+        self._cr.execute(query) # pylint: disable=sql-injection
 
         counter = 0
         for min_id, aggr_ids in self._cr.fetchall():

--- a/odoo/addons/test_lint/tests/__init__.py
+++ b/odoo/addons/test_lint/tests/__init__.py
@@ -1,3 +1,4 @@
+from . import test_checkers
 from . import test_pylint
 from . import test_pofile
 from . import test_ecmascript

--- a/odoo/addons/test_lint/tests/test_checkers.py
+++ b/odoo/addons/test_lint/tests/test_checkers.py
@@ -1,0 +1,91 @@
+import json
+import os
+import tempfile
+import unittest
+from subprocess import run, PIPE
+from textwrap import dedent
+
+from odoo import tools
+from odoo.tests.common import TransactionCase
+
+try:
+    import pylint
+except ImportError:
+    pylint = None
+try:
+    pylint_bin = tools.which('pylint')
+except IOError:
+    pylint_bin = None
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+@unittest.skipUnless(pylint and pylint_bin, "testing lints requires pylint")
+class TestSqlLint(TransactionCase):
+    def check(self, testtext):
+        with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8', delete=False) as f:
+            self.addCleanup(os.remove, f.name)
+            f.write(dedent(testtext).strip())
+
+        result = run(
+            [pylint_bin,
+             f'--rcfile={os.devnull}',
+             '--load-plugins=_odoo_checker_sql_injection',
+             '--disable=all',
+             '--enable=sql-injection',
+             '--output-format=json',
+             f.name,
+            ],
+            check=False,
+            stdout=PIPE, encoding='utf-8',
+            env={
+                **os.environ,
+                'PYTHONPATH': HERE+os.pathsep+os.environ.get('PYTHONPATH', ''),
+            }
+        )
+        return result.returncode, json.loads(result.stdout)
+
+    def test_printf(self):
+        r, [err] = self.check("""
+        def do_the_thing(cr, name):
+            cr.execute('select %s from thing' % name)
+        """)
+        self.assertTrue(r, "should have noticed the injection")
+        self.assertEqual(err['line'], 2, err)
+
+        r, errs = self.check("""
+        def do_the_thing(self):
+            self.env.cr.execute("select thing from %s" % self._table)
+        """)
+        self.assertFalse(r, f"underscore-attributes are allowed\n{errs}")
+
+        r, errs = self.check("""
+        def do_the_thing(self):
+            query = "select thing from %s"
+            self.env.cr.execute(query % self._table)
+        """)
+        self.assertFalse(r, f"underscore-attributes are allowed\n{errs}")
+
+    def test_fstring(self):
+        r, [err] = self.check("""
+        def do_the_thing(cr, name):
+            cr.execute(f'select {name} from thing')
+        """)
+        self.assertTrue(r, "should have noticed the injection")
+        self.assertEqual(err['line'], 2, err)
+
+        r, errs = self.check("""
+        def do_the_thing(cr, name):
+            cr.execute(f'select name from thing')
+        """)
+        self.assertFalse(r, f"unnecessary fstring should be innocuous\n{errs}")
+
+        r, errs = self.check("""
+        def do_the_thing(cr, name, value):
+            cr.execute(f'select {name} from thing where field = %s', [value])
+        """)
+        self.assertFalse(r, f"probably has a good reason for the extra arg\n{errs}")
+
+        r, errs = self.check("""
+        def do_the_thing(self):
+            self.env.cr.execute(f'select name from {self._table}')
+        """)
+        self.assertFalse(r, f'underscore-attributes are allowable\n{errs}')

--- a/odoo/modules/db.py
+++ b/odoo/modules/db.py
@@ -29,7 +29,7 @@ def initialize(cr):
         raise IOError(m)
 
     with odoo.tools.misc.file_open(f) as base_sql_file:
-        cr.execute(base_sql_file.read())
+        cr.execute(base_sql_file.read())  # pylint: disable=sql-injection
 
     for i in odoo.modules.get_modules():
         mod_path = odoo.modules.get_module_path(i)

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -737,7 +737,7 @@ def convert_file(cr, module, filename, idref, mode='update', noupdate=False, kin
             raise ValueError("Can't load unknown file type %s.", filename)
 
 def convert_sql_import(cr, fp):
-    cr.execute(fp.read())
+    cr.execute(fp.read()) # pylint: disable=sql-injection
 
 def convert_csv_import(cr, module, fname, csvcontent, idref=None, mode='init',
         noupdate=False):


### PR DESCRIPTION
Those were not accounted for, leading to fstrings passing through
unflagged.

Also update the SQL checker to be stricter but smarter:

The previous version would "fail open", unknown nodes would be allowed
through hence f-strings not being flagged when they started appearing
in arg0 position, should now fail-closed, anything that's not allowed
is forbidden.

This flags a few more cases, all of which seem acceptable upon review.

However the previous version would also only resolve arg0 (in case it
had a `NAME`, to see if that resolved to an acceptable form of
query-building). The new version performs resolution during
`_check_concatenation` and should thus allow e.g. format strings to be
separate variables (though not e.g. module-level constants, yet
anyway).

In resolution, replace the ad-hoc process by astroid's built-in
`lookup` which seems to provide the same information. Slightly more in
fact, as it yields every assignment in case of e.g. conditionals, but
making use of that would require a lot more changes in the checker so
leaving the behaviour as-is for now.

It's important to *not* use `ilookup` here, because ilookup is not
"iterable" but "inferring", and we don't want values, we want
expression ASTs for analysis.

NOTE: previous improvements as well as fixes to existing code were
only implemented in 14.0, hence this being merged in 14.0 not 13.0
despite 13.0 still being supported.
