### PR TITLE
[FIX] website: delete website assets/views on uninstallation

### DIFF
--- a/addons/website/__init__.py
+++ b/addons/website/__init__.py
@@ -11,6 +11,14 @@ from functools import partial
 
 
 def uninstall_hook(cr, registry):
+    # Force remove ondelete='cascade' elements,
+    # This might be prevented by another ondelete='restrict' field
+    # TODO: This should be an Odoo generic fix, not a website specific one
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    website_domain = [('website_id', '!=', False)]
+    env['ir.asset'].search(website_domain).unlink()
+    env['ir.ui.view'].search(website_domain).with_context(active_test=False, _force_unlink=True).unlink()
+
     def rem_website_id_null(dbname):
         db_registry = odoo.modules.registry.Registry.new(dbname)
         with db_registry.cursor() as cr:


### PR DESCRIPTION
### To reproduce (V15):

Video: https://drive.google.com/file/d/1wCebPCVQMXmQk7G4CIMkh1MbZ89HW9ek/view
1. Install the module "Product Availability" ("website_sale_stock") (that will install ecommerce & stock)
2. Choose a theme for the website (like developement)
3. Uninstall website
=> Internal server error
```
Exception: Unallowed to fetch files from addon website

Error when render the template
Exception: Unallowed to fetch files from addon website
Template: web.frontend_layout
Path: /t/html/head/t[1]
Node: <t t-call-assets="web.assets_common" t-js="false"/> - - -
```

### Analysis:
The assets and view should in theory be deleted in cascade when
the websites records are uninstalled.
However, if a website record fails to be removed,
for instance - in this case - because of pricelist which have an
`ondelete=restrict` PSQL constraint on its `website_id` field.
The PSQL cascade constraints on the other record are dropped 
before being applied which result in the ressource being still 
there but not usable.

Note: this issue is not specific to the website app in particular.
It's just not worth to think for a more sophisticated way to fix
this issue in a stable version.

OPW-2700476

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
