### PR TITLE
[IMP] mrp : split / merge manufacturing orders

### DIFF
--- a/addons/mrp/__manifest__.py
+++ b/addons/mrp/__manifest__.py
@@ -24,6 +24,7 @@
         'wizard/mrp_consumption_warning_views.xml',
         'wizard/mrp_immediate_production_views.xml',
         'wizard/stock_assign_serial_numbers.xml',
+        'wizard/mrp_production_split.xml',
         'views/mrp_views_menus.xml',
         'views/stock_move_views.xml',
         'views/mrp_workorder_views.xml',

--- a/addons/mrp/security/ir.model.access.csv
+++ b/addons/mrp/security/ir.model.access.csv
@@ -58,3 +58,6 @@ access_mrp_immediate_production,access.mrp.immediate.production,model_mrp_immedi
 access_mrp_immediate_production_line,access.mrp.immediate.production.line,model_mrp_immediate_production_line,mrp.group_mrp_user,1,1,1,0
 access_mrp_workcenter_tag_group_user,access.mrp.workcenter.tag,model_mrp_workcenter_tag,mrp.group_mrp_user,1,0,0,0
 access_mrp_workcenter_tag_manager,access.mrp.workcenter.tag,model_mrp_workcenter_tag,mrp.group_mrp_manager,1,1,1,1
+access_mrp_production_split_multi,access.mrp.production.split.multi,model_mrp_production_split_multi,mrp.group_mrp_user,1,1,1,0
+access_mrp_production_split,access.mrp.production.split,model_mrp_production_split,mrp.group_mrp_user,1,1,1,0
+access_mrp_production_split_line,access.mrp.production.split.line,model_mrp_production_split_line,mrp.group_mrp_user,1,1,1,1

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -47,14 +47,22 @@
             </field>
         </record>
 
-        <record id="production_order_server_action" model="ir.actions.server">
-            <field name="name">Mrp: Plan Production Orders</field>
+        <record id="action_production_order_split" model="ir.actions.server">
+            <field name="name">Split</field>
+            <field name="model_id" ref="mrp.model_mrp_production"/>
+            <field name="binding_model_id" ref="mrp.model_mrp_production"/>
+            <field name="binding_view_types">list,form</field>
+            <field name="state">code</field>
+            <field name="code">action = records.action_split()</field>
+        </record>
+
+        <record id="action_production_order_merge" model="ir.actions.server">
+            <field name="name">Merge</field>
             <field name="model_id" ref="mrp.model_mrp_production"/>
             <field name="binding_model_id" ref="mrp.model_mrp_production"/>
             <field name="binding_view_types">list</field>
-            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_routings'))]"/>
             <field name="state">code</field>
-            <field name="code">records.button_plan()</field>
+            <field name="code">action = records.action_merge()</field>
         </record>
 
         <record id="action_production_order_mark_done" model="ir.actions.server">

--- a/addons/mrp/wizard/__init__.py
+++ b/addons/mrp/wizard/__init__.py
@@ -7,3 +7,4 @@ from . import mrp_production_backorder
 from . import mrp_consumption_warning
 from . import mrp_immediate_production
 from . import stock_assign_serial_numbers
+from . import mrp_production_split

--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, Command
+from odoo.tools import float_round, float_compare
+
+
+class MrpProductionSplitMulti(models.TransientModel):
+    _name = 'mrp.production.split.multi'
+    _description = "Wizard to Split Multiple Productions"
+
+    production_ids = fields.One2many('mrp.production.split', 'production_split_multi_id', 'Productions To Split')
+
+
+class MrpProductionSplit(models.TransientModel):
+    _name = 'mrp.production.split'
+    _description = "Wizard to Split a Production"
+
+    production_split_multi_id = fields.Many2one('mrp.production.split.multi', 'Split Productions')
+    production_id = fields.Many2one('mrp.production', 'Manufacturing Order', readonly=True)
+    product_id = fields.Many2one(related='production_id.product_id')
+    product_qty = fields.Float(related='production_id.product_qty')
+    product_uom_id = fields.Many2one(related='production_id.product_uom_id')
+    counter = fields.Integer(
+        "Split #", default=0, compute="_compute_counter",
+        store=True, readonly=False)
+    production_detailed_vals_ids = fields.One2many(
+        'mrp.production.split.line', 'mrp_production_split_id',
+        'Split Details', compute="_compute_details", store=True, readonly=False)
+    valid_details = fields.Boolean("Valid", compute="_compute_valid_details")
+
+    @api.depends('production_detailed_vals_ids')
+    def _compute_counter(self):
+        for wizard in self:
+            wizard.counter = len(wizard.production_detailed_vals_ids)
+
+    @api.depends('counter')
+    def _compute_details(self):
+        for wizard in self:
+            commands = [Command.clear()]
+            if wizard.counter < 1 or not wizard.production_id:
+                wizard.production_detailed_vals_ids = commands
+                continue
+            quantity = float_round(wizard.product_qty / wizard.counter, precision_rounding=wizard.product_uom_id.rounding)
+            remaining_quantity = wizard.product_qty
+            for _ in range(wizard.counter - 1):
+                commands.append(Command.create({
+                    'quantity': quantity,
+                    'user_id': wizard.production_id.user_id,
+                    'date': wizard.production_id.date_planned_start,
+                }))
+                remaining_quantity = float_round(remaining_quantity - quantity, precision_rounding=wizard.product_uom_id.rounding)
+            commands.append(Command.create({
+                'quantity': remaining_quantity,
+                'user_id': wizard.production_id.user_id,
+                'date': wizard.production_id.date_planned_start,
+            }))
+            wizard.production_detailed_vals_ids = commands
+
+    @api.depends('production_detailed_vals_ids')
+    def _compute_valid_details(self):
+        self.valid_details = False
+        for wizard in self:
+            if wizard.production_detailed_vals_ids:
+                wizard.valid_details = float_compare(wizard.product_qty, sum(wizard.production_detailed_vals_ids.mapped('quantity')), precision_rounding=wizard.product_uom_id.rounding) == 0
+
+    def action_split(self):
+        productions = self.production_id._split_productions({self.production_id: [detail.quantity for detail in self.production_detailed_vals_ids]})
+        for production, detail in zip(productions, self.production_detailed_vals_ids):
+            production.user_id = detail.user_id
+            production.date_planned_start = detail.date
+        if self.production_split_multi_id:
+            saved_production_split_multi_id = self.production_split_multi_id.id
+            self.production_split_multi_id.production_ids = [Command.unlink(self.id)]
+            action = self.env['ir.actions.actions']._for_xml_id('mrp.action_mrp_production_split_multi')
+            action['res_id'] = saved_production_split_multi_id
+            return action
+
+    def action_prepare_split(self):
+        action = self.env['ir.actions.actions']._for_xml_id('mrp.action_mrp_production_split')
+        action['res_id'] = self.id
+        return action
+
+    def action_return_to_list(self):
+        self.production_detailed_vals_ids = [Command.clear()]
+        self.counter = 0
+        action = self.env['ir.actions.actions']._for_xml_id('mrp.action_mrp_production_split_multi')
+        action['res_id'] = self.production_split_multi_id.id
+        return action
+
+
+class MrpProductionSplitLine(models.TransientModel):
+    _name = 'mrp.production.split.line'
+    _description = "Split Production Detail"
+
+    mrp_production_split_id = fields.Many2one(
+        'mrp.production.split', 'Split Production', required=True, ondelete="cascade")
+    quantity = fields.Float('Quantity To Produce', digits='Product Unit of Measure', required=True)
+    user_id = fields.Many2one(
+        'res.users', 'Responsible', required=True,
+        domain=lambda self: [('groups_id', 'in', self.env.ref('mrp.group_mrp_user').id)])
+    date = fields.Datetime('Schedule Date')

--- a/addons/mrp/wizard/mrp_production_split.xml
+++ b/addons/mrp/wizard/mrp_production_split.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <record id="view_mrp_production_split_multi_form" model="ir.ui.view">
+            <field name="name">mrp.production.split.multi.form</field>
+            <field name="model">mrp.production.split.multi</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Split Productions">
+                    <field name="production_ids">
+                        <tree create="0" editable="top">
+                            <field name="production_id"/>
+                            <field name="product_id"/>
+                            <field name="product_qty"/>
+                            <field name="product_uom_id"/>
+                            <button name="action_prepare_split" type="object" icon="fa-scissors" width="0.1" title="Split Production"/>
+                        </tree>
+                    </field>
+                    <footer>
+                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="z"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="view_mrp_production_split_form" model="ir.ui.view">
+            <field name="name">Split Production</field>
+            <field name="model">mrp.production.split</field>
+            <field name="arch" type="xml">
+                <form string="Split Production">
+                    <group>
+                        <group>
+                            <field name="production_id" readonly="1"/>
+                        </group>
+                        <group>
+                            <field name="product_id"/>
+                            <field name="product_qty"/>
+                            <field name="product_uom_id"/>
+                        </group>
+                        <group>
+                            <field name="counter"/>
+                        </group>
+                    </group>
+                    <field name="production_detailed_vals_ids" attrs="{'invisible': [('counter', '=', 0)]}">
+                        <tree editable="top">
+                            <field name="quantity"/>
+                            <field name="user_id"/>
+                            <field name="date"/>
+                        </tree>
+                    </field>
+                    <field name="production_split_multi_id" invisible="1"/>
+                    <field name="valid_details" invisible="1"/>
+                    <footer>
+                        <button string="Split" class="btn-primary" type="object" name="action_split" data-hotkey="q" attrs="{'invisible': [('valid_details', '=', False)]}"/>
+                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="z" attrs="{'invisible': [('production_split_multi_id', '!=', False)]}"/>
+                        <button string="Discard" class="btn-secondary" type="object" name="action_return_to_list" data-hotkey="z" attrs="{'invisible': [('production_split_multi_id', '=', False)]}"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_mrp_production_split_multi" model="ir.actions.act_window">
+            <field name="name">Split productions</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">mrp.production.split.multi</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+        </record>
+
+        <record id="action_mrp_production_split" model="ir.actions.act_window">
+            <field name="name">Split production</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">mrp.production.split</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+        </record>
+
+    </data>
+</odoo>    

--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -3,7 +3,7 @@
 
 from collections import defaultdict
 from odoo import fields, models, _, api
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools.float_utils import float_compare, float_is_zero
 
 
@@ -34,6 +34,11 @@ class MrpProduction(models.Model):
                 move['additional'] = True
                 production.move_raw_ids = [(0, 0, move)]
                 production.move_raw_ids.filtered(lambda m: m.product_id == product_id)[:1].move_line_ids = lines
+
+    def action_merge(self):
+        if any(production._get_subcontract_move() for production in self):
+            raise ValidationError(_("Subcontracted manufacturing orders cannot be merged."))
+        super().action_merge()
 
     def subcontracting_record_component(self):
         self.ensure_one()


### PR DESCRIPTION
Split a manufacturing order in several parts
using the back order mechanism

Merge several manufacturing orders related to the same product/bom
by cancelling all of them and creating a new one

task: 2662566

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
