### PR TITLE
[FIX] stock_landed_cost: reconcilliation with partial/zero journal items

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -203,7 +203,7 @@ class StockLandedCost(models.Model):
                 for product in cost.cost_lines.product_id:
                     accounts = product.product_tmpl_id.get_product_accounts()
                     input_account = accounts['stock_input']
-                    all_amls.filtered(lambda aml: aml.account_id == input_account and not aml.full_reconcile_id).reconcile()
+                    all_amls.filtered(lambda aml: aml.account_id == input_account and not aml.reconciled).reconcile()
 
         return True
 

--- a/doc/cla/corporate/systemworks.md
+++ b/doc/cla/corporate/systemworks.md
@@ -1,0 +1,18 @@
+South Africa, 2022-01-10
+
+SystemWorks agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Michael de Villiers michael@systemworks.co.za https://github.com/COUR4G3
+
+List of contributors:
+
+Michael de Villiers michael@systemworks.co.za https://github.com/COUR4G3
+Mziwakhe Ndinga mzi@systemworks.co.za https://github.com/mndinga
+Alex Zimmerman alexz@systemworks.co.za https://github.com/AFZimmers
+


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When you attempt to validate a landed cost with an invoice that has items with zero totals or items that have been fully reconciled by multiple partial reconciles you get a 'You are trying to reconcile some entries that are already reconciled.' error. This is because the code uses the presence of `full_reconcile_id` to filter records to reconcile, whereas it should use the `reconciled` attribute which will return True if it is zero or has been reconciled by multiple partials.

Current behavior before PR:

Validating a landed cost with an invoice that has 1) items with zero totals, or 2) items that have been fully reconciled by multiple partial reconciles will give a 'You are trying to reconcile some entries that are already reconciled.' error.

Desired behavior after PR is merged:

Validating a landed cost should work.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
