### PR TITLE
[FIX] web_editor: change fix for scrolling powerbox

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1624,7 +1624,6 @@ export class OdooEditor extends EventTarget {
     // ===========
 
     _createCommandBar() {
-        this.options.noScrollSelector = this.options.noScrollSelector || 'body';
         this.commandbarTablePicker = new TablePicker({
             document: this.document,
             floating: true,
@@ -1733,16 +1732,6 @@ export class OdooEditor extends EventTarget {
             shouldActivate: () => !!this.options.getPowerboxElement(),
             onActivate: () => {
                 this._beforeCommandbarStepIndex = this._historySteps.length - 1;
-                this.observerUnactive();
-                for (const element of document.querySelectorAll(this.options.noScrollSelector)) {
-                    element.classList.add('oe-noscroll');
-                }
-                for (const element of this.document.querySelectorAll(
-                    this.options.noScrollSelector,
-                )) {
-                    element.classList.add('oe-noscroll');
-                }
-                this.observerActive();
             },
             preValidate: () => {
                 this._historyRevertUntil(this._beforeCommandbarStepIndex);
@@ -1754,16 +1743,6 @@ export class OdooEditor extends EventTarget {
             },
             postValidate: () => {
                 this.historyStep(true);
-            },
-            onStop: () => {
-                this.observerUnactive();
-                for (const element of document.querySelectorAll('.oe-noscroll')) {
-                    element.classList.remove('oe-noscroll');
-                }
-                for (const element of this.document.querySelectorAll('.oe-noscroll')) {
-                    element.classList.remove('oe-noscroll');
-                }
-                this.observerActive();
             },
             commands: [...mainCommands, ...(this.options.commands || [])],
         });

--- a/addons/web_editor/static/lib/odoo-editor/src/style.css
+++ b/addons/web_editor/static/lib/odoo-editor/src/style.css
@@ -4,10 +4,6 @@
     position: absolute;
 }
 
-.oe-noscroll {
-    overflow: hidden !important;
-}
-
 /* toolbar styling */
 
 .oe-toolbar {
@@ -218,6 +214,7 @@ li.oe-nested {
     flex: 1 1 auto;
     overflow: auto;
     padding: 5px 0;
+    overscroll-behavior: contain;
 }
 
 .oe-commandbar-groupName,  .oe-commandbar-noResult {

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -124,7 +124,6 @@ const Wysiwyg = Widget.extend({
                     return !(record.target.classList && record.target.classList.contains('o_header_standard'));
                 });
             },
-            noScrollSelector: 'body, .note-editable, .o_content, #wrapwrap',
             commands: commands,
             plugins: options.editorPlugins,
         }, editorCollaborationOptions));


### PR DESCRIPTION
The fix to add an `overflow: hidden` in order to prevent the browser
from chaining the scroll create a glitch where the scrollbar disappear
when it is overflow: hidden.
A new css property exists to specify exactly this behavior
(`overscroll-behavior: contain;`).

Task-2728791

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
