### PR TITLE
dropping 'False' partner_ids for google and microsoft calendar synchronization

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -142,7 +142,7 @@ class Meeting(models.Model):
                 # Create new attendees
                 if attendee[2].get('self'):
                     partner = self.env.user.partner_id
-                else:
+                elif attendee[1].id:
                     partner = attendee[1]
                 attendee_commands += [(0, 0, {'state': attendee[2].get('responseStatus'), 'partner_id': partner.id})]
                 partner_commands += [(4, partner.id)]

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -174,7 +174,7 @@ class Meeting(models.Model):
             if email in attendees_by_emails:
                 # Update existing attendees
                 commands_attendee += [(1, attendees_by_emails[email].id, {'state': state})]
-            else:
+            elif attendee[1].id:
                 # Create new attendees
                 partner = attendee[1]
                 commands_attendee += [(0, 0, {'state': state, 'partner_id': partner.id})]

--- a/doc/cla/individual/andro19951.md
+++ b/doc/cla/individual/andro19951.md
@@ -1,0 +1,11 @@
+Belgium, 2021-12-31
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Andro andro19951@gmail.com https://github.com/andro19951


### PR DESCRIPTION


Description of the issue/feature this PR addresses: in version 15, sometimes Google and Microsoft calendar synchronizations break with error: 

- Create/update: a mandatory field is not set.
- Delete: another model requires the record being deleted. If possible, archive it instead.
Model: Calendar Attendee Information (calendar.attendee), Field: Contact (partner_id)


Current behavior before PR: In some cases, usually when microsoft or google event is created by someone outside of company, Odoo creates extra partner_id for said event, with partner_id=false value. Since partner_id value should never be false, synchronization stops and user gets above mentioned error. The only way customer can solve the issue is to delete said events from their calendar.

Desired behavior after PR is merged: Odoo will check if partner_id actually exists, before assigning it to the event. this way events do not get assigned with empty participant values and synchronization continues smoothly.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
