### PR TITLE
[FIX] web_editor: replace a video with an image

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/toggleList.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/toggleList.js
@@ -33,7 +33,7 @@ HTMLElement.prototype.oToggleList = function (offset, mode = 'UL') {
         for (const attribute of this.attributes) {
             list.setAttribute(attribute.name, attribute.value);
         }
-        restoreCursor(new Map([[this, list.firstElementChild]]));
+        restoreCursor({ replace: new Map([[this, list.firstElementChild]]) });
     }
 };
 
@@ -45,7 +45,7 @@ HTMLParagraphElement.prototype.oToggleList = function (offset, mode = 'UL') {
     }
     this.remove();
 
-    restoreCursor(new Map([[this, list.firstChild]]));
+    restoreCursor({ replace: new Map([[this, list.firstChild]])});
     return true;
 };
 

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
@@ -140,7 +140,7 @@ class Sanitize {
                 node.remove();
                 fillEmpty(pnode);
                 this._parse(next);
-                restoreCursor(new Map([[node, pnode]]));
+                restoreCursor({ replace: new Map([[node, pnode]]) });
                 return;
             }
         }

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -619,6 +619,7 @@ export function getDeepRange(editable, { range, sel, splitText, select, correctT
     // Target the deepest descendant of the range nodes.
     [start, startOffset] = getDeepestPosition(start, startOffset);
     [end, endOffset] = getDeepestPosition(end, endOffset);
+    const isCollapsed = start === end && startOffset === endOffset;
 
     // Split text nodes if that was requested.
     if (splitText) {
@@ -655,6 +656,7 @@ export function getDeepRange(editable, { range, sel, splitText, select, correctT
     if (
         correctTripleClick &&
         !endOffset &&
+        !isCollapsed &&
         (!beforeEnd || (beforeEnd.nodeType === Node.TEXT_NODE && !isVisibleStr(beforeEnd)))
     ) {
         const previous = previousLeaf(end, editable, true);
@@ -747,11 +749,11 @@ export function getCursors(document) {
 export function preserveCursor(document) {
     const sel = document.getSelection();
     const cursorPos = [sel.anchorNode, sel.anchorOffset, sel.focusNode, sel.focusOffset];
-    return replace => {
+    return ({replace, normalize} = {}) => {
         replace = replace || new Map();
         cursorPos[0] = replace.get(cursorPos[0]) || cursorPos[0];
         cursorPos[2] = replace.get(cursorPos[2]) || cursorPos[2];
-        setSelection(...cursorPos);
+        setSelection(...cursorPos, normalize);
     };
 }
 

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1216,12 +1216,13 @@ const Wysiwyg = Widget.extend({
             if (params.htmlClass) {
                 element.className += " " + params.htmlClass;
             }
-            restoreSelection();
+            restoreSelection({ normalize: false });
             if (wysiwygUtils.isImg($node[0]) || wasFontAwesome) {
                 $node.replaceWith(element);
                 this.odooEditor.unbreakableStepUnactive();
                 this.odooEditor.historyStep();
             } else if (element) {
+                $node.remove();
                 this.odooEditor.execCommand('insertHTML', element.outerHTML);
             }
         });
@@ -1229,7 +1230,7 @@ const Wysiwyg = Widget.extend({
             // if the mediaDialog content has been saved
             // the previous selection in not relevant anymore
             if (mediaDialog.destroyAction !== 'save') {
-                restoreSelection();
+                restoreSelection({ normalize: false });
             }
         });
     },


### PR DESCRIPTION
Before this commit, there was 2 errors that the editor made:

1) The selection was normalized needlessly and the selection was wrong
for the use case.
2) The getDeepRange triple click correction was done although it was
not a triple click selection.

Task-2725573




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
