### PR TITLE
[FIX] calendar: Error stop displaying private name

### DIFF
--- a/addons/calendar/models/calendar.py
+++ b/addons/calendar/models/calendar.py
@@ -1730,6 +1730,21 @@ class Meeting(models.Model):
                     del r[k]
         return result
 
+    def name_get(self):
+        """ Hide private events' name for events which don't belong to the current user
+        """
+        hidden = self.filtered(
+            lambda evt:
+                evt.privacy == 'private' and
+                evt.user_id.id != self.env.uid and
+                self.env.user.partner_id not in evt.partner_ids
+        )
+
+        shown = self - hidden
+        shown_names = super(Meeting, shown).name_get()
+        obfuscated_names = [(eid, _('Busy')) for eid in hidden.ids]
+        return shown_names + obfuscated_names
+
     def unlink(self, can_be_deleted=True):
         # Get concerned attendees to notify them if there is an alarm on the unlinked events,
         # as it might have changed their next event notification


### PR DESCRIPTION
Step to reproduce:
- Two internal users, A and B
- As A, create a calendar event and set its privacy to private
- As B, display everybody's calendar
- Double click on the private event created by A
- Click on save

Current Behaviour:
- True name is shown as part of the error

Behaviour After PR:
- For private event not related to the users, 'Busy' or its translation is shown to the user

opw-2723904

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
