### PR TITLE
[IMP] remove _read_template cache as it's already cached by _compile

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1847,11 +1847,6 @@ actual arch.
 
     # apply ormcache_context decorator unless in dev mode...
     @api.model
-    @tools.conditional(
-        'xml' not in config['dev_mode'],
-        tools.ormcache('frozenset(self.env.user.groups_id.ids)', 'view_id',
-                       'tuple(self._context.get(k) for k in self._read_template_keys())'),
-    )
     def _read_template(self, view_id):
         arch_tree = self.browse(view_id)._get_combined_arch()
         self.distribute_branding(arch_tree)


### PR DESCRIPTION
QWeb views are cached two times, first in _compile who itself calls _read_template that is
also cached. The result is a 0% HIT rate on _read_template, and all frontend views are two
times stored in the cache.

Note that _read_template is only used by _compile, and another one in web_studio (that does
not need to be cached). So, removing this cache won't impact the CPU performance, but will
reuce memory usage and LRU invalidations.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
