### PR TITLE
[IMP] mail: make the activity popover test more reliable

### DIFF
--- a/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover.js
+++ b/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover.js
@@ -60,6 +60,9 @@ export class ActivityMarkDonePopover extends Component {
      * @private
      */
     _onBlur() {
+        if (!this.activity) {
+            return;
+        }
         this.activity.update({
             feedbackBackup: this._feedbackTextareaRef.el.value,
         });


### PR DESCRIPTION
This PR make the activity popover test use the mock model and a chatter as
component.
