### PR TITLE
[FIX] web: debug manager fields view get with owl renderers

### DIFF
--- a/addons/web/static/src/js/tools/debug_manager_backend.js
+++ b/addons/web/static/src/js/tools/debug_manager_backend.js
@@ -432,8 +432,9 @@ DebugManager.include({
         var self = this;
         var dialog = new Dialog(this, { title: _t("Fields View Get") });
         dialog.opened().then(function () {
+            const arch = self._controller.renderer.arch || self._controller.renderer.props.arch;
             $('<pre>').text(utils.json_node_to_xml(
-                self._controller.renderer.arch, true)
+                arch, true)
             ).appendTo(dialog.$el);
         });
         dialog.open();


### PR DESCRIPTION
**Steps to follow**

  - Go to the CRM app
  - Switch to the pivot view
  - Click on 'Fields View Get' in the Developer Tools (bug icon)
  -> `self._controller.renderer.arch` is undefined

**Cause of the issue**

  Owl renderers use `props.arch`
  See V15 dialog: https://github.com/odoo/odoo/blob/3b29dd230acd961a72fb0cb971f9363958f65b60/addons/web/static/src/views/debug_items.js#L28

opw-2713451