### PR TITLE
[FIX] stock: add a partner on warehouse doesn't set correct properties

### DIFF
--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -170,7 +170,11 @@ class Warehouse(models.Model):
 
         # If another partner assigned
         if vals.get('partner_id'):
-            warehouses._update_partner_data(vals['partner_id'], vals.get('company_id'))
+            if vals.get('company_id'):
+                warehouses._update_partner_data(vals['partner_id'], vals.get('company_id'))
+            else:
+                for warehouse in self:
+                    warehouse._update_partner_data(vals['partner_id'], warehouse.company_id.id)
 
         res = super(Warehouse, self).write(vals)
 


### PR DESCRIPTION
- Install stock with demo data
- Log in Chicago company
- Chicago partner has inter-company transit set on Customer and Supplier
locations
- Jeff Lawson (partner address of chicago warehouse) has Customer and
supplier locations set instead of inter-company transit.

However if you log in San Francisco company Jeff Lawson has
inter-company transit set while it should not.

It happens because during the demo install the partner is added through
a write and the company is not provided and the code was missing a part
in that case.
