### PR TITLE
[FIX] web: match downloaded pdf with preview

### DIFF
--- a/addons/web/models/base_document_layout.py
+++ b/addons/web/models/base_document_layout.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import markupsafe
 from PIL import Image
 from markupsafe import Markup
 
@@ -117,7 +118,7 @@ class BaseDocumentLayout(models.TransientModel):
                     wizard_with_logo = wizard.with_context(bin_size=False)
                 else:
                     wizard_with_logo = wizard
-                preview_css = self._get_css_for_preview(styles, wizard_with_logo.id)
+                preview_css = markupsafe.Markup(self._get_css_for_preview(styles, wizard_with_logo.id))
                 ir_ui_view = wizard_with_logo.env['ir.ui.view']
                 wizard.preview = ir_ui_view._render_template('web.report_invoice_wizard_preview', {'company': wizard_with_logo, 'preview_css': preview_css})
             else:

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -160,8 +160,8 @@
                                <tr>
                                    <th name="th_description" class="text-left"><span>Description</span></th>
                                    <th name="th_quantity" class="text-right"><span>Quantity</span></th>
-                                   <th name="th_priceunit" class="text-right d-none d-md-table-cell"><span>Unit Price</span></th>
-                                   <th name="th_taxes" class="text-left d-none d-md-table-cell"><span>Taxes</span></th>
+                                   <th name="th_priceunit" class="text-right d-md-table-cell"><span>Unit Price</span></th>
+                                   <th name="th_taxes" class="text-left d-md-table-cell"><span>Taxes</span></th>
                                    <th name="th_subtotal" class="text-right">
                                        <span>Amount</span>
                                    </th>
@@ -174,10 +174,10 @@
                                    <td class="text-right">
                                        <span>5.000</span>
                                    </td>
-                                   <td class="text-right d-none d-md-table-cell">
+                                   <td class="text-right d-md-table-cell">
                                        <span class="text-nowrap">1,500.00</span>
                                    </td>
-                                   <td class="text-left d-none d-md-table-cell">
+                                   <td class="text-left d-md-table-cell">
                                        <span id="line_tax_ids">15.00%</span>
                                    </td>
                                    <td class="text-right o_price_total">
@@ -190,10 +190,10 @@
                                    <td class="text-right">
                                        <span>5.000</span>
                                    </td>
-                                   <td class="text-right d-none d-md-table-cell">
+                                   <td class="text-right d-md-table-cell">
                                        <span class="text-nowrap">2,350.00</span>
                                    </td>
-                                   <td class="text-left d-none d-md-table-cell">
+                                   <td class="text-left d-md-table-cell">
                                        <span id="line_tax_ids">15.00%</span>
                                    </td>
                                    <td class="text-right o_price_total">


### PR DESCRIPTION
### Current behavior
PDF Preview in document layout settings doesn't match the downloaded one (colors of div with the total and the columns displayed)

### Steps to reproduce
- Go to Settings
- 'Configure Document Layout' under Companies
- Set layout to Boxed
- Change the colors
- Download the PDF Preview

### Reason
- The columns for the unit price and taxes had the 'd-none' class so they weren't visible when printing the pdf preview. To keep coherence, if we see them in the preview we must see them in the pdf.
- Colors, especially the total div with a 'Boxed' layout, weren't taken into account for some elements in the preview. This is due to a character sanitized in the CSS, specifically `>` which becomes `&gt;` for the '.row > div > table' selector. 

OPW-2716089
