### PR TITLE
[IMP] l10n_in: simplify place of supply

### DIFF
--- a/addons/l10n_in/data/res_country_state_data.xml
+++ b/addons/l10n_in/data/res_country_state_data.xml
@@ -8,6 +8,13 @@
         <field name="l10n_in_tin">97</field>
     </record>
 
+    <record id="state_in_oc" model="res.country.state">
+        <field name="name">Other Country</field>
+        <field name="code">IN_OC</field>
+        <field name="country_id" ref="base.in"/>
+        <field name="l10n_in_tin">96</field>
+    </record>
+
     <record id="base.state_in_an" model="res.country.state">
         <field name="l10n_in_tin">35</field>
     </record>

--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -7,6 +7,8 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='ref']" position="after">
                 <field name="country_code" invisible="1"/>
+                <field name="l10n_in_state_id"
+                    attrs="{'invisible': ['|', ('country_code', '!=', 'IN'), ('move_type', '=', 'entry')], 'required': [('country_code', '=', 'IN'), ('move_type', '!=', 'entry')], 'readonly': [('state', '!=', 'draft')]}"/>
                 <field name="l10n_in_gst_treatment"
                     attrs="{'invisible': ['|', ('country_code', '!=', 'IN'), ('move_type', '=', 'entry')], 'required': [('country_code', '=', 'IN'), ('move_type', '!=', 'entry')], 'readonly': [('state', '!=', 'draft')]}"/>
             </xpath>

--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -6,12 +6,7 @@
         </xpath>
         <xpath expr="//t[@t-set='address']" position="inside">
             <t t-if="o.company_id.account_fiscal_country_id.code == 'IN' and o.l10n_in_state_id" class="mt16">
-                <t t-if="o.move_type in ('in_invoice', 'in_refund')">
-                    Destination of supply: <span t-esc="o.l10n_in_state_id.name"/>
-                </t>
-                <t t-if="o.move_type in ('out_invoice', 'out_refund')">
-                    Place of supply: <span t-esc="o.l10n_in_state_id.name"/>
-                </t>
+                Place of supply: <span t-esc="o.l10n_in_state_id.name"/>
             </t>
         </xpath>
         <xpath expr="//div[@t-if='not is_html_empty(o.narration)']" position="before">


### PR DESCRIPTION
We just set a place of supply from partner_id in the Invoice/Bill because there are many complex cases so we can't get it automatically in all cases like
(a) where the supply involves movement of goods, whether by the supplier or
the recipient or by any other person, the place of supply of such goods shall be the
location of the goods at the time at which the movement of goods terminates for
delivery to the recipient;

(b) where the goods are delivered by the supplier to a recipient or any other
person on the direction of a third person, whether acting as an agent or otherwise,
before or during movement of goods, either by way of transfer of documents of title
to the goods or otherwise, it shall be deemed that the said third person has received
the goods and the place of supply of such goods shall be the principal place of business
of such person;

(c) where the supply does not involve movement of goods, whether by the
supplier or the recipient, the place of supply shall be the location of such goods at the
time of the delivery to the recipient;

(d) where the goods are assembled or installed at site, the place of supply shall
be the place of such installation or assembly;

(e) where the goods are supplied on board a conveyance, including a vessel, an
aircraft, a train or a motor vehicle, the place of supply shall be the location at which
such goods are taken on board.

for more details check CHAPTER V here https://www.cbic.gov.in/resources//htdocs-cbec/gst/igst-act.pdf;jsessionid=63D695F612B9972934E8131415FEBA28


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
