### PR TITLE
[ADD] test_sale_product_configurators: test the product configurators

### DIFF
--- a/addons/sale_product_configurator/__manifest__.py
+++ b/addons/sale_product_configurator/__manifest__.py
@@ -32,9 +32,6 @@ It also enables the "optional products" feature.
             'sale_product_configurator/static/src/js/product_configurator_widget.js',
             'sale_product_configurator/static/src/js/product_configurator_modal.js',
         ],
-        'web.assets_tests': [
-            'sale_product_configurator/static/tests/tours/**/*',
-        ],
         'web.qunit_suite_tests': [
             'sale_product_configurator/static/tests/product_configurator.test.js',
         ],

--- a/addons/sale_product_configurator/static/tests/product_configurator.test.js
+++ b/addons/sale_product_configurator/static/tests/product_configurator.test.js
@@ -1,12 +1,12 @@
 odoo.define('sale.product.configurator.tests', function (require) {
 "use strict";
 
-var FormView = require('web.FormView');
-var ProductConfiguratorFormView = require('sale_product_configurator.ProductConfiguratorFormView');
-var testUtils = require('web.test_utils');
-var createView = testUtils.createView;
+const FormView = require('web.FormView');
+const ProductConfiguratorFormView = require('sale_product_configurator.ProductConfiguratorFormView');
+const testUtils = require('web.test_utils');
+const createView = testUtils.createView;
 
-var getArch = function (){
+const getArch = function (){
     return '<form>' +
     '<sheet>' +
     '<field name="pricelist_id" widget="selection" />' +
@@ -141,7 +141,7 @@ QUnit.module('Product Configurator', {
     QUnit.test('Select a non configurable product template and verify that the product_id is correctly set', async function (assert) {
         assert.expect(2);
 
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'sale_order',
             data: this.data,
@@ -177,7 +177,7 @@ QUnit.module('Product Configurator', {
     QUnit.test('Select a configurable product template and verify that the product configurator is opened', async function (assert) {
         assert.expect(2);
 
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'sale_order',
             data: this.data,
@@ -206,14 +206,14 @@ QUnit.module('Product Configurator', {
     QUnit.test('trigger_up the "add_record" event and checks that rows are correctly added to the list', async function (assert) {
         assert.expect(1);
 
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'sale_order',
             data: this.data,
             arch: getArch()
         });
 
-        var list = form.renderer.allFieldWidgets[form.handle][1];
+        let list = form.renderer.allFieldWidgets[form.handle][1];
 
         list.trigger_up('add_record', {
             context: [{default_product_id: 1, default_product_uom_qty: 2}, {default_product_id: 2, default_product_uom_qty: 3}],
@@ -229,7 +229,7 @@ QUnit.module('Product Configurator', {
     QUnit.test('Select a product in the list and check for template loading', async function (assert) {
         assert.expect(1);
 
-        var product_configurator_form = await createView({
+        const product_configurator_form = await createView({
             View: ProductConfiguratorFormView,
             model: 'sale_product_configurator',
             data: this.data,

--- a/addons/sale_product_configurator/tests/__init__.py
+++ b/addons/sale_product_configurator/tests/__init__.py
@@ -1,5 +1,0 @@
-# -*- coding: utf-8 -*-
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-from . import common
-from . import test_sale_product_configurator_ui

--- a/addons/sale_product_configurator/tests/common.py
+++ b/addons/sale_product_configurator/tests/common.py
@@ -93,12 +93,24 @@ class TestProductConfiguratorCommon(TransactionCase):
 
         # Setup a second optional product
         cls.product_product_conf_chair_floor_protect = cls.env['product.template'].create({
-            'name': 'Chair floor protection',
+            'name': 'Chair floor protection (TEST)',
             'list_price': 12.0,
         })
         cls.product_product_conf_chair.optional_product_ids = [(4, cls.product_product_conf_chair_floor_protect.id)]
 
+        cls.custom_pricelist = cls.env['product.pricelist'].create({
+            'name': 'Custom pricelist (TEST)',
+            'item_ids': [(0, 0, {
+                'base': 'list_price',
+                'applied_on': '1_product',
+                'product_tmpl_id': cls.product_product_custo_desk.id,
+                'price_discount': 20,
+                'min_quantity': 2,
+                'compute_price': 'formula'
+            })]
+        })
 
+    @classmethod
     def _create_pricelist(cls, pricelists):
         for pricelist in pricelists:
             if not pricelist.item_ids.filtered(lambda i: i.product_tmpl_id == cls.product_product_custo_desk and i.price_discount == 20):

--- a/addons/sale_product_matrix/__manifest__.py
+++ b/addons/sale_product_matrix/__manifest__.py
@@ -25,9 +25,6 @@
         'web.qunit_suite_tests': [
             'sale_product_matrix/static/tests/section_and_note_widget_tests.js',
         ],
-        'web.assets_tests': [
-            'sale_product_matrix/static/tests/tours/**/*',
-        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/sale_product_matrix/static/tests/section_and_note_widget_tests.js
+++ b/addons/sale_product_matrix/static/tests/section_and_note_widget_tests.js
@@ -1,9 +1,9 @@
 odoo.define('sale_product_matrix.section_and_note_widget_tests', function (require) {
 "use strict";
 
-var FormView = require('web.FormView');
-var testUtils = require('web.test_utils');
-var createView = testUtils.createView;
+const FormView = require('web.FormView');
+const testUtils = require('web.test_utils');
+const createView = testUtils.createView;
 
 QUnit.module('section_and_note: sale_product_matrix', {
     beforeEach: function () {
@@ -58,7 +58,7 @@ QUnit.module('section_and_note: sale_product_matrix', {
             },
             grid: () => {},
         };
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'sale_order',
             data: this.data,

--- a/addons/sale_product_matrix/tests/__init__.py
+++ b/addons/sale_product_matrix/tests/__init__.py
@@ -1,4 +1,0 @@
-# -*- coding: utf-8 -*-
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-from . import test_sale_matrix

--- a/addons/test_sale_product_configurators/__manifest__.py
+++ b/addons/test_sale_product_configurators/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "Sale Product Configurators Tests",
+    'summary': "Test Suite for Sale Product Configurator",
+    'category': "Hidden",
+    'depends': [
+        'event_sale',
+        'sale_management',
+        'sale_product_configurator',
+        'sale_product_matrix',
+    ],
+    'assets': {
+        'web.assets_tests': [
+            'test_sale_product_configurators/static/tests/tours/**/*',
+        ],
+    },
+    'application': False,
+    'license': 'OEEL-1',
+}

--- a/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
@@ -1,0 +1,121 @@
+/** @odoo-module **/
+
+import tour from 'web_tour.tour';
+
+tour.register('event_sale_with_product_configurator_tour', {
+    url: '/web',
+    test: true,
+}, [tour.stepUtils.showAppsMenuItem(), {
+    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
+}, {
+    trigger: '.o_list_button_add',
+    extra_trigger: ".o_sale_order",
+}, {
+    trigger: '.o_required_modifier[name=partner_id] input',
+    run: 'text Tajine Saucisse',
+}, {
+    trigger: '.ui-menu-item > a:contains("Tajine Saucisse")',
+    auto: true,
+}, {
+    trigger: "a:contains('Add a product')",
+}, {
+    trigger: 'div[name="product_template_id"] input',
+    run: 'text event (',
+}, {
+    trigger: 'ul.ui-autocomplete a:contains("Registration Event (TEST variants)")',
+}, {
+    trigger: '.js_product:has(strong:contains(Memorabilia)) .js_add',
+    extra_trigger: '.oe_advanced_configurator_modal',
+}, {
+    trigger: 'button span:contains(Confirm)',
+    extra_trigger: '.oe_advanced_configurator_modal',  // to confirm the first wizard
+}, {
+    trigger: '.o_input_dropdown input',
+    extra_trigger: '.o_technical_modal',  // to be in the event wizard
+}, {
+    trigger: 'div[name="event_id"] input',
+}, {
+    trigger: 'ul.ui-autocomplete a:contains("TestEvent")',
+    in_modal: false,
+}, {
+    trigger: 'div[name="event_ticket_id"] input',
+    run: 'click',
+}, {
+    trigger: 'ul.ui-autocomplete a:contains("Kid + meal")',
+    in_modal: false,
+}, {
+    trigger: '.o_event_sale_js_event_configurator_ok'
+}, {
+    trigger: 'a:contains("Add a product")',
+    extra_trigger: '.o_monetary_cell span:contains("16.50")',  // wait for the optional product line
+}, {
+    trigger: 'div[name="product_template_id"] input',
+    extra_trigger: '.o_field_many2one[name="product_template_id"] .o_dropdown_button',
+    run: 'text event (',
+}, {
+    trigger: 'ul.ui-autocomplete a:contains("Registration Event (TEST variants)")',
+}, {
+    trigger: '.radio_input_value span:contains(Adult)',
+}, {
+    trigger: '.js_quantity',
+    extra_trigger: '.oe_advanced_configurator_modal',
+    run: 'text 5',
+}, {
+    trigger: '.js_price_total span:contains("150.00")',  // to be sure the correct variant is set
+}, {
+    trigger: 'button span:contains(Confirm)',
+    extra_trigger: '.oe_advanced_configurator_modal',
+}, {
+    trigger: '.o_input_dropdown input',
+    extra_trigger: '.o_technical_modal',
+}, {
+    trigger: 'div[name="event_id"] input',
+}, {
+    trigger: 'ul.ui-autocomplete a:contains("TestEvent")',
+    in_modal: false,
+}, {
+    trigger: 'div[name="event_ticket_id"] input',
+    run: 'click',
+}, {
+    trigger: 'ul.ui-autocomplete a:contains("Adult")',
+    in_modal: false,
+}, {
+    trigger: '.o_event_sale_js_event_configurator_ok'
+}, {
+    trigger: 'a:contains("Add a product")',
+    extra_trigger: '.o_monetary_cell span:contains("150.00")',  // wait for the adult tickets line
+}, {
+    trigger: 'div[name="product_template_id"] input',
+    extra_trigger: '.o_field_many2one[name="product_template_id"] .o_dropdown_button',
+    run: 'text event (',
+}, {
+    trigger: 'ul.ui-autocomplete a:contains("Registration Event (TEST variants)")',
+}, {
+    trigger: '.radio_input_value span:contains(VIP)',
+}, {
+    trigger: '.js_price_total span:contains("60.00")',  // to be sure the correct variant is set
+}, {
+    trigger: 'button span:contains(Confirm)',
+    extra_trigger: '.oe_advanced_configurator_modal',
+}, {
+    trigger: '.o_input_dropdown input',
+    extra_trigger: '.o_technical_modal',
+}, {
+    trigger: 'div[name="event_id"] input',
+}, {
+    trigger: 'ul.ui-autocomplete a:contains("TestEvent")',
+    in_modal: false,
+}, {
+    trigger: 'div[name="event_ticket_id"] input',
+    run: 'click',
+}, {
+    trigger: 'ul.ui-autocomplete a:contains("VIP")',
+    in_modal: false,
+}, {
+    trigger: '.o_event_sale_js_event_configurator_ok',
+}, {
+    trigger: '.o_form_button_save:contains("Save")',
+    extra_trigger: '.o_field_cell.o_data_cell.o_list_number:contains("60.00")',
+    run: 'click' // SAVE Sales Order, after the last ticket has been applied.
+}
+]);

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
@@ -1,48 +1,34 @@
-odoo.define('sale.sale_product_configurator_advanced_tour', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var tour = require('web_tour.tour');
+import tour from 'web_tour.tour';
 
-var optionVariantImage;
+let optionVariantImage;
 
 tour.register('sale_product_configurator_advanced_tour', {
-    url: "/web",
+    url: '/web',
     test: true,
 }, [tour.stepUtils.showAppsMenuItem(), {
-    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',  // Note: The module sale_management is mandatory
-    edition: 'community'
-}, {
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    edition: 'enterprise'
 },  {
-    trigger: ".o_list_button_add",
-    extra_trigger: ".o_sale_order"
+    trigger: '.o_list_button_add',
+    extra_trigger: '.o_sale_order'
 }, {
-    trigger: ".o_required_modifier[name=partner_id] input",
-    run: "text Tajine Saucisse",
+    trigger: '.o_required_modifier[name=partner_id] input',
+    run: 'text Tajine Saucisse',
 }, {
-    trigger: ".ui-menu-item > a:contains('Tajine Saucisse')",
+    trigger: '.ui-menu-item > a:contains("Tajine Saucisse")',
     auto: true,
 }, {
-    trigger: "a:contains('Add a product')",
-    extra_trigger: ".o_field_widget[name=partner_shipping_id] .o_external_button", // Wait for onchange_partner_id
+    trigger: 'a:contains("Add a product")',
+    extra_trigger: '.o_field_widget[name=partner_shipping_id] .o_external_button', // Wait for onchange_partner_id
 }, {
     trigger: 'div[name="product_template_id"] input',
-    run: function (){
-        var $input = $('div[name="product_template_id"] input');
-        $input.click();
-        $input.val('Custo');
-        var keyDownEvent = jQuery.Event("keydown");
-        keyDownEvent.which = 42;
-        $input.trigger(keyDownEvent);
-    }
+    run: 'text Custo',
 }, {
     trigger: 'ul.ui-autocomplete a:contains("Customizable Desk (TEST)")',
-    run: 'click'
 }, {
     trigger: 'span:contains("Custom")',
     extra_trigger: '.oe_advanced_configurator_modal',
-    run: 'click'
 }, {
     trigger: '.oe_advanced_configurator_modal ul.js_add_cart_variants li[data-attribute_id]:nth-child(1) .variant_custom_value',
     extra_trigger: '.oe_advanced_configurator_modal',
@@ -50,7 +36,6 @@ tour.register('sale_product_configurator_advanced_tour', {
 }, {
     trigger: '.oe_advanced_configurator_modal ul.js_add_cart_variants li[data-attribute_id]:nth-child(3) span:contains("PAV9")',
     extra_trigger: '.oe_advanced_configurator_modal',
-    run: 'click'
 }, {
     trigger: '.oe_advanced_configurator_modal ul.js_add_cart_variants li[data-attribute_id]:nth-child(3) .variant_custom_value',
     extra_trigger: '.oe_advanced_configurator_modal',
@@ -58,12 +43,11 @@ tour.register('sale_product_configurator_advanced_tour', {
 }, {
     trigger: '.oe_advanced_configurator_modal ul.js_add_cart_variants li[data-attribute_id]:nth-child(4) span:contains("PAV5")',
     extra_trigger: '.oe_advanced_configurator_modal',
-    run: 'click'
 }, {
     trigger: '.oe_advanced_configurator_modal ul.js_add_cart_variants li[data-attribute_id]:nth-child(6) select ',
     extra_trigger: '.oe_advanced_configurator_modal',
     run: function (){
-        var inputValue = $('.oe_advanced_configurator_modal ul.js_add_cart_variants li[data-attribute_id]:nth-child(6) option[data-value_name="PAV9"]').val();
+        let inputValue = $('.oe_advanced_configurator_modal ul.js_add_cart_variants li[data-attribute_id]:nth-child(6) option[data-value_name="PAV9"]').val();
         $('.oe_advanced_configurator_modal ul.js_add_cart_variants li[data-attribute_id]:nth-child(6) select').val(inputValue);
         $('.oe_advanced_configurator_modal ul.js_add_cart_variants li[data-attribute_id]:nth-child(6) select').trigger('change');
     }
@@ -85,19 +69,18 @@ tour.register('sale_product_configurator_advanced_tour', {
 }, {
     trigger: '.oe_advanced_configurator_modal .js_product:eq(1) div:contains("Conference Chair (TEST) (Aluminium)")',
     run: function () {
-        var newVariantImage = $('.oe_advanced_configurator_modal .js_product:eq(1) img.variant_image').attr('src');
+        let newVariantImage = $('.oe_advanced_configurator_modal .js_product:eq(1) img.variant_image').attr('src');
         if (newVariantImage !== optionVariantImage) {
             $('<p>').text('image variant option src changed').insertAfter('.oe_advanced_configurator_modal .js_product:eq(1) .product-name');
         }
 
     }
 }, {
-    extra_trigger: '.oe_advanced_configurator_modal .js_product:eq(1) div:contains("image variant option src changed")',
     trigger: '.oe_advanced_configurator_modal .js_product:eq(1) input[data-value_name="Steel"]',
+    extra_trigger: '.oe_advanced_configurator_modal .js_product:eq(1) div:contains("image variant option src changed")',
 }, {
     trigger: 'button span:contains(Confirm)',
     extra_trigger: '.oe_advanced_configurator_modal',
-    run: 'click'
 }, {
     trigger: 'td.o_data_cell:contains("Customizable Desk (TEST) (Custom, White, PAV9, PAV5, PAV1)")',
     extra_trigger: 'div[name="order_line"]',
@@ -134,5 +117,3 @@ tour.register('sale_product_configurator_advanced_tour', {
     in_modal: false,
     run: function (){} //check
 }]);
-
-});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
@@ -1,35 +1,22 @@
-odoo.define('sale.product_configurator_edition_tour', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var tour = require('web_tour.tour');
+import tour from 'web_tour.tour';
 
 tour.register('sale_product_configurator_edition_tour', {
-    url: "/web",
+    url: '/web',
     test: true,
 }, [tour.stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    edition: 'community'
 }, {
-    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    edition: 'enterprise'
+    trigger: '.o_list_button_add',
+    extra_trigger: '.o_sale_order',
 }, {
-    trigger: ".o_list_button_add",
-    extra_trigger: ".o_sale_order"
-}, {
-    trigger: "a:contains('Add a product')"
+    trigger: 'a:contains("Add a product")',
 }, {
     trigger: 'div[name="product_template_id"] input',
-    run: function (){
-        var $input = $('div[name="product_template_id"] input');
-        $input.click();
-        $input.val('Custo');
-        var keyDownEvent = jQuery.Event("keydown");
-        keyDownEvent.which = 42;
-        $input.trigger(keyDownEvent);
-    }
+    run: 'text Custo',
 }, {
     trigger: 'ul.ui-autocomplete a:contains("Customizable Desk (TEST)")',
-    run: 'click'
 }, {
     trigger: '.main_product span:contains("Steel")',
     run: function () {
@@ -49,7 +36,6 @@ tour.register('sale_product_configurator_edition_tour', {
 }, {
     trigger: 'button span:contains(Confirm)',
     extra_trigger: '.oe_advanced_configurator_modal',
-    run: 'click'
 }, {
     trigger: 'td.o_data_cell:contains("Customizable Desk (TEST) (Aluminium, White)")',
     extra_trigger: 'div[name="order_line"]',
@@ -89,7 +75,6 @@ tour.register('sale_product_configurator_edition_tour', {
     run: 'text nice custom value'
 }, {
     trigger: 'input[data-value_name="Black"]',
-    run: 'click'
 }, {
     trigger: '.o_sale_product_configurator_edit[request_count="2"]',
     run: function (){} // used to sync with "get_combination_info" completion
@@ -158,5 +143,3 @@ tour.register('sale_product_configurator_edition_tour', {
     extra_trigger: 'div[name="order_line"]',
     run: function (){}
 }]);
-
-});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
@@ -1,35 +1,22 @@
-odoo.define('sale.product_configurator_optional_products_tour', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var tour = require('web_tour.tour');
+import tour from 'web_tour.tour';
 
 tour.register('sale_product_configurator_optional_products_tour', {
-    url: "/web",
+    url: '/web',
     test: true,
 }, [tour.stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    edition: 'community'
 }, {
-    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    edition: 'enterprise'
+    trigger: '.o_list_button_add',
+    extra_trigger: '.o_sale_order'
 }, {
-    trigger: ".o_list_button_add",
-    extra_trigger: ".o_sale_order"
-}, {
-    trigger: "a:contains('Add a product')"
+    trigger: 'a:contains("Add a product")',
 }, {
     trigger: 'div[name="product_template_id"] input',
-    run: function () {
-        var $input = $('div[name="product_template_id"] input');
-        $input.click();
-        $input.val('Customizable Desk');
-        var keyDownEvent = jQuery.Event("keydown");
-        keyDownEvent.which = 42;
-        $input.trigger(keyDownEvent);
-    }
+    run: 'text Custo',
 }, {
     trigger: 'ul.ui-autocomplete a:contains("Customizable Desk (TEST)")',
-    run: 'click'
 }, {
     trigger: 'tr:has(.td-product_name:contains("Office Chair Black")) .js_add',
 }, {
@@ -51,7 +38,6 @@ tour.register('sale_product_configurator_optional_products_tour', {
 }, {
     trigger: 'button span:contains(Confirm)',
     extra_trigger: '.oe_advanced_configurator_modal',
-    run: 'click'
 }, {
     trigger: 'tr:has(td.o_data_cell:contains("Customizable Desk")) td.o_data_cell:contains("2.0")',
     extra_trigger: 'div[name="order_line"]',
@@ -73,5 +59,3 @@ tour.register('sale_product_configurator_optional_products_tour', {
     extra_trigger: 'div[name="order_line"]',
     run: function () {}, // check added product
 }]);
-
-});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
@@ -1,10 +1,9 @@
-odoo.define('sale.product_configurator_pricelist_tour', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var tour = require('web_tour.tour');
+import tour from 'web_tour.tour';
 
 tour.register('sale_product_configurator_pricelist_tour', {
-    url: "/web",
+    url: '/web',
     test: true,
 },
 [
@@ -12,11 +11,6 @@ tour.stepUtils.showAppsMenuItem(),
 {
     content: "navigate to the sale app",
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    edition: 'community'
-}, {
-    content: "navigate to the sale app",
-    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    edition: 'enterprise'
 }, {
     content: "create a new order",
     trigger: '.o_list_button_add',
@@ -36,20 +30,12 @@ tour.stepUtils.showAppsMenuItem(),
     content: "select the pricelist",
     trigger: 'ul.ui-autocomplete > li > a:contains(Custom pricelist (TEST))',
 }, {
-    trigger: "a:contains('Add a product')"
+    trigger: 'a:contains("Add a product")',
 }, {
     trigger: 'div[name="product_template_id"] input',
-    run: function (){
-        var $input = $('div[name="product_template_id"] input');
-        $input.click();
-        $input.val('Custo');
-        var keyDownEvent = jQuery.Event("keydown");
-        keyDownEvent.which = 42;
-        $input.trigger(keyDownEvent);
-    }
+    run: 'text Custo',
 }, {
     trigger: 'ul.ui-autocomplete a:contains("Customizable Desk (TEST)")',
-    run: 'click'
 }, {
     content: "check price is correct (USD)",
     trigger: 'span.oe_currency_value:contains("750.00")',
@@ -65,17 +51,14 @@ tour.stepUtils.showAppsMenuItem(),
     content: "check we are on the add modal",
     trigger: '.td-product_name:contains("Customizable Desk (TEST) (Steel, White)")',
     extra_trigger: '.oe_advanced_configurator_modal',
-    run: 'click'
 }, {
     content: "add conference chair",
     trigger: '.js_product:has(strong:contains(Conference Chair)) .js_add',
     extra_trigger: '.oe_advanced_configurator_modal .js_product:has(strong:contains(Conference Chair))',
-    run: 'click'
 }, {
     content: "add chair floor protection",
     trigger: '.js_product:has(strong:contains(Chair floor protection)) .js_add',
     extra_trigger: '.oe_advanced_configurator_modal .js_product:has(strong:contains(Chair floor protection))',
-    run: 'click'
 }, {
     content: "verify configurator final price", // tax excluded
     trigger: '.o_total_row .oe_currency_value:contains("1,257.00")',
@@ -83,7 +66,6 @@ tour.stepUtils.showAppsMenuItem(),
     content: "add to SO",
     trigger: 'button span:contains(Confirm)',
     extra_trigger: '.oe_advanced_configurator_modal',
-    run: 'click'
 }, {
     content: "verify SO final price excluded",
     trigger: 'span[name="Untaxed Amount"]:contains("1,257.00")',
@@ -92,5 +74,3 @@ tour.stepUtils.showAppsMenuItem(),
     trigger: 'span[name="amount_total"]:contains("1,437.00")',
 }
 ]);
-
-});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
@@ -1,36 +1,22 @@
-odoo.define('sale.product_configurator_single_custom_attribute_tour', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var tour = require('web_tour.tour');
+import tour from 'web_tour.tour';
 
 tour.register('sale_product_configurator_single_custom_attribute_tour', {
-    url: "/web",
+    url: '/web',
     test: true,
 }, [tour.stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    edition: 'community'
 }, {
-    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    edition: 'enterprise'
+    trigger: '.o_list_button_add',
+    extra_trigger: '.o_sale_order'
 }, {
-    trigger: ".o_list_button_add",
-    extra_trigger: ".o_sale_order"
-}, {
-    trigger: "a:contains('Add a product')"
+    trigger: 'a:contains("Add a product")'
 }, {
     trigger: 'div[name="product_template_id"] input',
-    run: function (){
-        var $input = $('div[name="product_template_id"] input');
-        $input.click();
-        $input.val('Custo');
-        // fake keydown to trigger search
-        var keyDownEvent = jQuery.Event("keydown");
-        keyDownEvent.which = 42;
-        $input.trigger(keyDownEvent);
-    }
+    run: 'text Custo',
 }, {
     trigger: 'ul.ui-autocomplete a:contains("Customizable Desk (TEST)")',
-    run: 'click'
 }, {
     trigger: '.oe_advanced_configurator_modal span:contains("Aluminium")',
     run: function () {
@@ -50,7 +36,6 @@ tour.register('sale_product_configurator_single_custom_attribute_tour', {
 }, {
     trigger: 'button span:contains(Confirm)',
     extra_trigger: '.oe_advanced_configurator_modal',
-    run: 'click'
 }, {
     trigger: 'td.o_data_cell:contains("single product attribute value: great single custom value")',
     extra_trigger: 'div[name="order_line"]',
@@ -73,5 +58,3 @@ tour.register('sale_product_configurator_single_custom_attribute_tour', {
         //check
     }
 }]);
-
-});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
@@ -1,45 +1,30 @@
-odoo.define('sale.product_configurator_tour', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var tour = require('web_tour.tour');
+import tour from 'web_tour.tour';
 
 // Note: please keep this test without pricelist for maximum coverage.
 // The pricelist is tested on the other tours.
 
 tour.register('sale_product_configurator_tour', {
-    url: "/web",
+    url: '/web',
     test: true,
 }, [tour.stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    edition: 'community'
 }, {
-    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    edition: 'enterprise'
+    trigger: '.o_list_button_add',
+    extra_trigger: '.o_sale_order'
 }, {
-    trigger: ".o_list_button_add",
-    extra_trigger: ".o_sale_order"
-}, {
-    trigger: "a:contains('Add a product')",
+    trigger: 'a:contains("Add a product")',
 }, {
     trigger: 'div[name="product_template_id"] input',
-    run: function (){
-        var $input = $('div[name="product_template_id"] input');
-        $input.click();
-        $input.val('Custo');
-        // fake keydown to trigger search
-        var keyDownEvent = jQuery.Event("keydown");
-        keyDownEvent.which = 42;
-        $input.trigger(keyDownEvent);
-    }
+    run: 'text Custo',
 }, {
     trigger: 'ul.ui-autocomplete a:contains("Customizable Desk (TEST)")',
-    run: 'click'
 }, {
     trigger: '.main_product span:contains("Steel")',
     run: function () {},
 }, {
     trigger: '.main_product span:contains("Aluminium")',
-    run: 'click'
 }, {
     trigger: 'span.oe_currency_value:contains("800.40")',
     run: function (){} // check updated price
@@ -56,16 +41,13 @@ tour.register('sale_product_configurator_tour', {
 }, {
     trigger: 'span:contains("Aluminium"):eq(1)',
     extra_trigger: '.oe_advanced_configurator_modal',
-    run: 'click'
 }, {
     trigger: '.js_product:has(strong:contains(Chair floor protection)) .js_add',
     extra_trigger: '.oe_advanced_configurator_modal',
-    run: 'click'
 }, {
     trigger: 'button span:contains(Confirm)',
     extra_trigger: '.oe_advanced_configurator_modal',
-    id: "quotation_product_selected",
-    run: 'click'
+    id: 'quotation_product_selected',
 },
 // check that 3 products were added to the SO
 {
@@ -89,5 +71,3 @@ tour.register('sale_product_configurator_tour', {
     run: function (){}
 }
 ]);
-
-});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
@@ -1,7 +1,7 @@
-odoo.define('sale_product_matrix.sale_matrix_tour', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var tour = require('web_tour.tour');
+import tour from 'web_tour.tour';
+
 let EXPECTED = [
     "Matrix", "PAV11", "PAV12 + $ 50.00",
 ]
@@ -18,28 +18,20 @@ for (let no of ['PAV41', 'PAV42']) {
 }
 
 tour.register('sale_matrix_tour', {
-    url: "/web",
+    url: '/web',
     test: true,
 }, [tour.stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
 }, {
-    trigger: ".o_list_button_add",
-    extra_trigger: ".o_sale_order"
+    trigger: '.o_list_button_add',
+    extra_trigger: '.o_sale_order'
 }, {
-    trigger: "a:contains('Add a product')"
+    trigger: 'a:contains("Add a product")'
 }, {
     trigger: 'div[name="product_template_id"] input',
-    run: function () {
-        var $input = $('div[name="product_template_id"] input');
-        $input.click();
-        $input.val('Matrix');
-        var keyDownEvent = jQuery.Event("keydown");
-        keyDownEvent.which = 42;
-        $input.trigger(keyDownEvent);
-    }
+    run: "text Matrix",
 }, {
     trigger: 'ul.ui-autocomplete a:contains("Matrix")',
-    run: 'click'
 }, {
     trigger: '.o_product_variant_matrix',
     run: function () {
@@ -48,14 +40,11 @@ tour.register('sale_matrix_tour', {
     }
 }, {
     trigger: 'span:contains("Confirm")',
-    run: 'click'
 }, {
     trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\n\nPA4: PAV41")',
     extra_trigger: '.o_form_editable',
-    run: 'click'
 }, {
-    trigger: '.o_edit_product_configuration',
-    run: 'click' // edit the matrix
+    trigger: '.o_edit_product_configuration',  // edit the matrix
 }, {
     trigger: '.o_product_variant_matrix',
     run: function () {
@@ -75,15 +64,13 @@ tour.register('sale_matrix_tour', {
         $('.o_matrix_input').val(3);
     }
 }, {
-    trigger: 'span:contains("Confirm")',
-    run: 'click' // apply the matrix
+    trigger: 'span:contains("Confirm")',  // apply the matrix
 }, {
     trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\n\nPA4: PAV41")',
     extra_trigger: '.o_form_editable',
     run: 'click'
 }, {
-    trigger: '.o_edit_product_configuration',
-    run: 'click' // edit the matrix
+    trigger: '.o_edit_product_configuration',  // edit the matrix
 }, {
     trigger: '.o_product_variant_matrix',
     run: function () {
@@ -91,32 +78,28 @@ tour.register('sale_matrix_tour', {
         $('.o_matrix_input').val(1);
     }
 }, {
-    trigger: 'span:contains("Confirm")',
-    run: 'click' // apply the matrix
+    trigger: 'span:contains("Confirm")',  // apply the matrix
 }, {
-    trigger: ".o_form_editable .o_field_many2one[name='partner_id'] input",
+    trigger: '.o_form_editable .o_field_many2one[name="partner_id"] input',
     // wait for qty to be 1
     extra_trigger: '.o_sale_order .o_field_cell.o_data_cell.o_list_number:contains("1.00")',
     run: 'text Agrolait'
 }, {
-    trigger: ".ui-menu-item > a",
+    trigger: '.ui-menu-item > a',
     auto: true,
     in_modal: false,
 }, {
-    trigger: '.o_form_button_save:contains("Save")',
-    run: 'click' // SAVE Sales Order.
+    trigger: '.o_form_button_save:contains("Save")',  // SAVE Sales Order.
 },
 // Open the matrix through the pencil button next to the product in line edit mode.
 {
-    trigger: '.o_form_button_edit:contains("Edit")',
-    run: 'click' // Edit Sales Order.
+    trigger: '.o_form_button_edit:contains("Edit")',  // Edit Sales Order.
 }, {
     trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\n\nPA4: PAV41")',
     extra_trigger: '.o_form_editable',
     run: 'click'
 }, {
-    trigger: '.o_edit_product_configuration',
-    run: 'click' // edit the matrix
+    trigger: '.o_edit_product_configuration',  // edit the matrix
 }, {
     trigger: '.o_product_variant_matrix',
     run: function () {
@@ -124,48 +107,34 @@ tour.register('sale_matrix_tour', {
         $('.o_matrix_input').slice(8, 16).val(4);
     } // set the qty to 4 for half of the matrix products.
 }, {
-    trigger: 'span:contains("Confirm")',
-    run: 'click' // apply the matrix
+    trigger: 'span:contains("Confirm")',  // apply the matrix
 }, {
     trigger: '.o_form_button_save:contains("Save")',
     extra_trigger: '.o_field_cell.o_data_cell.o_list_number:contains("4.00")',
     run: 'click' // SAVE Sales Order, after matrix has been applied (extra_trigger).
 }, {
-    trigger: '.o_form_button_edit:contains("Edit")',
-    run: 'click' // Edit Sales Order.
+    trigger: '.o_form_button_edit:contains("Edit")',  // Edit Sales Order.
 },
 // Ensures the matrix is opened with the values, when adding the same product.
 {
-    trigger: "a:contains('Add a product')",
+    trigger: 'a:contains("Add a product")',
     extra_trigger: '.o_form_editable',
 }, {
     trigger: 'div[name="product_template_id"] input',
-    run: function () {
-        var $input = $('div[name="product_template_id"] input');
-        $input.click();
-        $input.val('Matrix');
-        var keyDownEvent = jQuery.Event("keydown");
-        keyDownEvent.which = 42;
-        $input.trigger(keyDownEvent);
-    }
+    run: 'text Matrix',
 }, {
     trigger: 'ul.ui-autocomplete a:contains("Matrix")',
-    run: 'click'
 }, {
-    trigger: "input[value='4']",
+    trigger: 'input[value="4"]',
     run: function () {
         // update some values of the matrix
         $("input[value='4']").slice(0, 4).val(8.2);
     }
 }, {
-    trigger: 'span:contains("Confirm")',
-    run: 'click' // apply the matrix
+    trigger: 'span:contains("Confirm")',  // apply the matrix
 }, {
     trigger: '.o_form_button_save:contains("Save")',
     extra_trigger: '.o_field_cell.o_data_cell.o_list_number:contains("8.20")',
     run: 'click' // SAVE Sales Order, after matrix has been applied (extra_trigger).
 },
 ]);
-
-
-});

--- a/addons/test_sale_product_configurators/tests/__init__.py
+++ b/addons/test_sale_product_configurators/tests/__init__.py
@@ -1,0 +1,5 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_event_sale_with_product_configurator
+from . import test_sale_product_matrix
+from . import test_sale_product_configurator

--- a/addons/test_sale_product_configurators/tests/test_event_sale_with_product_configurator.py
+++ b/addons/test_sale_product_configurators/tests/test_event_sale_with_product_configurator.py
@@ -1,0 +1,121 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime, timedelta
+
+from odoo import fields
+from odoo.tests import HttpCase, tagged
+
+from odoo.addons.mail.tests.common import mail_new_test_user
+
+
+@tagged('post_install', '-at_install')
+class TestEventProductConfiguratorUi(HttpCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Adding sale users to test the access rights
+        cls.salesman = mail_new_test_user(
+            cls.env,
+            name='Salesman',
+            login='salesman',
+            password='salesman',
+            groups='sales_team.group_sale_salesman',
+        )
+
+        # Setup partner since user salesman don't have the right to create it on the fly
+        cls.env['res.partner'].create({'name': 'Tajine Saucisse'})
+
+        # Setup attributes and attributes values
+        product_attribute_age = cls.env['product.attribute'].create({
+            'name': 'Age',
+            'sequence': 10,
+        })
+        product_attribute_value_0 = cls.env['product.attribute.value'].create({
+            'name': 'Kid',
+            'attribute_id': product_attribute_age.id,
+            'sequence': 1,
+        })
+        product_attribute_value_1 = cls.env['product.attribute.value'].create({
+            'name': 'Adult',
+            'attribute_id': product_attribute_age.id,
+            'sequence': 2,
+        })
+        product_attribute_value_2 = cls.env['product.attribute.value'].create({
+            'name': 'Senior',
+            'attribute_id': product_attribute_age.id,
+            'sequence': 3,
+        })
+        product_attribute_value_3 = cls.env['product.attribute.value'].create({
+            'name': 'VIP',
+            'attribute_id': product_attribute_age.id,
+            'sequence': 3,
+        })
+
+        # Create product template
+        cls.event_product_template = cls.env['product.template'].create({
+            'name': 'Registration Event (TEST variants)',
+            'list_price': 30.0,
+            'detailed_type': 'event',
+        })
+
+        # Generate variants
+        cls.env['product.template.attribute.line'].create([{
+            'product_tmpl_id': cls.event_product_template.id,
+            'attribute_id': product_attribute_age.id,
+            'value_ids': [
+                (4, product_attribute_value_0.id),
+                (4, product_attribute_value_1.id),
+                (4, product_attribute_value_2.id),
+                (4, product_attribute_value_3.id),
+            ],
+        }])
+
+        # Apply a price_extra for the attributes
+        cls.event_product_template.attribute_line_ids[0].product_template_value_ids[0]. \
+            price_extra = -20.00
+        cls.event_product_template.attribute_line_ids[0].product_template_value_ids[2]. \
+            price_extra = -10.00
+        cls.event_product_template.attribute_line_ids[0].product_template_value_ids[3]. \
+            price_extra = 30.00
+
+        # Create the event and link it to the product variants as event tickets
+        cls.event = cls.env['event.event'].create({
+            'name': 'TestEvent',
+            'auto_confirm': True,
+            'date_begin': fields.Datetime.to_string(datetime.today() + timedelta(days=1)),
+            'date_end': fields.Datetime.to_string(datetime.today() + timedelta(days=15)),
+            'date_tz': 'Europe/Brussels',
+        })
+
+        for variant in cls.event_product_template.attribute_line_ids[0].product_template_value_ids:
+            cls.env['event.event.ticket'].create({
+                'name': variant.name,
+                'event_id': cls.event.id,
+                'product_id': variant.ptav_product_variant_ids[0].id,
+            })
+            if variant.name != 'VIP':
+                cls.env['event.event.ticket'].create({
+                    'name': variant.name + ' + meal',
+                    'event_id': cls.event.id,
+                    'product_id': variant.ptav_product_variant_ids[0].id,
+                    'price': variant.ptav_product_variant_ids[0].lst_price + 5,
+                })
+
+            # Adding an optional product
+            cls.product_product_memorabilia = cls.env['product.template'].create({
+                'name': 'Memorabilia (TEST)',
+                'list_price': 16.50,
+            })
+
+            cls.event_product_template.optional_product_ids = [cls.product_product_memorabilia.id,]
+
+    def test_event_using_product_configurator(self):
+        self.start_tour("/web", 'event_sale_with_product_configurator_tour', login='salesman')
+
+        sale_order = self.env['sale.order'].search([('create_uid', "=", self.salesman.id)])
+
+        # Check that all the so lines are in the so and that the total amount is correct
+        self.assertEqual(len(sale_order.order_line), 4)
+        self.assertEqual(sale_order.amount_total, 277.73)


### PR DESCRIPTION
Before this commit, some tours from `sale_product_configurator` and
`sale_product_matrix` were not working since there wasn't a dependency
with `sale_management`.

They are now in a test module with all the other configurators and the
missing dependency.

Additionally, other tests are added to improve the coverage of the
configurators' logic.

task-2049081

See also: 
- https://github.com/odoo/enterprise/pull/23199

