### PR TITLE
[FIX] sale_product_configurator: allow float product qty

### DIFF
--- a/addons/sale_product_configurator/static/src/js/product_configurator_modal.js
+++ b/addons/sale_product_configurator/static/src/js/product_configurator_modal.js
@@ -179,7 +179,7 @@ var OptionalProductsModal = Dialog.extend(ServicesMixin, VariantMixin, {
         var products = [this.rootProduct];
         this.$modal.find('.js_product.in_cart:not(.main_product)').each(function () {
             var $item = $(this);
-            var quantity = parseInt($item.find('input[name="add_qty"]').val(), 10);
+            var quantity = parseFloat($item.find('input[name="add_qty"]').val(), 10);
             var parentUniqueId = this.dataset.parentUniqueId;
             var uniqueId = this.dataset.uniqueId;
             var productCustomVariantValues = self.getCustomVariantValues($(this));
@@ -472,7 +472,7 @@ var OptionalProductsModal = Dialog.extend(ServicesMixin, VariantMixin, {
         if (this.$modal.find('.js_price_total').length) {
             var price = 0;
             this.$modal.find('.js_product.in_cart').each(function () {
-                var quantity = parseInt($(this).find('input[name="add_qty"]').first().val(), 10);
+                var quantity = parseFloat($(this).find('input[name="add_qty"]').first().val(), 10);
                 price += parseFloat($(this).find('.js_raw_price').html()) * quantity;
             });
 


### PR DESCRIPTION
Step to reproduce:
1. Create a product with an optional product.
2. Create a sales order with the main product.
3. Add the optional product with a decimal value

Current behaviour:
- Product qty is rounded down to the nearest integer

Behaviour after PR:
- Product qty is left as is and will be rounded down according to the product uom on closing of the configurator wizard

opw-2722552

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
