### PR TITLE
[FIX] hr_holidays: translate field names of form dialogs

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar.js
@@ -96,6 +96,7 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
                     context: {
                         'default_date_from': moment().format('YYYY-MM-DD'),
                         'default_date_to': moment().add(1, 'days').format('YYYY-MM-DD'),
+                        'lang': self.context.lang,
                     },
                     title: _t("New time off"),
                     disable_multiple_selection: true,
@@ -125,6 +126,7 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
                     view_id: ids,
                     context: {
                         'default_state': 'confirm',
+                        'lang': self.context.lang,
                     },
                     title: _t("New Allocation"),
                     disable_multiple_selection: true,

--- a/addons/hr_holidays/static/src/js/time_off_calendar_employee.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar_employee.js
@@ -193,6 +193,7 @@ odoo.define('hr_holidays.employee.dashboard.views', function(require) {
                         'default_employee_id': self.context.employee_id[0],
                         'default_date_from': moment().format('YYYY-MM-DD'),
                         'default_date_to': moment().add(1, 'days').format('YYYY-MM-DD'),
+                        'lang': self.context.lang,
                     },
                     title: _t("New time off"),
                     disable_multiple_selection: true,
@@ -223,6 +224,7 @@ odoo.define('hr_holidays.employee.dashboard.views', function(require) {
                     context: {
                         'default_employee_ids': self.context.employee_id,
                         'default_state': 'confirm',
+                        'lang': self.context.lang,
                     },
                     title: _t("New Allocation"),
                     disable_multiple_selection: true,


### PR DESCRIPTION
'New Time Off' and 'Allocation Request' dialogs were not translated to the user's language

Steps to reproduce:
1. Install the Time Off app
2. Go to General Settings, add a language and switch to it
3. Open the Time Off app and click on the button 'New Time Off' (which is now translated to the language you chose)
4. The field names of the dialog that opens are not translated

Solution:
Add the user's language to the context of the dialogs

OPW-2715396