### PR TITLE
[FIX] web: Traceback on comparison with no data

### DIFF
--- a/addons/web/static/src/js/views/graph/graph_renderer.js
+++ b/addons/web/static/src/js/views/graph/graph_renderer.js
@@ -880,10 +880,13 @@ return AbstractRenderer.extend({
         }
 
         // center the points in the chart (without that code they are put on the left and the graph seems empty)
-        data.labels = data.labels.length > 1 ?
-            data.labels :
-            Array.prototype.concat.apply([], [[['']], data.labels, [['']]]);
 
+        if (data.labels.length < 2) {
+            data.labels = Array.prototype.concat.apply([], [[['']], data.labels, [['']]]);
+            for (let i = 0; i < data.labels.length; i++) {
+                data.labels[i].isNoData = true;
+            }
+        }
         // prepare options
         var options = this._prepareOptions(data.datasets.length);
 


### PR DESCRIPTION
Steps:
- CRM
- Reporting -> Leads
- Choose a filter with Creation date to get no data (Exemple January 2020 in runbot 14.0)
- Select Comparison-> Creation Date: Previous Period

currently there is a traceback because the variable which allows to know if there are no data (`isNoData`)has been lost

The error occurs here because there is no `referenceIndex` and `dateClass`:
https://github.com/odoo/odoo/blob/49a97305b1f214b7d27f3de3bd0a91b6c551f8cd/addons/web/static/src/js/core/data_comparison_utils.js#L63-L66

`representative()` is called here because condition line 723 is `true` because `isNoData` is `undefined`, and it should be `true` in this case.
The fix therefore adds an `isNoData` property to true in the event that there is no data to avoid calling `representative()` in the `_relabelling()` function

https://github.com/odoo/odoo/blob/5408b186a0c790ac56615b9b2ac74687c42482da/addons/web/static/src/js/views/graph/graph_renderer.js#L722-L729



opw-2724028