### PR TITLE
[FIX] mail: temporary id should be negative

### DIFF
--- a/addons/mail/static/src/components/file_uploader/file_uploader.js
+++ b/addons/mail/static/src/components/file_uploader/file_uploader.js
@@ -11,7 +11,7 @@ const { useRef } = owl.hooks;
 const geAttachmentNextTemporaryId = (function () {
     let tmpId = 0;
     return () => {
-        tmpId += 1;
+        tmpId -= 1;
         return tmpId;
     };
 })();


### PR DESCRIPTION
Before this commit temporary id could match an existing attachment id and
replace that attachment by the new uploaded one.
Even if this is very unlikly, using a negative id avoid it completly.
