### PR TITLE
[IMP] payment: filter out acquirers based on the amount

### DIFF
--- a/addons/account_payment/controllers/portal.py
+++ b/addons/account_payment/controllers/portal.py
@@ -23,7 +23,7 @@ class PortalAccount(portal.PortalAccount):
         PaymentPortal._ensure_matching_companies(partner, invoice_company)
 
         acquirers_sudo = request.env['payment.acquirer'].sudo()._get_compatible_acquirers(
-            invoice_company.id, partner.id, currency_id=invoice.currency_id.id
+            invoice_company.id, partner.id, invoice.amount_total, currency_id=invoice.currency_id.id
         )  # In sudo mode to read the fields of acquirers and partner (if not logged in)
         tokens = request.env['payment.token'].search(
             [('acquirer_id', 'in', acquirers_sudo.ids), ('partner_id', '=', partner.id)]

--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -122,7 +122,7 @@ class PaymentPortal(portal.CustomerPortal):
 
         # Select all acquirers and tokens that match the constraints
         acquirers_sudo = request.env['payment.acquirer'].sudo()._get_compatible_acquirers(
-            company_id, partner_sudo.id, currency_id=currency.id, **kwargs
+            company_id, partner_sudo.id, amount, currency_id=currency.id, **kwargs
         )  # In sudo mode to read the fields of acquirers and partner (if not logged in)
         if acquirer_id in acquirers_sudo.ids:  # Only keep the desired acquirer if it's suitable
             acquirers_sudo = acquirers_sudo.browse(acquirer_id)
@@ -193,7 +193,11 @@ class PaymentPortal(portal.CustomerPortal):
         """
         partner_sudo = request.env.user.partner_id  # env.user is always sudoed
         acquirers_sudo = request.env['payment.acquirer'].sudo()._get_compatible_acquirers(
-            request.env.company.id, partner_sudo.id, force_tokenization=True, is_validation=True
+            request.env.company.id,
+            partner_sudo.id,
+            0.,  # There is no amount to pay with validation transactions.
+            force_tokenization=True,
+            is_validation=True,
         )
 
         # Get all partner's tokens for which acquirers are not disabled.

--- a/addons/payment/tests/test_payment_acquirer.py
+++ b/addons/payment/tests/test_payment_acquirer.py
@@ -9,28 +9,61 @@ from odoo.addons.payment.tests.common import PaymentCommon
 class TestPaymentAcquirer(PaymentCommon):
 
     def test_published_acquirer_compatible_with_all_users(self):
+        """ Test that a published acquirer is always available to all users. """
         for user in (self.public_user, self.portal_user):
             self.env = self.env(user=user)
 
             compatible_acquirers = self.env['payment.acquirer'].sudo()._get_compatible_acquirers(
-                self.company.id, self.partner.id
+                self.company.id, self.partner.id, self.amount
             )
-        self.assertIn(self.acquirer, compatible_acquirers)
+            self.assertIn(self.acquirer, compatible_acquirers)
 
     def test_unpublished_acquirer_compatible_with_internal_user(self):
+        """ Test that an unpublished acquirer is still available to internal users. """
         self.acquirer.is_published = False
 
         compatible_acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
-            self.company.id, self.partner.id
+            self.company.id, self.partner.id, self.amount
         )
         self.assertIn(self.acquirer, compatible_acquirers)
 
     def test_unpublished_acquirer_not_compatible_with_non_internal_user(self):
+        """ Test that an unpublished acquirer is not available to non-internal users. """
         self.acquirer.is_published = False
         for user in (self.public_user, self.portal_user):
             self.env = self.env(user=user)
 
             compatible_acquirers = self.env['payment.acquirer'].sudo()._get_compatible_acquirers(
-                self.company.id, self.partner.id
+                self.company.id, self.partner.id, self.amount
             )
+            self.assertNotIn(self.acquirer, compatible_acquirers)
+
+    def test_acquirer_compatible_when_maximum_amount_is_zero(self):
+        """ Test that the maximum amount has no effect on the acquirer's compatibility when it is
+        set to 0. """
+        self.acquirer.maximum_amount = 0.
+
+        compatible_acquirers = self.acquirer._get_compatible_acquirers(
+            self.company.id, self.partner.id, self.amount, currency_id=self.currency.id
+        )
+        self.assertIn(self.acquirer, compatible_acquirers)
+
+    def test_acquirer_compatible_when_payment_below_maximum_amount(self):
+        """ Test that an acquirer is compatible when the payment amount is less than the maximum
+        amount. """
+        self.acquirer.maximum_amount = self.amount + 10.0
+
+        compatible_acquirers = self.acquirer._get_compatible_acquirers(
+            self.company.id, self.partner.id, self.amount, currency_id=self.currency.id
+        )
+        self.assertIn(self.acquirer, compatible_acquirers)
+
+    def test_acquirer_not_compatible_when_payment_above_maximum_amount(self):
+        """ Test that an acquirer is not compatible when the payment amount is more than the maximum
+        amount. """
+        self.acquirer.maximum_amount = self.amount - 10.0
+
+        compatible_acquirers = self.acquirer._get_compatible_acquirers(
+            self.company.id, self.partner.id, self.amount, currency_id=self.currency.id
+        )
         self.assertNotIn(self.acquirer, compatible_acquirers)

--- a/addons/payment/views/payment_acquirer_views.xml
+++ b/addons/payment/views/payment_acquirer_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <form string="Payment Acquirer">
                 <field name="is_published" invisible="1"/>
+                <field name="main_currency_id" invisible="1"/>
                 <field name="support_fees" invisible="1"/>
                 <field name="support_manual_capture" invisible="1"/>
                 <field name="support_tokenization" invisible="1"/>
@@ -82,7 +83,11 @@
                                     <field name="capture_manually" attrs="{'invisible': [('support_manual_capture', '=', False)]}"/>
                                 </group>
                                 <group string="Availability" name="availability">
-                                    <field name="country_ids" widget="many2many_tags" placeholder="Select countries. Leave empty to use everywhere." options="{'no_open': True, 'no_create': True}"/>
+                                    <field name="maximum_amount" widget="monetary" options="{'currency_field': 'main_currency_id'}"/>
+                                    <field name="available_country_ids"
+                                           widget="many2many_tags"
+                                           placeholder="Select countries. Leave empty to make available everywhere."
+                                           options="{'no_open': True, 'no_create': True}"/>
                                 </group>
                                 <group string="Payment Followup" name="payment_followup">
                                     <field name="journal_id" context="{'default_type': 'bank'}"
@@ -125,7 +130,7 @@
                 <field name="name"/>
                 <field name="provider"/>
                 <field name="state"/>
-                <field name="country_ids" widget="many2many_tags" optional="hide"/>
+                <field name="available_country_ids" widget="many2many_tags" optional="hide"/>
                 <field name="company_id" groups="base.group_multi_company" optional="show"/>
             </tree>
         </field>

--- a/addons/payment/views/payment_portal_templates.xml
+++ b/addons/payment/views/payment_portal_templates.xml
@@ -6,7 +6,7 @@
         <xpath expr="//div[hasclass('o_portal_my_details')]" position="inside">
             <t t-set="partner" t-value="request.env.user.partner_id"/>
             <t t-set="acquirers_allowing_tokenization"
-               t-value="request.env['payment.acquirer'].sudo()._get_compatible_acquirers(request.env.company.id, partner.id, allow_tokenization=True, is_validation=True)"/>
+               t-value="request.env['payment.acquirer'].sudo()._get_compatible_acquirers(request.env.company.id, partner.id, 0., allow_tokenization=True, is_validation=True)"/>
             <t t-set="existing_tokens" t-value="partner.payment_token_ids + partner.commercial_partner_id.sudo().payment_token_ids"/>
             <!-- Only show the link if a token can be created or if one already exists -->
             <div t-if="acquirers_allowing_tokenization or existing_tokens"

--- a/addons/payment/wizards/payment_link_wizard.py
+++ b/addons/payment/wizards/payment_link_wizard.py
@@ -91,6 +91,7 @@ class PaymentLinkWizard(models.TransientModel):
                 res_id=link.res_id,
                 company_id=link.company_id.id,
                 partner_id=link.partner_id.id,
+                amount=link.amount,
                 currency_id=link.currency_id.id,
             )
 
@@ -115,6 +116,7 @@ class PaymentLinkWizard(models.TransientModel):
                     res_id=res_id,
                     company_id=company_id.id,
                     partner_id=partner_id.id,
+                    amount=related_document.amount_total,
                     currency_id=currency_id.id,
                 ).name_get()
             )

--- a/addons/payment_alipay/tests/test_alipay.py
+++ b/addons/payment_alipay/tests/test_alipay.py
@@ -19,29 +19,21 @@ class AlipayTest(AlipayCommon, PaymentHttpCommon):
     def test_compatible_acquirers(self):
         self.alipay.alipay_payment_method = 'express_checkout'
         acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
-            partner_id=self.partner.id,
-            currency_id=self.currency_yuan.id,  # 'CNY'
-            company_id=self.company.id,
+            self.company.id, self.partner.id, self.amount, currency_id=self.currency_yuan.id
         )
         self.assertIn(self.alipay, acquirers)
         acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
-            partner_id=self.partner.id,
-            currency_id=self.currency_euro.id,
-            company_id=self.company.id,
+            self.company.id, self.partner.id, self.amount, currency_id=self.currency_euro.id
         )
         self.assertNotIn(self.alipay, acquirers)
 
         self.alipay.alipay_payment_method = 'standard_checkout'
         acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
-            partner_id=self.partner.id,
-            currency_id=self.currency_yuan.id,  # 'CNY'
-            company_id=self.company.id,
+            self.company.id, self.partner.id, self.amount, currency_id=self.currency_yuan.id
         )
         self.assertIn(self.alipay, acquirers)
         acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
-            partner_id=self.partner.id,
-            currency_id=self.currency_euro.id,
-            company_id=self.company.id,
+            self.company.id, self.partner.id, self.amount, currency_id=self.currency_euro.id
         )
         self.assertIn(self.alipay, acquirers)
 

--- a/addons/payment_authorize/tests/test_authorize.py
+++ b/addons/payment_authorize/tests/test_authorize.py
@@ -17,14 +17,12 @@ class AuthorizeTest(AuthorizeCommon):
         # Note: in the test common, 'USD' is specified as authorize_currency_id
         unsupported_currency = self._prepare_currency('CHF')
         acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
-            partner_id=self.partner.id,
-            currency_id=unsupported_currency.id,
-            company_id=self.company.id)
+            self.company.id, self.partner.id, self.amount, currency_id=unsupported_currency.id
+        )
         self.assertNotIn(self.authorize, acquirers)
         acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
-            partner_id=self.partner.id,
-            currency_id=self.currency_usd.id,
-            company_id=self.company.id)
+            self.company.id, self.partner.id, self.amount, currency_id=self.currency_usd.id
+        )
         self.assertIn(self.authorize, acquirers)
 
     def test_processing_values(self):

--- a/addons/payment_authorize/views/payment_views.xml
+++ b/addons/payment_authorize/views/payment_views.xml
@@ -27,7 +27,7 @@
                 <field name="authorize_payment_method_type"
                        attrs="{'invisible': [('provider', '!=', 'authorize')], 'required':[('provider', '=', 'authorize'), ('state', '!=', 'disabled')]}"/>
             </field>
-            <xpath expr="//field[@name='country_ids']" position="after">
+            <xpath expr="//field[@name='available_country_ids']" position="after">
                 <label for="authorize_currency_id" string="Currency" attrs="{'invisible': [('provider', '!=', 'authorize')]}"/>
                 <div attrs="{'invisible': [('provider', '!=', 'authorize')]}">
                     <field name="authorize_currency_id"/>

--- a/addons/payment_flutterwave/tests/test_payment_acquirer.py
+++ b/addons/payment_flutterwave/tests/test_payment_acquirer.py
@@ -10,13 +10,13 @@ class TestPaymentAcquirer(FlutterwaveCommon):
 
     def test_incompatible_with_unsupported_currencies(self):
         compatible_acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
-            self.company_id, self.partner.id, currency_id=self.env.ref('base.AFN').id
+            self.company_id, self.partner.id, self.amount, currency_id=self.env.ref('base.AFN').id
         )
         self.assertNotIn(self.flutterwave, compatible_acquirers)
 
     def test_incompatible_with_validation_transactions(self):
         compatible_acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
-            self.company_id, self.partner.id, is_validation=True
+            self.company_id, self.partner.id, 0., is_validation=True
         )
         self.assertNotIn(self.flutterwave, compatible_acquirers)
 

--- a/addons/payment_ogone/tests/test_ogone.py
+++ b/addons/payment_ogone/tests/test_ogone.py
@@ -20,7 +20,7 @@ class OgoneTest(OgoneCommon, PaymentHttpCommon):
 
     def test_incompatibility_with_validation_operation(self):
         acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
-            self.company.id, self.partner.id, is_validation=True
+            self.company.id, self.partner.id, 0., is_validation=True
         )
         self.assertNotIn(self.ogone, acquirers)
 

--- a/addons/payment_payulatam/tests/test_payulatam.py
+++ b/addons/payment_payulatam/tests/test_payulatam.py
@@ -24,14 +24,14 @@ class PayULatamTest(PayULatamCommon, PaymentHttpCommon):
         for supported_currency_code in SUPPORTED_CURRENCIES:
             supported_currency = self._prepare_currency(supported_currency_code)
             compatible_acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
-                self.company.id, self.partner.id, currency_id=supported_currency.id,
+                self.company.id, self.partner.id, self.amount, currency_id=supported_currency.id
             )
             self.assertIn(self.payulatam, compatible_acquirers)
 
     def test_incompatibility_with_unsupported_currency(self):
         """ Test that the PayULatam acquirer is not compatible with an unsupported currency. """
         compatible_acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
-            self.company.id, self.partner.id, currency_id=self.currency_euro.id,
+            self.company.id, self.partner.id, self.amount, currency_id=self.currency_euro.id
         )
         self.assertNotIn(self.payulatam, compatible_acquirers)
 

--- a/addons/payment_payumoney/tests/test_payumoney.py
+++ b/addons/payment_payumoney/tests/test_payumoney.py
@@ -16,16 +16,12 @@ class PayUMoneyTest(PayumoneyCommon, PaymentHttpCommon):
 
     def test_compatible_acquirers(self):
         acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
-            partner_id=self.partner.id,
-            company_id=self.company.id,
-            currency_id=self.currency.id,
+            self.company.id, self.partner.id, self.amount, currency_id=self.currency.id
         )
         self.assertIn(self.payumoney, acquirers)
 
         acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
-            partner_id=self.partner.id,
-            company_id=self.company.id,
-            currency_id=self.currency_euro.id,
+            self.company.id, self.partner.id, self.amount, currency_id=self.currency_euro.id
         )
         self.assertNotIn(self.payumoney, acquirers)
 

--- a/addons/payment_sips/tests/test_sips.py
+++ b/addons/payment_sips/tests/test_sips.py
@@ -23,17 +23,13 @@ class SipsTest(SipsCommon, PaymentHttpCommon):
         for curr in SUPPORTED_CURRENCIES:
             currency = self._prepare_currency(curr)
             acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
-                partner_id=self.partner.id,
-                company_id=self.company.id,
-                currency_id=currency.id,
+                self.company.id, self.partner.id, self.amount, currency_id=currency.id
             )
             self.assertIn(self.sips, acquirers)
 
         unsupported_currency = self._prepare_currency('VEF')
         acquirers = self.env['payment.acquirer']._get_compatible_acquirers(
-            partner_id=self.partner.id,
-            company_id=self.company.id,
-            currency_id=unsupported_currency.id,
+            self.company.id, self.partner.id, self.amount, currency_id=unsupported_currency.id
         )
         self.assertNotIn(self.sips, acquirers)
 

--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -166,6 +166,7 @@ class CustomerPortal(portal.CustomerPortal):
             acquirers_sudo = request.env['payment.acquirer'].sudo()._get_compatible_acquirers(
                 order_sudo.company_id.id,
                 order_sudo.partner_id.id,
+                order_sudo.amount_total,
                 currency_id=order_sudo.currency_id.id,
                 sale_order_id=order_sudo.id,
             )  # In sudo mode to read the fields of acquirers and partner (if not logged in)

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1014,6 +1014,7 @@ class WebsiteSale(http.Controller):
         acquirers_sudo = request.env['payment.acquirer'].sudo()._get_compatible_acquirers(
             order.company_id.id,
             order.partner_id.id,
+            order.amount_total,
             currency_id=order.currency_id.id,
             sale_order_id=order.id,
             website_id=request.website.id,


### PR DESCRIPTION
This commit adds the possibility to define a maximum payment amount that
a given acquirer can process. If the payment amount exceeds the value,
the acquirer is filtered out of the available acquirers listed on the
payment forms.

While we're at it, the field `country_ids` is renamed to
`available_country_ids` to better depict that it is not a property of
the acquirer, but a configuration option. It will also be coherent with
the field `available_currency_ids` that is expected to be added soon.

Task - 2162165

See also:
- https://github.com/odoo/enterprise/pull/24412
- https://github.com/odoo/documentation/pull/1835
- https://github.com/odoo/upgrade/pull/3703