### PR TITLE
[FIX] web: add record id when uploading

### DIFF
--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1540,7 +1540,7 @@
             <t t-set="fileupload_action" t-translation="off">/web/binary/upload_attachment</t>
             <t t-set="multi_upload" t-value="true"/>
             <input type="hidden" name="model" t-att-value="widget.model"/>
-            <input type="hidden" name="id" value="0"/>
+            <input type="hidden" name="id" t-att-value="widget.res_id or 0"/>
         </t>
     </div>
 </div>


### PR DESCRIPTION
Before that, uploading a file from a kanban was adding res_id=0
Was missing from 5e81850ea6
