### PR TITLE
[FIX] account: multicurrency balance amount

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3741,7 +3741,8 @@ class AccountMoveLine(models.Model):
             if line.currency_id == line.move_id.company_id.currency_id:
                 line.amount_currency = line.balance
             else:
-                continue
+                company = line.move_id.company_id
+                line.amount_currency = line.company_currency_id._convert(line.balance, line.currency_id, company, line.move_id.date or fields.Date.context_today(line))
             if not line.move_id.is_invoice(include_receipts=True):
                 continue
             line.update(line._get_fields_onchange_balance())


### PR DESCRIPTION
Steps to reproduce:
Company currency USD
Create MISC JE in USD
Put $100 in the amount in currency field and hit enter
A second line with $-100 is added

Create a MISC JE in EUR
Put 100 Euros in the amount in currency field and hit enter
A second line with EUR is added but does not have -100

Solution:
Complete the path when currency selected is not the same as the currency of the company

OPW-2712565
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
