### PR TITLE
[FIX] google_calendar: fix attendee deletion

### DIFF
--- a/addons/google_calendar/models/calendar_recurrence_rule.py
+++ b/addons/google_calendar/models/calendar_recurrence_rule.py
@@ -109,7 +109,7 @@ class RecurrenceRule(models.Model):
         for odoo_attendee_email in set(existing_attendees.mapped('email')):
             # Remove old attendees
             if email_normalize(odoo_attendee_email) not in emails:
-                attendee = existing_attendees.filtered(lambda att: att.email == email_normalize(odoo_attendee_email))
+                attendee = existing_attendees.exists().filtered(lambda att: att.email == email_normalize(odoo_attendee_email))
                 self.calendar_event_ids.write({'need_sync': False, 'partner_ids': [(3, attendee.partner_id.id)]})
 
         # Update the recurrence values

--- a/addons/google_calendar/models/calendar_recurrence_rule.py
+++ b/addons/google_calendar/models/calendar_recurrence_rule.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import re
-from odoo import api, models
+from odoo import api, models, Command
 from odoo.tools import email_normalize
 
 from odoo.addons.google_calendar.utils.google_calendar import GoogleCalendarService
@@ -107,10 +107,10 @@ class RecurrenceRule(models.Model):
                     partner.name = attendee[2].get('displayName')
 
         for odoo_attendee_email in set(existing_attendees.mapped('email')):
-            # Remove old attendees
+            # Remove old attendees. Sometimes, several partners have the same email.
             if email_normalize(odoo_attendee_email) not in emails:
-                attendee = existing_attendees.exists().filtered(lambda att: att.email == email_normalize(odoo_attendee_email))
-                self.calendar_event_ids.write({'need_sync': False, 'partner_ids': [(3, attendee.partner_id.id)]})
+                attendees = existing_attendees.exists().filtered(lambda att: att.email == email_normalize(odoo_attendee_email))
+                self.calendar_event_ids.write({'need_sync': False, 'partner_ids': [Command.unlink(att.partner_id.id) for att in attendees]})
 
         # Update the recurrence values
         old_event_values = self.base_event_id and self.base_event_id.read(base_event_time_fields)[0]

--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -237,7 +237,7 @@ class GoogleSync(models.AbstractModel):
                 except HTTPError as e:
                     if e.response.status_code in (400, 403):
                         self._google_error_handling(e)
-                self.need_sync = False
+                self.exists().with_context(dont_notify=True).need_sync = False
 
     @after_commit
     def _google_insert(self, google_service: GoogleCalendarService, values, timeout=TIMEOUT):
@@ -255,7 +255,7 @@ class GoogleSync(models.AbstractModel):
                 except HTTPError as e:
                     if e.response.status_code in (400, 403):
                         self._google_error_handling(e)
-                        self.need_sync = False
+                        self.with_context(dont_notify=True).need_sync = False
 
     def _get_records_to_sync(self, full_sync=False):
         """Return records that should be synced from Odoo to Google

--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -173,6 +173,12 @@ class GoogleSync(models.AbstractModel):
         # We only handle the most problematic errors of sync events.
         if http_error.response.status_code in (403, 400):
             response = http_error.response.json()
+            if not self.exists():
+                reason = "Google gave the following explanation: %s" % response['error'].get('message')
+                error_log = "Error while syncing record. It does not exists anymore in the database. %s" % reason
+                _logger.error(error_log)
+                return 
+
             if self._name == 'calendar.event':
                 start = self.start and self.start.strftime('%Y-%m-%d at %H:%M') or _("undefined time")
                 event_ids = self.id

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -975,3 +975,75 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
         attendee = recurrence.calendar_event_ids.attendee_ids.mapped('state')
         self.assertEqual(attendee, ['declined', 'declined', 'declined'], "All events should be declined")
         self.assertGoogleAPINotCalled()
+
+    @patch_api
+    def test_several_attendee_have_the_same_mail(self):
+        """
+        In google, One mail = One attendee but on Odoo, some partners could share the same mail
+        This test checks that the deletion of such attendee has no harm: all attendee but the given mail are deleted.
+        """
+        partner1 = self.env['res.partner'].create({
+            'name': 'joe',
+            'email': 'dalton@example.com',
+        })
+        partner2 = self.env['res.partner'].create({
+            'name': 'william',
+            'email': 'dalton@example.com',
+        })
+        partner3 = self.env['res.partner'].create({
+            'name': 'jack',
+            'email': 'dalton@example.com',
+        })
+        partner4 = self.env['res.partner'].create({
+            'name': 'averell',
+            'email': 'dalton@example.com',
+        })
+        google_id = "aaaaaaaaaaaaaaaaa"
+        event = self.env['calendar.event'].create({
+            'name': 'coucou',
+            'start': datetime(2020, 1, 13, 16, 0),
+            'stop': datetime(2020, 1, 13, 20),
+            'allday': False,
+            'google_id': google_id,
+            'need_sync': False,
+            'user_id': self.env.user.partner_id.id,
+            'partner_ids': [(6, 0, [self.env.user.partner_id.id, partner1.id, partner2.id, partner3.id, partner4.id],)]
+            # current user is attendee
+        })
+        recurrence = self.env['calendar.recurrence'].create({
+            'google_id': google_id,
+            'rrule': 'FREQ=WEEKLY;COUNT=3;BYDAY=MO',
+            'need_sync': False,
+            'base_event_id': event.id,
+            'calendar_event_ids': [(4, event.id)],
+        })
+        recurrence._apply_recurrence()
+        recurrence.calendar_event_ids.attendee_ids.state = 'accepted'
+        mails = sorted(set(event.attendee_ids.mapped('email')))
+        self.assertEqual(mails, ['dalton@example.com', 'odoobot@example.com'])
+        gevent = GoogleEvent([{
+            'id': google_id,
+            'description': 'coucou',
+            "updated": self.now,
+            'organizer': {'email': 'odoobot@example.com', 'self': True},
+            'summary': False,
+            'visibility': 'public',
+            'attendees': [],
+            'reminders': {'useDefault': True},
+            'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event.id, }},
+            'recurrence': ['RRULE:FREQ=WEEKLY;COUNT=3;BYDAY=MO'],
+            'start': {
+                'dateTime': '2020-01-13T16:00:00+01:00',
+                'timeZone': 'Europe/Brussels'
+            },
+            'end': {
+                'dateTime': '2020-01-13T20:00:00+01:00',
+                'timeZone': 'Europe/Brussels'
+            },
+        }])
+        self.sync(gevent)
+        # User attendee removed but gevent owner might be added after synch.
+        mails = sorted(set(event.attendee_ids.mapped('email')))
+        self.assertEqual(mails, ['odoobot@example.com'])
+
+        self.assertGoogleAPINotCalled()


### PR DESCRIPTION
This PR solves several issues occurring during synchronization.

 * When an attendee is deleted in google, we need to sync the odoo attendees and delete the ones that do not exist anymore in google. Unfortunately, by doing so, we introduced an issue. We filtered attendees that were no longer existing when we looped on the attendee emails.
 *  If an event do not exists when a google related error occurs, some traceback can happen during error handling.
 * In some weird circumstances, some cache miss error happens when an event is deleted and the system tries to write a patch to google to update the event. The reason of this weird behavior is not well understood and easily reproducible.
 * If a recurrent event has several attendees whose email are identical, a traceback would occurs when the attendee are deleted from google.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
