### PR TITLE
[FIX] l10n_ar: use E document types for invoices and bills

### DIFF
--- a/addons/l10n_ar/models/account_journal.py
+++ b/addons/l10n_ar/models/account_journal.py
@@ -49,7 +49,7 @@ class AccountJournal(models.Model):
                 '99': []
             },
             'received': {
-                '1': ['A', 'B', 'C', 'M', 'I'],
+                '1': ['A', 'B', 'C', 'E', 'M', 'I'],
                 '3': ['B', 'C', 'I'],
                 '4': ['B', 'C', 'I'],
                 '5': ['B', 'C', 'I'],


### PR DESCRIPTION
E documents cannot be selected for invoices and bills which is a problem for companies in Tierra del Fuego, a fiscal exception of Argentina

Steps to reproduce:
1. Install the l10n_ar module
2. Switch to the company '(AR) Responsable Inscripto'
3. Open the Invoicing app and go to Vendors->Bills
4. Create a new Bill and select '(AR) Responsable Inscripto' as vendor
5. The document type '(19) Facturas de exportacion' is not available

Solution:
Add 'E' as journal letter for AFIP responsibility type 'IVA Responsable Inscripto'

OPW-2713805