### PR TITLE
[FIX] stock_landed_costs: fix `MemoryError` on m2m compute

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -82,6 +82,9 @@ class LandedCost(models.Model):
 
     @api.depends('company_id')
     def _compute_allowed_picking_ids(self):
+        # Backport of f329de26: allowed_picking_ids is useless, view_stock_landed_cost_form no longer uses it,
+        # the field and its compute are kept since this is a stable version. Still, this compute has been made
+        # more resilient to MemoryErrors.
         valued_picking_ids_per_company = defaultdict(list)
         if self.company_id:
             self.env.cr.execute("""SELECT sm.picking_id, sm.company_id
@@ -92,7 +95,10 @@ class LandedCost(models.Model):
             for res in self.env.cr.fetchall():
                 valued_picking_ids_per_company[res[1]].append(res[0])
         for cost in self:
-            cost.allowed_picking_ids = valued_picking_ids_per_company[cost.company_id.id]
+            n = 5000
+            cost.allowed_picking_ids = valued_picking_ids_per_company[cost.company_id.id][:n]
+            for ids_chunk in tools.split_every(n, valued_picking_ids_per_company[cost.company_id.id][n:]):
+                cost.allowed_picking_ids = tuple((4, id_) for id_ in ids_chunk)
 
     @api.model
     def create(self, vals):

--- a/addons/stock_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/stock_landed_costs/views/stock_landed_cost_views.xml
@@ -29,8 +29,8 @@
                         <group>
                             <group>
                                 <field name="date"/>
-                                <field name="allowed_picking_ids" invisible="1"/>
-                                <field name="picking_ids" widget="many2many_tags" options="{'no_create_edit': True}" domain="[('id', 'in', allowed_picking_ids)]"/>
+                                <field name="picking_ids" widget="many2many_tags" options="{'no_create_edit': True}"
+                                       domain="[('company_id', '=', company_id), ('move_lines.stock_valuation_layer_ids', '!=', False)]"/>
                             </group>
                             <group>
                                 <label for="account_journal_id" string="Journal"/>


### PR DESCRIPTION
Backport of f329de26.

When there are millions of records in stock_picking table the compute of
alowed_picking_ids may fail with `MemoryError`. This field is only used
on the view view_stock_landed_cost_form thus after this patch it will be
useless. We keep it, but also fix its compute, to not touch the
interface of a stable version.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
