### PR TITLE
[FIX] product: add missing dep ctx on price

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -191,6 +191,7 @@ class ProductTemplate(models.Model):
     def _compute_cost_currency_id(self):
         self.cost_currency_id = self.env.company.currency_id.id
 
+    @api.depends_context('pricelist', 'partner', 'quantity', 'uom', 'date', 'no_variant_attributes_price_extra')
     def _compute_template_price(self):
         prices = self._compute_template_price_no_inverse()
         for template in self:


### PR DESCRIPTION
This depends context was missing and getting the price of product.tempalte for different pricelist was not working.
We use the same depends_context as in product.product _compute_product_price

related to adhoc task 25493 and #55652



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
