### PR TITLE
[FIX] product: packaging correctly chosen

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -782,19 +782,10 @@ class ProductPackaging(models.Model):
         # per package might be a float, leading to incorrect results. For example:
         # 8 % 1.6 = 1.5999999999999996
         # 5.4 % 1.8 = 2.220446049250313e-16
-        if (
-            product_qty
-            and packaging_qty
-            and float_compare(
-                product_qty / packaging_qty,
-                float_round(product_qty / packaging_qty, precision_rounding=1.0),
-                precision_rounding=default_uom.rounding
-            )
-            != 0
-        ):
-            return float_round(
-                product_qty / packaging_qty, precision_rounding=1.0, rounding_method=rounding_method
-            ) * packaging_qty
+        if product_qty and packaging_qty:
+            rounded_qty = float_round(product_qty / packaging_qty, precision_rounding=1.0,
+                                  rounding_method=rounding_method) * packaging_qty
+            return rounded_qty if float_compare(rounded_qty, product_qty, precision_rounding=default_uom.rounding) else product_qty
         return product_qty
 
     def _find_suitable_product_packaging(self, product_qty, uom_id):


### PR DESCRIPTION
Step to reproduce:
- create a unit of measurement (UoM) and set it's rounding to 1.000
- create a product that uses this UoM
- create two packaging for this product
- create a sales order and in the sales order line set the created product
- you can already see the packaging is set, but anyways set a quantity to near the defined in the package
- the quantity will be updated

Current behaviour:
- Packaging always update to bigger package even if it doesn't fit

Behaviour after PR:
- Packaging update to the biggest package which is a full divider of the qty
- If no package fit, then no package are applied

opw-2718146

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
