### PR TITLE
[FIX] stock: solve traceback

### DIFF
--- a/addons/stock/models/stock_production_lot.py
+++ b/addons/stock/models/stock_production_lot.py
@@ -188,7 +188,7 @@ class ProductionLot(models.Model):
             })
         return action
 
-    def _find_delivery_ids_by_lot(self, lot_path=None):
+    def _find_delivery_ids_by_lot(self, lot_path=None, delivery_by_lot=None):
         if lot_path is None:
             lot_path = set()
 
@@ -198,7 +198,8 @@ class ProductionLot(models.Model):
             '|', ('picking_code', '=', 'outgoing'), ('produce_line_ids', '!=', False)
         ]
         move_lines = self.env['stock.move.line'].search(domain)
-        delivery_by_lot = dict()
+        if delivery_by_lot is None:
+            delivery_by_lot = dict()
         for lot in self:
             delivery_ids = set()
             if lot.id in lot_path:
@@ -208,7 +209,7 @@ class ProductionLot(models.Model):
                     # Do the same process for lot_id contained in produce_line_ids,
                     # to fetch the end product deliveries
                     lot_path.add(lot.id)
-                    for delivery_ids_set in line.produce_line_ids.lot_id._find_delivery_ids_by_lot(lot_path=lot_path).values():
+                    for delivery_ids_set in line.produce_line_ids.lot_id._find_delivery_ids_by_lot(lot_path=lot_path, delivery_by_lot=delivery_by_lot).values():
                         delivery_ids.update(delivery_ids_set)
                 else:
                     delivery_ids.add(line.picking_id.id)


### PR DESCRIPTION
After the commit #77895 if _find_delivery_ids_by_lot is calling by lot
with lot_path gone flush delivery_by_lot as it's not passed with
the calling.

issue to reproduce:
    open lot and serial number with group by category id, and try to
unfold category which lot have reproduced lines but not lot is there.
    steps: https://bit.ly/3qwFmKg

```
2021-12-28 09:22:14,914 3403132 ERROR 60316_upg odoo.http: Exception during JSON request handling.
Traceback (most recent call last):
  File "/home/hpr/src/odoo/15.0/odoo/api.py", line 886, in get
    return field_cache[record._ids[0]]
KeyError: 13

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/hpr/src/odoo/15.0/odoo/fields.py", line 1057, in __get__
    value = env.cache.get(record, self)
  File "/home/hpr/src/odoo/15.0/odoo/api.py", line 889, in get
    raise CacheMiss(record, field)
odoo.exceptions.CacheMiss: 'stock.production.lot(13,).last_delivery_partner_id'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/hpr/src/odoo/15.0/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/home/hpr/src/odoo/15.0/odoo/http.py", line 687, in dispatch
    result = self._call_function(**self.params)
  File "/home/hpr/src/odoo/15.0/odoo/http.py", line 359, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/hpr/src/odoo/15.0/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/hpr/src/odoo/15.0/odoo/http.py", line 348, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/hpr/src/odoo/15.0/odoo/http.py", line 916, in __call__
    return self.method(*args, **kw)
  File "/home/hpr/src/odoo/15.0/odoo/http.py", line 535, in response_wrap
    response = f(*args, **kw)
  File "/home/hpr/src/odoo/15.0/addons/web/controllers/main.py", line 1293, in search_read
    return self.do_search_read(model, fields, offset, limit, domain, sort)
  File "/home/hpr/src/odoo/15.0/addons/web/controllers/main.py", line 1312, in do_search_read
    return Model.web_search_read(domain, fields, offset=offset, limit=limit, order=sort)
  File "/home/hpr/src/odoo/15.0/addons/web/models/models.py", line 62, in web_search_read
    records = self.search_read(domain, fields, offset=offset, limit=limit, order=order)
  File "/home/hpr/src/odoo/15.0/odoo/models.py", line 5036, in search_read
    result = records.read(fields, **read_kwargs)
  File "/home/hpr/src/odoo/15.0/odoo/models.py", line 3227, in read
    return self._read_format(fnames=fields, load=load)
  File "/home/hpr/src/odoo/15.0/odoo/models.py", line 3247, in _read_format
    vals[name] = convert(record[name], record, use_name_get)
  File "/home/hpr/src/odoo/15.0/odoo/models.py", line 5874, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "/home/hpr/src/odoo/15.0/odoo/fields.py", line 2603, in __get__
    return super().__get__(records, owner)
  File "/home/hpr/src/odoo/15.0/odoo/fields.py", line 1106, in __get__
    self.compute_value(recs)
  File "/home/hpr/src/odoo/15.0/odoo/fields.py", line 1265, in compute_value
    records._compute_field_value(self)
  File "/home/hpr/src/odoo/15.0/addons/mail/models/mail_thread.py", line 410, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/hpr/src/odoo/15.0/odoo/models.py", line 4256, in _compute_field_value
    getattr(self, field.compute)()
  File "/home/hpr/src/odoo/15.0/addons/stock/models/stock_production_lot.py", line 124, in _compute_delivery_ids
    lot.delivery_ids = delivery_ids_by_lot[lot.id]
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/hpr/src/odoo/15.0/odoo/http.py", line 643, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/hpr/src/odoo/15.0/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
KeyError: 369
```

after this commit delivery_by_lot is passed with the present values so,
it'll not fluch in between recursion.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
