### PR TITLE
[FIX] payment,sale: fix inv. id mistaken as so id

### DIFF
--- a/addons/payment/wizards/payment_link_wizard.py
+++ b/addons/payment/wizards/payment_link_wizard.py
@@ -153,37 +153,23 @@ class PaymentLinkWizard(models.TransientModel):
             company_id = related_document.company_id
             partner_id = related_document.partner_id
             currency_id = related_document.currency_id
-            if res_model == "sale.order":
-                # If the Order contains a recurring product but is not already linked to a
-                # subscription, the payment acquirer must support tokenization. The res_id allows
-                # the overrides of sale_subscription to check this condition.
-                selection.extend(
-                    self._get_payment_acquirer_available(
-                        company_id.id, partner_id.id, currency_id.id, res_id,
-                    ).name_get()
-                )
-            else:
-                selection.extend(
-                    self._get_payment_acquirer_available(
-                        company_id.id, partner_id.id, currency_id.id,
-                    ).name_get()
-                )
+            selection.extend(
+                self._get_payment_acquirer_available(
+                    res_model=res_model,
+                    res_id=res_id,
+                    company_id=company_id.id,
+                    partner_id=partner_id.id,
+                    currency_id=currency_id.id,
+                ).name_get()
+            )
         return selection
 
-    def _get_payment_acquirer_available(self, company_id=None, partner_id=None, currency_id=None):
+    def _get_payment_acquirer_available(self, **kwargs):
         """ Select and return the acquirers matching the criteria.
-
-        :param int company_id: The company to which acquirers must belong, as a `res.company` id
-        :param int partner_id: The partner making the payment, as a `res.partner` id
-        :param int currency_id: The payment currency if known beforehand, as a `res.currency` id
         :return: The compatible acquirers
         :rtype: recordset of `payment.acquirer`
         """
-        return self.env['payment.acquirer'].sudo()._get_compatible_acquirers(
-            company_id=company_id or self.company_id.id,
-            partner_id=partner_id or self.partner_id.id,
-            currency_id=currency_id or self.currency_id.id
-        )
+        return self.env['payment.acquirer'].sudo()._get_compatible_acquirers(**kwargs)
 
     @api.depends('available_acquirer_ids')
     def _compute_has_multiple_acquirers(self):

--- a/addons/sale/wizard/sale_payment_link.py
+++ b/addons/sale/wizard/sale_payment_link.py
@@ -24,22 +24,16 @@ class PaymentLinkWizard(models.TransientModel):
             })
         return res
 
-    def _get_payment_acquirer_available(self, company_id=None, partner_id=None, currency_id=None, sale_order_id=None):
+    def _get_payment_acquirer_available(self, res_model, res_id, **kwargs):
         """ Select and return the acquirers matching the criteria.
-
-        :param int company_id: The company to which acquirers must belong, as a `res.company` id
-        :param int partner_id: The partner making the payment, as a `res.partner` id
-        :param int currency_id: The payment currency if known beforehand, as a `res.currency` id
-        :param int sale_order_id: The sale order currency if known beforehand, as a `sale.order` id
+        :param str res_model: active model
+        :param int res_id: id of 'active_model' record
         :return: The compatible acquirers
         :rtype: recordset of `payment.acquirer`
         """
-        return self.env['payment.acquirer'].sudo()._get_compatible_acquirers(
-            company_id=company_id or self.company_id.id,
-            partner_id=partner_id or self.partner_id.id,
-            currency_id=currency_id or self.currency_id.id,
-            sale_order_id=sale_order_id or self.res_id,
-        )
+        if res_model == 'sale.order':
+            kwargs['sale_order_id'] = res_id
+        return super()._get_payment_acquirer_available(**kwargs)
 
     def _generate_link(self):
         """ Override of payment to add the sale_order_id in the link. """


### PR DESCRIPTION
Before this fix, invoice ids could be wrongly used in place of
sale order ids when generating a payment link, leading to a missing
record error.

Fix PR #79949

task-2716889


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
