### PR TITLE
[FIX] website: prevents the deletion of the form's default values

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -144,9 +144,9 @@ odoo.define('website.s_website_form', function (require) {
                 for (const name of fieldNames) {
                     const fieldEl = this.$target[0].querySelector(`[name="${name}"]`);
                     let newValue;
-                    if (!fieldEl.value && dataForValues && dataForValues[name]) {
+                    if (dataForValues && dataForValues[name]) {
                         newValue = dataForValues[name];
-                    } else if (!fieldEl.value && this.preFillValues[fieldEl.dataset.fillWith]) {
+                    } else if (this.preFillValues[fieldEl.dataset.fillWith]) {
                         newValue = this.preFillValues[fieldEl.dataset.fillWith];
                     }
                     if (newValue) {

--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -49,6 +49,7 @@ odoo.define('website.s_website_form', function (require) {
         init: function () {
             this._super(...arguments);
             this._recaptcha = new ReCaptcha();
+            this.initialValues = new Map();
             this._visibilityFunctionByFieldName = new Map();
             this._visibilityFunctionByFieldEl = new Map();
             this.__started = new Promise(resolve => this.__startResolve = resolve);
@@ -72,8 +73,6 @@ odoo.define('website.s_website_form', function (require) {
             return res;
         },
         start: function () {
-            var self = this;
-
             // Prepare visibility data and update field visibilities
             const visibilityFunctionsByFieldName = new Map();
             for (const fieldEl of this.$target[0].querySelectorAll('[data-visibility-dependency]')) {
@@ -126,19 +125,35 @@ odoo.define('website.s_website_form', function (require) {
             // Because, using t-att- inside form make it non-editable
             // Data-fill-with attribute is given during registry and is used by
             // to know which user data should be used to prfill fields.
-            var $dataFor = $('[data-for=' + this.$target.attr('id') + ']');
-            if ($dataFor.length || !_.isEmpty(this.preFillValues)) {
-                var dataForValues = $dataFor.length ? JSON.parse($dataFor.data('values').replace('False', '""').replace('None', '""').replace(/'/g, '"')) : [];
-                var fields = _.pluck(this.$target.serializeArray(), 'name');
-                _.each(fields, function (field) {
-                    var $field = self.$target.find('input[name="' + field + '"], textarea[name="' + field + '"]');
-                    if (!$field.val() && _.has(dataForValues, field) && dataForValues[field]) {
-                        $field.val(dataForValues[field]);
-                    } else if (!$field.val() && $field.data('fill-with')) {
-                        $field.val(self.preFillValues[$field.data('fill-with')] || '');
+            const dataForEl = document.querySelector(`[data-for='${this.$target[0].id}']`);
+            if (dataForEl || Object.keys(this.preFillValues).length) {
+                const dataForValues = dataForEl ?
+                    JSON.parse(dataForEl.dataset.values
+                        .replace('False', '""')
+                        .replace('None', '""')
+                        .replace(/'/g, '"')
+                    ) : {};
+                const fieldNames = this.$target.serializeArray().map(el => el.name);
+                // All types of inputs do not have a value property (eg:hidden),
+                // for these inputs any function that is supposed to put a value
+                // property actually puts a HTML value attribute. Because of
+                // this, we have to clean up these values at destroy or else the
+                // data loaded here could become default values. We could set
+                // the values to submit() for these fields but this could break
+                // customizations that use the current behavior as a feature.
+                for (const name of fieldNames) {
+                    const fieldEl = this.$target[0].querySelector(`[name="${name}"]`);
+                    let newValue;
+                    if (!fieldEl.value && dataForValues && dataForValues[name]) {
+                        newValue = dataForValues[name];
+                    } else if (!fieldEl.value && this.preFillValues[fieldEl.dataset.fillWith]) {
+                        newValue = this.preFillValues[fieldEl.dataset.fillWith];
                     }
-                    $field.data('website_form_original_default_value', $field.val());
-                });
+                    if (newValue) {
+                        this.initialValues.set(fieldEl, fieldEl.getAttribute('value'));
+                        fieldEl.value = newValue;
+                    }
+                }
             }
 
             // Check disabled states
@@ -193,6 +208,15 @@ odoo.define('website.s_website_form', function (require) {
 
             // All 'hidden if' fields start with d-none
             this.$target[0].querySelectorAll('.s_website_form_field_hidden_if:not(.d-none)').forEach(el => el.classList.add('d-none'));
+
+            // Reset the initial default values.
+            for (const [fieldEl, initialValue] of this.initialValues.entries()) {
+                if (initialValue) {
+                    fieldEl.setAttribute('value', initialValue);
+                } else {
+                    fieldEl.removeAttribute('value');
+                }
+            }
 
             this.$el.off('.s_website_form');
         },

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -385,14 +385,6 @@ options.registry.WebsiteFormEditor = FormEditor.extend({
             this.$target.removeClass('d-none');
             this.$message.addClass("d-none");
         }
-
-        // Clear default values coming from data-for/data-values attributes
-        this.$target.find('input[name],textarea[name]').each(function () {
-            var original = $(this).data('website_form_original_default_value');
-            if (original !== undefined && $(this).val() === original) {
-                $(this).val('').removeAttr('value');
-            }
-        });
     },
     /**
      * @override

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -1330,6 +1330,8 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
      * @param {HTMLElement} fieldEl
      */
     _replaceFieldElement(fieldEl) {
+        const inputEl = this.$target[0].querySelector('input');
+        const dataFillWith = inputEl ? inputEl.dataset.fillWith : undefined;
         const hasConditionalVisibility = this.$target[0].classList.contains('s_website_form_field_hidden_if');
         const previousName = this.$target[0].querySelector('.s_website_form_input').name;
         [...this.$target[0].childNodes].forEach(node => node.remove());
@@ -1349,6 +1351,10 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
             for (const fieldEl of dependentFieldEls) {
                 this._deleteConditionalVisibility(fieldEl);
             }
+        }
+        const newInputEl = this.$target[0].querySelector('input');
+        if (newInputEl) {
+            newInputEl.dataset.fillWith = dataFillWith;
         }
     },
     /**

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -300,6 +300,15 @@ odoo.define('website.tour.form_editor', function (require) {
             trigger: '.s_website_form_send.btn.btn-sm.btn-secondary.rounded-circle',
             run: () => null,
         },
+        // Add a default value.
+        {
+            content: 'Select the name field',
+            trigger: '.s_website_form_field:eq(0)',
+        }, {
+            content: 'Set a default value to the name field',
+            trigger: 'we-input[data-attribute-name="value"] input',
+            run: 'text John Smith',
+        },
         // Save the page
         {
             trigger: 'body',
@@ -314,6 +323,28 @@ odoo.define('website.tour.form_editor', function (require) {
         {
             content:  "Wait reloading...",
             trigger:  "html:not(:has(#completlyloaded)) div",
+        },
+        // Check that if we edit again and save again the default value is not deleted.
+        {
+            content: 'Enter in edit mode again',
+            trigger: 'a[data-action="edit"]',
+            run: 'click',
+        },
+        {
+            content: 'Edit the form',
+            trigger: '.s_website_form_field:eq(0) input',
+            extra_trigger: 'button[data-action="save"]',
+            run: 'click',
+        },
+        ...addCustomField('many2one', 'select', 'Select Field', true),
+        {
+            content: 'Save the page',
+            trigger: 'button[data-action=save]',
+            run: 'click',
+        },
+        {
+            content: 'Verify that the value has not been deleted',
+            trigger: '.s_website_form_field:eq(0) input[value="John Smith"]',
         }
     ]);
 
@@ -321,7 +352,7 @@ odoo.define('website.tour.form_editor', function (require) {
         test: true,
     },[
         {
-            content:  "Try to send empty form",
+            content:  "Try to send the form with some required fields not filled in",
             extra_trigger:  "form[data-model_name='mail.mail']" +
                             "[data-success-page='/contactus-thank-you']" +
                             ":has(.s_website_form_field:has(label:contains('Your Name')):has(input[type='text'][name='name'][required]))" +
@@ -349,7 +380,7 @@ odoo.define('website.tour.form_editor', function (require) {
         {
             content:  "Check if required fields were detected and complete the Subject field",
             extra_trigger:  "form:has(#s_website_form_result.text-danger)" +
-                            ":has(.s_website_form_field:has(label:contains('Your Name')).o_has_error)" +
+                            ":has(.s_website_form_field:has(label:contains('Your Name')):not(.o_has_error))" +
                             ":has(.s_website_form_field:has(label:contains('Email')).o_has_error)" +
                             ":has(.s_website_form_field:has(label:contains('Your Question')).o_has_error)" +
                             ":has(.s_website_form_field:has(label:contains('Subject')).o_has_error)" +
@@ -369,7 +400,7 @@ odoo.define('website.tour.form_editor', function (require) {
         {
             content:  "Check if required fields were detected and complete the Message field",
             extra_trigger:  "form:has(#s_website_form_result.text-danger)" +
-                            ":has(.s_website_form_field:has(label:contains('Your Name')).o_has_error)" +
+                            ":has(.s_website_form_field:has(label:contains('Your Name')):not(.o_has_error))" +
                             ":has(.s_website_form_field:has(label:contains('Email')).o_has_error)" +
                             ":has(.s_website_form_field:has(label:contains('Your Question')).o_has_error)" +
                             ":has(.s_website_form_field:has(label:contains('Subject')):not(.o_has_error))" +
@@ -389,7 +420,7 @@ odoo.define('website.tour.form_editor', function (require) {
         {
             content:  "Check if required fields was detected and check a product. If this fails, you probably broke the cleanForSave.",
             extra_trigger:  "form:has(#s_website_form_result.text-danger)" +
-                            ":has(.s_website_form_field:has(label:contains('Your Name')).o_has_error)" +
+                            ":has(.s_website_form_field:has(label:contains('Your Name')):not(.o_has_error))" +
                             ":has(.s_website_form_field:has(label:contains('Email')).o_has_error)" +
                             ":has(.s_website_form_field:has(label:contains('Your Question')).o_has_error)" +
                             ":has(.s_website_form_field:has(label:contains('Subject')):not(.o_has_error))" +

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -300,7 +300,7 @@ odoo.define('website.tour.form_editor', function (require) {
             trigger: '.s_website_form_send.btn.btn-sm.btn-secondary.rounded-circle',
             run: () => null,
         },
-        // Add a default value.
+        // Add a default value to a auto-fillable field.
         {
             content: 'Select the name field',
             trigger: '.s_website_form_field:eq(0)',
@@ -309,20 +309,13 @@ odoo.define('website.tour.form_editor', function (require) {
             trigger: 'we-input[data-attribute-name="value"] input',
             run: 'text John Smith',
         },
-        // Save the page
-        {
-            trigger: 'body',
-            run: function () {
-                $('body').append('<div id="completlyloaded"></div>');
-            },
-        },
         {
             content:  "Save the page",
             trigger:  "button[data-action=save]",
         },
         {
-            content:  "Wait reloading...",
-            trigger:  "html:not(:has(#completlyloaded)) div",
+            content: 'Verify value attribute and property',
+            trigger: '.s_website_form_field:eq(0) input[value="John Smith"]:propValue("Mitchell Admin")',
         },
         // Check that if we edit again and save again the default value is not deleted.
         {

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -140,6 +140,12 @@ odoo.define('website.tour.form_editor', function (require) {
             content: "Complete Recipient E-mail",
             trigger: '[data-field-name="email_to"] input',
             run: 'text_blur test@test.test',
+        }, {
+            content: 'Edit the Phone Number field',
+            trigger: 'input[name="phone"]',
+        }, {
+            content: 'Change the label position of the phone field',
+            trigger: 'we-button[data-select-label-position="right"]',
         },
         ...addExistingField('email_cc', 'text', 'Test conditional visibility', false, {visibility: CONDITIONALVISIBILITY, condition: 'odoo'}),
 
@@ -316,6 +322,10 @@ odoo.define('website.tour.form_editor', function (require) {
         {
             content: 'Verify value attribute and property',
             trigger: '.s_website_form_field:eq(0) input[value="John Smith"]:propValue("Mitchell Admin")',
+        },
+        {
+            content: 'Verify that phone field is still auto-fillable',
+            trigger: '.s_website_form_field input[data-fill-with="phone"]:propValue("+1 555-555-5555")',
         },
         // Check that if we edit again and save again the default value is not deleted.
         {

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -75,6 +75,14 @@ odoo.define('website_hr_recruitment.tour', function(require) {
         content: 'Enter in edit mode',
         trigger: 'a[data-action="edit"]',
     }, {
+        content: 'Add a fake default value for the job_id field',
+        trigger: 'button[data-action="save"]',
+        run: () => {
+            // It must be done in this way because the editor does not allow to
+            // put a default value on a field with type="hidden".
+            document.querySelector('input[name="job_id"]').value = 'FAKE_JOB_ID_DEFAULT_VAL';
+        },
+    }, {
         content: 'Edit the form',
         trigger: 'input[type="file"]',
         extra_trigger: '#oe_snippets.o_loaded',
@@ -100,9 +108,21 @@ odoo.define('website_hr_recruitment.tour', function(require) {
         content: 'Check that a job_id has been loaded',
         trigger: 'form',
         run: () => {
-            const selector = 'input[name="job_id"]:not([value=""])';
+            const selector =
+                'input[name="job_id"]:not([value=""]):not([value = "FAKE_JOB_ID_DEFAULT_VAL"])';
             if (!document.querySelector(selector)) {
                 console.error('The job_id field has a wrong value');
+            }
+        }
+    }, {
+        content: 'Enter in edit mode',
+        trigger: 'a[data-action="edit"]',
+    }, {
+        content: 'Verify that the job_id field has kept its default value',
+        trigger: 'button[data-action="save"]',
+        run: () => {
+            if (!document.querySelector('input[name="job_id"][value="FAKE_JOB_ID_DEFAULT_VAL"]')) {
+                console.error('The job_id field has lost its default value');
             }
         }
     },


### PR DESCRIPTION
Some form fields are dynamically filled. As the inputs that hold these
fields do not always have a value property, their HTML value attribute
can be modified. Therefore the form option deletes the values so that
they do not become default values (see [1]). Unfortunately this system
is problematic and makes it possible to delete a default value. This
PR ensures that only auto-fillable fields and values from data-for
values will be removed by the option afterwards.

This PR also gives the priority to the auto-fill over the default
value.
Tests are added with this PR to verify that
- when a form field has both a default value and auto-fill, the
  auto-fill has the priority.
- the default values are not erased on later form edit.
- even if the application form is updated, the job_id does not become a
  default value.

Step to reproduce the fixed issue:
- Create a form, add a (required hidden) field with a default value
- Save, then enter edit mode again
- Add a new field and save again

The default values of the form are gone. Enter edit mode again to see
the hidden input, you will see there is no value.

While fixing the bug, another bug has been discovered. Fields that can be auto-filled are no longer auto-filled if certain options are applied to them. This PR contains a commit that fixes this problem as well and improves a test to detect if this problem occurs again.
Steps to reproduce this bug:
 - Go to the "contact us" page or drop a form in a page
 - Edit an auto-fillable field of the form ("Your Name" for example)
 - Change the label position of the field
 - Save

The field is no longer auto-fillable.

[1]: https://github.com/odoo/odoo/commit/b637a5e32f767b62736241042f88fa0cecf9f10b

task-2715201
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
