### PR TITLE
[FIX] stock_inventory: Fix Memory Error

### DIFF
--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -426,8 +426,14 @@ class InventoryLine(models.Model):
         return res
 
     def _check_no_duplicate_line(self):
-        # Performance: restrict domain on 'not null' fields of stock_inventory_line.
-        domain = [('product_id', 'in', self.product_id.ids), ('location_id', 'in', self.location_id.ids)]
+        domain = [
+            ('product_id', 'in', self.product_id.ids),
+            ('location_id', 'in', self.location_id.ids),
+            '|', ('partner_id', 'in', self.partner_id.ids), ('partner_id', '=', None),
+            '|', ('package_id', 'in', self.package_id.ids), ('package_id', '=', None),
+            '|', ('prod_lot_id', 'in', self.prod_lot_id.ids), ('prod_lot_id', '=', None),
+            '|', ('inventory_id', 'in', self.inventory_id.ids), ('inventory_id', '=', None),
+        ]
         groupby_fields = ['product_id', 'location_id', 'partner_id', 'package_id', 'prod_lot_id', 'inventory_id']
         lines_count = {}
         for group in self.read_group(domain, ['product_id'], groupby_fields, lazy=False):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Add filters on the read_group domain of _check_no_duplicate_line()

Current behavior before PR:
On database with a lot stock.inventory.line (more than 1 million), a Memory Error was happening 

Desired behavior after PR is merged:
No Memory error.
Those filters were removed on commit ba92e1da by AVD to prevent a test error where those fields were False. On his advises, I re-added them with the '|' comparator to handle the False cases.

OPW-2714644

This PR must be forwarded up to 14.0

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
