### PR TITLE
[FIX] repair : add part when repairing S/N product

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -527,7 +527,7 @@ class Repair(models.Model):
 
             moves = self.env['stock.move']
             for operation in repair.operations:
-                move = Move.create({
+                move = Move.with_context(default_lot_id=None).create({
                     'name': repair.name,
                     'product_id': operation.product_id.id,
                     'product_uom_qty': operation.product_uom_qty,


### PR DESCRIPTION
Steps :
- Create a Product
	> General Information > Product Type : Storable Product
	> Inventory > Traceability > Tracking : By Unique S/N
	> On Hand : Create a S/N
- Create a Product (Component)
	> General Information > Product Type : Storable Product
- Create a Helpdesk Team > Settings > After-Sales > Repairs : activate
- Create a Ticket in
	- Product : your Product
	- Serial Number : your S/N
- Click Repair > Parts > Add your Component
- Click Confirm Repair, Start Repair, End Repair

Issue :
- Validation Error :
	The lot (Product) is incompatible with this product (Component)

Cause :
- When ending the repair, a stock.move.line is created.
- Its product is the Component.
- Because the lot_id of the Product is still in the context,
	it is added by default on the stock.move.line.
- Then a check happens :
	if line.lot_id and line.product_id != line.lot_id.sudo().product_id
	throw ValidationError

Fix:
- Get the lot_id out of the context.

opw-2714093

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
