### PR TITLE
[FIX] point_of_sale : Variant changing price

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1813,7 +1813,8 @@ exports.Orderline = Backbone.Model.extend({
         }
 
         // just like in sale.order changing the quantity will recompute the unit price
-        if(! keep_price && ! this.price_manually_set){
+        if (!keep_price && !this.price_manually_set && !(
+            this.pos.config.product_configurator && _.some(this.product.attribute_line_ids, (id) => id in this.pos.attributes_by_ptal_id))){
             this.set_unit_price(this.product.get_price(this.order.pricelist, this.get_quantity(), this.get_price_extra()));
             this.order.fix_tax_included_price(this);
         }


### PR DESCRIPTION
Current behavior:
When using variant in PoS the price was not always correct

Steps to reproduce:
1. Set up items with modifiers (Modifier type must be of type `variant creation mode : never`, where adding a modifier leads to a different price than with the base item e.g. base item is 10 USD, modifier is 5 USD, total price is 15 USD;
2. Activate Product configurator and make sure it's a Bar/Restaurant in the PoS settings
3. Select the items with the modifier;
5. Leave the table and come back to the table
5. Change the quantity of this product
6. The price is back to the base price without the modifier

opw-2696529

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
