### PR TITLE
[FIX] mail: remove auto isCausal on inverses of required fields

### DIFF
--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -636,9 +636,6 @@ export class ModelManager {
                 ) {
                     throw new Error(`Mismatched relation types: ${field} on ${Model} (${field.relationType}) and ${inverseField} on ${RelatedModel} (${inverseField.relationType}).`);
                 }
-                if (field.required && !inverseField.isCausal) {
-                    throw new Error(`${field} on ${Model} is required but its inverse ${inverseField} on ${RelatedModel} is not causal.`);
-                }
             }
             for (const identifyingField of Model.__identifyingFieldsFlattened) {
                 const field = Model.__fieldMap[identifyingField];
@@ -1069,9 +1066,9 @@ export class ModelManager {
             relFunc(Model.name, { inverse: field.fieldName }),
             {
                 fieldName: `_inverse_${Model}/${field.fieldName}`,
-                // Note that an identifying field is not necessarily defined as
-                // `required` (example: identifyingFields with an OR). 
-                isCausal: field.required || Model.__identifyingFieldsFlattened.has(field.fieldName),
+                // Allows the inverse of an identifying field to be
+                // automatically generated.
+                isCausal: Model.__identifyingFieldsFlattened.has(field.fieldName),
             },
         ));
         return inverseField;

--- a/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
@@ -219,6 +219,7 @@ registerModel({
          */
         popoverViewOwner: one2one('PopoverView', {
             inverse: 'channelInvitationForm',
+            isCausal: true,
             readonly: true,
         }),
         /**

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -135,6 +135,10 @@ registerModel({
             compute: '_computeCanPostMessage',
             default: false,
         }),
+        composerViews: one2many('ComposerView', {
+            inverse: 'composer',
+            isCausal: true,
+        }),
         /**
          * This field determines whether some attachments linked to this
          * composer are being uploaded.

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -953,6 +953,7 @@ registerModel({
          */
         composer: many2one('Composer', {
             compute: '_computeComposer',
+            inverse: 'composerViews',
             required: true,
         }),
         /**

--- a/addons/mail/static/src/models/file_uploader_view/file_uploader_view.js
+++ b/addons/mail/static/src/models/file_uploader_view/file_uploader_view.js
@@ -166,17 +166,14 @@ registerModel({
     fields: {
         activityView: one2one('ActivityView', {
             inverse: 'fileUploaderView',
-            isCausal: true,
             readonly: true,
         }),
         attachmentBoxView: one2one('AttachmentBoxView', {
             inverse: 'fileUploaderView',
-            isCausal: true,
             readonly: true,
         }),
         composerView: one2one('ComposerView', {
             inverse: 'fileUploaderView',
-            isCausal: true,
             readonly: true,
         }),
         fileInputRef: attr(),

--- a/addons/mail/static/src/models/thread_cache/thread_cache.js
+++ b/addons/mail/static/src/models/thread_cache/thread_cache.js
@@ -403,7 +403,6 @@ registerModel({
         }),
         thread: one2one('Thread', {
             inverse: 'cache',
-            isCausal: true,
             readonly: true,
             required: true,
         }),

--- a/addons/mail/static/src/models/thread_view/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_view/thread_viewer.js
@@ -61,12 +61,10 @@ registerModel({
     fields: {
         chatter: one2one('Chatter', {
             inverse: 'threadViewer',
-            isCausal: true,
             readonly: true,
         }),
         chatWindow: one2one('ChatWindow', {
             inverse: 'threadViewer',
-            isCausal: true,
             readonly: true,
         }),
         /**
@@ -77,7 +75,6 @@ registerModel({
         }),
         discuss: one2one('Discuss', {
             inverse: 'threadViewer',
-            isCausal: true,
             readonly: true,
         }),
         discussPublicView: one2one('DiscussPublicView', {


### PR DESCRIPTION
Previously, relational required fields had their auto-generated inverses defined with `isCausal: true`, which seemed logical: if a record is deleted, all the records that depend on it must be deleted too.

In practice, it turned out to be a bad idea since there are some cases where you don't want the dependent records to be deleted. For example, there is no point in deleting the current record when a required field is replaced by another one.

Furthermore, this actually led to the introduction of new bugs, as the one described in task-2730667.

Fixes bug described in task-2730667.
Reverts some of these changes: https://github.com/odoo/odoo/pull/81679