### PR TITLE
[FIX] core: unexpected display_name "False"

### DIFF
--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -585,6 +585,22 @@ class TestOnChange(SavepointCaseWithUserDemo):
         self.assertEqual(payment.tag_repeat, 3)
         self.assertEqual(payment.tag_string, 'BarBarBar')
 
+    def test_display_name(self):
+        self.env['ir.ui.view'].create({
+            'name': 'test_new_api.multi.tag form view',
+            'model': 'test_new_api.multi.tag',
+            'arch': """
+                <form>
+                    <field name="name"/>
+                    <field name="display_name"/>
+                </form>
+            """,
+        })
+
+        form = common.Form(self.env['test_new_api.multi.tag'])
+        self.assertEqual(form.name, False)
+        self.assertEqual(form.display_name, False)
+
 
 class TestComputeOnchange(common.TransactionCase):
 

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -921,7 +921,7 @@ class Field(MetaField('DummyField', (object,), {})):
 
     def convert_to_display_name(self, value, record):
         """ Convert ``value`` from the record format to a suitable display name. """
-        return ustr(value)
+        return ustr(value) if value else False
 
     ############################################################################
     #
@@ -2639,7 +2639,7 @@ class Reference(Selection):
         return value.display_name if value else ''
 
     def convert_to_display_name(self, value, record):
-        return ustr(value and value.display_name)
+        return value.display_name if value else False
 
 
 class _Relational(Field):
@@ -2882,7 +2882,7 @@ class Many2one(_Relational):
         return value.display_name if value else ''
 
     def convert_to_display_name(self, value, record):
-        return ustr(value.display_name)
+        return value.display_name
 
     def convert_to_onchange(self, value, record, names):
         if not value.id:


### PR DESCRIPTION
If a form view contains the field `display_name`, when creating a new record, the initial value of `display_name` is the string `"False"`, and that weird value also appears in the breadcrumb instead of `"New"`.  In order to avoid this unexpected behavior, the conversion of a value to a display name should be `False`, like any other field would.