### PR TITLE
[IMP] hr_holidays: allow modifying a time off that is in draft or to …

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -732,7 +732,7 @@ class HolidaysRequest(models.Model):
         is_officer = self.env.user.has_group('hr_holidays.group_hr_holidays_user') or self.env.is_superuser()
 
         if not is_officer:
-            if any(hol.date_from.date() < fields.Date.today() for hol in self):
+            if any(hol.date_from.date() < fields.Date.today() for hol in self) and self.state not in ['draft', 'confirm']:
                 raise UserError(_('You must have manager rights to modify/validate a time off that already begun'))
 
         employee_id = values.get('employee_id', False)


### PR DESCRIPTION
…validate state

It is not possible to modify a time off that is in draft or to validate state.

This PR allows modifying a time off that is in draft or to validate state

task-2681288

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
