### PR TITLE
[ADD] web_editor: two new powerbox widgets to rate with 3 or 5 stars

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -118,64 +118,25 @@ class Web_Editor(http.Controller):
         htmlelem = etree.fromstring("<div>%s</div>" % value, etree.HTMLParser())
         checked = bool(checked)
 
-        li = htmlelem.find(".//li[@id='checklist-id-" + str(checklistId) + "']")
+        li = htmlelem.find(".//li[@id='%s']" % checklistId)
 
-        if not li or not self._update_checklist_recursive(li, checked, children=True, ancestors=True):
+        if li is None:
+            return value
+
+        classname = li.get('class', '')
+        if ('o_checked' in classname) != checked:
+            if checked:
+                classname = '%s o_checked' % classname
+            else:
+                classname = re.sub(r"\s?o_checked\s?", '', classname)
+            li.set('class', classname)
+        else:
             return value
 
         value = etree.tostring(htmlelem[0][0], encoding='utf-8', method='html')[5:-6]
         record.write({filename: value})
 
         return value
-
-    def _update_checklist_recursive (self, li, checked, children=False, ancestors=False):
-        if 'checklist-id-' not in li.get('id', ''):
-            return False
-
-        classname = li.get('class', '')
-        if ('o_checked' in classname) == checked:
-            return False
-
-        # check / uncheck
-        if checked:
-            classname = '%s o_checked' % classname
-        else:
-            classname = re.sub(r"\s?o_checked\s?", '', classname)
-        li.set('class', classname)
-
-        # propagate to children
-        if children:
-            node = li.getnext()
-            ul = None
-            if node is not None:
-                if node.tag == 'ul':
-                    ul = node
-                if node.tag == 'li' and len(node.getchildren()) == 1 and node.getchildren()[0].tag == 'ul':
-                    ul = node.getchildren()[0]
-
-            if ul is not None:
-                for child in ul.getchildren():
-                    if child.tag == 'li':
-                        self._update_checklist_recursive(child, checked, children=True)
-
-        # propagate to ancestors
-        if ancestors:
-            allSelected = True
-            ul = li.getparent()
-            if ul.tag == 'li':
-                ul = ul.getparent()
-
-            for child in ul.getchildren():
-                if child.tag == 'li' and 'checklist-id' in child.get('id', '') and 'o_checked' not in child.get('class', ''):
-                    allSelected = False
-
-            node = ul.getprevious()
-            if node is None:
-                node = ul.getparent().getprevious()
-            if node is not None and node.tag == 'li':
-                self._update_checklist_recursive(node, allSelected, ancestors=True)
-
-        return True
 
     @http.route('/web_editor/video_url/data', type='json', auth='user', website=True)
     def video_url_data(self, video_url, autoplay=False, loop=False,

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -445,6 +445,7 @@ export class OdooEditor extends EventTarget {
             this.observer = new MutationObserver(records => {
                 records = this.filterMutationRecords(records);
                 if (!records.length) return;
+                this.dispatchEvent(new Event('contentChanged'));
                 clearTimeout(this.observerTimeout);
                 if (this._observerTimeoutUnactive.size === 0) {
                     this.observerTimeout = setTimeout(() => {

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1827,6 +1827,12 @@ export class OdooEditor extends EventTarget {
         const sel = this.document.getSelection();
         if (!sel.anchorNode) {
             show = false;
+        } else {
+            const selAncestors = [sel.anchorNode, ...ancestors(sel.anchorNode, this.editable)];
+            const isInStars = selAncestors.some(node => node.classList && node.classList.contains('o_stars'));
+            if (isInStars) {
+                show = false;
+            }
         }
         if (this.options.autohideToolbar) {
             if (show !== undefined && !this.isMobile) {

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -47,6 +47,8 @@ import {
     unwrapContents,
     peek,
     rightPos,
+    getAdjacentPreviousSiblings,
+    getAdjacentNextSiblings,
 } from './utils/utils.js';
 import { editorCommands } from './commands/commands.js';
 import { Powerbox } from './powerbox/Powerbox.js';
@@ -1721,6 +1723,30 @@ export class OdooEditor extends EventTarget {
                     this.commandbarTablePicker.show();
                 },
             },
+            {
+                groupName: 'Widgets',
+                title: '3 Stars',
+                description: 'Insert a rating over 3 stars.',
+                fontawesome: 'fa-star-o',
+                callback: () => {
+                    let html = '<span contenteditable="false" class="o_stars o_three_stars">';
+                    html += Array(3).fill().map(() => '<i class="fa fa-star-o"></i>').join('');
+                    html += '</span>';
+                    this.execCommand('insertHTML', html);
+                },
+            },
+            {
+                groupName: 'Widgets',
+                title: '5 Stars',
+                description: 'Insert a rating over 5 stars.',
+                fontawesome: 'fa-star',
+                callback: () => {
+                    let html = '<span contenteditable="false" class="o_stars o_five_stars">';
+                    html += Array(5).fill().map(() => '<i class="fa fa-star-o"></i>').join('');
+                    html += '</span>';
+                    this.execCommand('insertHTML', html);
+                },
+            },
         ];
         this.commandBar = new Powerbox({
             editable: this.editable,
@@ -2522,6 +2548,29 @@ export class OdooEditor extends EventTarget {
                 toggleClass(node, 'o_checked');
                 ev.preventDefault();
                 this.historyStep();
+            }
+        }
+
+        // handle stars
+        if (node.nodeType === Node.ELEMENT_NODE && node.className.includes('fa-star') &&
+            node.parentElement && node.parentElement.className.includes('o_stars')) {
+            const previousStars = getAdjacentPreviousSiblings(node, sib => (
+                sib.nodeType === Node.ELEMENT_NODE && sib.className.includes('fa-star')
+            ));
+            const nextStars = getAdjacentNextSiblings(node, sib => (
+                sib.nodeType === Node.ELEMENT_NODE && sib.className.includes('fa-star')
+            ));
+            if (nextStars.length || previousStars.length) {
+                const shouldToggleOff = node.classList.contains('fa-star') &&
+                    (!nextStars[0] || !nextStars[0].classList.contains('fa-star'));
+                for (const star of [...previousStars, node]) {
+                    star.classList.toggle('fa-star-o', shouldToggleOff);
+                    star.classList.toggle('fa-star', !shouldToggleOff);
+                };
+                for (const star of nextStars) {
+                    star.classList.toggle('fa-star-o', true);
+                    star.classList.toggle('fa-star', false);
+                };
             }
         }
     }

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
@@ -133,8 +133,9 @@ class Sanitize {
             }
         }
 
-        // Ensure unique ids on checklists.
-        if (node.nodeName == 'LI' && node.parentElement && node.parentElement.classList.contains('o_checklist')) {
+        // Ensure unique ids on checklists and stars.
+        if (node.nodeName == 'LI' && node.parentElement && node.parentElement.classList.contains('o_checklist') ||
+            node.classList && node.classList.contains('o_stars')) {
             node.setAttribute('id', Math.floor(new Date() * Math.random()));
         }
 

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
@@ -133,6 +133,11 @@ class Sanitize {
             }
         }
 
+        // Ensure unique ids on checklists.
+        if (node.nodeName == 'LI' && node.parentElement && node.parentElement.classList.contains('o_checklist')) {
+            node.setAttribute('id', Math.floor(new Date() * Math.random()));
+        }
+
         // FIXME not parse out of editable zone...
         this._parse(node.firstChild);
         this._parse(node.nextSibling);

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -454,27 +454,6 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
      */
     _onChange: function (ev) {
         this._doDebouncedAction.apply(this, arguments);
-
-        var $lis = this.$content.find('.note-editable ul.o_checklist > li:not(:has(> ul.o_checklist))');
-        if (!$lis.length) {
-            return;
-        }
-        var max = 0;
-        var ids = [];
-        $lis.map(function () {
-            var checklistId = parseInt(($(this).attr('id') || '0').replace(/^checklist-id-/, ''));
-            if (ids.indexOf(checklistId) === -1) {
-                if (checklistId > max) {
-                    max = checklistId;
-                }
-                ids.push(checklistId);
-            } else {
-                $(this).removeAttr('id');
-            }
-        });
-        $lis.not('[id]').each(function () {
-            $(this).attr('id', 'checklist-id-' + (++max));
-        });
     },
     /**
      * Allows Enter keypress in a textarea (source mode)
@@ -503,7 +482,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
         ev.stopPropagation();
         ev.preventDefault();
         var checked = $(ev.target).hasClass('o_checked');
-        var checklistId = parseInt(($(ev.target).attr('id') || '0').replace(/^checklist-id-/, ''));
+        var checklistId = parseInt($(ev.target).attr('id') || '0');
 
         this._rpc({
             route: '/web_editor/checklist',

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -1,14 +1,14 @@
-odoo.define('web_editor.field.html', function (require) {
+/** @odoo-module alias=web_editor.field.html */
 'use strict';
 
-var ajax = require('web.ajax');
-var basic_fields = require('web.basic_fields');
-var core = require('web.core');
-var wysiwygLoader = require('web_editor.loader');
-var field_registry = require('web.field_registry');
-const {QWebPlugin} = require('@web_editor/js/backend/QWebPlugin');
+import ajax from 'web.ajax';
+import basic_fields from 'web.basic_fields';
+import core from 'web.core';
+import wysiwygLoader from 'web_editor.loader';
+import field_registry from 'web.field_registry';
+import {QWebPlugin} from '@web_editor/js/backend/QWebPlugin';
 // must wait for web/ to add the default html widget, otherwise it would override the web_editor one
-require('web._field_registry');
+import 'web._field_registry';
 
 var _lt = core._lt;
 var TranslatableFieldMixin = basic_fields.TranslatableFieldMixin;
@@ -552,5 +552,4 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
 field_registry.add('html', FieldHtml);
 
 
-return FieldHtml;
-});
+export default FieldHtml;

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -206,7 +206,9 @@ const Wysiwyg = Widget.extend({
                 }).join(' ');
             }
 
-            self.openMediaDialog(params);
+            if (!$el.parent().hasClass('o_stars')) {
+                self.openMediaDialog(params);
+            }
         });
 
         if (options.snippets) {
@@ -1364,7 +1366,7 @@ const Wysiwyg = Widget.extend({
         this.toolbar.$el.find('#create-link').toggleClass('d-none', !range || spansBlocks);
         // Only show the media tools in the toolbar if the current selected
         // snippet is a media.
-        const isInMedia = $target.is(mediaSelector);
+        const isInMedia = $target.is(mediaSelector) && !$target.parent().hasClass('o_stars');
         this.toolbar.$el.find([
             '#image-shape',
             '#image-width',

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -129,6 +129,11 @@ const Wysiwyg = Widget.extend({
             plugins: options.editorPlugins,
         }, editorCollaborationOptions));
 
+        this.odooEditor.addEventListener('contentChanged', function () {
+            self.$editable.trigger('content_changed');
+            self.trigger_up('wysiwyg_change');
+        });
+
         const $wrapwrap = $('#wrapwrap');
         if ($wrapwrap.length) {
             $wrapwrap[0].addEventListener('scroll', this.odooEditor.multiselectionRefresh, { passive: true });
@@ -1510,22 +1515,7 @@ const Wysiwyg = Widget.extend({
         }
     },
     _editorOptions: function () {
-        var self = this;
-        var options = Object.assign({}, this.defaultOptions, this.options);
-        options.onChange = function (html, $editable) {
-            $editable.trigger('content_changed');
-            self.trigger_up('wysiwyg_change');
-        };
-        options.onUpload = function (attachments) {
-            self.trigger_up('wysiwyg_attachment', attachments);
-        };
-        options.onFocus = function () {
-            self.trigger_up('wysiwyg_focus');
-        };
-        options.onBlur = function () {
-            self.trigger_up('wysiwyg_blur');
-        };
-        return options;
+        return Object.assign({}, this.defaultOptions, this.options);
     },
     _insertSnippetMenu: function () {
         return this.snippetsMenu.insertBefore(this.$el);

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -159,6 +159,11 @@ ol > li.o_indent, ul > li.o_indent {
     }
 }
 
+// Stars widget
+.o_stars .fa.fa-star {
+    color: gold;
+}
+
 // Medias
 img.o_we_custom_image {
     // Images added with the editor are .img-fluid by default but should


### PR DESCRIPTION
This adds two new widgets to the powerbox, which allow the user to quickly insert 3 or 5 stars, then click on them to color them gold.
Similar to checklists, this allows the user to click the powerbox stars widgets even in readonly mode, so as to change a rating without going in edit mode.

While implementing this it became apparent that the checklist readonly checking feature was broken so this fixes it too. In order to be able to import Odoo Editor utils into field_html, the widget was turned into a js module with modern imports.

task-2575449

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
