### PR TITLE
[FIX] mail_group: add missing SMTP headers

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -532,21 +532,6 @@ class Channel(models.Model):
                 groups[index] = (group_name, lambda partner: False, group_data)
         return groups
 
-    def _notify_email_header_dict(self):
-        headers = super(Channel, self)._notify_email_header_dict()
-        headers['Precedence'] = 'list'
-        # avoid out-of-office replies from MS Exchange
-        # http://blogs.technet.com/b/exchange/archive/2006/10/06/3395024.aspx
-        headers['X-Auto-Response-Suppress'] = 'OOF'
-        if self.alias_domain and self.alias_name:
-            headers['List-Id'] = '<%s.%s>' % (self.alias_name, self.alias_domain)
-            headers['List-Post'] = '<mailto:%s@%s>' % (self.alias_name, self.alias_domain)
-            # Avoid users thinking it was a personal message
-            # X-Forge-To: will replace To: after SMTP envelope is determined by ir.mail.server
-            list_to = '"%s" <%s@%s>' % (self.name, self.alias_name, self.alias_domain)
-            headers['X-Forge-To'] = list_to
-        return headers
-
     def _notify_thread(self, message, msg_vals=False, **kwargs):
         # link message to channel
         rdata = super(Channel, self)._notify_thread(message, msg_vals=msg_vals, **kwargs)

--- a/addons/mail_group/models/mail_group.py
+++ b/addons/mail_group/models/mail_group.py
@@ -424,10 +424,19 @@ class MailGroup(models.Model):
                 # SMTP headers related to the subscription
                 email_url_encoded = urls.url_quote(email_member)
                 headers = {
+                    ** self._notify_email_header_dict(),
                     'List-Archive': f'<{base_url}/groups/{slug(self)}>',
                     'List-Subscribe': f'<{base_url}/groups?email={email_url_encoded}>',
                     'List-Unsubscribe': f'<{base_url}/groups?unsubscribe&email={email_url_encoded}>',
+                    'Precedence': 'list',
+                    'X-Auto-Response-Suppress': 'OOF',  # avoid out-of-office replies from MS Exchange
                 }
+                if self.alias_name and self.alias_domain:
+                    headers.update({
+                        'List-Id': f'<{self.alias_name}.{self.alias_domain}>',
+                        'List-Post': f'<mailto:{self.alias_name}@{self.alias_domain}>',
+                        'X-Forge-To': f'"{self.name}" <{self.alias_name}@{self.alias_domain}>',
+                    })
 
                 if message.mail_message_id.parent_id:
                     headers['In-Reply-To'] = message.mail_message_id.parent_id.message_id


### PR DESCRIPTION
Bug
===
Since 2d359b909bc27fd41125c9e44d9376b5a910f6d5 we moved the mailing
list feature of the <mail.channel> in a different model, <mail.group>.

During this split, some SMTP headers have been forgotten.

Task-2721009