### PR TITLE
[FIX] mail: clean message view component to ease the enterprise part

### DIFF
--- a/addons/mail/static/src/components/delete_message_confirm_dialog/delete_message_confirm_dialog.xml
+++ b/addons/mail/static/src/components/delete_message_confirm_dialog/delete_message_confirm_dialog.xml
@@ -5,7 +5,7 @@
             <t t-if="messageActionList">
                 <p>Are you sure you want to delete this message?</p>
                 <blockquote class="o_DeleteMessageConfirmDialog_blockquote">
-                    <Message messageViewLocalId="messageActionList.messageViewForDelete.localId"/>
+                    <Message localId="messageActionList.messageViewForDelete.localId"/>
                 </blockquote>
                 <small t-if="!messageActionList.message.originThread or messageActionList.message.originThread.model !== 'mail.channel'">Pay attention: The followers of this document who were notified by email will still be able to read the content of this message and reply to it.</small>
                 <t t-set-slot="buttons">

--- a/addons/mail/static/src/components/message/message.js
+++ b/addons/mail/static/src/components/message/message.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { useComponentToModel } from '@mail/component_hooks/use_component_to_model/use_component_to_model';
+import { useUpdateToModel } from '@mail/component_hooks/use_update_to_model/use_update_to_model';
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 import { useUpdate } from '@mail/component_hooks/use_update/use_update';
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
@@ -22,7 +23,8 @@ export class Message extends Component {
      */
     setup() {
         super.setup();
-        useComponentToModel({ fieldName: 'component', modelName: 'mail.message_view', propNameAsRecordLocalId: 'messageViewLocalId' });
+        useComponentToModel({ fieldName: 'component', modelName: 'mail.message_view', propNameAsRecordLocalId: 'localId' });
+        useUpdateToModel({ methodName: 'onComponentUpdate', modelName: 'mail.message_view', propNameAsRecordLocalId: 'localId' });
         this.state = useState({
             /**
              * Determine whether the message is hovered. When message is hovered
@@ -219,7 +221,7 @@ export class Message extends Component {
      * @returns {mail.message_view}
      */
     get messageView() {
-        return this.messaging && this.messaging.models['mail.message_view'].get(this.props.messageViewLocalId);
+        return this.messaging && this.messaging.models['mail.message_view'].get(this.props.localId);
     }
     /**
      * @returns {string}
@@ -563,9 +565,7 @@ export class Message extends Component {
 }
 
 Object.assign(Message, {
-    props: {
-        messageViewLocalId: String,
-    },
+    props: { localId: String },
     template: 'mail.Message',
 });
 

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -15,8 +15,8 @@
                 'o-selected': isSelected,
                 'o-squashed': messageView and messageView.isSquashed,
                 'o-starred': messageView and messageView.message.isStarred,
-                'mt-3': messageView and !messageView.isSquashed,
-            }" t-attf-class="{{ className }}" t-on-click="_onClick" t-on-mouseenter="state.isHovered = true" t-on-mouseleave="state.isHovered = false" t-att-data-message-local-id="messageView and messageView.message.localId"
+                'mt-3': messageView and !messageView.isSquashed and messageView.threadView,
+            }" t-attf-class="{{ messageView and messageView.extraClass }} {{ className }}" t-on-click="_onClick" t-on-mouseenter="state.isHovered = true" t-on-mouseleave="state.isHovered = false" t-att-data-message-local-id="messageView and messageView.message.localId"
             t-ref="root"
         >
             <t t-if="messageView" name="rootCondition">

--- a/addons/mail/static/src/components/message/tests/message_tests.js
+++ b/addons/mail/static/src/components/message/tests/message_tests.js
@@ -572,7 +572,7 @@ QUnit.test('do not show messaging seen indicator if before last seen by all mess
         },
     ]);
     await createRootMessagingComponent(this, "Message", {
-        props: { messageViewLocalId: threadViewer.threadView.messageViews[0].localId },
+        props: { localId: threadViewer.threadView.messageViews[0].localId },
         target: this.widget.el,
     });
 

--- a/addons/mail/static/src/components/message_list/message_list.js
+++ b/addons/mail/static/src/components/message_list/message_list.js
@@ -122,9 +122,6 @@ export class MessageList extends Component {
                     // position
                     this._adjustScrollForExtraMessagesAtTheStart();
                     break;
-                case 'highlight-reply':
-                    this._highlightMessageView(hint.data);
-                    break;
             }
             if (threadView && threadView.exists()) {
                 threadView.markComponentHintProcessed(hint);
@@ -242,7 +239,7 @@ export class MessageList extends Component {
         if (!threadView || !threadView.exists()) {
             return;
         }
-        const { length, [length - 1]: lastMessageView } = this.threadView.messageViews;
+        const { lastMessageView } = this.threadView;
         if (lastMessageView && lastMessageView.component && lastMessageView.component.isPartiallyVisible()) {
             threadView.handleVisibleMessage(lastMessageView.message);
         }
@@ -257,19 +254,6 @@ export class MessageList extends Component {
             return this.props.getScrollableElement();
         } else {
             return this.root.el;
-        }
-    }
-
-    /**
-     * Scrolls to a given message view and briefly highlights it.
-     *
-     * @private
-     * @param {mail.message_view} messageView
-     */
-    _highlightMessageView(messageView) {
-        if (messageView.exists() && messageView.component && messageView.component.el) {
-            messageView.component.el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-            messageView.highlight();
         }
     }
 
@@ -313,7 +297,6 @@ export class MessageList extends Component {
      * @private
      */
     _update() {
-        this._checkMostRecentMessageIsVisible();
         this.adjustFromComponentHints();
     }
 

--- a/addons/mail/static/src/components/message_list/message_list.xml
+++ b/addons/mail/static/src/components/message_list/message_list.xml
@@ -61,7 +61,7 @@
                                 <t t-set="current_day" t-value="message_day"/>
                             </div>
                         </t>
-                        <Message className="'o_MessageList_item o_MessageList_message'" messageViewLocalId="messageView.localId"/>
+                        <Message localId="messageView.localId"/>
                     </t>
                 </t>
                 <!-- LOADING (if order desc)-->

--- a/addons/mail/static/src/models/message_in_reply_to_view/message_in_reply_to_view.js
+++ b/addons/mail/static/src/models/message_in_reply_to_view/message_in_reply_to_view.js
@@ -33,7 +33,7 @@ registerModel({
             if (!parentMessageView) {
                 return;
             }
-            threadView.addComponentHint('highlight-reply', parentMessageView);
+            parentMessageView.update({ doHighlight: true });
         },
         /**
          * @private

--- a/addons/mail/static/src/models/message_view/message_view.js
+++ b/addons/mail/static/src/models/message_view/message_view.js
@@ -20,6 +20,19 @@ registerModel({
                 }, 2000),
             });
         },
+        onComponentUpdate() {
+            if (!this.exists()) {
+                return;
+            }
+            if (this.doHighlight && this.component && this.component.root.el) {
+                this.component.root.el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                this.highlight();
+                this.update({ doHighlight: clear() });
+            }
+            if (this.threadView && this.threadView.lastMessageView === this && this.component && this.component.isPartiallyVisible()) {
+                this.threadView.handleVisibleMessage(this.message);
+            }
+        },
         /**
          * Action to initiate reply to current messageView.
          */
@@ -84,6 +97,16 @@ registerModel({
         },
         /**
          * @private
+         * @returns {string|FieldCommand}
+         */
+        _computeExtraClass() {
+            if (this.threadView) {
+                return 'o_MessageList_item o_MessageList_message';
+            }
+            return clear();
+        },
+        /**
+         * @private
          * @returns {FieldCommand}
          */
         _computeMessageActionList() {
@@ -129,6 +152,18 @@ registerModel({
         composerViewInEditing: one2one('mail.composer_view', {
             inverse: 'messageViewInEditing',
             isCausal: true,
+        }),
+        /**
+         * Determines whether this message view should be highlighted at next
+         * render. Scrolls into view and briefly highlights it.
+         */
+        doHighlight: attr(),
+        /**
+         * Determines which extra class this message view component should have.
+         */
+        extraClass: attr({
+            compute: '_computeExtraClass',
+            default: '',
         }),
         /**
          * id of the current timeout that will reset isHighlighted to false.

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -97,6 +97,14 @@ registerModel({
         },
         /**
          * @private
+         * @returns {FieldCommand}
+         */
+        _computeLastMessageView() {
+            const { length, [length - 1]: lastMessageView } = this.messageViews;
+            return lastMessageView ? replace(lastMessageView) : clear();
+        },
+        /**
+         * @private
          * @returns {mail.message_view[]}
          */
         _computeMessageViews() {
@@ -418,6 +426,9 @@ registerModel({
          */
         lastMessage: many2one('mail.message', {
             related: 'thread.lastMessage',
+        }),
+        lastMessageView: one2one('mail.message_view', {
+            compute: '_computeLastMessageView',
         }),
         /**
          * Most recent message in this ThreadView that has been shown to the

--- a/addons/mail/static/src/utils/test_utils.js
+++ b/addons/mail/static/src/utils/test_utils.js
@@ -431,7 +431,7 @@ function getCreateMessageComponent({ components, env, modelManager, widget }) {
             qunitTest: insertAndReplace(),
         });
         await createRootMessagingComponent({ components, env }, "Message", {
-            props: { messageViewLocalId: messageView.localId },
+            props: { localId: messageView.localId },
             target: widget.el,
         });
     };


### PR DESCRIPTION
- Move extra class to field to avoid reliance on specific template.
- Rename prop to be generic.
- Remove extra margin-top in message view outside of thread view (bonus fix).
- Move code using message view component out of message list update to break
  infinite loop.

task-2728107