### PR TITLE
[FIX] sale_coupon: check coupon's date with present time

### DIFF
--- a/addons/sale_coupon/models/sale_coupon.py
+++ b/addons/sale_coupon/models/sale_coupon.py
@@ -54,7 +54,7 @@ class SaleCoupon(models.Model):
         message = {}
         applicable_programs = order._get_applicable_programs()
         if self.state in ('used', 'expired') or \
-           (self.expiration_date and self.expiration_date < order.date_order.date()):
+           (self.expiration_date and self.expiration_date < fields.Datetime.now().date()):
             message = {'error': _('This coupon %s has been used or is expired.') % (self.code)}
         elif self.state == 'reserved':
             message = {'error': _('This coupon %s exists but the origin sales order is not validated yet.') % (self.code)}

--- a/addons/sale_coupon/models/sale_coupon_program.py
+++ b/addons/sale_coupon/models/sale_coupon_program.py
@@ -173,7 +173,7 @@ class SaleCouponProgram(models.Model):
             message = {'error': _('The promotional offer is already applied on this order')}
         elif not self.active:
             message = {'error': _('Promo code is invalid')}
-        elif self.rule_date_from and self.rule_date_from > order.date_order or self.rule_date_to and order.date_order > self.rule_date_to:
+        elif self.rule_date_from and self.rule_date_from > fields.Datetime.now() or self.rule_date_to and fields.Datetime.now() > self.rule_date_to:
             message = {'error': _('Promo code is expired')}
         elif order.promo_code and self.promo_code_usage == 'code_needed':
             message = {'error': _('Promotionals codes are not cumulative.')}
@@ -226,9 +226,9 @@ class SaleCouponProgram(models.Model):
     @api.model
     def _filter_on_validity_dates(self, order):
         return self.filtered(lambda program:
-            (not program.rule_date_from or program.rule_date_from <= order.date_order)
+            (not program.rule_date_from or program.rule_date_from <= fields.Datetime.now())
             and
-            (not program.rule_date_to or program.rule_date_to >= order.date_order)
+            (not program.rule_date_to or program.rule_date_to >= fields.Datetime.now())
         )
 
     @api.model

--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -282,8 +282,8 @@ class SaleOrder(models.Model):
             no_outdated_coupons=True
         ).search([
             ('company_id', 'in', [self.company_id.id, False]),
-            '|', ('rule_date_from', '=', False), ('rule_date_from', '<=', self.date_order),
-            '|', ('rule_date_to', '=', False), ('rule_date_to', '>=', self.date_order),
+            '|', ('rule_date_from', '=', False), ('rule_date_from', '<=', fields.Datetime.now()),
+            '|', ('rule_date_to', '=', False), ('rule_date_to', '>=', fields.Datetime.now()),
         ], order="id")._filter_programs_from_common_rules(self)
         # no impact code...
         # should be programs = programs.filtered if we really want to filter...
@@ -298,8 +298,8 @@ class SaleOrder(models.Model):
             applicable_coupon=True,
         ).search([
             ('promo_code_usage', '=', 'no_code_needed'),
-            '|', ('rule_date_from', '=', False), ('rule_date_from', '<=', self.date_order),
-            '|', ('rule_date_to', '=', False), ('rule_date_to', '>=', self.date_order),
+            '|', ('rule_date_from', '=', False), ('rule_date_from', '<=', fields.Datetime.now()),
+            '|', ('rule_date_to', '=', False), ('rule_date_to', '>=', fields.Datetime.now()),
             '|', ('company_id', '=', self.company_id.id), ('company_id', '=', False),
         ])._filter_programs_from_common_rules(self)
         return programs


### PR DESCRIPTION
Before this commit: a coupon's start and end dates were compared with
the order date. When a customer adds a product to the cart, it creates
an order on the website. If the customer makes an order, it will remain
active until he completes it, even when the coupon is expired.

To reproduce the problem, add a product to the cart, create a coupon,
and set its end date to present time. Now you can use the coupon after
the end date has passed. So it's better to check the date with the
current time.

opw-2711987
