### PR TITLE
[FIX] web_editor: prevent editor powerbox hint duplication

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1469,6 +1469,7 @@ export class OdooEditor extends EventTarget {
         const result = this._protect(() => this._applyRawCommand(...args));
         this.sanitize();
         this.historyStep();
+        this._handleCommandHint();
         return result;
     }
     /**


### PR DESCRIPTION
Whenever the browser is lagging between multiple enter,
the command hints were not being updated until the browser
main thread process the event queue.

Task-2728794




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
