### PR TITLE
[FIX] hr_fleet : UserError on empty pdf

### DIFF
--- a/addons/hr_fleet/controllers/main.py
+++ b/addons/hr_fleet/controllers/main.py
@@ -67,6 +67,9 @@ class HrFleet(Controller):
                 page.mergePage(header_pdf.getPage(0))
                 writer.addPage(page)
 
+        if not writer.getNumPages():
+            request.not_found(_('There is no pdf attached to generate a claim report.'))
+
         _buffer = io.BytesIO()
         writer.write(_buffer)
         merged_pdf = _buffer.getvalue()

--- a/addons/hr_fleet/i18n/hr_fleet.pot
+++ b/addons/hr_fleet/i18n/hr_fleet.pot
@@ -119,6 +119,11 @@ msgid ""
 msgstr ""
 
 #. module: hr_fleet
+#: code:addons/hr_fleet/controllers/main.py:0
+msgid "There is no pdf attached to generate a claim report."
+msgstr ""
+
+#. module: hr_fleet
 #: model:ir.model,name:hr_fleet.model_res_users
 msgid "Users"
 msgstr ""


### PR DESCRIPTION
Step to reproduce:
- Print a 'claim car report' on a car with no attachment

Current Behaviour:
- Print a empty PDF

Behaviour after PR:
- Raise an userError to explain that there is no attachement linked to the car

opw-2714493

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
