### PR TITLE
[IMP] l10n_fr_fec: solve some issues with the french FEC

### DIFF
--- a/addons/l10n_fr_fec/wizard/account_fr_fec.py
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec.py
@@ -59,7 +59,6 @@ class AccountFrFec(models.TransientModel):
             am.date < %s
             AND am.company_id = %s
             AND aat.include_initial_balance IS NOT TRUE
-            AND (aml.debit != 0 OR aml.credit != 0)
         '''
         # For official report: only use posted entries
         if self.export_type == "official":
@@ -87,16 +86,10 @@ class AccountFrFec(models.TransientModel):
         """
         dom_tom_group = self.env.ref('l10n_fr.dom-tom')
         is_dom_tom = company.country_id.code in dom_tom_group.country_ids.mapped('code')
-        if not is_dom_tom and not company.vat:
-            raise Warning(
-                _("Missing VAT number for company %s") % company.name)
-        if not is_dom_tom and company.vat[0:2] != 'FR':
-            raise Warning(
-                _("FEC is for French companies only !"))
-
-        return {
-            'siren': company.vat[4:13] if not is_dom_tom else '',
-        }
+        if not company.vat or is_dom_tom:
+            return {'siren': ''}
+        else:
+            return {'siren': company.vat[4:13]}
 
     def generate_fec(self):
         self.ensure_one()
@@ -171,7 +164,6 @@ class AccountFrFec(models.TransientModel):
             am.date < %s
             AND am.company_id = %s
             AND aat.include_initial_balance = 't'
-            AND (aml.debit != 0 OR aml.credit != 0)
         '''
 
         # For official report: only use posted entries
@@ -182,8 +174,7 @@ class AccountFrFec(models.TransientModel):
 
         sql_query += '''
         GROUP BY aml.account_id, aat.type
-        HAVING round(sum(aml.balance), %s) != 0
-        AND aat.type not in ('receivable', 'payable')
+        HAVING aat.type not in ('receivable', 'payable')
         '''
         formatted_date_from = fields.Date.to_string(self.date_from).replace('-', '')
         date_from = self.date_from
@@ -191,7 +182,7 @@ class AccountFrFec(models.TransientModel):
         currency_digits = 2
 
         self._cr.execute(
-            sql_query, (formatted_date_year, formatted_date_from, formatted_date_from, formatted_date_from, self.date_from, company.id, currency_digits))
+            sql_query, (formatted_date_year, formatted_date_from, formatted_date_from, formatted_date_from, self.date_from, company.id))
 
         for row in self._cr.fetchall():
             listrow = list(row)
@@ -269,7 +260,6 @@ class AccountFrFec(models.TransientModel):
             am.date < %s
             AND am.company_id = %s
             AND aat.include_initial_balance = 't'
-            AND (aml.debit != 0 OR aml.credit != 0)
         '''
 
         # For official report: only use posted entries
@@ -280,11 +270,10 @@ class AccountFrFec(models.TransientModel):
 
         sql_query += '''
         GROUP BY aml.account_id, aat.type, rp.ref, rp.id
-        HAVING round(sum(aml.balance), %s) != 0
-        AND aat.type in ('receivable', 'payable')
+        HAVING aat.type in ('receivable', 'payable')
         '''
         self._cr.execute(
-            sql_query, (formatted_date_year, formatted_date_from, formatted_date_from, formatted_date_from, self.date_from, company.id, currency_digits))
+            sql_query, (formatted_date_year, formatted_date_from, formatted_date_from, formatted_date_from, self.date_from, company.id))
 
         for row in self._cr.fetchall():
             listrow = list(row)
@@ -350,7 +339,6 @@ class AccountFrFec(models.TransientModel):
             am.date >= %s
             AND am.date <= %s
             AND am.company_id = %s
-            AND (aml.debit != 0 OR aml.credit != 0)
         '''
 
         # For official report: only use posted entries


### PR DESCRIPTION
This PR:

1. Allows exporting the FEC without any VAT number. Indeed, a company can have to submit its FEC without being submitted to VAT regulation.

2. Allows non french companies to export FEC file.

3. The FEC now includes the journal items == 0 and/or journal entries which total is 0.
Initially, french tax administration rejected the journal items which balance is 0.
But after several requests from tax payers, they agreed because they prefer continuous sequences and some tax payers post entries which total amount is 0.

task-2717676
