### PR TITLE
[IMP] hr_skills: improve readability for dropdown lists

### DIFF
--- a/addons/hr_skills/models/hr_skills.py
+++ b/addons/hr_skills/models/hr_skills.py
@@ -14,6 +14,11 @@ class Skill(models.Model):
     sequence = fields.Integer(default=10)
     skill_type_id = fields.Many2one('hr.skill.type', ondelete='cascade')
 
+    def name_get(self):
+        if not self._context.get('from_skill_dropdown'):
+            return super().name_get()
+        return [(record.id, f"{record.name} ({record.skill_type_id.name})") for record in self]
+
 
 class EmployeeSkill(models.Model):
     _name = 'hr.employee.skill'
@@ -68,6 +73,11 @@ class SkillLevel(models.Model):
     name = fields.Char(required=True)
     level_progress = fields.Integer(string="Progress", help="Progress from zero knowledge (0%) to fully mastered (100%).")
     default_level = fields.Boolean(help="If checked, this level will be the default one selected when choosing this skill.")
+
+    def name_get(self):
+        if not self._context.get('from_skill_level_dropdown'):
+            return super().name_get()
+        return [(record.id, f"{record.name} ({record.level_progress}%)") for record in self]
 
     def create(self, vals_list):
         levels = super().create(vals_list)

--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -265,11 +265,15 @@
                             <field name="skill_id" options="{'no_open': True, 'no_create_edit': True}"
                                     context="{'default_skill_type_id': skill_type_id}"
                                     domain="[('skill_type_id', '=', skill_type_id)]"
-                                    attrs="{'readonly': [('skill_type_id', '=', False)]}"/>
-                            <label for="skill_level_id" />
-                            <div class="o_row">
+                                    attrs="{'invisible': [('skill_type_id', '=', False)]}"/>
+                            <label for="skill_level_id"
+                                    attrs="{'invisible': ['|', ('skill_id', '=', False), ('skill_type_id', '=', False)]}"/>
+                            <div class="o_row"
+                                    attrs="{'invisible': ['|', ('skill_id', '=', False), ('skill_type_id', '=', False)]}">
                                 <span class="col-4 pl-0">
-                                    <field name="skill_level_id" attrs="{'readonly': [('skill_id', '=', False)]}" />
+                                    <field name="skill_level_id"
+                                            attrs="{'readonly': [('skill_id', '=', False)]}"
+                                            context="{'from_skill_level_dropdown': True}" />
                                 </span>
                                 <span class="col-8">
                                     <field name="level_progress" widget="progressbar" class="o_hr_skills_progress" attrs="{'invisible': [('skill_level_id', '=', False)]}" />


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When you want to add/select new skills, it could be more clear.

Current behavior before PR:
When you want to change a skill level, you have to select a skill level to see its progression value

Desired behavior after PR is merged:
- The progression value is displayed beside the skill level in the dropdown list.
- In the appraisal module, the same thing applies to skills, which also feature the skill type in the dropdown list.

task: #2719642 [Skills] Overwrite name_get()
community PR : [odoo/enterprise#23237](https://github.com/odoo/enterprise/pull/23237)