### PR TITLE
[FIX] point_of_sale : Cahsh in/out button not showing

### DIFF
--- a/addons/point_of_sale/static/src/xml/Chrome.xml
+++ b/addons/point_of_sale/static/src/xml/Chrome.xml
@@ -12,7 +12,8 @@
                     <TicketButton isTicketScreenShown="isTicketScreenShown" />
                 </div>
                 <div class="pos-rightheader">
-                    <TicketButton isTicketScreenShown="isTicketScreenShown" t-if="env.isMobile" />
+                    <CashMoveButton t-if="showCashMoveButton() and env.isMobile" />
+                    <TicketButton isTicketScreenShown="isTicketScreenShown" t-if="env.isMobile and !state.mobileSearchBarIsShown" />
                     <div class="search-bar-portal" />
                     <div class="status-buttons-portal" />
                 </div>


### PR DESCRIPTION
Current behavior :
Cash in/out button not showing in PoS mobile app

Steps to reproduce :
- Go in the PoS mobile app

opw-2704097

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
