### PR TITLE
[FIX] account: fix payment widget (exchange difference values)

### DIFF
--- a/addons/account/static/src/xml/account_payment.xml
+++ b/addons/account/static/src/xml/account_payment.xml
@@ -37,8 +37,11 @@
                         <td>
                            <a role="button" tabindex="0" class="js_payment_info fa fa-info-circle" t-att-index="line.index" style="margin-right:5px;" aria-label="Info" title="Journal Entry Info" data-toggle="tooltip"></a>
                         </td>
-                        <td>
-                            <i class="o_field_widget text-right o_payment_label">Paid on <t t-esc="line.date"></t></i>
+                        <td t-if="!line.is_exchange">
+                            <i class="o_field_widget text-left o_payment_label">Paid on <t t-esc="line.date"></t></i>
+                        </td>
+                        <td t-if="line.is_exchange">
+                            <i class="o_field_widget text-left o_payment_label text-muted">Exchange Difference</i>
                         </td>
                     </t>
                         <td style="text-align:right;">
@@ -46,7 +49,12 @@
                                 <t t-if="line.position === 'before'">
                                     <t t-esc="line.currency"/>
                                 </t>
-                                <t t-esc="line.amount"></t>
+                                <t t-if="!line.is_exchange">
+                                    <t t-esc="line.amount"/>
+                                </t>
+                                <t t-if="line.is_exchange">
+                                    <i class="text-muted"><t t-esc="line.amount"/></i>
+                                </t>
                                 <t t-if="line.position === 'after'">
                                     <t t-esc="line.currency"/>
                                 </t>
@@ -64,12 +72,9 @@
                 <tr>
                     <td><strong>Amount: </strong></td>
                     <td>
-                        <t t-if="position === 'before'">
-                            <t t-esc="currency"/>
-                        </t>
-                        <t t-esc="amount"></t>
-                        <t t-if="position === 'after'">
-                            <t t-esc="currency"/>
+                        <t t-esc="amount_company_currency"></t>
+                        <t t-if="amount_foreign_currency">
+                            (<span class="fa fa-money"/> <t t-esc="amount_foreign_currency"/>)
                         </t>
                     </td>
                 </tr>

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -141,7 +141,7 @@
                                         <t t-if="o.payment_state != 'invoicing_legacy'">
                                             <t t-set="payments_vals" t-value="o.sudo()._get_reconciled_info_JSON_values()"/>
                                             <t t-foreach="payments_vals" t-as="payment_vals">
-                                                <tr>
+                                                <tr t-if="payment_vals['is_exchange'] == 0">
                                                     <td>
                                                         <i class="oe_form_field text-right oe_payment_label">Paid on <t t-esc="payment_vals['date']" t-options='{"widget": "date"}'/></i>
                                                     </td>


### PR DESCRIPTION
Task ID: 2712093

Currently:
- In the payment widget the exchange difference value is always shown as 0 and is described as "Paid on", which can be confusing for a user
- In the Reconciled entries smart button of the exchange difference entry not all reconciled lines are visible
- If the invoice is in a foreign currency but the customer paid in company currency, the widget still shows foreign currency that can fluctuate and can be confusing

Desired:
- The exchange difference should have the difference amount and be described as "Exchange difference" (text-muted)
- All reconciled lines should be visible when opening Reconciled Entries from the Exchange difference entry
- When the invoice is in a foreign currency, show the foreign amount with ~ and show the actual amount paid in the pop-up


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
