### PR TITLE
[IMP] website: Save one sql for all images on published record

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -16,7 +16,7 @@ from functools import partial
 import odoo
 from odoo import api, models
 from odoo import registry, SUPERUSER_ID
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, MissingError
 from odoo.http import request
 from odoo.tools.safe_eval import safe_eval
 from odoo.osv.expression import FALSE_DOMAIN
@@ -410,8 +410,11 @@ class Http(models.AbstractModel):
         elif id and model in self.env:
             obj = self.env[model].browse(int(id))
         if obj and 'website_published' in obj._fields:
-            if self.env[obj._name].sudo().search([('id', '=', obj.id), ('website_published', '=', True)]):
-                self = self.sudo()
+            try:
+                if obj.sudo().website_published:
+                    self = self.sudo()
+            except MissingError:
+                pass
         return super(Http, self).binary_content(
             xmlid=xmlid, model=model, id=id, field=field, unique=unique, filename=filename,
             filename_field=filename_field, download=download, mimetype=mimetype,

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -34,8 +34,16 @@ class UtilPerf(HttpCase):
 class TestStandardPerformance(UtilPerf):
     def test_10_perf_sql_img_controller(self):
         self.authenticate('demo', 'demo')
+        # not published user, get the not found image placeholder
+        self.assertEqual(self.env['res.users'].sudo().browse(2).website_published, False)
         url = '/web/image/res.users/2/image_256'
         self.assertEqual(self._get_url_hot_query(url), 6)
+
+    def test_11_perf_sql_img_controller(self):
+        self.authenticate('demo', 'demo')
+        self.env['res.users'].sudo().browse(2).website_published = True
+        url = '/web/image/res.users/2/image_256'
+        self.assertEqual(self._get_url_hot_query(url), 5)
 
     def test_20_perf_sql_img_controller_bis(self):
         url = '/web/image/website/1/favicon'


### PR DESCRIPTION
The record is read directly in sudo, the prefetch is in the sudo
environment. When reading the other information there is no longer any
need to make a request.
