### PR TITLE
[FIX] web_editor: disable editor video on the chatter

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -197,6 +197,7 @@ export class OdooEditor extends EventTarget {
                 isHintBlacklisted: () => false,
                 filterMutationRecords: (records) => records,
                 _t: string => string,
+                allowCommandVideo: true,
             },
             options,
         );
@@ -2975,7 +2976,7 @@ export class OdooEditor extends EventTarget {
                                 },
                             ].concat(baseEmbedCommand),
                         });
-                    } else if (youtubeUrl) {
+                    } else if (this.options.allowCommandVideo && youtubeUrl) {
                         const stepIndexBeforeInsert = this._historySteps.length - 1;
                         this.execCommand('insertText', splitAroundUrl[i]);
                         this.commandBar.open({

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -200,6 +200,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
             iframeCssAssets: this.nodeOptions.cssEdit,
             snippets: this.nodeOptions.snippets,
             value: this.value,
+            allowCommandVideo: Boolean(this.nodeOptions.allowCommandVideo) && (!this.field.sanitize || !this.field.sanitize_tags),
             mediaModalParams: {
                 noVideos: 'noVideos' in this.nodeOptions ? this.nodeOptions.noVideos : true,
             },

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -60,6 +60,7 @@ const Wysiwyg = Widget.extend({
         colors: customColors,
         recordInfo: {context: {}},
         document: document,
+        allowCommandVideo: true,
     },
     init: function (parent, options) {
         this._super.apply(this, arguments);
@@ -132,6 +133,7 @@ const Wysiwyg = Widget.extend({
             controlHistoryFromDocument: this.options.controlHistoryFromDocument,
             getContentEditableAreas: this.options.getContentEditableAreas,
             defaultLinkAttributes: this.options.userGeneratedContent ? {rel: 'ugc' } : {},
+            allowCommandVideo: this.options.allowCommandVideo,
             getYoutubeVideoElement: getYoutubeVideoElement,
             getContextFromParentRect: options.getContextFromParentRect,
             getPowerboxElement: () => {
@@ -1775,7 +1777,9 @@ const Wysiwyg = Widget.extend({
                     this.openMediaDialog();
                 },
             },
-            {
+        ];
+        if (options.allowCommandVideo) {
+            commands.push({
                 groupName: 'Medias',
                 title: 'Video',
                 description: 'Insert a video.',
@@ -1783,8 +1787,8 @@ const Wysiwyg = Widget.extend({
                 callback: () => {
                     this.openMediaDialog({noVideos: false, noImages: true, noIcons: true, noDocuments: true});
                 },
-            },
-        ];
+            });
+        }
         if (options.powerboxCommands) {
             commands.push(...options.powerboxCommands);
         }


### PR DESCRIPTION
The chatter html have the video being sanitized upon save.
As it is a desired behavior, disable the ability to add video from
the editor for that field.

Task-2726483



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
