### PR TITLE
[IMP] mail: add test for file upload activity type

### DIFF
--- a/addons/mail/static/src/components/activity/tests/activity_tests.js
+++ b/addons/mail/static/src/components/activity/tests/activity_tests.js
@@ -788,7 +788,7 @@ QUnit.test('activity upload document is available', async function (assert) {
     });
     this.data['mail.activity'].records.push({
         activity_category: 'upload_file',
-        activity_type_id: 1,
+        activity_type_id: 28,
         can_write: true,
         id: 12,
         res_id: 100,
@@ -1272,6 +1272,54 @@ QUnit.test('data-oe-id & data-oe-model link redirection on click', async functio
     assert.verifySteps(
         ['do-action:openFormView_some.model_250'],
         "should have open form view on related record after click on link"
+    );
+});
+
+QUnit.test('button related to file uploading is replaced when updating activity type from "Upload Document" to "Email"', async function (assert) {
+    assert.expect(2);
+
+    const activityId = 513;
+    this.data['res.partner'].records.push({
+        activity_ids: [activityId],
+        id: 100,
+    });
+    this.data['mail.activity'].records.push({
+        activity_category: 'upload_file',
+        activity_type_id: 28,
+        can_write: true,
+        id: activityId,
+        res_id: 100,
+        res_model: 'res.partner',
+    });
+    const { createChatterContainerComponent } = await this.start();
+    await createChatterContainerComponent({
+        threadId: 100,
+        threadModel: 'res.partner',
+    });
+
+    // Update the record server side then fetch updated data in order to
+    // emulate what happens when using the form view.
+    await this.env.services.rpc({
+        model: 'mail.activity',
+        method: 'write',
+        args: [[activityId], {
+            activity_category: 'default',
+            activity_type_id: 1,
+        }],
+    });
+    await afterNextRender(async () => {
+        const activity = this.messaging.models['Activity'].findFromIdentifyingData({ id: activityId });
+        await activity.fetchAndUpdate();
+    });
+    assert.containsOnce(
+        document.body,
+        '.o_Activity_markDoneButton',
+        "should have a mark done button when changing activity type from 'Upload Document' to 'Email'"
+    );
+    assert.containsNone(
+        document.body,
+        '.o_Activity_uploadButton',
+        "should not have an upload button after changing the activity type from 'Upload Document' to 'Email'"
     );
 });
 

--- a/addons/mail/static/tests/helpers/mock_models.js
+++ b/addons/mail/static/tests/helpers/mock_models.js
@@ -69,6 +69,7 @@ export class MockModels {
                 },
                 records: [
                     { icon: 'fa-envelope', id: 1, name: "Email" },
+                    { icon: 'fa-upload', id: 28, name: "Upload Document" },
                 ],
             },
             'mail.channel': {


### PR DESCRIPTION
Some recent changes have evidenced that the modification of the activity type of an 'upload_file' activity was not properly covered by the tests.

This commit adds a new test for this specific case.

Part of task-2730667