### PR TITLE
[IMP] web: custom command palette

### DIFF
--- a/addons/web/static/src/core/commands/command_palette.scss
+++ b/addons/web/static/src/core/commands/command_palette.scss
@@ -1,4 +1,6 @@
 .o_command_palette {
+  margin-top: 10vh;
+
   &.modal-content {
     border: none;
     border-radius: 3px !important;

--- a/addons/web/static/src/core/commands/command_palette.xml
+++ b/addons/web/static/src/core/commands/command_palette.xml
@@ -4,7 +4,7 @@
   <t t-name="web.CommandPalette" owl="1">
     <div>
       <div class="o_command_palette_search">
-        <input type="text" t-model="state.searchValue" t-on-input="onDebouncedSearchInput" autofocus="" t-att-placeholder="state.placeholder"/>
+        <input type="text" t-model="state.searchValue" t-on-input="onSearchInput" autofocus="" t-att-placeholder="state.placeholder"/>
         <i  t-att-title="state.placeholder" role="img"  t-att-aria-label="state.placeholder" class="fa fa-search"></i>
       </div>
 

--- a/addons/web/static/src/core/commands/command_service.js
+++ b/addons/web/static/src/core/commands/command_service.js
@@ -54,7 +54,11 @@ export const commandService = {
             global: true,
         });
 
-        function openMainPalette() {
+        /**
+         * @param {CommandPaletteConfig} config command palette config merged with default config
+         * @returns the actual command palette config if the command palette is already open
+         */
+        function openMainPalette(config = {}) {
             const categoriesByNamespace = {};
             commandCategoryRegistry.getEntries().forEach(([category, el]) => {
                 const namespace = el.namespace ? el.namespace : "default";
@@ -69,14 +73,16 @@ export const commandService = {
             commandEmptyMessageRegistry.getEntries().forEach(([key, message]) => {
                 emptyMessageByNamespace[key] = message.toString();
             });
-
-            const config = {
-                categoriesByNamespace,
-                emptyMessageByNamespace,
-                footerTemplate,
-                placeholder: env._t("Search for a command..."),
-                providers: commandProviderRegistry.getAll(),
-            };
+            config = Object.assign(
+                {
+                    categoriesByNamespace,
+                    emptyMessageByNamespace,
+                    footerTemplate,
+                    placeholder: env._t("Search for a command..."),
+                    providers: commandProviderRegistry.getAll(),
+                },
+                config
+            );
             return openPalette(config);
         }
 
@@ -176,6 +182,7 @@ export const commandService = {
                     (command) => command.activeElement === activeElement || command.global
                 );
             },
+            openMainPalette,
             openPalette,
         };
     },

--- a/addons/web/static/tests/core/commands/command_palette_tests.js
+++ b/addons/web/static/tests/core/commands/command_palette_tests.js
@@ -416,6 +416,56 @@ QUnit.test("check the concurrency during a research", async (assert) => {
     assert.verifySteps(["b"]);
 });
 
+QUnit.test(
+    "open the command palette with a searchValue already in the searchbar",
+    async (assert) => {
+        testComponent = await mount(TestComponent, { env, target });
+        const action = () => {};
+        const providers = [
+            {
+                provide: () => [
+                    {
+                        name: "Command1",
+                        action,
+                    },
+                    {
+                        name: "Command2",
+                        action,
+                    },
+                ],
+            },
+            {
+                namespace: "@",
+                provide: () => [
+                    {
+                        name: "Command3",
+                        action,
+                    },
+                    {
+                        name: "Command4",
+                        action,
+                    },
+                ],
+            },
+        ];
+        const config = {
+            searchValue: "C1",
+            providers,
+        };
+        env.services.dialog.add(CommandPaletteDialog, {
+            config,
+        });
+        await nextTick();
+        assert.containsOnce(target, ".o_command_palette");
+        assert.strictEqual(target.querySelector(".o_command_palette_search input").value, "C1");
+        assert.containsN(target, ".o_command", 1);
+        assert.deepEqual(
+            [...target.querySelectorAll(".o_command")].map((el) => el.textContent),
+            ["Command1"]
+        );
+    }
+);
+
 QUnit.test("open the command palette with a namespace already in the searchbar", async (assert) => {
     testComponent = await mount(TestComponent, { env, target });
     const action = () => {};
@@ -447,7 +497,7 @@ QUnit.test("open the command palette with a namespace already in the searchbar",
         },
     ];
     const config = {
-        namespace: "@",
+        searchValue: "@",
         providers,
     };
     env.services.dialog.add(CommandPaletteDialog, {


### PR DESCRIPTION
This commit adds the possibility to open the custom main command palette.
So it is possible to replace some parts of the default command palette
config.

For example, we will customize the placeholder:
```
    this.command_service.openMainPalette({
        placeholder: "My custom placeholder",
    })
```

This commit also modify the api of CommandPaletteConfig, we replace
namespace by searchValue. Now it is possible to open a command palette
with a value in its input.

For example:
```
    this.command_service.openPalette({
        searchValue: "@test",
    })
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
