### PR TITLE
[FIX] website: remove snippet duplicates in drag and drop test

### DIFF
--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -1,6 +1,15 @@
 odoo.define("website.tour.snippets_all_drag_and_drop", async function (require) {
 "use strict";
 
+const snippetsEditor = require('web_editor.snippet.editor');
+
+snippetsEditor.SnippetEditor.include({
+    removeSnippet: async function (shouldRecordUndo = true) {
+        await this._super(...arguments);
+        $('body').attr('test-dd-snippet-removed', true);
+    },
+});
+
 const tour = require("web_tour.tour");
 
 let snippetsNames = (new URL(document.location.href)).searchParams.get('snippets_names') || '';
@@ -25,13 +34,11 @@ for (const snippet of snippetsNames) {
         trigger: "we-button.oe_snippet_remove:last"
     }, {
         content: `click on 'BLOCKS' tab (${snippet})`,
+        extra_trigger: 'body[test-dd-snippet-removed]',
         trigger: ".o_we_add_snippet_btn",
         run: function (actions) {
-            // FIXME cannot find the reason why this setTimeout is needed to
-            // after reverting ab7508393376075f95d6dd5925e7f4462936d2, to check
-            // (this commit is however reverted temporarily until a better
-            // solution is found).
-            setTimeout(() => actions.auto(), 0);
+            $('body').removeAttr('test-dd-snippet-removed');
+            actions.auto();
         },
     }];
 

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -24,9 +24,9 @@ class TestSnippets(odoo.tests.HttpCase):
         data_snippet_els = html_template.xpath("//*[@class='o_panel' and not(contains(@class, 'd-none'))]//*[@data-snippet]")
         blacklist = [
             's_facebook_page',  # avoid call to external services (facebook.com)
-            's_map', # avoid call to maps.google.com
+            's_map',  # avoid call to maps.google.com
         ]
-        snippets_names = ','.join([el.attrib['data-snippet'] for el in data_snippet_els if el.attrib['data-snippet'] not in blacklist])
+        snippets_names = ','.join(set(el.attrib['data-snippet'] for el in data_snippet_els if el.attrib['data-snippet'] not in blacklist))
         self.start_tour("/?enable_editor=1&snippets_names=%s" % snippets_names, "snippets_all_drag_and_drop", login='admin', timeout=300)
 
     def test_04_countdown_preview(self):


### PR DESCRIPTION
A mega-tour was introduced with [1] to test every single snippet.
This tour, despite being very useful as it tests the core behavior of the
website builder, is creating a lot of race conditions.

This commit won't fix anything but will actually reduce the tour length,
hopefully also reducing the amount of race condition while those are fixed.
Indeed, some snippets were tested multiple times, as a snippet might include
another snippet in its DOM, the xpath query would return multiple times the
same snippet.

Duplicates: s_card (5), s_banner (2), s_donation_button (2),
s_dynamic_snippet_products (2), s_newsletter_subscribe_form (3),
s_searchbar_input (2), s_text_block (3), s_hr (2).

[1]: https://github.com/odoo/odoo/commit/460d5ecb926c13a79ba363f8f86442433d91bf6f

task-2726529
