### PR TITLE
[FIX] base: use defaultdict to avoid `address_format` keyerror

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -987,13 +987,13 @@ class Partner(models.Model):
         # get the information that will be injected into the display format
         # get the address format
         address_format = self._get_address_format()
-        args = {
+        args = collections.defaultdict(str, {
             'state_code': self.state_id.code or '',
             'state_name': self.state_id.name or '',
             'country_code': self.country_id.code or '',
             'country_name': self._get_country_name(),
             'company_name': self.commercial_company_name or '',
-        }
+        })
         for field in self._formatting_address_fields():
             args[field] = getattr(self, field) or ''
         if without_company:


### PR DESCRIPTION
When `res_country.address_format` use custom patern (even comming
from custom module), including Odoo fields that are not defined
in `ADDRESS_FIELDS`, there's a KeyError on this field.

Using a `defaultdict` with `str` as default allow to avoid this
error by filling the missing key value with an empty string.

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/15.0/odoo/service/server.py", line 1246, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/home/odoo/src/odoo/15.0/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/15.0/odoo/modules/loading.py", line 490, in load_modules
    migrations.migrate_module(package, 'end')
  File "/home/odoo/src/odoo/15.0/odoo/modules/migration.py", line 180, in migrate_module
    migrate(self.cr, installed_version)
  File "/tmp/tmphz5w26th/migrations/base/saas~14.5.1.3/end-migrate.py", line 18, in migrate
    company.company_details = env["base.document.layout"].with_company(company)._default_company_details()
  File "/home/odoo/src/odoo/15.0/addons/web/models/base_document_layout.py", line 43, in _default_company_details
    return Markup(nl2br(address_format)) % company_data
  File "/home/odoo/.odoo-venvs/15.0/lib/python3.8/site-packages/markupsafe/__init__.py", line 102, in __mod__
    return self.__class__(text_type.__mod__(self, arg))
  File "/home/odoo/.odoo-venvs/15.0/lib/python3.8/site-packages/markupsafe/__init__.py", line 301, in __getitem__
    return _MarkupEscapeHelper(self.obj[item], self.escape)
KeyError: 'town_name'
```

upg-93972