### PR TITLE
[FIX] point_of_sale: Spanish decimalSeparator

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1760,7 +1760,7 @@ exports.Orderline = Backbone.Model.extend({
     },
     // sets a discount [0,100]%
     set_discount: function(discount){
-        var parsed_discount = isNaN(parseFloat(discount)) ? 0 : field_utils.parse.float('' + discount);
+        var parsed_discount = typeof(discount) === 'number' ? discount : isNaN(parseFloat(discount)) ? 0 : field_utils.parse.float('' + discount);
         var disc = Math.min(Math.max(parsed_discount || 0, 0),100);
         this.discount = disc;
         this.discountStr = '' + disc;


### PR DESCRIPTION
Current behavior:
When using spanish language in PoS the "," decimal separator was ignored

Steps to reproduce:
- Create a sale order with a discount
- Change profile language in spanish
- Open PoS and load the order created before in the PoS
- The discount is not correct, for example 18.2 will become 100

opw-2718260

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
