### PR TITLE
[FIX] web: Add word-break to kanban_content

### DIFF
--- a/addons/web/static/src/scss/kanban_view.scss
+++ b/addons/web/static/src/scss/kanban_view.scss
@@ -219,6 +219,10 @@
                 }
             }
         }
+
+        .oe_kanban_content {
+            overflow-wrap: break-word;
+        }
     }
 
     // -------  Compatibility of old (<= v10) Generic layouts -------


### PR DESCRIPTION
When we create a record with a very long continuous title (without spaces) the string comes out of the kanban block.
Reproducible on several applications such as Notes, CRM, etc.

Before:
![image](https://user-images.githubusercontent.com/77889661/148344520-bf3d391b-397f-423c-a60d-88d15e5e1dd7.png)

After: 
![image](https://user-images.githubusercontent.com/77889661/148344558-68297764-3af0-4dc5-8359-b684f04ba7c7.png)

opw-2680915
