### PR TITLE
[FIX] website: do not translate code

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-27 09:21+0000\n"
-"PO-Revision-Date: 2020-04-27 09:21+0000\n"
+"POT-Creation-Date: 2022-01-07 12:31+0000\n"
+"PO-Revision-Date: 2022-01-07 12:31+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -37,6 +37,24 @@ msgstr ""
 #. module: website
 #: code:addons/website/models/website_rewrite.py:0
 #, python-format
+msgid "\"URL to\" cannot contain parameter %s which is not used in \"URL from\"."
+msgstr ""
+
+#. module: website
+#: code:addons/website/models/website_rewrite.py:0
+#, python-format
+msgid "\"URL to\" is invalid: %s"
+msgstr ""
+
+#. module: website
+#: code:addons/website/models/website_rewrite.py:0
+#, python-format
+msgid "\"URL to\" must contain parameter %s used in \"URL from\"."
+msgstr ""
+
+#. module: website
+#: code:addons/website/models/website_rewrite.py:0
+#, python-format
 msgid "\"URL to\" must start with a leading slash."
 msgstr ""
 
@@ -55,17 +73,6 @@ msgstr ""
 #. module: website
 #: model_terms:ir.ui.view,arch_db:website.show_website_info
 msgid "&amp;times;"
-msgstr ""
-
-#. module: website
-#: model_terms:ir.ui.view,arch_db:website.sitemap_index_xml
-#: model_terms:ir.ui.view,arch_db:website.sitemap_xml
-msgid "&lt;?xml version=\"1.0\" encoding=\"UTF-8\"?&gt;"
-msgstr ""
-
-#. module: website
-#: model_terms:ir.ui.view,arch_db:website.default_xml
-msgid "&lt;?xml version=\"1.0\" encoding=\"utf-8\"?&gt;"
 msgstr ""
 
 #. module: website
@@ -106,11 +113,6 @@ msgstr ""
 msgid ""
 ".\n"
 "            Changing its name will break these calls."
-msgstr ""
-
-#. module: website
-#: model_terms:ir.ui.view,arch_db:website.default_csv
-msgid "1,2,3"
 msgstr ""
 
 #. module: website
@@ -2874,15 +2876,6 @@ msgstr ""
 #: code:addons/website/static/src/xml/website.pageProperties.xml:0
 #, python-format
 msgid "It looks like your file is being called by"
-msgstr ""
-
-#. module: website
-#. openerp-web
-#: code:addons/website/static/src/js/content/website_root.js:0
-#, python-format
-msgid ""
-"It might be possible to edit the relevant items or fix the issue in <a "
-"href=\"%s\">the classic Odoo interface</a>"
 msgstr ""
 
 #. module: website
@@ -5847,11 +5840,6 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website.brand_promotion
 #: model_terms:ir.ui.view,arch_db:website.menu_search
 msgid "website"
-msgstr ""
-
-#. module: website
-#: model_terms:ir.ui.view,arch_db:website.res_config_settings_view_form
-msgid "www.odoo.com"
 msgstr ""
 
 #. module: website

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -762,7 +762,7 @@
     </script>
 </template>
 <template id="default_xml">
-    &lt;?xml version="1.0" encoding="utf-8"?&gt;
+    <t t-translation="off">&lt;?xml version="1.0" encoding="utf-8"?&gt;</t>
 </template>
 <template id="default_css">
     <style type="text/css">
@@ -786,7 +786,7 @@
     </style>
 </template>
 <template id="default_csv">
-    1,2,3
+    <t t-translation="off">1,2,3</t>
 </template>
 
 <template id="page_404">
@@ -918,18 +918,19 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
     </url>
 </template>
 
-<template id="sitemap_xml">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+<template id="sitemap_xml"><t t-translation="off">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</t>
 <urlset t-attf-xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <t t-raw="content"/>
 </urlset>
 </template>
 
-<template id="sitemap_index_xml">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+<template id="sitemap_index_xml"><t t-translation="off">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 <sitemapindex t-attf-xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap t-translation="off" t-foreach="pages" t-as="page">
     <loc><t t-esc="url_root"/>sitemap-<t t-esc="page"/>.xml</loc>
   </sitemap>
 </sitemapindex>
+</t>
 </template>
 
 <template id="company_description" name="Company Description">


### PR DESCRIPTION
Header of XML files should not be translated.
Before this commit, some users may translate the XML header and get
invalid XML if translating words like "encoding"

Fixes odoo/odoo#82155
