### PR TITLE
[FIX] pos_coupon : Discount not applied correctly

### DIFF
--- a/addons/pos_coupon/static/src/js/coupon.js
+++ b/addons/pos_coupon/static/src/js/coupon.js
@@ -935,9 +935,9 @@ odoo.define('pos_coupon.pos', function (require) {
                 if (program.discount_specific_product_ids.has(line.get_product().id)) {
                     const key = this._getGroupKey(line);
                     if (!(key in amountsToDiscount)) {
-                        amountsToDiscount[key] = line.get_quantity() * line.get_lst_price();
+                        amountsToDiscount[key] = line.get_quantity() * line.price;
                     } else {
-                        amountsToDiscount[key] += line.get_quantity() * line.get_lst_price();
+                        amountsToDiscount[key] += line.get_quantity() * line.price;
                     }
                     productIdsToAccount.add(line.get_product().id);
                 }
@@ -959,14 +959,14 @@ odoo.define('pos_coupon.pos', function (require) {
             const orderlines = this._getRegularOrderlines();
             if (orderlines.length > 0) {
                 const cheapestLine = orderlines.reduce((min_line, line) => {
-                    if (line.get_lst_price() < min_line.get_lst_price()) {
+                    if (line.price < min_line.price) {
                         return line;
                     } else {
                         return min_line;
                     }
                 }, orderlines[0]);
                 const key = this._getGroupKey(cheapestLine);
-                amountsToDiscount[key] = cheapestLine.get_lst_price();
+                amountsToDiscount[key] = cheapestLine.price;
             }
             return this._createDiscountRewards(program, coupon_id, amountsToDiscount);
         },
@@ -987,9 +987,9 @@ odoo.define('pos_coupon.pos', function (require) {
             for (let line of this._getRegularOrderlines()) {
                 const key = this._getGroupKey(line);
                 if (!(key in amountsToDiscount)) {
-                    amountsToDiscount[key] = line.get_quantity() * line.get_lst_price();
+                    amountsToDiscount[key] = line.get_quantity() * line.price;
                 } else {
-                    amountsToDiscount[key] += line.get_quantity() * line.get_lst_price();
+                    amountsToDiscount[key] += line.get_quantity() * line.price;
                 }
                 productIdsToAccount.add(line.get_product().id);
             }


### PR DESCRIPTION
Current behavior:
When using a pricelist and discount, the discount wasn't applied on the price from the pricelist but on the price defined on the product.

Steps to reproduce:
- Create a pricelist for a products
- Set the pricelist on the POS session
- Open the POS session
- Apply the 10% coupon code to the product.

opw-2714342

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
