### PR TITLE
[IMP] sale_*: conversion to computes (2)

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -10,6 +10,21 @@ from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import float_is_zero, html_keep_url, is_html_empty
 
+OPEN_FIELD_STATES = {
+    state: [('readonly', False)]
+    for state in {'draft', 'sent'}
+}
+
+READONLY_FIELD_STATES = {
+    state: [('readonly', True)]
+    for state in {'sale', 'done', 'cancel'}
+}
+
+LOCKED_FIELD_STATES = {
+    state: [('readonly', True)]
+    for state in {'done', 'cancel'}
+}
+
 
 class SaleOrder(models.Model):
     _name = "sale.order"
@@ -17,19 +32,6 @@ class SaleOrder(models.Model):
     _description = "Sales Order"
     _order = 'date_order desc, id desc'
     _check_company_auto = True
-
-    def _default_validity_date(self):
-        if self.env['ir.config_parameter'].sudo().get_param('sale.use_quotation_validity_days'):
-            days = self.env.company.quotation_validity_days
-            if days > 0:
-                return fields.Datetime.now() + timedelta(days)
-        return False
-
-    def _get_default_require_signature(self):
-        return self.env.company.portal_confirmation_sign
-
-    def _get_default_require_payment(self):
-        return self.env.company.portal_confirmation_pay
 
     @api.depends('order_line.price_total')
     def _amount_all(self):
@@ -153,16 +155,29 @@ class SaleOrder(models.Model):
         ('done', 'Locked'),
         ('cancel', 'Cancelled'),
         ], string='Status', readonly=True, copy=False, index=True, tracking=3, default='draft')
-    date_order = fields.Datetime(string='Order Date', required=True, readonly=True, index=True, states={'draft': [('readonly', False)], 'sent': [('readonly', False)]}, copy=False, default=fields.Datetime.now, help="Creation date of draft/sent orders,\nConfirmation date of confirmed orders.")
-    validity_date = fields.Date(string='Expiration', readonly=True, copy=False, states={'draft': [('readonly', False)], 'sent': [('readonly', False)]},
-                                default=_default_validity_date)
+    date_order = fields.Datetime(
+        string='Order Date', required=True, readonly=True, index=True,
+        states=OPEN_FIELD_STATES,
+        copy=False, default=fields.Datetime.now,
+        help="Creation date of draft/sent orders,\nConfirmation date of confirmed orders.")
+    validity_date = fields.Date(
+        string="Expiration",
+        compute='_compute_validity_date',
+        store=True, readonly=False, copy=False, precompute=True,
+        states=READONLY_FIELD_STATES)
     is_expired = fields.Boolean(compute='_compute_is_expired', string="Is expired")
-    require_signature = fields.Boolean('Online Signature', default=_get_default_require_signature, readonly=True,
-        states={'draft': [('readonly', False)], 'sent': [('readonly', False)]},
-        help='Request a online signature to the customer in order to confirm orders automatically.')
-    require_payment = fields.Boolean('Online Payment', default=_get_default_require_payment, readonly=True,
-        states={'draft': [('readonly', False)], 'sent': [('readonly', False)]},
-        help='Request an online payment to the customer in order to confirm orders automatically.')
+    require_signature = fields.Boolean(
+        string="Online Signature",
+        compute='_compute_require_signature',
+        store=True, readonly=False, precompute=True,
+        states=READONLY_FIELD_STATES,
+        help="Request a online signature to the customer in order to confirm orders automatically.")
+    require_payment = fields.Boolean(
+        string="Online Payment",
+        compute='_compute_require_payment',
+        store=True, readonly=False, precompute=True,
+        states=READONLY_FIELD_STATES,
+        help="Request an online payment to the customer in order to confirm orders automatically.")
     create_date = fields.Datetime(string='Creation Date', readonly=True, index=True, help="Date on which sales order is created.")
 
     user_id = fields.Many2one(
@@ -171,7 +186,7 @@ class SaleOrder(models.Model):
         domain=lambda self: [('groups_id', 'in', self.env.ref('sales_team.group_sale_salesman').id)])
     partner_id = fields.Many2one(
         'res.partner', string='Customer', readonly=False,
-        states={'sale': [('readonly', True)], 'done': [('readonly', True)], 'cancel': [('readonly', True)]},
+        states=READONLY_FIELD_STATES,
         required=True, change_default=True, index=True, tracking=1,
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",)
     partner_invoice_id = fields.Many2one(
@@ -188,7 +203,7 @@ class SaleOrder(models.Model):
     pricelist_id = fields.Many2one(
         'product.pricelist', string='Pricelist', required=False, check_company=True,  # Unrequired company
         compute='_compute_pricelist_id', store=True, precompute=True, readonly=False,
-        states={'sale': [('readonly', True)], 'done': [('readonly', True)], 'cancel': [('readonly', True)]},
+        states=READONLY_FIELD_STATES,
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", tracking=1,
         help="If you change the pricelist, only newly added lines will be affected.")
     currency_id = fields.Many2one(
@@ -196,11 +211,13 @@ class SaleOrder(models.Model):
     analytic_account_id = fields.Many2one(
         'account.analytic.account', 'Analytic Account',
         readonly=True, copy=False, check_company=True,  # Unrequired company
-        states={'draft': [('readonly', False)], 'sent': [('readonly', False)]},
+        states=OPEN_FIELD_STATES,
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
         help="The analytic account related to a sales order.")
 
-    order_line = fields.One2many('sale.order.line', 'order_id', string='Order Lines', states={'cancel': [('readonly', True)], 'done': [('readonly', True)]}, copy=True, auto_join=True)
+    order_line = fields.One2many(
+        'sale.order.line', 'order_id', string='Order Lines',
+        states=LOCKED_FIELD_STATES, copy=True, auto_join=True)
 
     invoice_count = fields.Integer(string='Invoice Count', compute='_get_invoiced')
     invoice_ids = fields.Many2many("account.move", string='Invoices', compute="_get_invoiced", copy=False, search="_search_invoice_ids")
@@ -255,7 +272,7 @@ class SaleOrder(models.Model):
 
     commitment_date = fields.Datetime(
         'Delivery Date', copy=False,
-        states={'done': [('readonly', True)], 'cancel': [('readonly', True)]},
+        states=LOCKED_FIELD_STATES,
         help="This is the delivery date promised to the customer. "
              "If set, the delivery order will be scheduled based on "
              "this date rather than product lead times.")
@@ -296,6 +313,31 @@ class SaleOrder(models.Model):
                     quote_company=order.company_id.display_name,
                     bad_products=', '.join(bad_products.mapped('display_name')),
                 ))
+
+    @api.depends('company_id')
+    def _compute_validity_date(self):
+        enabled_feature = bool(self.env['ir.config_parameter'].sudo().get_param('sale.use_quotation_validity_days'))
+        if not enabled_feature:
+            self.validity_date = False
+            return
+
+        today = fields.Date.context_today(self)
+        for order in self:
+            days = order.company_id.quotation_validity_days
+            if days > 0:
+                order.validity_date = today + timedelta(days)
+            else:
+                order.validity_date = False
+
+    @api.depends('company_id')
+    def _compute_require_signature(self):
+        for order in self:
+            order.require_signature = order.company_id.portal_confirmation_sign
+
+    @api.depends('company_id')
+    def _compute_require_payment(self):
+        for order in self:
+            order.require_payment = order.company_id.portal_confirmation_pay
 
     @api.depends('currency_id', 'date_order', 'company_id')
     def _compute_currency_rate(self):

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -10,11 +10,6 @@ from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import float_is_zero, html_keep_url, is_html_empty
 
-OPEN_FIELD_STATES = {
-    state: [('readonly', False)]
-    for state in {'draft', 'sent'}
-}
-
 READONLY_FIELD_STATES = {
     state: [('readonly', True)]
     for state in {'sale', 'done', 'cancel'}
@@ -156,8 +151,8 @@ class SaleOrder(models.Model):
         ('cancel', 'Cancelled'),
         ], string='Status', readonly=True, copy=False, index=True, tracking=3, default='draft')
     date_order = fields.Datetime(
-        string='Order Date', required=True, readonly=True, index=True,
-        states=OPEN_FIELD_STATES,
+        string='Order Date', required=True, index=True,
+        states=READONLY_FIELD_STATES,
         copy=False, default=fields.Datetime.now,
         help="Creation date of draft/sent orders,\nConfirmation date of confirmed orders.")
     validity_date = fields.Date(
@@ -210,8 +205,8 @@ class SaleOrder(models.Model):
         related='pricelist_id.currency_id', depends=["pricelist_id"], store=True, precompute=True, ondelete="restrict")
     analytic_account_id = fields.Many2one(
         'account.analytic.account', 'Analytic Account',
-        readonly=True, copy=False, check_company=True,  # Unrequired company
-        states=OPEN_FIELD_STATES,
+        copy=False, check_company=True,  # Unrequired company
+        states=READONLY_FIELD_STATES,
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
         help="The analytic account related to a sales order.")
 

--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -132,7 +132,7 @@ class SaleOrder(models.Model):
 
         for order in self:
             if order.sale_order_template_id and order.sale_order_template_id.mail_template_id:
-                self.sale_order_template_id.mail_template_id.send_mail(order.id)
+                order.sale_order_template_id.mail_template_id.send_mail(order.id)
         return res
 
     def get_access_action(self, access_uid=None):

--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -7,28 +7,60 @@ from odoo import SUPERUSER_ID, api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import is_html_empty
 
+from odoo.addons.sale.models.sale_order import READONLY_FIELD_STATES
+
 
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    @api.model
-    def default_get(self, fields_list):
-        default_vals = super(SaleOrder, self).default_get(fields_list)
-        if "sale_order_template_id" in fields_list and not default_vals.get("sale_order_template_id"):
-            company_id = default_vals.get('company_id', False)
-            company = self.env["res.company"].browse(company_id) if company_id else self.env.company
-            default_vals['sale_order_template_id'] = company.sale_order_template_id.id
-        return default_vals
-
     sale_order_template_id = fields.Many2one(
-        'sale.order.template', 'Quotation Template',
-        readonly=True, check_company=True,
-        states={'draft': [('readonly', False)], 'sent': [('readonly', False)]},
+        comodel_name='sale.order.template',
+        string="Quotation Template",
+        compute='_compute_sale_order_template_id',
+        store=True, readonly=False, check_company=True, precompute=True,
+        states=READONLY_FIELD_STATES,
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
     sale_order_option_ids = fields.One2many(
-        'sale.order.option', 'order_id', 'Optional Products Lines',
-        copy=True, readonly=True,
-        states={'draft': [('readonly', False)], 'sent': [('readonly', False)]})
+        comodel_name='sale.order.option', inverse_name='order_id',
+        string="Optional Products Lines",
+        states=READONLY_FIELD_STATES,
+        copy=True)
+
+    #=== COMPUTE METHODS ===#
+
+    @api.depends('company_id')
+    def _compute_sale_order_template_id(self):
+        for order in self:
+            order.sale_order_template_id = order.company_id.sale_order_template_id.id
+
+    @api.depends('partner_id', 'sale_order_template_id')
+    def _compute_note(self):
+        super()._compute_note()
+        for order in self.filtered('sale_order_template_id'):
+            template = order.sale_order_template_id.with_context(lang=order.partner_id.lang)
+            order.note = template.note if not is_html_empty(template.note) else order.note
+
+    @api.depends('sale_order_template_id')
+    def _compute_require_signature(self):
+        super()._compute_require_signature()
+        for order in self.filtered('sale_order_template_id'):
+            order.require_signature = order.sale_order_template_id.require_signature
+
+    @api.depends('sale_order_template_id')
+    def _compute_require_payment(self):
+        super()._compute_require_payment()
+        for order in self.filtered('sale_order_template_id'):
+            order.require_payment = order.sale_order_template_id.require_payment
+
+    @api.depends('sale_order_template_id')
+    def _compute_validity_date(self):
+        super()._compute_validity_date()
+        for order in self.filtered('sale_order_template_id'):
+            validity_days = order.sale_order_template_id.number_of_days
+            if validity_days > 0:
+                order.validity_date = fields.Date.context_today(order) + timedelta(validity_days)
+
+    #=== CONSTRAINT METHODS ===#
 
     @api.constrains('company_id', 'sale_order_option_ids')
     def _check_optional_product_company_id(self):
@@ -43,113 +75,53 @@ class SaleOrder(models.Model):
                     bad_products=', '.join(bad_products.mapped('display_name')),
                 ))
 
-    @api.returns('self', lambda value: value.id)
-    def copy(self, default=None):
-        if self.sale_order_template_id and self.sale_order_template_id.number_of_days > 0:
-            default = dict(default or {})
-            default['validity_date'] = fields.Date.context_today(self) + timedelta(self.sale_order_template_id.number_of_days)
-        return super(SaleOrder, self).copy(default=default)
+    #=== ONCHANGE METHODS ===#
 
-    @api.depends('partner_id', 'sale_order_template_id')
-    def _compute_note(self):
-        super()._compute_note()
-        for order in self.filtered('sale_order_template_id'):
-            template = order.sale_order_template_id.with_context(lang=order.partner_id.lang)
-            order.note = template.note if not is_html_empty(template.note) else order.note
+    # TODO convert to compute ???
+    @api.onchange('sale_order_template_id')
+    def _onchange_sale_order_template_id(self):
+        sale_order_template = self.sale_order_template_id.with_context(lang=self.partner_id.lang)
+
+        self.order_line = [
+            fields.Command.create(
+                self._compute_line_data_for_template_change(line)
+            )
+            for line in sale_order_template.sale_order_template_line_ids
+        ]
+
+        option_lines_data = [fields.Command.clear()]
+        option_lines_data += [
+            fields.Command.create(
+                self._compute_option_data_for_template_change(option)
+            )
+            for option in sale_order_template.sale_order_template_option_ids
+        ]
+
+        self.sale_order_option_ids = option_lines_data
+
+    # TODO delegate to sub models (note: overridden in sale_quotation_builder)
 
     def _compute_line_data_for_template_change(self, line):
         return {
             'display_type': line.display_type,
             'name': line.name,
-            'state': 'draft',
+            'product_id': line.product_id.id,
+            'product_uom_qty': line.product_uom_qty,
+            'product_uom': line.product_uom_id.id,
         }
 
     def _compute_option_data_for_template_change(self, option):
-        price = option.product_id.lst_price
-        discount = 0
-
-        if self.pricelist_id:
-            pricelist_price = self.pricelist_id._get_product_price(option.product_id, 1, uom=option.uom_id)
-
-            if self.pricelist_id.discount_policy == 'without_discount' and price:
-                discount = max(0, (price - pricelist_price) * 100 / price)
-            else:
-                price = pricelist_price
-
         return {
-            'product_id': option.product_id.id,
             'name': option.name,
+            'product_id': option.product_id.id,
             'quantity': option.quantity,
             'uom_id': option.uom_id.id,
-            'price_unit': price,
-            'discount': discount
         }
 
-    def update_prices(self):
-        self.ensure_one()
-        super().update_prices()
-        # Special case: we want to overwrite the existing discount on update_prices call
-        # i.e. to make sure the discount is correctly reset
-        # if pricelist discount_policy is different than when the price was first computed.
-        self.sale_order_option_ids.discount = 0.0
-        self.sale_order_option_ids._compute_price_unit()
-        self.sale_order_option_ids._compute_discount()
-
-    @api.onchange('sale_order_template_id')
-    def onchange_sale_order_template_id(self):
-
-        if not self.sale_order_template_id:
-            self.require_signature = self._get_default_require_signature()
-            self.require_payment = self._get_default_require_payment()
-            return
-
-        template = self.sale_order_template_id.with_context(lang=self.partner_id.lang)
-
-        # --- first, process the list of products from the template
-        order_lines = [(5, 0, 0)]
-        for line in template.sale_order_template_line_ids:
-            data = self._compute_line_data_for_template_change(line)
-
-            if line.product_id:
-                price = line.product_id.lst_price
-                discount = 0
-
-                if self.pricelist_id:
-                    pricelist_price = self.pricelist_id._get_product_price(line.product_id, 1, uom=line.product_uom_id)
-
-                    if self.pricelist_id.discount_policy == 'without_discount' and price:
-                        discount = max(0, (price - pricelist_price) * 100 / price)
-                    else:
-                        price = pricelist_price
-
-                data.update({
-                    'price_unit': price,
-                    'discount': discount,
-                    'product_uom_qty': line.product_uom_qty,
-                    'product_id': line.product_id.id,
-                    'product_uom': line.product_uom_id.id,
-                })
-
-            order_lines.append((0, 0, data))
-
-        self.order_line = order_lines
-
-        # then, process the list of optional products from the template
-        option_lines = [(5, 0, 0)]
-        for option in template.sale_order_template_option_ids:
-            data = self._compute_option_data_for_template_change(option)
-            option_lines.append((0, 0, data))
-
-        self.sale_order_option_ids = option_lines
-
-        if template.number_of_days > 0:
-            self.validity_date = fields.Date.context_today(self) + timedelta(template.number_of_days)
-
-        self.require_signature = template.require_signature
-        self.require_payment = template.require_payment
+    #=== ACTION METHODS ===#
 
     def action_confirm(self):
-        res = super(SaleOrder, self).action_confirm()
+        res = super().action_confirm()
         if self.env.su:
             self = self.with_user(SUPERUSER_ID)
 
@@ -164,13 +136,22 @@ class SaleOrder(models.Model):
         user = access_uid and self.env['res.users'].sudo().browse(access_uid) or self.env.user
 
         if not self.sale_order_template_id or (not user.share and not self.env.context.get('force_website')):
-            return super(SaleOrder, self).get_access_action(access_uid)
+            return super().get_access_action(access_uid)
         return {
             'type': 'ir.actions.act_url',
             'url': self.get_portal_url(),
             'target': 'self',
             'res_id': self.id,
         }
+
+    def update_prices(self):
+        super().update_prices()
+        # Special case: we want to overwrite the existing discount on update_prices call
+        # i.e. to make sure the discount is correctly reset
+        # if pricelist discount_policy is different than when the price was first computed.
+        self.sale_order_option_ids.discount = 0.0
+        self.sale_order_option_ids._compute_price_unit()
+        self.sale_order_option_ids._compute_discount()
 
 
 class SaleOrderLine(models.Model):
@@ -196,42 +177,59 @@ class SaleOrderOption(models.Model):
     _description = "Sale Options"
     _order = 'sequence, id'
 
+    # FIXME ANVFE wtf is it not required ???
+    # TODO related to order.company_id and restrict product choice based on company
+    order_id = fields.Many2one('sale.order', 'Sales Order Reference', ondelete='cascade', index=True)
+
+    product_id = fields.Many2one(
+        comodel_name='product.product',
+        required=True,
+        domain=[('sale_ok', '=', True)])
+    line_id = fields.Many2one(
+        comodel_name='sale.order.line', ondelete='set null', copy=False)
+    sequence = fields.Integer(
+        string='Sequence', help="Gives the sequence order when displaying a list of optional products.")
+
+    name = fields.Text(
+        string="Description",
+        compute='_compute_name',
+        store=True, readonly=False,
+        required=True, precompute=True)
+
+    quantity = fields.Float(
+        string="Quantity",
+        required=True,
+        digits='Product Unit of Measure',
+        default=1)
+    uom_id = fields.Many2one(
+        comodel_name='uom.uom',
+        string="Unit of Measure",
+        compute='_compute_uom_id',
+        store=True, readonly=False,
+        required=True, precompute=True,
+        domain="[('category_id', '=', product_uom_category_id)]")
+    product_uom_category_id = fields.Many2one(related='product_id.uom_id.category_id')
+
+    price_unit = fields.Float(
+        string="Unit Price",
+        digits='Product Price',
+        compute='_compute_price_unit',
+        store=True, readonly=False,
+        required=True, precompute=True)
+    discount = fields.Float(
+        string="Discount (%)",
+        digits='Discount',
+        compute='_compute_discount',
+        store=True, readonly=False, precompute=True)
+
     is_present = fields.Boolean(
         string="Present on Quotation",
-        compute="_compute_is_present", search="_search_is_present",
+        compute='_compute_is_present',
+        search='_search_is_present',
         help="This field will be checked if the option line's product is "
              "already present in the quotation.")
-    order_id = fields.Many2one('sale.order', 'Sales Order Reference', ondelete='cascade', index=True)
-    line_id = fields.Many2one('sale.order.line', ondelete="set null", copy=False)
-    name = fields.Text(
-        'Description', required=True,
-        compute='_compute_name', store=True, readonly=False, precompute=True)
-    product_id = fields.Many2one('product.product', 'Product', required=True, domain=[('sale_ok', '=', True)])
-    price_unit = fields.Float(
-        'Unit Price', required=True, digits='Product Price',
-        compute='_compute_price_unit', store=True, readonly=False, precompute=True)
-    discount = fields.Float(
-        'Discount (%)', digits='Discount',
-        compute='_compute_discount', store=True, readonly=False, precompute=True)
-    uom_id = fields.Many2one(
-        'uom.uom', 'Unit of Measure ', required=True,
-        compute='_compute_uom_id', store=True, readonly=False, precompute=True,
-        domain="[('category_id', '=', product_uom_category_id)]")
-    product_uom_category_id = fields.Many2one(related='product_id.uom_id.category_id', readonly=True)
-    quantity = fields.Float('Quantity', required=True, digits='Product Unit of Measure', default=1)
-    sequence = fields.Integer('Sequence', help="Gives the sequence order when displaying a list of optional products.")
 
-    @api.depends('line_id', 'order_id.order_line', 'product_id')
-    def _compute_is_present(self):
-        # NOTE: this field cannot be stored as the line_id is usually removed
-        # through cascade deletion, which means the compute would be false
-        for option in self:
-            option.is_present = bool(option.order_id.order_line.filtered(lambda l: l.product_id == option.product_id))
-
-    def _search_is_present(self, operator, value):
-        if (operator, value) in [('=', True), ('!=', False)]:
-            return [('line_id', '=', False)]
-        return [('line_id', '!=', False)]
+    #=== COMPUTE METHODS ===#
 
     @api.depends('product_id')
     def _compute_name(self):
@@ -270,6 +268,32 @@ class SaleOrderOption(models.Model):
             new_sol._compute_discount()
             option.discount = new_sol.discount
 
+    def _get_values_to_add_to_order(self):
+        self.ensure_one()
+        return {
+            'order_id': self.order_id.id,
+            'price_unit': self.price_unit,
+            'name': self.name,
+            'product_id': self.product_id.id,
+            'product_uom_qty': self.quantity,
+            'product_uom': self.uom_id.id,
+            'discount': self.discount,
+        }
+
+    @api.depends('line_id', 'order_id.order_line', 'product_id')
+    def _compute_is_present(self):
+        # NOTE: this field cannot be stored as the line_id is usually removed
+        # through cascade deletion, which means the compute would be false
+        for option in self:
+            option.is_present = bool(option.order_id.order_line.filtered(lambda l: l.product_id == option.product_id))
+
+    def _search_is_present(self, operator, value):
+        if (operator, value) in [('=', True), ('!=', False)]:
+            return [('line_id', '=', False)]
+        return [('line_id', '!=', False)]
+
+    #=== ACTION METHODS ===#
+
     def button_add_to_order(self):
         self.add_option_to_order()
 
@@ -287,17 +311,3 @@ class SaleOrderOption(models.Model):
         self.write({'line_id': order_line.id})
         if sale_order:
             sale_order.add_option_to_order_with_taxcloud()
-
-
-    def _get_values_to_add_to_order(self):
-        self.ensure_one()
-        return {
-            'order_id': self.order_id.id,
-            'price_unit': self.price_unit,
-            'name': self.name,
-            'product_id': self.product_id.id,
-            'product_uom_qty': self.quantity,
-            'product_uom': self.uom_id.id,
-            'discount': self.discount,
-            'company_id': self.order_id.company_id.id,
-        }

--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -31,6 +31,11 @@ class SaleOrder(models.Model):
     @api.depends('company_id')
     def _compute_sale_order_template_id(self):
         for order in self:
+            if order.state != 'draft':
+                # Do NOT update existing SO's template and dependent fields
+                # Especially when installing sale_management in a db
+                # already containing SO records
+                continue
             order.sale_order_template_id = order.company_id.sale_order_template_id.id
 
     @api.depends('partner_id', 'sale_order_template_id')

--- a/addons/sale_management/models/sale_order_template.py
+++ b/addons/sale_management/models/sale_order_template.py
@@ -9,26 +9,56 @@ class SaleOrderTemplate(models.Model):
     _name = "sale.order.template"
     _description = "Quotation Template"
 
-    def _get_default_require_signature(self):
-        return self.env.company.portal_confirmation_sign
+    active = fields.Boolean(
+        default=True,
+        help="If unchecked, it will allow you to hide the quotation template without removing it.")
+    company_id = fields.Many2one(comodel_name='res.company')
 
-    def _get_default_require_payment(self):
-        return self.env.company.portal_confirmation_pay
+    name = fields.Char(string="Quotation Template", required=True)
+    note = fields.Html(string="Terms and conditions", translate=True)
 
-    name = fields.Char('Quotation Template', required=True)
-    sale_order_template_line_ids = fields.One2many('sale.order.template.line', 'sale_order_template_id', 'Lines', copy=True)
-    note = fields.Html('Terms and conditions', translate=True)
-    sale_order_template_option_ids = fields.One2many('sale.order.template.option', 'sale_order_template_id', 'Optional Products', copy=True)
-    number_of_days = fields.Integer('Quotation Duration',
-        help='Number of days for the validity date computation of the quotation')
-    require_signature = fields.Boolean('Online Signature', default=_get_default_require_signature, help='Request a online signature to the customer in order to confirm orders automatically.')
-    require_payment = fields.Boolean('Online Payment', default=_get_default_require_payment, help='Request an online payment to the customer in order to confirm orders automatically.')
     mail_template_id = fields.Many2one(
-        'mail.template', 'Confirmation Mail',
+        comodel_name='mail.template',
+        string="Confirmation Mail",
         domain=[('model', '=', 'sale.order')],
         help="This e-mail template will be sent on confirmation. Leave empty to send nothing.")
-    active = fields.Boolean(default=True, help="If unchecked, it will allow you to hide the quotation template without removing it.")
-    company_id = fields.Many2one('res.company', string='Company')
+    number_of_days = fields.Integer(
+        string="Quotation Duration",
+        help="Number of days for the validity date computation of the quotation")
+
+    require_signature = fields.Boolean(
+        string="Online Signature",
+        compute='_compute_require_signature',
+        store=True, readonly=False,
+        help="Request a online signature to the customer in order to confirm orders automatically.")
+    require_payment = fields.Boolean(
+        string="Online Payment",
+        compute='_compute_require_payment',
+        store=True, readonly=False,
+        help="Request an online payment to the customer in order to confirm orders automatically.")
+
+    sale_order_template_line_ids = fields.One2many(
+        comodel_name='sale.order.template.line', inverse_name='sale_order_template_id',
+        string="Lines",
+        copy=True)
+    sale_order_template_option_ids = fields.One2many(
+        comodel_name='sale.order.template.option', inverse_name='sale_order_template_id',
+        string="Optional Products",
+        copy=True)
+
+    #=== COMPUTE METHODS ===#
+
+    @api.depends('company_id')
+    def _compute_require_signature(self):
+        for order in self:
+            order.require_signature = (order.company_id or order.env.company).portal_confirmation_sign
+
+    @api.depends('company_id')
+    def _compute_require_payment(self):
+        for order in self:
+            order.require_payment = (order.company_id or order.env.company).portal_confirmation_pay
+
+    #=== CONSTRAINT METHODS ===#
 
     @api.constrains('company_id', 'sale_order_template_line_ids', 'sale_order_template_option_ids')
     def _check_company_id(self):
@@ -43,15 +73,11 @@ class SaleOrderTemplate(models.Model):
                     template_company=template.company_id.display_name,
                 ))
 
-    @api.onchange('sale_order_template_line_ids', 'sale_order_template_option_ids')
-    def _onchange_template_line_ids(self):
-        companies = self.mapped('sale_order_template_option_ids.product_id.company_id') | self.mapped('sale_order_template_line_ids.product_id.company_id')
-        if companies and self.company_id not in companies:
-            self.company_id = companies[0]
+    #=== CRUD METHODS ===#
 
     @api.model_create_multi
     def create(self, vals_list):
-        records = super(SaleOrderTemplate, self).create(vals_list)
+        records = super().create(vals_list)
         records._update_product_translations()
         return records
 
@@ -59,7 +85,7 @@ class SaleOrderTemplate(models.Model):
         if 'active' in vals and not vals.get('active'):
             companies = self.env['res.company'].sudo().search([('sale_order_template_id', 'in', self.ids)])
             companies.sale_order_template_id = None
-        result = super(SaleOrderTemplate, self).write(vals)
+        result = super().write(vals)
         self._update_product_translations()
         return result
 
@@ -68,14 +94,16 @@ class SaleOrderTemplate(models.Model):
         for lang in languages:
             for line in self.sale_order_template_line_ids:
                 if line.name == line.product_id.get_product_multiline_description_sale():
-                    self.create_or_update_translations(model_name='sale.order.template.line,name', lang_code=lang.code,
-                                                       res_id=line.id,src=line.name,
-                                                       value=line.product_id.with_context(lang=lang.code).get_product_multiline_description_sale())
+                    self.create_or_update_translations(
+                        model_name='sale.order.template.line,name', lang_code=lang.code,
+                        res_id=line.id, src=line.name,
+                        value=line.product_id.with_context(lang=lang.code).get_product_multiline_description_sale())
             for option in self.sale_order_template_option_ids:
                 if option.name == option.product_id.get_product_multiline_description_sale():
-                    self.create_or_update_translations(model_name='sale.order.template.option,name', lang_code=lang.code,
-                                                       res_id=option.id,src=option.name,
-                                                       value=option.product_id.with_context(lang=lang.code).get_product_multiline_description_sale())
+                    self.create_or_update_translations(
+                        model_name='sale.order.template.option,name', lang_code=lang.code,
+                        res_id=option.id, src=option.name,
+                        value=option.product_id.with_context(lang=lang.code).get_product_multiline_description_sale())
 
     def create_or_update_translations(self, model_name, lang_code, res_id, src, value):
         data = {
@@ -87,57 +115,21 @@ class SaleOrderTemplate(models.Model):
             'value': value,
             'state': 'inprogress',
         }
-        existing_trans = self.env['ir.translation'].search([('name', '=', model_name),
-                                                            ('res_id', '=', res_id),
-                                                            ('lang', '=', lang_code)])
+        existing_trans = self.env['ir.translation'].search([
+            ('name', '=', model_name),
+            ('res_id', '=', res_id),
+            ('lang', '=', lang_code)
+        ])
         if not existing_trans:
             self.env['ir.translation'].create(data)
         else:
             existing_trans.write(data)
 
 
-
 class SaleOrderTemplateLine(models.Model):
     _name = "sale.order.template.line"
     _description = "Quotation Template Line"
     _order = 'sale_order_template_id, sequence, id'
-
-    sequence = fields.Integer('Sequence', help="Gives the sequence order when displaying a list of sale quote lines.",
-        default=10)
-    sale_order_template_id = fields.Many2one(
-        'sale.order.template', 'Quotation Template Reference',
-        required=True, ondelete='cascade', index=True)
-    company_id = fields.Many2one('res.company', related='sale_order_template_id.company_id', store=True, index=True)
-    name = fields.Text('Description', required=True, translate=True)
-    product_id = fields.Many2one(
-        'product.product', 'Product', check_company=True,
-        domain=[('sale_ok', '=', True)])
-    product_uom_qty = fields.Float('Quantity', required=True, digits='Product Unit of Measure', default=1)
-    product_uom_id = fields.Many2one('uom.uom', 'Unit of Measure', domain="[('category_id', '=', product_uom_category_id)]")
-    product_uom_category_id = fields.Many2one(related='product_id.uom_id.category_id', readonly=True)
-
-    display_type = fields.Selection([
-        ('line_section', "Section"),
-        ('line_note', "Note")], default=False, help="Technical field for UX purpose.")
-
-    @api.onchange('product_id')
-    def _onchange_product_id(self):
-        self.ensure_one()
-        if self.product_id:
-            self.product_uom_id = self.product_id.uom_id.id
-            self.name = self.product_id.get_product_multiline_description_sale()
-
-    @api.model_create_multi
-    def create(self, vals_list):
-        for vals in vals_list:
-            if vals.get('display_type', self.default_get(['display_type'])['display_type']):
-                vals.update(product_id=False, product_uom_qty=0, product_uom_id=False)
-        return super().create(vals_list)
-
-    def write(self, values):
-        if 'display_type' in values and self.filtered(lambda line: line.display_type != values.get('display_type')):
-            raise UserError(_("You cannot change the type of a sale quote line. Instead you should delete the current line and create a new line of the proper type."))
-        return super(SaleOrderTemplateLine, self).write(values)
 
     _sql_constraints = [
         ('accountable_product_id_required',
@@ -149,26 +141,126 @@ class SaleOrderTemplateLine(models.Model):
             "Forbidden product, unit price, quantity, and UoM on non-accountable sale quote line"),
     ]
 
+    sale_order_template_id = fields.Many2one(
+        comodel_name='sale.order.template',
+        string='Quotation Template Reference',
+        index=True, required=True,
+        ondelete='cascade')
+    sequence = fields.Integer(
+        string="Sequence",
+        help="Gives the sequence order when displaying a list of sale quote lines.",
+        default=10)
+
+    company_id = fields.Many2one(
+        related='sale_order_template_id.company_id', store=True, index=True)
+
+    product_id = fields.Many2one(
+        comodel_name='product.product',
+        required=True, check_company=True,
+        domain="[('sale_ok', '=', True), ('company_id', 'in', [company_id, False])]")
+
+    name = fields.Text(
+        string="Description",
+        compute='_compute_name',
+        store=True, readonly=False, precompute=True,
+        required=True,
+        translate=True)
+
+    product_uom_id = fields.Many2one(
+        comodel_name='uom.uom',
+        string="Unit of Measure",
+        compute='_compute_product_uom_id',
+        store=True, readonly=False, precompute=True,
+        domain="[('category_id', '=', product_uom_category_id)]")
+    product_uom_category_id = fields.Many2one(related='product_id.uom_id.category_id')
+    product_uom_qty = fields.Float(
+        string='Quantity',
+        required=True,
+        digits='Product Unit of Measure',
+        default=1)
+
+    display_type = fields.Selection([
+        ('line_section', "Section"),
+        ('line_note', "Note")], default=False, help="Technical field for UX purpose.")
+
+    #=== COMPUTE METHODS ===#
+
+    @api.depends('product_id')
+    def _compute_name(self):
+        for option in self:
+            if not option.product_id:
+                continue
+            option.name = option.product_id.get_product_multiline_description_sale()
+
+    @api.depends('product_id')
+    def _compute_product_uom_id(self):
+        for option in self:
+            option.product_uom_id = option.product_id.uom_id
+
+    #=== CRUD METHODS ===#
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get('display_type', self.default_get(['display_type'])['display_type']):
+                vals.update(product_id=False, product_uom_qty=0, product_uom_id=False)
+        return super().create(vals_list)
+
+    def write(self, values):
+        if 'display_type' in values and self.filtered(lambda line: line.display_type != values.get('display_type')):
+            raise UserError(_("You cannot change the type of a sale quote line. Instead you should delete the current line and create a new line of the proper type."))
+        return super().write(values)
+
 
 class SaleOrderTemplateOption(models.Model):
     _name = "sale.order.template.option"
     _description = "Quotation Template Option"
     _check_company_auto = True
 
-    sale_order_template_id = fields.Many2one('sale.order.template', 'Quotation Template Reference', ondelete='cascade',
-        index=True, required=True)
-    company_id = fields.Many2one('res.company', related='sale_order_template_id.company_id', store=True, index=True)
-    name = fields.Text('Description', required=True, translate=True)
-    product_id = fields.Many2one(
-        'product.product', 'Product', domain=[('sale_ok', '=', True)],
-        required=True, check_company=True)
-    uom_id = fields.Many2one('uom.uom', 'Unit of Measure ', required=True, domain="[('category_id', '=', product_uom_category_id)]")
-    product_uom_category_id = fields.Many2one(related='product_id.uom_id.category_id', readonly=True)
-    quantity = fields.Float('Quantity', required=True, digits='Product Unit of Measure', default=1)
+    sale_order_template_id = fields.Many2one(
+        comodel_name='sale.order.template',
+        string="Quotation Template Reference",
+        index=True, required=True,
+        ondelete='cascade')
 
-    @api.onchange('product_id')
-    def _onchange_product_id(self):
-        if not self.product_id:
-            return
-        self.uom_id = self.product_id.uom_id
-        self.name = self.product_id.get_product_multiline_description_sale()
+    company_id = fields.Many2one(
+        related='sale_order_template_id.company_id', store=True, index=True)
+
+    product_id = fields.Many2one(
+        comodel_name='product.product',
+        required=True, check_company=True,
+        domain="[('sale_ok', '=', True), ('company_id', 'in', [company_id, False])]")
+
+    name = fields.Text(
+        string="Description",
+        compute='_compute_name',
+        store=True, readonly=False, precompute=True,
+        required=True, translate=True)
+
+    uom_id = fields.Many2one(
+        comodel_name='uom.uom',
+        string="Unit of Measure",
+        compute='_compute_uom_id',
+        store=True, readonly=False,
+        required=True, precompute=True,
+        domain="[('category_id', '=', product_uom_category_id)]")
+    product_uom_category_id = fields.Many2one(related='product_id.uom_id.category_id')
+    quantity = fields.Float(
+        string="Quantity",
+        required=True,
+        digits='Product Unit of Measure',
+        default=1)
+
+    #=== COMPUTE METHODS ===#
+
+    @api.depends('product_id')
+    def _compute_name(self):
+        for option in self:
+            if not option.product_id:
+                continue
+            option.name = option.product_id.get_product_multiline_description_sale()
+
+    @api.depends('product_id')
+    def _compute_uom_id(self):
+        for option in self:
+            option.uom_id = option.product_id.uom_id

--- a/addons/sale_management/tests/test_sale_order.py
+++ b/addons/sale_management/tests/test_sale_order.py
@@ -49,17 +49,13 @@ class TestSaleOrder(TestSaleCommon):
         })
 
         SaleOrderTemplateLine.create({
-            'name': 'Product 1',
             'sale_order_template_id': cls.quotation_template_no_discount.id,
             'product_id': cls.product_1.id,
-            'product_uom_id': cls.product_1.uom_id.id
         })
 
         SaleOrderTemplateOption.create({
-            'name': 'Optional product 1',
             'sale_order_template_id': cls.quotation_template_no_discount.id,
             'product_id': cls.optional_product.id,
-            'uom_id': cls.optional_product.uom_id.id
         })
 
         # create some pricelists
@@ -124,7 +120,7 @@ class TestSaleOrder(TestSaleCommon):
         self.sale_order_no_price_list.write({
             'sale_order_template_id': self.quotation_template_no_discount.id
         })
-        self.sale_order_no_price_list.onchange_sale_order_template_id()
+        self.sale_order_no_price_list._onchange_sale_order_template_id()
 
         self.assertEqual(
             len(self.sale_order_no_price_list.order_line),
@@ -194,7 +190,7 @@ class TestSaleOrder(TestSaleCommon):
             'pricelist_id': self.discount_included_price_list.id,
             'sale_order_template_id': self.quotation_template_no_discount.id
         })
-        self.sale_order.onchange_sale_order_template_id()
+        self.sale_order._onchange_sale_order_template_id()
 
         self.assertEqual(
             self.sale_order.order_line[0].price_unit,
@@ -223,12 +219,13 @@ class TestSaleOrder(TestSaleCommon):
         the price used in the sale order is the product public price and
         the discount is computed according to the price list.
         """
+        self.env.user.groups_id += self.env.ref('product.group_discount_per_so_line')
 
         self.sale_order.write({
             'pricelist_id': self.discount_excluded_price_list.id,
             'sale_order_template_id': self.quotation_template_no_discount.id
         })
-        self.sale_order.onchange_sale_order_template_id()
+        self.sale_order._onchange_sale_order_template_id()
 
         self.assertEqual(
             self.sale_order.order_line[0].price_unit,

--- a/addons/sale_management/views/sale_order_template_views.xml
+++ b/addons/sale_management/views/sale_order_template_views.xml
@@ -7,6 +7,9 @@
             <search string="Search Quotation Template">
                 <field name="name"/>
                 <filter string="Archived" name="inactive" domain="[('active','=', False)]"/>
+                <group expand="1" string="Group By">
+                    <filter string="Company" name="company_id" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>
+                </group>
             </search>
         </field>
     </record>
@@ -49,6 +52,7 @@
                                 <field name="sequence" invisible="1"/>
                                 <field name="display_type" invisible="1"/>
                                 <field name="product_uom_category_id" invisible="1"/>
+                                <field name="company_id" invisible="1"/>
                                 <group attrs="{'invisible': [('display_type', '!=', False)]}">
                                     <group>
                                         <field name="product_id" attrs="{'required': [('display_type', '=', False)]}"/>
@@ -78,6 +82,7 @@
                                 </control>
 
                                 <field name="display_type" invisible="1"/>
+                                <field name="company_id" invisible="1"/>
                                 <field name="sequence" widget="handle"/>
                                 <field name="product_id"/>
                                 <field name="name" widget="section_and_note_text"/>
@@ -99,6 +104,7 @@
                             <field name="quantity"/>
                             <field name="product_uom_category_id" invisible="1"/>
                             <field name="uom_id" groups="uom.group_uom"/>
+                            <field name="company_id" invisible="1"/>
                           </tree>
                         </field>
                     </page>
@@ -124,6 +130,7 @@
         <field name="arch" type="xml">
             <tree string="Quotation Template">
                 <field name="name"/>
+                <field name="company_id" groups="base.group_multi_company"/>
             </tree>
         </field>
     </record>

--- a/addons/sale_quotation_builder/__init__.py
+++ b/addons/sale_quotation_builder/__init__.py
@@ -3,3 +3,30 @@
 
 from . import controllers
 from . import models
+
+def _pre_init_sale_quotation_builder(cr):
+    """ Allow installing sale_quotation_builder in databases
+    with large sale.order / sale.order.line tables.
+
+    Since website_description fields computation is based
+    on new fields added by the module, they will be empty anyway.
+
+    By avoiding the computation of those fields,
+    we reduce the installation time noticeably
+    """
+    cr.execute("""
+        ALTER TABLE "sale_order"
+        ADD COLUMN "website_description" text
+    """)
+    cr.execute("""
+        ALTER TABLE "sale_order_line"
+        ADD COLUMN "website_description" text
+    """)
+    cr.execute("""
+        ALTER TABLE "sale_order_template_line"
+        ADD COLUMN "website_description" text
+    """)
+    cr.execute("""
+        ALTER TABLE "sale_order_template_option"
+        ADD COLUMN "website_description" text
+    """)

--- a/addons/sale_quotation_builder/__manifest__.py
+++ b/addons/sale_quotation_builder/__manifest__.py
@@ -18,4 +18,5 @@
     ],
     'installable': True,
     'license': 'LGPL-3',
+    'pre_init_hook': '_pre_init_sale_quotation_builder',
 }

--- a/addons/sale_quotation_builder/models/product_template.py
+++ b/addons/sale_quotation_builder/models/product_template.py
@@ -1,24 +1,32 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, api
+from odoo import fields, models
 from odoo.tools.translate import html_translate
 
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    quotation_only_description = fields.Html('Quotation Only Description', sanitize_attributes=False,
-        translate=html_translate, help="The quotation description (not used on eCommerce)")
+    quotation_only_description = fields.Html(
+        string="Quotation Only Description",
+        translate=html_translate,
+        sanitize_attributes=False,
+        help="The quotation description (not used on eCommerce)")
 
-    quotation_description = fields.Html('Quotation Description', compute='_compute_quotation_description',
-        sanitize_attributes=False, help="This field uses the Quotation Only Description if it is defined, otherwise it will try to read the eCommerce Description.")
+    quotation_description = fields.Html(
+        string="Quotation Description",
+        compute='_compute_quotation_description',
+        sanitize_attributes=False,
+        help="This field uses the Quotation Only Description if it is defined, "
+            "otherwise it will try to read the eCommerce Description.")
 
     def _compute_quotation_description(self):
-        for record in self:
-            if record.quotation_only_description:
-                record.quotation_description = record.quotation_only_description
-            elif hasattr(record, 'website_description') and record.website_description:
-                record.quotation_description = record.website_description
+        for template in self:
+            if template.quotation_only_description:
+                template.quotation_description = template.quotation_only_description
+            elif hasattr(template, 'website_description') and template.website_description:
+                # Defined in website_sale
+                template.quotation_description = template.website_description
             else:
-                record.quotation_description = ''
+                template.quotation_description = ''

--- a/addons/sale_quotation_builder/models/sale_order_option.py
+++ b/addons/sale_quotation_builder/models/sale_order_option.py
@@ -9,8 +9,10 @@ class SaleOrderOption(models.Model):
     _inherit = "sale.order.option"
 
     website_description = fields.Html(
-        'Website Description', sanitize_attributes=False, translate=html_translate,
-        compute='_compute_website_description', store=True, readonly=False, precompute=True)
+        string="Website Description",
+        compute='_compute_website_description',
+        store=True, readonly=False, precompute=True,
+        sanitize_attributes=False, translate=html_translate)
 
     @api.depends('product_id', 'uom_id')
     def _compute_website_description(self):
@@ -21,6 +23,6 @@ class SaleOrderOption(models.Model):
             option.website_description = product.quotation_description
 
     def _get_values_to_add_to_order(self):
-        values = super(SaleOrderOption, self)._get_values_to_add_to_order()
+        values = super()._get_values_to_add_to_order()
         values.update(website_description=self.website_description)
         return values


### PR DESCRIPTION
Convert most remaining onchanges/defaults/... to computed fields and compute methods.

- [x] Check perf of sale_mngmt/sale_quot_builder install on existing db with sale (pre-create columns to avoid useless updates/recomputations) ?
- [x] Verify multi-comp behavior (make sure company_id is correctly computed on order lines & options, s.t. the dynamic domains work as expected).

Task ID - 2716304

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
