### PR TITLE
[IMP] l10n_pt_invoice: add qr code to invoice

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -11,7 +11,7 @@
                         <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/></div>
                 </t>
                 <div class="page">
-                    <h2>
+                    <h2 id="title">
                         <span t-if="o.type == 'out_invoice' and o.state == 'posted'">Invoice</span>
                         <span t-if="o.type == 'out_invoice' and o.state == 'draft'">Draft Invoice</span>
                         <span t-if="o.type == 'out_invoice' and o.state == 'cancel'">Cancelled Invoice</span>

--- a/addons/l10n_pt_invoice/__init__.py
+++ b/addons/l10n_pt_invoice/__init__.py
@@ -1,0 +1,4 @@
+# -*- encoding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/l10n_pt_invoice/__manifest__.py
+++ b/addons/l10n_pt_invoice/__manifest__.py
@@ -1,0 +1,16 @@
+# -*- encoding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Portugal - Invoice',
+    'version': '1.0.0',
+    'author': 'Odoo S.A.',
+    'category': 'Accounting/Localizations',
+    'license': 'LGPL-3',
+    'description': """
+    Invoices for the Portuguese Republic
+""",
+    'depends': ['l10n_pt', 'account'],
+    'data': [
+        'views/report_invoice.xml',
+    ],
+}

--- a/addons/l10n_pt_invoice/models/__init__.py
+++ b/addons/l10n_pt_invoice/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- encoding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import account_move

--- a/addons/l10n_pt_invoice/models/account_move.py
+++ b/addons/l10n_pt_invoice/models/account_move.py
@@ -75,7 +75,7 @@ class AccountMove(models.Model):
             qr_code_str += f"D:{invoice_type_map[record.type]}*"
             qr_code_str += f"E:N*"
             qr_code_str += f"F:{format_date(self.env, record.date, date_format='yyyyMMdd')}*"
-            qr_code_str += f"G:{(record.type + ' ' + record.display_name)[:60]}*"
+            qr_code_str += f"G:{(record.type + ' ' + record.ref)[:60]}*"
             qr_code_str += f"H:0*"
             qr_code_str += f"I1:{record.company_id.country_id.code}*"
             base_vat_exempt = get_base_and_vat(record, 'IVA 0%')

--- a/addons/l10n_pt_invoice/models/account_move.py
+++ b/addons/l10n_pt_invoice/models/account_move.py
@@ -34,6 +34,7 @@ class AccountMove(models.Model):
         for record in self:  # record is of type account.move
             # Check needed values are filled
             record.company_id.vat
+            "PT" in record.company_id.country_id.code
             record.partner_id.country_id
             record.type in {'out_invoice', 'out_refund', 'out_receipt'}
 
@@ -52,27 +53,25 @@ class AccountMove(models.Model):
             qr_code_str += f"G:{(record.type + ' ' + record.display_name)[:60]}*"
             qr_code_str += f"H:0*"
             qr_code_str += f"I1:{record.company_id.country_id.code}*"
-            if "PT" in record.company_id.country_id.code:
-                base_vat_exempt = get_base_and_vat(record.amount_by_group, 'IVA 0%', record.currency_id)
-                base_vat_reduced = get_base_and_vat(record.amount_by_group, 'IVA 6%', record.currency_id)
-                base_vat_intermediate = get_base_and_vat(record.amount_by_group, 'IVA 13%', record.currency_id)
-                base_vat_normal = get_base_and_vat(record.amount_by_group, 'IVA 23%', record.currency_id)
-                if base_vat_exempt:
-                    qr_code_str += f"I2:{base_vat_exempt['base']}*"
-                if base_vat_reduced:
-                    qr_code_str += f"I3:{base_vat_reduced['base']}*"
-                    qr_code_str += f"I4:{base_vat_reduced['vat']}*"
-                if base_vat_intermediate:
-                    qr_code_str += f"I5:{base_vat_intermediate['base']}*"
-                    qr_code_str += f"I6:{base_vat_intermediate['vat']}*"
-                if base_vat_normal:
-                    qr_code_str += f"I7:{base_vat_normal['base']}*"
-                    qr_code_str += f"I8:{base_vat_normal['vat']}*"
-
-
-            # E.g.: A:509445535*B:123456823*C:BE*D:FT*E:N*F:20220103*G:FT 01P2022/1*H:0*I1:PT*I7:325.20*I8:74.80*N:74.80*O:400.00*P:0.00*Q:P0FE*R:2230
-            # E.g.: A:509445535*B:999999990*C:PT*D:FT*E:N*F:20220103*G:FT 01P2022/2*H:0*I1:PT*I7:2.03*I8:0.47*N:0.47*O:2.50*P:0.00*Q:ZYpH*R:2230
-            #A:False*B:999999990*C:US*D:FT*E:N*F:20220104*G:out_invoice INV/2022/0020*H:0*I1:PT
+            base_vat_exempt = get_base_and_vat(record.amount_by_group, 'IVA 0%', record.currency_id)
+            base_vat_reduced = get_base_and_vat(record.amount_by_group, 'IVA 6%', record.currency_id)
+            base_vat_intermediate = get_base_and_vat(record.amount_by_group, 'IVA 13%', record.currency_id)
+            base_vat_normal = get_base_and_vat(record.amount_by_group, 'IVA 23%', record.currency_id)
+            if base_vat_exempt:
+                qr_code_str += f"I2:{base_vat_exempt['base']}*"
+            if base_vat_reduced:
+                qr_code_str += f"I3:{base_vat_reduced['base']}*"
+                qr_code_str += f"I4:{base_vat_reduced['vat']}*"
+            if base_vat_intermediate:
+                qr_code_str += f"I5:{base_vat_intermediate['base']}*"
+                qr_code_str += f"I6:{base_vat_intermediate['vat']}*"
+            if base_vat_normal:
+                qr_code_str += f"I7:{base_vat_normal['base']}*"
+                qr_code_str += f"I8:{base_vat_normal['vat']}*"
+            qr_code_str += f"N:{record.amount_tax}*"
+            qr_code_str += f"O:{record.amount_total}*"
+            qr_code_str += f"Q:TODO*"
+            qr_code_str += f"R:TODO*"
 
             if qr_code_str[-1] == "*":
                 qr_code_str = qr_code_str[:-1]

--- a/addons/l10n_pt_invoice/models/account_move.py
+++ b/addons/l10n_pt_invoice/models/account_move.py
@@ -44,15 +44,20 @@ class AccountMove(models.Model):
         E.g.: A:509445535*B:123456823*C:BE*D:FT*E:N*F:20220103*G:FT 01P2022/1*H:0*I1:PT*I7:325.20*I8:74.80*N:74.80*O:400.00*P:0.00*Q:P0FE*R:2230
         """
 
-        def get_base_and_vat(amount_by_group, vat_name, currency):
-            vat_names = [line[0] for line in amount_by_group]
-            vat_values = [line[1] for line in amount_by_group]
-            vat_bases = [line[2] for line in amount_by_group]
+        def get_local_monetary(amount, record):
+            pt_currency = self.env.ref('base.EUR')
+            return float_repr(record.currency_id._convert(amount, pt_currency, record.company_id, record.date), pt_currency.decimal_places)
+
+        def get_base_and_vat(account_move, vat_name):
+            """Returns the base and value tax for each type of tax"""
+            vat_names = [line[0] for line in account_move.amount_by_group]
+            vat_values = [line[1] for line in account_move.amount_by_group]
+            vat_bases = [line[2] for line in account_move.amount_by_group]
             if vat_name not in vat_names:
                 return False
             index = vat_names.index(vat_name)
-            return {'base': float_repr(vat_bases[index], currency.decimal_places),
-                    'vat': float_repr(vat_values[index], currency.decimal_places)}
+            return {'base': get_local_monetary(vat_bases[index], record),
+                    'vat': get_local_monetary(vat_values[index], record)}
 
         for record in self:  # record is of type account.move
             if record.company_id.country_id.code != "PT":
@@ -73,23 +78,32 @@ class AccountMove(models.Model):
             qr_code_str += f"G:{(record.type + ' ' + record.display_name)[:60]}*"
             qr_code_str += f"H:0*"
             qr_code_str += f"I1:{record.company_id.country_id.code}*"
-            base_vat_exempt = get_base_and_vat(record.amount_by_group, 'IVA 0%', record.currency_id)
-            base_vat_reduced = get_base_and_vat(record.amount_by_group, 'IVA 6%', record.currency_id)
-            base_vat_intermediate = get_base_and_vat(record.amount_by_group, 'IVA 13%', record.currency_id)
-            base_vat_normal = get_base_and_vat(record.amount_by_group, 'IVA 23%', record.currency_id)
+            base_vat_exempt = get_base_and_vat(record, 'IVA 0%')
+            base_vat_reduced = get_base_and_vat(record, 'IVA 6%')
+            base_vat_intermediate = get_base_and_vat(record, 'IVA 13%')
+            base_vat_normal = get_base_and_vat(record, 'IVA 23%')
+            amount_tax = 0.0
+            amount_total = 0.0
             if base_vat_exempt:
                 qr_code_str += f"I2:{base_vat_exempt['base']}*"
+                amount_total += float(base_vat_exempt['base'])
             if base_vat_reduced:
                 qr_code_str += f"I3:{base_vat_reduced['base']}*"
                 qr_code_str += f"I4:{base_vat_reduced['vat']}*"
+                amount_total += float(base_vat_reduced['base'])
+                amount_tax += float(base_vat_reduced['vat'])
             if base_vat_intermediate:
                 qr_code_str += f"I5:{base_vat_intermediate['base']}*"
                 qr_code_str += f"I6:{base_vat_intermediate['vat']}*"
+                amount_total += float(base_vat_intermediate['base'])
+                amount_tax += float(base_vat_intermediate['vat'])
             if base_vat_normal:
                 qr_code_str += f"I7:{base_vat_normal['base']}*"
                 qr_code_str += f"I8:{base_vat_normal['vat']}*"
-            qr_code_str += f"N:{record.amount_tax}*"
-            qr_code_str += f"O:{record.amount_total}*"
+                amount_total += float(base_vat_normal['base'])
+                amount_tax += float(base_vat_normal['vat'])
+            qr_code_str += f"N:{float_repr(amount_tax, record.company_id.currency_id.decimal_places)}*"
+            qr_code_str += f"O:{float_repr(amount_total, record.company_id.currency_id.decimal_places)}*"
             qr_code_str += f"Q:TODO*"
             qr_code_str += f"R:TODO*"
 

--- a/addons/l10n_pt_invoice/models/account_move.py
+++ b/addons/l10n_pt_invoice/models/account_move.py
@@ -22,11 +22,5 @@ class AccountMove(models.Model):
 
         for record in self:
             qr_code_str = ''
-            if record.company_id.vat:
-                # seller_name_enc = get_qr_encoding(1, record.company_id.display_name)
-                # company_vat_enc = get_qr_encoding(2, record.company_id.vat)
-                # invoice_total_enc = get_qr_encoding(4, str(record.amount_total))
-                # total_vat_enc = get_qr_encoding(5, str(record.currency_id.round(record.amount_total - record.amount_untaxed)))
-
-                qr_code_str = "RIIIIIIIIIIIIIIIIIIIICARDO"
-            record.l10n_pt_qr_code_str = qr_code_str
+            # Check needed values are filled
+            record.l10n_pt_qr_code_str = "RIIIIIIIIIIIIIIIIIIIICARDO"

--- a/addons/l10n_pt_invoice/models/account_move.py
+++ b/addons/l10n_pt_invoice/models/account_move.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    l10n_pt_qr_code_str = fields.Char(string='QR Code', compute='_compute_qr_code_str')
+
+    @api.depends('amount_total', 'amount_untaxed', 'company_id', 'company_id.vat')
+    def _compute_qr_code_str(self):
+        """ Generate the qr code for Portugal invoicing.
+        """
+        def get_qr_encoding(tag, field):
+            company_name_byte_array = field.encode('UTF-8')
+            company_name_tag_encoding = tag.to_bytes(length=1, byteorder='big')
+            company_name_length_encoding = len(company_name_byte_array).to_bytes(length=1, byteorder='big')
+            return company_name_tag_encoding + company_name_length_encoding + company_name_byte_array
+
+        for record in self:
+            qr_code_str = ''
+            if record.company_id.vat:
+                # seller_name_enc = get_qr_encoding(1, record.company_id.display_name)
+                # company_vat_enc = get_qr_encoding(2, record.company_id.vat)
+                # invoice_total_enc = get_qr_encoding(4, str(record.amount_total))
+                # total_vat_enc = get_qr_encoding(5, str(record.currency_id.round(record.amount_total - record.amount_untaxed)))
+
+                qr_code_str = "RIIIIIIIIIIIIIIIIIIIICARDO"
+            record.l10n_pt_qr_code_str = qr_code_str

--- a/addons/l10n_pt_invoice/models/account_move.py
+++ b/addons/l10n_pt_invoice/models/account_move.py
@@ -31,11 +31,11 @@ class AccountMove(models.Model):
 
     def preview_invoice(self):
         self.check_necessary_fields()
-        super().preview_invoice()
+        return super().preview_invoice()
 
     def action_invoice_sent(self):
         self.check_necessary_fields()
-        super().action_invoice_sent()
+        return super().action_invoice_sent()
 
     @api.depends('partner_id', 'currency_id', 'date', 'type', 'display_name', 'amount_by_group', 'amount_total',
                  'amount_untaxed', 'company_id', 'company_id.vat', 'company_id.country_id', 'partner_id.country_id')

--- a/addons/l10n_pt_invoice/models/account_move.py
+++ b/addons/l10n_pt_invoice/models/account_move.py
@@ -3,6 +3,7 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
+from odoo.tools import format_date
 
 
 class AccountMove(models.Model):
@@ -13,14 +14,53 @@ class AccountMove(models.Model):
     @api.depends('amount_total', 'amount_untaxed', 'company_id', 'company_id.vat')
     def _compute_qr_code_str(self):
         """ Generate the qr code for Portugal invoicing.
-        """
-        def get_qr_encoding(tag, field):
-            company_name_byte_array = field.encode('UTF-8')
-            company_name_tag_encoding = tag.to_bytes(length=1, byteorder='big')
-            company_name_length_encoding = len(company_name_byte_array).to_bytes(length=1, byteorder='big')
-            return company_name_tag_encoding + company_name_length_encoding + company_name_byte_array
+        E.g.: A:509445535*B:123456823*C:BE*D:FT*E:N*F:20220103*G:FT 01P2022/1*H:0*I1:PT*I7:325.20*I8:74.80*N:74.80*O:400.00*P:0.00*Q:P0FE*R:2230
+        E.g.: A:509445535*B:999999990*C:PT*D:FT*E:N*F:20220103*G:FT 01P2022/2*H:0*I1:PT*I7:2.03*I8:0.47*N:0.47*O:2.50*P:0.00*Q:ZYpH*R:2230
 
-        for record in self:
-            qr_code_str = ''
+        A:False*B:999999990*C:res.country(233,)*D:FT*E:N*F:20220104*G:out_invoice INV/2022/0019*H:0*I1:res.country()
+
+        """
+
+        def get_base_vat(amount_by_group, vat_name):
+            vat_names = [line[0] for line in amount_by_group]
+            vat_values = [line[1] for line in amount_by_group]
+            vat_bases = [line[2] for line in amount_by_group]
+            if vat_name not in vat_names:
+                return False
+            index = vat_names.index(vat_name)
+            return vat_bases[index], vat_values[index]
+
+        for record in self:  # record is of type account.move
             # Check needed values are filled
-            record.l10n_pt_qr_code_str = "RIIIIIIIIIIIIIIIIIIIICARDO"
+            record.company_id.vat
+            record.partner_id.country_id
+            record.type in {'out_invoice', 'out_refund', 'out_receipt'}
+
+            qr_code_str = ""
+            qr_code_str += f"A:{record.company_id.vat}*"
+            qr_code_str += f"B:{record.partner_id.vat or '999999990'}*"
+            qr_code_str += f"C:{record.partner_id.country_id.code}*"
+            invoice_type_map = {
+                "out_invoice": "FT",
+                "out_refund": "NC",
+                "out_receipt": "FR",
+            }
+            qr_code_str += f"D:{invoice_type_map[record.type]}*"
+            qr_code_str += f"E:N*"
+            qr_code_str += f"F:{format_date(self.env, record.date, date_format='yyyyMMdd')}*"
+            qr_code_str += f"G:{(record.type + ' ' + record.display_name)[:60]}*"
+            qr_code_str += f"H:0*"
+            qr_code_str += f"I1:{record.company_id.country_id.code}*"
+            if "PT" in record.company_id.country_id.code:
+                if get_base_vat(record.amount_by_group, 'IVA 0%'):
+                    qr_code_str += f"I2:{record.company_id.country_id.code}*"
+
+
+            # E.g.: A:509445535*B:123456823*C:BE*D:FT*E:N*F:20220103*G:FT 01P2022/1*H:0*I1:PT*I7:325.20*I8:74.80*N:74.80*O:400.00*P:0.00*Q:P0FE*R:2230
+            # E.g.: A:509445535*B:999999990*C:PT*D:FT*E:N*F:20220103*G:FT 01P2022/2*H:0*I1:PT*I7:2.03*I8:0.47*N:0.47*O:2.50*P:0.00*Q:ZYpH*R:2230
+            #A:False*B:999999990*C:US*D:FT*E:N*F:20220104*G:out_invoice INV/2022/0020*H:0*I1:PT
+
+            if qr_code_str[-1] == "*":
+                qr_code_str = qr_code_str[:-1]
+            record.l10n_pt_qr_code_str = qr_code_str
+            print(qr_code_str)

--- a/addons/l10n_pt_invoice/models/account_move.py
+++ b/addons/l10n_pt_invoice/models/account_move.py
@@ -3,7 +3,7 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools import format_date
+from odoo.tools import format_date, float_repr
 
 
 class AccountMove(models.Model):
@@ -21,14 +21,15 @@ class AccountMove(models.Model):
 
         """
 
-        def get_base_vat(amount_by_group, vat_name):
+        def get_base_and_vat(amount_by_group, vat_name, currency):
             vat_names = [line[0] for line in amount_by_group]
             vat_values = [line[1] for line in amount_by_group]
             vat_bases = [line[2] for line in amount_by_group]
             if vat_name not in vat_names:
                 return False
             index = vat_names.index(vat_name)
-            return vat_bases[index], vat_values[index]
+            return {'base': float_repr(vat_bases[index], currency.decimal_places),
+                    'vat': float_repr(vat_values[index], currency.decimal_places)}
 
         for record in self:  # record is of type account.move
             # Check needed values are filled
@@ -52,8 +53,21 @@ class AccountMove(models.Model):
             qr_code_str += f"H:0*"
             qr_code_str += f"I1:{record.company_id.country_id.code}*"
             if "PT" in record.company_id.country_id.code:
-                if get_base_vat(record.amount_by_group, 'IVA 0%'):
-                    qr_code_str += f"I2:{record.company_id.country_id.code}*"
+                base_vat_exempt = get_base_and_vat(record.amount_by_group, 'IVA 0%', record.currency_id)
+                base_vat_reduced = get_base_and_vat(record.amount_by_group, 'IVA 6%', record.currency_id)
+                base_vat_intermediate = get_base_and_vat(record.amount_by_group, 'IVA 13%', record.currency_id)
+                base_vat_normal = get_base_and_vat(record.amount_by_group, 'IVA 23%', record.currency_id)
+                if base_vat_exempt:
+                    qr_code_str += f"I2:{base_vat_exempt['base']}*"
+                if base_vat_reduced:
+                    qr_code_str += f"I3:{base_vat_reduced['base']}*"
+                    qr_code_str += f"I4:{base_vat_reduced['vat']}*"
+                if base_vat_intermediate:
+                    qr_code_str += f"I5:{base_vat_intermediate['base']}*"
+                    qr_code_str += f"I6:{base_vat_intermediate['vat']}*"
+                if base_vat_normal:
+                    qr_code_str += f"I7:{base_vat_normal['base']}*"
+                    qr_code_str += f"I8:{base_vat_normal['vat']}*"
 
 
             # E.g.: A:509445535*B:123456823*C:BE*D:FT*E:N*F:20220103*G:FT 01P2022/1*H:0*I1:PT*I7:325.20*I8:74.80*N:74.80*O:400.00*P:0.00*Q:P0FE*R:2230

--- a/addons/l10n_pt_invoice/views/report_invoice.xml
+++ b/addons/l10n_pt_invoice/views/report_invoice.xml
@@ -3,7 +3,7 @@
     <template id="report_invoice" inherit_id="account.report_invoice_document">
         <xpath expr="//h2[@id='title']" position="after">
             <img t-if="o.l10n_pt_qr_code_str"
-                 style="display:inline;margin:10% auto 0 auto;"
+                 style="display:block;margin:0.25cm;"
                  t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', o.l10n_pt_qr_code_str, 150, 150)"/>
         </xpath>
     </template>

--- a/addons/l10n_pt_invoice/views/report_invoice.xml
+++ b/addons/l10n_pt_invoice/views/report_invoice.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="report_invoice" inherit_id="account.report_invoice_document">
-        <xpath expr="//div[@id='qrcode']" position="inside">
+        <xpath expr="//h2[@id='title']" position="after">
             <img t-if="o.l10n_pt_qr_code_str"
-                 style="display:block;margin:10% auto 0 auto;"
+                 style="display:inline;margin:10% auto 0 auto;"
                  t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', o.l10n_pt_qr_code_str, 150, 150)"/>
         </xpath>
     </template>

--- a/addons/l10n_pt_invoice/views/report_invoice.xml
+++ b/addons/l10n_pt_invoice/views/report_invoice.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_invoice" inherit_id="account.report_invoice_document">
+        <xpath expr="//div[@id='qrcode']" position="inside">
+            <img t-if="o.l10n_pt_qr_code_str"
+                 style="display:block;margin:10% auto 0 auto;"
+                 t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', o.l10n_pt_qr_code_str, 150, 150)"/>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Starting 1 January 2022, invoices should contain a QR code which holds multiple information about the invoice (such as the document id, the document date, ...) following a specific format.

Links:
Summary https://snitechnology.net/portugal-makes-atcud-and-qr-codes-obligatory-invoice-elements/ 
Official specifications https://info.portaldasfinancas.gov.pt/pt/docs/Conteudos_1pagina/Documents/QR_Code_Technical_Specifications.pdf 

This PR implements this QR code and adds it to the invoices

task-2700432