### PR TITLE
[FIX] web: Sales description overlap

### DIFF
--- a/addons/web/static/src/scss/report.scss
+++ b/addons/web/static/src/scss/report.scss
@@ -25,6 +25,9 @@ body {
 
 /* See https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1524 */
 .table-sm {
+    > thead, > tfoot {
+        display: table-row-group !important;
+    }
     > thead > tr > th {
         border-bottom: none !important;
     }


### PR DESCRIPTION
Steps to reproduce the issue:

- Let's consider a product P with a big customer description
- Create a SO with several lines
- Set P on each line
- Print the quotation report

Bug:

The head of the table was repeated and overlapped by the customer description of each line

opw:2679866