### PR TITLE
[FIX] mail: user cannot edit a message that is not a comment type

### DIFF
--- a/addons/mail/i18n/en_GB.po
+++ b/addons/mail/i18n/en_GB.po
@@ -5656,3 +5656,9 @@ msgstr ""
 #, python-format
 msgid "unknown target model %s"
 msgstr ""
+
+#. module: mail
+#: code:addons/mail/models/mail_thread.py:1892
+#, python-format
+msgid "Only messages type comment can have their content updated"
+msgstr ""

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1888,6 +1888,8 @@ class MailThread(models.AbstractModel):
             raise exceptions.UserError(_("Only logged notes can have their content updated on model '%s'", self._name))
         if message.tracking_value_ids:
             raise exceptions.UserError(_("Messages with tracking values cannot be modified"))
+        if not message.message_type == 'comment':
+            raise exceptions.UserError(_("Only messages type comment can have their content updated"))
 
     # ------------------------------------------------------
     # MESSAGE POST TOOLS


### PR DESCRIPTION
Before this PR, user could edit notifications message.

task-2713602
