### PR TITLE
[FIX] sale_{project,timesheet}: fix SO stat button displayed in project update

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -126,10 +126,11 @@ class Project(models.Model):
         if self.user_has_groups('sales_team.group_sale_salesman_all_leads'):
             buttons.append({
                 'icon': 'dollar',
-                'text': _('Sales Order'),
+                'text': _('Sales Orders'),
+                'number': self.sale_order_count,
                 'action_type': 'object',
                 'action': 'action_view_sos',
-                'show': bool(self.sale_order_id),
+                'show': self.sale_order_count > 0,
                 'sequence': 1,
             })
         return buttons

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -83,7 +83,7 @@ class Project(models.Model):
         }
         if len(all_sale_orders) == 1:
             action_window.update({
-                "res_id": self.sale_order_id.id,
+                "res_id": all_sale_orders.id,
                 "views": [[False, "form"]],
             })
         else:


### PR DESCRIPTION
## [FIX] sale_{project,timesheet}: hide SO stat button in project update

Before this commit, when the project has a SO related, the 'Sales Order'
stat button is shown in right side panel in project update even if the
allow_billable=False in this project. If `allow_billable=False` then the
project should be non billable and thus this stat button should not be
visible.

This commit hides the stat button when the project is
non billable.

### Steps to reproduce:

1) Install sale_timesheet module
2) Create a billable Project
3) Edit the project to set a SOL (Set a customer and a SOL) and save.
4) Edit the project and set `allow_billable` to `False`.
5) Go to the kanban view of the Project Update.

### Expected Behaviour:

The 'x Sales Orders' stat button should not be visible.

### Actual Behaviour:

The 'x Sales Orders' stat button is visible.

## [FIX] sale_project: display the SO related of the project

Before this commit, when the project has no SO set in its model and it
has a task with a SO set. When the user clicks on the Sales Order stat
button shown in project form or the project update. He sees a form view
of `sale.order` to create a new record because the action does not give
the id of the Sales Order related. Indeed, we give the id of the SO set
on the project if we found only one SO related to the project.

This commit fixes the issue by given the id of the SO related to allow
the user to see the SO related to the project.

### Steps to reproduce:

1) Create a project A with allow_billable set to `True`.
2) Create a Quotation for a customer C with a SOL containing service
product and confirm it to create a SO.
3) Create a task in the project A and set the customer C to this task
and set the SOL of the SO created in the step 2.
4) Go to the project update of the project A
5) Click on the 'x Sales Orders' stat button.

### Expected Behaviour:

The user should see the SO related to the project, that is the one
selected in the related task.

### Actual Behaviour:

The user sees an empty form view of `sale.order` to create a SO because
no SO is found.

Part of task-2710808

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
