### PR TITLE
[FIX] fetchmail: using undeclared variable

### DIFF
--- a/doc/cla/corporate/tecnativa.md
+++ b/doc/cla/corporate/tecnativa.md
@@ -16,7 +16,7 @@ Pedro M. Baeza pedro.baeza@tecnativa.com https://github.com/pedrobaeza
 Rafael Blasco rafael.blasco@tecnativa.com https://github.com/rafaelbn
 Sergio Teruel sergio.teruel@tecnativa.com https://github.com/sergio-teruel
 Carlos Dauden carlos.dauden@tecnativa.com https://github.com/carlosdauden
-Jairo Llopis jairo.llopis@tecnativa.com https://github.com/yajo
+Jairo Llopis jairo.llopis@tecnativa.com https://github.com/yajo (up to 2021-11-25)
 David Vidal david.vidal@tecnativa.com https://github.com/chienandalu
 Cristina Martín cristina.martin@tecnativa.com https://github.com/cristinamartinrod (up to 2019-04-30)
 Ernesto Tejeda ernesto.tejeda@tecnativa.com https://github.com/ernestotejeda


### PR DESCRIPTION
When there are no emails to fetch, you get this error:

```
INFO odoo odoo.addons.fetchmail.models.fetchmail: start checking for new emails on pop server XXXX 
INFO odoo odoo.addons.fetchmail.models.fetchmail: General failure when trying to fetch mail from pop server XXXX.                                                                                                                                                                                                          
Traceback (most recent call last):       
  File "/opt/odoo/auto/addons/fetchmail/models/fetchmail.py", line 210, in fetch_mail                                                         
    _logger.info("Fetched %d email(s) on %s server %s; %d succeeded, %d failed.", num, server.server_type, server.name, (num - failed_in_loop), failed_in_loop)         
UnboundLocalError: local variable 'num' referenced before assignment                                                                                 
```

The fix is pretty obvious.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
MT-118 @moduon