### PR TITLE
[IMP] survey: allow un-ticking choices

### DIFF
--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -440,9 +440,10 @@
                             <t t-set="selection_key_class" t-value="'position-relative o_survey_radio_btn float-left d-flex'"/>
                         </t>
                         <span class="ml-2" t-field='label.value'/>
-                        <input t-att-id="str(question.id) + '_' + str(label.id)" type="radio" t-att-value='label.id' class="o_survey_form_choice_item invisible position-absolute"
+                        <input t-att-id="str(question.id) + '_' + str(label.id)" type="radio" t-att-value='label.id'
+                               t-attf-class="o_survey_form_choice_item invisible position-absolute #{'o_survey_form_choice_item_selected' if answer_selected else ''}"
                                t-att-name='question.id'
-                               t-att-checked="answer_line and answer_line.suggested_answer_id.id == label.id and 'checked' or None"
+                               t-att-checked="'checked' if answer_selected else None"
                                t-att-data-selection-key="letters[item_idx] if useKeySelection else ''"/>
                         <i class="fa fa-check-circle float-right mt-1 position-relative"></i>
                         <i class="fa fa-circle-thin float-right mt-1 position-relative"></i>


### PR DESCRIPTION
For surveys, we want to allow the end-user to un-tick an option he had ticked
before, for any kind of questions with choices (simple / multi-choices and
matrix).

e.g: You select an option but on second thoughts you're unsure it's the right
answer, you want to be able to remove your answer.

Especially if the question is not mandatory and you loose points if you don't
answer correctly.

Since the base browser behavior does not allow un-ticking a previously ticked
radio input, we have to play around a bit with specific classes.

Task-2727592

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
