### PR TITLE
[FIX] stock_account: always use first move

### DIFF
--- a/addons/stock_account/wizard/stock_picking_return.py
+++ b/addons/stock_account/wizard/stock_picking_return.py
@@ -18,7 +18,7 @@ class StockReturnPicking(models.TransientModel):
         new_picking_id, pick_type_id = super(StockReturnPicking, self)._create_returns()
         new_picking = self.env['stock.picking'].browse([new_picking_id])
         for move in new_picking.move_lines:
-            return_picking_line = self.product_return_moves.filtered(lambda r: r.move_id == move.origin_returned_move_id)
+            return_picking_line = self.product_return_moves.filtered(lambda r: r.move_id == move.origin_returned_move_id)[:1]
             if return_picking_line and return_picking_line.to_refund:
                 move.to_refund = True
         return new_picking_id, pick_type_id


### PR DESCRIPTION
Description of the issue/feature this PR addresses: See https://github.com/odoo/odoo/pull/62081 for the backstory & extra context

Current behavior before PR: Before this commit it is technically possible for "return_picking_line" to be a recordset instead of a record.

Desired behavior after PR is merged: By taking the first element ([0]) we're sure it is always a record instead of a recordset to work with.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
