### PR TITLE
[FIX] point_of_sale : Cash in/out button not showing in mobile app

### DIFF
--- a/addons/point_of_sale/static/src/xml/Chrome.xml
+++ b/addons/point_of_sale/static/src/xml/Chrome.xml
@@ -13,6 +13,7 @@
                     <TicketButton isTicketScreenShown="isTicketScreenShown" />
                 </div>
                 <div class="pos-rightheader">
+                    <CashMoveButton t-if="showCashMoveButton() and env.isMobile and !state.mobileSearchBarIsShown" />
                     <TicketButton isTicketScreenShown="isTicketScreenShown" t-if="env.isMobile and !state.mobileSearchBarIsShown" />
                     <div class="search-bar-portal" />
                     <div class="status-buttons-portal" t-att-class="{ oe_hidden: state.mobileSearchBarIsShown }"/>


### PR DESCRIPTION
Current behavior :
Cash in/out button is not present on mobile PoS app

Steps to reproduce :
- Go on your mobile app
- Go in PoS app

opw-2704097

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
