### PR TITLE
[FIX] Edi proxy client user registration patch

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -134,7 +134,7 @@ class AccountEdiProxyClientUser(models.Model):
                     'company_id': company.id,
                     'edi_format_code': edi_format.code,
                     'edi_identification': edi_identification,
-                    'public_key': base64.b64encode(public_pem)
+                    'public_key': base64.b64encode(public_pem).decode()
                 })
             except AccountEdiProxyError as e:
                 raise UserError(e.message)

--- a/doc/cla/corporate/iscanet.md
+++ b/doc/cla/corporate/iscanet.md
@@ -1,0 +1,15 @@
+Italy, 2021-12-20
+
+Iscanet Internet Services S.r.l. agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Rocco Lucia rlucia@iscanet.com https://github.com/rlucia
+
+List of contributors:
+
+Rocco Lucia rlucia@iscanet.com https://github.com/rlucia


### PR DESCRIPTION
We need to decode binary data to allow JSON serialization.

Description of the issue/feature this PR addresses:

Current behavior before PR:
Cannot register EDI proxy client user on Odoo FatturaPA gateway (Settings > Accounting > Electronic Document Invoicing > Register throws a JSON serialization error).

Desired behavior after PR is merged:
Settings > Accounting > Electronic Document Invoicing > Register will work and not throw any error



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
