### PR TITLE
[FIX] accounting: backport fix in calculation

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -1296,7 +1296,7 @@ class AccountTax(models.Model):
             return base_amount - (base_amount / (1 + self.amount / 100))
         # base / (1 - tax_amount) = new_base
         if self.amount_type == 'division' and not price_include:
-            return base_amount / (1 - self.amount / 100) - base_amount
+            return base_amount / (1 - self.amount / 100) - base_amount if (1 - self.amount / 100) else 0.0
         # <=> new_base * (1 - tax_amount) = base
         if self.amount_type == 'division' and price_include:
             return base_amount - (base_amount * (self.amount / 100))


### PR DESCRIPTION
This commit backports fix in:
https://github.com/odoo/odoo/commit/0b11474a168037b5469176433256759916e8276b
to accounting of saas-12.3

Description of the issue/feature this PR addresses: An upgrade request with 100% tax and amount type division is failing with division by zero.

Current behavior before PR: The upgrade of the db fails because of division by zero error.

Desired behavior after PR is merged: Division by zero error should not happen when an amount for a single tax is computed, and 0 should be returned if tax is 100% and amount type is division.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
