### PR TITLE
[FIX] website_sale,payment: Block UI only on click pay

### DIFF
--- a/addons/payment/static/src/js/checkout_form.js
+++ b/addons/payment/static/src/js/checkout_form.js
@@ -74,6 +74,10 @@ odoo.define('payment.checkout_form', require => {
             // Make the payment
             this._hideError(); // Don't keep the error displayed if the user is going through 3DS2
             this._disableButton(true); // Disable until it is needed again
+            $('body').block({
+                message: false,
+                overlayCSS: {backgroundColor: "#000", opacity: 0, zIndex: 1050},
+            });
             this._processPayment(provider, paymentOptionId, flow);
         },
 

--- a/addons/payment/static/src/js/manage_form.js
+++ b/addons/payment/static/src/js/manage_form.js
@@ -206,6 +206,10 @@ odoo.define('payment.manage_form', require => {
             // Save the payment method
             this._hideError(); // Don't keep the error displayed if the user is going through 3DS2
             this._disableButton(true); // Disable until it is needed again
+            $('body').block({
+                message: false,
+                overlayCSS: {backgroundColor: "#000", opacity: 0, zIndex: 1050},
+            });
             if (flow !== 'token') { // Creation of a new token
                 this.txContext.tokenizationRequested = true;
                 this.txContext.isValidation = true;

--- a/addons/payment/static/src/js/payment_form_mixin.js
+++ b/addons/payment/static/src/js/payment_form_mixin.js
@@ -104,6 +104,7 @@ odoo.define('payment.payment_form_mixin', require => {
                     .scrollIntoView({behavior: 'smooth', block: 'center'});
             }
             this._enableButton(); // Enable button back after it was disabled before processing
+            $('body').unblock(); // The page is blocked at this point, unblock it
         },
 
         /**

--- a/addons/payment_adyen/static/src/js/payment_form.js
+++ b/addons/payment_adyen/static/src/js/payment_form.js
@@ -196,7 +196,7 @@ odoo.define('payment_adyen.payment_form', require => {
          * @param {string} flow - The online payment flow of the transaction
          * @return {Promise}
          */
-        _processPayment: function (provider, paymentOptionId, flow) {
+        async _processPayment(provider, paymentOptionId, flow) {
             if (provider !== 'adyen' || flow === 'token') {
                 return this._super(...arguments); // Tokens are handled by the generic flow
             }
@@ -205,7 +205,7 @@ odoo.define('payment_adyen.payment_form', require => {
                     _t("Server Error"), _t("We are not able to process your payment.")
                 );
             } else {
-                return this.adyenDropin.submit();
+                return await this.adyenDropin.submit();
             }
         },
 

--- a/addons/payment_authorize/static/src/js/payment_form.js
+++ b/addons/payment_authorize/static/src/js/payment_form.js
@@ -130,6 +130,7 @@ odoo.define('payment_authorize.payment_form', require => {
 
             if (!this._validateFormInputs(paymentOptionId)) {
                 this._enableButton(); // The submit button is disabled at this point, enable it
+                $('body').unblock(); // The page is blocked at this point, unblock it
                 return Promise.resolve();
             }
 

--- a/addons/website_sale/static/src/js/website_sale_payment.js
+++ b/addons/website_sale/static/src/js/website_sale_payment.js
@@ -54,26 +54,6 @@ odoo.define('website_sale.payment', require => {
         //----------------------------------------------------------------------
 
         /**
-         * @override
-         */
-        _disableButton(showLoadingAnimation = true) {
-            $("body").block({
-                message: false,
-                overlayCSS: {backgroundColor: "#000", opacity: 0, zIndex: 1050},
-            });
-            this._super(...arguments);
-        },
-        /**
-         * @override
-         */
-        _enableButton() {
-            const res = this._super(...arguments);
-            if (res) {
-                $('body').unblock();
-            }
-            return res;
-        },
-        /**
          * Verify that the Terms and Condition checkbox is checked.
          *
          * @override method from payment.payment_form_mixin


### PR DESCRIPTION
Step to reproduce:

  - Install website_sale module
  - Go to the shop
  - Add a product to the cart and proceed to checkout
  - Click on Customize and activate `Accept Terms & Conditions`
  - Deactivate the `Accept Terms & Conditions` or click on a
    payment method.

Issue:

  UI freeze.

Solution:

  Freeze ui only when clicking on pay button.
  Unfreeze only if payment process fails.
  revert of odoo@41b91e1

See also:
- Enterprise PR: odoo/enterprise#23560

opw-2702798