### PR TITLE
[FIX] stock_account: fix user group check

### DIFF
--- a/addons/stock_account/report/report_stock_forecasted.xml
+++ b/addons/stock_account/report/report_stock_forecasted.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template id="stock_account_report_product_product_replenishment" inherit_id="stock.report_replenishment_header">
         <xpath expr="//div[@name='pending_forecasted']" position="after">
-            <div t-attf-class="mx-3 text-center" t-if="docs['product_templates'].user_has_groups('stock.group_stock_manager')">
+            <div t-attf-class="mx-3 text-center" t-if="env.user.has_group('stock.group_stock_manager')">
                 <div class="h3">
                     <t t-esc="docs['value']"/>
                 </div>


### PR DESCRIPTION
Steps to reproduce the bug:
- Connect as Admin
- install stock_account
- Go to inventory > Product Variants > choose any product > click on the FORECAST button
- Traceback

Problem:
docs['product_templates'] can be False, so we can't use it to check the user's group: https://github.com/odoo/odoo/blob/15.0/addons/stock/report/report_stock_forecasted.py#L98

Opw-2728473




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
