### PR TITLE
Fix ab testing

### DIFF
--- a/addons/mass_mailing/data/mass_mailing_data.xml
+++ b/addons/mass_mailing/data/mass_mailing_data.xml
@@ -20,6 +20,7 @@
             <field name="state">code</field>
             <field name="code">model._cron_process_mass_mailing_ab_testing()</field>
             <field name="user_id" ref="base.user_root"/>
+            <field name="active" eval="False"/>
             <field name="interval_number">1</field>
             <field name="interval_type">days</field>
             <field name="numbercall">-1</field>

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -609,7 +609,7 @@ class MassMailing(models.Model):
             'type': 'ir.actions.act_window',
             'view_mode': 'tree,kanban,form,calendar,graph',
             'res_model': 'mailing.mailing',
-            'domain': [('campaign_id', '=', self.campaign_id.id), ('ab_testing_enabled', '=', True)],
+            'domain': [('campaign_id', '=', self.campaign_id.id), ('ab_testing_enabled', '=', True), ('mailing_type', '=', self.mailing_type)],
         }
         if self.mailing_type == 'mail':
             action['views'] = [

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -199,8 +199,8 @@ class MassMailing(models.Model):
     def _compute_total(self):
         for mass_mailing in self:
             total = self.env[mass_mailing.mailing_model_real].search_count(mass_mailing._parse_mailing_domain())
-            if mass_mailing.ab_testing_pc < 100:
-                total = int(total / 100.0 * mass_mailing.ab_testing_pc)
+            if total and mass_mailing.ab_testing_pc < 100:
+                total = max(int(total / 100.0 * mass_mailing.ab_testing_pc), 1)
             mass_mailing.total = total
 
     def _compute_clicks_ratio(self):
@@ -806,7 +806,9 @@ class MassMailing(models.Model):
         # randomly choose a fragment
         if self.ab_testing_enabled and self.ab_testing_pc < 100:
             contact_nbr = self.env[self.mailing_model_real].search_count(mailing_domain)
-            topick = int(contact_nbr / 100.0 * self.ab_testing_pc)
+            topick = 0
+            if contact_nbr:
+                topick = max(int(contact_nbr / 100.0 * self.ab_testing_pc), 1)
             if self.campaign_id and self.ab_testing_enabled:
                 already_mailed = self.campaign_id._get_mailing_recipients()[self.campaign_id.id]
             else:

--- a/addons/mass_mailing/tests/test_mailing_ab_testing.py
+++ b/addons/mass_mailing/tests/test_mailing_ab_testing.py
@@ -106,6 +106,16 @@ class TestMailingABTesting(MassMailCommon):
         self.assertEqual(ab_mailing.ab_testing_winner_selection, 'manual', "The selection winner has been propagated correctly")
         self.assertEqual(ab_mailing.ab_testing_schedule_datetime, schedule_datetime, "The schedule date has been propagated correctly")
 
+    @users('user_marketing')
+    def test_mailing_ab_testing_compare(self):
+        # compare version feature should returns all mailings of the same
+        # campaign having a/b testing enabled.
+        compare_version = self.ab_testing_mailing_1.action_compare_versions()
+        self.assertEqual(
+            self.env['mailing.mailing'].search(compare_version.get('domain')),
+            self.ab_testing_mailing_1 + self.ab_testing_mailing_2
+        )
+
     @mute_logger('odoo.addons.mail.models.mail_mail')
     @users('user_marketing')
     def test_mailing_ab_testing_manual_flow(self):

--- a/addons/mass_mailing/tests/test_mailing_ab_testing.py
+++ b/addons/mass_mailing/tests/test_mailing_ab_testing.py
@@ -147,3 +147,22 @@ class TestMailingABTesting(MassMailCommon):
         self.ab_testing_mailing_ids.invalidate_cache()
         winner_mailing = self.ab_testing_campaign.mailing_mail_ids.filtered(lambda mailing: mailing.ab_testing_pc == 100)
         self.assertEqual(winner_mailing.subject, 'A/B Testing V2')
+
+    @mute_logger('odoo.addons.mail.models.mail_mail')
+    @users('user_marketing')
+    def test_mailing_ab_testing_minimum_participants(self):
+        """ Test that it should send minimum one mail(if possible) when ab_testing_pc is too small compared to the amount of targeted records."""
+        mailing_list = self._create_mailing_list_of_x_contacts(10)
+        ab_testing = self.env['mailing.mailing'].create({
+            'subject': 'A/B Testing SMS V1',
+            'contact_list_ids': mailing_list.ids,
+            'ab_testing_enabled': True,
+            'ab_testing_pc': 2,
+            'ab_testing_schedule_datetime': datetime.now(),
+            'mailing_type': 'mail',
+            'campaign_id': self.ab_testing_campaign.id,
+        })
+        with self.mock_mail_gateway():
+            ab_testing.action_send_mail()
+        self.assertEqual(ab_testing.state, 'done')
+        self.assertEqual(len(self._mails), 1)

--- a/addons/mass_mailing_sms/tests/__init__.py
+++ b/addons/mass_mailing_sms/tests/__init__.py
@@ -4,3 +4,4 @@
 from . import common
 from . import test_mailing_internals
 from . import test_mailing_retry
+from . import test_mailing_sms_ab_testing

--- a/addons/mass_mailing_sms/tests/test_mailing_sms_ab_testing.py
+++ b/addons/mass_mailing_sms/tests/test_mailing_sms_ab_testing.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime
+
+from odoo.addons.mass_mailing_sms.tests.common import MassSMSCommon
+from odoo.addons.mass_mailing.tests.test_mailing_ab_testing import TestMailingABTesting
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestMailingSMSABTesting(MassSMSCommon, TestMailingABTesting):
+    def setUp(self):
+        super().setUp()
+        self.ab_testing_mailing_sms_1 = self.env['mailing.mailing'].create({
+            'subject': 'A/B Testing SMS V1',
+            'contact_list_ids': self.mailing_list.ids,
+            'ab_testing_enabled': True,
+            'ab_testing_pc': 10,
+            'ab_testing_schedule_datetime': datetime.now(),
+            'mailing_type': 'sms'
+        })
+        self.ab_testing_mailing_sms_2 = self.ab_testing_mailing_sms_1.copy({
+            'subject': 'A/B Testing SMS V2',
+            'ab_testing_pc': 20,
+        })
+
+    def test_mailing_sms_ab_testing_compare(self):
+        # compare version feature should returns all mailings of the same
+        # campaign having a/b testing enabled and of mailing_type 'sms'.
+        compare_version = self.ab_testing_mailing_sms_1.action_compare_versions()
+        self.assertEqual(
+            self.env['mailing.mailing'].search(compare_version.get('domain')),
+            self.ab_testing_mailing_sms_1 + self.ab_testing_mailing_sms_2
+        )


### PR DESCRIPTION
Purpose
To fix A/B testing in mass_mailing and mass_mailing_sms

SPECIFICATION
Current:
- Cron is by default true for a/b testing if a/b testig is not active in settings
- There are two different buttons, which are performing same thing
- In sms app, a/b testing buttons are not visible after creating a new version of that record

To Be:
- Cron should be inactive by default
- There should be only one button in view
- Buttons should be visible in view , after creating new version of that record in sms too.

TaskId-2713198

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
