### PR TITLE
[IMP] mail: fix reply-to value of email

### DIFF
--- a/addons/mail/data/mail_data.xml
+++ b/addons/mail/data/mail_data.xml
@@ -262,7 +262,7 @@
     <!-- CONTENT -->
     <tr>
         <td style="padding: 0">
-            <t t-raw="message.body"/>
+            <t t-raw="message.body or rendered_body"/>
             <div t-if="is_online and not record._context.get('proforma')" style="margin: 32px 0px 32px 0px; text-align: center;">
                 <a t-att-href="access_url"
                     style="background-color: #875A7B; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px; font-size:13px;">

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -314,8 +314,8 @@ class MailComposer(models.TransientModel):
                     mail_values['auto_delete'] = True
                 # rendered values using template
                 if mass_mail_mode and self.model:
-                    rendered_values = self.render_message(res_ids, mail_values.copy())
-                email_dict = rendered_values[res_id]
+                    rendered_values = self.render_message(res_id, mail_values.copy())
+                email_dict = rendered_values
                 mail_values['partner_ids'] += email_dict.pop('partner_ids', [])
                 mail_values.update(email_dict)
                 if not self.no_auto_thread:

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -61,7 +61,7 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +51 compared to local
-        with self.assertQueryCount(__system__=1718, marketing=1720):  # test_mass_mailing_only: 1665 - 1666
+        with self.assertQueryCount(__system__=1766, marketing=1768):  # test_mass_mailing_only: 1665 - 1666
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)
@@ -101,7 +101,7 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +63 compared to local
-        with self.assertQueryCount(__system__=1995, marketing=1997):  # test_mass_mailing only: 1931 - 1932
+        with self.assertQueryCount(__system__=1994, marketing=1996):  # test_mass_mailing only: 1931 - 1932
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)


### PR DESCRIPTION
PURPOSE

The rendered value should be displayed in the reply-to field in
the email.

SPECIFICATIONS

While sending multiple invoices/bills, the reply-to value is not set properly.

With this commit, We have passed the rendered email address in the
def get_mail_values() method. so, The rendering value will be shown 
in the reply-to field.  

PR #82194
Task-2704083



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
