### PR TITLE
[IMP] web_editor: improve video embed regexes (youku, dailymotion)

### DIFF
--- a/addons/web_editor/tests/test_tools.py
+++ b/addons/web_editor/tests/test_tools.py
@@ -14,7 +14,14 @@ class TestVideoUtils(common.BaseCase):
         'vimeo': 'https://vimeo.com/395399735',
         'dailymotion': 'https://www.dailymotion.com/video/x7svr6t',
         'youku': 'https://v.youku.com/v_show/id_XMzY1MjY4.html?spm=a2hzp.8244740.0.0',
-        'instagram': 'https://www.instagram.com/p/B6dXGTxggTG/'
+        'instagram': 'https://www.instagram.com/p/B6dXGTxggTG/',
+        'dailymotion_hub_no_video': 'http://www.dailymotion.com/hub/x9q_Galatasaray',
+        'dailymotion_hub_#video': 'http://www.dailymotion.com/hub/x9q_Galatasaray#video=x2jvvep',
+        'dai.ly': 'https://dai.ly/x578has',
+        'dailymotion_embed': 'https://www.dailymotion.com/embed/video/x578has?autoplay=1',
+        'dailymotion_video_extra': 'https://www.dailymotion.com/video/x2jvvep_hakan-yukur-klip_sport',
+        'player_youku': 'https://player.youku.com/player.php/sid/XMTI5Mjg5NjE4MA==/v.swf',
+        'youku_embed': 'https://player.youku.com/embed/XNTIwMzE1MzUzNg',
     }
 
     def test_player_regexes(self):
@@ -40,9 +47,22 @@ class TestVideoUtils(common.BaseCase):
         #dailymotion
         self.assertEqual('dailymotion', tools.get_video_source_data(TestVideoUtils.urls['dailymotion'])[0])
         self.assertEqual('x7svr6t', tools.get_video_source_data(TestVideoUtils.urls['dailymotion'])[1])
+        self.assertEqual(None, tools.get_video_source_data(TestVideoUtils.urls['dailymotion_hub_no_video']))
+        self.assertEqual('dailymotion', tools.get_video_source_data(TestVideoUtils.urls['dailymotion_hub_#video'])[0])
+        self.assertEqual('x2jvvep', tools.get_video_source_data(TestVideoUtils.urls['dailymotion_hub_#video'])[1])
+        self.assertEqual('dailymotion', tools.get_video_source_data(TestVideoUtils.urls['dai.ly'])[0])
+        self.assertEqual('x578has', tools.get_video_source_data(TestVideoUtils.urls['dai.ly'])[1])
+        self.assertEqual('dailymotion', tools.get_video_source_data(TestVideoUtils.urls['dailymotion_embed'])[0])
+        self.assertEqual('x578has', tools.get_video_source_data(TestVideoUtils.urls['dailymotion_embed'])[1])
+        self.assertEqual('dailymotion', tools.get_video_source_data(TestVideoUtils.urls['dailymotion_video_extra'])[0])
+        self.assertEqual('x2jvvep', tools.get_video_source_data(TestVideoUtils.urls['dailymotion_video_extra'])[1])
         #youku
         self.assertEqual('youku', tools.get_video_source_data(TestVideoUtils.urls['youku'])[0])
         self.assertEqual('XMzY1MjY4', tools.get_video_source_data(TestVideoUtils.urls['youku'])[1])
+        self.assertEqual('youku', tools.get_video_source_data(TestVideoUtils.urls['player_youku'])[0])
+        self.assertEqual('XMTI5Mjg5NjE4MA', tools.get_video_source_data(TestVideoUtils.urls['player_youku'])[1])
+        self.assertEqual('youku', tools.get_video_source_data(TestVideoUtils.urls['youku_embed'])[0])
+        self.assertEqual('XNTIwMzE1MzUzNg', tools.get_video_source_data(TestVideoUtils.urls['youku_embed'])[1])
         #instagram
         self.assertEqual('instagram', tools.get_video_source_data(TestVideoUtils.urls['instagram'])[0])
         self.assertEqual('B6dXGTxggTG', tools.get_video_source_data(TestVideoUtils.urls['instagram'])[1])

--- a/addons/web_editor/tools.py
+++ b/addons/web_editor/tools.py
@@ -18,9 +18,9 @@ valid_url_regex = r'^(http://|https://|//)[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{
 player_regexes = {
     'youtube': r'^(?:(?:https?:)?//)?(?:www\.)?(?:youtu\.be/|youtube(-nocookie)?\.com/(?:embed/|v/|watch\?v=|watch\?.+&v=))((?:\w|-){11})\S*$',
     'vimeo': r'//(player.)?vimeo.com/([a-z]*/)*([0-9]{6,11})[?]?.*',
-    'dailymotion': r'(?:.+dailymotion.com/(video|hub|embed/video|embed)|dai\.ly)/([^_?]+)[^#]*(#video=([^_&]+))?',
+    'dailymotion': r'(https?:\/\/)(www\.)?(dailymotion\.com\/(embed\/video\/|embed\/|video\/|hub\/.*#video=)|dai\.ly\/)(?P<id>[A-Za-z0-9]{6,7})',
     'instagram': r'(?:(.*)instagram.com|instagr\.am)/p/(.[a-zA-Z0-9-_\.]*)',
-    'youku': r'(.*).youku\.com/(v_show/id_|embed/)(.+)',
+    'youku': r'(?:(https?:\/\/)?(v\.youku\.com/v_show/id_|player\.youku\.com/player\.php/sid/|player\.youku\.com/embed/|cloud\.youku\.com/services/sharev\?vid=|video\.tudou\.com/v/)|youku:)(?P<id>[A-Za-z0-9]+)(?:\.html|/v\.swf|)',
 }
 
 
@@ -40,16 +40,13 @@ def get_video_source_data(video_url):
             return ('vimeo', vimeo_match[3], vimeo_match)
         dailymotion_match = re.search(player_regexes['dailymotion'], video_url)
         if dailymotion_match:
-            return ('dailymotion', dailymotion_match[2], dailymotion_match)
+            return ('dailymotion', dailymotion_match.group("id"), dailymotion_match)
         instagram_match = re.search(player_regexes['instagram'], video_url)
         if instagram_match:
             return ('instagram', instagram_match[2], instagram_match)
         youku_match = re.search(player_regexes['youku'], video_url)
         if youku_match:
-            youku_link = youku_match[3]
-            if '.html?' in youku_link:
-                youku_link = youku_link.split('.html?')[0]
-            return ('youku', youku_link, youku_match)
+            return ('youku', youku_match.group("id"), youku_match)
     return None
 
 


### PR DESCRIPTION
**Current behavior before PR:**

The regex patterns for dailymotion and youku were too permissive and
not specific enough for the way they were intended to be used.

**Desired behavior after PR is merged:**

The new regexes should correctly isolate the video ID from the URL
string and cover all embedding needs for the two providers.

For the initiating discussion and PR, see following link:
https://github.com/odoo/odoo/pull/44537#discussion_r753250276

task-2696033
