### PR TITLE
[IMP] mass_mailing: allow responsible to turn off mailing reports

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -23,6 +23,7 @@
     'data': [
         'security/mass_mailing_security.xml',
         'security/ir.model.access.csv',
+        'data/digest_data.xml',
         'data/mail_data.xml',
         'data/mailing_data_templates.xml',
         'data/mass_mailing_data.xml',

--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -195,3 +195,18 @@ class MassMailController(http.Controller):
                 record.sudo().message_post(body=_("Feedback from %(email)s: %(feedback)s", email=email, feedback=feedback))
             return bool(records)
         return 'error'
+
+    @http.route('/mailing/report/unsubscribe', type='http', website=True, auth='public')
+    def turn_off_mailing_reports(self, token, user_id):
+        if not token or not user_id:
+            raise werkzeug.exceptions.NotFound()
+        user_id = int(user_id)
+        correct_token = consteq(token, request.env['mailing.mailing']._get_unsubscribe_token(user_id))
+        user = request.env['res.users'].sudo().browse(user_id)
+        if correct_token and user.has_group('mass_mailing.group_mass_mailing_user'):
+            request.env['ir.config_parameter'].sudo().set_param('mass_mailing.mass_mailing_reports', False)
+            if user.has_group('base.group_system'):
+                menu_id = request.env.ref('mass_mailing.menu_mass_mailing_global_settings').id
+                return request.render('mass_mailing.mailing_report_deactivated', {'menu_id': menu_id})
+            return request.render('mass_mailing.mailing_report_deactivated')
+        raise werkzeug.exceptions.NotFound()

--- a/addons/mass_mailing/data/digest_data.xml
+++ b/addons/mass_mailing/data/digest_data.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="digest_mail_main" inherit_id="digest.digest_mail_main">
+            <xpath expr="//div[hasclass('by_odoo')]/t[last()]" position="after">
+                <t t-if="mailing_report_token">
+                    –
+                    <a t-attf-href="/mailing/report/unsubscribe?token=#{mailing_report_token}&amp;user_id=#{user_id}"
+                       target="_blank" style="text-decoration: none;">
+                        <span style="color: #8f8f8f;">Turn off Mailing Reports</span>
+                    </a>
+                </t>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/addons/mass_mailing/data/mailing_data_templates.xml
+++ b/addons/mass_mailing/data/mailing_data_templates.xml
@@ -60,7 +60,7 @@
                                 <td style="width: 30%;padding: 10px 0; text-align: center; border: 1px solid #e7e7e7;">%Click (Total)</td>
                             </tr>
                             <tr t-foreach="link_trackers" t-as="link_tracker" style="color: #888888; font-size: 15px; font-weight: 300;">
-                                <td style="width: 70%;padding: 10px 0; text-align: center; border: 1px solid #e7e7e7;">
+                                <td style="width: 70%;padding: 10px 0; border: 1px solid #e7e7e7;">
                                     <a t-att-href="link_tracker.absolute_url" target="_blank" style="color: #56b3b5; text-decoration: none;" t-esc="link_tracker.label or link_tracker.url"/>
                                 </td>
                                 <td style="width: 30%;padding: 10px 0; text-align: center;  border: 1px solid #e7e7e7;">

--- a/addons/mass_mailing/data/mass_mailing_data.xml
+++ b/addons/mass_mailing/data/mass_mailing_data.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
+        <!-- Enable Mass Mailing Reports -->
+        <function model="ir.config_parameter" name="set_param" eval="('mass_mailing.mass_mailing_reports', 'True')" />
         <!-- Cron that processes the mass mailing queue -->
         <record id="ir_cron_mass_mailing_queue" model="ir.cron">
             <field name="name">Mail Marketing: Process queue</field>

--- a/addons/mass_mailing/models/res_config_settings.py
+++ b/addons/mass_mailing/models/res_config_settings.py
@@ -14,6 +14,8 @@ class ResConfigSettings(models.TransientModel):
     show_blacklist_buttons = fields.Boolean(string="Blacklist Option when Unsubscribing",
                                                  config_parameter='mass_mailing.show_blacklist_buttons',
                                                  help="""Allow the recipient to manage himself his state in the blacklist via the unsubscription page.""")
+    mass_mailing_reports = fields.Boolean(string='24H Stat Mailing Reports', config_parameter='mass_mailing.mass_mailing_reports',
+                                          help='Check how well your mailing is doing a day after it has been sent.')
 
     @api.onchange('mass_mailing_outgoing_mail_server')
     def _onchange_mass_mailing_outgoing_mail_server(self):

--- a/addons/mass_mailing/views/mass_mailing_templates_portal.xml
+++ b/addons/mass_mailing/views/mass_mailing_templates_portal.xml
@@ -1,5 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <template id="mailing_report_deactivated" name="Report Unsubscribed">
+        <t t-call="mass_mailing.layout">
+            <div class="container mt8">
+                <div class="row">
+                    <div class="col-lg-6 offset-lg-3">
+                        <h3>Mailing Reports Turned Off</h3>
+                        <div class="alert alert-success text-center" role="status">
+                            <p>
+                                Mailing Reports have been turned off for all users. <br/>
+                                If needed, they can be turned back on from the
+                                <a t-if="menu_id" t-attf-href="/web#menu_id=#{menu_id}">
+                                    Settings Menu.
+                                </a>
+                                <t t-else="">
+                                    Settings Menu.
+                                </t>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </t>
+    </template>
+
     <template id="unsubscribe">
         <div class="container o_unsubscribe_form">
             <div class="row">

--- a/addons/mass_mailing/views/res_config_settings_views.xml
+++ b/addons/mass_mailing/views/res_config_settings_views.xml
@@ -42,7 +42,7 @@
                             </div>
                             <div class="col-md-6 o_setting_box col-xs-12" name="allow_blacklist_setting_container">
                                 <div class="o_setting_left_pane" title="Allow the recipient to manage himself his state in the blacklist via the unsubscription page.
-                                If the option is active, the 'Blacklist Me' button is hidden on the unsubscription page.  
+                                If the option is active, the 'Blacklist Me' button is hidden on the unsubscription page.
                                 The 'come Back' button will always be visible in any case to allow leads and partners to re-subscribe.">
                                     <field name="show_blacklist_buttons"/>
                                 </div>
@@ -50,6 +50,17 @@
                                     <label for="show_blacklist_buttons"/>
                                     <div class="text-muted">
                                         Allow recipients to blacklist themselves
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-md-6 o_setting_box col-xs-12" name="mass_mailing_reports_setting_container">
+                                <div class="o_setting_left_pane" title="Send a report to the mailing responsible one day after the mailing has been sent.">
+                                    <field name="mass_mailing_reports"/>
+                                </div>
+                                <div class="o_setting_right_pane">
+                                    <label for="mass_mailing_reports"/>
+                                    <div class="text-muted">
+                                        Check how well your mailing is doing a day after it has been sent
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Purpose
=======
Allow users with enough access rights to disable next-day report on
mass mailing lists. The option has been added in the mass mailing
settings and is enabled by default. Mass mailing reports can also be
disabled with a "Turn off mailing reports" button in the report email
itself. Reports are enabled and disabled for all responsible.

Task-2692211
