### PR TITLE
[FIX] lunch: do not generate custom code counted by cloc

### DIFF
--- a/addons/lunch/data/lunch_demo.xml
+++ b/addons/lunch/data/lunch_demo.xml
@@ -76,6 +76,13 @@
             <field name="name">Office 3</field>
         </record>
 
+        <record id="alert_office_3" model="lunch.alert">
+            <field name="name">Alert for Office 3</field>
+            <field name="message">Please order</field>
+            <field name="location_ids" eval="[(4, ref('location_office_3'))]" />
+            <field name="mode">chat</field>
+        </record>
+
         <record id="base.user_admin" model="res.users">
             <field name="last_lunch_location_id" ref="location_office_2"/>
         </record>

--- a/addons/lunch/models/lunch_alert.py
+++ b/addons/lunch/models/lunch_alert.py
@@ -136,6 +136,14 @@ class LunchAlert(models.Model):
             }
             for _ in range(len(vals_list))
         ])
+        self.env['ir.model.data'].sudo().create([{
+            'name': f'lunch_alert_cron_sa_{cron.ir_actions_server_id.id}',
+            'module': 'lunch',
+            'res_id': cron.ir_actions_server_id.id,
+            'model': 'ir.actions.server',
+            # noupdate is set to true to avoid to delete record at module update
+            'noupdate': True,
+        } for cron in crons])
         for vals, cron in zip(vals_list, crons):
             vals['cron_id'] = cron.id
 
@@ -150,8 +158,10 @@ class LunchAlert(models.Model):
 
     def unlink(self):
         crons = self.cron_id.sudo()
+        server_actions = crons.ir_actions_server_id
         super().unlink()
         crons.unlink()
+        server_actions.unlink()
 
     def _notify_chat(self):
         # Called daily by cron

--- a/addons/lunch/models/lunch_supplier.py
+++ b/addons/lunch/models/lunch_supplier.py
@@ -168,6 +168,14 @@ class LunchSupplier(models.Model):
             }
             for _ in range(len(vals_list))
         ])
+        self.env['ir.model.data'].sudo().create([{
+            'name': f'lunch_supplier_cron_sa_{cron.ir_actions_server_id.id}',
+            'module': 'lunch',
+            'res_id': cron.ir_actions_server_id.id,
+            'model': 'ir.actions.server',
+            # noupdate is set to true to avoid to delete record at module update
+            'noupdate': True,
+        } for cron in crons])
         for vals, cron in zip(vals_list, crons):
             vals['cron_id'] = cron.id
 
@@ -192,8 +200,10 @@ class LunchSupplier(models.Model):
 
     def unlink(self):
         crons = self.cron_id.sudo()
+        server_actions = crons.ir_actions_server_id
         super().unlink()
         crons.unlink()
+        server_actions.unlink()
 
     def toggle_active(self):
         """ Archiving related lunch product """


### PR DESCRIPTION
  Issue
  -----
  
  The module lunch generate ir.cron and thus server action when
  lunch.supplier and lunch.alert are created.
  Those server action are counted as customization by cloc and thus
  customer should pays maintenance fee just for the installation of
  data_merge module
  
  Cron are deleted when supplier and alert are deleted but the server
  action remains.
  
  Solution
  --------
  Avoid to count server action generated by lunch by adding
  a xml_id from lunch module to those SA
  
  Delete server actions as well


Fixes: [Ticket #2718351](https://www.odoo.com/web#id=2718351&cids=1&model=project.task&view_type=form)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
