### PR TITLE
[FIX] packaging: add explicit depends on multilingual fonts

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,8 @@ Depends:
  ${misc:Depends},
  ${python3:Depends},
  adduser,
+# support for multilingual fonts
+ fonts-dejavu-core | fonts-freefont-ttf | fonts-freefont-otf | fonts-noto-core,
  fonts-inconsolata,
  fonts-font-awesome,
  fonts-roboto-unhinted,


### PR DESCRIPTION
A bug[0] was detected in the Odoo Docker image 15.0 when trying to print
invoices with arabic fonts (and probably other languages that need
specific font) . It appears that the necessary fonts are not available
in the container image.

Strangely, the issue did not exists in previous Odoo Docker images.

It appears that `fonts-dejavu-core` package was installed incidentally
by `wkhtmltox`[1] which is installed from the official website.
Note that the Debian version of `wkhtmltopdf`[2] does not provide this
dependency.

In the 15.0 Docker image, while the `wkhtmltox` is installed the same
way, the `fonts-dejavu-core` package was not installed because the
dependency of `fontconfig-config`[3] was already fulfilled by the
`python3-renderpm`[4] from Debian Bullseye.

Finally, to add more confusion, the Odoo package have an indirect
dependency on `fonts-dejavu-core` through the `python3-pydot`[5] package.
This explains why the issue was not found before.

In order to avoid all this spaghetti dependency hell, this commit adds
an explicit dependency on one of the multilingual fonts available in the
Debian packages.

[0] https://github.com/odoo/docker/issues/400
[1] https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.5/
[2] https://packages.debian.org/bullseye/wkhtmltopdf
[3] https://packages.debian.org/bullseye/fontconfig-config
[4] https://packages.debian.org/bullseye/python3-renderpm
[5] https://packages.debian.org/bullseye/python3-pydot

