### PR TITLE
[IMP] hr_holidays: add tooltip on allocation_validation_type field of…

### DIFF
--- a/addons/hr_holidays/i18n/hr_holidays.pot
+++ b/addons/hr_holidays/i18n/hr_holidays.pot
@@ -2972,6 +2972,14 @@ msgid "Select Time Off Type"
 msgstr ""
 
 #. module: hr_holidays
+#: model:ir.model.fields,help:hr_holidays.field_hr_leave_type__allocation_validation_type
+msgid "Select the level of approval needed in case of request by employee "
+"- No validation needed: The employee's request is automatically approved. "
+"- Approved by Time Off Officer: The employee's request need to be manually approved by the Time Off Officer. "
+"- Set by Time Off Officer: The request is directly set by the time off officer and don't need additional approbation."
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_employee__leave_manager_id
 #: model:ir.model.fields,help:hr_holidays.field_hr_employee_base__leave_manager_id
 #: model:ir.model.fields,help:hr_holidays.field_hr_employee_public__leave_manager_id

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -91,7 +91,11 @@ class HolidaysType(models.Model):
     allocation_validation_type = fields.Selection([
         ('no', 'No validation needed'),
         ('officer', 'Approved by Time Off Officer'),
-        ('set', "Set by Time Off Officer")], default='officer', string='Approval')
+        ('set', "Set by Time Off Officer")], default='officer', string='Approval',
+        help="""Select the level of approval needed in case of request by employee
+        - No validation needed: The employee's request is automatically approved.
+        - Approved by Time Off Officer: The employee's request need to be manually approved by the Time Off Officer.
+        - Set by Time Off Officer: The request is directly set by the time off officer and don't need additional approbation.""")
     has_valid_allocation = fields.Boolean(compute='_compute_valid', search='_search_valid', help='This indicates if it is still possible to use this type of leave')
     time_type = fields.Selection([('leave', 'Time Off'), ('other', 'Other')], default='leave', string="Kind of Leave",
                                  help="Whether this should be computed as a holiday or as work time (eg: formation)")


### PR DESCRIPTION
… hr.leave.type

Since 15.0, the time off type can have different types of approval:
- No validation neededd
- Approved by Time Off Officer
- Set by Time Off Officer

This commit adds a tooltip on the allocation_validation_type to improve usability

task-2681288

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
