### PR TITLE
[FIX] web: pass user-context in legacy RPC

### DIFF
--- a/addons/web/static/src/legacy/utils.js
+++ b/addons/web/static/src/legacy/utils.js
@@ -141,6 +141,13 @@ export function mapLegacyEnvToWowlEnv(legacyEnv, wowlEnv) {
         let rejection;
         const prom = new Promise((resolve, reject) => {
             const [route, params, settings = {}] = args;
+            // Add user context in kwargs if there are kwargs
+            if (params && params.kwargs) {
+                params.kwargs.context = Object.assign(
+                    params.kwargs.context || {},
+                    legacyEnv.session.user_context
+                );
+            }
             const jsonrpc = wowlEnv.services.rpc(route, params, {
                 silent: settings.shadow,
                 xhr: settings.xhr,

--- a/addons/web/static/tests/legacy/views/qweb_tests.js
+++ b/addons/web/static/tests/legacy/views/qweb_tests.js
@@ -40,7 +40,7 @@ QUnit.module("Views", {
                     case 'test.wheee':
                         assert.step('unfold');
                         assert.deepEqual(args.args, [42]);
-                        assert.deepEqual(args.kwargs, {other: 5});
+                        assert.deepEqual(args.kwargs, { other: 5, context: {} });
                         return Promise.resolve('<div id="sub">ok</div>');
                 }
             }


### PR DESCRIPTION
Previously, RPCs would always receive the user-context as a keyword
argument. When creating the translation layer between the old API and
the new RPC service, this was overlooked, resulting in all legacy RPCs
losing their user-context. This commit fixes that.
