### PR TITLE
[FIX] web_editor: allow to select inside a button when editing

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_iframe.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_iframe.scss
@@ -79,4 +79,7 @@ body.o_in_iframe {
             min-height: 800px;
         }
     }
+    .btn {
+        user-select: auto;
+    }
 }


### PR DESCRIPTION
When the user-select is none in firefox, it is impossible to select the
text even if the content is editable.

Task-2716365




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
