### PR TITLE
[IMP] delivery: _should_generate_commercial_invoice()

### DIFF
--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -257,6 +257,10 @@ class StockPicking(models.Model):
             weight += move.product_qty * move.product_id.weight
         return weight
 
+    def _should_generate_commercial_invoice(self):
+        self.ensure_one()
+        return self.picking_type_id.warehouse_id.partner_id.country_id != self.partner_id.country_id
+
 
 class StockReturnPicking(models.TransientModel):
     _inherit = 'stock.return.picking'

--- a/addons/l10n_in/models/__init__.py
+++ b/addons/l10n_in/models/__init__.py
@@ -9,4 +9,5 @@ from . import port_code
 from . import res_config_settings
 from . import res_country_state
 from . import res_partner
+from . import stock_picking
 from . import uom_uom

--- a/addons/l10n_in/models/stock_picking.py
+++ b/addons/l10n_in/models/stock_picking.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    def _should_generate_commercial_invoice(self):
+        super(StockPicking, self)._should_generate_commercial_invoice()
+        return True


### PR DESCRIPTION
Usually we want to create commercial invoices in case the warehouse is in a
different country than the recipient. However, some countries like India
need those documents for internal shipping as well.

The added function can easily be overriden in a dedicated module for the
countries that require such a commercial invoice.

When the method `_should_generate_commercial_invoice` is called and the
Indian localisation is active, the function should return True.

When using delivery providers, with the ship_from country is IN, the
commercial invoice information is mandatory.

The indian law demands a commercial invoice when using shipping methods:
https://cleartax.in/s/commercial-invoice/#:~:text=Shipping%20bill-,Time%20Limit%20for%20Raising%20a%20Commercial%20Invoice%20Under%20Indian%20Law,additional%20information%20may%20be%20necessary.

related PR: https://github.com/odoo/enterprise/pull/23124

task-2701428