### PR TITLE
[FIX] mrp{_subcontracting}: install subcontracting

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -197,11 +197,8 @@
                                     context="{'default_product_id': product_id, 'default_company_id': company_id}" attrs="{'invisible': [('product_tracking', 'in', ('none', False))]}"/>
                                 <button name="action_generate_serial" type="object" class="btn btn-primary fa fa-plus-square-o" aria-label="Creates a new serial/lot number" title="Creates a new serial/lot number" role="img" attrs="{'invisible': ['|', ('product_tracking', 'in', ('none', False)), ('lot_producing_id', '!=', False)]}"/>
                             </div>
-                            <label for="bom_id" name="bom_label"/>
-                            <div class='o_row d-flex' name="bom_div">
-                                <field name="bom_id"
-                                    context="{'default_product_tmpl_id': product_tmpl_id}" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
-                            </div>
+                            <field name="bom_id"
+                                context="{'default_product_tmpl_id': product_tmpl_id}" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                         </group>
                         <group name="group_extra_info">
                             <label for="date_planned_start"/>

--- a/addons/mrp_subcontracting/views/mrp_production_views.xml
+++ b/addons/mrp_subcontracting/views/mrp_production_views.xml
@@ -24,10 +24,7 @@
             <xpath expr="//page[@name='miscellaneous']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
-            <xpath expr="//label[@name='bom_label']" position="attributes">
-                <attribute name="invisible">1</attribute>
-            </xpath>
-            <xpath expr="//div[@name='bom_div']" position="attributes">
+            <xpath expr="//field[@name='bom_id']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//field[@name='move_byproduct_ids']" position="attributes">


### PR DESCRIPTION
This commit reverts [1]. Otherwise, all databases created before the
creation of [1] won't have the possibility to install
`mrp_subcontracting`, because xPaths in
`addons/mrp_subcontracting/views/mrp_production_views.xml` are based on
the new version of `addons/mrp/views/mrp_production_views.xml`. So since
these DBs have the old version of
addons/mrp/views/mrp_production_views.xml, `//label[@name='bom_label']`
targets nothing

Another PR is in charge of reverting [2]

[1] odoo/odoo@6317c34808d381e54bae2431fec2de4b8503b447
[2] odoo/enterprise@f1fe64af2902963532f5f713e0efa2ab2009a52e

OPW-2720409