### PR TITLE
[FIX] stock(_account): traceback with stock user on forecast report

### DIFF
--- a/addons/stock/static/src/js/report_stock_forecasted.js
+++ b/addons/stock/static/src/js/report_stock_forecasted.js
@@ -63,6 +63,9 @@ const ReplenishReport = clientAction.extend({
             promController.then(() => {
                 this.iframe.removeEventListener('load', appendGraph);
                 const $reportGraphDiv = $(this.iframe).contents().find('.o_report_graph');
+                if (!$reportGraphDiv) {
+                    return;
+                }
                 dom.append(this.$el, viewController.$el, {
                     in_DOM: true,
                     callbacks: [{widget: viewController}],

--- a/addons/stock_account/report/report_stock_forecasted.py
+++ b/addons/stock_account/report/report_stock_forecasted.py
@@ -11,6 +11,8 @@ class ReplenishmentReport(models.AbstractModel):
     def _compute_draft_quantity_count(self, product_template_ids, product_variant_ids, wh_location_ids):
         """ Overrides to computes the valuations of the stock. """
         res = super()._compute_draft_quantity_count(product_template_ids, product_variant_ids, wh_location_ids)
+        if not self.user_has_groups('stock.group_stock_manager'):
+            return res
         domain = self._product_domain(product_template_ids, product_variant_ids)
         company = self.env['stock.location'].browse(wh_location_ids).mapped('company_id')
         svl = self.env['stock.valuation.layer'].search(domain + [('company_id', '=', company.id)])

--- a/addons/stock_account/report/report_stock_forecasted.xml
+++ b/addons/stock_account/report/report_stock_forecasted.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template id="stock_account_report_product_product_replenishment" inherit_id="stock.report_replenishment_header">
         <xpath expr="//div[@name='pending_forecasted']" position="after">
-            <div t-attf-class="mx-3 text-center">
+            <div t-attf-class="mx-3 text-center" t-if="env.user.has_group('stock.group_stock_manager')">
                 <div class="h3">
                     <t t-esc="docs['value']"/>
                 </div>


### PR DESCRIPTION
backport of: https://github.com/odoo/odoo/pull/82053/commits/dcc300c51b7f9f5e9e6f1111344fef75eb097532

2 issues:
- When going to the report forecast the value of the stock is computed.
However the stock user should not be able to access the valuations
- Since an access error is return the graph view is not instanciate and
the javascript code try to amend an empty result to the DOM. It results
with a traceback on top of 403 page

opw-2725974
opw-2727384




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
