### PR TITLE
[FIX] delivery: missing field rename in forward port

### DIFF
--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -174,7 +174,7 @@ class StockPicking(models.Model):
         self.carrier_price = res['exact_price'] * (1.0 + (self.carrier_id.margin / 100.0))
         if res['tracking_number']:
             previous_pickings = self.env['stock.picking']
-            previous_moves = self.move_lines.move_orig_ids
+            previous_moves = self.move_ids.move_orig_ids
             while previous_moves:
                 previous_pickings |= previous_moves.picking_id
                 previous_moves = previous_moves.move_orig_ids


### PR DESCRIPTION
In saas-15.1 move_lines on `stock.picking` has been rename in
move_ids.

It was miss during #81595 and it's fixed now
