### PR TITLE
[FIX] mail: Message from mailing channel should mark as seen

### DIFF
--- a/addons/mail/static/src/components/thread_preview/thread_preview.xml
+++ b/addons/mail/static/src/components/thread_preview/thread_preview.xml
@@ -28,7 +28,7 @@
                         <span class="o_ThreadPreview_name" t-att-class="{ 'o-mobile': env.messaging.device.isMobile, 'o-muted': thread.localMessageUnreadCounter === 0 }">
                             <t t-esc="thread.displayName"/>
                         </span>
-                        <t t-if="thread.localMessageUnreadCounter > 0">
+                        <t t-if="thread.displayCounter > 0">
                             <span class="o_ThreadPreview_counter" t-att-class="{ 'o-muted': thread.localMessageUnreadCounter === 0 }">
                                 (<t t-esc="thread.localMessageUnreadCounter"/>)
                             </span>

--- a/addons/mail/static/src/models/messaging_menu/messaging_menu.js
+++ b/addons/mail/static/src/models/messaging_menu/messaging_menu.js
@@ -63,7 +63,7 @@ function factory(dependencies) {
             }
             const inboxMailbox = this.env.messaging.inbox;
             const unreadChannels = this.env.models['mail.thread'].all(thread =>
-                thread.localMessageUnreadCounter > 0 &&
+                thread.displayCounter > 0 &&
                 thread.model === 'mail.channel' &&
                 thread.isPinned
             );

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1203,6 +1203,17 @@ function factory(dependencies) {
 
         /**
          * @private
+         * @returns {integer}
+         */
+        _computeDisplayCounter() {
+            if (this.mass_mailing && this.env.session.notification_type === 'email') {
+                return 0;
+            }
+            return this.localMessageUnreadCounter;
+        }
+
+        /**
+         * @private
          * @returns {string}
          */
         _computeDisplayName() {
@@ -1858,6 +1869,16 @@ function factory(dependencies) {
         }),
         creator: many2one('mail.user'),
         custom_channel_name: attr(),
+        /**
+         * Determines whether counter should be displayed or not.
+         */
+        displayCounter: attr({
+            compute: '_computeDisplayCounter',
+            dependencies: [
+                'localMessageUnreadCounter',
+                'mass_mailing',
+            ],
+        }),
         displayName: attr({
             compute: '_computeDisplayName',
             dependencies: [


### PR DESCRIPTION
currently,
Message from mailing channel make a notification in Odoo for users
with notification "Handled by Email" when user is not log-in. this is happening
because mailing channel is marked ans seen from
"messaging_notification_handler.js" which is not executed when user is not
log-in and receive message so message counter is increase when user log-in.

after this commit,
Message from mailing channel should mark as seen at client side in Odoo for
users with notification "Handled by Email". to achieve that mark mailing channel
as seen if user has notification "Handled by Email" from "thread.js" when
unread-message counter is calculated.

TaskId-2541660
