### PR TITLE
[FIX] mail: make the mute and deafen button behavior more intuitive

### DIFF
--- a/addons/mail/models/mail_channel_rtc_session.py
+++ b/addons/mail/models/mail_channel_rtc_session.py
@@ -104,7 +104,7 @@ class MailRtcSession(models.Model):
             vals.update({
                 'isCameraOn': self.is_camera_on,
                 'isDeaf': self.is_deaf,
-                'isMuted': self.is_muted,
+                'isSelfMuted': self.is_muted,
                 'isScreenSharingOn': self.is_screen_sharing_on,
             })
         if self.guest_id:

--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
@@ -47,7 +47,7 @@
                             </t>
                         </span>
                         <div class="o_RtcCallParticipantCard_overlayTop">
-                            <t t-if="callParticipantCard.rtcSession.isMuted">
+                            <t t-if="callParticipantCard.rtcSession.isMuted and !callParticipantCard.rtcSession.isDeaf">
                                 <span class="o_RtcCallParticipantCard_overlayTopElement" t-att-class="{'o-isMinimized': callParticipantCard.isMinimized }" title="muted" aria-label="muted">
                                     <i class="fa fa-microphone-slash"/>
                                 </span>

--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
@@ -47,7 +47,7 @@
                             </t>
                         </span>
                         <div class="o_RtcCallParticipantCard_overlayTop">
-                            <t t-if="callParticipantCard.rtcSession.isMuted and !callParticipantCard.rtcSession.isDeaf">
+                            <t t-if="callParticipantCard.rtcSession.isSelfMuted and !callParticipantCard.rtcSession.isDeaf">
                                 <span class="o_RtcCallParticipantCard_overlayTopElement" t-att-class="{'o-isMinimized': callParticipantCard.isMinimized }" title="muted" aria-label="muted">
                                     <i class="fa fa-microphone-slash"/>
                                 </span>

--- a/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
+++ b/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
@@ -6,19 +6,19 @@
             <t t-if="rtcController and messaging">
                 <div class="o_RtcController_buttons">
                     <t t-if="rtcController.callViewer.threadView.thread.rtc and messaging.rtc.currentRtcSession">
-                        <t t-if="messaging.rtc.currentRtcSession.isMuted"><t t-set="microphoneTitle">Unmute</t></t>
+                        <t t-if="messaging.rtc.currentRtcSession.isMuteOrDeaf"><t t-set="microphoneTitle">Unmute</t></t>
                         <t t-else=""><t t-set="microphoneTitle">Mute</t></t>
                         <button class="o_RtcController_button"
-                            t-att-class="{ 'o-isActive': !messaging.rtc.currentRtcSession.isMuted, 'o-isSmall': rtcController.isSmall }"
+                            t-att-class="{ 'o-isActive': !messaging.rtc.currentRtcSession.isMuteOrDeaf, 'o-isSmall': rtcController.isSmall }"
                             t-att-aria-label="microphoneTitle"
                             t-att-title="microphoneTitle"
                             t-on-click="rtcController.onClickMicrophone">
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
                                 <i class="fa" t-att-class="{
                                     'fa-lg': !rtcController.isSmall,
-                                    'fa-microphone': !messaging.rtc.currentRtcSession.isMuted,
-                                    'fa-microphone-slash': messaging.rtc.currentRtcSession.isMuted,
-                                    'text-danger': messaging.rtc.currentRtcSession.isMuted,
+                                    'fa-microphone': !messaging.rtc.currentRtcSession.isMuteOrDeaf,
+                                    'fa-microphone-slash': messaging.rtc.currentRtcSession.isMuteOrDeaf,
+                                    'text-danger': messaging.rtc.currentRtcSession.isMuteOrDeaf,
                                 }"/>
                             </div>
                         </button>

--- a/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
+++ b/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
@@ -6,19 +6,19 @@
             <t t-if="rtcController and messaging">
                 <div class="o_RtcController_buttons">
                     <t t-if="rtcController.callViewer.threadView.thread.rtc and messaging.rtc.currentRtcSession">
-                        <t t-if="messaging.rtc.currentRtcSession.isMuteOrDeaf"><t t-set="microphoneTitle">Unmute</t></t>
+                        <t t-if="messaging.rtc.currentRtcSession.isMute"><t t-set="microphoneTitle">Unmute</t></t>
                         <t t-else=""><t t-set="microphoneTitle">Mute</t></t>
                         <button class="o_RtcController_button"
-                            t-att-class="{ 'o-isActive': !messaging.rtc.currentRtcSession.isMuteOrDeaf, 'o-isSmall': rtcController.isSmall }"
+                            t-att-class="{ 'o-isActive': !messaging.rtc.currentRtcSession.isMute, 'o-isSmall': rtcController.isSmall }"
                             t-att-aria-label="microphoneTitle"
                             t-att-title="microphoneTitle"
                             t-on-click="rtcController.onClickMicrophone">
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
                                 <i class="fa" t-att-class="{
                                     'fa-lg': !rtcController.isSmall,
-                                    'fa-microphone': !messaging.rtc.currentRtcSession.isMuteOrDeaf,
-                                    'fa-microphone-slash': messaging.rtc.currentRtcSession.isMuteOrDeaf,
-                                    'text-danger': messaging.rtc.currentRtcSession.isMuteOrDeaf,
+                                    'fa-microphone': !messaging.rtc.currentRtcSession.isMute,
+                                    'fa-microphone-slash': messaging.rtc.currentRtcSession.isMute,
+                                    'text-danger': messaging.rtc.currentRtcSession.isMute,
                                 }"/>
                             </div>
                         </button>

--- a/addons/mail/static/src/models/partner/partner.js
+++ b/addons/mail/static/src/models/partner/partner.js
@@ -44,7 +44,7 @@ function factory(dependencies) {
                 data2.id = data.id;
             }
             if ('is_muted' in data) {
-                data2.isMuted = data.is_muted;
+                data2.isSelfMuted = data.is_muted;
             }
             if ('im_status' in data) {
                 data2.im_status = data.im_status;

--- a/addons/mail/static/src/models/rtc/rtc.js
+++ b/addons/mail/static/src/models/rtc/rtc.js
@@ -110,6 +110,10 @@ function factory(dependencies) {
         // Public
         //----------------------------------------------------------------------
 
+        async deafen() {
+            await this._setDeafState(true);
+        }
+
         /**
          * Removes and disconnects all the peerConnections that are not current members of the call.
          *
@@ -214,6 +218,10 @@ function factory(dependencies) {
             }
         }
 
+        async mute() {
+            await this._setMuteState(true);
+        }
+
         /**
          * Resets the state of the model and cleanly ends all connections and
          * streams.
@@ -249,23 +257,6 @@ function factory(dependencies) {
         }
 
         /**
-         * Mutes and unmutes the microphone, will not unmute if deaf.
-         *
-         * @param {Object} [param0]
-         * @param {string} [param0.requestAudioDevice] true if requesting the audio input device
-         *                 from the user
-         */
-        async toggleMicrophone({ requestAudioDevice = true } = {}) {
-            const shouldMute = this.currentRtcSession.isDeaf || !this.currentRtcSession.isMuted;
-            this.currentRtcSession.updateAndBroadcast({ isMuted: shouldMute || !this.audioTrack });
-            if (!this.audioTrack && !shouldMute && requestAudioDevice) {
-                // if we don't have an audioTrack, we try to request it again
-                await this.updateLocalAudioTrack(true);
-            }
-            await this.async(() => this._updateLocalAudioTrackEnabledState());
-        }
-
-        /**
          * toggles screen broadcasting to peers.
          */
         async toggleScreenShare() {
@@ -277,6 +268,19 @@ function factory(dependencies) {
          */
         async toggleUserVideo() {
             this._toggleVideoBroadcast({ type: 'user-video' });
+        }
+
+        async undeafen() {
+            await this._setDeafState(false);
+        }
+
+        async unmute() {
+            if (this.audioTrack) {
+                await this._setMuteState(false);
+            } else {
+                // if we don't have an audioTrack, we try to request it again
+                await this.updateLocalAudioTrack(true);
+            }
         }
 
         /**
@@ -321,7 +325,7 @@ function factory(dependencies) {
                     await this.async(() => this._updateLocalAudioTrackEnabledState());
                 });
                 this.currentRtcSession.updateAndBroadcast({ isMuted: false });
-                audioTrack.enabled = !this.currentRtcSession.isMuted && this.currentRtcSession.isTalking;
+                audioTrack.enabled = !this.currentRtcSession.isMuteOrDeaf && this.currentRtcSession.isTalking;
                 this.update({ audioTrack });
                 await this.async(() => this.updateVoiceActivation());
                 for (const [token, peerConnection] of Object.entries(this._peerConnections)) {
@@ -347,6 +351,7 @@ function factory(dependencies) {
             this._disconnectAudioMonitor && this._disconnectAudioMonitor();
             if (this.messaging.userSetting.usePushToTalk || !this.channel || !this.audioTrack) {
                 this.currentRtcSession.update({ isTalking: false });
+                await this._updateLocalAudioTrackEnabledState();
                 return;
             }
             try {
@@ -368,6 +373,7 @@ function factory(dependencies) {
                 });
                 this.currentRtcSession.update({ isTalking: true });
             }
+            await this._updateLocalAudioTrackEnabledState();
         }
 
         //----------------------------------------------------------------------
@@ -514,7 +520,10 @@ function factory(dependencies) {
                         type: 'peerToPeer',
                         payload: {
                             type: 'audio',
-                            state: { isTalking: this.currentRtcSession.isTalking, isMuted: this.currentRtcSession.isMuted },
+                            state: {
+                                isTalking: this.audioTrack && this.audioTrack.enabled,
+                                isMuted: this.currentRtcSession.isMuted,
+                            },
                         },
                     });
                 } catch (e) {
@@ -881,6 +890,28 @@ function factory(dependencies) {
         }
 
         /**
+         * @param {Boolean} isDeaf
+         */
+        async _setDeafState(isDeaf) {
+            this.currentRtcSession.updateAndBroadcast({ isDeaf });
+            for (const session of this.messaging.models['mail.rtc_session'].all()) {
+                if (!session.audioElement) {
+                    continue;
+                }
+                session.audioElement.muted = isDeaf;
+            }
+            await this._updateLocalAudioTrackEnabledState();
+        }
+
+        /**
+         * @param {Boolean} isMuted
+         */
+        async _setMuteState(isMuted) {
+            this.currentRtcSession.updateAndBroadcast({ isMuted });
+            await this._updateLocalAudioTrackEnabledState();
+        }
+
+        /**
          * Updates the "isTalking" state of the current user and sets the
          * enabled state of its audio track accordingly.
          *
@@ -895,7 +926,7 @@ function factory(dependencies) {
                 return;
             }
             this.currentRtcSession.update({ isTalking });
-            if (!this.currentRtcSession.isMuted) {
+            if (!this.currentRtcSession.isMuteOrDeaf) {
                 await this._updateLocalAudioTrackEnabledState();
             }
         }
@@ -976,8 +1007,8 @@ function factory(dependencies) {
         }
 
         /**
-         * Sets the enabled property of the local audio track based on the
-         * current session state. And notifies peers of the new audio state.
+         * Sets the enabled property of the local audio track and notifies
+         * peers of the new state.
          *
          * @private
          */
@@ -985,14 +1016,14 @@ function factory(dependencies) {
             if (!this.audioTrack) {
                 return;
             }
-            this.audioTrack.enabled = !this.currentRtcSession.isMuted && this.currentRtcSession.isTalking;
+            this.audioTrack.enabled = !this.currentRtcSession.isMuteOrDeaf && this.currentRtcSession.isTalking;
             await this._notifyPeers(Object.keys(this._peerConnections), {
                 event: 'trackChange',
                 type: 'peerToPeer',
                 payload: {
                     type: 'audio',
                     state: {
-                        isTalking: this.currentRtcSession.isTalking && !this.currentRtcSession.isMuted,
+                        isTalking: this.audioTrack.enabled,
                         isMuted: this.currentRtcSession.isMuted,
                         isDeaf: this.currentRtcSession.isDeaf,
                     },
@@ -1177,19 +1208,22 @@ function factory(dependencies) {
             if (!this.channel) {
                 return;
             }
-            if (this.messaging.userSetting.rtcConfigurationMenu.isRegisteringKey) {
+            if (!this.messaging.userSetting.usePushToTalk || !this.messaging.userSetting.isPushToTalkKey(ev)) {
                 return;
             }
-            if (!this.messaging.userSetting.usePushToTalk || !this.messaging.userSetting.isPushToTalkKey(ev)) {
+            if (this.currentRtcSession.isMuteOrDeaf) {
+                return;
+            }
+            if (this.messaging.userSetting.rtcConfigurationMenu.isRegisteringKey) {
                 return;
             }
             if (this._pushToTalkTimeoutId) {
                 browser.clearTimeout(this._pushToTalkTimeoutId);
             }
-            if (!this.currentRtcSession.isTalking && !this.currentRtcSession.isMuted) {
+            if (!this.currentRtcSession.isTalking) {
                 this.messaging.soundEffects.pushToTalk.play({ volume: 0.3 });
+                this._setSoundBroadcast(true);
             }
-            this._setSoundBroadcast(true);
         }
 
         /**
@@ -1206,7 +1240,7 @@ function factory(dependencies) {
             if (!this.currentRtcSession.isTalking) {
                 return;
             }
-            if (!this.currentRtcSession.isMuted) {
+            if (!this.currentRtcSession.isMuteOrDeaf) {
                 this.messaging.soundEffects.pushToTalk.play({ volume: 0.3 });
             }
             this._pushToTalkTimeoutId = browser.setTimeout(

--- a/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
+++ b/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
@@ -111,7 +111,7 @@ function factory(dependencies) {
          * @returns {boolean}
          */
         _computeIsTalking() {
-            return Boolean(this.rtcSession && this.rtcSession.isTalking && !this.rtcSession.isMuteOrDeaf);
+            return Boolean(this.rtcSession && this.rtcSession.isTalking && !this.rtcSession.isMute);
         }
 
         /**

--- a/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
+++ b/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
@@ -111,7 +111,7 @@ function factory(dependencies) {
          * @returns {boolean}
          */
         _computeIsTalking() {
-            return Boolean(this.rtcSession && this.rtcSession.isTalking && !this.rtcSession.isMuted);
+            return Boolean(this.rtcSession && this.rtcSession.isTalking && !this.rtcSession.isMuteOrDeaf);
         }
 
         /**

--- a/addons/mail/static/src/models/rtc_controller/rtc_controller.js
+++ b/addons/mail/static/src/models/rtc_controller/rtc_controller.js
@@ -37,14 +37,27 @@ function factory(dependencies) {
          * @param {MouseEvent} ev
          */
         async onClickDeafen(ev) {
-            await this.messaging.rtc.currentRtcSession.toggleDeaf();
+            if (this.messaging.rtc.currentRtcSession.isDeaf) {
+                this.messaging.rtc.undeafen();
+            } else {
+                this.messaging.rtc.deafen();
+            }
         }
 
         /**
          * @param {MouseEvent} ev
          */
         onClickMicrophone(ev) {
-            this.messaging.rtc.toggleMicrophone();
+            if (this.messaging.rtc.currentRtcSession.isMuteOrDeaf) {
+                if (this.messaging.rtc.currentRtcSession.isMuted) {
+                    this.messaging.rtc.unmute();
+                }
+                if (this.messaging.rtc.currentRtcSession.isDeaf) {
+                    this.messaging.rtc.undeafen();
+                }
+            } else {
+                this.messaging.rtc.mute();
+            }
         }
 
         /**

--- a/addons/mail/static/src/models/rtc_controller/rtc_controller.js
+++ b/addons/mail/static/src/models/rtc_controller/rtc_controller.js
@@ -48,8 +48,8 @@ function factory(dependencies) {
          * @param {MouseEvent} ev
          */
         onClickMicrophone(ev) {
-            if (this.messaging.rtc.currentRtcSession.isMuteOrDeaf) {
-                if (this.messaging.rtc.currentRtcSession.isMuted) {
+            if (this.messaging.rtc.currentRtcSession.isMute) {
+                if (this.messaging.rtc.currentRtcSession.isSelfMuted) {
                     this.messaging.rtc.unmute();
                 }
                 if (this.messaging.rtc.currentRtcSession.isDeaf) {

--- a/addons/mail/static/src/models/rtc_session/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session/rtc_session.js
@@ -60,10 +60,10 @@ function factory(dependencies) {
         /**
          * @param {Object} param0
          * @param {MediaStream} param0.audioStream
-         * @param {boolean} param0.isMuted
+         * @param {boolean} param0.isSelfMuted
          * @param {boolean} param0.isTalking
          */
-        async setAudio({ audioStream, isMuted, isTalking }) {
+        async setAudio({ audioStream, isSelfMuted, isTalking }) {
             const audioElement = this.audioElement || new window.Audio();
             try {
                 audioElement.srcObject = audioStream;
@@ -86,7 +86,7 @@ function factory(dependencies) {
             this.update({
                 audioElement,
                 audioStream,
-                isMuted,
+                isSelfMuted,
                 isTalking,
             });
             try {
@@ -177,7 +177,7 @@ function factory(dependencies) {
                                 values: {
                                     is_camera_on: this.isCameraOn,
                                     is_deaf: this.isDeaf,
-                                    is_muted: this.isMuted,
+                                    is_muted: this.isSelfMuted,
                                     is_screen_sharing_on: this.isScreenSharingOn,
                                 },
                             },
@@ -212,8 +212,8 @@ function factory(dependencies) {
          * @private
          * @returns {boolean}
          */
-        _computeIsMuteOrDeaf() {
-            return this.isMuted || this.isDeaf;
+        _computeIsMute() {
+            return this.isSelfMuted || this.isDeaf;
         }
 
         /**
@@ -376,14 +376,14 @@ function factory(dependencies) {
          * means that they cannot send sound regardless of the push to talk or
          * voice activation (isTalking) state.
          */
-        isMuted: attr({
+        isSelfMuted: attr({
             default: false,
         }),
         /**
-         * Determine whether current session is either muted or deaf.
+         * Determine whether current session is unable to speak.
          */
-        isMuteOrDeaf: attr({
-            compute: '_computeIsMuteOrDeaf',
+        isMute: attr({
+            compute: '_computeIsMute',
             default: false,
         }),
         /**

--- a/addons/mail/tests/test_rtc.py
+++ b/addons/mail/tests/test_rtc.py
@@ -49,7 +49,7 @@ class TestChannelInternals(MailCommon):
                             'id': channel_partner.rtc_session_ids.id + 1,
                             'isCameraOn': False,
                             'isDeaf': False,
-                            'isMuted': False,
+                            'isSelfMuted': False,
                             'isScreenSharingOn': False,
                             'partner': [('insert', {
                                 'id': self.user_employee.partner_id.id,
@@ -68,7 +68,7 @@ class TestChannelInternals(MailCommon):
                     'id': channel_partner.rtc_session_ids.id,
                     'isCameraOn': False,
                     'isDeaf': False,
-                    'isMuted': False,
+                    'isSelfMuted': False,
                     'isScreenSharingOn': False,
                     'partner': [('insert', {
                         'id': self.user_employee.partner_id.id,
@@ -109,7 +109,7 @@ class TestChannelInternals(MailCommon):
                             'id': last_rtc_session_id + 1,
                             'isCameraOn': False,
                             'isDeaf': False,
-                            'isMuted': False,
+                            'isSelfMuted': False,
                             'isScreenSharingOn': False,
                             'partner': [('insert', {
                                 'id': self.user_employee.partner_id.id,
@@ -164,7 +164,7 @@ class TestChannelInternals(MailCommon):
                             'id': last_rtc_session_id + 1,
                             'isCameraOn': False,
                             'isDeaf': False,
-                            'isMuted': False,
+                            'isSelfMuted': False,
                             'isScreenSharingOn': False,
                             'partner': [('insert', {
                                 'id': self.user_employee.partner_id.id,
@@ -181,7 +181,7 @@ class TestChannelInternals(MailCommon):
                             'id': last_rtc_session_id + 1,
                             'isCameraOn': False,
                             'isDeaf': False,
-                            'isMuted': False,
+                            'isSelfMuted': False,
                             'isScreenSharingOn': False,
                             'partner': [('insert', {
                                 'id': self.user_employee.partner_id.id,
@@ -248,7 +248,7 @@ class TestChannelInternals(MailCommon):
                                 'id': channel_partner.rtc_session_ids.id + 1,
                                 'isCameraOn': False,
                                 'isDeaf': False,
-                                'isMuted': False,
+                                'isSelfMuted': False,
                                 'isScreenSharingOn': False,
                                 'partner': [('insert', {
                                     'id': test_user.partner_id.id,
@@ -294,7 +294,7 @@ class TestChannelInternals(MailCommon):
                                 'id': channel_partner.rtc_session_ids.id + 2,
                                 'isCameraOn': False,
                                 'isDeaf': False,
-                                'isMuted': False,
+                                'isSelfMuted': False,
                                 'isScreenSharingOn': False,
                                 'guest': [('insert', {
                                     'id': test_guest.id,
@@ -461,7 +461,7 @@ class TestChannelInternals(MailCommon):
                             'id': channel_partner.rtc_session_ids.id,
                             'isCameraOn': False,
                             'isDeaf': False,
-                            'isMuted': False,
+                            'isSelfMuted': False,
                             'isScreenSharingOn': False,
                             'partner': [('insert', {
                                 'id': self.user_employee.partner_id.id,
@@ -478,7 +478,7 @@ class TestChannelInternals(MailCommon):
                             'id': channel_partner.rtc_session_ids.id,
                             'isCameraOn': False,
                             'isDeaf': False,
-                            'isMuted': False,
+                            'isSelfMuted': False,
                             'isScreenSharingOn': False,
                             'partner': [('insert', {
                                 'id': self.user_employee.partner_id.id,


### PR DESCRIPTION
* When a user is already muted when setting their state as deafened
the mute state should remain after the deafen state is removed.
* When a user clicks the microphone (mute/unmute) button while being in
the deaf state, the user should end up undeafen and unmute.

This commit also fixes a case where the track could
be left enabled when transitioning from voice activation
to push-to-talk (the track would still properly be
disabled on the next release of the push-to-talk key).

task-2720026