### PR TITLE
[FIX] base_automation: impossible to execute an action with unlink

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -256,7 +256,8 @@ class BaseAutomation(models.Model):
             records.write(values)
 
         # execute server actions
-        if self.action_server_id:
+        action_server = self.action_server_id
+        if action_server:
             for record in records:
                 # we process the action if any watched field has been modified
                 if self._check_trigger_fields(record):
@@ -267,7 +268,7 @@ class BaseAutomation(models.Model):
                         'domain_post': domain_post,
                     }
                     try:
-                        self.action_server_id.sudo().with_context(**ctx).run()
+                        action_server.sudo().with_context(**ctx).run()
                     except Exception as e:
                         self._add_postmortem_action(e)
                         raise e


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Create two record with state == 'one' and with activities
- Create an automated action if state == 'two' then record.sudo().activity_ids.action_done()
- Set state == 'two' in same time of two record

In the loop line 261, for the first record self.action_record_id is in cache, but for the second record it is not in cache because of the unlink made by action_done(). When the orm raise during put in cache because he have no access to self.


Current behavior before PR:
![image](https://user-images.githubusercontent.com/16716992/147927105-37f2b3b9-a2c7-4776-a94b-5e83179d3d61.png)


Desired behavior after PR is merged:
No error

@rco-odoo 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
