### PR TITLE
[FIX] stock: display forecasted quantity with correct precision

### DIFF
--- a/addons/stock/report/report_stock_forecasted.xml
+++ b/addons/stock/report/report_stock_forecasted.xml
@@ -129,7 +129,7 @@
                             <td t-esc="line['receipt_date'] or ''"
                                 t-attf-class="#{line['is_late'] and 'o_grid_warning'}"/>
                             <td t-if="docs['multiple_product']" t-esc="line['product']['display_name']"/>
-                            <td class="text-right"><t t-if="not line['replenishment_filled']">- </t><t t-esc="line['quantity']"/></td>
+                            <td class="text-right"><t t-if="not line['replenishment_filled']">- </t><t t-esc="line['quantity']" t-options='{"widget": "float", "decimal_precision": "Product Unit of Measure"}'/></td>
                             <td t-esc="line['uom_id'].name" groups="uom.group_uom"/>
                             <td t-attf-class="#{not line['replenishment_filled'] and 'o_grid_warning'}">
                                 <a t-if="line['document_out']"


### PR DESCRIPTION
The quantity of the forecasted report was displayed without any precision specified

Steps to reproduce:
1. Install the Stock and Sales apps
2. Create a storable product
3. Create a quotation for this product with a quantity of 1.63
4. Confirm the quotation
5. Go to the product and open the forecasted report
6. The 'Not Available' quantity is -1.6300000000000001 instead of -1.63

Solution:
Specify the widget and decimal precision used for the quantity

OPW-2713548