### PR TITLE
[FIX] resource: prevent multiple resources per user

### DIFF
--- a/addons/resource/i18n/resource.pot
+++ b/addons/resource/i18n/resource.pot
@@ -22,6 +22,11 @@ msgid "%s (copy)"
 msgstr ""
 
 #. module: resource
+#: model:ir.model.constraint,message:resource.constraint_resource_resource_uniq_user_company
+msgid "A user can only have one resource per company"
+msgstr ""
+
+#. module: resource
 #: model:ir.model.fields,field_description:resource.field_resource_resource__active
 msgid "Active"
 msgstr ""

--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -762,6 +762,7 @@ class ResourceResource(models.Model):
 
     _sql_constraints = [
         ('check_time_efficiency', 'CHECK(time_efficiency>0)', 'Time efficiency must be strictly positive'),
+        ('uniq_user_company', 'UNIQUE(company_id, user_id)', 'A user can only have one resource per company'),
     ]
 
     @api.constrains('time_efficiency')


### PR DESCRIPTION
It was possible to create multiple `resource.resource` per `res.users`
per company, which could lead to errors.

TaskID: 2721841

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
