### PR TITLE
[FIX] mail, mass_mailing: fix attachment ownership

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -194,6 +194,16 @@ class MailTemplate(models.Model):
             self.sub_model_object_field = False
             self.null_value = False
 
+    @api.model
+    def create(self, values):
+        result = super().create(values)
+
+        # fix attachment ownership
+        if result.attachment_ids:
+            result.attachment_ids.write({'res_model': self._name, 'res_id': result.id})
+
+        return result
+
     def unlink(self):
         self.unlink_action()
         return super(MailTemplate, self).unlink()

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -233,7 +233,13 @@ class MassMailing(models.Model):
             values['body_html'] = self._convert_inline_images_to_urls(values['body_html'])
         if 'medium_id' not in values and values.get('mailing_type', 'mail') == 'mail':
             values['medium_id'] = self.env.ref('utm.utm_medium_email').id
-        return super(MassMailing, self).create(values)
+        result = super().create(values)
+
+        # fix attachment ownership
+        if result.attachment_ids:
+            result.attachment_ids.write({'res_model': self._name, 'res_id': result.id})
+
+        return result
 
     def write(self, values):
         if values.get('body_html'):


### PR DESCRIPTION
Attachments that are uploaded on a record that isn't saved yet are
created with res_id set to 0. In the case of attachments linked through
a m2m rather than the usual (res_model, res_id), it means they may not
be readable afer the creation of the record, except by their creator.

Re-attaching them to the mailing / template at the end of the create()
call fixes the ownership.

Fixes #81935