### PR TITLE
[imp] web:reduce two rpc to one

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -2911,31 +2911,15 @@ var BasicModel = AbstractModel.extend({
             return Promise.resolve();
         }
 
-        var self = this;
         return this._rpc({
                 model: field.relation,
                 method: 'search_read',
-                fields: ["id"].concat(fieldsToRead || []),
+                fields: ["id", "display_name"].concat(fieldsToRead || []),
                 context: context,
                 domain: domain,
             })
             .then(function (records) {
-                var ids = _.pluck(records, 'id');
-                return self._rpc({
-                        model: field.relation,
-                        method: 'name_get',
-                        args: [ids],
-                        context: context,
-                    })
-                    .then(function (name_gets) {
-                        _.each(records, function (rec) {
-                            var name_get = _.find(name_gets, function (n) {
-                                return n[0] === rec.id;
-                            });
-                            rec.display_name = name_get[1];
-                        });
-                        return records;
-                    });
+                return records;
             });
     },
     /**

--- a/addons/web/static/tests/legacy/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields_tests.js
@@ -782,7 +782,7 @@ QUnit.module('relational_fields', {
         });
 
         assert.strictEqual(count, 1, 'once search_read should have been done to fetch the relational values');
-        assert.strictEqual(nb_fields_fetched, 1, 'search_read should only fetch field id');
+        assert.strictEqual(nb_fields_fetched, 2, 'search_read should only fetch field id and display name');
         assert.containsN(form, '.o_statusbar_status button:not(.dropdown-toggle)', 2);
         assert.containsN(form, '.o_statusbar_status button:disabled', 2);
         assert.hasClass(form.$('.o_statusbar_status button[data-value="4"]'), 'btn-primary');


### PR DESCRIPTION
in _fetchSpecialMany2ones method there was consecutive rpc call of search_read
and name_get.instead  of pass 'id' in field pass 'dispaly_name' in search_read rpc.

Id-2724201

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
