### PR TITLE
[FIX] core: keep links in addons_path

### DIFF
--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -12,7 +12,7 @@ import pkg_resources
 import re
 import sys
 import warnings
-from os.path import join as opj, realpath
+from os.path import join as opj, normpath
 
 import odoo
 import odoo.tools as tools
@@ -386,7 +386,7 @@ def load_manifest(module, mod_path=None):
         manifest['auto_install'] = set(manifest['depends'])
 
     manifest['version'] = adapt_version(manifest['version'])
-    manifest['addons_path'] = realpath(opj(mod_path, os.pardir))
+    manifest['addons_path'] = normpath(opj(mod_path, os.pardir))
 
     return manifest
 


### PR DESCRIPTION
resolving the links may block reading static files if real path
doesn't belong to addons_path.

The problem is introduced on refactoring of the `load_manifest` function
odoo@2e29a93