### PR TITLE
[FIX] project: set sub_sub_tasks parent correctly

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -265,6 +265,9 @@ class Project(models.Model):
                 # set the parent to the duplicated task
                 defaults['parent_id'] = old_to_new_tasks.get(task.parent_id.id, False)
             new_task = task.copy(defaults)
+            # If child are created before parent (ex sub_sub_tasks)
+            new_child_ids = [old_to_new_tasks[child.id] for child in task.child_ids if child.id in old_to_new_tasks]
+            tasks.browse(new_child_ids).write({'parent_id': new_task.id})
             old_to_new_tasks[task.id] = new_task.id
             tasks += new_task
 


### PR DESCRIPTION
Step to reproduce:
- Create a Project with task A
- Create a Sub_Task to task A named sub_task B
- Create a Sub_Task to sub_task b name sub_sub_task C
- Duplicate Project

Current Behaviour:
- sub_sub_task C (copy) has no parent_id

Behaviour after PR:
- sub_sub_task C parent_id is sub_task b (copy)

opw-2727220

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
