### PR TITLE
[FIX] hr_recruitment_survey: fix default applicant_id

### DIFF
--- a/addons/hr_recruitment_survey/models/survey_invite.py
+++ b/addons/hr_recruitment_survey/models/survey_invite.py
@@ -6,17 +6,18 @@ from odoo import fields, models, _
 class SurveyInvite(models.TransientModel):
     _inherit = "survey.invite"
 
-    applicant_id = fields.Many2one('hr.applicant', string='Applicant', default=lambda self: self.env.context.get('active_id', None))
+    applicant_id = fields.Many2one('hr.applicant', string='Applicant', default=lambda self: self.env.context.get('active_id', None) if self.env.context.get('active_model') == 'hr.applicant' else False)
 
     def action_invite(self):
         self.ensure_one()
 
-        if not self.applicant_id.response_id:
+        if self.applicant_id and not self.applicant_id.response_id:
             response = self.applicant_id.survey_id._create_answer(partner=self.applicant_id.partner_id)
             self.applicant_id.response_id = response.id
 
-        body = _('The survey has been sent to "%s".', self.applicant_id.partner_name)
-        self.applicant_id.message_post(body=body)
+        if self.applicant_id:
+            body = _('The survey has been sent to "%s".', self.applicant_id.partner_name)
+            self.applicant_id.message_post(body=body)
 
         return super().action_invite()
 

--- a/addons/hr_recruitment_survey/tests/test_recruitment_survey.py
+++ b/addons/hr_recruitment_survey/tests/test_recruitment_survey.py
@@ -52,6 +52,8 @@ class TestRecruitmentSurvey(common.SingleTransactionCase):
         invite = invite_form.save()
         invite.action_invite()
 
+        self.assertEqual(action['context']['active_model'], 'hr.applicant')
+        self.assertEqual(invite.applicant_id, self.job_sysadmin)
         self.assertNotEqual(self.job_sysadmin.response_id.id, False)
         answers = Answer.search([('survey_id', '=', self.survey_sysadmin.id)])
         self.assertEqual(len(answers), 1)
@@ -67,3 +69,14 @@ class TestRecruitmentSurvey(common.SingleTransactionCase):
         self.job_sysadmin.response_id = self.env['survey.user_input'].create({'survey_id': self.survey_sysadmin.id})
         action_print_with_response = self.job_sysadmin.action_print_survey()
         self.assertIn(self.job_sysadmin.response_id.access_token, action_print_with_response['url'])
+
+    def test_send_survey_no_applicant(self):
+        action = self.job_sysadmin.action_send_survey()
+        invite_form = Form(self.env['survey.invite'].with_context({
+            **action['context'],
+            'active_id': 1,
+            'active_model': 'dummy.model',
+        }))
+        invite = invite_form.save()
+
+        self.assertFalse(invite.applicant_id, "Should not have an applicant")


### PR DESCRIPTION
When sending a survey invite, applicant_id was populated with whatever
active_id was available, regardless of the origin model.

This was preventing users without Recruitment access rights from sending
surveys.

TaskID: 2721987

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
