### PR TITLE
Support python 3.10 

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6599,9 +6599,9 @@ Fields:
         return self.concat(*records_batches)
 
 
-collections.Set.register(BaseModel)
+collections.abc.Set.register(BaseModel)
 # not exactly true as BaseModel doesn't have __reversed__, index or count
-collections.Sequence.register(BaseModel)
+collections.abc.Sequence.register(BaseModel)
 
 class RecordCache(MutableMapping):
     """ A mapping from field names to values, to read and update the cache of a record. """

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2518,7 +2518,7 @@ class O2MProxy(X2MProxy):
         del self._records[index]
         self._parent._perform_onchange([self._field])
 
-class M2MProxy(X2MProxy, collections.Sequence):
+class M2MProxy(X2MProxy, collections.abc.Sequence):
     """ M2MProxy()
 
     Behaves as a :class:`~collection.Sequence` of recordsets, can be

--- a/odoo/tools/_vendor/sessions.py
+++ b/odoo/tools/_vendor/sessions.py
@@ -26,7 +26,6 @@ from pickle import load
 from time import time
 
 from werkzeug.datastructures import CallbackDict
-from werkzeug.posixemulation import rename
 
 _sha1_re = re.compile(r"^[a-f0-9]{40}$")
 
@@ -198,7 +197,7 @@ class FilesystemSessionStore(SessionStore):
         finally:
             f.close()
         try:
-            rename(tmp, fn)
+            os.rename(tmp, fn)
             os.chmod(fn, self.mode)
         except (IOError, OSError):
             pass


### PR DESCRIPTION
`collections.Set` was deprecated since 3.6 and removed at 3.10
https://github.com/python/cpython/blob/3.9/Lib/collections/__init__.py#L62-L65