### PR TITLE
[IMP] mail: display edited at the end of the message

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -215,6 +215,7 @@ class DiscussController(http.Controller):
             'id': message_sudo.id,
             'body': message_sudo.body,
             'attachments': [('insert-and-replace', message_sudo.attachment_ids._attachment_format(commands=True))],
+            'editDate': message_sudo.edit_date,
         }
 
     @http.route('/mail/attachment/upload', methods=['POST'], type='http', auth='public')

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -126,7 +126,10 @@
                         </t>
                         <div class="o_Message_content mx-2" t-ref="content">
                             <t t-if="!messageView.composerViewInEditing">
-                                <div class="o_Message_prettyBody" t-ref="prettyBody"/><!-- messageView.message.prettyBody is inserted here from _update() -->
+                                <div class="o_Message_prettyBody float-left mr4" t-ref="prettyBody"/><!-- messageView.message.prettyBody is inserted here from _update() -->
+                                <t t-if="messageView.message.editDate">
+                                    <div class="text-muted float-left" t-att-title="messageView.message.editDatetime">(edited)</div>
+                                </t>
                             </t>
                             <t t-if="messageView.composerViewInEditing">
                                 <Composer

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -8,7 +8,8 @@ import { addLink, htmlToTextContentInline, parseAndTransform, timeFromNow } from
 
 import { session } from '@web/session';
 
-import { str_to_datetime } from 'web.time';
+import { format } from 'web.field_utils';
+import { str_to_datetime, getLangDatetimeFormat } from 'web.time';
 
 registerModel({
     name: 'Message',
@@ -47,6 +48,9 @@ registerModel({
             }
             if ('date' in data && data.date) {
                 data2.date = moment(str_to_datetime(data.date));
+            }
+            if ('edit_date' in data && data.edit_date) {
+                data2.editDate = moment(str_to_datetime(data.edit_date));
             }
             if ('email_from' in data) {
                 data2.email_from = data.email_from;
@@ -287,6 +291,9 @@ registerModel({
             if (!this.messaging) {
                 return;
             }
+            if (messageData.editDate) {
+                messageData.editDate = moment(str_to_datetime(messageData.editDate));
+            }
             this.messaging.models['Message'].insert(messageData);
         },
         /**
@@ -360,6 +367,15 @@ registerModel({
                 return clear();
             }
             return timeFromNow(this.date);
+        },
+        /**
+         * @returns {string}
+         */
+        _computeEditDatetime() {
+            if (!this.editDate) {
+                return clear();
+            }
+            return this.editDate.format(getLangDatetimeFormat());
         },
         /**
          * @returns {boolean}
@@ -592,6 +608,12 @@ registerModel({
          */
         dateFromNow: attr({
             compute: '_computeDateFromNow',
+        }),
+        editDate: attr({
+            default: false,
+        }),
+        editDatetime: attr({
+            compute: '_computeEditDatetime',
         }),
         email_from: attr(),
         failureNotifications: many('Notification', {


### PR DESCRIPTION
**PURPOSE**

Display to other users the information that a message has been edited.

**SPECIFICATION**

If the user edits a message, (edited) in muted is displayed at the end of the
message and hovering on (edited) should indicate the date and time at which
the message was last modified.

**Task**-2664848
