### PR TITLE
[FIX] account: reversal_date accrued_orders wizard

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -38,6 +38,8 @@ class AccruedExpenseRevenue(models.TransientModel):
         compute="_compute_reversal_date",
         required=True,
         readonly=False,
+        store=True,
+        precompute=True,
     )
     amount = fields.Monetary(string='Amount', help="Specify an arbitrary value that will be accrued on a \
         default account for the entire order, regardless of the products on the different lines.")


### PR DESCRIPTION
Before this commit, the field reversal_date was not stored, which lead to inconsistent behaviour when creating entries, as the reversal date was always recompute with the default value.

opw-2722435

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
