### PR TITLE
[IMP] core: don't add f_name in vals if there is child

### DIFF
--- a/odoo/addons/test_convert/models.py
+++ b/odoo/addons/test_convert/models.py
@@ -2,10 +2,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
+from odoo.exceptions import UserError
 
 class TestModel(models.Model):
     _name = 'test_convert.test_model'
     _description = "Test Convert Model"
+
+    usered_id = fields.Many2one('test_convert.usered')
+    name = fields.Char()
 
     @api.model
     def action_test_date(self, today_date):
@@ -25,6 +29,7 @@ class Usered(models.Model):
 
     name = fields.Char()
     user_id = fields.Many2one('res.users', default=lambda self: self.env.user)
+    test_model_o2m_ids = fields.One2many('test_convert.test_model', 'usered_id')
     tz = fields.Char(default=lambda self: self.env.context.get('tz') or self.env.user.tz)
 
     @api.model
@@ -33,3 +38,12 @@ class Usered(models.Model):
 
     def method(self, *args, **kwargs):
         return self, args, kwargs
+
+    def _load_records(self, data_list, update=False):
+        context = self.env.context
+        if context.get('install_filename') == 'test_convert_usered.xml':
+            for data in data_list:
+                values = data.get('values')
+                if 'test_model_o2m_ids' in values and not values['test_model_o2m_ids']:
+                    raise UserError("Null value in O2M When loading XML with sub records")
+        return super()._load_records(data_list, update=update)

--- a/odoo/addons/test_convert/tests/test_convert.py
+++ b/odoo/addons/test_convert/tests/test_convert.py
@@ -76,6 +76,25 @@ class TestEvalXML(common.TransactionCase):
         with self.assertRaises(IOError):
             self.eval_xml(Field('test_nofile.txt', type='file'), obj)
 
+    def test_o2m_sub_records(self):
+        record_attrs = {
+            'id': 'test_convert.test_o2m_records',
+            'model': 'test_convert.usered',
+        }
+        o2m_sub_record_attrs = {
+            'id': 'test_convert.test_o2m_sub_records',
+            'model': 'test_convert.test_model',
+        }
+        sub_xml = ET.Element('record', attrib=o2m_sub_record_attrs)
+        sub_xml.append(Field('Test child model', name='name'))
+        xml = ET.Element('record', attrib=record_attrs)
+        xml.append(Field("Test parent model" ,name="test_model_o2m_ids"))
+        xml.append(Field(sub_xml ,name="test_model_o2m_ids"))
+        # pass filename just becosue it's set in context by _tag_record method
+        obj = xml_import(self.cr, 'test_convert', None, 'init', xml_filename="test_convert_usered.xml")
+        # raise from model method _load_records if vals have o2m null record
+        obj._tags.get('record')(xml)
+
     def test_function(self):
         obj = xml_import(self.cr, 'test_convert', None, 'init')
 

--- a/odoo/addons/test_convert/tests/test_convert.py
+++ b/odoo/addons/test_convert/tests/test_convert.py
@@ -88,7 +88,7 @@ class TestEvalXML(common.TransactionCase):
         sub_xml = ET.Element('record', attrib=o2m_sub_record_attrs)
         sub_xml.append(Field('Test child model', name='name'))
         xml = ET.Element('record', attrib=record_attrs)
-        xml.append(Field("Test parent model" ,name="name"))
+        xml.append(Field("Test parent model", name="name"))
         xml.append(Field(sub_xml, name="test_model_o2m_ids"))
         # pass filename just becosue it's set in context by _tag_record method
         obj = xml_import(self.cr, 'test_convert', None, 'init', xml_filename="test_convert_usered.xml")

--- a/odoo/addons/test_convert/tests/test_convert.py
+++ b/odoo/addons/test_convert/tests/test_convert.py
@@ -89,7 +89,7 @@ class TestEvalXML(common.TransactionCase):
         sub_xml.append(Field('Test child model', name='name'))
         xml = ET.Element('record', attrib=record_attrs)
         xml.append(Field("Test parent model" ,name="name"))
-        xml.append(Field(sub_xml ,name="test_model_o2m_ids"))
+        xml.append(Field(sub_xml, name="test_model_o2m_ids"))
         # pass filename just becosue it's set in context by _tag_record method
         obj = xml_import(self.cr, 'test_convert', None, 'init', xml_filename="test_convert_usered.xml")
         # raise from model method _load_records if vals have o2m null record

--- a/odoo/addons/test_convert/tests/test_convert.py
+++ b/odoo/addons/test_convert/tests/test_convert.py
@@ -88,7 +88,7 @@ class TestEvalXML(common.TransactionCase):
         sub_xml = ET.Element('record', attrib=o2m_sub_record_attrs)
         sub_xml.append(Field('Test child model', name='name'))
         xml = ET.Element('record', attrib=record_attrs)
-        xml.append(Field("Test parent model" ,name="test_model_o2m_ids"))
+        xml.append(Field("Test parent model" ,name="name"))
         xml.append(Field(sub_xml ,name="test_model_o2m_ids"))
         # pass filename just becosue it's set in context by _tag_record method
         obj = xml_import(self.cr, 'test_convert', None, 'init', xml_filename="test_convert_usered.xml")

--- a/odoo/addons/test_convert/tests/test_convert.py
+++ b/odoo/addons/test_convert/tests/test_convert.py
@@ -77,23 +77,20 @@ class TestEvalXML(common.TransactionCase):
             self.eval_xml(Field('test_nofile.txt', type='file'), obj)
 
     def test_o2m_sub_records(self):
-        record_attrs = {
-            'id': 'test_convert.test_o2m_records',
-            'model': 'test_convert.usered',
-        }
-        o2m_sub_record_attrs = {
-            'id': 'test_convert.test_o2m_sub_records',
-            'model': 'test_convert.test_model',
-        }
-        sub_xml = ET.Element('record', attrib=o2m_sub_record_attrs)
-        sub_xml.append(Field('Test child model', name='name'))
-        xml = ET.Element('record', attrib=record_attrs)
-        xml.append(Field("Test parent model", name="name"))
-        xml.append(Field(sub_xml, name="test_model_o2m_ids"))
+        xml = ET.fromstring("""
+            <record id="test_convert.test_o2m_record" model="test_convert.usered">
+                <field name="name">Test parent model</field>
+                <field name="test_model_o2m_ids">
+                    <record id="test_convert.test_o2m_sub_record" model="test_convert.test_model">
+                        <field name="name">Test child model</field>
+                    </record>
+                </field>
+            </record>
+        """.strip())
         # pass filename just becosue it's set in context by _tag_record method
         obj = xml_import(self.cr, 'test_convert', None, 'init', xml_filename="test_convert_usered.xml")
         # raise from model method _load_records if vals have o2m null record
-        obj._tags.get('record')(xml)
+        obj._tag_record(xml)
 
     def test_function(self):
         obj = xml_import(self.cr, 'test_convert', None, 'init')

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -535,6 +535,7 @@ form: module.record_id""" % (xml_id,)
         res = {}
         sub_records = []
         for field in rec.findall('./field'):
+            o2m_have_sub_records = False
             #TODO: most of this code is duplicated above (in _eval_xml)...
             f_name = field.get("name")
             f_ref = field.get("ref")
@@ -582,8 +583,11 @@ form: module.record_id""" % (xml_id,)
                         if isinstance(f_val, str):
                             f_val = None
                         for child in field.findall('./record'):
+                            o2m_have_sub_records = True
                             sub_records.append((child, model._fields[f_name].inverse_name))
-            res[f_name] = f_val
+            # Not add in vals becouse it's added by sub_records
+            if not o2m_have_sub_records:
+                res[f_name] = f_val
         if extra_vals:
             res.update(extra_vals)
 

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -535,7 +535,6 @@ form: module.record_id""" % (xml_id,)
         res = {}
         sub_records = []
         for field in rec.findall('./field'):
-            o2m_have_sub_records = False
             #TODO: most of this code is duplicated above (in _eval_xml)...
             f_name = field.get("name")
             f_ref = field.get("ref")
@@ -545,6 +544,7 @@ form: module.record_id""" % (xml_id,)
                 f_model = model._fields[f_name].comodel_name
             f_use = field.get("use",'') or 'id'
             f_val = False
+            has_value = True
 
             if f_search:
                 idref2 = _get_idref(self, env, f_model, self.idref)
@@ -579,15 +579,14 @@ form: module.record_id""" % (xml_id,)
                         f_val = float(f_val)
                     elif field_type == 'boolean' and isinstance(f_val, str):
                         f_val = str2bool(f_val)
-                    elif field_type in 'one2many':
+                    elif field_type == 'one2many':
                         if isinstance(f_val, str):
-                            f_val = None
+                            has_value = False
                         for child in field.findall('./record'):
-                            o2m_have_sub_records = True
                             sub_records.append((child, model._fields[f_name].inverse_name))
-            # Not add in vals becouse it's added by sub_records
-            if not o2m_have_sub_records:
+            if has_value:
                 res[f_name] = f_val
+
         if extra_vals:
             res.update(extra_vals)
 


### PR DESCRIPTION
if there is the child then write vals is created like {'field_o2m_name': None} so it removes lines and adds them again by sub_records

so in this commit, we do not add f_name in vals if there is a child of o2m

this give a big effect on account.tax.report to check just update any localization module where account.tax.report is there, after the update all tag is removed from taxes and journal items(account.move.line)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
