### PR TITLE
[FIX] stock: correctly compare inventory adjustements difference

### DIFF
--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -528,7 +528,7 @@ class InventoryLine(models.Model):
         if not self.env.context.get('default_inventory_id'):
             raise NotImplementedError(_('Unsupported search on %s outside of an Inventory Adjustment') % 'difference_qty')
         lines = self.search([('inventory_id', '=', self.env.context.get('default_inventory_id'))])
-        line_ids = lines.filtered(lambda line: float_is_zero(line.difference_qty, line.product_id.uom_id.rounding) == result).ids
+        line_ids = lines.filtered(lambda line: float_is_zero(line.difference_qty, precision_rounding=line.product_id.uom_id.rounding) == result).ids
         return [('id', 'in', line_ids)]
 
     def _search_outdated(self, operator, value):


### PR DESCRIPTION
The filter 'Difference different than zero' is not correct

Steps to reproduce:
1. Install the Inventory app
2. Go to Inventory -> Operations -> Inventory Adjustments
3. Create a new Inventory Adjustments and start it
4. Change the number of Drawer counted so that the absolute difference is <= 0,498
5. Apply the filter 'Difference different than zero'
6. The line disappears although the difference is not null

Solution:
Specify the argument name 'precision_rounding' for the function 'float_is_zero()'

OPW-2699771