### PR TITLE
[FIX] payment_*: allow public user to read payment terms

### DIFF
--- a/addons/payment_adyen/controllers/main.py
+++ b/addons/payment_adyen/controllers/main.py
@@ -11,7 +11,7 @@ import pprint
 import werkzeug
 from werkzeug import urls
 
-from odoo import _, http
+from odoo import _, http, SUPERUSER_ID
 from odoo.exceptions import ValidationError
 from odoo.http import request
 from odoo.tools.pycompat import to_text
@@ -144,7 +144,7 @@ class AdyenController(http.Controller):
 
         # Handle the payment request response
         _logger.info("payment request response:\n%s", pprint.pformat(response_content))
-        request.env['payment.transaction'].sudo()._handle_feedback_data(
+        request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data(
             'adyen', dict(response_content, merchantReference=reference),  # Match the transaction
         )
         return response_content
@@ -173,7 +173,7 @@ class AdyenController(http.Controller):
 
         # Handle the payment details request response
         _logger.info("payment details request response:\n%s", pprint.pformat(response_content))
-        request.env['payment.transaction'].sudo()._handle_feedback_data(
+        request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data(
             'adyen', dict(response_content, merchantReference=reference),  # Match the transaction
         )
 
@@ -261,7 +261,7 @@ class AdyenController(http.Controller):
                     continue  # Don't handle unsupported event codes and failed events
 
                 # Handle the notification data as a regular feedback
-                PaymentTransaction.sudo()._handle_feedback_data('adyen', notification_data)
+                PaymentTransaction.with_user(SUPERUSER_ID)._handle_feedback_data('adyen', notification_data)
             except ValidationError:  # Acknowledge the notification to avoid getting spammed
                 _logger.exception("unable to handle the notification data; skipping to acknowledge")
 

--- a/addons/payment_alipay/controllers/main.py
+++ b/addons/payment_alipay/controllers/main.py
@@ -5,7 +5,7 @@ import pprint
 
 import requests
 
-from odoo import _, http
+from odoo import _, http, SUPERUSER_ID
 from odoo.exceptions import ValidationError
 from odoo.http import request
 
@@ -20,7 +20,7 @@ class AlipayController(http.Controller):
     def alipay_return_from_redirect(self, **data):
         """ Alipay return """
         _logger.info("received Alipay return data:\n%s", pprint.pformat(data))
-        request.env['payment.transaction'].sudo()._handle_feedback_data('alipay', data)
+        request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('alipay', data)
         return request.redirect('/payment/status')
 
     @http.route(_notify_url, type='http', auth='public', methods=['POST'], csrf=False)
@@ -28,7 +28,7 @@ class AlipayController(http.Controller):
         """ Alipay Notify """
         _logger.info("received Alipay notification data:\n%s", pprint.pformat(post))
         self._alipay_validate_notification(**post)
-        request.env['payment.transaction'].sudo()._handle_feedback_data('alipay', post)
+        request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('alipay', post)
         return 'success'  # Return 'success' to stop receiving notifications for this tx
 
     def _alipay_validate_notification(self, **post):

--- a/addons/payment_authorize/controllers/main.py
+++ b/addons/payment_authorize/controllers/main.py
@@ -3,7 +3,7 @@
 import logging
 import pprint
 
-from odoo import _, http
+from odoo import _, http, SUPERUSER_ID
 from odoo.exceptions import ValidationError
 from odoo.http import request
 
@@ -57,6 +57,6 @@ class AuthorizeController(http.Controller):
         # Still, we prefer to simulate the matching of the transaction by crafting dummy feedback
         # data in order to go through the centralized `_handle_feedback_data` method.
         feedback_data = {'reference': tx_sudo.reference, 'response': response_content}
-        request.env['payment.transaction'].sudo()._handle_feedback_data(
+        request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data(
             'authorize', feedback_data
         )

--- a/addons/payment_buckaroo/controllers/main.py
+++ b/addons/payment_buckaroo/controllers/main.py
@@ -3,7 +3,7 @@
 import logging
 import pprint
 
-from odoo import http
+from odoo import http, SUPERUSER_ID
 from odoo.http import request
 
 _logger = logging.getLogger(__name__)
@@ -19,5 +19,5 @@ class BuckarooController(http.Controller):
         :param dict data: The feedback data
         """
         _logger.info("received notification data:\n%s", pprint.pformat(data))
-        request.env['payment.transaction'].sudo()._handle_feedback_data('buckaroo', data)
+        request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('buckaroo', data)
         return request.redirect('/payment/status')

--- a/addons/payment_mollie/controllers/main.py
+++ b/addons/payment_mollie/controllers/main.py
@@ -4,7 +4,7 @@
 import logging
 import pprint
 
-from odoo import http
+from odoo import http, SUPERUSER_ID
 from odoo.exceptions import ValidationError
 from odoo.http import request
 
@@ -34,7 +34,7 @@ class MollieController(http.Controller):
                           embedded in the return URL
         """
         _logger.info("Received Mollie return data:\n%s", pprint.pformat(data))
-        request.env['payment.transaction'].sudo()._handle_feedback_data('mollie', data)
+        request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('mollie', data)
         return request.redirect('/payment/status')
 
     @http.route(_notify_url, type='http', auth='public', methods=['POST'], csrf=False)
@@ -48,7 +48,7 @@ class MollieController(http.Controller):
         """
         _logger.info("Received Mollie notify data:\n%s", pprint.pformat(data))
         try:
-            request.env['payment.transaction'].sudo()._handle_feedback_data('mollie', data)
+            request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('mollie', data)
         except ValidationError:  # Acknowledge the notification to avoid getting spammed
             _logger.exception("unable to handle the notification data; skipping to acknowledge")
         return ''  # Acknowledge the notification with an HTTP 200 response

--- a/addons/payment_ogone/controllers/main.py
+++ b/addons/payment_ogone/controllers/main.py
@@ -6,7 +6,7 @@ import re
 
 import werkzeug
 
-from odoo import _, http
+from odoo import _, http, SUPERUSER_ID
 from odoo.exceptions import ValidationError
 from odoo.http import request
 
@@ -43,7 +43,7 @@ class OgoneController(http.Controller):
 
         # Handle the feedback data
         _logger.info("entering _handle_feedback_data with data:\n%s", pprint.pformat(data))
-        request.env['payment.transaction'].sudo()._handle_feedback_data('ogone', data)
+        request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('ogone', data)
         return request.redirect('/payment/status')
 
     def _homogenize_data(self, data):

--- a/addons/payment_paypal/controllers/main.py
+++ b/addons/payment_paypal/controllers/main.py
@@ -5,7 +5,7 @@ import pprint
 
 import requests
 
-from odoo import _, http
+from odoo import _, http, SUPERUSER_ID
 from odoo.exceptions import ValidationError
 from odoo.http import request
 
@@ -30,7 +30,7 @@ class PaypalController(http.Controller):
             pass  # The transaction has been moved to state 'error'. Redirect to /payment/status.
         else:
             if data:
-                request.env['payment.transaction'].sudo()._handle_feedback_data('paypal', data)
+                request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('paypal', data)
             else:
                 pass  # The customer has cancelled the payment, don't do anything
         return request.redirect('/payment/status')
@@ -41,7 +41,7 @@ class PaypalController(http.Controller):
         _logger.info("beginning IPN with post data:\n%s", pprint.pformat(data))
         try:
             self._validate_data_authenticity(**data)
-            request.env['payment.transaction'].sudo()._handle_feedback_data('paypal', data)
+            request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('paypal', data)
         except ValidationError:  # Acknowledge the notification to avoid getting spammed
             _logger.exception("unable to handle the IPN data; skipping to acknowledge the notif")
         return ''

--- a/addons/payment_payulatam/controllers/main.py
+++ b/addons/payment_payulatam/controllers/main.py
@@ -3,7 +3,7 @@
 import logging
 import pprint
 
-from odoo import http
+from odoo import http, SUPERUSER_ID
 from odoo.http import request
 
 _logger = logging.getLogger(__name__)
@@ -15,5 +15,5 @@ class PayuLatamController(http.Controller):
     @http.route(_return_url, type='http', auth='public', methods=['GET'])
     def payulatam_return(self, **data):
         _logger.info("entering _handle_feedback_data with data:\n%s", pprint.pformat(data))
-        request.env['payment.transaction'].sudo()._handle_feedback_data('payulatam', data)
+        request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('payulatam', data)
         return request.redirect('/payment/status')

--- a/addons/payment_payumoney/controllers/main.py
+++ b/addons/payment_payumoney/controllers/main.py
@@ -3,7 +3,7 @@
 import logging
 import pprint
 
-from odoo import http
+from odoo import http, SUPERUSER_ID
 from odoo.http import request
 
 _logger = logging.getLogger(__name__)
@@ -30,5 +30,5 @@ class PayUMoneyController(http.Controller):
         :param dict data: The feedback data to process
         """
         _logger.info("entering handle_feedback_data with data:\n%s", pprint.pformat(data))
-        request.env['payment.transaction'].sudo()._handle_feedback_data('payumoney', data)
+        request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('payumoney', data)
         return request.redirect('/payment/status')

--- a/addons/payment_sips/controllers/main.py
+++ b/addons/payment_sips/controllers/main.py
@@ -4,7 +4,7 @@
 import logging
 import pprint
 
-from odoo import http
+from odoo import http, SUPERUSER_ID
 from odoo.exceptions import ValidationError
 from odoo.http import request
 
@@ -34,7 +34,7 @@ class SipsController(http.Controller):
         _logger.info("beginning Sips DPN _handle_feedback_data with data %s", pprint.pformat(post))
         try:
             if self._sips_validate_data(post):
-                request.env['payment.transaction'].sudo()._handle_feedback_data('sips', post)
+                request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('sips', post)
         except ValidationError:
             pass
         return request.redirect('/payment/status')
@@ -51,7 +51,7 @@ class SipsController(http.Controller):
         else:
             try:
                 if self._sips_validate_data(post):
-                    request.env['payment.transaction'].sudo()._handle_feedback_data('sips', post)
+                    request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('sips', post)
             except ValidationError:
                 pass  # Acknowledge the notification to avoid getting spammed
         return ''

--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 import werkzeug
 
-from odoo import http
+from odoo import http, SUPERUSER_ID
 from odoo.exceptions import ValidationError
 from odoo.http import request
 from odoo.tools import consteq
@@ -42,7 +42,7 @@ class StripeController(http.Controller):
         self._include_payment_intent_in_feedback_data(payment_intent, data)
 
         # Handle the feedback data crafted with Stripe API objects
-        request.env['payment.transaction'].sudo()._handle_feedback_data('stripe', data)
+        request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('stripe', data)
 
         # Redirect the user to the status page
         return request.redirect('/payment/status')
@@ -68,7 +68,7 @@ class StripeController(http.Controller):
         self._include_setup_intent_in_feedback_data(checkout_session.get('setup_intent', {}), data)
 
         # Handle the feedback data crafted with Stripe API objects
-        request.env['payment.transaction'].sudo()._handle_feedback_data('stripe', data)
+        request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('stripe', data)
 
         # Redirect the user to the status page
         return request.redirect('/payment/status')
@@ -113,7 +113,7 @@ class StripeController(http.Controller):
                         )
                         self._include_setup_intent_in_feedback_data(setup_intent, data)
                     # Handle the feedback data crafted with Stripe API objects as a regular feedback
-                    request.env['payment.transaction'].sudo()._handle_feedback_data('stripe', data)
+                    request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('stripe', data)
         except ValidationError:  # Acknowledge the notification to avoid getting spammed
             _logger.exception("unable to handle the event data; skipping to acknowledge")
         return ''

--- a/addons/payment_test/controllers/main.py
+++ b/addons/payment_test/controllers/main.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import http
+from odoo import http, SUPERUSER_ID
 from odoo.http import request
 
 
@@ -18,4 +18,4 @@ class PaymentTestController(http.Controller):
             'reference': reference,
             'cc_summary': customer_input[-4:],
         }
-        request.env['payment.transaction'].sudo()._handle_feedback_data('test', fake_api_response)
+        request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('test', fake_api_response)

--- a/addons/payment_transfer/controllers/main.py
+++ b/addons/payment_transfer/controllers/main.py
@@ -3,7 +3,7 @@
 import logging
 import pprint
 
-from odoo import http
+from odoo import http, SUPERUSER_ID
 from odoo.http import request
 
 _logger = logging.getLogger(__name__)
@@ -15,5 +15,5 @@ class TransferController(http.Controller):
     @http.route(_accept_url, type='http', auth='public', methods=['POST'], csrf=False)
     def transfer_form_feedback(self, **post):
         _logger.info("beginning _handle_feedback_data with post data %s", pprint.pformat(post))
-        request.env['payment.transaction'].sudo()._handle_feedback_data('transfer', post)
+        request.env['payment.transaction'].with_user(SUPERUSER_ID)._handle_feedback_data('transfer', post)
         return request.redirect('/payment/status')


### PR DESCRIPTION
After https://github.com/odoo/odoo/commit/61b4b6777d64218f94c51ec839
the public user doesn't have the rights to read the payment terms anymore.

This could happens after a successful payment of an invoice/subscription/...
when the user is not connected (public user).

When the email is generated, if fails.
The process is rollbacked, the payment doesn't appears in Odoo but the
card is charged. Customer often try multiple times and get charged multiple times.

OPW-2705525