### PR TITLE
[IMP] calendar: improve UI/UX

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -148,14 +148,18 @@ class Attendee(models.Model):
         """ Marks event invitation as Accepted. """
         for attendee in self:
             attendee.event_id.message_post(
-                body=_("%s has accepted invitation") % (attendee.common_name),
-                subtype_xmlid="calendar.subtype_invitation")
+                author_id=attendee.partner_id.id,
+                body=_("%s has accepted the invitation") % (attendee.common_name),
+                subtype_xmlid="calendar.subtype_invitation",
+            )
         return self.write({'state': 'accepted'})
 
     def do_decline(self):
         """ Marks event invitation as Declined. """
         for attendee in self:
             attendee.event_id.message_post(
-                body=_("%s has declined invitation") % (attendee.common_name),
-                subtype_xmlid="calendar.subtype_invitation")
+                author_id=attendee.partner_id.id,
+                body=_("%s has declined the invitation") % (attendee.common_name),
+                subtype_xmlid="calendar.subtype_invitation",
+            )
         return self.write({'state': 'declined'})

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -39,24 +39,20 @@
             <form string="Calendar Alarm">
                 <sheet>
                     <group>
-                        <group>
+                        <group name="left_details">
                             <field name="name" invisible="1"/>
                             <field name="alarm_type"/>
+                            <field name="mail_template_id" context="{'default_model': 'calendar.event'}"
+                                   attrs="{'invisible': [('alarm_type', '!=', 'email')], 'required': [('alarm_type', '=', 'email')]}"/>
+                            <field name="body" attrs="{'invisible': [('alarm_type', '!=', 'notification')]}"/>
                         </group>
-                        <group>
+                        <group name="right_details">
                             <label for="duration"/>
                             <div class="o_row">
                                 <field name="duration"/>
                                 <field name="interval"/>
                             </div>
                         </group>
-                        <group attrs="{'invisible': [('alarm_type','=','notification')]}">
-                            <field name="mail_template_id" attrs="{'invisible': [('alarm_type','!=','email')], 'required': [('alarm_type', '=', 'email')]}"
-                                context="{'default_model': 'calendar.event'}"/>
-                        </group>
-                    </group>
-                    <group attrs="{'invisible': [('alarm_type','!=','notification')]}">
-                        <field name="body"/>
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
A reorganization of the calendar alarm form view was necessary for easier
extension with new fields
(such as the one from appointment, see links).

The partner is now the author of notifications about their invitation
(instead of public user).

Task-2709580
See https://github.com/odoo/enterprise/pull/23191