### PR TITLE
[FIX] base_automation: error not correctly show

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -230,7 +230,7 @@ class BaseAutomation(models.Model):
             e.context['exception_class'] = 'base_automation'
             e.context['base_automation'] = {
                 'id': self.id,
-                'name': self.name,
+                'name': self.sudo().name,
             }
 
     def _process(self, records, domain_post=None):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
If an error append during an automation made by a standard user, the error is not correctly show. (A standard user have no access to read base.automation).


**Current behavior before PR:**
![image](https://user-images.githubusercontent.com/16716992/147921955-c195322e-87e7-4004-b09b-0b72ec1c644f.png)


**Desired behavior after PR is merged:**
![image](https://user-images.githubusercontent.com/16716992/147921913-9c515bb9-5aa9-4900-b211-e8e7b6a0ab48.png)

@rco-odoo 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
