### PR TITLE
[FIX] l10n_it_stock_ddt: translate DDT report

### DIFF
--- a/addons/l10n_it_stock_ddt/i18n/it.po
+++ b/addons/l10n_it_stock_ddt/i18n/it.po
@@ -1,0 +1,315 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_it_stock_ddt
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-01-11 14:02+0000\n"
+"PO-Revision-Date: 2022-01-11 14:02+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.actions.report,print_report_name:l10n_it_stock_ddt.action_report_ddt
+msgid ""
+"'DDT - %s - %s' % (object.partner_id.name or '', object.l10n_it_ddt_number)"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<b>Note:</b>"
+msgstr "<b>Nota:</b>"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<b>Total:</b>"
+msgstr "<b>Totale:</b>"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<b>Transportation Method Details: </b>"
+msgstr "<b>Dettagli metodo di trasporto</b>"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<span><strong>Customer Address:</strong></span>"
+msgstr "<span><strong>Indirizzo Cliente:</strong></span>"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<span><strong>Warehouse Address:</strong></span>"
+msgstr "<span><strong>Indirizzo Magazzino:</strong></span>"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<strong>Carrier Signature</strong>"
+msgstr "<strong>Firma Corriere</strong>"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<strong>Company Signature</strong>"
+msgstr "<strong>Firma Azienda</strong>"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<strong>Customer Signature</strong>"
+msgstr "<strong>Firma Cliente</strong>"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<strong>Product</strong>"
+msgstr "<strong>Prodotto</strong>"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<strong>Quantity</strong>"
+msgstr "<strong>Quantità</strong>"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<strong>Total Value</strong>"
+msgstr "<strong>Valore Totale</strong>"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__attemped_sale
+msgid "Attempted Sale"
+msgstr "Tentata Vendita"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Carrier"
+msgstr "Corriere"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Carrier Condition"
+msgstr "Termini di Resa"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking__l10n_it_country_code
+msgid "Country Code"
+msgstr "Codice Nazione"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_method__courier
+msgid "Courier service"
+msgstr "Servizio Corriere"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.view_picking_form_inherit_l10n_it_ddt
+msgid "DDT Information"
+msgstr "Informazioni DDT"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking__l10n_it_ddt_number
+msgid "DDT Number"
+msgstr "Numero DDT"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.actions.report,name:l10n_it_stock_ddt.action_report_ddt
+msgid "DDT report"
+msgstr "DDT"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.account_invoice_view_form_inherit_ddt
+msgid "DDTs"
+msgstr "DDT"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking__display_name
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking_type__display_name
+msgid "Display Name"
+msgstr "Nome visualizzato"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Documento di Trasporto"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__evaluation
+msgid "Evaluation"
+msgstr "Valutazione"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__gift
+msgid "Gift"
+msgstr "Regalo"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Gross Weight (kg)"
+msgstr "Peso lordo (kg)"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking__id
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking_type__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model,name:l10n_it_stock_ddt.model_account_move
+msgid "Journal Entry"
+msgstr "Registrazione contabile"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_bank_statement_line__l10n_it_ddt_ids
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_move__l10n_it_ddt_ids
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_payment__l10n_it_ddt_ids
+msgid "L10N It Ddt"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_bank_statement_line__l10n_it_ddt_count
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_move__l10n_it_ddt_count
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_payment__l10n_it_ddt_count
+msgid "L10N It Ddt Count"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking_type__l10n_it_ddt_sequence_id
+msgid "L10N It Ddt Sequence"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_move____last_update
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking____last_update
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking_type____last_update
+msgid "Last Modified on"
+msgstr "Ultima modifica il"
+
+#. module: l10n_it_stock_ddt
+#: code:addons/l10n_it_stock_ddt/models/account_invoice.py:0
+#, python-format
+msgid "Linked deliveries"
+msgstr "Spedizioni associate"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__loaned_use
+msgid "Loaned for Use"
+msgstr "Comodato d'uso"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Order"
+msgstr "Ordine"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__outsourcing
+msgid "Outsourcing"
+msgstr "Conto Lavorazione"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking__l10n_it_parcels
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Parcels"
+msgstr "Colli"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Picking Number"
+msgstr "Numero prelievo"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model,name:l10n_it_stock_ddt.model_stock_picking_type
+msgid "Picking Type"
+msgstr "Tipologia prelievo"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.view_picking_form_inherit_l10n_it_ddt
+msgid "Print"
+msgstr "Stampa"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_method__recipient
+msgid "Recipient"
+msgstr "Destinatario"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__repair
+msgid "Repair"
+msgstr "Conto Riparazione"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__sale
+msgid "Sale"
+msgstr "Vendita"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_method__sender
+msgid "Sender"
+msgstr "Mittente"
+
+#. module: l10n_it_stock_ddt
+#: code:addons/l10n_it_stock_ddt/models/stock_picking.py:0
+#, python-format
+msgid "Sequence"
+msgstr "Sequenza"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Shipping Date"
+msgstr "Data transporto"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__substitution
+msgid "Substitution"
+msgstr "Sostituzione"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,help:l10n_it_stock_ddt.field_stock_picking__l10n_it_country_code
+msgid ""
+"The ISO country code in two chars. \n"
+"You can use this field for quick search."
+msgstr ""
+"Il codice ISO nazionale in 2 caratteri. \n"
+"Puoi usare questo campo per la ricerca veloce."
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model,name:l10n_it_stock_ddt.model_stock_picking
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__transfer
+msgid "Transfer"
+msgstr "Trasferimento"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking__l10n_it_transport_method
+msgid "Transport Method"
+msgstr "Metodo di trasporto"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking__l10n_it_transport_method_details
+msgid "Transport Note"
+msgstr "Nota di trasporto"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking__l10n_it_transport_reason
+msgid "Transport Reason"
+msgstr "Ragione trasporto"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Transportation Method"
+msgstr "Metodo di trasporto"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Transportation Reason"
+msgstr "Ragione trasporto"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "VAT"
+msgstr "Pta IVA"
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "VAT:"
+msgstr "Pta IVA:"

--- a/addons/l10n_it_stock_ddt/i18n/l10n_it_stock_ddt.pot
+++ b/addons/l10n_it_stock_ddt/i18n/l10n_it_stock_ddt.pot
@@ -1,0 +1,314 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_it_stock_ddt
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-01-10 15:18+0000\n"
+"PO-Revision-Date: 2022-01-10 15:18+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_it_stock_ddt
+#: model:ir.actions.report,print_report_name:l10n_it_stock_ddt.action_report_ddt
+msgid ""
+"'DDT - %s - %s' % (object.partner_id.name or '', object.l10n_it_ddt_number)"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<b>Note:</b>"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<b>Total:</b>"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<b>Transportation Method Details: </b>"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<span><strong>Customer Address:</strong></span>"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<span><strong>Warehouse Address:</strong></span>"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<strong>Carrier Signature</strong>"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<strong>Company Signature</strong>"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<strong>Customer Signature</strong>"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<strong>Product</strong>"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<strong>Quantity</strong>"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "<strong>Total Value</strong>"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__attemped_sale
+msgid "Attempted Sale"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Carrier"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Carrier Condition"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking__l10n_it_country_code
+msgid "Country Code"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_method__courier
+msgid "Courier service"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.view_picking_form_inherit_l10n_it_ddt
+msgid "DDT Information"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking__l10n_it_ddt_number
+msgid "DDT Number"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.actions.report,name:l10n_it_stock_ddt.action_report_ddt
+msgid "DDT report"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.account_invoice_view_form_inherit_ddt
+msgid "DDTs"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking__display_name
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking_type__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Documento di Trasporto"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__evaluation
+msgid "Evaluation"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__gift
+msgid "Gift"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Gross Weight (kg)"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking__id
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking_type__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model,name:l10n_it_stock_ddt.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_bank_statement_line__l10n_it_ddt_ids
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_move__l10n_it_ddt_ids
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_payment__l10n_it_ddt_ids
+msgid "L10N It Ddt"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_bank_statement_line__l10n_it_ddt_count
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_move__l10n_it_ddt_count
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_payment__l10n_it_ddt_count
+msgid "L10N It Ddt Count"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking_type__l10n_it_ddt_sequence_id
+msgid "L10N It Ddt Sequence"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_account_move____last_update
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking____last_update
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking_type____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: code:addons/l10n_it_stock_ddt/models/account_invoice.py:0
+#, python-format
+msgid "Linked deliveries"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__loaned_use
+msgid "Loaned for Use"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Order"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__outsourcing
+msgid "Outsourcing"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking__l10n_it_parcels
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Parcels"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Picking Number"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model,name:l10n_it_stock_ddt.model_stock_picking_type
+msgid "Picking Type"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.view_picking_form_inherit_l10n_it_ddt
+msgid "Print"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_method__recipient
+msgid "Recipient"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__repair
+msgid "Repair"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__sale
+msgid "Sale"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_method__sender
+msgid "Sender"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: code:addons/l10n_it_stock_ddt/models/stock_picking.py:0
+#: code:addons/l10n_it_stock_ddt/models/stock_picking.py:0
+#, python-format
+msgid "Sequence"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Shipping Date"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__substitution
+msgid "Substitution"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,help:l10n_it_stock_ddt.field_stock_picking__l10n_it_country_code
+msgid ""
+"The ISO country code in two chars. \n"
+"You can use this field for quick search."
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model,name:l10n_it_stock_ddt.model_stock_picking
+#: model:ir.model.fields.selection,name:l10n_it_stock_ddt.selection__stock_picking__l10n_it_transport_reason__transfer
+msgid "Transfer"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking__l10n_it_transport_method
+msgid "Transport Method"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking__l10n_it_transport_method_details
+msgid "Transport Note"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model:ir.model.fields,field_description:l10n_it_stock_ddt.field_stock_picking__l10n_it_transport_reason
+msgid "Transport Reason"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Transportation Method"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "Transportation Reason"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "VAT"
+msgstr ""
+
+#. module: l10n_it_stock_ddt
+#: model_terms:ir.ui.view,arch_db:l10n_it_stock_ddt.report_ddt_view
+msgid "VAT:"
+msgstr ""

--- a/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
+++ b/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
@@ -1,178 +1,188 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <template id="report_ddt_view">
-        <t t-call="web.html_container">
-            <t t-foreach="docs" t-as="o">
-                <t t-call="web.external_layout">
-                    <div class="page">
-                        <div class="row">
-                            <div class="col-6">
-                               <span><strong>Warehouse Address:</strong></span>
-                                <t t-set="delivery_from" t-value="o.picking_type_id.warehouse_id.partner_id or o.company_id.partner_id"/>
-                                <t t-if="o.picking_type_id.warehouse_id.partner_id">
-                                    <div t-field="o.picking_type_id.warehouse_id.partner_id"
-                                        t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-                                </t>
-                                <t t-else="">
-                                    <div t-field="o.company_id.partner_id"
-                                    t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-                                </t>
-                                <p t-if="delivery_from.vat">Pta IVA: <span t-field="delivery_from.vat"/></p>
-                            </div>
-                            <div class="col-5 offset-1">
-                                <div>
-                                    <span><strong>Customer Address:</strong></span>
-                                    <div t-field="o.partner_id"
-                                           t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-                                    <p t-if="o.partner_id.vat"><t t-esc="o.company_id.country_id.vat_label or 'Pta IVA'"/>: <span t-field="o.partner_id.vat"/></p>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="mt16"/>
-                        <div class="mt64"/>
+        <t t-call="web.external_layout">
+            <t t-set="o" t-value="o.with_context(lang=lang)"/>
+            <div class="page">
+                <div class="row">
+                    <div class="col-6">
+                       <span><strong>Warehouse Address:</strong></span>
+                        <t t-set="delivery_from" t-value="o.picking_type_id.warehouse_id.partner_id or o.company_id.partner_id"/>
+                        <t t-if="o.picking_type_id.warehouse_id.partner_id">
+                            <div t-field="o.picking_type_id.warehouse_id.partner_id"
+                                t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
+                        </t>
+                        <t t-else="">
+                            <div t-field="o.company_id.partner_id"
+                            t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
+                        </t>
+                        <p t-if="delivery_from.vat">VAT: <span t-field="delivery_from.vat"/></p>
+                    </div>
+                    <div class="col-5 offset-1">
                         <div>
-                            <h1>Documento di Trasporto <span t-esc="o.l10n_it_ddt_number"/></h1>
+                            <span><strong>Customer Address:</strong></span>
+                            <div t-field="o.partner_id"
+                                   t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
+                            <p t-if="o.partner_id.vat">
+                                <t t-set="default_vat_label">VAT</t>
+                                <t t-esc="o.company_id.country_id.vat_label or default_vat_label"/>: <span t-field="o.partner_id.vat"/>
+                            </p>
                         </div>
-                        <div class="clearfix"/>
-                        <div class="mb32"/>
-                        <div class="row">
-                            <div class="col-6">
-                                <table class="table table-bordered">
-                                    <tbody>
-                                        <tr>
-                                            <td>Transportation Reason</td>
-                                            <td><span t-field="o.l10n_it_transport_reason"/></td>
-                                        </tr>
-                                        <tr>
-                                            <td>Transportation Method</td>
-                                            <td><span t-field="o.l10n_it_transport_method"/></td>
-                                        </tr>
-                                        <tr>
-                                            <td>Carrier Condition</td>
-                                            <td><span t-field="o.sale_id.incoterm.name"/></td>
-                                        </tr>
-                                        <tr>
-                                            <td>Carrier</td>
-                                            <td><span t-field="o.carrier_id"/></td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                                <div t-if="o.l10n_it_transport_method_details">
-                                    <b>Transportation Method Details: </b>
-                                    <span t-field="o.l10n_it_transport_method_details"/>
-                                </div>
-                            </div>
-                            <div class="col-5 offset-1">
-                                <table class="table table-bordered">
-                                    <tbody>
-                                        <tr>
-                                            <td>Order</td>
-                                            <td><span t-field="o.origin"/></td>
-                                        </tr>
-                                        <tr>
-                                            <td>Picking Number</td>
-                                            <td><span t-field="o.name"/></td>
-                                        </tr>
-                                        <tr>
-                                            <td>Shipping Date</td>
-                                            <td><span t-field="o.date_done"/></td>
-                                        </tr>
-                                        <tr>
-                                            <td>Gross Weight (kg)</td>
-                                            <td><span t-field="o.shipping_weight"/></td>
-                                        </tr>
-                                        <tr>
-                                            <td>Parcels</td>
-                                            <td><span t-field="o.l10n_it_parcels"/></td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-
-                        <div class="mt64"/>
-                        <div t-if="o.note"><b>Note:</b> <span t-field="o.note"/></div>
-
-                        <div class="mt64"/>
-                        <div class="mt64"/>
-
-                        <table class="table table-sm" name="document_details">
-                            <thead>
-                                <tr>
-                                    <th><strong>Product</strong></th>
-                                    <th><strong>Quantity</strong></th>
-                                    <th><strong>Total Value</strong></th>
-                                </tr>
-                            </thead>
+                    </div>
+                </div>
+                <div class="mt16"/>
+                <div class="mt64"/>
+                <div>
+                    <h1>Documento di Trasporto <span t-esc="o.l10n_it_ddt_number"/></h1>
+                </div>
+                <div class="clearfix"/>
+                <div class="mb32"/>
+                <div class="row">
+                    <div class="col-6">
+                        <table class="table table-bordered">
                             <tbody>
-                                <t t-set="total_value" t-value="0"/>
-                                <t t-foreach="o.move_lines" t-as="move">
-                                    <t t-if="move.quantity_done">
-                                        <tr>
-                                            <td>
-                                                <span t-field="move.product_id"/>
-                                            </td>
-                                            <td>
-                                                <span t-field="move.quantity_done"/>
-                                                <span t-field="move.product_uom" groups="uom.group_uom"/>
-                                            </td>
-                                            <td>
-                                                <t t-set="lst_price" t-value="move.product_id.lst_price * move.quantity_done"/>
-                                                <span t-esc="lst_price"  t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
-                                                <t t-set="total_value" t-value="total_value + lst_price"/>
-                                            </td>
-                                        </tr>
-                                    </t>
-                                </t>
                                 <tr>
-                                    <td>
-                                    </td>
-                                    <td style="text-align:right">
-                                        <b>Total:</b>
-                                    </td>
-                                    <td>
-                                        <span t-esc="total_value"  t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
-                                    </td>
+                                    <td>Transportation Reason</td>
+                                    <td><span t-field="o.l10n_it_transport_reason"/></td>
+                                </tr>
+                                <tr>
+                                    <td>Transportation Method</td>
+                                    <td><span t-field="o.l10n_it_transport_method"/></td>
+                                </tr>
+                                <tr>
+                                    <td>Carrier Condition</td>
+                                    <td><span t-field="o.sale_id.incoterm.name"/></td>
+                                </tr>
+                                <tr>
+                                    <td>Carrier</td>
+                                    <td><span t-field="o.carrier_id"/></td>
                                 </tr>
                             </tbody>
                         </table>
-                        <div class="mt64"/>
-                        <div class="mt64"/>
-                        <table class="table table-sm">
-                            <thead>
-                                <tr>
-                                    <th><div class="row"><span class="fa fa-pencil mt4"></span><div class="ml4"/><strong>Company Signature</strong></div></th>
-                                    <th><div class="row"><span class="fa fa-pencil mt4"></span><div class="ml4"/><strong>Carrier Signature</strong></div></th>
-                                    <th><div class="row"><span class="fa fa-pencil mt4"></span><div class="ml4"/><strong>Customer Signature</strong></div></th>
-                                </tr>
-                            </thead>
+                        <div t-if="o.l10n_it_transport_method_details">
+                            <b>Transportation Method Details: </b>
+                            <span t-field="o.l10n_it_transport_method_details"/>
+                        </div>
+                    </div>
+                    <div class="col-5 offset-1">
+                        <table class="table table-bordered">
                             <tbody>
                                 <tr>
-                                    <td>
-                                        <div class="col">
-                                        </div>
-                                    </td>
-                                    <td>
-                                        <div class="col">
-                                        </div>
-                                    </td>
-                                    <td>
-                                        <div class="col">
-                                        </div>
-                                    </td>
+                                    <td>Order</td>
+                                    <td><span t-field="o.origin"/></td>
+                                </tr>
+                                <tr>
+                                    <td>Picking Number</td>
+                                    <td><span t-field="o.name"/></td>
+                                </tr>
+                                <tr>
+                                    <td>Shipping Date</td>
+                                    <td><span t-field="o.date_done"/></td>
+                                </tr>
+                                <tr>
+                                    <td>Gross Weight (kg)</td>
+                                    <td><span t-field="o.shipping_weight"/></td>
+                                </tr>
+                                <tr>
+                                    <td>Parcels</td>
+                                    <td><span t-field="o.l10n_it_parcels"/></td>
                                 </tr>
                             </tbody>
                         </table>
                     </div>
-                </t>
+                </div>
+
+                <div class="mt64"/>
+                <div t-if="o.note"><b>Note:</b> <span t-field="o.note"/></div>
+
+                <div class="mt64"/>
+                <div class="mt64"/>
+
+                <table class="table table-sm" name="document_details">
+                    <thead>
+                        <tr>
+                            <th><strong>Product</strong></th>
+                            <th><strong>Quantity</strong></th>
+                            <th><strong>Total Value</strong></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <t t-set="total_value" t-value="0"/>
+                        <t t-foreach="o.move_lines" t-as="move">
+                            <t t-if="move.quantity_done">
+                                <tr>
+                                    <td>
+                                        <span t-field="move.product_id"/>
+                                    </td>
+                                    <td>
+                                        <span t-field="move.quantity_done"/>
+                                        <span t-field="move.product_uom" groups="uom.group_uom"/>
+                                    </td>
+                                    <td>
+                                        <t t-set="lst_price" t-value="move.product_id.lst_price * move.quantity_done"/>
+                                        <span t-esc="lst_price"  t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
+                                        <t t-set="total_value" t-value="total_value + lst_price"/>
+                                    </td>
+                                </tr>
+                            </t>
+                        </t>
+                        <tr>
+                            <td>
+                            </td>
+                            <td style="text-align:right">
+                                <b>Total:</b>
+                            </td>
+                            <td>
+                                <span t-esc="total_value"  t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <div class="mt64"/>
+                <div class="mt64"/>
+                <table class="table table-sm">
+                    <thead>
+                        <tr>
+                            <th><div class="row"><span class="fa fa-pencil mt4"></span><div class="ml4"/><strong>Company Signature</strong></div></th>
+                            <th><div class="row"><span class="fa fa-pencil mt4"></span><div class="ml4"/><strong>Carrier Signature</strong></div></th>
+                            <th><div class="row"><span class="fa fa-pencil mt4"></span><div class="ml4"/><strong>Customer Signature</strong></div></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <div class="col">
+                                </div>
+                            </td>
+                            <td>
+                                <div class="col">
+                                </div>
+                            </td>
+                            <td>
+                                <div class="col">
+                                </div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </t>
+    </template>
+
+    <template id="report_ddt">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-set="lang" t-value="o.partner_id.lang if o.partner_id.lang else o.env.lang"/>
+                <t t-call="l10n_it_stock_ddt.report_ddt_view" t-lang="lang"/>
             </t>
         </t>
     </template>
+
     <record id="action_report_ddt" model="ir.actions.report">
         <field name="name">DDT report</field>
         <field name="model">stock.picking</field>
         <field name="report_type">qweb-pdf</field>
-        <field name="report_name">l10n_it_stock_ddt.report_ddt_view</field>
+        <field name="report_name">l10n_it_stock_ddt.report_ddt</field>
         <field name="report_file">report_ddt</field>
         <field name="print_report_name">'DDT - %s - %s' % (object.partner_id.name or '', object.l10n_it_ddt_number)</field>
     </record>


### PR DESCRIPTION
DDT report was not translated in the user's language

Steps to reproduce:
1. Install the module l10n_it_stock_ddt
2. Open 'DDT report' in Setting -> Technical -> Reporting -> Reports and add to the print menu
3. Install the 'Italian / Italiano' language and set it as a customer's language
4. Create a sale order for that customer and confirm it
5. Open its delivery order
6. Print the 'DDT report'
7. The report is in English instead of in Italian

Solution:
Add a translation file for the report and render the report in the partner's language or the user's language if there is no partner

OPW-2697213