### PR TITLE
[IMP] l10n_pt: taxes for islands

### DIFF
--- a/addons/l10n_pt/data/account_data.xml
+++ b/addons/l10n_pt/data/account_data.xml
@@ -6,11 +6,29 @@
         <record id="tax_group_iva_0" model="account.tax.group">
             <field name="name">IVA 0%</field>
         </record>
+        <record id="tax_group_iva_4" model="account.tax.group">
+            <field name="name">IVA 4%</field>
+        </record>
+        <record id="tax_group_iva_5" model="account.tax.group">
+            <field name="name">IVA 5%</field>
+        </record>
         <record id="tax_group_iva_6" model="account.tax.group">
             <field name="name">IVA 6%</field>
         </record>
+        <record id="tax_group_iva_9" model="account.tax.group">
+            <field name="name">IVA 9%</field>
+        </record>
+        <record id="tax_group_iva_12" model="account.tax.group">
+            <field name="name">IVA 12%</field>
+        </record>
         <record id="tax_group_iva_13" model="account.tax.group">
             <field name="name">IVA 13%</field>
+        </record>
+        <record id="tax_group_iva_16" model="account.tax.group">
+            <field name="name">IVA 16%</field>
+        </record>
+        <record id="tax_group_iva_22" model="account.tax.group">
+            <field name="name">IVA 22%</field>
         </record>
         <record id="tax_group_iva_23" model="account.tax.group">
             <field name="name">IVA 23%</field>

--- a/addons/l10n_pt/data/account_tax_data.xml
+++ b/addons/l10n_pt/data/account_tax_data.xml
@@ -5,7 +5,7 @@
         <record id="iva23" model="account.tax.template">
             <field name="chart_template_id" ref="pt_chart_template"/>
             <field name="name">IVA23</field>
-            <field name="description">IVA23</field>
+            <field name="description">IVA23 (taxa normal Portugal Continental)</field>
             <field name="amount">23</field>
             <field name="amount_type">percent</field>
             <field name="tax_group_id" ref="tax_group_iva_23"/>
@@ -33,10 +33,72 @@
             ]"/>
         </record>
 
+        <record id="iva22" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA22</field>
+            <field name="description">IVA22 (taxa normal Madeira)</field>
+            <field name="amount">22</field>
+            <field name="amount_type">percent</field>
+            <field name="tax_group_id" ref="tax_group_iva_22"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+        </record>
+
+        <record id="iva16" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA16</field>
+            <field name="description">IVA16 (taxa normal Açores)</field>
+            <field name="amount">16</field>
+            <field name="amount_type">percent</field>
+            <field name="tax_group_id" ref="tax_group_iva_16"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+        </record>
+
         <record id="iva13" model="account.tax.template">
             <field name="chart_template_id" ref="pt_chart_template"/>
             <field name="name">IVA13</field>
-            <field name="description">IVA13</field>
+            <field name="description">IVA13 (taxa intermédia Portugal Continental)</field>
             <field name="amount">13</field>
             <field name="amount_type">percent</field>
             <field name="tax_group_id" ref="tax_group_iva_13"/>
@@ -64,13 +126,137 @@
             ]"/>
         </record>
 
+        <record id="iva12" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA12</field>
+            <field name="description">IVA12 (taxa intermédia Madeira)</field>
+            <field name="amount">12</field>
+            <field name="amount_type">percent</field>
+            <field name="tax_group_id" ref="tax_group_iva_12"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+        </record>
+
+        <record id="iva9" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA9</field>
+            <field name="description">IVA9 (taxa intermédia Açores)</field>
+            <field name="amount">9</field>
+            <field name="amount_type">percent</field>
+            <field name="tax_group_id" ref="tax_group_iva_9"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+        </record>
+
         <record id="iva6" model="account.tax.template">
             <field name="chart_template_id" ref="pt_chart_template"/>
             <field name="name">IVA6</field>
-            <field name="description">IVA6</field>
+            <field name="description">IVA6 (taxa reduzida Portugal Continental)</field>
             <field name="amount">6</field>
             <field name="amount_type">percent</field>
             <field name="tax_group_id" ref="tax_group_iva_6"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+        </record>
+
+        <record id="iva5" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA5</field>
+            <field name="description">IVA5 (taxa reduzida Madeira)</field>
+            <field name="amount">5</field>
+            <field name="amount_type">percent</field>
+            <field name="tax_group_id" ref="tax_group_iva_5"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+        </record>
+
+        <record id="iva4" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA4</field>
+            <field name="description">IVA4 (taxa reduzida Açores)</field>
+            <field name="amount">4</field>
+            <field name="amount_type">percent</field>
+            <field name="tax_group_id" ref="tax_group_iva_4"/>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
@@ -129,7 +315,7 @@
         <record id="compiva23" model="account.tax.template">
             <field name="chart_template_id" ref="pt_chart_template"/>
             <field name="name">IVA23 compra</field>
-            <field name="description">IVA23 compra</field>
+            <field name="description">IVA23 compra (taxa normal Portugal Continental)</field>
             <field name="amount">23</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -157,11 +343,75 @@
                 }),
             ]"/>
         </record>
+        
+        <record id="compiva22" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA22 compra</field>
+            <field name="description">IVA22 compra (taxa normal Madeira)</field>
+            <field name="amount">22</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_iva_22"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+        </record>
+        
+        <record id="compiva16" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA16 compra</field>
+            <field name="description">IVA16 compra (taxa normal Açores)</field>
+            <field name="amount">16</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_iva_16"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+        </record>
 
         <record id="compiva13" model="account.tax.template">
             <field name="chart_template_id" ref="pt_chart_template"/>
             <field name="name">IVA13 compra</field>
-            <field name="description">IVA13 compra</field>
+            <field name="description">IVA13 compra (taxa intermédia Portugal Continental)</field>
             <field name="amount">13</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -190,14 +440,142 @@
             ]"/>
         </record>
 
+        <record id="compiva12" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA12 compra</field>
+            <field name="description">IVA12 compra (taxa intermédia Madeira)</field>
+            <field name="amount">12</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_iva_12"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva9" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA9 compra</field>
+            <field name="description">IVA9 compra (taxa intermédia Açores)</field>
+            <field name="amount">9</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_iva_9"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+        </record>
+
         <record id="compiva6" model="account.tax.template">
             <field name="chart_template_id" ref="pt_chart_template"/>
             <field name="name">IVA6 compra</field>
-            <field name="description">IVA6 compra</field>
+            <field name="description">IVA6 compra (taxa reduzida Portugal Continental)</field>
             <field name="amount">6</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_iva_6"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva5" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA5 compra</field>
+            <field name="description">IVA5 compra (taxa reduzida Madeira)</field>
+            <field name="amount">5</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_iva_5"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva4" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA4 compra</field>
+            <field name="description">IVA4 compra (taxa reduzida Açores)</field>
+            <field name="amount">4</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_iva_4"/>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,


### PR DESCRIPTION
This PR adds the taxes values for the Portuguese islands (Madeira and Açores).

The values are taken from https://www.economias.pt/valor-do-iva-em-portugal
However the link is not up to date as the normal tax of the Açores has been modified on the 1st July 2021 as mentioned https://portal.azores.gov.pt/web/comunicacao/news-detail?id=3829054

task-2674543