### PR TITLE
[FIX] web_editor: ensure body_html visual similar to body_arch

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -72,7 +72,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
             self._isDirty = self.wysiwyg.isDirty();
             self._doAction();
 
-            convertInline.toInline($editable, self.cssRules);
+            convertInline.toInline($editable, self.cssRules, self.wysiwyg.$iframe);
 
             self.trigger_up('field_changed', {
                 dataPointID: self.dataPointID,

--- a/addons/mass_mailing/tests/test_mailing_ui.py
+++ b/addons/mass_mailing/tests/test_mailing_ui.py
@@ -20,4 +20,4 @@ class TestUi(HttpCaseWithUserDemo):
         # for email client compatibility should be saved in body_html. This
         # ensures both fields have different values.
         self.assertEqual(mail.body_arch, '<p><br></p>')
-        self.assertEqual(mail.body_html, '<p style="margin:0px 0 14px 0;box-sizing:border-box;font-family:Arial, sans-serif;"><br style="box-sizing:border-box;"></p>')
+        self.assertEqual(mail.body_html, '<p style="margin:0px 0 14px 0;box-sizing:border-box;"><br style="box-sizing:border-box;"></p>')

--- a/addons/mass_mailing/views/assets.xml
+++ b/addons/mass_mailing/views/assets.xml
@@ -14,6 +14,7 @@
 
     <template id="iframe_css_assets_readonly" groups="base.group_user">
         <link rel="stylesheet" type="text/scss" href="/mass_mailing/static/src/css/basic_theme_readonly.css"/>
+        <t t-call="mass_mailing.mass_mailing_mail_style"/>
     </template>
 
     <template id="mass_mailing_mail_style">
@@ -21,7 +22,7 @@
             * {
                 box-sizing: border-box !important;
             }
-            * h1, h2, h3, h4, h5, h6, p, td, th {
+            * h1, h2, h3, h4, h5, h6, p, td, th, div {
                 font-family: Arial, sans-serif !important;
             }
             /* Remove space around the email design. */

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -728,7 +728,8 @@ function normalizeRem($editable) {
  */
 function _applyColspan($element, colspan) {
     $element.attr('colspan', colspan);
-    const width = Math.round(+$element.attr('colspan') * 100 / 12) + '%';
+    // Round to 2 decimal places.
+    const width = (Math.round(+$element.attr('colspan') * 10000 / 12) / 100) + '%';
     $element.attr('width', width);
     $element.css('width', width);
 }

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -495,6 +495,29 @@ function formatTables($editable) {
             parent.style.setProperty('height', '0');
         }
     }
+    // Align self and justify content don't work on table cells.
+    for (const cell of $editable.find('td')) {
+        const alignSelf = cell.style.alignSelf;
+        const justifyContent = cell.style.justifyContent;
+        if (alignSelf === 'start' || justifyContent === 'start' || justifyContent === 'flex-start') {
+            cell.style.verticalAlign = 'top';
+        } else if (alignSelf === 'center' || justifyContent === 'center') {
+            cell.style.verticalAlign = 'middle';
+        } else if (alignSelf === 'end' || justifyContent === 'end' || justifyContent === 'flex-end') {
+            cell.style.verticalAlign = 'bottom';
+        }
+    }
+    // Align items doesn't work on table rows.
+    for (const cell of $editable.find('tr')) {
+        const alignItems = cell.style.alignItems;
+        if (alignItems === 'flex-start') {
+            cell.style.verticalAlign = 'top';
+        } else if (alignItems === 'center') {
+            cell.style.verticalAlign = 'middle';
+        } else if (alignItems === 'flex-end' || alignItems === 'baseline') {
+            cell.style.verticalAlign = 'bottom';
+        }
+    }
 }
 /**
  * Parse through the given document's stylesheets, preprocess(*) them and return

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -495,7 +495,9 @@ function formatTables($editable) {
     }
     // Ensure a tbody in every table and cancel its default style.
     for (const table of $editable.find('table:not(:has(tbody))')) {
-        $(table).contents().wrap('<tbody style="vertical-align: top;"/>');
+        const $contents = $(table).contents();
+        $(table).prepend('<tbody style="vertical-align: top;"/>');
+        $(table.firstChild).append($contents);
     }
     // Children will only take 100% height if the parent has a height property.
     for (const node of $editable.find('*').filter((i, n) => (

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -476,7 +476,7 @@ function formatTables($editable) {
         const $columns = $table.find('td').filter((i, td) => $(td).closest('table').is($table));
         for (const column of $columns) {
             const $column = $(column);
-            const $columnsInRow = $column.closest('tr').find('td');
+            const $columnsInRow = $column.closest('tr').find('td').filter((i, td) => $(td).closest('table').is($table));
             const columnIndex = $columnsInRow.toArray().findIndex(col => $(col).is($column));
             const rowIndex = $rows.toArray().findIndex(row => $(row).is($column.closest('tr')));
             if (!rowIndex) {

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -360,9 +360,9 @@ function toInline($editable, cssRules) {
     // fields).
     _.each(['width', 'height'], function (attribute) {
         $editable.find('img').attr(attribute, function () {
-            return $(this)[attribute]();
+            return ($(this).attr(attribute)) || (attribute === 'height' && this.offsetHeight) || $(this)[attribute]();
         }).css(attribute, function () {
-            return $(this).get(0).style[attribute] || attribute === 'width' ? $(this)[attribute]() + 'px' : '';
+            return $(this).attr(attribute);
         });
     });
 

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -709,7 +709,7 @@ function normalizeRem($editable) {
         const remMatch = node.getAttribute('style').match(/[\d\.]+\s*rem/g);
         for (const rem of remMatch || []) {
             const remValue = parseFloat(rem.replace(/[^\d\.]/g, ''));
-            const pxValue = Math.round(remValue * rootFontSize * 10) / 10;
+            const pxValue = Math.round(remValue * rootFontSize * 100) / 100;
             node.setAttribute('style', node.getAttribute('style').replace(rem, pxValue + 'px'));
         }
     }

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -289,6 +289,10 @@ function classToStyle($editable, cssRules) {
                 node.style[styleName] = '';
             }
         }
+        // Ignore font-family (mail-safe font declared in <head>)
+        if ('font-family' in css) {
+            delete css['font-family'];
+        }
 
         // Do not apply css that would override inline styles (which are prioritary).
         let style = $target.attr('style') || '';

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -251,9 +251,27 @@ QUnit.module('convert_inline', {}, function () {
         assert.strictEqual($editable.html(),
             getRegularTableHtml(3, 1, 12, 100)
                 .split('style="').join('class="card" style="')
-                .replace(/<td[^>]*>\(0, 0\)<\/td>/, '<td class="card-header"><span>HEADER</span></td>')
-                .replace(/<td[^>]*>\(1, 0\)<\/td>/, '<td class="card-body"><h2 class="card-title">TITLE</h2><small>BODY <img></small></td>')
-                .replace(/<td[^>]*>\(2, 0\)<\/td>/, '<td class="card-footer"><a href="#" class="btn">FOOTER</a></td>'),
+                .replace(/<td[^>]*>\(0, 0\)<\/td>/,
+                    `<td>` +
+                        `<table cellspacing=\"0\" cellpadding=\"0\" border=\"0\" width=\"100%\" align=\"center\" ` +
+                        `role=\"presentation\" style=\"width: 100% !important; border-collapse: collapse; text-align: inherit; ` +
+                        `font-size: unset; line-height: unset;\"><tr>` +
+                            `<td class="card-header"><span>HEADER</span></td>` +
+                        `</tr></table></td>`)
+                .replace(/<td[^>]*>\(1, 0\)<\/td>/,
+                    `<td>` +
+                        `<table cellspacing=\"0\" cellpadding=\"0\" border=\"0\" width=\"100%\" align=\"center\" ` +
+                        `role=\"presentation\" style=\"width: 100% !important; border-collapse: collapse; text-align: inherit; ` +
+                        `font-size: unset; line-height: unset;\"><tr>` +
+                            `<td class="card-body"><h2 class="card-title">TITLE</h2><small>BODY <img></small></td>` +
+                        `</tr></table></td>`)
+                .replace(/<td[^>]*>\(2, 0\)<\/td>/,
+                    `<td>` +
+                        `<table cellspacing=\"0\" cellpadding=\"0\" border=\"0\" width=\"100%\" align=\"center\" ` +
+                        `role=\"presentation\" style=\"width: 100% !important; border-collapse: collapse; text-align: inherit; ` +
+                        `font-size: unset; line-height: unset;\"><tr>` +
+                            `<td class="card-footer"><a href="#" class="btn">FOOTER</a></td>` +
+                        `</tr></table></td>`),
             "should have converted a card structure into a table");
     });
     QUnit.test('convert a list group to a table', async function (assert) {

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -320,7 +320,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.strictEqual($editable.html(),
             `<div style="font-size: 24px;">` +
                 `<div class="a" style="color: #000000; padding: 30px" width="100%">` +
-                    `<p style="border: 14.4px #aaaaaa solid; margin: 45.5px;">Test</p>` +
+                    `<p style="border: 14.4px #aaaaaa solid; margin: 45.48px;">Test</p>` +
                 `</div>` +
             `</div>`,
             "should have converted several rem sizes to px using the default rem size"

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -449,6 +449,27 @@ QUnit.module('convert_inline', {}, function () {
             "should have changed the height of the grandparent of a 100% height element"
         );
     });
+    QUnit.test('express align-self with vertical-align on table cells', async function (assert) {
+        assert.expect(3);
+
+        $editable = $(`<div><table><tbody><tr><td style="align-self: start;">yup</td></tr></tbody></table></div>`);
+        convertInline.formatTables($editable);
+        assert.strictEqual($editable.html(), `<table><tbody><tr><td style="align-self: start; vertical-align: top;">yup</td></tr></tbody></table>`,
+            "should have added a top vertical alignment"
+        );
+
+        $editable = $(`<div><table><tbody><tr><td style="align-self: center;">yup</td></tr></tbody></table></div>`);
+        convertInline.formatTables($editable);
+        assert.strictEqual($editable.html(), `<table><tbody><tr><td style="align-self: center; vertical-align: middle;">yup</td></tr></tbody></table>`,
+            "should have added a middle vertical alignment"
+        );
+
+        $editable = $(`<div><table><tbody><tr><td style="align-self: end;">yup</td></tr></tbody></table></div>`);
+        convertInline.formatTables($editable);
+        assert.strictEqual($editable.html(), `<table><tbody><tr><td style="align-self: end; vertical-align: bottom;">yup</td></tr></tbody></table>`,
+            "should have added a bottom vertical alignment"
+        );
+    });
 
     QUnit.module('Convert snippets and mailing bodies to tables');
     // Test addTables

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -28,13 +28,13 @@ QUnit.module('convert_inline', {}, function () {
         // 1x3
         $editable = $(`<div>${getRegularGridHtml(1, 3)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(1, 3, 4, 33),
+        assert.strictEqual($editable.html(), getRegularTableHtml(1, 3, 4, 33.33),
             "should have converted a 1x3 grid to an equivalent table");
 
         // 1x12
         $editable = $(`<div>${getRegularGridHtml(1, 12)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(1, 12, 1, 8),
+        assert.strictEqual($editable.html(), getRegularTableHtml(1, 12, 1, 8.33),
             "should have converted a 1x12 grid to an equivalent table");
     });
     QUnit.test('convert a single-row regular overflowing grid', async function (assert) {
@@ -44,7 +44,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${getRegularGridHtml(1, 13)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
-            getRegularTableHtml(1, 12, 1, 8).slice(0, -8) +
+            getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
                 `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 12)</td></tr></table>`,
             "should have converted a 1x13 grid to an equivalent table (overflowing)");
 
@@ -52,17 +52,17 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${getRegularGridHtml(1, 14)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
-            getRegularTableHtml(1, 12, 1, 8).slice(0, -8) +
-                `<tr><td colspan="1" width="8%" style="width: 8%;">(0, 12)</td>` +
-                `<td colspan="11" width="92%" style="width: 92%;">(0, 13)</td></tr></table>`,
+            getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
+                `<tr><td colspan="1" width="8.33%" style="width: 8.33%;">(0, 12)</td>` +
+                `<td colspan="11" width="91.67%" style="width: 91.67%;">(0, 13)</td></tr></table>`,
             "should have converted a 1x14 grid to an equivalent table (overflowing)");
 
         // 1x25
         $editable = $(`<div>${getRegularGridHtml(1, 25)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
-            getRegularTableHtml(1, 12, 1, 8).slice(0, -8) +
-            getRegularTableHtml(1, 12, 1, 8).replace(/\(0, (\d+)\)/g, (s, c) => `(0, ${+c + 12})`)
+            getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
+            getRegularTableHtml(1, 12, 1, 8.33).replace(/\(0, (\d+)\)/g, (s, c) => `(0, ${+c + 12})`)
                 .replace(/^<table[^<]*>/, '').slice(0, -8) +
                 `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 24)</td></tr></table>`,
             "should have converted a 1x25 grid to an equivalent table (overflowing)");
@@ -71,11 +71,11 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${getRegularGridHtml(1, 26)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
-            getRegularTableHtml(1, 12, 1, 8).slice(0, -8) +
-            getRegularTableHtml(1, 12, 1, 8).replace(/\(0, (\d+)\)/g, (s, c) => `(0, ${+c + 12})`)
+            getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
+            getRegularTableHtml(1, 12, 1, 8.33).replace(/\(0, (\d+)\)/g, (s, c) => `(0, ${+c + 12})`)
                 .replace(/^<table[^<]*>/, '').slice(0, -8) +
-                `<tr><td colspan="1" width="8%" style="width: 8%;">(0, 24)</td>` +
-                `<td colspan="11" width="92%" style="width: 92%;">(0, 25)</td></tr></table>`,
+                `<tr><td colspan="1" width="8.33%" style="width: 8.33%;">(0, 24)</td>` +
+                `<td colspan="11" width="91.67%" style="width: 91.67%;">(0, 25)</td></tr></table>`,
             "should have converted a 1x26 grid to an equivalent table (overflowing)");
     });
     QUnit.test('convert a multi-row regular grid', async function (assert) {
@@ -96,13 +96,13 @@ QUnit.module('convert_inline', {}, function () {
         // 3x3
         $editable = $(`<div>${getRegularGridHtml(3, 3)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(3, 3, 4, 33),
+        assert.strictEqual($editable.html(), getRegularTableHtml(3, 3, 4, 33.33),
             "should have converted a 3x3 grid to an equivalent table");
 
         // 3x[3,2,1]
         $editable = $(`<div>${getRegularGridHtml(3, [3,2,1])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(3, [3, 2, 1], [4, 6, 12], [33, 50, 100]),
+        assert.strictEqual($editable.html(), getRegularTableHtml(3, [3, 2, 1], [4, 6, 12], [33.33, 50, 100]),
             "should have converted a 3x[3,2,1] grid to an equivalent table");
     });
     QUnit.test('convert a multi-row regular overflowing grid', async function (assert) {
@@ -112,7 +112,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${getRegularGridHtml(2, [13, 1])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
-            getRegularTableHtml(1, 12, 1, 8).slice(0, -8) +
+            getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
                 `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 12)</td></tr>` +
                 `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 0)</td></tr></table>`,
             "should have converted a 2x[13,1] grid to an equivalent table (overflowing)");
@@ -121,7 +121,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${getRegularGridHtml(2, [1, 13])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
-            getRegularTableHtml(2, [1, 12], [12, 1], [100, 8]).slice(0, -8) +
+            getRegularTableHtml(2, [1, 12], [12, 1], [100, 8.33]).slice(0, -8) +
                 `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 12)</td></tr></table>`,
             "should have converted a 2x[1,13] grid to an equivalent table (overflowing)");
 
@@ -129,16 +129,16 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${getRegularGridHtml(3, [1, 13, 6])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
-            getRegularTableHtml(2, [1, 12], [12, 1], [100, 8]).slice(0, -8) +
+            getRegularTableHtml(2, [1, 12], [12, 1], [100, 8.33]).slice(0, -8) +
                 `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 12)</td></tr>` +
-                getRegularTableHtml(1, 6, 2, 17).replace(/\(0,/g, `(2,`).replace(/^<table[^<]*>/, ''),
+                getRegularTableHtml(1, 6, 2, 16.67).replace(/\(0,/g, `(2,`).replace(/^<table[^<]*>/, ''),
             "should have converted a 3x[1,13,6] grid to an equivalent table (overflowing)");
 
         // 3x[1,6,13]
         $editable = $(`<div>${getRegularGridHtml(3, [1, 6, 13])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
-            getRegularTableHtml(3, [1, 6, 12], [12, 2, 1], [100, 17, 8]).slice(0, -8) +
+            getRegularTableHtml(3, [1, 6, 12], [12, 2, 1], [100, 16.67, 8.33]).slice(0, -8) +
                 `<tr><td colspan="12" width="100%" style="width: 100%;">(2, 12)</td></tr></table>`,
             "should have converted a 3x[1,6,13] grid to an equivalent table (overflowing)");
     });
@@ -148,13 +148,13 @@ QUnit.module('convert_inline', {}, function () {
         // 1x2
         $editable = $(`<div>${getGridHtml([[8, 4]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getTableHtml([[[8, 67], [4, 33]]]),
+        assert.strictEqual($editable.html(), getTableHtml([[[8, 66.67], [4, 33.33]]]),
             "should have converted a 1x2 irregular grid to an equivalent table");
 
         // 1x3
         $editable = $(`<div>${getGridHtml([[2, 3, 7]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getTableHtml([[[2, 17], [3, 25], [7, 58]]]),
+        assert.strictEqual($editable.html(), getTableHtml([[[2, 16.67], [3, 25], [7, 58.33]]]),
             "should have converted a 1x3 grid to an equivalent table");
     });
     QUnit.test('convert a single-row irregular overflowing grid', async function (assert) {assert.expect(4);
@@ -164,8 +164,8 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${getGridHtml([[8, 5]])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getTableHtml([
-                [[8, 67], [4, 33, '']],
-                [[5, 42, '(0, 1)'], [7, 58, '']],
+                [[8, 66.67], [4, 33.33, '']],
+                [[5, 41.67, '(0, 1)'], [7, 58.33, '']],
             ]),
             "should have converted a 1x2 irregular overflowing grid to an equivalent table");
 
@@ -173,7 +173,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${getGridHtml([[7, 6, 9]])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getTableHtml([
-                [[7, 58], [5, 42, '']],
+                [[7, 58.33], [5, 41.67, '']],
                 [[6, 50, '(0, 1)'], [6, 50, '']],
                 [[9, 75, '(0, 2)'], [3, 25, '']],
             ]),
@@ -185,13 +185,13 @@ QUnit.module('convert_inline', {}, function () {
         // 2x2
         $editable = $(`<div>${getGridHtml([[1, 11], [2, 10]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getTableHtml([[[1, 8], [11, 92]], [[2, 17], [10, 83]]]),
+        assert.strictEqual($editable.html(), getTableHtml([[[1, 8.33], [11, 91.67]], [[2, 16.67], [10, 83.33]]]),
             "should have converted a 2x2 irregular grid to an equivalent table");
 
         // 2x[2,3]
         $editable = $(`<div>${getGridHtml([[3, 9], [4, 6, 2]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getTableHtml([[[3, 25], [9, 75]], [[4, 33], [6, 50], [2, 17]]]),
+        assert.strictEqual($editable.html(), getTableHtml([[[3, 25], [9, 75]], [[4, 33.33], [6, 50], [2, 16.67]]]),
             "should have converted a 2x[2,3] irregular grid to an equivalent table");
     });
     QUnit.test('convert a multi-row irregular overflowing grid', async function (assert) {
@@ -203,8 +203,8 @@ QUnit.module('convert_inline', {}, function () {
         assert.strictEqual($editable.html(),
             getTableHtml([
                 [[6, 50], [6, 50, '']],
-                [[8, 67, '(0, 1)'], [4, 33, '']],
-                [[7, 58, '(1, 0)'], [5, 42, '']],
+                [[8, 66.67, '(0, 1)'], [4, 33.33, '']],
+                [[7, 58.33, '(1, 0)'], [5, 41.67, '']],
                 [[9, 75, '(1, 1)'], [3, 25, '']],
             ]),
             "should have converted a 2x[1,13] irregular grid to an equivalent table (both rows overflowing)");
@@ -214,9 +214,9 @@ QUnit.module('convert_inline', {}, function () {
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getTableHtml([
-                [[5, 42], [7, 58, '']],
-                [[8, 67, '(0, 1)'], [4, 33, '']],
-                [[4, 33, '(1, 0)'], [2, 17, '(1, 1)'], [6, 50, '(1, 2)']],
+                [[5, 41.67], [7, 58.33, '']],
+                [[8, 66.67, '(0, 1)'], [4, 33.33, '']],
+                [[4, 33.33, '(1, 0)'], [2, 16.67, '(1, 1)'], [6, 50, '(1, 2)']],
             ]),
             "should have converted a 2x[2,3] irregular grid to an equivalent table (first row overflowing)");
 
@@ -225,9 +225,9 @@ QUnit.module('convert_inline', {}, function () {
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getTableHtml([
-                [[4, 33], [2, 17], [6, 50]],
-                [[5, 42], [7, 58, '']],
-                [[8, 67, '(1, 1)'], [4, 33, '']],
+                [[4, 33.33], [2, 16.67], [6, 50]],
+                [[5, 41.67], [7, 58.33, '']],
+                [[8, 66.67, '(1, 1)'], [4, 33.33, '']],
             ]),
             "should have converted a 2x[3,2] irregular grid to an equivalent table (second row overflowing)");
     });

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -406,7 +406,7 @@ QUnit.module('convert_inline', {}, function () {
                     `<td style="padding-right: 29.1px; padding-top: 10px;">(0, 4, 0)</td>` + // TR
                 `</tr>` +
                 `<tr>` +
-                    `<td style="padding-left: 40px;">` + // L
+                    `<td style="padding-right: 20px; padding-left: 40px;">` + // LR
                         `<table style="">` +
                             `<tbody>` +
                                 `<tr>` +


### PR DESCRIPTION
- The align-self and justify-content styles don't work on cells so when converting a Bootstrap column to a table cell, we should also apply a vertical alignment. The same applies to align-items on rows.
- The conversion from rem to px was rounding the value to 1 decimal place but the browser handles up to 2 decimal places. As a result there were visible inconsistencies in the conversion (12.25px in the original becoming 12.3px in the converted email).
- When converting from grid to tables, we need to convert values from x/12 to x/100. The rounding error was a little too big, making it too visible at times. With this commit we now round to 2 decimal places instead of rounding to the nearest integer.
- When fonts with a round border were converted to images, the dimensions often ended up slightly off, and most visibly a little bit cropped by the border. Note that this also removes the "alpha" argument of the font_to_img route since it wasn't used anywhere and transparency is not supported in emails anyway.
- The mail-safe font is applied to a style in <head> for emails. But the way it was applied, <div>s were forgotten. Since most of those are converted to tables when converting body_arch to body_html, it resulted in visible font differences between body_arch and body_html.
- When converting, we ensure each table has a tbody but inadvertently were wrapping each <tr> in a separate tbody rather than wrapping all the contents of the table.
- Cards need to be double wrapped in tables to be displayed properly because of a bizarre hack by bootstrap that uses background-color rather to give the effect of a border, and because we can have card-body be a sibling of a list-group. Incidentally this also prevents the introduction of a new row for each whitespace text node.
- The conversion of padding from grids to their equivalent tables was sometimes faulty due to an error in the evaluation of the cell's position within the table.
- Images sometimes shrunk on conversion because of a parenthesis error in a conditional chain, because dimensions set via element attributes should be preserved, and because the offset height should be used rather than the element height as returned by jQuery.
- The conversion process of emails for mail clients involves retrieving the dimensions of images and icons in order set them as element attributes. This can however not possibly work if they are invisible at the time of conversion. This therefore makes sure they are visible by changing the visibility of whichever parent was invisible before conversion and restoring it when we're done.

Enterprise PR: https://github.com/odoo/enterprise/pull/23249

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
