### PR TITLE
[IMP] stock: include UOM object in aggregated product quantities

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -680,6 +680,7 @@ class StockMoveLine(models.Model):
                                                    'description': description,
                                                    'qty_done': move_line.qty_done,
                                                    'product_uom': uom.name,
+                                                   'product_uom_rec': uom,
                                                    'product': move_line.product_id}
             else:
                 aggregated_move_lines[line_key]['qty_done'] += move_line.qty_done


### PR DESCRIPTION
with l10n_mx_edi_stock being introduced in enterprise - we require the unit of measure object in the aggregated lines so that it can be used on the delivery report.

odoo/enterprise#21591
Task-2585661





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
