### PR TITLE
[FIX] sale: only reconcile with posted payment if linked transactions

### DIFF
--- a/addons/sale/models/account_invoice.py
+++ b/addons/sale/models/account_invoice.py
@@ -81,7 +81,7 @@ class AccountMove(models.Model):
         posted = super()._post(soft)
 
         for invoice in posted.filtered(lambda move: move.is_invoice()):
-            payments = invoice.mapped('transaction_ids.payment_id')
+            payments = invoice.mapped('transaction_ids.payment_id').filtered(lambda p: p.state == 'posted')
             move_lines = payments.line_ids.filtered(lambda line: line.account_internal_type in ('receivable', 'payable') and not line.reconciled)
             for line in move_lines:
                 invoice.js_assign_outstanding_line(line.id)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

While posting an invoice, if the transactions linked with the invoice
are failed due to valid reason from the payment acquirer, forcing
reconciliation on transactions' payment will raise an error because such
payment isn't posted.

Current behavior before PR:

- If there is a failed transaction linked with an invoice, posting that invoice will raise an error because of not posted payment

Desired behavior after PR is merged:

- If there is a failed transaction linked with an invoice, posting that invoice will not reconcile the invoice with the transaction's payment if payment isn't posted



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
