### PR TITLE
[IMP] l10n_in: Add Non GST Supplies and State CESS tax report line

### DIFF
--- a/addons/l10n_in/data/account_tax_group_data.xml
+++ b/addons/l10n_in/data/account_tax_group_data.xml
@@ -29,5 +29,9 @@
             <field name="name">Nil Rated</field>
             <field name="country_id" ref="base.in"/>
         </record>
+        <record id="non_gst_supplies_group" model="account.tax.group">
+            <field name="name">Non GST Supplies</field>
+            <field name="country_id" ref="base.in"/>
+        </record>
     </data>
 </odoo>

--- a/addons/l10n_in/data/account_tax_template_data.xml
+++ b/addons/l10n_in/data/account_tax_template_data.xml
@@ -75,6 +75,17 @@
                         <field name="tag_name">Zero Rated</field>
                         <field name="sequence">7</field>
                     </record>
+                    <record id="tax_report_line_non_gst_supplies" model="account.tax.report.line">
+                        <field name="name">Non GST Supplies</field>
+                        <field name="tag_name">Non GST Supplies</field>
+                        <field name="sequence">8</field>
+                    </record>
+                    <!-- The government can impose CESS for purposes such as disaster relief in specific states. So not tax link with this, If government add CESS in specific states then use this in repartition lines-->
+                    <record id="tax_report_line_state_cess" model="account.tax.report.line">
+                        <field name="name">State CESS</field>
+                        <field name="tag_name">State CESS</field>
+                        <field name="sequence">9</field>
+                    </record>
                 </field>
             </record>
         </field>
@@ -146,6 +157,17 @@ if tax &gt; result:result=tax</field>
         <field name="tax_group_id" ref="nil_rated_group"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',                 'plus_report_line_ids': [ref('tax_report_line_nil_rated')],              }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',              }),         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',                 'minus_report_line_ids': [ref('tax_report_line_nil_rated')],             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',              }),         ]"/>
+    </record>
+    <record id="nil_rated_sale" model="account.tax.template">
+        <field name="name">Non GST Supplies</field>
+        <field name="description">Non GST Supplies</field>
+        <field name="type_tax_use">sale</field>
+        <field name="amount_type">percent</field>
+        <field name="amount">0</field>
+        <field name="chart_template_id" ref="indian_chart_template_standard"/>
+        <field name="tax_group_id" ref="non_gst_supplies_group"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',                 'plus_report_line_ids': [ref('tax_report_line_non_gst_supplies')],              }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',              }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',                 'minus_report_line_ids': [ref('tax_report_line_non_gst_supplies')],             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',              }),         ]"/>
     </record>
     <record id="igst_sale_0" model="account.tax.template">
         <field name="name">IGST 0%</field>


### PR DESCRIPTION
Non-GST Supplies and State CESS is required to get related value from the invoice for reporting purpose


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
