### PR TITLE
[FIX] http_routing: redirect no double query_string


### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -659,7 +659,8 @@ class IrHttp(models.AbstractModel):
         except werkzeug.exceptions.MethodNotAllowed:
             _ = router.match(path, method='GET')
         except werkzeug.routing.RequestRedirect as e:
-            new_url = e.new_url[7:]  # remove scheme
+            # get path from http://{path}?{current query string}
+            new_url = e.new_url.split('?')[0][7:]
         except werkzeug.exceptions.NotFound:
             new_url = path
         except Exception as e:

--- a/addons/test_website/controllers/main.py
+++ b/addons/test_website/controllers/main.py
@@ -138,3 +138,7 @@ class WebsiteTest(Home):
     @http.route(['/test_website/200/<model("test.model"):rec>'], type='http', auth="public", website=True, sitemap=False)
     def test_model_converter_seoname(self, rec, **kw):
         return request.make_response('ok')
+
+    @http.route(['/test_website/test_redirect_view_qs'], type='http', auth="public", website=True, sitemap=False)
+    def test_redirect_view_qs(self, **kw):
+        return request.render('test_website.test_redirect_view_qs')

--- a/addons/test_website/data/test_website_data.xml
+++ b/addons/test_website/data/test_website_data.xml
@@ -111,6 +111,9 @@
             <!-- `href` is send through `url_for` for non editor users -->
             <a href="/test_website/country/andorra-1">I am a link</a>
         </template>
+        <template id="test_redirect_view_qs">
+            <a href="/empty_controller_test?a=a">Home</a>
+        </template>
 
     </data>
 </odoo>

--- a/addons/test_website/tests/test_redirect.py
+++ b/addons/test_website/tests/test_redirect.py
@@ -160,3 +160,17 @@ class TestRedirect(HttpCase):
             resp = self.url_open("/test_website/308/xx-100", allow_redirects=False)
             self.assertEqual(resp.status_code, 404)
             self.assertEqual(resp.text, "CUSTOM 404")
+
+    def test_03_redirect_308_qs(self):
+        self.env['website.rewrite'].create({
+            'name': 'Test QS Redirect',
+            'redirect_type': '308',
+            'url_from': '/empty_controller_test',
+            'url_to': '/empty_controller_test_redirected',
+        })
+        r = self.url_open('/test_website/test_redirect_view_qs?a=a')
+        self.assertEqual(r.status_code, 200)
+        self.assertIn(
+            'href="/empty_controller_test_redirected?a=a"', r.text,
+            "Redirection should have been applied, and query string should not have been duplicated.",
+        )


### PR DESCRIPTION
Reproduction:

- have 308 redirection from /shop to /boutique and refresh routes
- go in incognito on /boutique?order=name+asc  (don't go on
  /boutique first, or restart odoo to clear ORM cache)
- select a sorting option eg. price

=> we are redirected to /boutique?order=name+asc?order=list_price+asc
and this error is shown:

Invalid "order" specified (is_published desc, name asc?order=list_price
 asc, id desc).

This is happening because url_rewrite is keeping current query string
(see ir.http()._slug_matching) and caching it. So if the first call
caches:

  url_rewrite('/boutique') => /boutique?order=name+asc

all other url_rewrite('/boutique') calls will give you
/boutique?order=name+asc even if the query string has changed.

In addition to that, url_for may append query_string to url_rewrite
return value, so you may get a double query_string such as:

?order=name+asc?order=list_price+asc

which causes the error.

In this fix, we restore the removal of query string that was removed in
3beb454.

opw-2702036