### PR TITLE
[FIX] l10n_sa_pos: qr code not seen on ticket

### DIFF
--- a/addons/l10n_sa_pos/static/src/js/OrderReceipt.js
+++ b/addons/l10n_sa_pos/static/src/js/OrderReceipt.js
@@ -1,56 +1,56 @@
-odoo.define('l10n_sa_pos.OrderReceipt', function (require) {
-    'use strict';
+odoo.define('l10n_sa_pos.pos', function (require) {
+"use strict";
 
-    const OrderReceipt = require('point_of_sale.OrderReceipt')
-    const Registries = require('point_of_sale.Registries');
+const { Gui } = require('point_of_sale.Gui');
+var models = require('point_of_sale.models');
+var rpc = require('web.rpc');
+var session = require('web.session');
+var core = require('web.core');
+var utils = require('web.utils');
 
-    const OrderReceiptQRCodeSA = OrderReceipt =>
-        class extends OrderReceipt {
-            mounted() {
-                super.mounted(...arguments);
-                if (this._receiptEnv.order.pos.company.country.code === 'SA') {
-                    const codeWriter = new window.ZXing.BrowserQRCodeSvgWriter()
-                    codeWriter.writeToDom('#qrcode', this._receiptEnv.receipt.qr_code, 150, 150);
-                }
-            }
+var _t = core._t;
+var round_di = utils.round_decimals;
 
-            get receiptEnv() {
-                if (this._receiptEnv.order.pos.company.country.code === 'SA') {
-                    let receipt_render_env = super.receiptEnv;
-                    let receipt = receipt_render_env.receipt;
-                    receipt.qr_code = this.compute_sa_qr_code(receipt.company.name, receipt.company.vat, receipt.date.isostring, receipt.total_with_tax, receipt.total_tax);
-                    return receipt_render_env;
-                }
-                return super.receiptEnv;
-            }
 
-            compute_sa_qr_code(name, vat, date_isostring, amount_total, amount_tax) {
-                /* Generate the qr code for Saudi e-invoicing. Specs are available at the following link at page 23
-                https://zatca.gov.sa/ar/E-Invoicing/SystemsDevelopers/Documents/20210528_ZATCA_Electronic_Invoice_Security_Features_Implementation_Standards_vShared.pdf
-                */
-                const seller_name_enc = this._compute_qr_code_field(1, name);
-                const company_vat_enc = this._compute_qr_code_field(2, vat);
-                const timestamp_enc = this._compute_qr_code_field(3, date_isostring);
-                const invoice_total_enc = this._compute_qr_code_field(4, amount_total.toString());
-                const total_vat_enc = this._compute_qr_code_field(5, amount_tax.toString());
+var _super_order = models.Order.prototype;
+models.Order = models.Order.extend({
+    export_for_printing: function() {
+      var result = _super_order.export_for_printing.apply(this,arguments);
+      if (this.pos.company.country.code === 'SA') {
+          const codeWriter = new window.ZXing.BrowserQRCodeSvgWriter()
+          let qr_values = this.compute_sa_qr_code(result.company.name, result.company.vat, result.date.isostring, result.total_with_tax, result.total_tax);
+          let qr_code_svg = new XMLSerializer().serializeToString(codeWriter.write(qr_values, 150, 150));
+          result.qr_code = "data:image/svg+xml;base64,"+ window.btoa(qr_code_svg);
+      }
+      return result;
+    },
+    compute_sa_qr_code(name, vat, date_isostring, amount_total, amount_tax) {
+        /* Generate the qr code for Saudi e-invoicing. Specs are available at the following link at page 23
+        https://zatca.gov.sa/ar/E-Invoicing/SystemsDevelopers/Documents/20210528_ZATCA_Electronic_Invoice_Security_Features_Implementation_Standards_vShared.pdf
+        */
+        const seller_name_enc = this._compute_qr_code_field(1, name);
+        const company_vat_enc = this._compute_qr_code_field(2, vat);
+        const timestamp_enc = this._compute_qr_code_field(3, date_isostring);
+        const invoice_total_enc = this._compute_qr_code_field(4, amount_total.toString());
+        const total_vat_enc = this._compute_qr_code_field(5, amount_tax.toString());
 
-                const str_to_encode = seller_name_enc.concat(company_vat_enc, timestamp_enc, invoice_total_enc, total_vat_enc);
+        const str_to_encode = seller_name_enc.concat(company_vat_enc, timestamp_enc, invoice_total_enc, total_vat_enc);
 
-                let binary = '';
-                for (let i = 0; i < str_to_encode.length; i++) {
-                    binary += String.fromCharCode(str_to_encode[i]);
-                }
-                return btoa(binary);
-            }
-
-            _compute_qr_code_field(tag, field) {
-                const textEncoder = new TextEncoder();
-                const name_byte_array = Array.from(textEncoder.encode(field));
-                const name_tag_encoding = [tag];
-                const name_length_encoding = [name_byte_array.length];
-                return name_tag_encoding.concat(name_length_encoding, name_byte_array);
-            }
+        let binary = '';
+        for (let i = 0; i < str_to_encode.length; i++) {
+            binary += String.fromCharCode(str_to_encode[i]);
         }
-    Registries.Component.extend(OrderReceipt, OrderReceiptQRCodeSA)
-    return OrderReceiptQRCodeSA
+        return btoa(binary);
+    },
+
+    _compute_qr_code_field(tag, field) {
+        const textEncoder = new TextEncoder();
+        const name_byte_array = Array.from(textEncoder.encode(field));
+        const name_tag_encoding = [tag];
+        const name_length_encoding = [name_byte_array.length];
+        return name_tag_encoding.concat(name_length_encoding, name_byte_array);
+    },
+
+});
+
 });

--- a/addons/l10n_sa_pos/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_sa_pos/static/src/xml/OrderReceipt.xml
@@ -3,7 +3,7 @@
     <t t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="1">
         <xpath expr="//img[hasclass('pos-receipt-logo')]" position="after">
             <t if="receipt.is_gcc_country">
-                <div t-if="receipt.qr_code" id="qrcode" class="pos-receipt-logo"/>
+                <img t-if="receipt.qr_code" id="qrcode" t-att-src="receipt.qr_code" class="pos-receipt-logo"/>
                 <br/>
             </t>
         </xpath>


### PR DESCRIPTION
When a ticket was sent by email or printed, the qr code was not
visible. This was because it was not correctly put in the report and was
injected in the DOM throught the mounted of the component.

So we are now setting it in the qweb and prepare the values in
export_for_printing instead of inject it through the component that
display it.

closes odoo/odoo#81562

Signed-off-by: Masereel Pierre <pim@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
