### PR TITLE
[IMP] add odoo.__main__

### DIFF
--- a/odoo/__main__.py
+++ b/odoo/__main__.py
@@ -1,0 +1,3 @@
+from .cli.command import main
+
+main()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This allows launching Odoo with `python -m odoo`.

Desired behavior after PR is merged:

This manner of launching python application is now widespread. In particular it makes it easier to configure an IDE debugger to run with the correct python version, by using the "launch a python module" feature.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
