### PR TITLE
[IMP] sale: Only record down payments when confirmed

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1245,6 +1245,25 @@ class SaleOrder(models.Model):
         self.ensure_one()
         return self.transaction_ids._get_last()
 
+    def _get_order_lines_to_report(self):
+        down_payment_lines = self.order_line.filtered(lambda line:
+            line.is_downpayment
+            and not line.display_type
+            and not line._get_downpayment_state()
+        )
+
+        def show_line(line):
+            if not line.is_downpayment:
+                return True
+            elif line.display_type and down_payment_lines:
+                return True  # Only show the down payment section if down payments were posted
+            elif line in down_payment_lines:
+                return True  # Only show posted down payments
+            else:
+                return False
+
+        return self.order_line.filtered(show_line)
+
     # PORTAL #
 
     def has_to_be_signed(self, include_draft=False):

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -63,7 +63,8 @@
             </div>
 
             <!-- Is there a discount on at least one line? -->
-            <t t-set="display_discount" t-value="any(l.discount for l in doc.order_line)"/>
+            <t t-set="lines_to_report" t-value="doc._get_order_lines_to_report()"/>
+            <t t-set="display_discount" t-value="any(l.discount for l in lines_to_report)"/>
 
             <table class="table table-sm o_main_table mt-4">
                 <!-- In case we want to repeat the header, remove "display: table-row-group" -->
@@ -86,7 +87,7 @@
 
                     <t t-set="current_subtotal" t-value="0"/>
 
-                    <t t-foreach="doc.order_line" t-as="line">
+                    <t t-foreach="lines_to_report" t-as="line">
 
                         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
                         <t t-set="current_subtotal" t-value="current_subtotal + line.price_total" groups="account.group_show_line_subtotals_tax_included"/>
@@ -107,7 +108,7 @@
                                 <td name="td_taxes" class="text-end">
                                     <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.tax_id))"/>
                                 </td>
-                                <td name="td_subtotal" class="text-end o_price_total">
+                                <td t-if="not line.is_downpayment" name="td_subtotal" class="text-end o_price_total">
                                     <span t-field="line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
                                     <span t-field="line.price_total" groups="account.group_show_line_subtotals_tax_included"/>
                                 </td>
@@ -126,7 +127,7 @@
                             </t>
                         </tr>
 
-                        <t t-if="current_section and (line_last or doc.order_line[line_index+1].display_type == 'line_section')">
+                        <t t-if="current_section and (line_last or doc.order_line[line_index+1].display_type == 'line_section') and not line.is_downpayment">
                             <tr class="is-subtotal text-end">
                                 <td name="td_section_subtotal" colspan="99">
                                     <strong class="mr16">Subtotal</strong>

--- a/addons/sale/tests/test_sale_refund.py
+++ b/addons/sale/tests/test_sale_refund.py
@@ -344,7 +344,8 @@ class TestSaleRefund(TestSaleCommon):
         })
         downpayment.create_invoices()
         sale_order_refund.invoice_ids[0].action_post()
-        sol_downpayment = sale_order_refund.order_line[1]
+        # order_line[1] is the down payment section
+        sol_downpayment = sale_order_refund.order_line[2]
 
         payment = self.env['sale.advance.payment.inv'].with_context(so_context).create({
             'deposit_account_id': self.company_data['default_account_revenue'].id
@@ -352,7 +353,8 @@ class TestSaleRefund(TestSaleCommon):
         payment.create_invoices()
 
         so_invoice = max(sale_order_refund.invoice_ids)
-        self.assertEqual(len(so_invoice.invoice_line_ids.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))), len(sale_order_refund.order_line), 'All lines should be invoiced')
+        self.assertEqual(len(so_invoice.invoice_line_ids.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))),
+                         len(sale_order_refund.order_line.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))), 'All lines should be invoiced')
         self.assertEqual(len(so_invoice.invoice_line_ids.filtered(lambda l: l.display_type == 'line_section' and l.name == "Down Payments")), 1, 'A single section for downpayments should be present')
         self.assertEqual(so_invoice.amount_total, sale_order_refund.amount_total - sol_downpayment.price_unit, 'Downpayment should be applied')
         so_invoice.action_post()

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -108,7 +108,7 @@ class TestSaleToInvoice(TestSaleCommon):
         self._check_order_search(self.sale_order, [('invoice_ids', '=', False)], self.env['sale.order'])
 
         self.assertEqual(len(self.sale_order.invoice_ids), 2, 'Invoice should be created for the SO')
-        downpayment_line = self.sale_order.order_line.filtered(lambda l: l.is_downpayment)
+        downpayment_line = self.sale_order.order_line.filtered(lambda l: l.is_downpayment and not l.display_type)
         self.assertEqual(len(downpayment_line), 2, 'SO line downpayment should be created on SO')
 
         # Update delivered quantity of SO lines
@@ -124,7 +124,8 @@ class TestSaleToInvoice(TestSaleCommon):
         self.assertEqual(len(self.sale_order.invoice_ids), 3, 'Invoice should be created for the SO')
 
         invoice = max(self.sale_order.invoice_ids)
-        self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))), len(self.sale_order.order_line), 'All lines should be invoiced')
+        self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))),
+                         len(self.sale_order.order_line.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))), 'All lines should be invoiced')
         self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda l: l.display_type == 'line_section' and l.name == "Down Payments")), 1, 'A single section for downpayments should be present')
         self.assertEqual(invoice.amount_total, self.sale_order.amount_total - sum(downpayment_line.mapped('price_unit')), 'Downpayment should be applied')
 
@@ -147,7 +148,7 @@ class TestSaleToInvoice(TestSaleCommon):
         payment.create_invoices()
 
         self.assertEqual(len(self.sale_order.invoice_ids), 1, 'Invoice should be created for the SO')
-        downpayment_line = self.sale_order.order_line.filtered(lambda l: l.is_downpayment)
+        downpayment_line = self.sale_order.order_line.filtered(lambda l: l.is_downpayment and not l.display_type)
         self.assertEqual(len(downpayment_line), 1, 'SO line downpayment should be created on SO')
         self.assertEqual(downpayment_line.price_unit, self.sale_order.amount_total/2, 'downpayment should have the correct amount')
 

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -503,8 +503,9 @@
                                     optional="show"
                                 />
                                 <field name="discount" string="Disc.%" groups="product.group_discount_per_so_line" optional="show" widget="product_discount"/>
-                                <field name="price_subtotal" widget="monetary" groups="account.group_show_line_subtotals_tax_excluded"/>
-                                <field name="price_total" widget="monetary" groups="account.group_show_line_subtotals_tax_included"/>
+                                <field name="is_downpayment" invisible="1"/>
+                                <field name="price_subtotal" widget="monetary" groups="account.group_show_line_subtotals_tax_excluded" attrs="{'invisible': [('is_downpayment', '=', True)]}"/>
+                                <field name="price_total" widget="monetary" groups="account.group_show_line_subtotals_tax_included" attrs="{'invisible': [('is_downpayment', '=', True)]}"/>
                                 <field name="state" invisible="1"/>
                                 <field name="invoice_status" invisible="1"/>
                                 <field name="currency_id" invisible="1"/>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -483,8 +483,9 @@
                     <tbody class="sale_tbody">
 
                         <t t-set="current_subtotal" t-value="0"/>
+                        <t t-set="lines_to_report" t-value="sale_order._get_order_lines_to_report()"/>
 
-                        <t t-foreach="sale_order.order_line" t-as="line">
+                        <t t-foreach="lines_to_report" t-as="line">
 
                             <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
                             <t t-set="current_subtotal" t-value="current_subtotal + line.price_total" groups="account.group_show_line_subtotals_tax_included"/>
@@ -519,7 +520,7 @@
                                     <td t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                                         <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.tax_id))"/>
                                     </td>
-                                    <td class="text-end">
+                                    <td t-if="not line.is_downpayment" class="text-end">
                                         <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
                                         <span class="oe_order_line_price_total" t-field="line.price_total" groups="account.group_show_line_subtotals_tax_included"/>
                                     </td>
@@ -537,8 +538,7 @@
                                     </td>
                                 </t>
                             </tr>
-
-                            <tr t-if="current_section and (line_last or sale_order.order_line[line_index+1].display_type == 'line_section')"
+                            <tr t-if="current_section and (line_last or lines_to_report[line_index+1].display_type == 'line_section') and not line.is_downpayment"
                                 class="is-subtotal text-end">
                                 <td colspan="99">
                                     <strong class="mr16">Subtotal</strong>

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -136,10 +136,25 @@ class SaleAdvancePaymentInv(models.TransientModel):
                     subtype_id=self.env.ref('mail.mt_note').id)
         return invoice
 
+    def _prepare_downpayment_section(self, order):
+        context = {'lang': order.partner_id.lang}
+
+        so_values = {
+            'name': _('Down Payments'),
+            'product_uom_qty': 0.0,
+            'order_id': order.id,
+            'display_type': 'line_section',
+            'is_downpayment': True,
+            'sequence': order.order_line and order.order_line[-1].sequence + 1 or 10,
+        }
+
+        del context
+        return so_values
+
     def _prepare_so_line(self, order, analytic_tag_ids, tax_ids, amount):
         context = {'lang': order.partner_id.lang}
         so_values = {
-            'name': _('Down Payment: %s') % (time.strftime('%m %Y'),),
+            'name': _('Down Payment: %s (Draft)') % (time.strftime('%m %Y'),),
             'price_unit': amount,
             'product_uom_qty': 0.0,
             'order_id': order.id,
@@ -178,6 +193,11 @@ class SaleAdvancePaymentInv(models.TransientModel):
                 analytic_tag_ids = []
                 for line in order.order_line:
                     analytic_tag_ids = [(4, analytic_tag.id, None) for analytic_tag in line.analytic_tag_ids]
+
+                # verify that no down payment section already exists
+                if not any(line.display_type and line.is_downpayment for line in order.order_line):
+                    so_downpayment_section_values = self._prepare_downpayment_section(order)
+                    sale_line_obj.create(so_downpayment_section_values)
 
                 so_line_values = self._prepare_so_line(order, analytic_tag_ids, tax_ids, amount)
                 so_line = sale_line_obj.create(so_line_values)


### PR DESCRIPTION
When creating down payments for sale orders the down payments
were shown even if the invoice was on a 'draft' status.
This might confuse users that are then not sure if the down payments
were settled or not only by looking at the SO.

Now down payments are easily discernible from draft down payments.

Task - 2702407



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
