### PR TITLE
[FIX] google_calendar, microsoft_calendar: ignore no partner created

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -142,8 +142,10 @@ class Meeting(models.Model):
                 # Create new attendees
                 if attendee[2].get('self'):
                     partner = self.env.user.partner_id
-                else:
+                elif attendee[1]:
                     partner = attendee[1]
+                else:
+                    continue
                 attendee_commands += [(0, 0, {'state': attendee[2].get('responseStatus'), 'partner_id': partner.id})]
                 partner_commands += [(4, partner.id)]
                 if attendee[2].get('displayName') and not partner.name:

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -174,7 +174,7 @@ class Meeting(models.Model):
             if email in attendees_by_emails:
                 # Update existing attendees
                 commands_attendee += [(1, attendees_by_emails[email].id, {'state': state})]
-            else:
+            elif attendee[1]:
                 # Create new attendees
                 partner = attendee[1]
                 commands_attendee += [(0, 0, {'state': state, 'partner_id': partner.id})]


### PR DESCRIPTION
Description of the issue/feature this PR addresses: in version 15,
sometimes Google and Microsoft calendar synchronizations break with error:

Create/update: a mandatory field is not set.
Delete: another model requires the record being deleted. If possible, archive it instead.
Model: Calendar Attendee Information (calendar.attendee), Field: Contact (partner_id)

This is happening, because when Odoo is syncing an event, it will match
attendee with res.partner, if no existing partner is found, a new one
will be created unless:

- the address matches an existing mail alias ([alias_name]@[mail.catchall.domain])
- the address is invalid (eg. in outlook the email address is sometimes
  in the form /o=ExchangeLabs/ou=.../cn=Recipients/cn=...

In this case we should not try to add the attendee to the odoo event.

Current behavior before PR: Error when syncing that the customer can
only solve by removing the erroneous attendee or remove the event from
their calendar.

Desired behavior after PR is merged: if the partner cannot be created
we ignore it.

opw-2670002
opw-2683889
opw-2702661
opw-2704631
opw-2711907
opw-2720032
opw-2722028
closes #82109
fixes #78678
Co-authored-by: andro19951