### PR TITLE
[FIX] calendar: Unable to create a meeting edited from a lead

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -902,7 +902,6 @@ class Lead(models.Model):
             'default_opportunity_id': current_opportunity_id,
             'default_partner_id': self.partner_id.id,
             'default_partner_ids': partner_ids,
-            'default_attendee_ids': [(0, 0, {'partner_id': pid}) for pid in partner_ids],
             'default_team_id': self.team_id.id,
             'default_name': self.name,
         }


### PR DESCRIPTION
PS: Florian has made a PR that fix the issue: https://github.com/odoo/odoo/pull/82286 (thanks to him).

Description of the issue/feature this PR addresses:

1) go on any lead
2) go on the smart button meeting
3) create a new meeting and edit it
4) save → An user error is raised while it's a pretty standard workflow

Current behavior before PR:
When we try to edit a meeting which is being created from a lead. There is an error because the field partner_id is empty, and it's set to NOT NULL in the db.

Desired behavior after PR is merged:
It should be possible to create and edit a meeting linked to a lead.

BUT, it seems that's in conflict with this commit:
https://github.com/odoo/odoo/commit/365459804b4f9a59abf4b6e90c1100f3d0a9eb9a (and recreate the bug associate)

And my first attempt was to remove `and 'attendee_ids' not in vals` here: https://github.com/odoo/odoo/blob/14.0/addons/calendar/models/calendar_event.py#L714
But it's also in conflict with this: https://github.com/odoo/odoo/pull/79313/files#diff-6c4c124bfb9e4397bed7221c7534c8f877904775e9db4cf81f72b5430b36ad06R714 (and recreate the bug associate)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
