### PR TITLE
[FIX]  calendar: correct errors for default attendee

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -839,7 +839,7 @@ class Meeting(models.Model):
                 if 'name' in fields:
                     activity_values['summary'] = event.name
                 if 'description' in fields:
-                    activity_values['note'] = tools.plaintext2html(event.description)
+                    activity_values['note'] = event.description and tools.plaintext2html(event.description)
                 if 'start' in fields:
                     # self.start is a datetime UTC *only when the event is not allday*
                     # activty.date_deadline is a date (No TZ, but should represent the day in which the user's TZ is)

--- a/addons/calendar/tests/test_attendees.py
+++ b/addons/calendar/tests/test_attendees.py
@@ -90,3 +90,44 @@ class TestEventNotifications(SavepointCase):
         self.assertNotIn(self.partner, self.event.attendee_ids.partner_id, "It should have removed the attendee")
         self.assertNotIn(self.partner, self.event.message_follower_ids.partner_id, "It should have unsubscribed the partner")
         self.assertIn(partner_bis, self.event.attendee_ids.partner_id, "It should have left the attendee")
+
+    def test_default_attendee(self):
+        """
+        Check if priority list id correctly followed
+        1) vals_list[0]['attendee_ids']
+        2) vals_list[0]['partner_ids']
+        3) context.get('default_attendee_ids')
+        """
+        partner_bis = self.env['res.partner'].create({'name': "Xavier"})
+        event = self.env['calendar.event'].with_user(
+            self.user
+        ).with_context(
+            default_attendee_ids=[(0, 0, {'partner_id': partner_bis.id})]
+        ).create({
+            'name': "Doom's day",
+            'partner_ids': [(4, self.partner.id)],
+            'start': datetime(2019, 10, 25, 8, 0),
+            'stop': datetime(2019, 10, 27, 18, 0),
+        })
+        self.assertIn(self.partner, event.attendee_ids.partner_id, "Partner should be in attendee")
+        self.assertNotIn(partner_bis, event.attendee_ids.partner_id, "Partner bis should not be in attendee")
+
+    def test_default_attendee_2(self):
+        """
+        Check if priority list id correctly followed
+        1) vals_list[0]['attendee_ids']
+        2) vals_list[0]['partner_ids']
+        3) context.get('default_attendee_ids')
+        """
+        partner_bis = self.env['res.partner'].create({'name': "Xavier"})
+        event = self.env['calendar.event'].with_user(
+            self.user
+        ).with_context(
+            default_attendee_ids=[(0, 0, {'partner_id': partner_bis.id})]
+        ).create({
+            'name': "Doom's day",
+            'start': datetime(2019, 10, 25, 8, 0),
+            'stop': datetime(2019, 10, 27, 18, 0),
+        })
+        self.assertNotIn(self.partner, event.attendee_ids.partner_id, "Partner should not be in attendee")
+        self.assertIn(partner_bis, event.attendee_ids.partner_id, "Partner bis should be in attendee")

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -197,7 +197,7 @@
 
                         <page name="page_invitations" string="Invitations" groups="base.group_no_one">
                             <button name="action_sendmail" type="object" string="Send mail" icon="fa-envelope" class="oe_link"/>
-                            <field name="attendee_ids" widget="one2many" mode="tree,kanban">
+                            <field name="attendee_ids" widget="one2many" mode="tree,kanban" readonly="1">
                                 <tree string="Invitation details" editable="top" create="false" delete="false">
                                     <field name="partner_id" />
                                     <field name="state" />


### PR DESCRIPTION
Step to reproduce:
- Create a lead
- go on the smart button meeting
- create a new meeting and edit it
- save

Current behaviour:
- Validation Error
- It seems the default_get apply command in onchange instead of passing the value which lead to missformed argument for meeting

Behaviour after PR:
- Take advantage of the automatic generation of attendee in  to avoid passing attendee command and get default partner in create for quick_create
- Automatic generation of attendee is more robust and also apply when the list is empty to accomodate for the default get setting the value to []

opw-2724372

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
