### PR TITLE
[FIX] sale: translate terms wherever they are used

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -348,6 +348,7 @@ class AccountMove(models.Model):
         if self.is_sale_document(include_receipts=True) and self.partner_id:
             self.invoice_payment_term_id = self.partner_id.property_payment_term_id or self.invoice_payment_term_id
             new_term_account = self.partner_id.commercial_partner_id.property_account_receivable_id
+            self.narration = self.company_id.with_context(lang=self.partner_id.lang).invoice_terms
         elif self.is_purchase_document(include_receipts=True) and self.partner_id:
             self.invoice_payment_term_id = self.partner_id.property_supplier_payment_term_id or self.invoice_payment_term_id
             new_term_account = self.partner_id.commercial_partner_id.property_account_payable_id

--- a/addons/sale/models/account_invoice.py
+++ b/addons/sale/models/account_invoice.py
@@ -49,13 +49,7 @@ class AccountMove(models.Model):
         addr = self.partner_id.address_get(['delivery'])
         self.partner_shipping_id = addr and addr.get('delivery')
 
-        res = super(AccountMove, self)._onchange_partner_id()
-
-        # Recompute 'narration' based on 'company.invoice_terms'.
-        if self.type == 'out_invoice':
-            self.narration = self.company_id.with_context(lang=self.partner_id.lang or self.env.lang).invoice_terms
-
-        return res
+        return super(AccountMove, self)._onchange_partner_id()
 
     @api.onchange('invoice_user_id')
     def onchange_user_id(self):


### PR DESCRIPTION
### Current behavior
General terms and conditions are only translated for Customer Invoice (`out_invoice`)

### Steps to reproduce
- Install Sales & Accounting
- Install a 2nd language
- Enable `Default Terms & Conditions` (Settings > Accounting)
- Set translation for both language
- Create a customer and set his language with the one previously installed
- Go to Accounting > Customers > Credit Notes (for example, Issue occurs everywhere except "Invoices") and create a new one
- Select your newly created client
-> Terms aren't translated

### Reason
General terms were added in many cases but they were only translated on an invoice.
https://github.com/odoo/odoo/blob/ed41d4f4f547303f5904ad03c258d9c2914d79df/addons/account/models/account_move.py#L421-L423

OPW-2722070