### PR TITLE
[IMP] mass_mailing: group visibility for email marketing

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -295,7 +295,7 @@
                             </page>
                             <page string="Settings" name="settings">
                                 <group>
-                                    <group string="Email Content">
+                                    <group string="Email Content" attrs="{'invisible': [('mailing_type', '!=', 'mail')]}">
                                         <field class="o_text_overflow" name="preview" string="Preview Text" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}" widget="char_emojis" placeholder="e.g. Check it out before it's too late!"/>
                                         <field name="email_from" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                         <label for="reply_to"/>
@@ -342,8 +342,9 @@
                                             class="o_text_overflow"
                                             groups="base.group_no_one"
                                             attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
-                                        <field name="user_id" widget="many2one_avatar_user"
-                                            domain="[('share', '=', False)]"/>
+                                    </group>
+                                    <group string="User">
+                                        <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
                                     </group>
                                     <group string="Advanced" groups="base.group_no_one">
                                         <field name="mail_server_available" invisible="1"/>


### PR DESCRIPTION
PURPOSE

While creating a new SMS mailing, The settings tab should have Responsible' and 'Include opt-out link' fields.

SPECIFICATIONS

While creating a new SMS mailing, There is an empty settings tab.

With this Commit,
- We have added a new 'User' group and set the 'Responsible'
and "Include opt-out link" fields inside this group.
- Show Email Content only while creating Email Marketing

PR #82196
Task-2710557


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
