### PR TITLE
[FIX] hr_holidays : allow user to submit past sick days

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -203,8 +203,8 @@ class HolidaysRequest(models.Model):
     # To display in form view
     supported_attachment_ids = fields.Many2many(
         'ir.attachment', string="Attach File", compute='_compute_supported_attachment_ids',
-        inverse='_inverse_supported_attachment_ids')
-    supported_attachment_ids_count = fields.Integer(compute='_compute_supported_attachment_ids')
+        inverse='_inverse_supported_attachment_ids', compute_sudo=True)
+    supported_attachment_ids_count = fields.Integer(compute='_compute_supported_attachment_ids', compute_sudo=True)
     # UX fields
     leave_type_request_unit = fields.Selection(related='holiday_status_id.request_unit', readonly=True)
     leave_type_support_document = fields.Boolean(related="holiday_status_id.support_document")
@@ -630,7 +630,7 @@ class HolidaysRequest(models.Model):
 
     def _inverse_supported_attachment_ids(self):
         for holiday in self:
-            holiday.attachment_ids = holiday.supported_attachment_ids
+            holiday.sudo().attachment_ids = holiday.supported_attachment_ids
 
     @api.constrains('date_from', 'date_to', 'employee_id')
     def _check_date(self):


### PR DESCRIPTION
Steps:
- Users > Admin > Acces Rights > Human Resources
	-  Time Off : empty
- Time Off > a past day > Time Off Request wizard :
	- Time Off Type :  Sick Time Off
- Confirm

Issue:
- User Error : 'You must have manager rights to modify/validate a time off that already begun'

Cause:
- When creating the request, attachments are writen onto the record.
- Yet the user do not have rights to write in hr_holidays.

Fix:
- sudo in the compute and inverse methods that write the attachments.

opw-2714597

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
