### PR TITLE
[FIX][15.0] survey: typo fix

### DIFF
--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -77,7 +77,7 @@ class SurveyQuestion(models.Model):
         ('numerical_box', 'Numerical Value'),
         ('date', 'Date'),
         ('datetime', 'Datetime'),
-        ('simple_choice', 'Multiple choice: only one answer'),
+        ('simple_choice', 'Simple choice: only one answer'),
         ('multiple_choice', 'Multiple choice: multiple answers allowed'),
         ('matrix', 'Matrix')], string='Question Type',
         compute='_compute_question_type', readonly=False, store=True)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
('simple_choice', 'Multiple choice: only one answer'),
should be 
('simple_choice', 'Simple choice: only one answer'),




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
