### PR TITLE
[FIX] convert: do not set one2many field when there are subrecords

### DIFF
--- a/odoo/addons/test_convert/models.py
+++ b/odoo/addons/test_convert/models.py
@@ -7,6 +7,8 @@ class TestModel(models.Model):
     _name = 'test_convert.test_model'
     _description = "Test Convert Model"
 
+    usered_ids = fields.One2many('test_convert.usered', 'test_id')
+
     @api.model
     def action_test_date(self, today_date):
         return True
@@ -25,6 +27,7 @@ class Usered(models.Model):
 
     name = fields.Char()
     user_id = fields.Many2one('res.users', default=lambda self: self.env.user)
+    test_id = fields.Many2one('test_convert.test_model')
     tz = fields.Char(default=lambda self: self.env.context.get('tz') or self.env.user.tz)
 
     @api.model

--- a/odoo/addons/test_convert/tests/test_convert.py
+++ b/odoo/addons/test_convert/tests/test_convert.py
@@ -76,6 +76,36 @@ class TestEvalXML(common.TransactionCase):
         with self.assertRaises(IOError):
             self.eval_xml(Field('test_nofile.txt', type='file'), obj)
 
+    def test_o2m_sub_records(self):
+        # patch the model's class with a proxy that copies the argument
+        Model = self.registry['test_convert.test_model']
+        call_args = []
+
+        def _load_records(self, data_list, update=False):
+            call_args.append(data_list)
+            return super(Model, self)._load_records(data_list, update=update)
+
+        self.patch(Model, '_load_records', _load_records)
+
+        # import a record with a subrecord
+        xml = ET.fromstring("""
+            <record id="test_convert.test_o2m_record" model="test_convert.test_model">
+                <field name="usered_ids">
+                    <record id="test_convert.test_o2m_subrecord" model="test_convert.usered">
+                        <field name="name">subrecord</field>
+                    </record>
+                </field>
+            </record>
+        """.strip())
+        obj = xml_import(self.cr, 'test_convert', None, 'init')
+        obj._tag_record(xml)
+
+        # check that field 'usered_ids' is not passed
+        self.assertEqual(len(call_args), 1)
+        for data in call_args[0]:
+            self.assertNotIn('usered_ids', data['values'],
+                             "Unexpected value in O2M When loading XML with sub records")
+
     def test_function(self):
         obj = xml_import(self.cr, 'test_convert', None, 'init')
 

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -544,6 +544,7 @@ form: module.record_id""" % (xml_id,)
                 f_model = model._fields[f_name].comodel_name
             f_use = field.get("use",'') or 'id'
             f_val = False
+            has_value = True
 
             if f_search:
                 idref2 = _get_idref(self, env, f_model, self.idref)
@@ -580,10 +581,12 @@ form: module.record_id""" % (xml_id,)
                         f_val = str2bool(f_val)
                     elif field_type == 'one2many':
                         if isinstance(f_val, str):
-                            f_val = None
+                            has_value = False
                         for child in field.findall('./record'):
                             sub_records.append((child, model._fields[f_name].inverse_name))
-            res[f_name] = f_val
+            if has_value:
+                res[f_name] = f_val
+
         if extra_vals:
             res.update(extra_vals)
 


### PR DESCRIPTION
This is both a correctness and performance fix.
    
Before this patch, when loading an XML `<record>`, if a one2many field is defined with inner <record> items, the one2many is first set to `None`, then subrecords are loaded afterwards.  When upgrading a module, this effectively deletes the lines of the one2many field then recreates them.
    
The issue is clearly visible on `account.tax.report`: upgrading any localization module where `account.tax.report` is there, removes all tags from taxes and journal items.
    
The fix consists in ignoring the one2many field when no explicit value is given, i.e., sending no value for the field instead of value `None`.