### PR TITLE
[REF] web: load fontawesome through cdn

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -266,7 +266,7 @@ This module provides the core of the Odoo Web Client.
             ('include', 'web._assets_bootstrap'),
 
             'base/static/src/css/description.css',
-            'web/static/lib/fontawesome/css/font-awesome.css',
+            'web/static/lib/fontawesome/scss/*',
             'web/static/fonts/fonts.scss',
             'web/static/src/legacy/scss/report.scss',
             'web/static/src/legacy/scss/layout_standard.scss',
@@ -328,7 +328,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/src/legacy/scss/tempusdominus_overridden.scss',
             'web/static/lib/tempusdominus/tempusdominus.scss',
             'web/static/lib/jquery.ui/jquery-ui.css',
-            'web/static/lib/fontawesome/css/font-awesome.css',
+            'web/static/lib/fontawesome/scss/*',
             'web/static/lib/select2/select2.css',
             'web/static/lib/select2-bootstrap-css/select2-bootstrap.css',
             'web/static/lib/daterangepicker/daterangepicker.css',

--- a/addons/web/static/lib/fontawesome/scss/font-awesome.scss
+++ b/addons/web/static/lib/fontawesome/scss/font-awesome.scss
@@ -1,17 +1,42 @@
 /*!
- *  Font Awesome 4.7.0 by @davegandy - http://fontawesome.io - @fontawesome
+ *  Based on Font Awesome 4.7.0 by @davegandy - http://fontawesome.io - @fontawesome
  *  License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
  */
-/* FONT PATH
- * -------------------------- */
+
+$fa-font-types: (
+  'woff2?v=4.7.0': 'woff2',
+  'woff?v=4.7.0': 'woff',
+  'ttf?v=4.7.0': 'truetype',
+  'eot?#iefix&v=4.7.0': 'embedded-opentype',
+  'svg?v=4.7.0#fontawesomeregular': 'svg',
+);
+
+$fa-font-sources: (
+  'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/fonts/fontawesome-webfont',
+  '/web/static/lib/fontawesome/fonts/fontawesome-webfont',
+);
+
+@function fa-print-urls() {
+  $-src: null;
+
+  @each $-format, $-type in $fa-font-types {
+    @each $-source in $fa-font-sources {
+      $-src: append($-src, url + "('" + $-source + "." + $-format + "') " + format(quote($-type)), comma);
+    }
+  }
+  @return $-src;
+}
+
 @font-face {
   font-family: 'FontAwesome';
-  src: url('../fonts/fontawesome-webfont.eot?v=4.7.0');
-  src: url('../fonts/fontawesome-webfont.eot?#iefix&v=4.7.0') format('embedded-opentype'), url('../fonts/fontawesome-webfont.woff2?v=4.7.0') format('woff2'), url('../fonts/fontawesome-webfont.woff?v=4.7.0') format('woff'), url('../fonts/fontawesome-webfont.ttf?v=4.7.0') format('truetype'), url('../fonts/fontawesome-webfont.svg?v=4.7.0#fontawesomeregular') format('svg');
+  src: url('/web/static/lib/fontawesome/fonts/fontawesome-webfont.eot?v=4.7.0');
+  src: fa-print-urls();
+
   font-weight: normal;
   font-style: normal;
   font-display: block;
 }
+
 .fa {
   display: inline-block;
   font: normal normal normal 14px/1 FontAwesome;
@@ -24,19 +49,12 @@
 .fa-lg {
   font-size: 1.33333333em;
   line-height: 0.75em;
-  vertical-align: -15%;
+  vertical-align: -.0667em;
 }
-.fa-2x {
-  font-size: 2em;
-}
-.fa-3x {
-  font-size: 3em;
-}
-.fa-4x {
-  font-size: 4em;
-}
-.fa-5x {
-  font-size: 5em;
+@for $i from 2 through 10 {
+  .fa-#{$i}x {
+    font-size: $i * 1em;
+  }
 }
 .fa-fw {
   width: 1.28571429em;
@@ -77,75 +95,29 @@
 .fa.fa-pull-right {
   margin-left: .3em;
 }
-/* Deprecated as of 4.4.0 */
-.pull-right {
-  float: right;
-}
-.pull-left {
-  float: left;
-}
-.fa.pull-left {
-  margin-right: .3em;
-}
-.fa.pull-right {
-  margin-left: .3em;
-}
 .fa-spin {
-  -webkit-animation: fa-spin 2s infinite linear;
   animation: fa-spin 2s infinite linear;
 }
 .fa-pulse {
-  -webkit-animation: fa-spin 1s infinite steps(8);
   animation: fa-spin 1s infinite steps(8);
-}
-@-webkit-keyframes fa-spin {
-  0% {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-  100% {
-    -webkit-transform: rotate(359deg);
-    transform: rotate(359deg);
-  }
 }
 @keyframes fa-spin {
   0% {
-    -webkit-transform: rotate(0deg);
     transform: rotate(0deg);
   }
   100% {
-    -webkit-transform: rotate(359deg);
     transform: rotate(359deg);
   }
 }
-.fa-rotate-90 {
-  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
-  -webkit-transform: rotate(90deg);
-  -ms-transform: rotate(90deg);
-  transform: rotate(90deg);
-}
-.fa-rotate-180 {
-  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2)";
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-}
-.fa-rotate-270 {
-  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=3)";
-  -webkit-transform: rotate(270deg);
-  -ms-transform: rotate(270deg);
-  transform: rotate(270deg);
+@each $-deg in 90, 180, 270 {
+  .fa-rotate-#{$-deg} {
+    transform: rotate($-deg * 1deg);
+  }
 }
 .fa-flip-horizontal {
-  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1)";
-  -webkit-transform: scale(-1, 1);
-  -ms-transform: scale(-1, 1);
   transform: scale(-1, 1);
 }
 .fa-flip-vertical {
-  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)";
-  -webkit-transform: scale(1, -1);
-  -ms-transform: scale(1, -1);
   transform: scale(1, -1);
 }
 :root .fa-rotate-90,


### PR DESCRIPTION
This commit reviews how fontAwesome is loaded by the system adding a
priority CDN option and using font-files in '/lib' as a fallback only.

It will also convert the original CSS file to SCSS, allowing to use a
SCSS function to output the necessary quite complicated src string.

FontAweome was made in 2017 and the original file included several
deprecated selector and vendor-prefix rules. These lines were no longer
necessary and have been removed.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
