### PR TITLE
[FIX] mass_mailing_sale: ensure mailing demo has body_arch field

### DIFF
--- a/addons/mass_mailing_sale/data/mass_mailing_demo.xml
+++ b/addons/mass_mailing_sale/data/mass_mailing_demo.xml
@@ -13,7 +13,7 @@
         <field name="mailing_domain">[]</field>
         <field name="reply_to_mode">new</field>
         <field name="reply_to">{{ object.company_id.email }}</field>
-        <field name="body_html" type="html">
+        <field name="body_arch" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 24px; background-color: white; color: #454748; border-collapse:separate;">
 <tbody>


### PR DESCRIPTION
### Current behavior
Mail body is missing on mailing demo

### Steps to reproduce
- Install Email Marketing & Sales
- Go to Email Marketing
- Select "_Our last promotions, just for you !_"

### Reason
mass_mail used to  the `body_html` but since this commit (de56e1919d11cc497341f59ef38fb2d756ede7a3) it now shows the `body_arch` field (and `body_html` in debug mode).

OPW-2702534