### PR TITLE
[FIX] point_of_sale: receipt automatic print image fail

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
@@ -27,7 +27,13 @@ odoo.define('point_of_sale.ReceiptScreen', function (require) {
                 // We are doing this because we want the receipt screen to be
                 // displayed regardless of what happen to the handleAutoPrint
                 // call.
-                setTimeout(async () => await this.handleAutoPrint(), 0);
+                setTimeout(async () => {
+                    let images = this.orderReceipt.el.getElementsByTagName('img');
+                    for(let image of images) {
+                        await image.decode();
+                    }
+                    await this.handleAutoPrint();
+                }, 0);
             }
             async onSendEmail() {
                 if (!is_email(this.orderUiState.inputEmail)) {


### PR DESCRIPTION
There were some issues when auto printing the receipt with images.
It could happen that the receipt was printed and the image were not yet visible.

To fix this, we make sure the image are rendered on the receipt before we print it.

Ticket-id: 2688238

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
