### PR TITLE
[FIX] hr_holidays: fix end of year error

### DIFF
--- a/addons/hr_holidays/tests/test_holidays_flow.py
+++ b/addons/hr_holidays/tests/test_holidays_flow.py
@@ -99,7 +99,6 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp_id,
                 'state': 'validate',
                 'date_from': time.strftime('%Y-%m-01'),
-                'date_to': time.strftime('%Y-12-31'),
             }, {
                 'name': 'Paid Time off for David',
                 'holiday_status_id': holiday_status_paid_time_off.id,
@@ -107,7 +106,6 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
                 'employee_id': self.ref('hr.employee_admin'),
                 'state': 'validate',
                 'date_from': time.strftime('%Y-%m-01'),
-                'date_to': time.strftime('%Y-12-31'),
             }
         ])
 
@@ -145,7 +143,6 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             'number_of_days': 2,
             'state': 'confirm',
             'date_from': time.strftime('%Y-%m-01'),
-            'date_to': time.strftime('%Y-12-31'),
         })
         # HrUser validates the first step
 


### PR DESCRIPTION
Fixes an error happening near the end of the year with one of the test.
The error was introduced with 254d6a71e8d5e7bdf8b302d774e024646921b72d

TaskId-2724172