### PR TITLE
[IMP] sale_stock: improve the error message

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -585,6 +585,5 @@ class SaleOrderLine(models.Model):
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
         line_products = self.filtered(lambda l: l.product_id.type in ['product', 'consu'])
         if line_products.mapped('qty_delivered') and float_compare(values['product_uom_qty'], max(line_products.mapped('qty_delivered')), precision_digits=precision) == -1:
-            raise UserError(_('You cannot decrease the ordered quantity below the delivered quantity.\n'
-                              'Create a return first.'))
+            raise UserError(_('The ordered quantity cannot be decreased below the amount already delivered. Instead, create a return in your inventory.'))
         super(SaleOrderLine, self)._update_line_quantity(values)


### PR DESCRIPTION
Currently, User/validation errors are sometimes not correct in English and/or quite obscure and don't help the user understand/solve the issue.

So in this commit, do some copywriting to make the experience better.

task-2615469

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
