### PR TITLE
[IMP] *: Print GS1 datamatrices + improve labels

### DIFF
--- a/addons/barcodes/models/barcode_nomenclature.py
+++ b/addons/barcodes/models/barcode_nomenclature.py
@@ -65,6 +65,7 @@ class BarcodeNomenclature(models.Model):
             'ean13': 13,
             'gtin14': 14,
             'upca': 12,
+            'sscc': 18,
         }
         barcode_size = barcode_sizes[encoding]
         return len(barcode) == barcode_size and re.match(r"^\d+$", barcode) and self.get_barcode_check_digit(barcode) == int(barcode[-1])

--- a/addons/barcodes/models/barcode_nomenclature.py
+++ b/addons/barcodes/models/barcode_nomenclature.py
@@ -63,6 +63,7 @@ class BarcodeNomenclature(models.Model):
         barcode_sizes = {
             'ean8': 8,
             'ean13': 13,
+            'gtin14': 14,
             'upca': 12,
         }
         barcode_size = barcode_sizes[encoding]

--- a/addons/barcodes_gs1_nomenclature/data/barcodes_gs1_rules.xml
+++ b/addons/barcodes_gs1_nomenclature/data/barcodes_gs1_rules.xml
@@ -30,7 +30,7 @@
         <record id="barcode_rule_gs1_02" model="barcode.rule">
             <field name="name">GTIN of contained trade items</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">101</field>
+            <field name="sequence">102</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(02)(\d{14})</field>
             <field name="type">product</field>
@@ -40,7 +40,7 @@
         <record id="barcode_rule_gs1_410" model="barcode.rule">
             <field name="name">Ship to / Deliver to Global Location Number (GLN)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">102</field>
+            <field name="sequence">110</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(410)(\d{13})</field>
             <field name="type">location_dest</field>
@@ -50,7 +50,7 @@
         <record id="barcode_rule_gs1_413" model="barcode.rule">
             <field name="name">Ship for / Deliver for - Forward to Global Location Number (GLN)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">103</field>
+            <field name="sequence">113</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(413)(\d{13})</field>
             <field name="type">location_dest</field>
@@ -60,7 +60,7 @@
         <record id="barcode_rule_gs1_414" model="barcode.rule">
             <field name="name">Identification of a physical location - Global Location Number (GLN)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">104</field>
+            <field name="sequence">114</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(414)(\d{13})</field>
             <field name="type">location</field>
@@ -71,7 +71,7 @@
         <record id="barcode_rule_gs1_10" model="barcode.rule">
             <field name="name">Batch or lot number</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">105</field>
+            <field name="sequence">125</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(10)([!"%-/0-9:-?A-Z_a-z]{0,20})</field>
             <field name="type">lot</field>
@@ -81,7 +81,7 @@
         <record id="barcode_rule_gs1_21" model="barcode.rule">
             <field name="name">Serial number</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">106</field>
+            <field name="sequence">126</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(21)([!"%-/0-9:-?A-Z_a-z]{0,20})</field>
             <field name="type">lot</field>
@@ -92,7 +92,7 @@
         <record id="barcode_rule_gs1_13" model="barcode.rule">
             <field name="name">Packaging date (YYMMDD)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">107</field>
+            <field name="sequence">137</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(13)(\d{6})</field>
             <field name="type">packaging_date</field>
@@ -102,7 +102,7 @@
         <record id="barcode_rule_gs1_15" model="barcode.rule">
             <field name="name">Best before date (YYMMDD)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">108</field>
+            <field name="sequence">138</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(15)(\d{6})</field>
             <field name="type">use_date</field>
@@ -112,7 +112,7 @@
         <record id="barcode_rule_gs1_17" model="barcode.rule">
             <field name="name">Expiration date (YYMMDD)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">109</field>
+            <field name="sequence">139</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(17)(\d{6})</field>
             <field name="type">expiration_date</field>
@@ -123,7 +123,7 @@
         <record id="barcode_rule_gs1_30" model="barcode.rule">
             <field name="name">Variable count of items (variable measure trade item)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">110</field>
+            <field name="sequence">300</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(30)(\d{0,8})</field>
             <field name="associated_uom_id" ref="uom.product_uom_unit"/>
@@ -135,7 +135,7 @@
         <record id="barcode_rule_gs1_37" model="barcode.rule">
             <field name="name">Count of trade items or trade item pieces contained in a logistic unit</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">111</field>
+            <field name="sequence">305</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(37)(\d{0,8})</field>
             <field name="associated_uom_id" ref="uom.product_uom_unit"/>
@@ -147,7 +147,7 @@
         <record id="barcode_rule_gs1_310y" model="barcode.rule">
             <field name="name">Net weight, kilograms (variable measure trade item)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">112</field>
+            <field name="sequence">310</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(310[0-5])(\d{6})</field>
             <field name="associated_uom_id" ref="uom.product_uom_kgm"/>
@@ -159,7 +159,7 @@
         <record id="barcode_rule_gs1_311y" model="barcode.rule">
             <field name="name">Length or first dimension, metres (variable measure trade item)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">113</field>
+            <field name="sequence">311</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(311[0-5])(\d{6})</field>
             <field name="associated_uom_id" ref="uom.product_uom_meter"/>
@@ -168,10 +168,22 @@
             <field name="gs1_decimal_usage">True</field>
         </record>
 
+        <record id="barcode_rule_gs1_314y" model="barcode.rule">
+            <field name="name">Area, square meters (variable measure trade item)</field>
+            <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
+            <field name="sequence">314</field>
+            <field name="encoding">gs1-128</field>
+            <field name="pattern">(314[0-5])(\d{6})</field>
+            <field name="associated_uom_id" ref="uom.uom_square_meter"/>
+            <field name="type">quantity</field>
+            <field name="gs1_content_type">measure</field>
+            <field name="gs1_decimal_usage">True</field>
+        </record>
+
         <record id="barcode_rule_gs1_315y" model="barcode.rule">
             <field name="name">Net volume, litres (variable measure trade item)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">114</field>
+            <field name="sequence">315</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(315[0-5])(\d{6})</field>
             <field name="associated_uom_id" ref="uom.product_uom_litre"/>
@@ -183,7 +195,7 @@
         <record id="barcode_rule_gs1_316y" model="barcode.rule">
             <field name="name">Net volume, cubic metres (variable measure trade item)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">115</field>
+            <field name="sequence">316</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(316[0-5])(\d{6})</field>
             <field name="associated_uom_id" ref="uom.product_uom_cubic_meter"/>
@@ -192,10 +204,22 @@
             <field name="gs1_decimal_usage">True</field>
         </record>
 
+        <record id="barcode_rule_gs1_320y" model="barcode.rule">
+            <field name="name">Net weight, pounds (variable measure trade item)</field>
+            <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
+            <field name="sequence">320</field>
+            <field name="encoding">gs1-128</field>
+            <field name="pattern">(320[0-5])(\d{6})</field>
+            <field name="associated_uom_id" ref="uom.product_uom_lb"/>
+            <field name="type">quantity</field>
+            <field name="gs1_content_type">measure</field>
+            <field name="gs1_decimal_usage">True</field>
+        </record>
+
         <record id="barcode_rule_gs1_321y" model="barcode.rule">
             <field name="name">Length or first dimension, inches (variable measure trade item)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">116</field>
+            <field name="sequence">321</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(321[0-5])(\d{6})</field>
             <field name="associated_uom_id" ref="uom.product_uom_inch"/>
@@ -204,10 +228,46 @@
             <field name="gs1_decimal_usage">True</field>
         </record>
 
+        <record id="barcode_rule_gs1_322y" model="barcode.rule">
+            <field name="name">Length or first dimension, feet (variable measure trade item)</field>
+            <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
+            <field name="sequence">322</field>
+            <field name="encoding">gs1-128</field>
+            <field name="pattern">(322[0-5])(\d{6})</field>
+            <field name="associated_uom_id" ref="uom.product_uom_foot"/>
+            <field name="type">quantity</field>
+            <field name="gs1_content_type">measure</field>
+            <field name="gs1_decimal_usage">True</field>
+        </record>
+
+        <record id="barcode_rule_gs1_323y" model="barcode.rule">
+            <field name="name">Length or first dimension, yards (variable measure trade item)</field>
+            <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
+            <field name="sequence">323</field>
+            <field name="encoding">gs1-128</field>
+            <field name="pattern">(322[0-5])(\d{6})</field>
+            <field name="associated_uom_id" ref="uom.product_uom_yard"/>
+            <field name="type">quantity</field>
+            <field name="gs1_content_type">measure</field>
+            <field name="gs1_decimal_usage">True</field>
+        </record>
+
+        <record id="barcode_rule_gs1_351y" model="barcode.rule">
+            <field name="name">Area, square feet (variable measure trade item)</field>
+            <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
+            <field name="sequence">351</field>
+            <field name="encoding">gs1-128</field>
+            <field name="pattern">(351[0-5])(\d{6})</field>
+            <field name="associated_uom_id" ref="uom.uom_square_foot"/>
+            <field name="type">quantity</field>
+            <field name="gs1_content_type">measure</field>
+            <field name="gs1_decimal_usage">True</field>
+        </record>
+
         <record id="barcode_rule_gs1_357y" model="barcode.rule">
             <field name="name">Net weight (or volume), ounces (variable measure trade item)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">117</field>
+            <field name="sequence">357</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(357[0-5])(\d{6})</field>
             <field name="associated_uom_id" ref="uom.product_uom_oz"/>
@@ -216,10 +276,46 @@
             <field name="gs1_decimal_usage">True</field>
         </record>
 
+        <record id="barcode_rule_gs1_360y" model="barcode.rule">
+            <field name="name">Net volume, quarts (variable measure trade item)</field>
+            <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
+            <field name="sequence">360</field>
+            <field name="encoding">gs1-128</field>
+            <field name="pattern">(360[0-5])(\d{6})</field>
+            <field name="associated_uom_id" ref="uom.product_uom_qt"/>
+            <field name="type">quantity</field>
+            <field name="gs1_content_type">measure</field>
+            <field name="gs1_decimal_usage">True</field>
+        </record>
+
+        <record id="barcode_rule_gs1_361y" model="barcode.rule">
+            <field name="name">Net volume, gallons U.S. (variable measure trade item)</field>
+            <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
+            <field name="sequence">361</field>
+            <field name="encoding">gs1-128</field>
+            <field name="pattern">(361[0-5])(\d{6})</field>
+            <field name="associated_uom_id" ref="uom.product_uom_gal"/>
+            <field name="type">quantity</field>
+            <field name="gs1_content_type">measure</field>
+            <field name="gs1_decimal_usage">True</field>
+        </record>
+
+        <record id="barcode_rule_gs1_364y" model="barcode.rule">
+            <field name="name">Net volume, cubic inches (variable measure trade item)</field>
+            <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
+            <field name="sequence">364</field>
+            <field name="encoding">gs1-128</field>
+            <field name="pattern">(364[0-5])(\d{6})</field>
+            <field name="associated_uom_id" ref="uom.product_uom_cubic_inch"/>
+            <field name="type">quantity</field>
+            <field name="gs1_content_type">measure</field>
+            <field name="gs1_decimal_usage">True</field>
+        </record>
+
         <record id="barcode_rule_gs1_365y" model="barcode.rule">
             <field name="name">Net volume, cubic feet (variable measure trade item)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">118</field>
+            <field name="sequence">365</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(365[0-5])(\d{6})</field>
             <field name="associated_uom_id" ref="uom.product_uom_cubic_foot"/>
@@ -232,7 +328,7 @@
         <record id="barcode_rule_gs1_91" model="barcode.rule">
             <field name="name">Package type</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
-            <field name="sequence">200</field>
+            <field name="sequence">500</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(91)([!"%-/0-9:-?A-Z_a-z]{0,90})</field>
             <field name="type">package_type</field>

--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -36,8 +36,17 @@ class StockQuantPackage(models.Model):
         for package in self:
             package.weight_uom_name = self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
 
-    weight = fields.Float(compute='_compute_weight', help="Total weight of all the products contained in the package.")
+    def _compute_weight_is_kg(self):
+        self.weight_is_kg = False
+        uom_id = self.env['product.template']._get_weight_uom_id_from_ir_config_parameter()
+        if uom_id == self.env.ref('uom.product_uom_kgm'):
+            self.weight_is_kg = True
+        self.weight_uom_rounding = uom_id.rounding
+
+    weight = fields.Float(compute='_compute_weight', digits='Stock Weight', help="Total weight of all the products contained in the package.")
     weight_uom_name = fields.Char(string='Weight unit of measure label', compute='_compute_weight_uom_name', readonly=True, default=_get_default_weight_uom)
+    weight_is_kg = fields.Boolean("Technical field indicating whether weight uom is kg or not (i.e. lb)", compute="_compute_weight_is_kg")
+    weight_uom_rounding = fields.Float("Technical field indicating weight's number of decimal places", compute="_compute_weight_is_kg")
     shipping_weight = fields.Float(string='Shipping Weight', help="Total weight of the package.")
 
 

--- a/addons/delivery/views/report_package_barcode.xml
+++ b/addons/delivery/views/report_package_barcode.xml
@@ -1,19 +1,76 @@
 <odoo>
+    <template id="label_package_template_view_delivery" inherit_id="stock.label_package_template_view">
+        <xpath expr="//t[@name='datamatrix_pack_date']" position="after">
+            <t t-if="package.shipping_weight or package.weight">
+                <t t-if="package.shipping_weight" t-set="weight_str" t-value="str(int(package.shipping_weight/package.weight_uom_rounding))"/>
+                <t t-else="" t-set="weight_str" t-value="str(int(package.weight/package.weight_uom_rounding))"/>
+                <t t-if="len(weight_str) &lt;= 6">
+                    <t t-if="package.weight_is_kg" t-set="barcode" t-value="barcode + '310'"/>
+                    <t t-else="" t-set="barcode" t-value="barcode + '320'"/>
+                    <t t-set="barcode" t-value="barcode + str(len(str(package.weight_uom_rounding).split('.')[1]))"/>
+                    <t t-set="barcode" t-value="barcode + '0' * (6 - len(str(weight_str))) + weight_str"/>
+                </t>
+^FO310,200
+                <t t-if="package.shipping_weight">
+^A0N,44,33^FDShipping Weight: <t t-out="package.shipping_weight"/> <t t-out="package.weight_uom_name"/>^FS
+                </t>
+                <t t-else="">
+^A0N,44,33^FDWeight: <t t-out="package.weight"/> <t t-out="package.weight_uom_name"/>^FS
+                </t>
+            </t>
+        </xpath>
+    </template>
+
     <template id="report_package_barcode_delivery" inherit_id="stock.report_package_barcode">
+        <xpath expr="//div[@name='datamatrix_barcode']" position="before">
+            <t t-if="o.shipping_weight or o.weight">
+                <t t-if="o.shipping_weight" t-set="weight_str" t-value="str(int(o.shipping_weight/o.weight_uom_rounding))"/>
+                <t t-else="" t-set="weight_str" t-value="str(int(o.weight/o.weight_uom_rounding))"/>
+                <t t-if="len(weight_str) &lt;= 6">
+                    <t t-if="o.weight_is_kg" t-set="barcode" t-value="barcode + '310'"/>
+                    <t t-else="" t-set="barcode" t-value="barcode + '320'"/>
+                    <t t-set="barcode" t-value="barcode + str(len(str(o.weight_uom_rounding).split('.')[1]))"/>
+                    <t t-set="barcode" t-value="barcode + '0' * (6 - len(str(weight_str))) + weight_str"/>
+                </t>
+            </t>
+        </xpath>
         <xpath expr="//div[hasclass('o_packaging_type')]" position="after">
-            <div t-if="o.shipping_weight" class="col-auto">
-                <strong>Shipping Weight:</strong>
-                <br/>
-                <span t-field="o.shipping_weight"/>
-                <span t-esc="env['product.template']._get_weight_uom_id_from_ir_config_parameter().display_name"/>
-            </div>
+            <t t-if="o.valid_sscc and env['ir.actions.report'].datamatrix_available()">
+                <!-- SSCC uses weight if necessary/available, standard barcode will not -->
+                <div t-if="o.shipping_weight" class="col-auto"><strong>Shipping Weight: </strong><span t-field="o.shipping_weight"/> <t t-out="o.weight_uom_name"/></div>
+                <div t-elif="o.weight" class="col-auto"><strong>Weight: </strong><span t-field="o.weight"/> <t t-out="o.weight_uom_name"/></div>
+            </t>
+            <t t-else="">
+                <div t-if="o.shipping_weight" class="col-auto">
+                    <strong>Shipping Weight:</strong>
+                    <br/>
+                    <span t-field="o.shipping_weight"/>
+                    <span t-out="env['product.template']._get_weight_uom_id_from_ir_config_parameter().display_name"/>
+                </div>
+            </t>
         </xpath>
     </template>
 
     <template id="report_package_barcode_small_delivery" inherit_id="stock.report_package_barcode_small">
+        <xpath expr="//div[@name='datamatrix_barcode']" position="before">
+            <t t-if="o.shipping_weight or o.weight">
+                <t t-if="o.shipping_weight" t-set="weight_str" t-value="str(int(o.shipping_weight/o.weight_uom_rounding))"/>
+                <t t-else="" t-set="weight_str" t-value="str(int(o.weight/o.weight_uom_rounding))"/>
+                <t t-if="len(weight_str) &lt;= 6">
+                    <t t-if="o.weight_is_kg" t-set="barcode" t-value="barcode + '310'"/>
+                    <t t-else="" t-set="barcode" t-value="barcode + '320'"/>
+                    <t t-set="barcode" t-value="barcode + str(len(str(o.weight_uom_rounding).split('.')[1]))"/>
+                    <t t-set="barcode" t-value="barcode + '0' * (6 - len(str(weight_str))) + weight_str"/>
+                </t>
+            </t>
+        </xpath>
+        <xpath expr="//div[@name='datamatrix_pack_type']" position="after">
+            <div t-if="o.shipping_weight" class="row">Shipping Weight: <span t-field="o.shipping_weight"/> <t t-out="o.weight_uom_name"/></div>
+            <div t-elif="o.weight" class="row">Weight: <span t-field="o.weight"/> <t t-out="o.weight_uom_name"/></div>
+        </xpath>
         <xpath expr="//div[hasclass('o_packaging_type')]" position="after">
             <div class="row o_package_shipping_weight" t-if="o.shipping_weight">
-                <div class="col-12 text-center" style="font-size:24px; font-weight:bold;"><span>Shipping Weight: </span><span t-field="o.shipping_weight"/> <t t-esc="env['product.template']._get_weight_uom_id_from_ir_config_parameter().display_name"/></div>
+                <div class="col-12 text-center" style="font-size:24px; font-weight:bold;"><span>Shipping Weight: </span><span t-field="o.shipping_weight"/> <t t-out="o.weight_uom_name"/></div>
             </div>
         </xpath>
     </template>

--- a/addons/mrp/report/mrp_production_templates.xml
+++ b/addons/mrp/report/mrp_production_templates.xml
@@ -111,76 +111,66 @@
 
 <template id="label_production_view_pdf">
     <t t-call="web.basic_layout">
-        <div class="page">
-            <t t-set="uom_categ_unit" t-value="env.ref('uom.product_uom_categ_unit')"/>
-            <t t-foreach="docs" t-as="production">
-                <t t-foreach="production.move_finished_ids" t-as="move">
-                    <t t-if="production.state == 'done'">
-                        <t t-set="move_lines" t-value="move.move_line_ids.filtered(lambda x: x.state == 'done' and x.qty_done)"/>
-                    </t>
-                    <t t-else="">
-                        <t t-set="move_lines" t-value="move.move_line_ids.filtered(lambda x: x.state != 'done' and x.reserved_qty)"/>
-                    </t>
-                    <t t-foreach="move_lines" t-as="move_line">
-                        <t t-if="move_line.product_uom_id.category_id == uom_categ_unit">
-                            <t t-set="qty" t-value="int(move_line.qty_done)"/>
-                        </t>
-                        <t t-else="">
-                            <t t-set="qty" t-value="1"/>
-                        </t>
-                        <t t-foreach="range(qty)" t-as="item">
-                            <t t-translation="off">
-                                <div style="display: inline-table; height: 10rem; width: 32%;">
-                                    <table class="table table-bordered" style="border: 2px solid black;" t-if="production.move_finished_ids">
-                                        <tr>
-                                            <th class="table-active text-left" style="height:4rem;">
-                                                <span t-esc="move.product_id.display_name"/>
-                                                <br/>
-                                                <span>Quantity:</span>
-                                                <t t-if="move_line.product_uom_id.category_id == uom_categ_unit">
-                                                    <span>1.0</span>
-                                                    <span t-field="move_line.product_uom_id" groups="uom.group_uom"/>
-                                                </t>
-                                                <t t-else="">
-                                                    <span t-esc="move_line.reserved_uom_qty" t-if="move_line.state !='done'"/>
-                                                    <span t-esc="move_line.qty_done"  t-if="move_line.state =='done'"/>
-                                                    <span t-field="move_line.product_uom_id" groups="uom.group_uom"/>
-                                                </t>
-                                            </th>
-                                        </tr>
-                                        <t t-if="move_line.product_id.tracking != 'none'">
-                                            <tr>
-                                                <td class="text-center align-middle">
-                                                    <t t-if="move_line.lot_name or move_line.lot_id">
-                                                        <div t-field="move_line.lot_name or move_line.lot_id.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 150, 'img_style': 'width:100%;height:4rem'}"/>
-                                                        <span t-esc="move_line.lot_name or move_line.lot_id.name"/>
-                                                    </t>
-                                                    <t t-else="">
-                                                        <span class="text-muted">No barcode available</span>
-                                                    </t>
-                                                </td>
-                                            </tr>
-                                        </t>
-                                        <t t-if="move_line.product_id.tracking == 'none'">
-                                            <tr>
-                                                <td class="text-center align-middle" style="height: 6rem;">
-                                                    <t t-if="move_line.product_id.barcode">
-                                                        <div t-field="move_line.product_id.barcode" t-options="{'widget': 'barcode', 'width': 600, 'height': 150, 'img_style': 'width:100%;height:4rem'}"/>
-                                                        <span t-esc="move_line.product_id.barcode"/>
-                                                    </t>
-                                                    <t t-else="">
-                                                        <span class="text-muted">No barcode available</span>
-                                                    </t>
-                                                </td>
-                                            </tr>
-                                        </t>
-                                    </table>
-                                </div>
-                            </t>
-                        </t>
-                    </t>
-                </t>
+        <t t-set='nRows' t-value='12'/>
+        <t t-set='nCols' t-value='4'/>
+        <t t-set="uom_categ_unit" t-value="env.ref('uom.product_uom_categ_unit')"/>
+        <t t-set="move_lines" t-value="docs.move_finished_ids.move_line_ids.filtered(lambda ml: ml.move_id.production_id.state == 'done' and ml.state == 'done' and ml.qty_done)"/>
+        <t t-set="move_line_qtys" t-value="[]"/>
+        <t t-foreach="move_lines" t-as="move_line">
+            <t t-if="move_line.product_uom_id.category_id == uom_categ_unit">
+                <!-- print 1 label per 1 uom when uom category = units -->
+                <t t-set="move_line_qtys" t-value="move_line_qtys + [int(move_line.qty_done)]"/>
             </t>
+            <t t-else="">
+                <t t-set="move_line_qtys" t-value="move_line_qtys + [1]"/>
+            </t>
+        </t>
+        <t t-set="index_to_qtys" t-value="{i: qty for i, qty in zip(range(0, len(move_line_qtys)), move_line_qtys)}"/>
+        <t t-set="num_pages" t-value="sum(move_line_qtys)// (nRows * nCols) + 1"/>
+        <div t-foreach="range(num_pages)" t-as="page" class="o_label_sheet" t-att-style="'padding: 20mm 8mm'">
+            <table class="my-0 table table-sm table-borderless">
+                <t t-foreach="range(nRows)" t-as="row">
+                    <tr>
+                        <t t-foreach="range(nCols)" t-as="column">
+                            <t t-if="index_to_qtys and not current_quantity">
+                                <t t-set="index_to_qty" t-value="index_to_qtys.popitem()"/>
+                                <t t-set="move_line" t-value="move_lines[index_to_qty[0]]"/>
+                                <t t-set="current_quantity" t-value="index_to_qty[1]"/>
+                            </t>
+                            <t t-if="current_quantity">
+                                <t t-set="make_invisible" t-value="False"/>
+                                <t t-set="current_quantity" t-value="current_quantity - 1"/>
+                            </t>
+                            <t t-else="">
+                                <t t-set="make_invisible" t-value="True"/>
+                            </t>
+                            <td t-att-style="make_invisible and 'visibility:hidden'">
+                                <div t-if="move_line" t-translation="off" t-att-style="'position:relative; width:43mm; height:19mm; border: 1px solid %s;' % (move_line.env.user.company_id.primary_color or 'black')">
+                                    <div class="o_label_name o_label_4x12 font-weight-bold">
+                                        <div t-out="move_line.product_id.display_name"/>
+                                        <div><span>Quantity: </span>
+                                            <span t-if="move_line.product_uom_id.category_id == uom_categ_unit">1.0</span>
+                                            <span t-else="" t-out="move_line.qty_done"/>
+                                            <span t-field="move_line.product_uom_id" groups="uom.group_uom"/>
+                                        </div>
+                                    </div>
+                                    <t t-if="move_line.product_id.tracking != 'none' and (move_line.lot_name or move_line.lot_id)">
+                                        <div t-field="move_line.lot_name or move_line.lot_id.name" t-options="{'widget': 'barcode', 'img_style': 'width:100%;height:35%'}"/>
+                                        <div class="o_label_4x12 text-center" t-out="move_line.lot_name or move_line.lot_id.name"/>
+                                    </t>
+                                    <t t-elif="move_line.product_id.tracking == 'none' and move_line.product_id.barcode">
+                                        <div t-field="move_line.product_id.barcode" t-options="{'widget': 'barcode', 'img_style': 'width:100%;height:35%'}"/>
+                                        <div class="o_label_4x12 text-center" t-out="move_line.product_id.barcode"/>
+                                    </t>
+                                    <t t-else="">
+                                        <span class="text-muted">No barcode available</span>
+                                    </t>
+                                </div>
+                            </td>
+                        </t>
+                    </tr>
+                </t>
+            </table>
         </div>
     </t>
 </template>

--- a/addons/mrp/report/mrp_report_views_main.xml
+++ b/addons/mrp/report/mrp_report_views_main.xml
@@ -36,6 +36,7 @@
             <field name="report_type">qweb-pdf</field>
             <field name="report_name">mrp.label_production_view_pdf</field>
             <field name="report_file">mrp.label_production_view_pdf</field>
+            <field name="paperformat_id" ref="product.paperformat_label_sheet"/>
             <field name="print_report_name">'Finished products - %s' % object.name</field>
             <field name="binding_model_id" ref="model_mrp_production"/>
             <field name="binding_type">report</field>

--- a/addons/mrp/report/mrp_zebra_production_templates.xml
+++ b/addons/mrp/report/mrp_zebra_production_templates.xml
@@ -23,14 +23,17 @@
 ^FO100,150^BY3
 ^BCN,100,Y,N,N
 ^FD<t t-esc="move_line.lot_id.name"/>^FS
-^XZ
 </t>
-<t t-if="move_line.product_id.tracking == 'none' and move_line.product_id.barcode">
+<t t-elif="move_line.product_id.tracking == 'none' and move_line.product_id.barcode">
 ^FO100,100^BY3
 ^BCN,100,Y,N,N
 ^FD<t t-esc="move_line.product_id.barcode"/>^FS
-^XZ
 </t>
+<t t-else="">
+^FO100,100
+^A0N,44,33^FDNo barcode available^FS
+</t>
+^XZ
                             </t>
                         </t>
                     </t>

--- a/addons/product/static/src/scss/report_label_sheet.scss
+++ b/addons/product/static/src/scss/report_label_sheet.scss
@@ -66,4 +66,13 @@
     div.o_label_clear {
         clear: both;
     }
+
+    // generic 4x12 label w/ all same size font
+    div.o_label_4x12 {
+        padding:0;
+        line-height:1;
+        font-size:55%;
+        overflow:hidden;
+        white-space:nowrap;
+    }
 }

--- a/addons/product_expiry/__manifest__.py
+++ b/addons/product_expiry/__manifest__.py
@@ -27,6 +27,7 @@ Also implements the removal strategy First Expiry First Out (FEFO) widely used, 
              'wizard/confirm_expiry_view.xml',
              'report/report_deliveryslip.xml',
              'report/report_lot_barcode.xml',
+             'report/report_package_barcode.xml',
              'data/product_expiry_data.xml'],
     'license': 'LGPL-3',
 }

--- a/addons/product_expiry/report/report_lot_barcode.xml
+++ b/addons/product_expiry/report/report_lot_barcode.xml
@@ -1,19 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 <template id="report_lot_label_expiry" inherit_id="stock.report_lot_label">
-    <xpath expr="//tr[@name='lot_name']" position="after">
-        <tr t-if="o.use_expiration_date">
-            <td>
-                <div t-if="o.use_date">
-                    Best before:
-                    <span style="float:right;" t-field="o.use_date" t-options='{"widget": "date"}'/>
-                </div>
-                <div t-if="o.expiration_date">
-                    Use by:
-                    <span style="float:right;" t-field="o.expiration_date" t-options='{"widget": "date"}'/>
-                </div>
-            </td>
-        </tr>
+    <xpath expr="//div[@name='lot_name']" position="after">
+        <t t-if="o.use_expiration_date">
+            <div class="o_label_4x12" t-if="o.use_date">
+                Best before: <span t-field="o.use_date" t-options='{"widget": "date"}'/>
+            </div>
+            <div class="o_label_4x12" t-if="o.expiration_date">
+                Use by: <span t-field="o.expiration_date" t-options='{"widget": "date"}'/>
+            </div>
+        </t>
     </xpath>
 </template>
 

--- a/addons/product_expiry/report/report_lot_barcode.xml
+++ b/addons/product_expiry/report/report_lot_barcode.xml
@@ -11,46 +11,60 @@
             </div>
         </t>
     </xpath>
+    <xpath expr="//t[@name='gs1_datamatrix_lot']" position="before">
+        <t t-if="o.use_expiration_date">
+            <t t-if="o.use_date" t-set="final_barcode" t-value="(final_barcode or '') + '15' + o.use_date.strftime('%y%m%d')"/>
+            <t t-if="o.expiration_date" t-set="final_barcode" t-value="(final_barcode or '') + '17' + o.expiration_date.strftime('%y%m%d')"/>
+        </t>
+    </xpath>
 </template>
 
 <template id="label_lot_template_view_expiry" inherit_id="stock.label_lot_template_view">
-    <xpath expr="//t" position="replace">
-        <t t-foreach="docs" t-as="lot">
-            <t t-translation="off">
-^XA
-^FO100,50
-^A0N,44,33^FD<t t-esc="lot.product_id.display_name"/>^FS
-^FO100,100
-^A0N,44,33^FDLN/SN: <t t-esc="lot.name"/>^FS
-<t t-if="lot.use_expiration_date and lot.use_date">
+    <xpath expr="//t[@name='datamatrix_lot']" position="before">
+        <t t-if="lot.use_expiration_date">
+            <t t-if="lot.use_date">
+                <t t-set="final_barcode" t-value="(final_barcode or '') + '15' + lot.use_date.strftime('%y%m%d')"/>
 ^FO100,150
-^A0N,44,33^FDBest before: <t t-esc="lot.use_date" t-options='{"widget": "date"}'/>^FS
-<t t-if="lot.expiration_date">
+^A0N,44,33^FDBest before: <t t-out="lot.use_date" t-options='{"widget": "date"}'/>^FS
+            </t>
+            <t t-if="lot.expiration_date">
+                <t t-set="final_barcode" t-value="(final_barcode or '') + '17' + lot.expiration_date.strftime('%y%m%d')"/>
+                    <t t-if="not lot.use_date">
+^FO100,150
+                    </t>
+                    <t t-else="">
 ^FO100,200
-^A0N,44,33^FDUse by: <t t-esc="lot.expiration_date" t-options='{"widget": "date"}'/>^FS
-^FO100,250^BY3
-^BCN,100,Y,N,N
-^FD<t t-esc="lot.name"/>^FS
-</t>
-<t t-else="">
-^FO100,200^BY3
-^BCN,100,Y,N,N
-^FD<t t-esc="lot.name"/>^FS
-</t>
-</t>
-<t t-elif="lot.use_expiration_date and lot.expiration_date">
+                    </t>
+^A0N,44,33^FDUse by: <t t-out="lot.expiration_date" t-options='{"widget": "date"}'/>^FS
+            </t>
+        </t>
+    </xpath>
+    <xpath expr="//t[@name='code128_barcode']" position="before">
+        <t t-elif="lot.use_expiration_date and (lot.use_date or lot.expiration_date)">
+^FO100,50
+^A0N,44,33^FD<t t-out="lot.product_id.display_name"/>^FS
+^FO100,100
+^A0N,44,33^FDLN/SN: <t t-out="lot.name"/>^FS
+            <t t-if="lot.use_date">
 ^FO100,150
-^A0N,44,33^FDUse by: <t t-esc="lot.expiration_date" t-options='{"widget": "date"}'/>^FS
+^A0N,44,33^FDBest before: <t t-out="lot.use_date" t-options='{"widget": "date"}'/>^FS
+                <t t-if="lot.expiration_date">
+^FO100,200
+^A0N,44,33^FDUse by: <t t-out="lot.expiration_date" t-options='{"widget": "date"}'/>^FS
+^FO100,250^BY3
+                </t>
+                <t t-else="">
+^FO100,200^BY3
+                </t>
+^BCN,100,Y,N,N
+^FD<t t-out="lot.name"/>^FS
+            </t>
+            <t t-elif="lot.expiration_date">
+^FO100,150
+^A0N,44,33^FDUse by: <t t-out="lot.expiration_date" t-options='{"widget": "date"}'/>^FS
 ^FO100,200^BY3
 ^BCN,100,Y,N,N
-^FD<t t-esc="lot.name"/>^FS
-</t>
-<t t-else="">
-^FO100,150^BY3
-^BCN,100,Y,N,N
-^FD<t t-esc="lot.name"/>^FS
-</t>
-^XZ
+^FD<t t-out="lot.name"/>^FS
             </t>
         </t>
     </xpath>

--- a/addons/product_expiry/report/report_package_barcode.xml
+++ b/addons/product_expiry/report/report_package_barcode.xml
@@ -1,0 +1,10 @@
+<odoo>
+    <template id="report_package_barcode_expiry" inherit_id="stock.report_package_barcode">
+        <xpath expr="//t[@name='product_barcode_lot_datamatrix']" position="before">
+            <t t-if="l.use_expiration_date">
+                <t t-if="l.lot_id.use_date" t-set="product_barcode" t-value="product_barcode + '15' + l.lot_id.use_date.strftime('%y%m%d')"/>
+                <t t-if="l.lot_id.expiration_date" t-set="product_barcode" t-value="product_barcode + '17' + l.lot_id.expiration_date.strftime('%y%m%d')"/>
+            </t>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -7,7 +7,7 @@
     'summary': 'Manage your stock and logistics activities',
     'description': "",
     'website': 'https://www.odoo.com/app/inventory',
-    'depends': ['product', 'barcodes', 'digest'],
+    'depends': ['product', 'barcodes_gs1_nomenclature', 'digest'],
     'category': 'Inventory/Inventory',
     'sequence': 25,
     'demo': [

--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -65,6 +65,8 @@
         'wizard/stock_package_destination_views.xml',
         'wizard/stock_inventory_adjustment_name.xml',
         'wizard/stock_inventory_warning.xml',
+        'wizard/stock_label_type.xml',
+        'wizard/stock_lot_label_layout.xml',
 
         'views/res_partner_views.xml',
         'views/product_strategy_views.xml',

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -101,11 +101,19 @@ class Product(models.Model):
     storage_category_capacity_ids = fields.One2many('stock.storage.category.capacity', 'product_id', 'Storage Category Capacity')
     show_on_hand_qty_status_button = fields.Boolean(compute='_compute_show_qty_status_button')
     show_forecasted_qty_status_button = fields.Boolean(compute='_compute_show_qty_status_button')
+    valid_ean = fields.Boolean('Barcode is valid EAN', compute='_compute_valid_ean')
 
     def _compute_show_qty_status_button(self):
         for product in self:
             product.show_on_hand_qty_status_button = product.product_tmpl_id.show_on_hand_qty_status_button
             product.show_forecasted_qty_status_button = product.product_tmpl_id.show_forecasted_qty_status_button
+
+    @api.depends('barcode')
+    def _compute_valid_ean(self):
+        self.valid_ean = False
+        for product in self:
+            if product.barcode:
+                product.valid_ean = self.env['barcode.nomenclature'].check_encoding(product.barcode.rjust(14, '0'), 'gtin14')
 
     @api.depends('stock_move_ids.product_qty', 'stock_move_ids.state')
     @api.depends_context(

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -12,6 +12,8 @@ class ResConfigSettings(models.TransientModel):
         help="Track following dates on lots & serial numbers: best before, removal, end of life, alert. \n Such dates are set automatically at lot/serial number creation based on values set on the product (in days).")
     group_stock_production_lot = fields.Boolean("Lots & Serial Numbers",
         implied_group='stock.group_production_lot')
+    group_stock_lot_print_gs1 = fields.Boolean("Print GS1 Barcodes for Lots & Serial Numbers",
+        implied_group='stock.group_stock_lot_print_gs1')
     group_lot_on_delivery_slip = fields.Boolean("Display Lots & Serial Numbers on Delivery Slips",
         implied_group='stock.group_lot_on_delivery_slip', group="base.group_user,base.group_portal")
     group_stock_tracking_lot = fields.Boolean("Packages",

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1496,6 +1496,19 @@ class Picking(models.Model):
                 'default_picking_quantity': 'picking'},
         }
 
+    def action_open_label_type(self):
+        if self.user_has_groups('stock.group_production_lot') and self.move_line_ids.lot_id:
+            view = self.env.ref('stock.picking_label_type_form')
+            return {
+                'name': _('Choose Type of Labels To Print'),
+                'type': 'ir.actions.act_window',
+                'res_model': 'picking.label.type',
+                'views': [(view.id, 'form')],
+                'target': 'new',
+                'context': {'default_picking_ids': self.ids},
+            }
+        return self.action_open_label_layout()
+
     def _attach_sign(self):
         """ Render the delivery report in pdf and attach it to the picking in `self`. """
         self.ensure_one()

--- a/addons/stock/report/package_templates.xml
+++ b/addons/stock/report/package_templates.xml
@@ -5,11 +5,26 @@
             <t t-foreach="docs" t-as="package">
                 <t t-translation="off">
 ^XA
+                    <t t-if="package.valid_sscc">
+                        <t t-set="barcode" t-value="'00' + package.name"/>
+                        <t t-if="package.pack_date" name="datamatrix_pack_date" t-set="barcode" t-value="barcode + '13' + package.pack_date.strftime('%y%m%d')"/>
+^FO310,50
+^A0N,44,33^FDSSCC: <t t-out="package.name"/>^FS
+^FO310,100^BY3
+<t t-if="package.pack_date">^A0N,44,33^FDPack Date: <t t-out="package.pack_date" t-options='{"widget": "date"}'/>^FS</t>
+^FO310,150^BY3
+<t t-if="package.package_type_id">^A0N,44,33^FDPackage Type: <t t-out="package.package_type_id.name"/>^FS</t>
+^FO100,50^BY3
+^BXN,10,200
+^FD<t t-out="barcode"/>^FS
+                    </t>
+                    <t t-else="">
 ^FO100,50
-^A0N,44,33^FD<t t-esc="package.name"/>^FS
+^A0N,44,33^FD<t t-out="package.name"/>^FS
 ^FO100,100^BY3
 ^BCN,100,Y,N,N
-^FD<t t-esc="package.name"/>^FS
+^FD<t t-out="package.name"/>^FS
+                    </t>
 ^XZ
                 </t>
             </t>

--- a/addons/stock/report/product_templates.xml
+++ b/addons/stock/report/product_templates.xml
@@ -38,17 +38,29 @@
                 </t>
             </t>
         </template>
+
         <template id="label_lot_template_view">
             <t t-foreach="docs" t-as="lot">
                 <t t-translation="off">
 ^XA
 ^FO100,50
-^A0N,44,33^FD<t t-esc="lot.product_id.display_name"/>^FS
+^A0N,44,33^FD<t t-out="lot.product_id.display_name"/>^FS
 ^FO100,100
-^A0N,44,33^FDLN/SN: <t t-esc="lot.name"/>^FS
+^A0N,44,33^FDLN/SN: <t t-out="lot.name"/>^FS
+                    <t t-if="env.user.has_group('stock.group_stock_lot_print_gs1')">
+                        <t t-if="lot.product_id.valid_ean" t-set="final_barcode" t-value="'01' + '0' * (14 - len(lot.product_id.barcode)) + lot.product_id.barcode"/>
+                        <!-- TODO: must keep lot/sn as last value in barcode because we cannot pad '0's without changing lot/sn name until we can scan in FNC1. -->
+                        <t t-if="lot.product_id.tracking == 'lot'" name="datamatrix_lot" t-set="final_barcode" t-value="(final_barcode or '') + '10' + lot.name"/>
+                        <t t-elif="lot.product_id.tracking == 'serial'" t-set="final_barcode" t-value="(final_barcode or '') + '21' + lot.name"/>
+^FO425,150^BY3
+^BXN,8,200
+^FD<t t-out="final_barcode"/>^FS
+                    </t>
+                    <t t-else="" name="code128_barcode">
 ^FO100,150^BY3
 ^BCN,100,Y,N,N
-^FD<t t-esc="lot.name"/>^FS
+^FD<t t-out="lot.name"/>^FS
+                    </t>
 ^XZ
                 </t>
             </t>

--- a/addons/stock/report/report_lot_barcode.xml
+++ b/addons/stock/report/report_lot_barcode.xml
@@ -3,35 +3,34 @@
 <data>
 <template id="report_lot_label">
     <t t-call="web.basic_layout">
-        <t t-foreach="docs" t-as="o">
-            <t>
-                <div class="page">
-                    <div class="oe_structure"/>
-                    <div class="row">
-                        <div class="col-8">
-                            <table class="table table-condensed" style="border-bottom: 0px solid white !important;width: 3in;">
-                                <tr>
-                                  <th style="text-align: left;">
-                                    <span t-field="o.product_id.display_name"/>
-                                  </th>
-                                </tr>
-                                <tr name="lot_name">
-                                    <td>
-                                        <span>LN/SN:</span>
-                                        <span t-field="o.name"/>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td style="text-align: center; vertical-align: middle;" class="col-5">
-                                        <div t-field="o.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 150, 'img_style': 'width:100%;height:20%;'}"/>
-                                    </td>
-                                </tr>
-                            </table>
-                        </div>
-                    </div>
-                </div>
-            </t>
-        </t>
+        <t t-set='nRows' t-value='12'/>
+        <t t-set='nCols' t-value='4'/>
+        <div t-foreach="[docs[x:x + nRows * nCols] for x in range(0, len(docs), nRows * nCols)]" t-as="page_docs" class="o_label_sheet" t-att-style="'padding: 20mm 8mm'">
+            <table class="my-0 table table-sm table-borderless">
+                <t t-foreach="range(nRows)" t-as="row">
+                    <tr>
+                        <t t-foreach="range(nCols)" t-as="col">
+                            <t t-set="barcode_index" t-value="(row * nCols + col)"/>
+                            <t t-if="barcode_index &lt; len(page_docs)">
+                                <t t-set="o" t-value="page_docs[barcode_index]"/>
+                            </t>
+                            <t t-else="">
+                                <t t-set="o" t-value="page_docs[0]"/>
+                            </t>
+                            <td t-att-style="barcode_index &gt;= len(page_docs) and 'visibility:hidden'">
+                                <div t-att-style="'width:43mm; height:19mm; border: 1px solid %s;' % (o.env.user.company_id.primary_color or 'black')">
+                                    <div class="o_label_4x12" t-field="o.product_id.display_name"/>
+                                    <div class="o_label_4x12" name="lot_name">
+                                        LN/SN: <span t-field="o.name"/>
+                                    </div>
+                                    <div t-field="o.name" t-options="{'widget': 'barcode', 'img_style': 'width:100%; height:35%'}"/>
+                                </div>
+                            </td>
+                        </t>
+                    </tr>
+                </t>
+            </table>
+        </div>
     </t>
 </template>
 </data>

--- a/addons/stock/report/report_lot_barcode.xml
+++ b/addons/stock/report/report_lot_barcode.xml
@@ -18,12 +18,22 @@
                                 <t t-set="o" t-value="page_docs[0]"/>
                             </t>
                             <td t-att-style="barcode_index &gt;= len(page_docs) and 'visibility:hidden'">
-                                <div t-att-style="'width:43mm; height:19mm; border: 1px solid %s;' % (o.env.user.company_id.primary_color or 'black')">
+                                <div t-att-style="'position:relative; width:43mm; height:19mm; border: 1px solid %s;' % (o.env.user.company_id.primary_color or 'black')">
                                     <div class="o_label_4x12" t-field="o.product_id.display_name"/>
                                     <div class="o_label_4x12" name="lot_name">
                                         LN/SN: <span t-field="o.name"/>
                                     </div>
-                                    <div t-field="o.name" t-options="{'widget': 'barcode', 'img_style': 'width:100%; height:35%'}"/>
+                                    <t t-if="env.user.has_group('stock.group_stock_lot_print_gs1') and env['ir.actions.report'].datamatrix_available()">
+                                        <!-- ensure we clear barcode string when multi-record print -->
+                                        <t t-set="final_barcode" t-value="''"/>
+                                        <t t-if="o.product_id.valid_ean" t-set="final_barcode" t-value="'01' + '0' * (14 - len(o.product_id.barcode)) + o.product_id.barcode"/>
+                                        <t name="gs1_datamatrix_lot" t-if="o.product_id.tracking == 'lot'" t-set="final_barcode" t-value="(final_barcode or '') + '10' + o.name"/>
+                                        <t t-elif="o.product_id.tracking == 'serial'" t-set="final_barcode" t-value="(final_barcode or '') + '21' + o.name"/>
+                                        <div t-if="final_barcode" t-att-style="'position:absolute; right:.5px; bottom:.5px'" t-out="final_barcode" t-options="{'widget': 'barcode', 'symbology': 'DataMatrix', 'width': 45, 'height': 45}"/>
+                                    </t>
+                                    <t t-else="">
+                                        <div t-field="o.name" t-options="{'widget': 'barcode', 'img_style': 'width:100%; height:35%'}"/>
+                                    </t>
                                 </div>
                             </td>
                         </t>

--- a/addons/stock/report/report_package_barcode.xml
+++ b/addons/stock/report/report_package_barcode.xml
@@ -88,5 +88,10 @@
         </t>
     </t>
 </template>
+
+<template id="report_picking_packages">
+    <t t-set="docs" t-value="docs.move_line_ids.mapped('result_package_id')"/>
+    <t t-call="stock.report_package_barcode"/>
+</template>
 </data>
 </odoo>

--- a/addons/stock/report/report_package_barcode.xml
+++ b/addons/stock/report/report_package_barcode.xml
@@ -3,6 +3,9 @@
 <data>
 <template id="report_package_barcode">
     <t t-call="web.basic_layout">
+        <!-- quantity patterns are always 3 digit codes + 1 digit for number of digits (excluding units) -->
+        <t t-set="uom_unit_id" t-value="env.ref('uom.product_uom_unit').id"/>
+        <t t-set="gs1_uom_patterns" t-value="{rule.associated_uom_id.id: rule.pattern[1:4] + str(len(str(rule.associated_uom_id.rounding).split('.')[1])) for rule in env['barcode.rule'].search([('associated_uom_id', '!=', False), ('associated_uom_id.id', '!=', uom_unit_id), ('is_gs1_nomenclature', '=', True)])}"/>
         <t t-foreach="docs" t-as="o">
             <t>
                 <div class="page">
@@ -66,6 +69,18 @@
                                 <td class="text-right" t-if="has_ean_barcode">
                                     <t t-if="l.product_id.valid_ean">
                                         <t t-set="product_barcode" t-value="'01' + '0' * (14 - len(l.product_id.barcode)) + l.product_id.barcode"/>
+                                        <t t-set="gs1_pattern" t-value="gs1_uom_patterns.get(l.product_uom_id.id, False)"/>
+                                        <t t-if="(gs1_pattern or l.product_uom_id.id == uom_unit_id) and l.quantity &gt;= 0">
+                                            <t t-if="gs1_pattern">
+                                                <t t-set="qty_str" t-value="str(int(l.quantity/l.product_uom_id.rounding))"/>
+                                                <t t-if="len(qty_str) &lt;= 6" t-set="product_barcode" t-value="product_barcode + gs1_pattern +  '0' * (6 - len(qty_str)) + qty_str"/>
+                                            </t>
+                                            <t t-else="">
+                                                <!-- GS1 have no decimal indicator for unit uom => round for now.. -->
+                                                <t t-set="qty_str" t-value="str(int(round(l.quantity)))"/>
+                                                <t t-if="len(qty_str) &lt;=8" t-set="product_barcode" t-value="product_barcode + '30' +  '0' * (8 - len(qty_str)) + qty_str"/>
+                                            </t>
+                                        </t>
                                         <!-- TODO: lot/sn ALWAYS has to be last part of barcode since left padding '0's = different sn/lot name match when scanning => fix when FNC1 can be used,  -->
                                         <t name="product_barcode_lot_datamatrix" t-if="l.product_id.tracking == 'lot' and l.lot_id" t-set="product_barcode" t-value="product_barcode + '10' + l.lot_id.name"/>
                                         <t t-elif="l.product_id.tracking == 'serial' and l.lot_id" t-set="product_barcode" t-value="product_barcode + '21' +  l.lot_id.name"/>

--- a/addons/stock/report/report_package_barcode.xml
+++ b/addons/stock/report/report_package_barcode.xml
@@ -24,14 +24,16 @@
                             <p t-field="o.package_type_id.name"/>
                         </div>
                     </div>
-                    <table class="table table-sm" style="border-bottom: 0px solid white !important;">
+                    <table class="table table-sm table-striped" style="border-bottom: 0px solid white !important;">
                         <t t-set="has_serial_number" t-value="o.quant_ids.mapped('lot_id')" />
+                        <t t-set="has_ean_barcode" t-value="env['ir.actions.report'].datamatrix_available() and any(valid_ean for valid_ean in o.quant_ids.product_id.mapped('valid_ean'))" />
                         <thead>
                             <tr>
                                 <th>Product</th>
                                 <th name="th_quantity" class="text-right">Quantity</th>
                                 <th name="th_uom" groups="uom.group_uom"/>
                                 <th name="th_serial" class="text-right" t-if="has_serial_number">Lot/Serial Number</th>
+                                <th name="th_barcode" class="text-right" t-if="has_ean_barcode"/>
                             </tr>
                         </thead>
                         <tbody>
@@ -47,6 +49,15 @@
                                 </td>
                                 <td class="text-right" t-if="has_serial_number">
                                     <t t-if="l.lot_id"><span t-field="l.lot_id.name"/></t>
+                                </td>
+                                <td class="text-right" t-if="has_ean_barcode">
+                                    <t t-if="l.product_id.valid_ean">
+                                        <t t-set="product_barcode" t-value="'01' + '0' * (14 - len(l.product_id.barcode)) + l.product_id.barcode"/>
+                                        <!-- TODO: lot/sn ALWAYS has to be last part of barcode since left padding '0's = different sn/lot name match when scanning => fix when FNC1 can be used,  -->
+                                        <t name="product_barcode_lot_datamatrix" t-if="l.product_id.tracking == 'lot' and l.lot_id" t-set="product_barcode" t-value="product_barcode + '10' + l.lot_id.name"/>
+                                        <t t-elif="l.product_id.tracking == 'serial' and l.lot_id" t-set="product_barcode" t-value="product_barcode + '21' +  l.lot_id.name"/>
+                                        <span t-out="product_barcode" t-options="{'widget': 'barcode', 'symbology': 'DataMatrix', 'width': 45, 'height': 45}"/>
+                                    </t>
                                 </td>
                             </tr>
                         </tbody>

--- a/addons/stock/report/report_package_barcode.xml
+++ b/addons/stock/report/report_package_barcode.xml
@@ -13,12 +13,25 @@
                               <h1 t-field="o.name" class="mt0 float-left"/>
                             </th>
                             <th name="td_pk_barcode" style="text-align: center">
-                                <div t-field="o.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:300px;height:50px;'}"/>
-                                <p t-field="o.name"/>
+                                <t t-if="o.valid_sscc and env['ir.actions.report'].datamatrix_available()">
+                                    <div class="row text-left">
+                                        <t t-set="barcode" t-value="'00' + o.name"/>
+                                        <t t-if="o.pack_date" t-set="barcode" t-value="barcode + '13' + o.pack_date.strftime('%y%m%d')"/>
+                                        <div class="col-3" name="datamatrix_barcode" style="margin: 0px 20px 40px 60px" t-out="barcode" t-options="{'widget': 'barcode', 'symbology': 'DataMatrix', 'width': 100, 'height': 100}"/>
+                                    </div>
+                                </t>
+                                <t t-else="">
+                                    <div t-field="o.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:300px;height:50px;'}"/>
+                                    <p t-field="o.name"/>
+                                </t>
                             </th>
                         </tr>
                     </table>
                     <div class="row mt32 mb32">
+                        <div t-if="o.pack_date" class="col-auto">
+                            <strong>Pack Date:</strong>
+                            <p t-field="o.pack_date"/>
+                        </div>
                         <div t-if="o.package_type_id" class="o_packaging_type col-auto">
                             <strong>Package Type:</strong>
                             <p t-field="o.package_type_id.name"/>
@@ -74,15 +87,30 @@
             <t>
                 <div class="page">
                     <div class="oe_structure"/>
-                    <div class="row">
-                        <div class="col-12 text-center">
-                            <div t-field="o.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:600px;height:100px;'}"/>
-                            <p t-field="o.name"  style="font-size:20px;"></p>
+                    <t t-if="o.valid_sscc and env['ir.actions.report'].datamatrix_available()">
+                        <div class="row">
+                            <t t-set="barcode" t-value="'00' + o.name"/>
+                            <t t-if="o.pack_date" t-set="barcode" t-value="barcode + '13' + o.pack_date.strftime('%y%m%d')"/>
+                            <div class="col-5 text-right" name="datamatrix_barcode" style="margin: 0px 20px 40px 60px" t-out="barcode" t-options="{'widget': 'barcode', 'symbology': 'DataMatrix', 'width': 200, 'height': 200}"/>
+                            <div class="col-7 text-left" style="font-size:20px;">
+                                <div class="row">SSCC: <span t-field="o.name"/></div>
+                                <div t-if="o.pack_date" class="row">Pack Date: <span t-field="o.pack_date"/></div>
+                                <div t-if="o.package_type_id" class="row" name="datamatrix_pack_type">Package Type: <span t-field="o.package_type_id.name"/></div>
+                            </div>
                         </div>
-                    </div>
-                    <div class="row o_packaging_type" t-if="o.package_type_id">
-                        <div class="col-12 text-center" style="font-size:24px; font-weight:bold;"><span>Package Type: </span><span t-field="o.package_type_id.name"/></div>
-                    </div>
+                    </t>
+                    <t t-else="">
+                        <div class="row">
+                            <div class="text-center col-12">
+                                <div t-field="o.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:600px;height:100px;'}"/>
+                                <div t-field="o.name" style="font-size:20px;"/>
+                            </div>
+                        </div>
+                        <div t-if="o.pack_date" class="col-12 text-center" style="font-size:24px; font-weight:bold;">Pack Date: <span t-field="o.pack_date"/></div>
+                        <div class="row o_packaging_type" t-if="o.package_type_id">
+                            <div class="col-12 text-center" style="font-size:24px; font-weight:bold;"><span>Package Type: </span><span t-field="o.package_type_id.name"/></div>
+                        </div>
+                    </t>
                 </div>
             </t>
         </t>

--- a/addons/stock/report/stock_report_views.xml
+++ b/addons/stock/report/stock_report_views.xml
@@ -21,6 +21,17 @@
             <field name="binding_model_id" ref="model_stock_picking"/>
             <field name="binding_type">report</field>
         </record>
+        <record id="action_report_picking_packages" model="ir.actions.report">
+            <field name="name">Packages</field>
+            <field name="model">stock.picking</field>
+            <field name="report_type">qweb-pdf</field>
+            <field name="report_name">stock.report_picking_packages</field>
+            <field name="report_file">stock.report_picking_packages</field>
+            <field name="print_report_name">'Packages - %s' % (object.name)</field>
+            <field name="binding_model_id" ref="model_stock_picking"/>
+            <field name="binding_type">report</field>
+            <field name="groups_id" eval="[Command.link(ref('stock.group_tracking_lot'))]"/>
+        </record>
         <record id="action_report_inventory" model="ir.actions.report">
             <field name="name">Count Sheet</field>
             <field name="model">stock.quant</field>

--- a/addons/stock/report/stock_report_views.xml
+++ b/addons/stock/report/stock_report_views.xml
@@ -65,6 +65,7 @@
             <field name="report_type">qweb-pdf</field>
             <field name="report_name">stock.report_lot_label</field>
             <field name="report_file">stock.report_lot_label</field>
+            <field name="paperformat_id" ref="product.paperformat_label_sheet"/>
             <field name="print_report_name">'Lot-Serial - %s' % object.name</field>
             <field name="binding_model_id" ref="model_stock_lot"/>
             <field name="binding_type">report</field>

--- a/addons/stock/security/ir.model.access.csv
+++ b/addons/stock/security/ir.model.access.csv
@@ -88,3 +88,5 @@ access_stock_inventory_warning,stock.inventory.warning,model_stock_inventory_war
 access_stock_inventory_adjustment_name,stock.inventory.adjustment.name,model_stock_inventory_adjustment_name,stock.group_stock_manager,1,1,1,0
 access_stock_request_count,stock.request.count,model_stock_request_count,stock.group_stock_manager,1,1,1,0
 access_stock_replenishment_info,stock.replenishment.info,model_stock_replenishment_info,stock.group_stock_manager,1,1,1,0
+access_stock_picking_label_type_user,picking.label.type.user,model_picking_label_type,stock.group_stock_user,1,1,1,0
+access_stock_lot_label_layout_user,lot.label.layout.user,model_lot_label_layout,stock.group_stock_user,1,1,1,0

--- a/addons/stock/security/stock_security.xml
+++ b/addons/stock/security/stock_security.xml
@@ -34,6 +34,11 @@
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 
+    <record id="group_stock_lot_print_gs1" model="res.groups">
+        <field name="name">Print GS1 Barcodes for Lot &amp; Serial Numbers</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+    </record>
+
     <record id="group_lot_on_delivery_slip" model="res.groups">
         <field name="name">Display Serial &amp; Lot Number in Delivery Slips</field>
         <field name="category_id" ref="base.module_category_hidden"/>

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -335,6 +335,13 @@
                                     <div class="text-muted">
                                         Get a full traceability from vendors to customers
                                     </div>
+                                    <div class="row mt-2" attrs="{'invisible': [('group_stock_production_lot','=',False)]}">
+                                        <field name="group_stock_lot_print_gs1" class="col-lg-1 ml16 mr0"/>
+                                        <div class="col pl-0">
+                                            <label for="group_stock_lot_print_gs1"/>
+                                            <div class="text-muted">Use GS1 nomenclature datamatrix whenever barcodes are printed for lots and serial numbers. Printing datamatrix requires extra software. If software can't be found then 1D barcodes will be printed.</div>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                             <div class="col-12 col-lg-6 o_setting_box"

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -253,7 +253,7 @@
                             attrs="{'invisible': ['|', '|', ('id', '=', False), ('picking_type_code', '!=', 'outgoing'), ('state', '=', 'done')]}"
                             full_name="partner_id" groups="stock.group_stock_sign_delivery"/>
                     <button name="do_print_picking" string="Print" groups="stock.group_stock_user" type="object" attrs="{'invisible': [('state', '!=', 'assigned')]}" data-hotkey="o"/>
-                    <button string="Print Labels" type="object" name="action_open_label_layout"/>
+                    <button string="Print Labels" type="object" name="action_open_label_type"/>
                     <button name="%(action_report_delivery)d" string="Print" attrs="{'invisible': [('state', '!=', 'done')]}" type="action" groups="base.group_user" data-hotkey="o"/>
                     <button name="%(act_stock_return_picking)d" string="Return" attrs="{'invisible': [('state', '!=', 'done')]}" type="action" groups="base.group_user" data-hotkey="k"/>
                     <button name="do_unreserve" string="Unreserve" groups="base.group_user" type="object" attrs="{'invisible': ['|', '|', '|', ('picking_type_code', '=', 'incoming'), ('immediate_transfer', '=', True), '&amp;', ('state', '!=', 'assigned'), ('move_type', '!=', 'one'), '&amp;', ('state', 'not in', ('assigned', 'confirmed')), ('move_type', '=', 'one')]}" data-hotkey="w"/>

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -227,11 +227,14 @@
                         <h1><field name="name" class="oe_inline" placeholder="e.g. PACK0000007"/></h1>
                     </div>
                     <group>
-                        <group id='stock.package_location_group'>
+                        <group>
                             <field name="package_type_id"/>
                             <field name='company_id' groups="base.group_multi_company"/>
                             <field name='owner_id' groups="stock.group_tracking_owner"/>
                             <field name="location_id" options="{'no_create': True}"/>
+                        </group>
+                        <group>
+                            <field name="pack_date"/>
                         </group>
                     </group>
                     <separator string="Content"/>

--- a/addons/stock/wizard/__init__.py
+++ b/addons/stock/wizard/__init__.py
@@ -8,6 +8,8 @@ from . import stock_change_product_qty
 from . import stock_inventory_conflict
 from . import stock_inventory_warning
 from . import stock_inventory_adjustment_name
+from . import stock_label_type
+from . import stock_lot_label_layout
 from . import stock_scheduler_compute
 from . import stock_immediate_transfer
 from . import stock_backorder_confirmation

--- a/addons/stock/wizard/stock_label_type.py
+++ b/addons/stock/wizard/stock_label_type.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, fields, models
+
+
+class ProductLabelLayout(models.TransientModel):
+    _name = 'picking.label.type'
+    _description = 'Choose whether to print product or lot/sn labels'
+
+    picking_ids = fields.Many2many('stock.picking')
+    label_type = fields.Selection([
+        ('products', 'Product Labels'),
+        ('lots', 'Lot/SN Labels')], string="Labels to print", required=True, default='products')
+
+    def process(self):
+        if self.label_type == 'products':
+            return self.picking_ids.action_open_label_layout()
+        view = self.env.ref('stock.lot_label_layout_form_picking')
+        return {
+            'name': _('Choose Labels Layout'),
+            'type': 'ir.actions.act_window',
+            'res_model': 'lot.label.layout',
+            'views': [(view.id, 'form')],
+            'target': 'new',
+            'context': {'default_picking_ids': self.picking_ids.ids},
+        }

--- a/addons/stock/wizard/stock_label_type.xml
+++ b/addons/stock/wizard/stock_label_type.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="picking_label_type_form" model="ir.ui.view">
+        <field name="name">picking.label.type.form</field>
+        <field name="model">picking.label.type</field>
+        <field name="mode">primary</field>
+        <field name="priority">25</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <field name="label_type" widget="radio"/>
+                </group>
+                <footer>
+                    <button name="process" string="Confirm" type="object" class="btn-primary" data-hotkey="q"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="z"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/stock/wizard/stock_lot_label_layout.py
+++ b/addons/stock/wizard/stock_lot_label_layout.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from collections import defaultdict
+from odoo import fields, models
+
+
+class ProductLabelLayout(models.TransientModel):
+    _name = 'lot.label.layout'
+    _description = 'Choose the sheet layout to print lot labels'
+
+    picking_ids = fields.Many2many('stock.picking')
+    label_quantity = fields.Selection([
+        ('lots', 'One per lot/SN'),
+        ('units', 'One per unit')], string="Quantity to print", required=True, default='lots')
+    print_format = fields.Selection([
+        ('4x12', '4 x 12'),
+        ('zpl', 'ZPL Labels')], string="Format", default='4x12', required=True)
+
+    def process(self):
+        self.ensure_one()
+        xml_id = 'stock.action_report_lot_label'
+        if self.print_format == 'zpl':
+            xml_id = 'stock.label_lot_template'
+        if self.label_quantity == 'lots':
+            docids = self.picking_ids.move_line_ids.lot_id.ids
+        else:
+            uom_categ_unit = self.env.ref('uom.product_uom_categ_unit')
+            quantity_by_lot = defaultdict(int)
+            for move_line in self.picking_ids.move_line_ids:
+                if not move_line.lot_id:
+                    continue
+                if move_line.product_uom_id.category_id == uom_categ_unit:
+                    quantity_by_lot[move_line.lot_id.id] += int(move_line.qty_done)
+                else:
+                    quantity_by_lot[move_line.lot_id.id] += 1
+            docids = []
+            for lot_id, qty in quantity_by_lot.items():
+                docids.append([lot_id] * qty)
+        report_action = self.env.ref(xml_id).report_action(docids)
+        report_action.update({'close_on_report_download': True})
+        return report_action

--- a/addons/stock/wizard/stock_lot_label_layout.xml
+++ b/addons/stock/wizard/stock_lot_label_layout.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="lot_label_layout_form_picking" model="ir.ui.view">
+        <field name="name">lot.label.layout.form</field>
+        <field name="model">lot.label.layout</field>
+        <field name="mode">primary</field>
+        <field name="priority">25</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <field name="label_quantity" widget="radio"/>
+                    <field name="print_format" widget="radio"/>
+                </group>
+                <footer>
+                    <button name="process" string="Confirm" type="object" class="btn-primary" data-hotkey="q"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="z"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -280,6 +280,16 @@ class StockPickingBatch(models.Model):
         return action
 
     def action_open_label_layout(self):
+        if self.user_has_groups('stock.group_production_lot') and self.move_line_ids.lot_id:
+            view = self.env.ref('stock.picking_label_type_form')
+            return {
+                'name': _('Choose Type of Labels To Print'),
+                'type': 'ir.actions.act_window',
+                'res_model': 'picking.label.type',
+                'views': [(view.id, 'form')],
+                'target': 'new',
+                'context': {'default_picking_ids': self.picking_ids.ids},
+            }
         view = self.env.ref('stock.product_label_layout_form_picking')
         return {
             'name': _('Choose Labels Layout'),

--- a/addons/uom/data/uom_data.xml
+++ b/addons/uom/data/uom_data.xml
@@ -149,6 +149,12 @@
         <field name="factor">3.28084</field>
         <field name="uom_type">smaller</field>
     </record>
+    <record id="product_uom_yard" model="uom.uom">
+        <field name="name">yd</field>
+        <field name="category_id" ref="uom_categ_length"/>
+        <field name="factor">1.09361</field>
+        <field name="uom_type">smaller</field>
+    </record>
     <record id="product_uom_mile" model="uom.uom">
         <field name="name">mi</field>
         <field name="category_id" ref="uom_categ_length"/>


### PR DESCRIPTION
This PR does a few things:

GS1 / Datamatrix (DM) related parts: 
- Adds in ability to print DM barcode (note: still requires additional package installation to work correctly)
- Adds UoM GS1 rules + yard UoM (note: some Odoo UoMs are not supported by GS1 and will not print in GS1 DMs)
- Print product GS1 barcodes in "Package Barcode with Content" report (note: only when product barcode is EAN compliant + prints additional info when applicable in this case)
- Include product UoM in DM in "Package Barcode with Content" report when valid product GS1 (note: number of digits, including precision digits, are limited in GS1 and will not print in GS1 DM if too long) 
- Add option to print GS1 DMs for Lot/SN labels (note: will only include product in GS1 barcode if EAN compliant)
- Print GS1 SSCC DM for packages when package name is a valid SSCC number (note: for reports: Package with Content, Package Barcode (PDF), and Package Barcode (ZPL))

Label improvements related parts:
- Make Lot/SN label PDF reports match ZPL layout and also follow 4x12 format (same as product label 4x12 layout)
- Allow printing "Package Barcode with Content" directly from picking
- Make MRP "Finish Product Labels" (PDF) print in standard 4x12 layout (previously was a non-standard format)
- Fix MRP label (ZPL) so that a valid zpl is always created regardless of barcode/tracking status
- Add new wizard to print a pickings' SN/Lot labels (via existing "Print Label" button)

See individual commits for additional details for each part's implementations.

ENT PR: odoo/enterprise#23323
Upgrade PR: odoo/upgrade#3202

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
