### PR TITLE
[REF][ADD] hr: split appointment module according to hr dependancy

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -17,6 +17,7 @@ HR_READABLE_FIELDS = [
     'last_activity_time',
     'can_edit',
     'is_system',
+    'employee_resource_calendar_id',
 ]
 
 HR_WRITABLE_FIELDS = [
@@ -136,6 +137,7 @@ class User(models.Model):
     last_activity = fields.Date(related='employee_id.last_activity')
     last_activity_time = fields.Char(related='employee_id.last_activity_time')
     employee_type = fields.Selection(related='employee_id.employee_type', readonly=False, related_sudo=False)
+    employee_resource_calendar_id = fields.Many2one(related='employee_id.resource_calendar_id', string="Employee's Working Hours", readonly=True)
 
     can_edit = fields.Boolean(compute='_compute_can_edit')
     is_system = fields.Boolean(compute="_compute_is_system")


### PR DESCRIPTION
When setting users on the appointment type as staff, we want to consider
their resource_calendar_id (work schedules) only if they correspond to the
current company and are linked to employees, not the ones linked to the users
directly. In order to display those work hours correctly, we use a new related
field on the employee_id in res_users model as it will return the employee of
the user in the current company, if any.

Therefore, we add the new field employee_resource_calendar_id directly in
hr module (in res.users model) to reduce diff and centralize the fields as
close as possible to the employee_id definition.

--- Links ---
Task-2499566
