### PR TITLE
[FIX] web_editor: fix some colorpicker issues

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1387,7 +1387,7 @@ export class OdooEditor extends EventTarget {
                 if (hasGradient && hasTextGradientClass) {
                     foreColor = backgroundImage;
                 } else {
-                    foreColor = document.queryCommandValue('foreColor');
+                    foreColor = this.document.queryCommandValue('foreColor');
                 }
             }
             if (!hiliteColor) {

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 import {
     ancestors,
+    descendants,
     childNodeIndex,
     closestBlock,
     closestElement,
@@ -29,6 +30,7 @@ import {
     setSelection,
     setCursorStart,
     setTagName,
+    splitAroundUntil,
     splitElement,
     splitTextNode,
     startPos,
@@ -505,15 +507,15 @@ export const editorCommands = {
         const selectedNodes = getSelectedNodes(editor.editable);
         const fonts = selectedNodes.flatMap(node => {
             let font = closestElement(node, 'font');
-            const children = font && [...font.childNodes];
+            const children = font && descendants(font);
             if (font && font.nodeName === 'FONT') {
                 // Partially selected <font>: split it.
                 const selectedChildren = children.filter(child => selectedNodes.includes(child));
                 if (selectedChildren.length) {
-                    const after = selectedChildren[selectedChildren.length - 1].nextSibling;
-                    font = after ? splitElement(font, childNodeIndex(after))[0] : font;
-                    const before = selectedChildren[0].previousSibling;
-                    font = before ? splitElement(font, childNodeIndex(before) + 1)[1] : font;
+                    const splitResult = splitAroundUntil(selectedChildren, font);
+                    font = splitResult[0] || splitResult[1] || font;
+                } else {
+                    font = [];
                 }
             } else if (node.nodeType === Node.TEXT_NODE && isVisibleStr(node)) {
                 // Node is a visible text node: wrap it in a <font>.

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -309,6 +309,20 @@ export function ancestors(node, editable) {
     return [node.parentElement, ...ancestors(node.parentElement, editable)];
 }
 
+/**
+ * Take a node, return all of its descendants, in depth-first order.
+ *
+ * @param {Node} node
+ * @returns {Node[]}
+ */
+export function descendants(node) {
+    const posterity = [];
+    for (const child of (node.childNodes || [])) {
+        posterity.push(child, ...descendants(child));
+    }
+    return posterity;
+}
+
 export function closestBlock(node) {
     return findNode(closestPath(node), node => isBlock(node));
 }
@@ -1366,6 +1380,44 @@ export function splitElement(element, offset) {
     element.after(after);
     element.remove();
     return [before, after];
+}
+
+/**
+ * Split around the given elements, until a given ancestor (included). Elements
+ * will be removed in the process so caution is advised in dealing with their
+ * references. Returns a tuple containing the new elements on both sides of the
+ * split.
+ *
+ * @see splitElement
+ * @param {Node[] | Node} elements
+ * @param {Node} limitAncestor
+ * @returns {[Node, Node]}
+ */
+export function splitAroundUntil(elements, limitAncestor) {
+    elements = Array.isArray(elements) ? elements : [elements];
+    let after = elements[elements.length - 1].nextSibling;
+    let newUntil = limitAncestor;
+    let beforeSplit, afterSplit;
+    // Split up ancestors up to font
+    while (after && after.parentElement !== limitAncestor) {
+        afterSplit = splitElement(after.parentElement, childNodeIndex(after))[0];
+        newUntil = afterSplit;
+        after = newUntil.nextSibling;
+    }
+    if (after) {
+        afterSplit = splitElement(limitAncestor, childNodeIndex(after))[0];
+        limitAncestor = afterSplit;
+    }
+    let before = elements[0].previousSibling;
+    while (before && before.parentElement !== limitAncestor) {
+        beforeSplit = splitElement(before.parentElement, childNodeIndex(before) + 1)[1];
+        newUntil = beforeSplit;
+        before = newUntil.previousSibling;
+    }
+    if (before) {
+        beforeSplit = splitElement(limitAncestor, childNodeIndex(before) + 1)[1];
+    }
+    return [beforeSplit, afterSplit];
 }
 
 export function insertText(sel, content) {

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -2248,7 +2248,7 @@ X[]
                         contentAfter: '<p><b>abc</b></p><p>[]<br></p>',
                     });
                 });
-                it.only('should insert line breaks outside the edges of an anchor', async () => {
+                it('should insert line breaks outside the edges of an anchor', async () => {
                     const pressEnter = editor => {
                         editor.document.execCommand('insertParagraph');
                     }
@@ -3114,6 +3114,18 @@ X[]
                     },
                     contentAfter: '<p>ad[]</p>',
                 });
+            });
+        });
+    });
+
+    describe('applyColor', () => {
+        it('should apply a color to a slice of text in a span in a font', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>a<font>b<span>c[def]g</span>h</font>i</p>',
+                stepFunction: editor => editor.execCommand('applyColor', 'rgb(255, 0, 0)', 'color'),
+                contentAfter: '<p>a<font>b<span>c</span></font>' +
+                    '<font style="color: rgb(255, 0, 0);"><span>[def]</span></font>' +
+                    '<font><span>g</span>h</font>i</p>',
             });
         });
     });


### PR DESCRIPTION
The colorpicker failed in cases like:
```xml
<font>a<span>b</span>c</font>
```
where we select the letter "b".
This was because `applyColor` only considered direct children of the `font` element. This extends it to deal with further descendants of it.

The editor toolbar button to trigger the colorpicker is supposed to show the color of the currently selected text. This was failing in iframes because the code was called on the wrong document.

task-2623347

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
