### PR TITLE
[ADD] payment_authorize: Implement the webhook and check the signature

### DIFF
--- a/addons/payment_authorize/controllers/main.py
+++ b/addons/payment_authorize/controllers/main.py
@@ -57,3 +57,7 @@ class AuthorizeController(http.Controller):
             reference, pprint.pformat(response_content)
         )
         tx_sudo._handle_notification_data('authorize', {'response': response_content})
+
+    @http.route('/payment/authorize/webhook', type='http', auth='public')
+    def authorize_notification(self):
+        return ''


### PR DESCRIPTION
Implementing the webhook for Authorize.net.
At the end of this task the authorize acquirer should implement
webhook notifications to be handled.

Task - 2694036



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
