### PR TITLE
[FIX] mail: copy existing attachments when selecting a template

### DIFF
--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -126,13 +126,13 @@ class TestComposerForm(TestMailComposer):
         """Tests that all attachments are added to the composer, static attachments
         are not duplicated and while reports are re-generated, and that intermediary
         attachments are dropped."""
-        attachment_data = self._generate_attachments_data(2)
-        template_1 = self.template.copy({
+        attachment_data = self._generate_attachments_data(2, res_id=0)
+        template_1 = self.template.with_user(self.template.create_uid).copy({
             'attachment_ids': [(0, 0, a) for a in attachment_data],
             'report_name': 'TestReport for {{ object.name }}.html',  # test cursor forces html
             'report_template': self.test_report.id,
         })
-        template_1_attachments = template_1.attachment_ids
+        template_1_attachments = set(template_1.attachment_ids.mapped('name'))
         self.assertEqual(len(template_1_attachments), 2)
         template_2 = self.template.copy({
             'attachment_ids': False,
@@ -146,27 +146,27 @@ class TestComposerForm(TestMailComposer):
         self.assertEqual(len(composer_form.attachment_ids), 0)
 
         # change template: 2 static (attachment_ids) and 1 dynamic (report)
-        composer_form.template_id = template_1
+        composer_form.template_id = template_1.with_user(self.env.user)
         self.assertEqual(len(composer_form.attachment_ids), 3)
-        report_attachments = [att for att in composer_form.attachment_ids if att not in template_1_attachments]
+        report_attachments = set(att for att in composer_form.attachment_ids if att.name not in template_1_attachments)
         self.assertEqual(len(report_attachments), 1)
-        tpl_attachments = composer_form.attachment_ids[:] - report_attachments[0]
+        tpl_attachments = set(att for att in composer_form.attachment_ids if att.name not in report_attachments)
         self.assertEqual(tpl_attachments, template_1_attachments)
 
         # change template: 0 static (attachment_ids) and 1 dynamic (report)
         composer_form.template_id = template_2
         self.assertEqual(len(composer_form.attachment_ids), 1)
-        report_attachments = [att for att in composer_form.attachment_ids if att not in template_1_attachments]
+        report_attachments = [att for att in composer_form.attachment_ids if att.name not in template_1_attachments]
         self.assertEqual(len(report_attachments), 1)
-        tpl_attachments = composer_form.attachment_ids[:] - report_attachments[0]
+        tpl_attachments = set(att for att in composer_form.attachment_ids if att.name not in report_attachments)
         self.assertEqual(tpl_attachments, self.env['ir.attachment'])
 
         # change back to template 1
         composer_form.template_id = template_1
         self.assertEqual(len(composer_form.attachment_ids), 3)
-        report_attachments = [att for att in composer_form.attachment_ids if att not in template_1_attachments]
+        report_attachments = set(att for att in composer_form.attachment_ids if att.name not in template_1_attachments)
         self.assertEqual(len(report_attachments), 1)
-        tpl_attachments = composer_form.attachment_ids[:] - report_attachments[0]
+        tpl_attachments = set(att for att in composer_form.attachment_ids if att.name not in report_attachments)
         self.assertEqual(tpl_attachments, template_1_attachments)
 
         # reset template


### PR DESCRIPTION
The user may not have access to them

Adapt test to compare attachment names instead of id. This adds a `check` call on `ir.attachment` as it happens when displaying in the composer.