### PR TITLE
[IMP] mail: properly detect nonexisting fields

### DIFF
--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -156,7 +156,7 @@ class Users(models.Model):
             'needaction_inbox_counter': self.partner_id._get_needaction_count(),
             'partner_root': partner_root.sudo().mail_partner_format().get(partner_root),
             'public_partners': list(self.env.ref('base.group_public').sudo().with_context(active_test=False).users.partner_id.mail_partner_format().values()),
-            'shortcodes': self.env['mail.shortcode'].sudo().search_read([], ['source', 'substitution', 'description']),
+            'shortcodes': self.env['mail.shortcode'].sudo().search_read([], ['source', 'substitution']),
             'starred_counter': self.partner_id._get_starred_count(),
         }
         return values

--- a/addons/mail/static/src/components/chatter_topbar/tests/chatter_topbar_tests.js
+++ b/addons/mail/static/src/components/chatter_topbar/tests/chatter_topbar_tests.js
@@ -456,7 +456,6 @@ QUnit.test('rendering with multiple partner followers', async function (assert) 
     );
     const chatter = this.messaging.models['Chatter'].create({
         id: 11,
-        followerIds: [1, 2],
         threadId: 100,
         threadModel: 'res.partner',
     });

--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -417,12 +417,9 @@ export class ModelManager {
      * @param {Object} [data={}]
      */
     _addDefaultData(Model, data = {}) {
-        const data2 = {};
+        const data2 = { ...data };
         for (const field of Model.__fieldList) {
-            // `undefined` should have the same effect as not passing the field
-            if (data[field.fieldName] !== undefined) {
-                data2[field.fieldName] = data[field.fieldName];
-            } else if (field.default !== undefined) {
+            if (data2[field.fieldName] === undefined && field.default !== undefined) {
                 data2[field.fieldName] = field.default;
             }
         }

--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -2111,7 +2111,7 @@ MockServer.include({
             needaction_inbox_counter: this._mockResPartner_GetNeedactionCount(user.partner_id),
             partner_root: this._mockResPartnerMailPartnerFormat(this.partnerRootId).get(this.partnerRootId),
             public_partners: [...this._mockResPartnerMailPartnerFormat(this.publicPartnerId).values()],
-            shortcodes: this._getRecords('mail.shortcode', []),
+            shortcodes: this._mockSearchRead('mail.shortcode', [[], ['source', 'substitution']], {}),
             starred_counter: this._getRecords('mail.message', [['starred_partner_ids', 'in', user.partner_id]]).length,
         };
     },

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -739,13 +739,11 @@ class TestDiscussFullPerformance(TransactionCase):
             'mail_failures': [],
             'shortcodes': [
                 {
-                    'description': False,
                     'id': 1,
                     'source': 'hello',
                     'substitution': 'Hello. How may I help you?',
                 },
                 {
-                    'description': False,
                     'id': 2,
                     'source': 'bye',
                     'substitution': 'Thanks for your feedback. Good bye!',


### PR DESCRIPTION
Invalid data provided at record creation were silently skipped by the framework without triggering an error. This commit ensures that data are no longer accidentally filtered and therefore that an error will be raised if a key that does not match an actual field is provided.

This commit also removes the dead code that was detected thanks to these changes.