### PR TITLE
[FIX] web_editor: remove rename button from custom snippet on drag

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2358,7 +2358,7 @@ var SnippetsMenu = Widget.extend({
                 handle: '.oe_snippet_thumbnail:not(.o_we_already_dragging)',
                 helper: function () {
                     const dragSnip = this.cloneNode(true);
-                    dragSnip.querySelectorAll('.o_delete_btn').forEach(
+                    dragSnip.querySelectorAll('.o_delete_btn, .o_rename_btn').forEach(
                         el => el.remove()
                     );
                     return dragSnip;


### PR DESCRIPTION
Commit [1] added a rename button for custom snippets... but forgot to
remove it once the snippet is being dragged.

[1]: https://github.com/odoo/odoo/commit/1044a76a19d94ce93c4cd41841fb805d36a160e3
