### PR TITLE
[14.0][FIX] Point of sale fix wrong counterpart account

### DIFF
--- a/addons/account/wizard/pos_box.py
+++ b/addons/account/wizard/pos_box.py
@@ -33,8 +33,8 @@ class CashBox(models.TransientModel):
             if record.state == 'confirm':
                 raise UserError(_("You cannot put/take money in/out for a bank statement which is closed."))
             values = box._calculate_values_for_statement_line(record)
-            account = record.journal_id.company_id.transfer_account_id
-            self.env['account.bank.statement.line'].with_context(counterpart_account_id=account.id).sudo().create(values)
+            values["counterpart_account_id"] = record.journal_id.company_id.transfer_account_id.id
+            self.env['account.bank.statement.line'].sudo().create(values)
 
 
 class CashBoxOut(CashBox):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

put/remove money in cash box do not use internal transfer account
Indeed here the correct account is passed in the context
https://github.com/odoo/odoo/blob/1bcbd64065c283accc705ce08aa5490dde9756b8/addons/account/wizard/pos_box.py#L37

And here the code try to read it from the vals (and so no account is found)
https://github.com/odoo/odoo/blob/5169fc0c20695907228fc16737060a50e1569f8f/addons/account/models/account_bank_statement.py#L858

Note : 15 and master are also impacted

Current behavior before PR:

put/remove money in cash box use suspense account

Desired behavior after PR is merged:

put/remove money in cash box use internal transfer account


@smetl @alexis-via @PierrickBrun 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
