### PR TITLE
[FIX][14.0] web: Fix avatar ratio

### DIFF
--- a/addons/web/static/src/scss/web_calendar.scss
+++ b/addons/web/static/src/scss/web_calendar.scss
@@ -605,6 +605,7 @@ $o-cw-filter-avatar-size: 20px;
                 &.o_beside_avatar {
                     @include size($o-cw-filter-avatar-size);
                     border-radius: 2px;
+                    object-fit: cover;
                 }
             }
 


### PR DESCRIPTION
This PR
-------
In the calendar UI, with images that are not square, the profile picture will be distorted
Before:
![image](https://user-images.githubusercontent.com/26604325/147070672-fe879205-fd3c-4bde-a432-4a84b78947aa.png)
After:
![image](https://user-images.githubusercontent.com/26604325/147070776-9f564e88-7117-443c-92e7-fdf64294a332.png)





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
