### PR TITLE
[FIX] web: see detailed KPI views in 'dev' mode

### DIFF
--- a/addons/web/static/src/views/graph/graph_view.js
+++ b/addons/web/static/src/views/graph/graph_view.js
@@ -143,6 +143,7 @@ GraphView.props = {
     additionalMeasures: { type: Array, elements: String, optional: true },
     displayGroupByMenu: { type: Boolean, optional: true },
     displayScaleLabels: { type: Boolean, optional: true },
+    additional_context: { type: Object, elements: String, optional: true },
 };
 
 GraphView.type = "graph";

--- a/addons/web/static/src/views/pivot/pivot_view.js
+++ b/addons/web/static/src/views/pivot/pivot_view.js
@@ -162,6 +162,7 @@ PivotView.components = { Renderer: PivotRenderer, Layout };
 PivotView.props = {
     ...standardViewProps,
     additionalMeasures: { type: Array, elements: String, optional: 1 },
+    additional_context: { type: Object, elements: String, optional: 1 },
 };
 PivotView.defaultProps = {
     additionalMeasures: [],


### PR DESCRIPTION
Error when trying to open detailed analysis of Revenue KPIs in 'dev' mode

Steps to reproduce:
1. Install Subscriptions app
2. Put yourself in debug (either 1 or assets)
3. Go to Subscriptions -> Reporting -> Revenue KPIs -> Monthly Recurring Revenue (or Net Revenue, Non-Recurring Revenue)
4. Click on the button 'Detailed Analysis'
5. An error is thrown : Unknown prop 'additional_context' given to component 'PivotView'

Solution:
Add 'additional_context' to PivotView and GraphView props

OPW-2716646