### PR TITLE
[FIX] Youtube Uncaught TypeError: YT.Player is not a constructor

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -824,10 +824,12 @@ registry.backgroundVideo = publicWidget.Widget.extend({
         // YouTube does not allow to auto-play video in mobile devices, so we
         // have to play the video manually.
         if (this.isMobileEnv && this.isYoutubeVideo) {
-            new window.YT.Player(this.iframeID, {
-                events: {
-                    onReady: ev => ev.target.playVideo(),
-                }
+            window.YT.ready(() => {
+                new window.YT.Player(this.iframeID, {
+                    events: {
+                        onReady: ev => ev.target.playVideo(),
+                    }
+                });
             });
         }
     },


### PR DESCRIPTION
The problem was that users got an error when a website used a youtube autoplay video on the mobile phone.

Steps to reproduce:

1) Use a youtube video with autoplay on a website
2) Open the website with cleared cash on the mobile

After some searching, I found a working CodeSandbox sandbox, https://codesandbox.io/s/youtube-iframe-api-tpjwj, which used an undocumented API, YT.ready().

It seems to wait until the player instance is "ready."

So the fix is to wait within the callback of YT.ready.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
