### PR TITLE
[FIX] payment_authorize: don't error on long company names

### DIFF
--- a/addons/payment_authorize/models/authorize_request.py
+++ b/addons/payment_authorize/models/authorize_request.py
@@ -149,11 +149,12 @@ class AuthorizeAPI:
         bill_to = {}
         if 'profile' not in tx_data:
             split_name = payment_utils.split_partner_name(tx.partner_name)
+            partner_name = (tx.partner_name or "")[:50]  # max length defined by the Authorize API
             bill_to = {
                 'billTo': {
                     'firstName': '' if tx.partner_id.is_company else split_name[0],
                     'lastName': split_name[1],  # lastName is always required
-                    'company': tx.partner_name if tx.partner_id.is_company else '',
+                    'company': partner_name if tx.partner_id.is_company else '',
                     'address': tx.partner_address,
                     'city': tx.partner_city,
                     'state': tx.partner_state_id.name or '',


### PR DESCRIPTION
A company name >50 chars leads to:

Authorize.Net: Received data with status code "3" and error code "The
'AnetApi/xml/v1/schema/AnetApiSchema.xsd:company' element is invalid -
The value XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX is
invalid according to its datatype 'String' - The actual length is
greater than the MaxLength value."

This limits the company name to the specified 50 chars [1][2]. Cutting
off the company name should be fine for the same reasons as outlined in
64b86f36264c2e655681c7b6bed69e89891107bf.

[1] https://developer.authorize.net/api/reference/index.html#payment-transactions-charge-a-credit-card
[2] https://api.authorize.net/xml/v1/schema/AnetApiSchema.xsd

opw-2725246
