### PR TITLE
[FIX] account: don't mistake a tax with a sum of tax repartition factors == 0 for a 0% tax

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -1773,7 +1773,7 @@ class AccountTax(models.Model):
             price_include = self._context.get('force_price_include', tax.price_include)
 
             #compute the tax_amount
-            if price_include and total_included_checkpoints.get(i):
+            if price_include and total_included_checkpoints.get(i) and sum_repartition_factor != 0:
                 # We know the total to reach for that tax, so we make a substraction to avoid any rounding issues
                 tax_amount = total_included_checkpoints[i] - (base + cumulated_tax_included_amount)
                 cumulated_tax_included_amount = 0

--- a/addons/account/tests/test_tax.py
+++ b/addons/account/tests/test_tax.py
@@ -1031,3 +1031,61 @@ class TestTax(AccountTestUsers):
             ],
             res3
         )
+
+    def test_price_included_repartition_sum_0(self):
+        """ Tests the case where a tax with a non-zero value has a sum
+        of tax repartition factors of zero and is included in price. It
+        shouldn't behave in the same way as a 0% tax.
+        """
+        test_tax = self.tax_model.create({
+            'name': "Definitely not a 0% tax",
+            'amount_type': 'percent',
+            'amount': 42,
+            'price_include': True,
+            'invoice_repartition_line_ids': [
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                }),
+            ],
+            'refund_repartition_line_ids': [
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                }),
+            ],
+        })
+
+        compute_all_res = test_tax.compute_all(100)
+        self._check_compute_all_results(
+            100,         # 'total_included'
+            100,         # 'total_excluded'
+            [
+                # base , amount
+                # ---------------
+                (100, 42),
+                (100, -42),
+                # ---------------
+            ],
+            compute_all_res
+        )


### PR DESCRIPTION
Consider this example:

- Create a 42% tax, price-included, with two tax repartition lines doing +100 -100
- Create an invoice of 100€ using this tax, and look at the move lines generated

==> Only a base line of 100 and a receivable/payable line of 100 have been created; no tax line.

This is wrong, as we'd expect to see:

- 100 in payable/receivable
- 100 for the base line
- 42 for the +100 tax repartition line
- -42 for the -100 tax repartition line

The two tax lines are missing because the compute_all considers the tax as a 0% one, because of the +100 -100 stuff.

OPW 2716083
