### PR TITLE
[FIX] resource : compute the correct default dates when planning a shift

### DIFF
--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -617,12 +617,14 @@ class ResourceCalendar(models.Model):
         def interval_dt(interval):
             return interval[1 if match_end else 0]
 
+        tz = resource.tz if resource else self.tz
         if resource is None:
             resource = self.env['resource.resource']
 
         if not dt.tzinfo or search_range and not (search_range[0].tzinfo and search_range[1].tzinfo):
             raise ValueError('Provided datetimes needs to be timezoned')
-        dt = dt.astimezone(timezone(self.tz))
+
+        dt = dt.astimezone(timezone(tz))
 
         if not search_range:
             range_start = dt + relativedelta(hour=0, minute=0, second=0)

--- a/addons/resource/tests/test_resource.py
+++ b/addons/resource/tests/test_resource.py
@@ -502,6 +502,21 @@ class TestResMixin(TestResourceCommon):
             datetime_tz(2020, 4, 2, 18, 0, tzinfo='UTC')
         ), "It should have found the start and end of the shift on the same day on April 2nd, 2020")
 
+    def test_adjust_calendar_timezone_before(self):
+        # Calendar:
+        # Every day 8-16
+        self.jean.tz = 'Japan'
+        self.calendar_jean.tz = 'Europe/Brussels'
+
+        result = self.jean._adjust_to_calendar(
+            datetime_tz(2020, 4, 1, 0, 0, 0, tzinfo='Japan'),
+            datetime_tz(2020, 4, 1, 23, 59, 59, tzinfo='Japan'),
+        )
+        self.assertEqual(result[self.jean], (
+            datetime_tz(2020, 4, 1, 8, 0, 0, tzinfo='Japan'),
+            datetime_tz(2020, 4, 1, 16, 0, 0, tzinfo='Japan'),
+        ), "It should have found a starting time the 1st")
+
     def test_adjust_calendar_timezone_after(self):
         # Calendar:
         # Tuesdays 8-16


### PR DESCRIPTION
Steps :
- Install Planning
- Users > Mitchell Admin > Preferences > Timezone :
	Europe/Brussels
- Settings > Employees > Company Working Hours > Timezone :
	Japan
- Planning > Gantt View > Week > Mitchell Admin x Friday > Click "+" button

Issue :
- Start date is set by default to Thursday 13:00
	whereas it is expected to be set on Friday 8:00

Cause :
- When we want to plan a shift on a day,
	we look into the 00:00 to 23:59 range for this day in calendar's tz
	to get the closest work time inside of it.
- Yet, this doesn't take the "resource user" into account.

Fix :
- Set these limits for the day in resource's tz.

opw-2678221

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
