### PR TITLE
[FIX] web_editor: disable linktool when selection not in editable

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -28,12 +28,8 @@ const LinkTools = Link.extend({
     /**
      * @override
      */
-    init: function (parent, options, editable, data, $button, node) {
-        if (node && !$(node).is('a')) {
-            $(node).wrap('<a href="#"/>');
-            node = node.parentElement;
-        }
-        this._link = node || this.getOrCreateLink(editable);
+    init: function (parent, options, editable, data, $button, link) {
+        this._link = link;
         this._observer = new MutationObserver(() =>{
             this._setLinkContent = false;
             this._observer.disconnect();

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -15,6 +15,7 @@ const OdooEditorLib = require('@web_editor/../lib/odoo-editor/src/OdooEditor');
 const snippetsEditor = require('web_editor.snippet.editor');
 const Toolbar = require('web_editor.toolbar');
 const weWidgets = require('wysiwyg.widgets');
+const Link = require('wysiwyg.widgets.Link');
 const wysiwygUtils = require('@web_editor/js/common/wysiwyg_utils');
 const weUtils = require('web_editor.utils');
 const { PeerToPeer } = require('@web_editor/js/wysiwyg/PeerToPeer');
@@ -1032,8 +1033,15 @@ const Wysiwyg = Widget.extend({
             if (options.forceOpen || !this.linkTools) {
                 const $btn = this.toolbar.$el.find('#create-link');
                 if (!this.linkTools || ![options.link, ...wysiwygUtils.ancestors(options.link)].includes(this.linkTools.$link[0])) {
+                    const { link } = Link.getOrCreateLink({
+                        containerNode: this.odooEditor.editable,
+                        startNode: options.link || this.lastMediaClicked,
+                    });
+                    if (!link) {
+                        return
+                    }
                     const linkToolsData = Object.assign({}, this.options.defaultDataForLinkTools);
-                    this.linkTools = new weWidgets.LinkTools(this, {wysiwyg: this, noFocusUrl: options.noFocusUrl}, this.odooEditor.editable, linkToolsData, $btn, options.link || this.lastMediaClicked);
+                    this.linkTools = new weWidgets.LinkTools(this, {wysiwyg: this, noFocusUrl: options.noFocusUrl}, this.odooEditor.editable, linkToolsData, $btn, link );
                 }
                 this.linkTools.noFocusUrl = options.noFocusUrl;
                 const _onMousedown = ev => {
@@ -1054,17 +1062,37 @@ const Wysiwyg = Widget.extend({
                     this.linkTools.appendTo(this.toolbar.$el);
                 }
             } else {
+                const selection = this.odooEditor.document.getSelection();
+                const link = this.linkTools.$link[0];
+                if (selection && link.parentElement) {
+                    // Focus the link after the dialog element is removed.
+                    // In order to not refactor the legacy dialog widget,
+                    // use a hackhy microtask strategy.
+                    // Using a microtask to set the focus might break if
+                    // another microtask which focus an element in the dom
+                    // occurs at the same time (but this case seems
+                    // unlikely).
+                    Promise.resolve().then(() => {
+                        setSelection(link, 0, link, link.childNodes.length, false);
+                    });
+                }
                 this.linkTools.destroy();
                 this.linkTools = undefined;
             }
         } else {
-            let link;
+            let { link } = Link.getOrCreateLink({
+                containerNode: this.odooEditor.editable,
+                startNode: options.link,
+            });
+            if (!link) {
+                return
+            }
             const linkDialog = new weWidgets.LinkDialog(this, {
                 forceNewWindow: this.options.linkForceNewWindow,
                 wysiwyg: this,
             }, this.$editable[0], {
-                needLabel: true,
-            }, undefined, options.link);
+                needLabel: true
+            }, undefined, link);
             const restoreSelection = preserveCursor(this.odooEditor.document);
             linkDialog.open();
             linkDialog.on('save', this, data => {
@@ -1073,9 +1101,6 @@ const Wysiwyg = Widget.extend({
                 }
                 const linkWidget = linkDialog.linkWidget;
                 getDeepRange(this.$editable[0], {range: data.range, select: true});
-                if (!linkWidget.$link.length) {
-                    linkWidget.$link = $(linkWidget.getOrCreateLink(this.$editable[0]));
-                }
                 if (this.options.userGeneratedContent) {
                     data.rel = 'ugc';
                 }


### PR DESCRIPTION
Before this commit, when the selection was not in the editable at the time
of calling the LinkTool, a link was created outside the editable, which
is wrong.

Task-2696969

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
