### PR TITLE
[FIX] sale: avoid concurrent update on invoice

### DIFF
--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -150,6 +150,10 @@ class PaymentTransaction(models.Model):
                 if confirmed_orders:
                     confirmed_orders._force_lines_to_invoice_policy_order()
                     invoices = confirmed_orders._create_invoices()
+                    # Setup access token in advance to avoid serialization failure between
+                    # edi postprocessing of invoice and displaying the sale order on the portal
+                    for invoice in invoices:
+                        invoice._portal_ensure_token()
                     trans.invoice_ids = [(6, 0, invoices.ids)]
 
     @api.model


### PR DESCRIPTION
Issue
-----

When a customer sign and pay a sale order from the portal and  
automatic invoicing is enabled, it generate an invoice. 
Once the payment done the customer is redirected to
the sale order preview with a link to the invoice created.

To display the link to the invoice the method _portal_ensure_token() is
called and write the access token token.

In parallel, if the invoice need to send edi document, the cron job is
triggered at the posting of the invoice and thus the cron job try to
write as well on the invoice as the invoice link is displayed to the
customer

This lead to a concurrent update for the cron job that do not retry in
case of concurrent update as normal transactions do. So the edi document
is never synchronized and the invoice never sent

Solution
--------
Avoid to write on the invoice while displaying the sale order portal
view by already generating the access_token in the transaction that post
the invoice





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
