### PR TITLE
[FIX] stock_picking_batch: validate batch with done transfers

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -83,7 +83,7 @@ class StockPickingBatch(models.Model):
                 picking_to_backorder |= picking
             else:
                 picking.action_done()
-        if len(picking_without_qty_done) == len(pickings):
+        if pickings and len(picking_without_qty_done) == len(pickings):
             view = self.env.ref('stock.view_immediate_transfer')
             wiz = self.env['stock.immediate.transfer'].create({
                 'pick_ids': [(4, p.id) for p in picking_without_qty_done],


### PR DESCRIPTION
Validating a batch doesn't work if, for instance, all included pickings
are already done

To reproduce the issue:
1. In Settings, enable "Batch Pickings"
2. Create a batch transfer BT with one picking P
3. Confirm BT
4. Process P (not BT)
5. Mark BT as done

Error: The "Immediate Transfer" wizard is displayed while it shouldn't.
(Then if the user clicks on "Apply", nothing happens, the BT is still in
progress)

The wizard is displayed if the number of not done/cancelled picking is
equal to the number of not done/cancelled pickings that do not have any
done quantity (which is the case here, each is equal to `0`)

OPW-2727764
OPW-2726257