### PR TITLE
[FIX] point_of_sale: session's cash journal entries correctly computed

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1060,7 +1060,7 @@ class PosSession(models.Model):
         fully_reconciled_lines = reconcilable_lines.filtered(lambda aml: aml.full_reconcile_id)
         partially_reconciled_lines = reconcilable_lines - fully_reconciled_lines
 
-        cash_move_lines = self.env['account.move.line'].search([('statement_id', '=', self.cash_register_id.id)])
+        cash_move_lines = self.env['account.move.line'].search([('statement_id', 'in', self.statement_ids.ids)])
 
         ids = (non_reconcilable_lines.ids
                 + fully_reconciled_lines.mapped('full_reconcile_id').mapped('reconciled_line_ids').ids


### PR DESCRIPTION
Journal entries related to a POS session without cash are wrong

Steps to reproduce:
1. Install the Point of Sale and Accounting apps
2. Go to Point of Sale -> Configuration -> Point of Sale and create a new one
3. Remove the payment method 'Cash' for this POS and save
4. Open a session in this POS, sell something and then close and post journal entries
5. Open the Journal Items related to the session

Solution:
Fix the account_move_line query to match the statement_id with the session's statement_ids

OPW-2684748