### PR TITLE
[FIX] web_editor: re-encourage to use snippets in empty oe_structure

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1304,6 +1304,13 @@ var SnippetsMenu = Widget.extend({
             if ($target.closest(this._notActivableElementsSelector).length) {
                 return;
             }
+            const $oeStructure = $target.closest('.oe_structure');
+            if ($oeStructure.length && !$oeStructure.children().length && this.$snippets) {
+                // If empty oe_structure, encourage using snippets in there by
+                // making them "wizz" in the panel.
+                this.$snippets.odooBounce();
+                return;
+            }
             this._activateSnippet($target);
         };
 


### PR DESCRIPTION
This commit re-applies the commit that was merged at [1] but whose
code was lost during Jabberwock revert at [2].

Make the draggable snippets "wizz" when the user clicks on an empty
oe_structure.

[1]: https://github.com/odoo/odoo/commit/3ed3537abd416ebc35f8bc2ee65f209840c071bf
[2]: https://github.com/odoo/odoo/commit/e5572c317a7775a58675ed73efc89b5c9f6c0c39

Related to task-2363616
