### PR TITLE
 [FIX] project: fix task analysis report base on set project

### DIFF
--- a/addons/project/report/project_report.py
+++ b/addons/project/report/project_report.py
@@ -89,5 +89,6 @@ class ReportProjectTaskUser(models.Model):
               %s
               FROM project_task t
                 WHERE t.active = 'true'
+                AND t.project_id IS NOT NULL
                 %s
         """ % (self._table, self._select(), self._group_by()))


### PR DESCRIPTION
Purpose of this commit is to show only task that
has project_id set in 'Task Analysis' menu.

So, In this commit add domain to show only task
that has project_id set in 'Task Anamysis' menu's
action.

task-2722863
closes: #82063

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
