### PR TITLE
[IMP] Use image_128 instead of 1920 only to check if image exist

### DIFF
--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -237,7 +237,7 @@ class ProductTemplate(models.Model):
                 )
             list_price = product.price_compute('list_price')[product.id]
             price = product.price if pricelist else list_price
-            display_image = bool(product.image_1920)
+            display_image = bool(product.image_128)
             display_name = product.display_name
             price_extra = (product.price_extra or 0.0 ) + (sum(no_variant_attributes_price_extra) or 0.0)
         else:
@@ -246,7 +246,7 @@ class ProductTemplate(models.Model):
             price_extra = sum(current_attributes_price_extra)
             list_price = product_template.price_compute('list_price')[product_template.id]
             price = product_template.price if pricelist else list_price
-            display_image = bool(product_template.image_1920)
+            display_image = bool(product_template.image_128)
 
             combination_name = combination._get_combination_name()
             if combination_name:

--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -338,11 +338,11 @@ class ProductTemplate(models.Model):
         :rtype: recordset of 'product.template' or recordset of 'product.product'
         """
         self.ensure_one()
-        if self.image_1920:
+        if self.image_128:
             return self
         variant = self.env['product.product'].browse(self._get_first_possible_variant_id())
         # if the variant has no image anyway, spare some queries by using template
-        return variant if variant.image_variant_1920 else self
+        return variant if variant.image_variant_128 else self
 
     def _get_current_company_fallback(self, **kwargs):
         """Override: if a website is set on the product or given, fallback to


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
When calling `/shop` route (or any similar one), big files (for eg. image_1920) are read while they shouldn't.
The render of shop route triggers the method `_get_combination_info` and this method is reading all the big files just to know if they are there.

The problem is big if for those files you have some kind of latency (for eg. nfs storage or using https://github.com/camptocamp/odoo-cloud-platform/tree/13.0/attachment_s3)

I'm not sure which would be the proper way to fix this. (clearly not as done on this PR)

This is the how methods are called 
```

  /home/odoo/custom/odoo/addons/website/models/ir_ui_view.py(344)render()
-> return super(View, self).render(values, engine=engine, minimal_qcontext=minimal_qcontext)
  /home/odoo/custom/odoo/addons/web_editor/models/ir_ui_view.py(27)render()
-> return super(IrUiView, self).render(values=values, engine=engine, minimal_qcontext=minimal_qcontext)
  /home/odoo/custom/odoo/odoo/addons/base/models/ir_ui_view.py(1199)render()
-> return self.env[engine].render(self.id, qcontext)
  /home/odoo/custom/odoo/odoo/addons/base/models/ir_qweb.py(58)render()
-> result = super(IrQWeb, self).render(id_or_xml_id, values=values, **context)
  /home/odoo/custom/odoo/odoo/addons/base/models/qweb.py(260)render()
-> self.compile(template, options)(self, body.append, values or {})
  /home/odoo/custom/odoo/odoo/addons/base/models/qweb.py(333)_compiled_fn()
-> return compiled(self, append, new, options, log)
  <template>(1)template_website_sale_products_52()
  <template>(2)body_call_content_50()
  <template>(88)foreach_46()
  <template>(89)foreach_45()
  /home/odoo/custom/odoo/odoo/addons/base/models/qweb.py(333)_compiled_fn()
-> return compiled(self, append, new, options, log)
  <template>(1)template_website_sale_products_item_3018()
  /home/odoo/custom/odoo/addons/website_sale_stock/models/product_template.py(22)_get_combination_info()
-> parent_combination=parent_combination, only_template=only_template)
  /home/odoo/custom/odoo/addons/website_sale/models/product.py(286)_get_combination_info()
-> parent_combination=parent_combination, only_template=only_template)
  /home/odoo/custom/odoo/addons/sale/models/product_template.py(246)_get_combination_info()
-> display_image = bool(product_template.image_1920)
  /home/odoo/custom/odoo/odoo/fields.py(1045)__get__()
-> recs._fetch_field(self)
  /home/odoo/custom/odoo/odoo/models.py(3002)_fetch_field()
-> self._read(fnames)
  /home/odoo/custom/odoo/odoo/models.py(3102)_read()
-> field.read(fetched)
  /home/odoo/custom/odoo/odoo/fields.py(2013)read()
-> for att in records.env['ir.attachment'].sudo().search(domain)}
  /home/odoo/custom/odoo/odoo/fields.py(2013)<dictcomp>()
-> for att in records.env['ir.attachment'].sudo().search(domain)}
  /home/odoo/custom/odoo/odoo/fields.py(1062)__get__()
-> self.compute_value(recs)
  /home/odoo/custom/odoo/odoo/fields.py(1981)compute_value()
-> super().compute_value(records_no_bin_size)
  /home/odoo/custom/odoo/odoo/fields.py(1147)compute_value()
-> records._compute_field_value(self)
  /home/odoo/custom/odoo/odoo/models.py(4018)_compute_field_value()
-> getattr(self, field.compute)()
  /home/odoo/custom/odoo/odoo/addons/base/models/ir_attachment.py(199)_compute_datas()
-> attach.datas = self._file_read(attach.store_fname, bin_size)
```



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
