### PR TITLE
[IMP] mail: make the mute and deafen button behavior more intuitive

### DIFF
--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
@@ -49,7 +49,7 @@
                             </t>
                         </span>
                         <div class="o_RtcCallParticipantCard_overlayTop">
-                            <t t-if="callParticipantCard.rtcSession.isSelfMuted">
+                            <t t-if="callParticipantCard.rtcSession.isSelfMuted and !callParticipantCard.rtcSession.isDeaf">
                                 <span class="o_RtcCallParticipantCard_overlayTopElement" t-att-class="{'o-isMinimized': callParticipantCard.isMinimized }" title="muted" aria-label="muted">
                                     <i class="fa fa-microphone-slash"/>
                                 </span>

--- a/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
+++ b/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
@@ -6,19 +6,19 @@
             <t t-if="rtcController and messaging">
                 <div class="o_RtcController_buttons">
                     <t t-if="rtcController.callViewer.threadView.thread.rtc and messaging.rtc.currentRtcSession">
-                        <t t-if="messaging.rtc.currentRtcSession.isSelfMuted"><t t-set="microphoneTitle">Unmute</t></t>
+                        <t t-if="messaging.rtc.currentRtcSession.isMute"><t t-set="microphoneTitle">Unmute</t></t>
                         <t t-else=""><t t-set="microphoneTitle">Mute</t></t>
                         <button class="o_RtcController_button"
-                            t-att-class="{ 'o-isActive': !messaging.rtc.currentRtcSession.isSelfMuted, 'o-isSmall': rtcController.isSmall }"
+                            t-att-class="{ 'o-isActive': !messaging.rtc.currentRtcSession.isMute, 'o-isSmall': rtcController.isSmall }"
                             t-att-aria-label="microphoneTitle"
                             t-att-title="microphoneTitle"
                             t-on-click="rtcController.onClickMicrophone">
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
                                 <i class="fa" t-att-class="{
                                     'fa-lg': !rtcController.isSmall,
-                                    'fa-microphone': !messaging.rtc.currentRtcSession.isSelfMuted,
-                                    'fa-microphone-slash': messaging.rtc.currentRtcSession.isSelfMuted,
-                                    'text-danger': messaging.rtc.currentRtcSession.isSelfMuted,
+                                    'fa-microphone': !messaging.rtc.currentRtcSession.isMute,
+                                    'fa-microphone-slash': messaging.rtc.currentRtcSession.isMute,
+                                    'text-danger': messaging.rtc.currentRtcSession.isMute,
                                 }"/>
                             </div>
                         </button>

--- a/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
+++ b/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
@@ -94,7 +94,7 @@ registerModel({
          * @returns {boolean}
          */
         _computeIsTalking() {
-            return Boolean(this.rtcSession && this.rtcSession.isTalking && !this.rtcSession.isSelfMuted);
+            return Boolean(this.rtcSession && this.rtcSession.isTalking && !this.rtcSession.isMute);
         },
         /**
          * @private

--- a/addons/mail/static/src/models/rtc_controller/rtc_controller.js
+++ b/addons/mail/static/src/models/rtc_controller/rtc_controller.js
@@ -29,13 +29,26 @@ registerModel({
          * @param {MouseEvent} ev
          */
         async onClickDeafen(ev) {
-            await this.messaging.rtc.currentRtcSession.toggleDeaf();
+            if (this.messaging.rtc.currentRtcSession.isDeaf) {
+                this.messaging.rtc.undeafen();
+            } else {
+                this.messaging.rtc.deafen();
+            }
         },
         /**
          * @param {MouseEvent} ev
          */
         onClickMicrophone(ev) {
-            this.messaging.rtc.toggleMicrophone();
+            if (this.messaging.rtc.currentRtcSession.isMute) {
+                if (this.messaging.rtc.currentRtcSession.isSelfMuted) {
+                    this.messaging.rtc.unmute();
+                }
+                if (this.messaging.rtc.currentRtcSession.isDeaf) {
+                    this.messaging.rtc.undeafen();
+                }
+            } else {
+                this.messaging.rtc.mute();
+            }
         },
         /**
          * @param {MouseEvent} ev


### PR DESCRIPTION
* When a user is already muted when setting their state as deafened
the mute state should remain after the deafen state is removed.
* When a user clicks the microphone (mute/unmute) button while being in
the deaf state, the user should end up undeafen and unmute.

This commit also fixes a case where the track could
be left enabled when transitioning from voice activation
to push-to-talk (the track would still properly be
disabled on the next release of the push-to-talk key).

task-2720026