### PR TITLE
[FIX] hr_holidays_attendance: remove has_valid_allocation from search…

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -255,13 +255,14 @@ class HolidaysAllocation(models.Model):
 
     @api.depends('holiday_type')
     def _compute_from_holiday_type(self):
+        default_employee_ids = self.env['hr.employee'].browse(self.env.context.get('default_employee_id')) or self.env.user.employee_id
         for allocation in self:
             if allocation.holiday_type == 'employee':
                 if not allocation.employee_ids:
                     allocation.employee_ids = self.env.user.employee_id
                 allocation.mode_company_id = False
                 allocation.category_id = False
-            if allocation.holiday_type == 'company':
+            elif allocation.holiday_type == 'company':
                 allocation.employee_ids = False
                 if not allocation.mode_company_id:
                     allocation.mode_company_id = self.env.company
@@ -274,7 +275,7 @@ class HolidaysAllocation(models.Model):
                 allocation.employee_ids = False
                 allocation.mode_company_id = False
             else:
-                allocation.employee_ids = self.env.context.get('default_employee_id') or self.env.user.employee_id
+                allocation.employee_ids = default_employee_ids
 
     @api.depends('holiday_type', 'employee_id')
     def _compute_department_id(self):

--- a/addons/hr_holidays_attendance/models/res_users.py
+++ b/addons/hr_holidays_attendance/models/res_users.py
@@ -18,7 +18,6 @@ class ResUsers(models.Model):
     def _compute_request_overtime(self):
         is_holiday_user = self.env.user.has_group('hr_holidays.group_hr_holidays_user')
         time_off_types = self.env['hr.leave.type'].search_count([
-            ('has_valid_allocation', '=', True),
             ('requires_allocation', '=', 'yes'),
             ('employee_requests', '=', 'yes'),
             ('overtime_deductible', '=', True)


### PR DESCRIPTION
…_count

In hr_holidays_attendance, the model that inherits from res.users adds a request_overtime field.
This field is used to allow the user to request overtime based on the total overtime.
The domain for the time off type includes has_valid_allocation. If the user doesn't have any allocation,
he won't be able to deduct extra hours

task-2701128

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
