### PR TITLE
[FIX] sale: send invoice only when ready even without sale.order

### DIFF
--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -137,7 +137,9 @@ class PaymentTransaction(models.Model):
                 ('is_move_sent', '=', False),
                 ('state', '=', 'posted'),
             ])),
-            ('sale_order_ids.state', 'in', ('sale', 'done')),
+            "|",
+                ('sale_order_ids', '=', False),
+                ('sale_order_ids.state', 'in', ('sale', 'done')),
             ('last_state_change', '>=', retry_limit_date),
         ])._send_invoice()
 


### PR DESCRIPTION
the commit
https://github.com/odoo/odoo/commit/804f7ab180809a292ac34e4189baeaa5866c0f7c
delays the sending of the invoice after edi document have been
synchronized.

This issue is that only invoice linked with a sale.order were actually
sent but other invoice should be invoiced as well






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
