### PR TITLE
[FIX] sale_timesheet: hide SO stat button in project update

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -88,17 +88,21 @@ class Project(models.Model):
     #  Project Updates
     # ----------------------------
 
+    def _get_sale_order_stat_button(self):
+        self.ensure_one()
+        return {
+            'icon': 'dollar',
+            'text': _('Sales Order'),
+            'action_type': 'object',
+            'action': 'action_view_so',
+            'show': bool(self.sale_order_id),
+            'sequence': 1,
+        }
+
     def _get_stat_buttons(self):
         buttons = super(Project, self)._get_stat_buttons()
         if self.user_has_groups('sales_team.group_sale_salesman_all_leads'):
-            buttons.append({
-                'icon': 'dollar',
-                'text': _('Sales Order'),
-                'action_type': 'object',
-                'action': 'action_view_so',
-                'show': bool(self.sale_order_id),
-                'sequence': 1,
-            })
+            buttons.append(self._get_sale_order_stat_button())
         return buttons
 
 class ProjectTask(models.Model):

--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -398,6 +398,11 @@ class Project(models.Model):
             })
         return result
 
+    def _get_sale_order_stat_button(self):
+        so_button = super()._get_sale_order_stat_button()
+        so_button['show'] &= self.allow_billable
+        return so_button
+
     def _get_stat_buttons(self):
         buttons = super(Project, self)._get_stat_buttons()
         if self.user_has_groups('hr_timesheet.group_hr_timesheet_approver'):


### PR DESCRIPTION
Before this commit, when the project has a SO related, the 'Sales Order'
stat button is shown in right side panel in project update even if the
allow_billable=False in this project. If `allow_billable=False` then the
project should be non billable and thus this stat button should not be
visible.

This commit hides the stat button when the project is
non billable.

Steps to reproduce:
==================
1) Install sale_timesheet module
2) Create a billable Project
3) Edit the project to set a SOL (Set a customer and a SOL) and save.
4) Edit the project and set `allow_billable` to `False`.
5) Go to the kanban view of the Project Update.

Expected Behaviour:
==================
The 'Sales Order' stat button should not be visible.

Actual Behaviour:
================
The 'Sales Order' stat button is visible.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
