### PR TITLE
[FIX] purchase: show quantity by default

### DIFF
--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -17,7 +17,7 @@
                     <attribute name="optional">hide</attribute>
                 </xpath>
                 <xpath expr="//field[@name='min_qty']" position="attributes">
-                    <attribute name="optional">hide</attribute>
+                    <attribute name="optional">show</attribute>
                 </xpath>
                 <xpath expr="//field[@name='name']" position="attributes">
                     <attribute name="readonly">0</attribute>


### PR DESCRIPTION
Scale up game has been printed with the quantity show by default on the
supplier info. So we copy that behavior in standard for educational
purpose and avoid to print again all the scale up.

Also it's better from a usablity point of view since it's an important
information.

opw-fp
