### PR TITLE
[FIX] pos_cash_rounding : Unpaid orders when using cash rounding

### DIFF
--- a/addons/pos_cash_rounding/models/pos_order.py
+++ b/addons/pos_cash_rounding/models/pos_order.py
@@ -99,5 +99,5 @@ class PosOrder(models.Model):
                 maxDiff = currency.round(self.config_id.rounding_method.rounding)
 
             diff = currency.round(self.amount_total - self.amount_paid)
-            res = abs(diff) < maxDiff
+            res = abs(diff) <= maxDiff
         return res


### PR DESCRIPTION
Current behavior :
When using cash rounding method "HALF-UP" if the difference between the rounded price and the original price was exactly half of the cash rounding, the order would appear as unpaid.

Steps to reproduce :
- Create a rounding method of 0.5 (half-up)
- Sell a product for 11.25
- The order appears unpaid in the PoS orders list view

opw-2593687

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
