### PR TITLE
[FIX] point_of_sale: Use the right pricelist item in POS

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1536,8 +1536,8 @@ exports.Product = Backbone.Model.extend({
             return (! item.product_tmpl_id || item.product_tmpl_id[0] === self.product_tmpl_id) &&
                    (! item.product_id || item.product_id[0] === self.id) &&
                    (! item.categ_id || _.contains(category_ids, item.categ_id[0])) &&
-                   (! item.date_start || moment(item.date_start).isSameOrBefore(date)) &&
-                   (! item.date_end || moment(item.date_end).isSameOrAfter(date));
+                   (! item.date_start || moment.utc(item.date_start).isSameOrBefore(date)) &&
+                   (! item.date_end || moment.utc(item.date_end).isSameOrAfter(date));
         });
 
         var price = self.lst_price;


### PR DESCRIPTION
Steps to reproduce:

  (Assuming we are the 09/15/2021)
  - Install Point of Sale module
  - Go to Settings and activate Pricelists feature
  - Go to Point of Sale -> Product -> Products
  - Select 'Whiteboard Pen'
  - Edit Sales Price to 1.00$
  - In Pricing under 'Sales' tab, add a pricelist item with:
    Pricelist: Public Pricelist (USD)
    Price: 99.00 $
    Min Quantity: 0
    Start Date: 09/15/2021
    End Date: 09/16/2021
  - Go to Point of Sale dashboard an resume Shop session

Issue:

  'Whiteboard Pen' price is 1.00$ instead of 99.00$.

Cause:

  `item.date_start` is in UTC, and when doing moment(item.date_start),
  it will set the browser timezone to it.

Solution:

  Use moment.utc() instead to parse it as UTC time.

opw-2633611