### PR TITLE
[FIX] project: fix task analysis action

### DIFF
--- a/addons/project/report/project_report_views.xml
+++ b/addons/project/report/project_report_views.xml
@@ -87,6 +87,7 @@
             <field name="view_mode">graph,pivot</field>
             <field name="search_view_id" ref="view_task_project_user_search"/>
             <field name="context">{'group_by_no_leaf':1,'group_by':[]}</field>
+            <field name="domain">[('project_id', '!=', False)]</field>
             <field name="help">This report allows you to analyse the performance of your projects and users. You can analyse the quantities of tasks, the hours spent compared to the planned hours, the average number of days to open or close a task, etc.</field>
         </record>
 


### PR DESCRIPTION
Purpose of this commit is to show only task that
has project_id set in 'Task Analysis' menu.

So, In this commit add domain to show only task
that has project_id set in 'Task Anamysis' menu's
action.

task-2722863

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
