### PR TITLE
[FIX] purchase: no bulgarian for en_GB translation


### DIFF
--- a/addons/purchase/i18n/en_GB.po
+++ b/addons/purchase/i18n/en_GB.po
@@ -1401,7 +1401,7 @@ msgstr ""
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_order_notes
 msgid "Terms and Conditions"
-msgstr "Положения и условия"
+msgstr ""
 
 #. module: purchase
 #: model_terms:ir.actions.act_window,help:purchase.product_normal_action_puchased


### PR DESCRIPTION

The translation of purchase.order().notes name (Terms and Conditions) is
wrongly done in bulgarian since 2016
(d14efd562b4c6d8868662b104d9dcdce90456737).

opw-2719178
