### PR TITLE
[FIX] l10n_gcc_pos: Saudi Arabia taxes on receipt

### DIFF
--- a/addons/l10n_gcc_pos/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_gcc_pos/static/src/xml/OrderReceipt.xml
@@ -99,7 +99,7 @@
         <xpath expr="//t[@t-if='isSimple(line)']/div/span[hasclass('price_display')]" position="attributes">
             <attribute name="t-if">!receipt.is_gcc_country</attribute>
         </xpath>
-        <xpath expr="//t[@t-if='isSimple(line)']/div/span[hasclass('price_display')]" position="after">
+        <xpath expr="//t[@t-if='isSimple(line)']/WrappedProductNameLines" position="after">
             <div class="responsive-price" t-if="receipt.is_gcc_country">
                 <div class="pos-receipt-left-padding" style="display: inline-flex;">
                     <div t-translation="off">Taxes / الضرائب</div>:<span t-esc="env.pos.format_currency_no_symbol(line.tax)" style="margin-left: 5px"/>


### PR DESCRIPTION
Current behavior:
When product name is too long and need to be splitted on PoS receipt, the tax is inserted between the two lines of the product name

Steps to reproduce:
- Install SA modules
- Change company in SA
- Create a product with a very long name
- Try to buy it on the PoS
- The receipt is not correctly former

opw-2731585

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
