### PR TITLE
[FIX] web: fix calendar test

### DIFF
--- a/addons/web/static/tests/legacy/views/calendar_tests.js
+++ b/addons/web/static/tests/legacy/views/calendar_tests.js
@@ -4173,14 +4173,15 @@ QUnit.module('Views', {
             viewOptions: {
                 initialDate: initialDate,
             },
-        });
+        }, { positionalClicks: true });
 
         assert.equal(calendar.$('.fc-dayGridMonth-view').length, 12, "should display in year mode");
 
-        await testUtils.dom.dragAndDrop(
-            calendar.$('.fc-day-top[data-date="2016-11-13"]'),
-            calendar.$('.fc-day-top[data-date="2016-11-19"]'),
-        );
+        calendar.el.querySelector('.fc-day-top[data-date="2016-11-13"]').scrollIntoView();
+        // scroll to event as the calendar could be too small
+        await testUtils.dom.triggerMouseEvent(calendar.$('.fc-day-top[data-date="2016-11-13"]'), "mousedown");
+        await testUtils.dom.triggerMouseEvent(calendar.$('.fc-day-top[data-date="2016-11-19"]'), "mousemove");
+        await testUtils.dom.triggerMouseEvent(calendar.$('.fc-day-top[data-date="2016-11-19"]'), "mouseup");
 
         assert.ok($('.modal-body').length, "should open the form view in dialog when select multiple days");
         assert.hasAttrValue($('.fc-highlight'), 'colspan', "7", "should highlight 7 days");


### PR DESCRIPTION
This commit fixes the calendar test "select events and discard create"
which was crashing certainly because the event we want to click on was
out of the screen at this moment.
Calendar tests use positional mouse[down|up] events to simulate clicks
on events so we need first to scroll to the wanted event before clicking
on it.
