### PR TITLE
[FIX] payment: hide toaster notification for token deletion error

### DIFF
--- a/addons/payment/static/src/js/manage_form.js
+++ b/addons/payment/static/src/js/manage_form.js
@@ -94,6 +94,7 @@ odoo.define('payment.manage_form', require => {
                         this._disableButton(false);
                     }
                 }).guardedCatch(error => {
+                    error.event.preventDefault();
                     this._displayError(
                         _t("Server Error"),
                         _t("We are not able to delete your payment method."),


### PR DESCRIPTION
Before this commit, a toaster notification would be shown in addition to
the dedicated error div in the inline payment form when an exception is
raised while trying to archive a payment token.