### PR TITLE
[FIX] web: order company by their sequence in the company switcher

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -85,6 +85,7 @@ class Http(models.AbstractModel):
                         comp.id: {
                             'id': comp.id,
                             'name': comp.name,
+                            'sequence': comp.sequence,
                         } for comp in user.company_ids
                     },
                 },

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
@@ -8,7 +8,7 @@
                 <t t-if="!env.isSmall"><t t-esc="currentCompany.name"/></t>
             </span>
         </t>
-        <t t-foreach="Object.values(companyService.availableCompanies)" t-as="company">
+        <t t-foreach="Object.values(companyService.availableCompanies).sort((c1, c2) => c1.sequence - c2.sequence)" t-as="company">
             <t t-call="web.SwitchCompanyItem">
                 <t t-set="company" t-value="company" />
             </t>

--- a/addons/web/static/tests/webclient/switch_company_menu_tests.js
+++ b/addons/web/static/tests/webclient/switch_company_menu_tests.js
@@ -40,11 +40,11 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
     hooks.beforeEach(() => {
         patchWithCleanup(session.user_companies, {
             allowed_companies: {
-                1: { id: 1, name: "Hermit" },
-                2: { id: 2, name: "Herman's" },
-                3: { id: 3, name: "Heroes TM" },
+                3: { id: 3, name: "Hermit", sequence: 1 },
+                2: { id: 2, name: "Herman's", sequence: 2 },
+                1: { id: 1, name: "Heroes TM", sequence: 3 },
             },
-            current_company: 1,
+            current_company: 3,
         });
         serviceRegistry.add("ui", uiService);
         serviceRegistry.add("company", companyService);
@@ -90,28 +90,28 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         const scMenu = await createSwitchCompanyMenu({ onPushState });
 
         /**
-         *   [x] **Company 1**
-         *   [ ] Company 2
-         *   [ ] Company 3
+         *   [x] **Hermit**
+         *   [ ] Herman's
+         *   [ ] Heroes TM
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1]);
-        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
+        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [3]);
+        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 3);
         await click(scMenu.el.querySelector(".dropdown-toggle"));
         assert.containsN(scMenu.el, "[data-company-id]", 3);
         assert.containsN(scMenu.el, "[data-company-id] .fa-check-square", 1);
         assert.containsN(scMenu.el, "[data-company-id] .fa-square-o", 2);
 
         /**
-         *   [x] **Company 1**
-         *   [x] Company 2      -> toggle
-         *   [ ] Company 3
+         *   [x] **Hermit**
+         *   [x] Herman's      -> toggle
+         *   [ ] Heroes TM
          */
         await click(scMenu.el.querySelectorAll(".toggle_company")[1]);
         assert.containsOnce(scMenu.el, ".dropdown-menu", "dropdown is still opened");
         assert.containsN(scMenu.el, "[data-company-id] .fa-check-square", 2);
         assert.containsN(scMenu.el, "[data-company-id] .fa-square-o", 1);
         await prom;
-        assert.verifySteps(["cids=1%2C2"]);
+        assert.verifySteps(["cids=3%2C2"]);
     });
 
     QUnit.test("can toggle multiple companies at once", async (assert) => {
@@ -125,21 +125,21 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         const scMenu = await createSwitchCompanyMenu({ onPushState }, 50);
 
         /**
-         *   [x] **Company 1**
-         *   [ ] Company 2
-         *   [ ] Company 3
+         *   [x] **Hermit**
+         *   [ ] Herman's
+         *   [ ] Heroes TM
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1]);
-        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
+        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [3]);
+        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 3);
         await click(scMenu.el.querySelector(".dropdown-toggle"));
         assert.containsN(scMenu.el, "[data-company-id]", 3);
         assert.containsN(scMenu.el, "[data-company-id] .fa-check-square", 1);
         assert.containsN(scMenu.el, "[data-company-id] .fa-square-o", 2);
 
         /**
-         *   [ ] **Company 1**  -> toggle all
-         *   [x] Company 2      -> toggle all
-         *   [x] Company 3      -> toggle all
+         *   [ ] **Hermit**  -> toggle all
+         *   [x] Herman's      -> toggle all
+         *   [x] Heroes TM      -> toggle all
          */
         await click(scMenu.el.querySelectorAll(".toggle_company")[0]);
         await click(scMenu.el.querySelectorAll(".toggle_company")[1]);
@@ -150,7 +150,7 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
 
         assert.verifySteps([]);
         await prom; // await toggle promise
-        assert.verifySteps(["cids=2%2C3"]);
+        assert.verifySteps(["cids=2%2C1"]);
     });
 
     QUnit.test("single company selected: toggling it off will keep it", async (assert) => {
@@ -164,27 +164,27 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         const scMenu = await createSwitchCompanyMenu();
 
         /**
-         *   [x] **Company 1**
-         *   [ ] Company 2
-         *   [ ] Company 3
+         *   [x] **Hermit**
+         *   [ ] Herman's
+         *   [ ] Heroes TM
          */
-        assert.deepEqual(scMenu.env.services.router.current.hash, { cids: 1 });
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1]);
-        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
+        assert.deepEqual(scMenu.env.services.router.current.hash, { cids: 3 });
+        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [3]);
+        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 3);
         await click(scMenu.el.querySelector(".dropdown-toggle"));
         assert.containsN(scMenu.el, "[data-company-id]", 3);
         assert.containsN(scMenu.el, "[data-company-id] .fa-check-square", 1);
         assert.containsN(scMenu.el, "[data-company-id] .fa-square-o", 2);
 
         /**
-         *   [ ] **Company 1**  -> toggle off
-         *   [ ] Company 2
-         *   [ ] Company 3
+         *   [ ] **Hermit**  -> toggle off
+         *   [ ] Herman's
+         *   [ ] Heroes TM
          */
         await click(scMenu.el.querySelectorAll(".toggle_company")[0]);
-        assert.deepEqual(scMenu.env.services.router.current.hash, { cids: 1 });
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1]);
-        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
+        assert.deepEqual(scMenu.env.services.router.current.hash, { cids: 3 });
+        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [3]);
+        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 3);
         assert.containsOnce(scMenu.el, ".dropdown-menu", "dropdown is still opened");
         assert.containsN(scMenu.el, "[data-company-id] .fa-check-square", 0);
         assert.containsN(scMenu.el, "[data-company-id] .fa-square-o", 3);
@@ -199,21 +199,21 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         const scMenu = await createSwitchCompanyMenu({ onPushState });
 
         /**
-         *   [x] **Company 1**
-         *   [ ] Company 2
-         *   [ ] Company 3
+         *   [x] **Hermit**
+         *   [ ] Herman's
+         *   [ ] Heroes TM
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1]);
-        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
+        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [3]);
+        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 3);
         await click(scMenu.el.querySelector(".dropdown-toggle"));
         assert.containsN(scMenu.el, "[data-company-id]", 3);
         assert.containsN(scMenu.el, "[data-company-id] .fa-check-square", 1);
         assert.containsN(scMenu.el, "[data-company-id] .fa-square-o", 2);
 
         /**
-         *   [x] **Company 1**
-         *   [ ] Company 2      -> log into
-         *   [ ] Company 3
+         *   [x] **Hermit**
+         *   [ ] Herman's      -> log into
+         *   [ ] Heroes TM
          */
         await click(scMenu.el.querySelectorAll(".log_into")[1]);
         assert.containsNone(scMenu.el, ".dropdown-menu", "dropdown is directly closed");
@@ -230,9 +230,9 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         const scMenu = await createSwitchCompanyMenu({ onPushState });
 
         /**
-         *   [x] Company 1
-         *   [ ] Company 2
-         *   [x] **Company 3**
+         *   [x] Hermit
+         *   [ ] Herman's
+         *   [x] **Heroes TM**
          */
         assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [3, 1]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 3);
@@ -242,9 +242,9 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         assert.containsN(scMenu.el, "[data-company-id] .fa-square-o", 1);
 
         /**
-         *   [x] Company 1
-         *   [ ] Company 2      -> log into
-         *   [x] **Company 3**
+         *   [x] Hermit
+         *   [ ] Herman's      -> log into
+         *   [x] **Heroes TM**
          */
         await click(scMenu.el.querySelectorAll(".log_into")[1]);
         assert.containsNone(scMenu.el, ".dropdown-menu", "dropdown is directly closed");
@@ -257,15 +257,15 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         function onPushState(url) {
             assert.step(url.split("#")[1]);
         }
-        Object.assign(browser.location, { hash: "cids=2%2C3" });
+        Object.assign(browser.location, { hash: "cids=2%2C1" });
         const scMenu = await createSwitchCompanyMenu({ onPushState });
 
         /**
-         *   [ ] Company 1
-         *   [x] **Company 2**
-         *   [x] Company 3
+         *   [ ] Hermit
+         *   [x] **Herman's**
+         *   [x] Heroes TM
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [2, 3]);
+        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [2, 1]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 2);
         await click(scMenu.el.querySelector(".dropdown-toggle"));
         assert.containsN(scMenu.el, "[data-company-id]", 3);
@@ -273,13 +273,13 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         assert.containsN(scMenu.el, "[data-company-id] .fa-square-o", 1);
 
         /**
-         *   [ ] Company 1
-         *   [x] **Company 2**
-         *   [x] Company 3      -> log into
+         *   [ ] Hermit
+         *   [x] **Herman's**
+         *   [x] Heroes TM      -> log into
          */
         await click(scMenu.el.querySelectorAll(".log_into")[2]);
         assert.containsNone(scMenu.el, ".dropdown-menu", "dropdown is directly closed");
-        assert.verifySteps(["cids=3%2C2"]);
+        assert.verifySteps(["cids=1%2C2"]);
     });
 
     QUnit.test("companies can be logged in even if some toggled within delay", async (assert) => {
@@ -291,21 +291,21 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         const scMenu = await createSwitchCompanyMenu({ onPushState }, 50);
 
         /**
-         *   [x] **Company 1**
-         *   [ ] Company 2
-         *   [ ] Company 3
+         *   [x] **Hermit**
+         *   [ ] Herman's
+         *   [ ] Heroes TM
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1]);
-        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
+        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [3]);
+        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 3);
         await click(scMenu.el.querySelector(".dropdown-toggle"));
         assert.containsN(scMenu.el, "[data-company-id]", 3);
         assert.containsN(scMenu.el, "[data-company-id] .fa-check-square", 1);
         assert.containsN(scMenu.el, "[data-company-id] .fa-square-o", 2);
 
         /**
-         *   [ ] **Company 1**  -> toggled
-         *   [ ] Company 2      -> logged in
-         *   [ ] Company 3      -> toggled
+         *   [ ] **Hermit**  -> toggled
+         *   [ ] Herman's      -> logged in
+         *   [ ] Heroes TM      -> toggled
          */
         await click(scMenu.el.querySelectorAll(".toggle_company")[2]);
         await click(scMenu.el.querySelectorAll(".toggle_company")[0]);

--- a/addons/web/tests/test_session_info.py
+++ b/addons/web/tests/test_session_info.py
@@ -46,6 +46,7 @@ class TestSessionInfo(common.HttpCase):
             str(company.id): {
                 'id': company.id,
                 'name': company.name,
+                'sequence': company.sequence,
             } for company in self.companies
         }
         expected_user_companies = {


### PR DESCRIPTION
As JS is not taking the Object properties in the order they are written,
the order in the rendering was always following the property name order (=id).

Previous to this commit:

    - The companies were ordered by their id in the company switcher.

After this commit:

    - The companies will be sorted by their sequence in the company switcher.

task-2722235

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
