### PR TITLE
[FIX] base: error raised when automated action with many2many field and reference evaluation

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -14144,6 +14144,12 @@ msgid "Invalid model name %r in action definition."
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_actions.py:611
+#, python-format
+msgid "many2many fields cannot be evaluated by reference"
+msgstr ""
+
+#. module: base
 #: code:addons/template_inheritance.py:0
 #, python-format
 msgid "Invalid position attribute: '%s'"

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -604,6 +604,11 @@ class IrServerObjectLines(models.Model):
             else:
                 line.resource_ref = False
 
+    @api.constrains('col1', 'evaluation_type')
+    def _raise_many2many_error(self):
+        if self.filtered(lambda line: line.col1.ttype == 'many2many' and line.evaluation_type == 'reference'):
+            raise ValidationError(_('many2many fields cannot be evaluated by reference'))
+
     @api.onchange('resource_ref')
     def _set_resource_ref(self):
         for line in self.filtered(lambda line: line.evaluation_type == 'reference'):


### PR DESCRIPTION
Automated action with a many2many field and reference evaluation can be created but don't work

Steps to reproduce:
1. Install Automated Action Rules module and Contacts app
2. Create an automated action for model 'Contact' with trigger 'On Creation' and action 'Update the Record'
3. Add a line to the automated action 'Data to Write' for the field 'Tags (res.partner)' with evaluation type 'Reference'
4. Go to Contacts, create and save a new one
5. An error is raised when trying to execute the automated action

Solution:
Raise an error when a many2many field is of evaluation type 'Reference'

OPW-2673939