### PR TITLE
[FIX] survey: cookie managements for reloading answer

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -223,10 +223,11 @@ class Survey(http.Controller):
 
         access_data = self._get_access_data(survey_token, answer_token, ensure_token=False)
 
-        if answer_from_cookie and access_data['validity_code'] == 'answer_wrong_user':
-            # The cookie had been generated for another user; ignore this answer and redo the check.
-            answer_token = None
-            access_data = self._get_access_data(survey_token, answer_token, ensure_token=False)
+        if answer_from_cookie and access_data['validity_code'] in ('answer_wrong_user', 'token_wrong'):
+            # If the cookie had been generated for another user or does not correspond to any existing answer object
+            # (probably because it has been deleted), ignore it and redo the check.
+            # The cookie will be replaced by a legit value when resolving the URL, so we don't clean it further here.
+            access_data = self._get_access_data(survey_token, None, ensure_token=False)
 
         if access_data['validity_code'] is not True:
             return self._redirect_with_error(access_data, access_data['validity_code'])


### PR DESCRIPTION
[FIX] survey: Don't load answer from other user if a cookie exists 

To reproduce the issue:

1) Create a survey requiring user login, with multiple pages

2) Create portal user A and B

3) With user A, go to URL /survey/start/****, where **** is the access token of your test survey. Fill in the first pages of the survey, but don't finish your submission (so: the answer has to stay 'in progress').

4) Logout from user A.

5) From the same browser window (or without cleaning cookies, at least), directly login with user B, and go to the same /survey/start/**** link

====> The 'in progress' answer from A is loaded, even though we are connected with B and should hence not have access to it. Instead, we should have created a new blank answer for B.

This is due to our cookie management. When a cookie is kept in the browser with the token of a previously entered answer, we reload it without checking its owner.



[FIX] survey: Avoid forbidding access to survey when the answer cookie corresponds to no actual answer

To reproduce:

1) Create a survey and open it with a portal user with its /survey/start/*** link

2) In a private window, connect as the admin and remove the answer in 'Not started yet' state that step 1 created.

3) Go back to your portal user window and re-enter the same /survey/start/*** URL.
==> The portal user is brought back to the home page. He has no way to access the survey anymore, the link will always redirect him there.

This is because of cookies. The first time the user opens the survey, it creates a cookie in his browser allowing him to reload the answer he was working on. In our example, this answer has been deleted for some reason (maybe some cleaning of too old 'not started' or 'in progress' stuff); so the token stored in the cookie does not correspond to anything anymore. Instead of crashing and redirecting to home page, this commit makes it so that we now ignore the cookie in that case, so that the user directly has access to the survey to build a new answer.


Task-2729738