### PR TITLE
[FIX] web: no trigger of an onchange

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -744,8 +744,9 @@ function makeActionManager(env) {
      *
      * @private
      * @param {ActURLAction} action
+     * @param {ActionOptions} options
      */
-    function _executeActURLAction(action) {
+    function _executeActURLAction(action, options) {
         if (action.target === "self") {
             env.services.router.redirect(action.url);
         } else {
@@ -759,6 +760,9 @@ function makeActionManager(env) {
                     sticky: true,
                     type: "warning",
                 });
+            }
+            if (options.onClose) {
+                options.onClose();
             }
         }
     }
@@ -1101,7 +1105,7 @@ function makeActionManager(env) {
         action = _preprocessAction(action, options.additionalContext);
         switch (action.type) {
             case "ir.actions.act_url":
-                return _executeActURLAction(action);
+                return _executeActURLAction(action, options);
             case "ir.actions.act_window":
                 if (action.target !== "new") {
                     await clearUncommittedChanges(env);

--- a/addons/web/static/tests/webclient/actions/url_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/url_action_tests.js
@@ -4,6 +4,8 @@ import { registry } from "@web/core/registry";
 import { makeTestEnv } from "../../helpers/mock_env";
 import { makeFakeRouterService } from "../../helpers/mock_services";
 import { setupWebClientRegistries, doAction, getActionManagerServerData } from "./../helpers";
+import { patchWithCleanup } from "@web/../tests/helpers/utils";
+import { browser } from "@web/core/browser/browser";
 
 let serverData;
 const serviceRegistry = registry.category("services");
@@ -32,5 +34,18 @@ QUnit.module("ActionManager", (hooks) => {
             url: "/my/test/url",
         });
         assert.verifySteps(["/my/test/url"]);
+    });
+
+    QUnit.test("execute an 'ir.actions.act_url' action with onClose option", async (assert) => {
+        setupWebClientRegistries();
+        patchWithCleanup(browser, {
+            open: () => assert.step("browser open"),
+        });
+        const env = await makeTestEnv({ serverData });
+        const options = {
+            onClose: () => assert.step("onClose"),
+        };
+        await doAction(env, { type: "ir.actions.act_url" }, options);
+        assert.verifySteps(["browser open", "onClose"]);
     });
 });


### PR DESCRIPTION
Steps to reproduce:

- Install Argentinian Electronic Payment (l10n_ar_edi)
- Change company (ar responsable)
- Go in Accounting > Settings: in the AFIP section
- delete key and certificate
- click on `generate request`
-> the key is not persisted unless a manual refresh/discard is done

Solution:
In V14 the `onchange` is triggered. Why?
Because this https://github.com/odoo/odoo/blob/1723c52d42389a8b5124ab4d15d55dad0d119a8f/addons/web/static/src/js/chrome/action_manager.js#L130-L139
works because of the call of the `on_close` function:
https://github.com/odoo/odoo/blob/1723c52d42389a8b5124ab4d15d55dad0d119a8f/addons/web/static/src/js/chrome/action_manager.js#L534-L543

Why not in V15?
In V15 the onchange can be triggered when the `this.reload` function is called via the `on_closed` function:
https://github.com/odoo/odoo/blob/7ce6d8d70be79c9c626865598b898dce9a18b045/addons/web/static/src/legacy/js/views/basic/basic_controller.js#L472-L482

But to be triggered, in the `wrapSuccessOrFail` (when the `_trigger_up` funciton is called), the `onClose` must be called:
https://github.com/odoo/odoo/blob/fb3878b581b831c13550d40e38a8e8890d82ea0d/addons/web/static/src/legacy/action_adapters.js#L362-L376

In order to do that, we would have to use the `options` (the `params`) sent with the `doActionButton` in the `doAction` function.
https://github.com/odoo/odoo/blob/fee371be291ba3d6f1adc71c08420b6510fdf386/addons/web/static/src/webclient/actions/action_service.js#L1198-L1199

BUT the `options` are not used anymore when `_executeActURLAction`* is called (only the `action`paramater is required):
https://github.com/odoo/odoo/blob/fee371be291ba3d6f1adc71c08420b6510fdf386/addons/web/static/src/webclient/actions/action_service.js#L1098-L1104

Therefore, we find ourselves in a situation in which we cannot call the `on_closed` function in (the `options` are not even an 'option'**):
https://github.com/odoo/odoo/blob/fee371be291ba3d6f1adc71c08420b6510fdf386/addons/web/static/src/webclient/actions/action_service.js#L748-L764

Look again in V14 how the function is called:
https://github.com/odoo/odoo/blob/1723c52d42389a8b5124ab4d15d55dad0d119a8f/addons/web/static/src/js/chrome/action_manager.js#L527-L543

The solution is therefore easily understandable.

*we are in this specific switch_case because the action executed is:

https://github.com/odoo/enterprise/blob/6805d2f591237ad17d7db827dcf6fe36c2c2744f/l10n_ar_edi/models/res_config_settings.py#L30-L32

** no pun intended

OPW-2680841