### PR TITLE
[FIX] account : apply analytic rule on invoice

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -546,10 +546,11 @@ class SaleOrderLine(models.Model):
             'discount': self.discount,
             'price_unit': self.price_unit,
             'tax_ids': [(6, 0, self.tax_id.ids)],
-            'analytic_account_id': self.order_id.analytic_account_id.id,
             'analytic_tag_ids': [(6, 0, self.analytic_tag_ids.ids)],
             'sale_line_ids': [(4, self.id)],
         }
+        if self.order_id.analytic_account_id:
+            res['analytic_account_id'] = self.order_id.analytic_account_id.id
         if optional_values:
             res.update(optional_values)
         if self.display_type:

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -354,7 +354,7 @@ class SaleOrderLine(models.Model):
             to this sale order line, or the analytic account of the project which uses this sale order line, if it exists.
         """
         values = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
-        if not values['analytic_account_id']:
+        if not values.get('analytic_account_id'):
             if self.task_id.analytic_account_id:
                 values['analytic_account_id'] = self.task_id._get_task_analytic_account_id().id
             elif self.project_id.analytic_account_id:


### PR DESCRIPTION
Steps:
- Create an Analytic Account AA
- Create an Analytic Default Rule : when Product P > AA
- Create a Quotation including P, confirm and invoice

Issue:
- AA is not set for the invoice line of P

Cause:
- AA is computed on the invoice line when the product is added,
	but it is recomputed afterward from cache, where it is None

Fix:
- Not allow it to be recomputed afterward.

opw-2714340

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
