### PR TITLE
[FIX] calendar: create attendees at event creation

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -711,7 +711,7 @@ class Meeting(models.Model):
         # is already given (coming from Google event for example).
         vals_list = [
             dict(vals, attendee_ids=self._attendees_values(vals['partner_ids']))
-            if 'partner_ids' in vals and 'attendee_ids' not in vals
+            if 'partner_ids' in vals and not vals.get('attendee_ids')
             else vals
             for vals in vals_list
         ]


### PR DESCRIPTION
This commit https://github.com/odoo/odoo/commit/f5622acfba8024cdf71b2ffed92bd45a3ac3fa37 allowed to create attendees with states coming from google.
Unfortunately, it had a drawback and attendee would not be created automatically in the calendar view.

opw-ticket: 2721787



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
