### PR TITLE
[FIX] web_editor: fix image options visibility

### DIFF
--- a/addons/web_editor/static/src/js/editor/image_processing.js
+++ b/addons/web_editor/static/src/js/editor/image_processing.js
@@ -338,6 +338,13 @@ async function loadImageInfo(img, rpc, attachmentSrc = '') {
 function isImageSupportedForProcessing(mimetype) {
     return ['image/jpeg', 'image/png'].includes(mimetype);
 }
+/**
+ * @param {HTMLImageElement} img
+ * @returns {Boolean}
+ */
+function isImageSupportedForStyle(img) {
+    return img.parentElement && !img.parentElement.dataset.oeType;
+}
 
 return {
     applyModifications,
@@ -347,5 +354,6 @@ return {
     loadImage,
     removeOnImageChangeAttrs: [...cropperDataFields, ...modifierFields, 'aspectRatio'],
     isImageSupportedForProcessing,
+    isImageSupportedForStyle,
 };
 });

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2110,6 +2110,13 @@ var SnippetsMenu = Widget.extend({
             var target = $style.data('target');
             var noCheck = $style.data('no-check');
             var optionID = $style.data('js') || $style.data('option-name'); // used in tour js as selector
+            // TODO: adapt in master - used to hide XML 'img' options when image
+            // is not supported.
+            const xmlImageOption = !$style[0].hasAttribute('data-js') && (selector.indexOf('img') !== -1);
+            const nonSupportedImageSelector = '[data-oe-type="image"] > img';
+            if (xmlImageOption && !noCheck) {
+                exclude = [exclude, nonSupportedImageSelector].filter(value => !!value).join(', ');
+            }
             var option = {
                 'option': optionID,
                 'base_selector': selector,

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -3083,15 +3083,6 @@ options.registry.WebsiteAnimate = options.Class.extend({
             this.$target.toggleClass('o_animate_preview o_animate', !!widgetValue);
         }
     },
-    /**
-     * @override
-     */
-    async _computeWidgetVisibility(widgetName, params) {
-        if (widgetName === 'animation_launch_opt') {
-            return !this.$target[0].closest('.dropdown');
-        }
-        return this._super(...arguments);
-    },
 
     //--------------------------------------------------------------------------
     // Private
@@ -3119,6 +3110,9 @@ options.registry.WebsiteAnimate = options.Class.extend({
     _computeWidgetVisibility(widgetName, params) {
         if (widgetName === 'no_animation_opt') {
             return !this.isAnimatedText;
+        }
+        if (widgetName === 'animation_launch_opt') {
+            return !this.$target[0].closest('.dropdown');
         }
         return this._super(...arguments);
     },

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -11,6 +11,7 @@ const weUtils = require('web_editor.utils');
 var options = require('web_editor.snippets.options');
 const wLinkPopoverWidget = require('@website/js/widgets/link_popover_widget')[Symbol.for("default")];
 const wUtils = require('website.utils');
+const {isImageSupportedForStyle} = require('web_editor.image_processing');
 require('website.s_popup_options');
 
 var _t = core._t;
@@ -3113,6 +3114,15 @@ options.registry.WebsiteAnimate = options.Class.extend({
         }
         if (widgetName === 'animation_launch_opt') {
             return !this.$target[0].closest('.dropdown');
+        }
+        return this._super(...arguments);
+    },
+    /**
+     * @override
+     */
+    _computeVisibility(methodName, params) {
+        if (this.$target[0].matches('img')) {
+            return isImageSupportedForStyle(this.$target[0]);
         }
         return this._super(...arguments);
     },


### PR DESCRIPTION
Issue: 

from 15.0 onwards all image options are available on "/shop".

Details:

On v14.0, images options were removed for unsupported images (we had
a message: "Quality Options Unavailable" - see [1]) and images related
options on old editor toolbar were hidden too.

On v14.4 and after [2], images options from the toolbar (crop, width,...)
were moved to a separate 'ImageTools' option and as a consequence, they
don't respect the same visibility rules as 'ImageOptimize'. Other options
were added in XML and they have the same issue, they are visible as long
as the target is an 'img'.

This is a list of options that should be available for unsupported or
partly supported images:

[A]- for "t-field" images (shape & quality options are available only if
the image is supported for processing):

- Shape
- Filter
- Width (image width)
- Quality
- Transform (crop)

[B]- for external images or images unsupported for processing:

- Description
- Tooltip
- Transform (crop, transform)
- width (CSS width)
- Alignment
- Style
- Padding
- Animate

[C]- for illustrations:

- Same as [B]
- Dynamic colors

The goal of this commit is to fix this visibility issue on the JS code
of image options.

Remark: The '_computeWidgetVisibility()' method was duplicated on the
same 'WebsiteAnimate' option in [3], it's adapted in this commit too.

[1]: 84417a1
[2]: d619c52
[3]: 187acb9

task-2724946