### PR TITLE
[FIX] payment_authorize: show detailed transaction error messages

### DIFF
--- a/addons/payment_authorize/models/authorize_request.py
+++ b/addons/payment_authorize/models/authorize_request.py
@@ -58,9 +58,17 @@ class AuthorizeAPI:
 
         messages = response.get('messages')
         if messages and messages.get('resultCode') == 'Error':
+            err_msg = messages.get('message')[0].get('text', '')
+
+            tx_errors = response.get('transactionResponse', {}).get('errors')
+            if tx_errors:
+                if err_msg:
+                    err_msg += '\n'
+                err_msg += '\n'.join([e.get('errorText', '') for e in tx_errors])
+
             return {
                 'err_code': messages.get('message')[0].get('code'),
-                'err_msg': messages.get('message')[0].get('text')
+                'err_msg': err_msg,
             }
 
         return response


### PR DESCRIPTION
createTransactionRequests can return responses like this:

```
{'messages': {'message': [{'code': 'E00027',
                          'text': 'The transaction was unsuccessful.'}],
             'resultCode': 'Error'},
'transactionResponse': {'SupplementalDataQualificationIndicator': 0,
                        'accountNumber': 'XXXXXXXX',
                        'accountType': 'eCheck',
                        'authCode': '',
                        'avsResultCode': 'P',
                        'cavvResultCode': '',
                        'cvvResultCode': '',
                        'errors': [{'errorCode': '33',
                                    'errorText': 'Bill To Address is '
                                                 'required.'},
                                   {'errorCode': '33',
                                    'errorText': 'Bill To State/Province is '
                                                 'required.'}],
                        'refTransID': '',
                        'responseCode': '3',
                        'testRequest': '0',
                        'transHash': '',
                        'transHashSha2': 'xxx',
                        'transId': '0'}}
```

_make_request() threw out the detailed errors ("Bill To Address is
required" and "Bill to State/Province is required") and only returned:

```
{
  'err_code': 'E00027',
  'err_msg': 'The transaction was unsuccessful.'
}
```

which results in the following vague error on an SO:

```
  The transaction with reference SO1111/1111111 for US$ 100.00
  encountered an error (Authorize.net). Error: Authorize.Net: Received
  data with status code "3" and error code "The transaction was
  unsuccessful."
```

This commit extracts the transaction errors and appends them to
'err_msg'. After this commit the above response results in this chatter:

```
  The transaction with reference SO1111/1111111 for $ 100.00
  encountered an error (Authorize.net). Error: Authorize.Net: Received
  data with status code "3" and error code "The transaction was
  unsuccessful. Bill To Address is required. Bill To State/Province is
  required."
```
Ideally the error handling logic would be rewritten so that
_make_request() doesn't handle specific errors like this. But changing
it is too high risk in a stable release.

opw-2718318