### PR TITLE
[FIX] wesbite_sale: Prevent traceback on website/shop without headers

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -2,6 +2,9 @@ odoo.define('website_sale.utils', function (require) {
 'use strict';
 
 function animateClone($cart, $elem, offsetTop, offsetLeft) {
+    if (!$cart.length) {
+        return Promise.resolve();
+    }
     $cart.find('.o_animate_blink').addClass('o_red_highlight o_shadow_animation').delay(500).queue(function () {
         $(this).removeClass("o_shadow_animation").dequeue();
     }).delay(2000).queue(function () {


### PR DESCRIPTION
When you disable the headers through the website editor and try to add a product to the cart, a traceback occurs because there is an animation that uses the dom element of the cart that doesn't exist.

a solution would be to avoid the animation in the case where the element of the dom of the cart is not defined

https://github.com/odoo/odoo/blob/8c382a0dcafff51356d5be32c4a71848277c468d/addons/website_sale/static/src/js/website_sale_utils.js#L50-L76

opw-2722163