### PR TITLE
[FIX] mail: redefine UserSetting/volumeSettings

### DIFF
--- a/addons/mail/static/src/models/user_setting/user_setting.js
+++ b/addons/mail/static/src/models/user_setting/user_setting.js
@@ -281,5 +281,12 @@ registerModel({
         voiceActiveDuration: attr({
             default: 0,
         }),
+        /**
+         * Determines the volume chosen by the current user for each other user.
+         */
+        volumeSettings: one2many('VolumeSetting', {
+            inverse: 'userSetting',
+            isCausal: true,
+        }),
     },
 });

--- a/addons/mail/static/src/models/volume_setting/volume_setting.js
+++ b/addons/mail/static/src/models/volume_setting/volume_setting.js
@@ -39,6 +39,7 @@ registerModel({
             inverse: 'volumeSetting',
         }),
         userSetting: many2one('UserSetting', {
+            inverse: 'volumeSettings',
             required: true,
         }),
         volume: attr({


### PR DESCRIPTION
Follow-up of
https://github.com/odoo/odoo/pull/81679

This field was actually being used, so shouldn't have been deleted.