### PR TITLE
[REF] mail: rename isMuted into isSelfMuted

### DIFF
--- a/addons/mail/models/mail_channel_rtc_session.py
+++ b/addons/mail/models/mail_channel_rtc_session.py
@@ -104,7 +104,7 @@ class MailRtcSession(models.Model):
             vals.update({
                 'isCameraOn': self.is_camera_on,
                 'isDeaf': self.is_deaf,
-                'isMuted': self.is_muted,
+                'isSelfMuted': self.is_muted,
                 'isScreenSharingOn': self.is_screen_sharing_on,
             })
         if self.guest_id:

--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
@@ -49,7 +49,7 @@
                             </t>
                         </span>
                         <div class="o_RtcCallParticipantCard_overlayTop">
-                            <t t-if="callParticipantCard.rtcSession.isMuted">
+                            <t t-if="callParticipantCard.rtcSession.isSelfMuted">
                                 <span class="o_RtcCallParticipantCard_overlayTopElement" t-att-class="{'o-isMinimized': callParticipantCard.isMinimized }" title="muted" aria-label="muted">
                                     <i class="fa fa-microphone-slash"/>
                                 </span>

--- a/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
+++ b/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
@@ -6,19 +6,19 @@
             <t t-if="rtcController and messaging">
                 <div class="o_RtcController_buttons">
                     <t t-if="rtcController.callViewer.threadView.thread.rtc and messaging.rtc.currentRtcSession">
-                        <t t-if="messaging.rtc.currentRtcSession.isMuted"><t t-set="microphoneTitle">Unmute</t></t>
+                        <t t-if="messaging.rtc.currentRtcSession.isSelfMuted"><t t-set="microphoneTitle">Unmute</t></t>
                         <t t-else=""><t t-set="microphoneTitle">Mute</t></t>
                         <button class="o_RtcController_button"
-                            t-att-class="{ 'o-isActive': !messaging.rtc.currentRtcSession.isMuted, 'o-isSmall': rtcController.isSmall }"
+                            t-att-class="{ 'o-isActive': !messaging.rtc.currentRtcSession.isSelfMuted, 'o-isSmall': rtcController.isSmall }"
                             t-att-aria-label="microphoneTitle"
                             t-att-title="microphoneTitle"
                             t-on-click="rtcController.onClickMicrophone">
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
                                 <i class="fa" t-att-class="{
                                     'fa-lg': !rtcController.isSmall,
-                                    'fa-microphone': !messaging.rtc.currentRtcSession.isMuted,
-                                    'fa-microphone-slash': messaging.rtc.currentRtcSession.isMuted,
-                                    'text-danger': messaging.rtc.currentRtcSession.isMuted,
+                                    'fa-microphone': !messaging.rtc.currentRtcSession.isSelfMuted,
+                                    'fa-microphone-slash': messaging.rtc.currentRtcSession.isSelfMuted,
+                                    'text-danger': messaging.rtc.currentRtcSession.isSelfMuted,
                                 }"/>
                             </div>
                         </button>

--- a/addons/mail/static/src/models/partner/partner.js
+++ b/addons/mail/static/src/models/partner/partner.js
@@ -37,9 +37,6 @@ registerModel({
             if ('id' in data) {
                 data2.id = data.id;
             }
-            if ('is_muted' in data) {
-                data2.isMuted = data.is_muted;
-            }
             if ('im_status' in data) {
                 data2.im_status = data.im_status;
             }
@@ -441,9 +438,6 @@ registerModel({
          */
         isOnline: attr({
             compute: '_computeIsOnline',
-        }),
-        isMuted: attr({
-            default: false,
         }),
         memberThreads: many2many('Thread', {
             inverse: 'members',

--- a/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
+++ b/addons/mail/static/src/models/rtc_call_participant_card/rtc_call_participant_card.js
@@ -94,7 +94,7 @@ registerModel({
          * @returns {boolean}
          */
         _computeIsTalking() {
-            return Boolean(this.rtcSession && this.rtcSession.isTalking && !this.rtcSession.isMuted);
+            return Boolean(this.rtcSession && this.rtcSession.isTalking && !this.rtcSession.isSelfMuted);
         },
         /**
          * @private

--- a/addons/mail/static/src/models/rtc_session/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session/rtc_session.js
@@ -46,10 +46,10 @@ registerModel({
         /**
          * @param {Object} param0
          * @param {MediaStream} param0.audioStream
-         * @param {boolean} param0.isMuted
+         * @param {boolean} param0.isSelfMuted
          * @param {boolean} param0.isTalking
          */
-        async setAudio({ audioStream, isMuted, isTalking }) {
+        async setAudio({ audioStream, isSelfMuted, isTalking }) {
             const audioElement = this.audioElement || new window.Audio();
             try {
                 audioElement.srcObject = audioStream;
@@ -72,7 +72,7 @@ registerModel({
             this.update({
                 audioElement,
                 audioStream,
-                isMuted,
+                isSelfMuted,
                 isTalking,
             });
             try {
@@ -173,7 +173,7 @@ registerModel({
                                 values: {
                                     is_camera_on: this.isCameraOn,
                                     is_deaf: this.isDeaf,
-                                    is_muted: this.isMuted,
+                                    is_muted: this.isSelfMuted,
                                     is_screen_sharing_on: this.isScreenSharingOn,
                                 },
                             },
@@ -351,7 +351,7 @@ registerModel({
          * means that they cannot send sound regardless of the push to talk or
          * voice activation (isTalking) state.
          */
-        isMuted: attr({
+        isSelfMuted: attr({
             default: false,
         }),
         /**

--- a/addons/mail/tests/test_rtc.py
+++ b/addons/mail/tests/test_rtc.py
@@ -49,7 +49,7 @@ class TestChannelInternals(MailCommon):
                             'id': channel_partner.rtc_session_ids.id + 1,
                             'isCameraOn': False,
                             'isDeaf': False,
-                            'isMuted': False,
+                            'isSelfMuted': False,
                             'isScreenSharingOn': False,
                             'partner': [('insert', {
                                 'id': self.user_employee.partner_id.id,
@@ -68,7 +68,7 @@ class TestChannelInternals(MailCommon):
                     'id': channel_partner.rtc_session_ids.id,
                     'isCameraOn': False,
                     'isDeaf': False,
-                    'isMuted': False,
+                    'isSelfMuted': False,
                     'isScreenSharingOn': False,
                     'partner': [('insert', {
                         'id': self.user_employee.partner_id.id,
@@ -109,7 +109,7 @@ class TestChannelInternals(MailCommon):
                             'id': last_rtc_session_id + 1,
                             'isCameraOn': False,
                             'isDeaf': False,
-                            'isMuted': False,
+                            'isSelfMuted': False,
                             'isScreenSharingOn': False,
                             'partner': [('insert', {
                                 'id': self.user_employee.partner_id.id,
@@ -164,7 +164,7 @@ class TestChannelInternals(MailCommon):
                             'id': last_rtc_session_id + 1,
                             'isCameraOn': False,
                             'isDeaf': False,
-                            'isMuted': False,
+                            'isSelfMuted': False,
                             'isScreenSharingOn': False,
                             'partner': [('insert', {
                                 'id': self.user_employee.partner_id.id,
@@ -181,7 +181,7 @@ class TestChannelInternals(MailCommon):
                             'id': last_rtc_session_id + 1,
                             'isCameraOn': False,
                             'isDeaf': False,
-                            'isMuted': False,
+                            'isSelfMuted': False,
                             'isScreenSharingOn': False,
                             'partner': [('insert', {
                                 'id': self.user_employee.partner_id.id,
@@ -248,7 +248,7 @@ class TestChannelInternals(MailCommon):
                                 'id': channel_partner.rtc_session_ids.id + 1,
                                 'isCameraOn': False,
                                 'isDeaf': False,
-                                'isMuted': False,
+                                'isSelfMuted': False,
                                 'isScreenSharingOn': False,
                                 'partner': [('insert', {
                                     'id': test_user.partner_id.id,
@@ -294,7 +294,7 @@ class TestChannelInternals(MailCommon):
                                 'id': channel_partner.rtc_session_ids.id + 2,
                                 'isCameraOn': False,
                                 'isDeaf': False,
-                                'isMuted': False,
+                                'isSelfMuted': False,
                                 'isScreenSharingOn': False,
                                 'guest': [('insert', {
                                     'id': test_guest.id,
@@ -462,7 +462,7 @@ class TestChannelInternals(MailCommon):
                             'id': channel_partner.rtc_session_ids.id,
                             'isCameraOn': False,
                             'isDeaf': False,
-                            'isMuted': False,
+                            'isSelfMuted': False,
                             'isScreenSharingOn': False,
                             'partner': [('insert', {
                                 'id': self.user_employee.partner_id.id,
@@ -479,7 +479,7 @@ class TestChannelInternals(MailCommon):
                             'id': channel_partner.rtc_session_ids.id,
                             'isCameraOn': False,
                             'isDeaf': False,
-                            'isMuted': False,
+                            'isSelfMuted': False,
                             'isScreenSharingOn': False,
                             'partner': [('insert', {
                                 'id': self.user_employee.partner_id.id,


### PR DESCRIPTION
This commit renames the isMuted variable into isSelfMuted to reflect the
user action of self muting, as opposed to the state of being mute,
which will be distinct in an upcoming commit.

part of task-2720026

