### PR TITLE
[FIX] hr_holidays: fix test_leave_whole_company_07 test

### DIFF
--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -295,7 +295,9 @@ class TestCompanyLeave(SavepointCase):
             'employee_id': employee.id,
             'holiday_status_id': self.paid_time_off.id,
             'request_date_from': date(2020, 3, 29),
+            'date_from': datetime(2020, 3, 29, 7, 0, 0),
             'request_date_to': date(2020, 4, 1),
+            'date_to': datetime(2020, 4, 1, 19, 0, 0),
             'number_of_days': 3,
         } for employee in employees[0:15]])
         for leave in leaves:


### PR DESCRIPTION
test_leave_whole_company_07 test was failing due ot the hr_leave_date_check2
constraint.
This constraint check that date_from <= date_to for a leave.

date_from and date_to were not assigned any value before and had a default value
of fields.Datetime.now. Depending on which date_from or date_to is created first,
a few second difference can exist and this violates the hr_leave_date_check2 constraint

task-2726143

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
