### PR TITLE
[FIX] snailmail: change error code when timeout

### DIFF
--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -6,7 +6,7 @@ import datetime
 
 from odoo import fields, models, api, _, tools
 from odoo.addons.iap import jsonrpc
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, AccessError
 from odoo.tools.safe_eval import safe_eval
 
 DEFAULT_ENDPOINT = 'https://iap-snailmail.odoo.com'
@@ -305,7 +305,14 @@ class SnailmailLetter(models.Model):
         endpoint = self.env['ir.config_parameter'].sudo().get_param('snailmail.endpoint', DEFAULT_ENDPOINT)
         timeout = int(self.env['ir.config_parameter'].sudo().get_param('snailmail.timeout', DEFAULT_TIMEOUT))
         params = self._snailmail_create('print')
-        response = jsonrpc(endpoint + PRINT_ENDPOINT, params=params, timeout=timeout)
+        try:
+            response = jsonrpc(endpoint + PRINT_ENDPOINT, params=params, timeout=timeout)
+        except AccessError as ae:
+            for doc in params['documents']:
+                letter = self.browse(doc['letter_id'])
+                letter.state = 'error'
+                letter.error_code = 'UNKNOWN_ERROR'
+            raise ae
         for doc in response['request']['documents']:
             if doc.get('sent') and response['request_code'] == 200:
                 note = _('The document was correctly sent by post.<br>The tracking id is %s' % doc['send_id'])


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Odoo task-id: 2715227

Current behavior before PR:
When the snailmail API-call timed out, the SnailmailLetter.state and SnailmailLetter.error_code were not changed, which resulted in an infinite loop of retries  via the "Snailmail: process letters queue" cron job.

Desired behavior after PR is merged:
On a timeout the SnailmailLetter.state and SnailmailLetter.error_code is changed such that no retry happens. Following stable policy, no timeout error is added, but 'unknown error' will be used. Preventing retries on timeout is mandatory as timed-out request are indeed processed by IAP and customers are credited.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
