### PR TITLE
[IMP] website: remove 'styling' option from image wall

### DIFF
--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -96,12 +96,6 @@
             <we-range string="Images Spacing"
                 data-dependencies="!slideshow_mode_opt"
                 data-select-class="o_spc-none|o_spc-small|o_spc-medium|o_spc-big"/>
-            <we-select string="Styling" data-apply-to="img">
-                <we-button data-select-class="">Standard</we-button>
-                <we-button data-select-class="img-thumbnail">Thumbnails</we-button>
-                <we-button data-select-class="rounded-pill">Circle</we-button>
-                <we-button data-select-class="shadow">Shadows</we-button>
-            </we-select>
             <we-select string="Arrows" data-dependencies="slideshow_mode_opt">
                 <we-button data-select-class="">Standard</we-button>
                 <we-button data-select-class="s_image_gallery_indicators_arrows_boxed">Boxed</we-button>


### PR DESCRIPTION
The goal of this PR is to remove 'styling' option from image wall since user can achieve good
enough results using border and round corner options.

IMPORTANT: the option could be removed from image wall only (and
not from image gallery) using "data-dependencies=slideshow_mode_opt"
(since they use the same code), but it's removed from both "for now".

task-2692129