### PR TITLE
[IMP] web: trim keywords in the search bar

### DIFF
--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1517,7 +1517,10 @@ export class SearchModel extends EventBus {
         const domains = autocompleteValues.map(({ label, value, operator }) => {
             let domain;
             if (field.filterDomain) {
-                domain = new Domain(field.filterDomain).toList({ self: label, raw_value: value });
+                domain = new Domain(field.filterDomain).toList({
+                    self: label.trim(),
+                    raw_value: value,
+                });
             } else {
                 domain = [[field.fieldName, operator, value]];
             }

--- a/addons/web/static/tests/search/search_bar_tests.js
+++ b/addons/web/static/tests/search/search_bar_tests.js
@@ -659,6 +659,38 @@ QUnit.module("Search", (hooks) => {
         assert.deepEqual(getDomain(controlPanel), [["bool", "=", false]]);
     });
 
+    QUnit.test("the search value is trimmed to remove unnecessary spaces", async function (assert) {
+        const controlPanel = await makeWithSearch({
+            serverData,
+            resModel: "partner",
+            Component: ControlPanel,
+            searchMenuTypes: [],
+            searchViewId: false,
+            searchViewArch: `
+                        <search>
+                            <field name="foo" filter_domain="[('foo', 'ilike', self)]"/>
+                        </search>
+                    `,
+        });
+        await editSearch(controlPanel, "bar");
+        await validateSearch(controlPanel);
+
+        assert.deepEqual(getDomain(controlPanel), [["foo", "ilike", "bar"]]);
+
+        await removeFacet(controlPanel);
+
+        assert.deepEqual(getDomain(controlPanel), []);
+
+        await editSearch(controlPanel, "   bar ");
+        await validateSearch(controlPanel);
+
+        assert.deepEqual(
+            getDomain(controlPanel),
+            [["foo", "ilike", "bar"]],
+            "the value has been trimmed"
+        );
+    });
+
     QUnit.test("reference fields are supported in search view", async function (assert) {
         assert.expect(4);
 


### PR DESCRIPTION
When the search field is used to query an element, the value is
trimmed to remove unnecessary spaces before and after the actual
keywords. This eliminates the annoyance of a search having no
result because of a space that was left (for example when copy-
pasting some text). A test has been added to check if a value
has been trimmed when the text input contains spaces.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
