### PR TITLE
[FIX] base: HTML formatting of currencies with zero decimal places

### DIFF
--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -451,7 +451,7 @@ class MonetaryConverter(models.AbstractModel):
         else:
             post = '\N{NO-BREAK SPACE}{symbol}'.format(symbol=display_currency.symbol or '')
 
-        if options.get('label_price'):
+        if options.get('label_price') and lang.decimal_point in formatted_amount:
             sep = lang.decimal_point
             integer_part, decimal_part = formatted_amount.split(sep)
             integer_part += sep


### PR DESCRIPTION
Before this commit: printing a product's label which has currency with
zero decimal places (like CFA franc) raised a traceback error.

To fix this issue, I added a condition that checks whether there is
a separator in the value to ensure that the currency has a decimal point.

opw-2711074
