### PR TITLE
[FIX] pos_hr: allow user to close session.

### DIFF
--- a/addons/pos_hr/static/src/js/Chrome.js
+++ b/addons/pos_hr/static/src/js/Chrome.js
@@ -12,7 +12,7 @@ odoo.define('pos_hr.chrome', function (require) {
                 if (this.env.pos.config.module_pos_hr) this.showTempScreen('LoginScreen');
             }
             get headerButtonIsShown() {
-                return !this.env.pos.config.module_pos_hr || this.env.pos.get('cashier').role == 'manager';
+                return !this.env.pos.config.module_pos_hr || this.env.pos.get('cashier').role == 'manager' || this.env.pos.get_cashier().user_id[0] === this.env.pos.user.id;
             }
             showCashMoveButton() {
                 return super.showCashMoveButton() && this.env.pos.get('cashier').role == 'manager';


### PR DESCRIPTION
The current user of the pos session is unable to close the session even if he is the one who opened it.
This commit allows the cashier to close the session if he is linked to the user that opened the POS session.

task-id: 2713876

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
