### PR TITLE
[FIX] sale_management: Access error mail confirmation

### DIFF
--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -3,7 +3,7 @@
 
 from datetime import timedelta
 
-from odoo import api, fields, models, _
+from odoo import SUPERUSER_ID, api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import is_html_empty
 
@@ -151,6 +151,9 @@ class SaleOrder(models.Model):
 
     def action_confirm(self):
         res = super(SaleOrder, self).action_confirm()
+        if self.env.su:
+            self = self.with_user(SUPERUSER_ID)
+
         for order in self:
             if order.sale_order_template_id and order.sale_order_template_id.mail_template_id:
                 self.sale_order_template_id.mail_template_id.send_mail(order.id)


### PR DESCRIPTION
Current behavior:
You had a traceback when trying to pay with Stripe and a specific modified Quotation template

Steps to reproduce:
1. Set stripe as the payment acquirer (with default test values )
2. Modify the Quotation Template "4 person Desk"
- Uncheck "Online signature"
- Put "Confirmation Mail" as "Sales Order: Confirmation Email"
3. Create a SO
4. Set it's quotation template as "4 person Desk"
5. Action > Generate Payment link
6. Use the link as the public user (in incognito for instance)
7. Pay with Stripe
=> Traceback

opw-2721526

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
