### PR TITLE
[FIX] account: soften duplicate ref constrains

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1516,9 +1516,9 @@ class AccountMove(models.Model):
         if res:
             raise ValidationError(_('Posted journal entry must have an unique sequence number per company.'))
 
-    @api.constrains('ref', 'type', 'partner_id', 'journal_id', 'invoice_date')
+    @api.constrains('ref', 'type', 'partner_id', 'journal_id', 'invoice_date', 'state')
     def _check_duplicate_supplier_reference(self):
-        moves = self.filtered(lambda move: move.is_purchase_document() and move.ref)
+        moves = self.filtered(lambda move: move.state == 'posted' and move.is_purchase_document() and move.ref)
         if not moves:
             return
 

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1478,9 +1478,9 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         ''' Ensure two vendor bills can't share the same vendor reference. '''
         self.invoice.ref = 'a supplier reference'
         invoice2 = self.invoice.copy(default={'invoice_date': self.invoice.invoice_date})
-
+        invoice2.ref = 'a supplier reference'
         with self.assertRaises(ValidationError):
-            invoice2.ref = 'a supplier reference'
+            invoice2.action_post()
 
     def test_in_invoice_switch_in_refund_1(self):
         # Test creating an account_move with an in_invoice_type and switch it in an in_refund.


### PR DESCRIPTION
## [FIX] account: soften duplicate ref constrains
The aim of this commit is to allow EDIs to create and save account move
even if a supplier reference is duplicated.
This is achieved by delaying the moment to which the constrains is
triggered.

## Before this commit:
A user can only upload a bill once. (xml ubl format for instance)
If he needs to upload it a second time, he will be forced to find a
workaround.

## After this commit:
User will be able to upload as many bill as he wants but will receive a
ValidationError when trying to post the invoice if the reference is
duplicated.
The user will be able to post the bill very easily by changing the
reference a bit if he wants to pursue.

community-PR: #81748
enterprise-PR: odoo/enterprise#23255

task: #2612299