### PR TITLE
[FIX] wesbite_sale: Prevent traceback on website/shop without headers

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -2,6 +2,9 @@ odoo.define('website_sale.utils', function (require) {
 'use strict';
 
 function animateClone($cart, $elem, offsetTop, offsetLeft) {
+    if (!$cart.length) {
+        return Promise.resolve();
+    }
     $cart.find('.o_animate_blink').addClass('o_red_highlight o_shadow_animation').delay(500).queue(function () {
         $(this).removeClass("o_shadow_animation").dequeue();
     }).delay(2000).queue(function () {


### PR DESCRIPTION
When you disable the headers through the website editor and try to add
a product to the wishlist, a traceback occurs because there is an animation
that uses the dom element of the wishlist that doesn't exist.
We can avoid the animation in the case where the wish is not defined

reproducible in 14.0 with the wishlist (must be activated in settings)
and in 15.0 with the cart and the wishlist

opw-2722163