### PR TITLE
[FIX] account: bank reconciliation: don't force partner when mixing payments with and without partner

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -1268,8 +1268,8 @@ class AccountBankStatementLine(models.Model):
         if not self.partner_id:
             rec_overview_partners = set(overview['counterpart_line'].partner_id.id
                                         for overview in reconciliation_overview
-                                        if overview.get('counterpart_line') and overview['counterpart_line'].partner_id)
-            if len(rec_overview_partners) == 1:
+                                        if overview.get('counterpart_line'))
+            if len(rec_overview_partners) == 1 and rec_overview_partners != {False}:
                 self.line_ids.write({'partner_id': rec_overview_partners.pop()})
 
         # Refresh analytic lines.


### PR DESCRIPTION
Steps to reproduce :

- Create an invoice for a customer (ex $100)
- Create a payment for the invoice (ex $100)
- create a bank statement with a line item for $200
- In reconciliation, add either another journal entry or a manual operation without partner to reconcile the remaining $100

Issue:

All lines receive the partner from the invoice

opw-2691196

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
