### PR TITLE
[FIX] l10n_lu: fix tax report formula for 012 and 454

### DIFF
--- a/addons/l10n_lu/data/account_tax_report_line.xml
+++ b/addons/l10n_lu/data/account_tax_report_line.xml
@@ -277,7 +277,7 @@
       <field name="sequence">1</field>
       <field name="parent_id" ref="account_tax_report_line_1_assessment_taxable_turnover"/>
       <field name="country_id" ref="base.lu"/>
-      <field name="formula">LUTAX_471 + LUTAX_021 + LUTAX_037 + LUTAX_455 + LUTAX_456</field>
+      <field name="formula">LUTAX_471 + LUTAX_021 + LUTAX_037 + LUTAX_455</field>
     </record>
 
     <record id="account_tax_report_line_1a_vat_acc_scheme" model="account.tax.report.line">
@@ -292,7 +292,7 @@
         <field name="sequence" eval="2"/>
         <field name="parent_id" ref="account_tax_report_line_1a_overall_turnover"/>
         <field name="country_id" ref="base.lu"/>
-        <field name="formula">LUTAX_471 + LUTAX_021 + LUTAX_037</field>
+        <field name="formula">LUTAX_471 + LUTAX_021 + LUTAX_037 - LUTAX_456</field>
     </record>
 
     <!-- 471 not managed, only 472 is filled in -->


### PR DESCRIPTION
- Configure LU localization
- Go to Accounting > Accounting > Journal Entries
- Create a new entry with the following items:

 | Account | Taxes  | Debit | Credit | Tax Grids |
| --- | --- | --- | --- | --- |
| 746000 Benefits in kind | 17-ATN | 0 € | 100 € | (456)(701) |
| 461411 VAT received | | 0 € | 17 € | (702) |
| 621150 Benefits in kind | | 117 € | 0 € |

- Post it
- Go to Accounting > Reporting > Tax Report
Lines "I.A. Overall turnover (012)" and "I.A.2. Total Sales / Receipts (454)"
are incorrectly computed and have an exceeding amount of 100€.
Their child line "I.A.2.b) Other sales / receipts (472)" has the following
formula: LUTAX_021 + LUTAX_037 - LUTAX_456
But the substraction part of this formula (- LUTAX_456) is not present in
their own formula.

LUTAX_456 should be substracted from the formula of lines (012) and (454).

opw-2699920




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
