### PR TITLE
[FIX] sale_timesheet: Use invisible=1 on the non_allow_billable field

### DIFF
--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -153,7 +153,7 @@
                     <field name="so_line" readonly="1" attrs="{'column_invisible': [('parent.allow_billable', '=', False)]}" context="{'with_remaining_hours': True}" optional="hide"/>
                 </xpath>
                 <xpath expr="//field[@name='timesheet_ids']/tree" position="inside">
-                    <field name="non_allow_billable" attrs="{'column_invisible': ['|', '&amp;', '&amp;', '|', ('parent.bill_type', '!=', 'customer_project'), ('parent.pricing_type', '!=', 'employee_rate'), ('parent.timesheet_product_id', '=', False), ('parent.sale_line_id', '=', False), '&amp;', ('parent.bill_type', '=', 'customer_project'), ('parent.pricing_type', '=', 'employee_rate')]}" invisible="1"/>
+                    <field name="non_allow_billable" invisible="1"/>
                 </xpath>
                 <xpath expr="//field[@name='remaining_hours']" position="after">
                     <field name="remaining_hours_available" invisible="1"/>


### PR DESCRIPTION
**Steps to follow**

 -  Go to project
 -  Select a project task with timesheet
 -  Edit the view with studio
 -  Edit the timesheet list view
 -  Enable 'Show Invisible Elements'
 -  Select 'Non-Billable'
 -  Uncheck 'Invisible'
 -> An exception is thrown

**Cause of the issue**

  attrs.column_invisible was used with invisible

**Solution**

  remove attrs.column_invisible

opw-2706370