### PR TITLE
[FIX] l10n_it_edi: for foreign invoices without VAT, we need the coun…

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -116,6 +116,7 @@
                                 <IdCodice t-esc="'OO99999999999'"/>
                             </IdFiscaleIVA>
                             <IdFiscaleIVA t-if="not record.commercial_partner_id.vat and record.commercial_partner_id.country_id.code != 'IT'">
+                                <IdPaese t-esc="record.commercial_partner_id.country_id.code"/>
                                 <IdCodice t-esc="'0000000'"/>
                             </IdFiscaleIVA>
                             <CodiceFiscale t-if="not record.commercial_partner_id.vat" t-esc="record.commercial_partner_id.l10n_it_codice_fiscale"/>


### PR DESCRIPTION
…try code

The number is set as zeros, but we should still provide
the IdPaese tag.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
