### PR TITLE
[FIX] hr_holidays: fixed unavailability when monday is off in gantt view

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -194,6 +194,18 @@ class HrEmployeeBase(models.AbstractModel):
 class HrEmployeePrivate(models.Model):
     _inherit = 'hr.employee'
 
+    def write(self, vals):
+        res = super().write(vals)
+        if 'resource_calendar_id' in vals and vals['resource_calendar_id']:
+            resource_leaves = self.env['resource.calendar.leaves'].search([
+                ('resource_id', 'in', self.resource_id.ids),
+                ('date_from', '>=', fields.Datetime.today()),
+                ('holiday_id', '!=', False),
+            ])
+            if resource_leaves:
+                resource_leaves.write({'calendar_id': vals['resource_calendar_id']})
+        return res
+
 class HrEmployeePublic(models.Model):
     _inherit = 'hr.employee.public'
 


### PR DESCRIPTION
The gantt view does not show future leaves when the working hours
of resources change with monday off calendar.

so this commit resolves the issue by including future leaves on
monday off calendar.

TaskID - 2687135