### PR TITLE
[FIX] project: portal visibility of a task

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1006,7 +1006,7 @@ class Task(models.Model):
         if partner_ids:
             new_allowed_users = self.env['res.partner'].browse(partner_ids).user_ids.filtered('share')
             tasks = self.filtered(lambda task: task.project_id.privacy_visibility == 'portal')
-            tasks.sudo().write({'allowed_user_ids': [(4, user.id) for user in new_allowed_users]})
+            tasks.sudo().allowed_user_ids |= new_allowed_users
         return res
 
     # ----------------------------------------


### PR DESCRIPTION
Steps to reproduce:
- Install Project
- Create internal user with usable adress mail
- Create portal user
- Define the mail settings for ingoing/outgoing server
- Create a new project with an alias for the mails to be fetched; in settings put the portal user as visible
- Send an email with the email adress of the internal user
-> In the task created, the portal user does not appear

OPW-2704113
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
