### PR TITLE
[IMP] base: remove postprocessing of rendered pages

### DIFF
--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -54,7 +54,7 @@ class TestReports(TestReportsCommon):
             'company_id': self.env.company.id,
         })
         report = self.env.ref('stock.label_lot_template')
-        target = b'\n\n\n^XA\n^FO100,50\n^A0N,44,33^FD[C418]Mellohi^FS\n^FO100,100\n^A0N,44,33^FDLN/SN:Volume-Beta^FS\n^FO100,150^BY3\n^BCN,100,Y,N,N\n^FDVolume-Beta^FS\n^XZ\n\n\n'
+        target = b'\n\n^XA\n^FO100,50\n^A0N,44,33^FD[C418]Mellohi^FS\n^FO100,100\n^A0N,44,33^FDLN/SN:Volume-Beta^FS\n^FO100,150^BY3\n^BCN,100,Y,N,N\n^FDVolume-Beta^FS\n^XZ\n\n'
 
         rendering, qweb_type = report._render_qweb_text(lot1.id)
         self.assertEqual(target, rendering.replace(b' ', b''), 'The rendering is not good')

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -7,52 +7,49 @@
     </template>
 
     <template id="web.layout" name="Web layout">&lt;!DOCTYPE html&gt;
-        <html t-att="html_data or {}">
-            <head>
-                <meta charset="utf-8"/>
-                <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
-
-                <title t-esc="title or 'Odoo'"/>
-                <link type="image/x-icon" rel="shortcut icon" t-att-href="x_icon or '/web/static/img/favicon.ico'"/>
-
-                <script id="web.layout.odooscript" type="text/javascript">
-                    var odoo = {
-                        csrf_token: "<t t-esc="request.csrf_token(None)"/>",
-                        debug: "<t t-esc="debug"/>",
-                    };
-                </script>
-
-                <t t-out="head or ''"/>
-            </head>
-            <body t-att-class="body_classname">
-                <t t-out="0"/>
-            </body>
-        </html>
+<html t-att="html_data or {}">
+    <head>
+        <meta charset="utf-8"/>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+        <title t-esc="title or 'Odoo'"/>
+        <link type="image/x-icon" rel="shortcut icon" t-att-href="x_icon or '/web/static/img/favicon.ico'"/>
+        <script id="web.layout.odooscript" type="text/javascript">
+            var odoo = {
+                csrf_token: "<t t-esc="request.csrf_token(None)"/>",
+                debug: "<t t-esc="debug"/>",
+            };
+        </script>
+        <t t-out="head or ''"/>
+    </head>
+    <body t-att-class="body_classname">
+        <t t-out="0"/>
+    </body>
+</html>
     </template>
 
     <template id="web.frontend_layout" name="Frontend Layout" inherit_id="web.layout" primary="True">
-        <xpath expr="//head/meta[last()]" position="after">
-            <meta name="viewport" content="width=device-width, initial-scale=1"/>
-        </xpath>
-        <xpath expr="//head/link[last()]" position="after">
-            <link rel="preload" href="/web/static/lib/fontawesome/fonts/fontawesome-webfont.woff2?v=4.7.0" as="font" crossorigin=""/>
-            <t t-call-assets="web.assets_common" t-js="false"/>
-            <t t-call-assets="web.assets_frontend" t-js="false"/>
-        </xpath>
-        <xpath expr="//head/script[@id='web.layout.odooscript']" position="after">
-            <script type="text/javascript">
-                odoo.__session_info__ = <t t-out="json.dumps(request.env['ir.http'].get_frontend_session_info())"/>;
-                if (!/(^|;\s)tz=/.test(document.cookie)) {
-                    const userTZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
-                    document.cookie = `tz=${userTZ}; path=/`;
-                }
-            </script>
-            <t t-call-assets="web.assets_common_minimal" t-css="false" defer_load="True"/>
-            <t t-call-assets="web.assets_frontend_minimal" t-css="false" defer_load="True"/>
-            <t t-call="web.conditional_assets_tests"/>
-            <t t-call-assets="web.assets_common_lazy" t-css="false" lazy_load="True"/>
-            <t t-call-assets="web.assets_frontend_lazy" t-css="false" lazy_load="True"/>
-        </xpath>
+      <xpath expr="//head/meta[last()]" position="after">
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+      </xpath>
+      <xpath expr="//head/link[last()]" position="after">
+        <link rel="preload" href="/web/static/lib/fontawesome/fonts/fontawesome-webfont.woff2?v=4.7.0" as="font" crossorigin=""/>
+        <t t-call-assets="web.assets_common" t-js="false"/>
+        <t t-call-assets="web.assets_frontend" t-js="false"/>
+      </xpath>
+      <xpath expr="//head/script[@id='web.layout.odooscript']" position="after">
+        <script type="text/javascript">
+            odoo.__session_info__ = <t t-out="json.dumps(request.env['ir.http'].get_frontend_session_info())"/>;
+            if (!/(^|;\s)tz=/.test(document.cookie)) {
+                const userTZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+                document.cookie = `tz=${userTZ}; path=/`;
+            }
+        </script>
+        <t t-call-assets="web.assets_common_minimal" t-css="false" defer_load="True"/>
+        <t t-call-assets="web.assets_frontend_minimal" t-css="false" defer_load="True"/>
+        <t t-call="web.conditional_assets_tests"/>
+        <t t-call-assets="web.assets_common_lazy" t-css="false" lazy_load="True"/>
+        <t t-call-assets="web.assets_frontend_lazy" t-css="false" lazy_load="True"/>
+      </xpath>
         <xpath expr="//t[@t-out='0']" position="replace">
             <div id="wrapwrap" t-attf-class="#{pageName or ''}">
                 <header t-if="not no_header" id="top" data-anchor="true">

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -79,18 +79,18 @@
         <meta t-if="meta_description or editable" name="description" t-att-content="meta_description"/>
         <meta t-if="meta_keywords or editable" name="keywords" t-att-content="meta_keywords"/>
         <t t-if="seo_object">
-            <meta name="default_description" t-att-content="website_meta_description or website_meta.get('meta_description')" groups="website.group_website_designer"/>
+        <meta name="default_description" t-att-content="website_meta_description or website_meta.get('meta_description')" groups="website.group_website_designer"/>
             <!-- OpenGraph tags for Facebook sharing -->
             <t t-set="opengraph_meta" t-value="website_meta.get('opengraph_meta')"/>
             <t t-if="opengraph_meta">
                 <t t-foreach="opengraph_meta" t-as="property">
                     <t t-if="isinstance(opengraph_meta[property], list)">
                         <t t-foreach="opengraph_meta[property]" t-as="meta_content">
-                            <meta t-att-property="property" t-att-content="meta_content"/>
+        <meta t-att-property="property" t-att-content="meta_content"/>
                         </t>
                     </t>
                     <t t-else="">
-                        <meta t-att-property="property" t-att-content="opengraph_meta[property]"/>
+        <meta t-att-property="property" t-att-content="opengraph_meta[property]"/>
                     </t>
                 </t>
             </t>
@@ -98,7 +98,7 @@
             <t t-set="twitter_meta" t-value="website_meta.get('twitter_meta')"/>
             <t t-if="opengraph_meta">
                 <t t-foreach="twitter_meta" t-as="t_meta">
-                    <meta t-att-name="t_meta" t-att-content="twitter_meta[t_meta]"/>
+        <meta t-att-name="t_meta" t-att-content="twitter_meta[t_meta]"/>
                 </t>
             </t>
         </t>
@@ -110,7 +110,6 @@
             </t>
         </t>
         <link t-if="request and website" rel="canonical" t-att-href="website._get_canonical_url(canonical_params=canonical_params)"/>
-
         <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin=""/>
     </xpath>
 

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -846,7 +846,6 @@ class IrActionsReport(models.Model):
         if not data:
             data = {}
         data.setdefault('report_type', 'text')
-        data.setdefault('__keep_empty_lines', True)
         data = self._get_rendering_context(docids, data)
         return self._render_template(self.report_name, data), 'text'
 

--- a/odoo/addons/base/tests/test_profiler.py
+++ b/odoo/addons/base/tests/test_profiler.py
@@ -464,8 +464,7 @@ class TestProfiling(TransactionCase):
             'arch_db': '''<t t-name="root">
                 <t t-foreach="{'a': 3, 'b': 2, 'c': 1}" t-as="item">
                     [<t t-esc="item_index"/>: <t t-call="base.dummy"/> <t t-esc="item_value"/>]
-                    <b t-esc="add_one_query()"/>
-                </t>
+                    <b t-esc="add_one_query()"/></t>
             </t>'''
         })
         child_template = self.env['ir.ui.view'].create({

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -1174,12 +1174,12 @@ class TestQWebStaticXml(TransactionCase):
             # OrderedDict to ensure JSON mappings are iterated in source order
             # so output is predictable & repeatable
             params = {} if param is None else json.loads(param.text, object_pairs_hook=collections.OrderedDict)
-            params.setdefault('__keep_empty_lines', True)
 
+            rec = re.compile(r'\>[ \n\t]*\<')
             result = doc.find('result[@id="{}"]'.format(template)).text
             self.assertEqual(
-                qweb._render(template, values=params, load=loader).strip(),
-                (result or u'').strip().replace('&quot;', '&#34;'),
+                rec.sub('><', qweb._render(template, values=params, load=loader).strip()),
+                rec.sub('><', (result or u'').strip().replace('&quot;', '&#34;')),
                 template
             )
 
@@ -1188,110 +1188,6 @@ def load_tests(loader, suite, _):
     # instance
     suite.addTests(TestQWebStaticXml.get_cases())
     return suite
-
-class TestPageSplit(TransactionCase):
-    # need to explicitly assertTreesEqual because I guess it's registered for
-    # equality between _Element *or* HtmlElement but we're comparing a parsed
-    # HtmlElement and a convenience _Element
-    def test_split_before(self):
-        t = self.env['ir.ui.view'].create({
-            'name': 'test',
-            'type': 'qweb',
-            'arch_db': '''<t t-name='test'>
-            <div>
-                <table>
-                    <tr></tr>
-                    <tr data-pagebreak="before"></tr>
-                    <tr></tr>
-                </table>
-            </div>
-            </t>
-            '''
-        })
-        rendered = html.fromstring(self.env['ir.qweb']._render(t.id))
-        ref = E.div(
-            E.table(E.tr()),
-            E.div({'style': 'page-break-after: always'}),
-            E.table(E.tr({'data-pagebreak': 'before'}), E.tr())
-        )
-        self.assertTreesEqual(rendered, ref)
-
-    def test_split_after(self):
-        t = self.env['ir.ui.view'].create({
-            'name': 'test',
-            'type': 'qweb',
-            'arch_db': '''<t t-name='test'>
-            <div>
-                <table>
-                    <tr></tr>
-                    <tr data-pagebreak="after"></tr>
-                    <tr></tr>
-                </table>
-            </div>
-            </t>
-            '''
-        })
-        rendered = html.fromstring(self.env['ir.qweb']._render(t.id))
-        self.assertTreesEqual(
-            rendered,
-            E.div(
-                E.table(E.tr(), E.tr({'data-pagebreak': 'after'})),
-                E.div({'style': 'page-break-after: always'}),
-                E.table(E.tr())
-            )
-        )
-
-    def test_dontsplit(self):
-        t = self.env['ir.ui.view'].create({
-            'name': 'test',
-            'type': 'qweb',
-            'arch_db': '''<t t-name='test'>
-            <div>
-                <table>
-                    <tr></tr>
-                    <tr></tr>
-                    <tr></tr>
-                </table>
-            </div>
-            </t>
-            '''
-        })
-        rendered = html.fromstring(self.env['ir.qweb']._render(t.id))
-        self.assertTreesEqual(
-            rendered,
-            E.div(E.table(E.tr(), E.tr(), E.tr()))
-        )
-
-class TestEmptyLines(TransactionCase):
-    arch = '''<t t-name='test'>
-            
-                <div>
-                    
-                </div>
-                
-                
-            </t>'''
-
-    def test_no_empty_lines(self):
-        t = self.env['ir.ui.view'].create({
-            'name': 'test',
-            'type': 'qweb',
-            'arch_db': self.arch
-        })
-        rendered = self.env['ir.qweb']._render(t.id)
-        self.assertFalse(re.compile('^\s+\n').match(rendered))
-        self.assertFalse(re.compile('\n\s+\n').match(rendered))
-
-    def test_keep_empty_lines(self):
-        t = self.env['ir.ui.view'].create({
-            'name': 'test',
-            'type': 'qweb',
-            'arch_db': self.arch
-        })
-        rendered = self.env['ir.qweb']._render(t.id, {'__keep_empty_lines': True})
-        self.assertTrue(re.compile('^\s+\n').match(rendered))
-        self.assertTrue(re.compile('\n\s+\n').match(rendered))
-
 
 class TestQWebMisc(TransactionCase):
     def test_render_comment_tail(self):
@@ -1313,5 +1209,5 @@ class TestQWebMisc(TransactionCase):
             """
         })
         emptyline = '\n                '
-        expected = markupsafe.Markup('Text 1' + emptyline + 'Text 2' + emptyline + 'ok')
-        self.assertEqual(view1._render(), expected)
+        expected = markupsafe.Markup('Text 1' + emptyline + emptyline + 'Text 2' + emptyline + 'ok')
+        self.assertEqual(view1._render().strip(), expected)

--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -17,10 +17,10 @@ def add_text_before(node, text):
         return
     prev = node.getprevious()
     if prev is not None:
-        prev.tail = (prev.tail or "") + text
+        prev.tail = (prev.tail or "").rstrip() + text
     else:
         parent = node.getparent()
-        parent.text = (parent.text or "") + text
+        parent.text = (parent.text or "").rstrip() + text
 
 
 def add_text_inside(node, text):
@@ -28,7 +28,7 @@ def add_text_inside(node, text):
     if text is None:
         return
     if len(node):
-        node[-1].tail = (node[-1].tail or "") + text
+        node[-1].tail = (node[-1].tail or "").rstrip() + text
     else:
         node.text = (node.text or "") + text
 


### PR DESCRIPTION
This PR removes the two post processing operations applied on
rendered templates. This speed up the rendering of every page.

1/ Don't remove empty lines after rendering, but fix the root
cause of view inheritancies that was adding lots of empty lines.

2/ handle page break in the only report that uses it (financial
reports in Enterprise), rather than parsing every QWeb view rendered
to check if there is a page break.


It's the first step to stream QWeb templates to highly improve the TTFB
(Time to First Byte) and send the <head> to browser so that he can
load assets while Odoo is still computing the "slow" content to render.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
