### PR TITLE
[FIX] fleet: fleet cost report

### DIFF
--- a/addons/fleet/report/fleet_report.py
+++ b/addons/fleet/report/fleet_report.py
@@ -111,8 +111,7 @@ contract_costs AS (
         ve.id,
         date_start
 )
-SELECT
-    vehicle_id AS id,
+SELECT row_number() OVER (ORDER BY vehicle_id ASC) as id,
     company_id,
     vehicle_id,
     name,
@@ -121,12 +120,9 @@ SELECT
     date_start,
     vehicle_type,
     COST,
-    'service' as cost_type
-FROM
-    service_costs sc
-UNION ALL (
+    cost_type
+FROM (
     SELECT
-        vehicle_id AS id,
         company_id,
         vehicle_id,
         name,
@@ -135,9 +131,23 @@ UNION ALL (
         date_start,
         vehicle_type,
         COST,
-        'contract' as cost_type
+        'service' as cost_type
     FROM
-        contract_costs cc)
+        service_costs sc
+    UNION ALL (
+        SELECT
+            company_id,
+            vehicle_id,
+            name,
+            driver_id,
+            fuel_type,
+            date_start,
+            vehicle_type,
+            COST,
+            'contract' as cost_type
+        FROM
+            contract_costs cc)
+) c
 """
         tools.drop_view_if_exists(self.env.cr, self._table)
         self.env.cr.execute(


### PR DESCRIPTION
Steps to reproduce:
- Install Fleet
- Go on report-cost
- Click on a specifi vehicles
-> The cost associated are not correct

Solution:
Correction of the SQL-query which was not correct (id not unique)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
