### PR TITLE
[FIX] web: Fix access right issues on external layout prining

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -533,7 +533,7 @@
             </t>
         </t>
 
-        <t t-if="company.external_report_layout_id" t-call="{{company.external_report_layout_id.key}}"><t t-raw="0"/></t>
+        <t t-if="company.external_report_layout_id" t-call="{{company.external_report_layout_id.sudo().key}}"><t t-raw="0"/></t>
         <t t-else="else" t-call="web.external_layout_standard"><t t-raw="0"/></t>
 
     </template>


### PR DESCRIPTION
Backport of 3891ab34740a8 to 14.0 following f2c1ee5a622
It was not possible to print payslip report

Purpose

If the user doesn't have access to ir.ui.view (aka no admin or
website access rights), printing a report with a configured
external layout will lead to a traceback, as it's forbidden
for the use to read on the field "key" on the related ir.ui.view.

As we only want to retrieve the view key, this is safe to use
sudo at that point.

Fixes odoo/odoo#81960
