### PR TITLE
[IMP] sale: Prevent user to hide description column in SO

### DIFF
--- a/addons/account/static/src/js/section_and_note_fields_backend.js
+++ b/addons/account/static/src/js/section_and_note_fields_backend.js
@@ -25,6 +25,10 @@ var SectionAndNoteListRenderer = ListRenderer.extend({
         var isSection = record.data.display_type === 'line_section';
         var isNote = record.data.display_type === 'line_note';
 
+        if (node.attrs.name === "name") {
+            $cell.attr("title", record.data.name);
+        }
+
         if (isSection || isNote) {
             if (node.attrs.widget === "handle") {
                 return $cell;

--- a/addons/account/static/src/scss/section_and_note_backend.scss
+++ b/addons/account/static/src/scss/section_and_note_backend.scss
@@ -17,6 +17,13 @@ table.o_section_and_note_list_view tr.o_data_row.o_is_line_section {
     border-bottom: 1px solid #BBB;
 }
 
+table.o_section_and_note_list_view tr.o_data_row td.o_data_cell.o_field_cell span.o_field_text {
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 table.o_section_and_note_list_view tr.o_data_row {
     &.o_is_line_note,
     &.o_is_line_section {

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -425,7 +425,7 @@
                                     }"
                                     domain="[('sale_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"
                                     widget="product_configurator"/>
-                                <field name="name" widget="section_and_note_text" optional="show"/>
+                                <field name="name" widget="section_and_note_text"/>
                                 <field
                                     name="analytic_tag_ids"
                                     optional="hide"


### PR DESCRIPTION
Currently, deselecting the 'Description' field on the sale order lines
will result in hiding both section names and notes names, a buggy behavior.
After this modification the 'Description' column will no longer be optional.

Task - 2711604

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
