### PR TITLE
[FIX] stock: Owner filter crash

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -733,7 +733,7 @@ class QuantPackage(models.Model):
         else:
             packs = self.search([('quant_ids', operator, value)])
         if packs:
-            return [('id', 'parent_of', packs.ids)]
+            return [('id', 'in', packs.ids)]
         else:
             return [('id', '=', False)]
 


### PR DESCRIPTION
Current behavior:
Filter "Owner is not set" on Package in inventory app was causing a traceback

Steps to reproduce:
- Go in inventory app
- Go in package
- Apply a filter "Owner is not set"
- You get a traceback

opw-2714726

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
