### PR TITLE
[FIX] purchase: corrects the order date on validated RFQ/PO pdf report

### DIFF
--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -34,8 +34,12 @@
                     <strong>Your Order Reference:</strong>
                     <p t-field="o.partner_ref" class="m-0"/>
                 </div>
-                <div t-if="o.date_order" class="col-3 bm-2">
+                <div t-if="o.state in ['purchase','done'] and o.date_approve" class="col-3 bm-2">
                     <strong>Order Date:</strong>
+                    <p t-field="o.date_approve" class="m-0"/>
+                </div>
+                <div t-elif="o.date_order" class="col-3 bm-2">
+                    <strong >Order Deadline:</strong>
                     <p t-field="o.date_order" class="m-0"/>
                 </div>
             </div>

--- a/addons/purchase_stock/report/purchase_report_templates.xml
+++ b/addons/purchase_stock/report/purchase_report_templates.xml
@@ -13,7 +13,7 @@
                 </t>
             </t>
         </xpath>
-        <xpath expr="//div[@t-if='o.date_order']" position="after">
+        <xpath expr="//div[@t-elif='o.date_order']" position="after">
             <div t-if="o.incoterm_id" class="col-3 bm-2">
                 <strong>Incoterm:</strong>
                 <p t-field="o.incoterm_id.code" class="m-0"/>


### PR DESCRIPTION
### Expected behaviour

The order date on the Purchase Order report (printable pdf) should be the
confirmation date if available and the order deadline else.

### Observed Behaviour

The order date on the PO pdf is the order deadline of the RFQ, no matter
if the oder has been confirmed or not.

### Reproducibility

This issue can be reproduced following these steps:
1. Create a new RFQ
2. Set an order deadline different from the current day
3. Confirm the RFQ
4. Download the printable PDF (as pdf) and check the Order date

### Related ticket
- opw-2696794

X-original-commit: 91d0354

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
