### PR TITLE
[FIX] l10n_fr_fec: solve some issues with the french FEC

### DIFF
--- a/addons/l10n_fr_fec/wizard/account_fr_fec_view.xml
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec_view.xml
@@ -11,6 +11,7 @@
                         <field name="date_from"/>
                         <field name="date_to"/>
                         <field name="export_type" groups="base.group_no_one"/>
+                        <field name="include_zero_balance_items"/>
                     </group>
                 </page>
                 <page string="Technical Info">


### PR DESCRIPTION
THIS PR IS NOT WHAT YOU'RE LOOKING FOR, 
GO TO: https://github.com/odoo/odoo/pull/81923

This PR:

1. Allows exporting the FEC without any VAT number. Indeed, a company can have to submit its FEC without being submitted to VAT regulation.

2. Allows non french companies to export FEC file.

3. Allows exporting FEC with journal items == 0 and/or journal entries which total is 0.
Initially, french tax administration rejected the journal items which balance is 0.
But after several requests from tax payers, they agreed because they prefer continuous sequences and some tax payers post entries which total amount is 0.
Thus, a checkbox "Zero Balance Items" (not set by default) is added in the FEC wizard.

task-2717676
