### PR TITLE
15.0 escertfixes jco

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -37,13 +37,12 @@ class PatchedHTTPAdapter(requests.adapters.HTTPAdapter):
         # still made without checking temporary files exist.
         super().cert_verify(conn, url, verify, None)
         conn.cert_file = cert
-        conn.key_file = cert
+        conn.key_file = None
 
     def get_connection(self, url, proxies=None):
         # OVERRIDE
         # Patch the OpenSSLContext to decode the certificate in-memory.
         conn = super().get_connection(url, proxies=proxies)
-
         context = conn.conn_kw['ssl_context']
 
         def patched_load_cert_chain(l10n_es_odoo_certificate, keyfile=None, password=None):

--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -669,5 +669,5 @@ class AccountEdiFormat(models.Model):
                     'res_model': inv._name,
                     'res_id': inv.id,
                 })
-                res[inv] = {'attachment': attachment}
+                res[inv].update({'attachment': attachment})
         return res

--- a/addons/l10n_es_edi_sii/tests/test_edi_web_services.py
+++ b/addons/l10n_es_edi_sii/tests/test_edi_web_services.py
@@ -70,7 +70,6 @@ class TestEdiWebServices(TestEsEdiCommon):
 
     def test_edi_bizkaia(self):
         self.env.company.l10n_es_edi_tax_agency = 'bizkaia'
-
         self.moves.action_process_edi_web_services()
         generated_files = self._process_documents_web_services(self.moves, {'es_sii'})
         self.assertTrue(generated_files)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In 15.0 runbot this, the sending failed.  In v14.0, it works in runbot, but not on my laptop, so it should have to do with the versions of the libraries.  I put back my original hacks (as seen in the first commit) and it works, but the question is how we can keep them without the libraries being compromised (we could e.g. reset the library methods to their original values)

Current behavior before PR:
Traceback: 
```
  File "/home/odoo/src/odoo/addons/l10n_es_edi_sii/models/account_edi_format.py", line 460, in _l10n_es_edi_call_web_service_sign
    client = zeep.Client(connection_vals['url'], transport=transport)
  File "/usr/lib/python3/dist-packages/zeep/client.py", line 68, in __init__
    self.wsdl = Document(wsdl, self.transport, settings=self.settings)
  File "/usr/lib/python3/dist-packages/zeep/wsdl/wsdl.py", line 80, in __init__
    document = self._get_xml_document(location)
  File "/usr/lib/python3/dist-packages/zeep/wsdl/wsdl.py", line 142, in _get_xml_document
    return load_external(
  File "/usr/lib/python3/dist-packages/zeep/loader.py", line 78, in load_external
    content = transport.load(url)
  File "/usr/lib/python3/dist-packages/zeep/transports.py", line 110, in load
    content = self._load_remote_data(url)
  File "/usr/lib/python3/dist-packages/zeep/transports.py", line 126, in _load_remote_data
    response = self.session.get(url, timeout=self.load_timeout)
  File "/usr/lib/python3/dist-packages/requests/sessions.py", line 546, in get
    return self.request('GET', url, **kwargs)
  File "/usr/lib/python3/dist-packages/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python3/dist-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python3/dist-packages/requests/adapters.py", line 439, in send
    resp = conn.urlopen(
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 665, in urlopen
    httplib_response = self._make_request(
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 376, in _make_request
    self._validate_conn(conn)
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 996, in _validate_conn
    conn.connect()
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 366, in connect
    self.sock = ssl_wrap_socket(
  File "/usr/lib/python3/dist-packages/urllib3/util/ssl_.py", line 353, in ssl_wrap_socket
    if keyfile and key_password is None and _is_key_file_encrypted(keyfile):
  File "/usr/lib/python3/dist-packages/urllib3/util/ssl_.py", line 401, in _is_key_file_encrypted
    with open(key_file, "r") as f:
 
2021-11-18 12:00:35,146 837 ERROR arxi-team-v15-clean-demo-master-3627877 odoo.http: Exception during JSON request handling. 
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 665, in urlopen
    httplib_response = self._make_request(
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 376, in _make_request
    self._validate_conn(conn)
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 996, in _validate_conn
    conn.connect()
File "/usr/lib//python3/dist-packages/urllib3/connection.py", line 366, in connect
    self.sock = ssl_wrap_socket(
  File "/usr/lib/python3/dist-packages/urllib3/util/ssl_.py", line 353, in ssl_wrap_socket
    if keyfile and key_password is None and _is_key_file_encrypted(keyfile):
  File "/usr/lib/python3/dist-packages/urllib3/util/ssl_.py", line 402, in _is_key_file_encrypted
    for line in f:
OSError: [Errno 9] Bad file descriptor
```
During handling of the above exception, another exception occurred:
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/requests/adapters.py", line 439, in send
    resp = conn.urlopen(
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 719, in urlopen
    retries = retries.increment(
  File "/usr/lib/python3/dist-packages/urllib3/util/retry.py", line 400, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "/usr/lib/python3/dist-packages/six.py", line 702, in reraise
    raise value.with_traceback(tb)
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 665, in urlopen
    httplib_response = self._make_request(
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 376, in _make_request
    self._validate_conn(conn)
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 996, in _validate_conn
    conn.connect()
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 366, in connect
    self.sock = ssl_wrap_socket(
  File "/usr/lib/python3/dist-packages/urllib3/util/ssl_.py", line 353, in ssl_wrap_socket
    if keyfile and key_password is None and _is_key_file_encrypted(keyfile):
  File "/usr/lib/python3/dist-packages/urllib3/util/ssl_.py", line 402, in _is_key_file_encrypted
    for line in f:
urllib3.exceptions.ProtocolError: ('Connection aborted.', OSError(9, 'Bad file descriptor'))
```
Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
