### PR TITLE
[IMP] account: duplicated ref for bills

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -611,6 +611,15 @@
                                 attrs="{'invisible' : [('to_check', '=', False)]}" data-hotkey="k" />
                         <field name="state" widget="statusbar" statusbar_visible="draft,posted"/>
                     </header>
+                    <div class="alert alert-warning mb-0" role="alert"
+                         attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('duplicated_ref_ids', '=', [])]}">
+                        Warning: this bill might be a duplicate of
+                        <button name="open_duplicated_ref_bill_view"
+                                type="object"
+                                string="one of those bills"
+                                class="btn btn-link p-0"
+                        />
+                    </div>
                     <!-- Invoice outstanding credits -->
                     <div groups="account.group_account_invoice,account.group_account_readonly"
                          class="alert alert-warning mb-0" role="alert"
@@ -734,6 +743,7 @@
                         <field name="tax_cash_basis_created_move_ids" invisible="1"/>
                         <field name="quick_edit_mode" invisible="1"/>
                         <field name="hide_post_button" invisible="1"/>
+                        <field name="duplicated_ref_ids" invisible="1"/>
 
                         <div class="oe_title">
                             <span class="o_form_label"><field name="move_type" attrs="{'invisible': [('move_type', '=', 'entry')]}" readonly="1" nolabel="1"/></span>


### PR DESCRIPTION
## The aim of this commit is to:
improve UX by helping the user to find duplicate bills in a more convenient way.

With this commit, when a user create a bill or credit note on bill that might
be a duplicate, a warning banner is displayed on the Form view of the
account.move.
On this banner there is a button that leads to the list of the duplicate
bill/credit note.

## Context:
Previously, the warning for duplicated bills was thrown when the bill was
saved. This was changed with https://github.com/odoo/odoo/pull/81748
It made the blocking warning being delayed until the bill is posted.

## Previous to this commit:
A duplicate bill can only be detected automatically when posting the bill with
a blocking warning preventing the user to post his bill(s).

## After this commit:
A warning banner is displayed on the bill form during the bill creation.
The banner contains a button leading to the list of duplicates.
The blocking warning message is improved a bit by adding the amount.

community-PR: https://github.com/odoo/odoo/pull/81765

task: #2612299