### PR TITLE
[FIX] stock_account: allow overriding moves_lines loop

### DIFF
--- a/addons/stock_account/wizard/stock_picking_return.py
+++ b/addons/stock_account/wizard/stock_picking_return.py
@@ -17,11 +17,14 @@ class StockReturnPicking(models.TransientModel):
     def _create_returns(self):
         new_picking_id, pick_type_id = super(StockReturnPicking, self)._create_returns()
         new_picking = self.env['stock.picking'].browse([new_picking_id])
+        self._mark_return_moves(new_picking)
+        return new_picking_id, pick_type_id
+        
+    def _mark_return_moves(self, new_picking):
         for move in new_picking.move_lines:
             return_picking_line = self.product_return_moves.filtered(lambda r: r.move_id == move.origin_returned_move_id)[0]
             if return_picking_line and return_picking_line.to_refund:
                 move.to_refund = True
-        return new_picking_id, pick_type_id
 
 
 class StockReturnPickingLine(models.TransientModel):

--- a/addons/stock_account/wizard/stock_picking_return.py
+++ b/addons/stock_account/wizard/stock_picking_return.py
@@ -18,7 +18,7 @@ class StockReturnPicking(models.TransientModel):
         new_picking_id, pick_type_id = super(StockReturnPicking, self)._create_returns()
         new_picking = self.env['stock.picking'].browse([new_picking_id])
         for move in new_picking.move_lines:
-            return_picking_line = self.product_return_moves.filtered(lambda r: r.move_id == move.origin_returned_move_id)
+            return_picking_line = self.product_return_moves.filtered(lambda r: r.move_id == move.origin_returned_move_id)[0]
             if return_picking_line and return_picking_line.to_refund:
                 move.to_refund = True
         return new_picking_id, pick_type_id


### PR DESCRIPTION
Description of the issue/feature this PR addresses: See https://github.com/odoo/odoo/pull/62081 for the backstory & extra context

Current behavior before PR: Before this commit it is technically not possible to cleanly override/influence the loop over the lines

Desired behavior after PR is merged: By splitting it into a subfunction we can now override/copy `_mark_return_moves()` to do custom logic on lines.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
