### PR TITLE
[FIX] mail: check res_id!=0 when checking access rules

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -356,12 +356,12 @@ class MailActivity(models.Model):
             self._cr.execute("""
                 SELECT DISTINCT activity.id, activity.res_model, activity.res_id
                 FROM "%s" activity
-                WHERE activity.id = ANY (%%(ids)s)""" % self._table, dict(ids=list(sub_ids)))
+                WHERE activity.id = ANY (%%(ids)s) AND activity.res_id != 0""" % self._table, dict(ids=list(sub_ids)))
             activities_to_check += self._cr.dictfetchall()
 
         activity_to_documents = {}
         for activity in activities_to_check:
-            activity_to_documents.setdefault(activity['res_model'], list()).append(activity['res_id'])
+            activity_to_documents.setdefault(activity['res_model'], set()).add(activity['res_id'])
 
         allowed_ids = set()
         for doc_model, doc_ids in activity_to_documents.items():


### PR DESCRIPTION
Although 0 is a valid value (integer), this has been (ab)used to signal
that a mail activity is not linked to any other record via res_id.

The issue is that when we have `0` as res_id value we get an error here
https://github.com/odoo/odoo/blob/158c0ae425b3be446d81c3a6f4387b2d9426d10e/addons/mail/models/mail_activity.py#L377
more specifically on
https://github.com/odoo/odoo/blob/158c0ae425b3be446d81c3a6f4387b2d9426d10e/odoo/models.py#L3603
with `AttributeError: 'int' object has no attribute 'origin'`

To avoid the issue, here we discard id `0` when checking the linked
records access rules.

On #81292 (targeting master, >15.1 at the moment of writing) a
constraint will be added to avoid `0` on `res_id`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
