### PR TITLE
[FIX] pos_restaurant: distinguish product variants

### DIFF
--- a/addons/pos_restaurant/static/src/js/multiprint.js
+++ b/addons/pos_restaurant/static/src/js/multiprint.js
@@ -135,13 +135,16 @@ models.Order = models.Order.extend({
             var qty  = Number(line.get_quantity());
             var note = line.get_note();
             var product_id = line.get_product().id;
-            var product_resume = product_id in resume ? resume[product_id] : {
+            var product_name = line.get_full_product_name();
+            var p_key = product_id + " - " + product_name;
+            var product_resume = p_key in resume ? resume[p_key] : {
+                pid: product_id,
                 product_name_wrapped: line.generate_wrapped_product_name(),
                 qties: {},
             };
             if (note in product_resume['qties']) product_resume['qties'][note] += qty;
             else product_resume['qties'][note] = qty;
-            resume[product_id] = product_resume;
+            resume[p_key] = product_resume;
         });
         return resume;
     },
@@ -158,13 +161,14 @@ models.Order = models.Order.extend({
         var json        = this.export_as_JSON();
         var add = [];
         var rem = [];
-        var pid, note;
+        var p_key, note;
 
-        for (pid in current_res) {
-            for (note in current_res[pid]['qties']) {
-                var curr = current_res[pid];
-                var old  = old_res[pid] || {};
-                var found = pid in old_res && note in old_res[pid]['qties'];
+        for (p_key in current_res) {
+            for (note in current_res[p_key]['qties']) {
+                var curr = current_res[p_key];
+                var old  = old_res[p_key] || {};
+                var pid = curr.pid;
+                var found = p_key in old_res && note in old_res[p_key]['qties'];
 
                 if (!found) {
                     add.push({
@@ -194,11 +198,12 @@ models.Order = models.Order.extend({
             }
         }
 
-        for (pid in old_res) {
-            for (note in old_res[pid]['qties']) {
-                var found = pid in current_res && note in current_res[pid]['qties'];
+        for (p_key in old_res) {
+            for (note in old_res[p_key]['qties']) {
+                var found = p_key in current_res && note in current_res[p_key]['qties'];
                 if (!found) {
-                    var old = old_res[pid];
+                    var old = old_res[p_key];
+                    var pid = old.pid;
                     rem.push({
                         'id':       pid,
                         'name':     this.pos.db.get_product_by_id(pid).display_name,
@@ -295,6 +300,13 @@ models.Order = models.Order.extend({
     init_from_JSON: function(json){
         _super_order.init_from_JSON.apply(this,arguments);
         this.saved_resume = json.multiprint_resume && JSON.parse(json.multiprint_resume);
+        // Since the order summary structure has changed, we need to remove the old lines
+        // Otherwise, this fix deployment will lead to some errors
+        for (var key in this.saved_resume) {
+            if (this.saved_resume[key].pid == undefined) {
+                delete this.saved_resume[key];
+            }
+        }
     },
 });
 


### PR DESCRIPTION
When using a product attribute with a creation mode defined on "never",
the order sent to the kitchen doesn't consider the product attribute
value

To reproduce the issue:
(Use demo data)
1. Create a product P:
    - In variants, add the "size" attribute with at least two values
        - (Note that the creation mode of this attribute is "never")
    - Available in POS
        - Category: Miscellaneous
2. In Point of Sale, edit the "Bar" POS and enable:
    - Product Configurator
    - Order Printer (the Kitchen Printer must be working)
3. Start a POS session
4. Select a table and add:
    - 1 x P with a size value
    - 1 x P with another(!) size value
5. Send the order to the kitchen

Error: The printed order only contains one line: 2 x P with the first
size value selected

When checking if the current order has some changes, the lines summary
builder does not distinguish the product variants

OPW-2698626