### PR TITLE
[IMP] Support custom content shown on hover

### DIFF
--- a/addons/web/static/src/legacy/js/libs/jquery.js
+++ b/addons/web/static/src/legacy/js/libs/jquery.js
@@ -53,7 +53,7 @@ $.extend($.expr[':'], {
             return false;
         }
         var $parent = $element.parent();
-        if (!$parent.length || $element.is('html')) {
+        if ($(element).css('visibility') === 'visible' || !$parent.length || $element.is('html')) {
             return true;
         }
         return $parent.is(':hasVisibility');

--- a/addons/web/static/src/legacy/js/widgets/colorpicker.js
+++ b/addons/web/static/src/legacy/js/widgets/colorpicker.js
@@ -697,6 +697,40 @@ ColorpickerWidget.mixCssColors = function (cssColor1, cssColor2, weight) {
     return ColorpickerWidget.convertRgbaToCSSColor(r, g, b);
 };
 
+/**
+ * Calculates the actual background color of an element in the DOM.
+ *
+ * @static
+ * @param {DOMElement} el - An element in the DOM
+ * @returns {Object}
+ *          - red [0, 255] (integer)
+ *          - green [0, 255] (integer)
+ *          - blue [0, 255] (integer)
+ *          - opacity [0, 100.0] (float)
+ */
+ColorpickerWidget.getBackgroundRgbaColor = function (el) {
+    let [red, green, blue, alpha] = [0, 0, 0, 0];
+
+    while (alpha < 1 && el.tagName !== 'html') {
+        const cssColor = window.getComputedStyle(el).getPropertyValue('background-color');
+        const color = ColorpickerWidget.convertCSSColorToRgba(cssColor);
+        const opacity = alpha;
+
+        el = el.parentElement;
+
+        if (color.opacity === 0) {
+            continue;
+        }
+
+        alpha = color.opacity * (1.0 - opacity) / 100 + opacity;
+        red = (color.red * color.opacity * (1.0 - opacity) / 100 + red * opacity) / alpha;
+        blue = (color.blue * color.opacity * (1.0 - opacity) / 100 + blue * opacity) / alpha;
+        green = (color.green * color.opacity * (1.0 - opacity) / 100 + green * opacity) / alpha;
+    }
+
+    return {red, green, blue, opacity: alpha * 100};
+};
+
 const ColorpickerDialog = Dialog.extend({
     /**
      * @override

--- a/addons/web/static/tests/legacy/jquery_visibility_tests.js
+++ b/addons/web/static/tests/legacy/jquery_visibility_tests.js
@@ -1,0 +1,28 @@
+/** @odoo-module alias=web.jquery_visibility_tests **/
+'use strict';
+
+const html = `
+<div id="o_test_container_hidden" style="visibility: hidden;">
+    <div style="visibility: visible;"></div>
+</div>
+<div id="o_test_container_none" style="display: none;">
+    <div style="visibility: visible;"></div>
+</div>`;
+
+QUnit.module('JQuery Visibility Selectors', {
+}, function () {
+    QUnit.test("Should consider nested visible elements as having visibility", async function (assert) {
+        $('body').append(html);
+
+        const $hidden = $('body #o_test_container_hidden');
+        const $none = $('body #o_test_container_none');
+
+        assert.equal($hidden.find(':hasVisibility').length, 1);
+        assert.equal($hidden.find(':visible:hasVisibility').length, 1);
+        assert.equal($none.find(':hasVisibility').length, 1);
+        assert.equal($none.find(':visible:hasVisibility').length, 0);
+
+        $hidden.remove();
+        $none.remove();
+    });
+});

--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -358,6 +358,38 @@ function _getColorClass(el, colorNames, prefix) {
     const prefixedColorNames = _computeColorClasses(colorNames, prefix);
     return el.classList.value.split(' ').filter(cl => prefixedColorNames.includes(cl)).join(' ');
 }
+/**
+ * Checks if an element has the data-invisible attribute set or not.
+ *
+ * @private
+ * @param {Element} el element that needs to be checked
+ * @returns {boolean} a boolean indicating the absence of the data-invisible
+ * attribute
+ */
+function _isTargetVisible(el) {
+    return (el.dataset.invisible !== '1');
+}
+/**
+ * Toggles the data-invisible attribute on an element.
+ *
+ * @private
+ * @param {Element} el element that needs to be toggled
+ * @param {Element} [show] an optional boolean argument indicating the
+ * requested visibility state of the element
+ * @returns {boolean} a boolean indicating the absence of the data-invisible
+ * attribute
+ */
+function _toggleVisibilityStatus(el, show) {
+    if (show === undefined) {
+        show = !(_isTargetVisible(el));
+    }
+    if (show) {
+        delete el.dataset.invisible;
+    } else {
+        el.dataset.invisible = '1';
+    }
+    return show;
+}
 
 return {
     CSS_SHORTHANDS: CSS_SHORTHANDS,
@@ -378,5 +410,7 @@ return {
     backgroundImagePartsToCss: _backgroundImagePartsToCss,
     generateHTMLId: _generateHTMLId,
     getColorClass: _getColorClass,
+    isTargetVisible: _isTargetVisible,
+    toggleVisibilityStatus: _toggleVisibilityStatus,
 };
 });

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1905,7 +1905,6 @@ var SnippetsMenu = Widget.extend({
                         if (editor.isSticky()) {
                             editor.toggleOverlay(true, false);
                             customize$Elements = await editor.toggleOptions(true);
-                            break;
                         }
                     }
                 }

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1697,7 +1697,11 @@ var SnippetsMenu = Widget.extend({
             $selectorSiblings = $(_.uniq(($selectorSiblings || $()).add($selectorChildren.children()).get()));
         }
 
-        var noDropZonesSelector = '[data-invisible="1"], .o_we_no_overlay, :not(:visible)';
+        // The following selector finds all siblings of a currently visible
+        // hoverable overlay. Since the hoverable overlay hides these contents
+        // from view, they should not be searched for potential drop zones.
+        const visibleHoverableSiblings = ':has(> .s_hoverable > :not([data-invisible="1"])) > :not(.s_hoverable)';
+        const noDropZonesSelector = `[data-invisible="1"], .o_we_no_overlay, :not(:visible), ${visibleHoverableSiblings}, ${visibleHoverableSiblings} *`;
         if ($selectorSiblings) {
             $selectorSiblings.not(`.oe_drop_zone, .oe_drop_clone, ${noDropZonesSelector}`).each(function () {
                 var data;

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -540,6 +540,11 @@ var SnippetEditor = Widget.extend({
         if (shouldRecordUndo) {
             this.options.wysiwyg.odooEditor.historyStep();
         }
+
+        // TODO Currently the only way to guarantee that options get updated
+        // after the snippet removal, is by triggering an options update. This
+        // call can probably be removed if the promise above can be awaited.
+        this.trigger_up('snippet_option_update', {onSuccess: () => null});
     },
     /**
      * Displays/Hides the editor overlay.
@@ -3194,7 +3199,7 @@ var SnippetsMenu = Widget.extend({
 
             // Always enable the deepest editor whose DOM target is still inside
             // the document.
-            if (editors[0] !== this._enabledEditorHierarchy[0]) {
+            if (editors.length && editors[0] !== this._enabledEditorHierarchy[0]) {
                 // No awaiting this as the mutex is currently locked here.
                 this._activateSnippet(editors[0].$target);
             }

--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -1146,7 +1146,7 @@ registry.WebsiteAnimate = publicWidget.Widget.extend({
         this.$scrollingElement = $().getScrollingElement(this.ownerDocument);
         // By default, elements are hidden by the css of o_animate.
         // Render elements and trigger the animation then pause it in state 0.
-        this.$animatedElements = this.$target.find('.o_animate');
+        this.$animatedElements = this.$target.find(':not(.s_hoverable) > .o_animate');
         _.each(this.$animatedElements, el => {
             this._resetAnimation($(el));
         });

--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -387,6 +387,9 @@ weSnippetEditor.SnippetEditor.include({
      * @override
      */
     getName() {
+        if (this.$target[0].parentElement.classList.contains('s_hoverable')) {
+            return _t('Hover Item');
+        }
         if (this.$target[0].closest('[data-oe-field=logo]')) {
             return _t("Logo");
         }

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2312,6 +2312,7 @@ options.registry.MobileVisibility = options.Class.extend({
             // toggle and color styling options.
             hoverableEl.classList.add('d-none', `d-md-${display}`);
             hoverableEl.dataset.visible = '1';
+            this._applyColorClasses(hoverableEl);
         }
 
         if (widgetValue) {
@@ -2371,6 +2372,34 @@ options.registry.MobileVisibility = options.Class.extend({
         this.$target[0].appendChild(containerEl);
 
         return hoverableEl;
+    },
+    /**
+     * Returns the preset color class with the background color that differs as
+     * much as possible from the targets background color.
+     *
+     * @private
+     */
+    _applyColorClasses(hoverableEl) {
+        const color = ColorpickerWidget.getBackgroundRgbaColor(this.$target[0]);
+        const editorEl = this.$el[0].closest('we-customizeblock-options');
+        const optionEl = editorEl.querySelector('.snippet-option-Box [data-css-property="background-color"]');
+        const targetEl = optionEl ? hoverableEl.querySelector('.card') : hoverableEl;
+        let previewList;
+
+        previewList = previewList || optionEl && optionEl.querySelectorAll('.o_colorpicker_section[data-name="theme"] button');
+        previewList = previewList || editorEl.querySelectorAll('.snippet-option-ColoredLevelBackground .o_we_cc_preview_wrapper');
+
+        if (targetEl && previewList.length) {
+            const prefix = optionEl ? 'bg-' : 'o_cc';
+            const extraClasses = optionEl ? [] : ['o_colored_level', 'o_cc'];
+            const selectEl = _.max(previewList, function (preview) {
+                const bg = ColorpickerWidget.getBackgroundRgbaColor(preview);
+                const factors = {red: 3 - (bg.red + color.red < 256), green: 4, blue: 2 + (bg.red + color.red < 256)};
+                return _.reduce(color, (sum, v, k) => sum + (factors[k] || 0) * (v - bg[k]) ** 2, 0);
+            }).closest('[data-color]');
+            const className = prefix + selectEl.getAttribute('data-color');
+            targetEl.classList.add(className, ...extraClasses);
+        }
     },
 });
 

--- a/addons/website/static/src/scss/website.edit_mode.scss
+++ b/addons/website/static/src/scss/website.edit_mode.scss
@@ -239,6 +239,17 @@ body.editor_enable {
     }
 }
 
+// Hover Effect
+body.editor_enable {
+    *:hover > .s_hoverable.row > div {
+        visibility: hidden;
+    }
+    .s_hoverable.row > div[data-visible="1"] {
+        visibility: visible;
+    }
+}
+
+
 // Website Animate
 .editor_enable.o_animated_text_highlighted {
     .o_animated_text {

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2040,6 +2040,10 @@ ul.o_checklist > li.o_checked::after {
         overflow: hidden;
     }
 
+    *:not(:hover) > & > div {
+        animation-name: none !important;
+    }
+
     *:hover > & > div {
         visibility: visible;
     }

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2016,3 +2016,31 @@ ul.o_checklist > li.o_checked::after {
 .o_anim_del2500 {
     animation-delay: 2500ms;
 }
+
+// Hover Effect styles
+@mixin inherit-layout {
+    @include o-position-absolute(0, 0, 0, 0);
+    display: inherit;
+    // The padding is inherited so the contents of the hoverable element
+    // correspond to those from the original element.
+    padding: inherit;
+    flex-flow: inherit;
+    justify-content: inherit;
+    align-items: inherit;
+    align-content: inherit;
+}
+
+.s_hoverable.row {
+    @include inherit-layout();
+    visibility: hidden;
+    z-index: 1;
+
+    & > div {
+        @include inherit-layout();
+        overflow: hidden;
+    }
+
+    *:hover > & > div {
+        visibility: visible;
+    }
+}

--- a/addons/website/static/src/snippets/s_color_blocks_2/000.scss
+++ b/addons/website/static/src/snippets/s_color_blocks_2/000.scss
@@ -8,7 +8,7 @@
             }
         }
     }
-    .row {
+    > div > .row {
         display: flex;
         flex-flow: row wrap;
 
@@ -22,6 +22,15 @@
         padding: 8% 5%;
         padding-top: 8vw; // A flex item cannot have % padding top and bottom (even if it works on chrome)
         padding-bottom: 8vw; // Solution is vw units but we keep 8% as a fallback
+        & > .s_hoverable.row {
+            // The default inherited padding for the hover effect does not work
+            // because the width of the parent element is different. Since the
+            // snippet contains two boxes we can simply double the relative
+            // padding values.
+            padding: 16% 10%;
+            padding-top: 8vw;
+            padding-bottom: 8vw;
+        }
     }
     @include media-breakpoint-down(md) {
         [class*="col-lg-"] {

--- a/addons/website/static/src/snippets/s_popup/options.js
+++ b/addons/website/static/src/snippets/s_popup/options.js
@@ -8,15 +8,23 @@ options.registry.SnippetPopup = options.Class.extend({
      * @override
      */
     start: function () {
+        const $popup = this.$target.closest('.s_popup');
+
         // Note: the link are excluded here so that internal modal buttons do
         // not close the popup as we want to allow edition of those buttons.
         this.$target.on('click.SnippetPopup', '.js_close_popup:not(a, .btn)', ev => {
             ev.stopPropagation();
             this.onTargetHide();
-            this.trigger_up('snippet_option_visibility_update', {show: false});
+            this.trigger_up('snippet_option_visibility_update', {
+                $snippet: $popup,
+                show: false,
+            });
         });
         this.$target.on('shown.bs.modal.SnippetPopup', () => {
-            this.trigger_up('snippet_option_visibility_update', {show: true});
+            this.trigger_up('snippet_option_visibility_update', {
+                $snippet: $popup,
+                show: true,
+            });
             // TODO duplicated code from the popup public widget, this should
             // be moved to a *video* public widget and be reviewed in master
             this.$target[0].querySelectorAll('.media_iframe_video').forEach(media => {
@@ -25,7 +33,10 @@ options.registry.SnippetPopup = options.Class.extend({
             });
         });
         this.$target.on('hidden.bs.modal.SnippetPopup', () => {
-            this.trigger_up('snippet_option_visibility_update', {show: false});
+            this.trigger_up('snippet_option_visibility_update', {
+                $snippet: $popup,
+                show: false,
+            });
             this._removeIframeSrc();
         });
         // The video might be playing before entering edit mode (possibly with

--- a/addons/website/static/tests/tours/snippet_hoverable.js
+++ b/addons/website/static/tests/tours/snippet_hoverable.js
@@ -1,0 +1,109 @@
+/** @odoo-module alias=snippet.hoverable **/
+'use strict';
+
+import tour from 'web_tour.tour';
+import wTourUtils from 'website.tour_utils';
+
+const columnSelector = '.s_three_columns .col-lg-4:first-child';
+const hoverableSelector = `${columnSelector} > .s_hoverable > div`;
+
+const columnEditorSelector = 'we-title:has(span:contains("Column"):not(:contains("Columns")))';
+const activationSelector = `${columnEditorSelector} ~ * we-button[data-toggle-hoverable]`;
+const originalSelector = `${columnEditorSelector} ~ * we-button:has(:contains("Main"))`;
+const previewSelector = `${columnEditorSelector} ~ * we-button:has(:contains("Hover"))`;
+
+function startColumnEditor() {
+    return [{
+        content: 'Click on first column',
+        trigger: columnSelector,
+    }, {
+        content: 'Check if the column editor is active',
+        trigger: columnEditorSelector,
+    }];
+}
+
+function clickColumnHoverActivate(message = 'Click hoverable activation toggle') {
+    return {
+        content: message,
+        trigger: `${activationSelector} we-checkbox`,
+    };
+}
+
+function checkColumnHoverDeactivated() {
+    return {
+        content: 'Check if hoverable is deactivated',
+        trigger: columnSelector,
+        run: function () {
+            if (this.$anchor.find('.s_hoverable').length > 0) {
+                console.error('The hoverable overlay is not deactivated');
+            }
+        },
+    };
+}
+
+function checkColumnHoverVisibility(status, editMode = true) {
+    return [status ? {
+        content: 'Check if hoverable is shown',
+        trigger: hoverableSelector,
+        run: () => {},
+    } : {
+        content: 'Check if hoverable is hidden',
+        trigger: columnSelector,
+        run: function () {
+            // The offsetParent will be null if the element is not shown.
+            if (this.$anchor.find('.s_hoverable > div').is(':hasVisibility')) {
+                console.error('The hoverable overlay is not hidden');
+            }
+        },
+    }].concat(editMode ? [{
+        content: 'Check if the preview toggle is correctly rendered',
+        trigger: `${previewSelector}${status ? '.active' : ':not(.active)'}`,
+        run: () => {},
+    }] : []);
+}
+
+tour.register('snippet_hoverable', {
+    test: true,
+    url: '?enable_editor=1',
+}, [
+    wTourUtils.dragNDrop({
+        id: 's_three_columns',
+        name: 'Columns',
+    }),
+    ...startColumnEditor(),
+    checkColumnHoverDeactivated(),
+    clickColumnHoverActivate('Activate hoverable overlay'),
+    // Check the preview toggle buttons. When the overlay is activated, it
+    // should start in the visible state.
+    ...checkColumnHoverVisibility(true),
+    {
+        content: 'Hide hover effect overlay',
+        trigger: originalSelector,
+    },
+    ...checkColumnHoverVisibility(false),
+    {
+        content: 'Show hover effect overlay',
+        trigger: previewSelector,
+    },
+    ...checkColumnHoverVisibility(true),
+    // Close and reopen the editor to test the cleanForSave and start methods.
+    {
+        content: 'Close the editor',
+        trigger: '#oe_snippets button:contains("Save")',
+    },
+    ...checkColumnHoverVisibility(false, false),
+    {
+        content: 'Open the editor',
+        trigger: '.o_menu_systray a:contains("Edit")',
+    },
+    {
+        content: 'Wait for the editor to be ready',
+        trigger: '#oe_snippets #snippets_menu',
+        run: () => {},
+    },
+    ...startColumnEditor(),
+    ...checkColumnHoverVisibility(false),
+    // Check if hover effect deactivation removes the DOM element.
+    clickColumnHoverActivate('Deactivate hoverable overlay'),
+    checkColumnHoverDeactivated(),
+]);

--- a/addons/website/static/tests/tours/snippet_popup.js
+++ b/addons/website/static/tests/tours/snippet_popup.js
@@ -1,0 +1,90 @@
+/** @odoo-module alias=snippet.popup **/
+'use strict';
+
+import tour from 'web_tour.tour';
+import wTourUtils from 'website.tour_utils';
+
+const wrapSelector = '#wrap';
+const popupSelector = `${wrapSelector} > .s_popup`;
+const popupModalSelector = `${popupSelector} .modal:visible`;
+const popupCloseSelector = `.modal-content div.s_popup_close`;
+
+const popupEditorSelector = 'we-title:has(span:contains("Popup"))';
+
+const invisibleElementSelector = '.o_we_invisible_el_panel div:contains("Popup") > i';
+
+function clickPopupClose() {
+    return {
+        content: `Close the popup`,
+        trigger: popupCloseSelector,
+    };
+}
+
+function checkPopupDeactivated() {
+    return {
+        content: 'Check if hoverable is deactivated',
+        trigger: wrapSelector,
+        run: function () {
+            if (this.$anchor.find('.s_popup').length > 0) {
+                console.error('A popup is still present in the page');
+            }
+        },
+    };
+}
+
+function checkPopupVisibility(status) {
+    return [status ? {
+        content: 'Check if popup is shown',
+        trigger: popupModalSelector,
+        in_modal: false,
+        run: () => {},
+    } : {
+        content: 'Check if popup is hidden',
+        trigger: wrapSelector,
+        run: function () {
+            // The offsetParent will be null if the element is not shown.
+            if (this.$anchor.find('.s_popup .modal')[0].offsetParent !== null) {
+                console.error('The popup is not hidden');
+            }
+        },
+    }, {
+        content: 'Check if the invisible element is correctly rendered',
+        trigger: `${invisibleElementSelector}.${status ? 'fa-eye' : 'fa-eye-slash'}`,
+        in_modal: false,
+        run: () => {},
+    }];
+}
+
+function clickTogglePopupVisibility() {
+    return {
+        content: 'Toggle the visibility of the overlay using the invisible elements panel',
+        trigger: invisibleElementSelector,
+        in_modal: false,
+    };
+}
+
+tour.register('snippet_popup', {
+    test: true,
+    url: '/?enable_editor=1',
+}, [
+    wTourUtils.dragNDrop({
+        id: 's_popup',
+        name: 'Popup',
+    }),
+    {
+        content: 'Open the popup editor',
+        trigger: popupModalSelector,
+        in_modal: false,
+    },
+    ...checkPopupVisibility(true),
+    clickPopupClose(),
+    ...checkPopupVisibility(false),
+    clickTogglePopupVisibility(),
+    ...checkPopupVisibility(true),
+    {
+        content: 'Remove popup modal',
+        trigger: `${popupEditorSelector} we-button.fa-trash`,
+        in_modal: false,
+    },
+    checkPopupDeactivated(),
+]);

--- a/addons/website/static/tests/tours/sticky_overlay.js
+++ b/addons/website/static/tests/tours/sticky_overlay.js
@@ -1,0 +1,67 @@
+/** @odoo-module alias=sticky.overlay **/
+'use strict';
+
+import tour from 'web_tour.tour';
+import wTourUtils from 'website.tour_utils';
+
+tour.register('sticky_overlay', {
+    test: true,
+    url: '/?enable_editor=1',
+}, [
+    wTourUtils.dragNDrop({
+        id: 's_text_block',
+        name: 'Text',
+    }),
+    {
+        content: "Activate text block editor",
+        trigger: '#wrap .s_text_block p:first-child',
+    },
+    {
+        content: "Click on first paragraph node",
+        trigger: '#wrap .s_text_block p:first-child',
+        run: () => {
+            const $node = $('#wrap .s_text_block p:first-child');
+            const range = document.createRange();
+
+            range.selectNode($node[0]);
+            window.getSelection().addRange(range);
+        },
+    },
+    {
+        content: "Animate text",
+        trigger: 'div[title="Animate text"]',
+    },
+    {
+        content: "Activate the preview of the text block snippet",
+        trigger: 'we-customizeblock-options:nth-child(1)',
+        run: () => {
+            // The first and top-level editor corresponds to the text block.
+            $('we-customizeblock-options:nth-child(1)').mouseenter();
+        },
+    },
+    {
+        content: "Check the overlays",
+        trigger: '#oe_manipulators',
+        run: () => {
+            if ($('.oe_overlay.oe_active').length !== 1) {
+                console.error('Only the text block overlay should be shown');
+            }
+        },
+    },
+    {
+        content: "Deactivate the preview of the text block snippet",
+        trigger: 'we-customizeblock-options:nth-child(1)',
+        run: () => {
+            $('we-customizeblock-options:nth-child(1)').mouseleave();
+        },
+    },
+    {
+        content: "Check the overlays",
+        trigger: '#oe_manipulators',
+        run: () => {
+            if ($('.oe_overlay.oe_active').length !== 2) {
+                console.error('The animated text sticky overlay should have been reactivated');
+            }
+        },
+    },
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -290,3 +290,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_18_sticky_overlay(self):
         self.start_tour("/", "sticky_overlay", login="admin")
+
+    def test_19_snippet_hoverable(self):
+        self.start_tour("/", "snippet_hoverable", login="admin")

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -287,3 +287,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_17_website_edit_menus(self):
         self.start_tour("/", "edit_menus", login="admin")
+
+    def test_18_sticky_overlay(self):
+        self.start_tour("/", "sticky_overlay", login="admin")

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -179,6 +179,55 @@
     </xpath>
 </template>
 
+<template id="snippet_options_animation_options">
+    <div data-js="WebsiteAnimate"
+        t-att-data-selector="selector"
+        t-att-data-exclude="exclude">
+        <we-select string="Animate" data-is-animation-type-selection="true">
+            <we-button data-select-class="" data-name="no_animation_opt">No Animation</we-button>
+            <we-divider/>
+            <we-button data-select-class="o_anim_fade_in">Fade In</we-button>
+            <we-button data-select-class="o_anim_fade_in_down">Fade In-Down</we-button>
+            <we-button data-select-class="o_anim_fade_in_left">Fade In-Left</we-button>
+            <we-button data-select-class="o_anim_fade_in_right">Fade In-Right</we-button>
+            <we-button data-select-class="o_anim_fade_in_up">Fade In-Up</we-button>
+            <we-divider/>
+            <we-button data-select-class="o_anim_bounce_in">Bounce In</we-button>
+            <we-button data-select-class="o_anim_bounce_in_down">Bounce In-Down</we-button>
+            <we-button data-select-class="o_anim_bounce_in_left">Bounce In-Left</we-button>
+            <we-button data-select-class="o_anim_bounce_in_right">Bounce In-Right</we-button>
+            <we-divider/>
+            <we-button data-select-class="o_anim_rotate_in">Rotate In</we-button>
+            <we-button data-select-class="o_anim_rotate_in_down_left">Rotate In-Down-Left</we-button>
+            <we-button data-select-class="o_anim_rotate_in_down_right">Rotate In-Down-Right</we-button>
+            <we-divider/>
+            <we-button data-select-class="o_anim_zoom_out">Zoom Out</we-button>
+            <we-button data-select-class="o_anim_zoom_in">Zoom In</we-button>
+            <we-button data-select-class="o_anim_zoom_in_down">Zoom In-Down</we-button>
+            <we-button data-select-class="o_anim_zoom_in_left">Zoom In-Left</we-button>
+            <we-button data-select-class="o_anim_zoom_in_right">Zoom In-Right</we-button>
+            <we-divider/>
+            <we-button data-select-class="o_anim_flash">Flash</we-button>
+            <we-button data-select-class="o_anim_pulse">Pulse</we-button>
+            <we-button data-select-class="o_anim_shake">Shake</we-button>
+            <we-button data-select-class="o_anim_tada">Tada</we-button>
+            <we-divider/>
+            <we-button data-select-class="o_anim_flip_in_x">Flip-In-X</we-button>
+            <we-button data-select-class="o_anim_flip_in_y">Flip-In-Y</we-button>
+        </we-select>
+        <t t-if="with_animation_launch">
+            <we-select string="Animation Launch" data-dependencies="!no_animation_opt" data-name="animation_launch_opt">
+                <we-button data-select-class="">First Time Only</we-button>
+                <we-button data-select-class="o_animate_both_scroll">Every Time</we-button>
+            </we-select>
+        </t>
+        <we-input string="Animation Duration" data-dependencies="!no_animation_opt" class="o_we_small_input"
+            data-select-style="0.4s" data-css-property="animation-duration" data-unit="s"/>
+        <we-input string="Animation Delay" data-dependencies="!no_animation_opt" class="o_we_small_input"
+            data-select-style="0s" data-css-property="animation-delay" data-unit="s"/>
+    </div>
+</template>
+
 <template id="snippet_options_background_options" inherit_id="web_editor.snippet_options_background_options">
     <xpath expr="//we-button[@data-toggle-bg-image]" position="after">
         <we-button title="Video" class="fa fa-fw fa-film"
@@ -465,7 +514,7 @@
 
     <!-- Background -->
     <t t-set="only_bg_color_selector" t-value="'section .row > div, .s_text_highlight, .s_mega_menu_thumbnails_footer'"/>
-    <t t-set="only_bg_color_exclude" t-value="'.s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .s_image_gallery .row > div'"/>
+    <t t-set="only_bg_color_exclude" t-value="'.s_col_no_bgcolor, .s_col_no_bgcolor > .s_hoverable > div, .s_col_no_bgcolor.row > div, .s_col_no_bgcolor.row > div > .s_hoverable > div, .s_masonry_block .row > div, .s_masonry_block .row > div > .s_hoverable > div, .s_color_blocks_2 .row > div, .s_color_blocks_2 .row > div > .s_hoverable > div, .s_image_gallery .row > div, .s_image_gallery .row > div > .s_hoverable > div'"/>
 
     <t t-set="base_only_bg_image_selector" t-value="'.s_tabs .oe_structure > *, footer .oe_structure > *'"/>
     <t t-set="only_bg_image_selector" t-value="base_only_bg_image_selector"/>
@@ -502,7 +551,7 @@
     <!-- Border | Columns -->
     <div data-js="Box"
          data-selector="section .row > div"
-         data-exclude=".s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_image_gallery .row > div, .s_masonry_block .s_col_no_resize">
+         data-exclude=".s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_image_gallery .row > div, .s_masonry_block .s_col_no_resize, .s_three_columns .s_hoverable.row > div">
         <t t-call="website.snippet_options_border_widgets"/>
         <t t-call="website.snippet_options_shadow_widgets"/>
     </div>
@@ -1212,49 +1261,35 @@
     </div>
 
     <!-- Website Animate -->
-    <div data-js="WebsiteAnimate"
-         data-selector=".o_animable, section .row > div, img, .fa, .btn, .o_animated_text"
-         data-exclude=".o_not-animable, .s_col_no_resize.row > div, .s_col_no_resize">
-        <we-select string="Animate" data-is-animation-type-selection="true">
-            <we-button data-select-class="" data-name="no_animation_opt">No Animation</we-button>
-            <we-divider/>
-            <we-button data-select-class="o_anim_fade_in">Fade In</we-button>
-            <we-button data-select-class="o_anim_fade_in_down">Fade In-Down</we-button>
-            <we-button data-select-class="o_anim_fade_in_left">Fade In-Left</we-button>
-            <we-button data-select-class="o_anim_fade_in_right">Fade In-Right</we-button>
-            <we-button data-select-class="o_anim_fade_in_up">Fade In-Up</we-button>
-            <we-divider/>
-            <we-button data-select-class="o_anim_bounce_in">Bounce In</we-button>
-            <we-button data-select-class="o_anim_bounce_in_down">Bounce In-Down</we-button>
-            <we-button data-select-class="o_anim_bounce_in_left">Bounce In-Left</we-button>
-            <we-button data-select-class="o_anim_bounce_in_right">Bounce In-Right</we-button>
-            <we-divider/>
-            <we-button data-select-class="o_anim_rotate_in">Rotate In</we-button>
-            <we-button data-select-class="o_anim_rotate_in_down_left">Rotate In-Down-Left</we-button>
-            <we-button data-select-class="o_anim_rotate_in_down_right">Rotate In-Down-Right</we-button>
-            <we-divider/>
-            <we-button data-select-class="o_anim_zoom_out">Zoom Out</we-button>
-            <we-button data-select-class="o_anim_zoom_in">Zoom In</we-button>
-            <we-button data-select-class="o_anim_zoom_in_down">Zoom In-Down</we-button>
-            <we-button data-select-class="o_anim_zoom_in_left">Zoom In-Left</we-button>
-            <we-button data-select-class="o_anim_zoom_in_right">Zoom In-Right</we-button>
-            <we-divider/>
-            <we-button data-select-class="o_anim_flash">Flash</we-button>
-            <we-button data-select-class="o_anim_pulse">Pulse</we-button>
-            <we-button data-select-class="o_anim_shake">Shake</we-button>
-            <we-button data-select-class="o_anim_tada">Tada</we-button>
-            <we-divider/>
-            <we-button data-select-class="o_anim_flip_in_x">Flip-In-X</we-button>
-            <we-button data-select-class="o_anim_flip_in_y">Flip-In-Y</we-button>
-        </we-select>
-        <we-select string="Animation Launch" data-dependencies="!no_animation_opt" data-name="animation_launch_opt">
-            <we-button data-select-class="">First Time Only</we-button>
-            <we-button data-select-class="o_animate_both_scroll">Every Time</we-button>
-        </we-select>
-        <we-input string="Animation Duration" data-dependencies="!no_animation_opt" class="o_we_small_input"
-            data-select-style="0.4s" data-css-property="animation-duration" data-unit="s"/>
-        <we-input string="Animation Delay" data-dependencies="!no_animation_opt" class="o_we_small_input"
-            data-select-style="0s" data-css-property="animation-delay" data-unit="s"/>
+    <t t-call="website.snippet_options_animation_options">
+        <t t-set="selector" t-value="'.o_animable, section .row > div, img, .fa, .btn, .o_animated_text'"/>
+        <t t-set="exclude" t-value="'.o_not-animable, .s_col_no_resize.row > div, .s_col_no_resize, .s_hoverable.row > div'"/>
+        <t t-set="with_animation_launch" t-value="True"/>
+    </t>
+
+    <t t-call="website.snippet_options_animation_options">
+        <t t-set="selector" t-value="'.s_hoverable.row > div'"/>
+        <t t-set="exclude" t-value="''"/>
+        <t t-set="with_animation_launch" t-value="False"/>
+    </t>
+
+    <!-- Edit Hoverable -->
+    <div data-js="EditHoverable" data-selector="section .row > div"
+        data-exclude=".s_col_no_resize.row > div, .s_hoverable.row > div, .s_masonry_block .s_col_no_resize, .s_table_of_content .row > div, .s_website_form .row > div, .s_media_list .row > div">
+        <we-row string="Hover Effect" class="o_we_full_row">
+            <we-checkbox title="Activate hover content" data-toggle-hoverable="true"
+                data-name="toggle_hoverable_opt" data-no-preview="true"/>
+            <we-button-group  class="ml-auto">
+                <we-button title="Show the original item" data-preview-hoverable=""
+                    data-dependencies="toggle_hoverable_opt">
+                    Main
+                </we-button>
+                <we-button title="Show the hover item" data-preview-hoverable="1"
+                    data-dependencies="toggle_hoverable_opt">
+                    Hover
+                </we-button>
+            </we-button-group>
+        </we-row>
     </div>
 
     <!-- Theme options -->

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -565,13 +565,16 @@
     </div>
 
     <div data-js="sizing_y"
-        data-selector="section, .row > div, .parallax, .s_hr, .carousel-item, .s_rating"
+        data-selector="section, .row > div, .parallax, .s_hr, .carousel-item, .s_rating, .s_hoverable > div"
         data-exclude="section:has(> .carousel), .s_image_gallery .carousel-item, .s_col_no_resize.row > div, .s_col_no_resize"/>
 
     <div data-js="sizing_x"
         data-selector=".row > div"
-        data-drop-near=".row:not(.s_col_no_resize) > div"
         data-exclude=".s_col_no_resize.row > div, .s_col_no_resize"/>
+
+    <div data-selector=".row > div"
+        data-exclude=".s_col_no_resize.row > div, .s_col_no_resize, .s_hoverable > div"
+        data-drop-near=".row:not(.s_col_no_resize) > div"/>
 
     <t t-set="so_snippet_addition_selector" t-translation="off">section, .parallax</t>
     <div id="so_snippet_addition"


### PR DESCRIPTION
Add an option in the editor to activate custom content when hovering specific elements. Using this option adds an invisible overlay on top of the original element that will only be shown to the visitor when hovering the original element.
    
In edit mode the hovering behavior is deactivated, so both the original and the overlay content can be properly edited. A button is provided that allows the end user to quickly toggle between the original and overlay content. The hovering overlay is also added as an invisible snippet entry in the corresponding menu.