### PR TITLE
[FIX] project: Fix edit button in forms views

### DIFF
--- a/addons/project/static/src/js/project_form.js
+++ b/addons/project/static/src/js/project_form.js
@@ -9,6 +9,7 @@ import viewRegistry from 'web.view_registry';
 
 const ProjectFormController = FormController.extend({
     on_attach_callback() {
+        this._super(...arguments);
         if (!device.isMobile) {
             bus.on("DOM_updated", this, this._onDomUpdated);
         }
@@ -22,6 +23,7 @@ const ProjectFormController = FormController.extend({
         }
     },
     on_detach_callback() {
+        this._super(...arguments);
         bus.off('DOM_updated', this._onDomUpdated);
     },
     _getActionMenuItems(state) {


### PR DESCRIPTION
since https://github.com/odoo/odoo/pull/79947 edit buttons in forms views `o_form_buttons_view` are invisible
This is due to the missing super call in on_attach_callback and on_detach_callback
linked pr: https://github.com/odoo/enterprise/pull/23074