### PR TITLE
[FIX] project: show 'View Task' in subtask when same project than parent

### DIFF
--- a/addons/project/views/project_sharing_views.xml
+++ b/addons/project/views/project_sharing_views.xml
@@ -215,7 +215,7 @@
                                     <field name="stage_id" optional="show"/>
                                     <button name="action_open_task" type="object" title="View Task" string="View Task" class="btn btn-link pull-right"
                                             context="{'form_view_ref': 'project.project_sharing_project_task_view_form'}"
-                                            attrs="{'invisible': [('display_project_id', '!=', False), ('display_project_id', '!=', 'parent.display_project_id')]}"/>
+                                            attrs="{'invisible': &quot;[('display_project_id', '!=', False), ('display_project_id', '!=', active_id)]&quot;}"/>
                                 </tree>
                             </field>
                         </page>


### PR DESCRIPTION
Before this commit, when the a subtask is in the same project than the
parent one and the internal user has manually set the project to see
this task in the main kanban view of tasks of the project. In project
sharing view, the collaborator cannot see the 'View Task' button in the
sub list view of subtasks shown in the form view of the parent one.

This commit fixes it to shown the button when the subtask is in the same
project than the parent one.

Steps to reproduce:
==================
1) Create a Project A
2) Create a Task T in the Project A
3) Add a subtask in T and set the project A in the subtask
4) Share in edit mode the project A to a portal user
5) Log out and log in as the portal user
6) Go to the Project A to see the kanban view of tasks in project
sharing feature.
7) Go to the task T and see the subtasks list view.

Expected Behaviour:
==================
The 'View Task' should be shown for this subtask because the subtask is
in the same project than the parent one.

Actual Behaviour:
================
This button is not shown.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
