### PR TITLE
[FIX] pos_restaurant : Orders not synched

### DIFF
--- a/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
@@ -291,6 +291,9 @@ odoo.define('pos_restaurant.FloorScreen', function (require) {
                                 // do not count the orders that are already finalized
                                 !o.finalized
                         ).length;
+                    if (table_obj.order_count < table.orders) {
+                        this.env.pos.update_orders_for_table(table_obj);
+                    }
                     table_obj.order_count = table.orders + unsynced_orders;
                 });
                 this.render();

--- a/addons/pos_restaurant/static/src/js/floors.js
+++ b/addons/pos_restaurant/static/src/js/floors.js
@@ -298,6 +298,20 @@ models.PosModel = models.PosModel.extend({
         }
     },
 
+    update_orders_for_table(table) {
+        const self = this;
+        this._get_from_server(table.id).then(server_orders => {
+            server_orders.forEach(server_order => {
+                if (server_order.lines.length) {
+                    const new_order = new models.Order({}, { pos: self, json: server_order });
+                    self.get("orders").add(new_order);
+                }
+            })
+            posbus.trigger('table-set');
+        });
+
+    },
+
     // we need to prevent the creation of orders when there is no
     // table selected.
     add_new_order: function() {


### PR DESCRIPTION
Current behavior :
The orders where not automatically synchronised between two PoS sessions.

Steps to reproduce :
- Create an order for Table 1 as Server.
- For Server:
    - Order is shown on Table 1.
    - Order is shown on "Orders".
- For Cashier:
    - Order is shown on Table 1 (5 second delay).
    - Order is not shown on "Orders".

opw-2697583

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
