### PR TITLE
[FIX] google_spreadsheet: domain encoding

### DIFF
--- a/addons/google_spreadsheet/models/google_drive.py
+++ b/addons/google_spreadsheet/models/google_drive.py
@@ -75,7 +75,7 @@ class GoogleDrive(models.Model):
         try:
             req = requests.post(
                 'https://spreadsheets.google.com/feeds/cells/%s/od6/private/full/batch?%s' % (spreadsheet_key, werkzeug.url_encode({'v': 3, 'access_token': access_token})),
-                data=request,
+                data=request.encode('utf-8'),
                 headers={'content-type': 'application/atom+xml', 'If-Match': '*'},
                 timeout=TIMEOUT,
             )


### PR DESCRIPTION
Steps to reproduce:
- Go to Contacts
- type "управління" in the filter
- click on add to google spreadsheet
-> error

Solution:
- encode the domain in utf-8

OPW-2701434
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
