### PR TITLE
[FIX] stock: Fix quantity done on lots changing to 1

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -485,6 +485,8 @@ class StockMove(models.Model):
 
     def _set_lot_ids(self):
         for move in self:
+            if move.product_id.tracking != 'serial':
+                continue
             move_lines_commands = []
             if move.picking_type_id.show_reserved is False:
                 mls = move.move_line_nosuggest_ids

--- a/addons/stock/tests/test_robustness.py
+++ b/addons/stock/tests/test_robustness.py
@@ -277,3 +277,43 @@ class TestRobustness(SavepointCase):
         self.assertEqual(move.reserved_availability, 0)
         self.assertEqual(move.state, 'confirmed')
         self.assertEqual(quant.reserved_quantity, 0)
+
+
+    def test_lot_quantity_remains_unchanged_after_done(self):
+        """ Make sure the method _set_lot_ids does not change the quantities of lots to 1 once they are done.
+        """
+        productA = self.env['product.product'].create({
+            'name': 'ProductA',
+            'type': 'product',
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'tracking': 'lot',
+        })
+        lotA = self.env['stock.production.lot'].create({
+            'name': 'lotA',
+            'product_id': productA.id,
+            'company_id': self.env.company.id,
+
+        })
+        self.env['stock.quant']._update_available_quantity(productA, self.stock_location, 5, lot_id=lotA)
+        moveA = self.env['stock.move'].create({
+            'name': 'TEST_A',
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'product_id': productA.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 5.0,
+        })
+
+        moveA._action_confirm()
+        moveA.write({'move_line_ids': [(0, 0, {
+            'product_id': productA.id,
+            'product_uom_id': self.uom_unit.id,
+            'qty_done': 5,
+            'lot_id': lotA.id,
+            'location_id': moveA.location_id.id,
+            'location_dest_id': moveA.location_dest_id.id,
+        })]})
+        moveA._action_done()
+        moveA._set_lot_ids()
+
+        self.assertEqual(moveA.quantity_done, 5)


### PR DESCRIPTION
Issue:
At anypoint we should be able to call the method "_set_lot_ids" from stock.move on moves that are already done and the quantities should not change. 
This is not the case for lots that get their quantity changes to 1 as if the product was tracked by serial number. 

This commit should be seen a a complement to the commit: https://github.com/odoo/odoo/pull/79565

Fix:
Check the product is tracked by SN before trying to change the quantities to 1.

OPW-2689724

This PR should be forwarded to 15

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr