### PR TITLE
[FIX] mail: no more than 2 user in a chat

### DIFF
--- a/addons/im_livechat/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
+++ b/addons/im_livechat/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
@@ -16,7 +16,6 @@ registerInstancePatchModel('mail.discuss_sidebar_category_item', 'im_livechat/st
             if (this.channel.correspondent && this.channel.correspondent.id > 0) {
                 return this.channel.correspondent.avatarUrl;
             }
-            return '/mail/static/src/img/smiley/avatar.jpg';
         }
         return this._super();
     },

--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -444,6 +444,11 @@ msgid "<strong>Recommended Activities</strong>"
 msgstr ""
 
 #. module: mail
+#: code:addons/mail/models/mail_channel.py:0
+msgid "A channel of type 'chat' cannot have more than two users."
+msgstr ""
+
+#. module: mail
 #: model:ir.model.fields,help:mail.field_mail_alias__alias_defaults
 #: model:ir.model.fields,help:mail.field_mail_channel__alias_defaults
 msgid ""

--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -95,6 +95,14 @@ class Channel(models.Model):
         ('uuid_unique', 'UNIQUE(uuid)', 'The channel UUID must be unique'),
     ]
 
+    # CHAT CONSTRAINT
+
+    @api.constrains('channel_last_seen_partner_ids', 'channel_partner_ids')
+    def _constraint_partners_chat(self):
+        for ch in self.filtered(lambda ch: ch.channel_type == 'chat'):
+            if len(ch.channel_last_seen_partner_ids) > 2 or len(ch.channel_partner_ids) > 2:
+                raise ValidationError(_("A channel of type 'chat' cannot have more than two users."))
+
     # COMPUTE / INVERSE
 
     @api.depends('channel_type')

--- a/addons/mail/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
@@ -34,8 +34,11 @@ function factory(dependencies) {
                 case 'group':
                     return `/web/image/mail.channel/${this.channel.id}/avatar_128?unique=${this.channel.avatarCacheKey}`;
                 case 'chat':
-                    return this.channel.correspondent.avatarUrl;
+                    if (this.channel.correspondent) {
+                        return this.channel.correspondent.avatarUrl;
+                    }
             }
+            return '/mail/static/src/img/smiley/avatar.jpg';
         }
 
         /**

--- a/addons/mail/tests/test_mail_channel.py
+++ b/addons/mail/tests/test_mail_channel.py
@@ -378,7 +378,7 @@ class TestChannelInternals(MailCommon):
         self.test_channel.with_context(self._test_context).write({
             'channel_partner_ids': [Command.link(self.user_employee.partner_id.id), Command.link(test_partner.id)],
         })
-        test_chat = self.env['mail.channel'].with_context(self._test_context).create({
+        test_chat = self.env['mail.channel'].with_user(self.user_employee).with_context(self._test_context).create({
             'name': 'test',
             'channel_type': 'chat',
             'public': 'private',

--- a/addons/mail/views/mail_channel_views.xml
+++ b/addons/mail/views/mail_channel_views.xml
@@ -80,7 +80,8 @@
                                 </group>
                             </page>
                             <page string="Members" name="members">
-                                <field name="channel_last_seen_partner_ids" mode="tree" context="{'active_test': False}">
+                                <field name="channel_type" invisible="1"/>
+                                <field name="channel_last_seen_partner_ids" mode="tree" context="{'active_test': False}" attrs="{'readonly': [('channel_type', '=', 'chat')]}">
                                     <tree string="Members" editable="bottom">
                                         <field name="partner_id" required="1" attrs="{'readonly': [('id', '!=', False)]}"/>
                                         <field name="partner_email" readonly="1"/>


### PR DESCRIPTION
Step to reproduce:
- Settings -> Mail channel -> any chat-type channel
- Go to Members
- Add an user
- Refresh the page

Current Behaviour:
- Traceback
- Chat are designed for 2 users and you should not be able to add more

Behaviour after PR:
- Can only edit members of channel if it's not a chat
- User error if try to add more user
- Fix traceback if there is too much users

opw-2717341

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
