### PR TITLE
[IMP] project: improve on x2many tracking

### DIFF
--- a/addons/project/tests/__init__.py
+++ b/addons/project/tests/__init__.py
@@ -19,3 +19,4 @@ from . import test_multicompany
 from . import test_personal_stages
 from . import test_task_dependencies
 from . import test_task_follow
+from . import test_task_tracking

--- a/addons/project/tests/test_task_tracking.py
+++ b/addons/project/tests/test_task_tracking.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+from odoo.tests import tagged
+
+from odoo.addons.project.tests.test_project_base import TestProjectCommon
+
+
+@tagged('-at_install', 'post_install')
+class TestTaskTracking(TestProjectCommon):
+
+    def flush_tracking(self):
+        """ Force the creation of tracking values. """
+        self.env['base'].flush()
+        self.cr.precommit.run()
+
+    def test_many2many_tracking(self):
+        # Basic test
+        # Assign new user
+        self.cr.precommit.clear()
+        self.task_1.user_ids += self.user_projectmanager
+        self.flush_tracking()
+        self.assertEqual(len(self.task_1.message_ids), 1,
+            "Assigning a new user should log a message.")
+        # No change
+        self.task_1.user_ids += self.user_projectmanager
+        self.flush_tracking()
+        self.assertEqual(len(self.task_1.message_ids), 1,
+            "Assigning an already assigned user should not log a message.")
+        # Removing assigness
+        self.task_1.user_ids = False
+        self.flush_tracking()
+        self.assertEqual(len(self.task_1.message_ids), 2,
+            "Removing both assignees should only log one message.")
+
+    def test_many2many_tracking_context(self):
+        # Test that the many2many tracking does not throw an error when using
+        #  default values for fields that exists both on tasks and on messages
+        # Using an invalid value for this test
+        self.task_1.with_context(default_parent_id=-1).user_ids += self.user_projectmanager


### PR DESCRIPTION
While investigating an issue with the x2many tracking, we found a
better way that to track those field while also fixing the issue.

Fixes an issue with `default_*` context keys that are used in the
project app upon writing on tasks.

TaskId-2725014