### PR TITLE
[FIX] website: fix dynamic snippet render issues

### DIFF
--- a/addons/website/static/src/scss/website.edit_mode.scss
+++ b/addons/website/static/src/scss/website.edit_mode.scss
@@ -230,7 +230,10 @@ body.editor_enable {
 //s_dynamic_snippet
 body.editor_enable {
     .s_dynamic {
-        > * {
+        // TODO remove .stretched-link::after in master
+        // BS4 adds pointer-events: auto on it which breaks the editor.
+        // BS5 doesn't do that so this can safely be removed in master.
+        > *, .stretched-link::after {
             pointer-events: none;
         }
         [data-url] {

--- a/addons/website/static/src/snippets/s_dynamic_snippet/options.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/options.js
@@ -49,11 +49,14 @@ const dynamicSnippetOptions = options.Class.extend({
         }
         if (params.attributeName === 'numberOfRecords' && previewMode === false) {
             const dataSet = this.$target.get(0).dataset;
-            if (dataSet.numberOfElements > dataSet.numberOfRecords) {
-                dataSet.numberOfElements = dataSet.numberOfRecords;
+            const numberOfElements = parseInt(dataSet.numberOfElements);
+            const numberOfRecords = parseInt(dataSet.numberOfRecords);
+            const numberOfElementsSmallDevices = parseInt(dataSet.numberOfElementsSmallDevices);
+            if (numberOfElements > numberOfRecords) {
+                dataSet.numberOfElements = numberOfRecords;
             }
-            if (dataSet.numberOfElementsSmallDevices > dataSet.numberOfRecords) {
-                dataSet.numberOfElementsSmallDevices = dataSet.numberOfRecords;
+            if (numberOfElementsSmallDevices > numberOfRecords) {
+                dataSet.numberOfElementsSmallDevices = numberOfRecords;
             }
         }
     },
@@ -224,13 +227,11 @@ const dynamicSnippetOptions = options.Class.extend({
             if (!this.dynamicFilterTemplates[selectedTemplateId]) {
                 this.$target.get(0).dataset['templateKey'] = dynamicFilterTemplates[0].key;
                 this.isOptionDefault['templateKey'] = true;
-                setTimeout(() => {
-                    this._templateUpdated(dynamicFilterTemplates[0].key, selectedTemplateId);
-                    this._refreshPublicWidgets();
-                });
+                this._templateUpdated(dynamicFilterTemplates[0].key, selectedTemplateId);
+                await this._refreshPublicWidgets();
             }
         } else {
-            this._refreshPublicWidgets();
+            await this._refreshPublicWidgets();
         }
         const templatesSelectorEl = uiFragment.querySelector('[data-name="template_opt"]');
         return this._renderSelectUserValueWidgetButtons(templatesSelectorEl, this.dynamicFilterTemplates);


### PR DESCRIPTION
- Prior to this commit, if a user chose to fetch 16 elements
the snippet would bug out and display 16 elements per row.

- Some legacy code introduced in [1] could result in an infinite loading
animation locking the editor out. This commit removes the code as a
fix made at [2] makes it unneeded.

[1] : 3c0d98bcd8adf9325ee3497eb8d25ec7f904d6a5
[2] : ac8d83cc124a6175a263e11795fda35eebe69324

task-2677203

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
