### PR TITLE
[FIX] l10n_de_stock,stock: delivery address at the right place

### DIFF
--- a/addons/l10n_de_stock/models/stock.py
+++ b/addons/l10n_de_stock/models/stock.py
@@ -6,6 +6,7 @@ class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
     l10n_de_template_data = fields.Binary(compute='_compute_l10n_de_template_data')
+    l10n_de_addresses = fields.Binary(compute='_compute_l10n_de_addresses')
 
     def _compute_l10n_de_template_data(self):
         for record in self:
@@ -16,3 +17,15 @@ class StockPicking(models.Model):
                 data.append((_("Shipping Date"), format_date(self.env, record.date_done)))
             else:
                 data.append((_("Shipping Date"), format_date(self.env, record.scheduled_date)))
+
+    def _compute_l10n_de_addresses(self):
+        for record in self:
+            record.l10n_de_addresses = data = []
+            if record.partner_id:
+                if record.picking_type_id.code == 'incoming':
+                    data.append((_('Vendor Address:'), record.partner_id))
+                if record.picking_type_id.code == 'internal':
+                    data.append((_('Warehouse Address:'), record.partner_id))
+                if record.picking_type_id.code == 'outgoing' and record.move_ids_without_package and record.move_ids_without_package[0].partner_id \
+                        and record.move_ids_without_package[0].partner_id.id != record.partner_id.id:
+                    data.append((_('Customer Address:'), record.partner_id))

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -6,21 +6,23 @@
                 <t t-set="o" t-value="o.with_context(lang=o.partner_id.lang)" />
                 <t t-set="partner" t-value="o.partner_id or (o.move_lines and o.move_lines[0].partner_id) or False"/>
 
-                <div class="page">
-                    <div class="row">
-                        <div class="col-6" name="div_outgoing_address">
-                            <div t-if="o.move_ids_without_package and o.move_ids_without_package[0].partner_id and o.move_ids_without_package[0].partner_id.id != o.partner_id.id">
-                                <span><strong>Delivery Address:</strong></span>
-                                <div t-field="o.move_ids_without_package[0].partner_id"
-                                    t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-                            </div>
-                            <div t-if="o.picking_type_id.code != 'internal' and (not o.move_ids_without_package or not o.move_ids_without_package[0].partner_id) and o.picking_type_id.warehouse_id.partner_id">
-                                <span><strong>Warehouse Address:</strong></span>
-                                <div t-field="o.picking_type_id.warehouse_id.partner_id"
-                                    t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-                            </div>
+                <t t-set="address">
+                    <div name="div_outgoing_address">
+                        <div t-if="o.move_ids_without_package and o.move_ids_without_package[0].partner_id">
+                            <span><strong>Delivery Address:</strong></span>
+                            <div t-field="o.move_ids_without_package[0].partner_id"
+                                t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
                         </div>
-                        <div class="col-5 offset-1" name="div_incoming_address">
+                        <div t-if="o.picking_type_id.code != 'internal' and (not o.move_ids_without_package or not o.move_ids_without_package[0].partner_id) and o.picking_type_id.warehouse_id.partner_id">
+                            <span><strong>Warehouse Address:</strong></span>
+                            <div t-field="o.picking_type_id.warehouse_id.partner_id"
+                                t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
+                        </div>
+                    </div>
+                </t>
+                <t t-set="information_block">
+                    <div class="row">
+                        <div class="col-7" name="div_incoming_address">
                             <div t-if="o.picking_type_id.code=='incoming' and partner">
                                 <span><strong>Vendor Address:</strong></span>
                             </div>
@@ -37,6 +39,8 @@
                             </div>
                         </div>
                     </div>
+                </t>
+                <div class="page">
                     <h2>
                         <span t-field="o.name"/>
                     </h2>


### PR DESCRIPTION
'Delivery Slip' report with the document layout 'DIN5008' needs to have
the delivery address in the hole of the envelope

Steps to reproduce:
1. Install Sales app as well as Drop Shipping and l10n_de module
2. Go to General Settings -> Document Layout and select
external_layout_DIN5008
3. Specify a Dropship route for a product
4. Create and confirm an order for that product
5. Open the purchase order with the 'Purchase' tab
6. Confirm the corresponding purchase order
7. Open the 'Receipt' tab
8. Print the Delivery Slip
9. The document reference is above the address instead of under it

Solution:
Add the `l10n_de_addresses` computed field and set the addresses through
 `<t t-set="address">` and `<t t-set="information_block"/>`

OPW-2709866
OPW-2715851