### PR TITLE
[FIX] mail: consistent padding of attachment image/card in chatter

### DIFF
--- a/addons/mail/static/src/components/attachment_card/attachment_card.xml
+++ b/addons/mail/static/src/components/attachment_card/attachment_card.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.AttachmentCard" owl="1">
-        <div t-ref="root">
+        <div t-attf-class="{{ className }}" t-ref="root">
             <t t-if="attachmentCard">
                 <div class="o_AttachmentCard d-flex o-has-card-details"
-                    t-attf-class="{{ className }}"
                      t-att-class="{
                             'o-downloadable': !attachmentCard.attachmentList.composerView,
                             'o-isUploading': attachmentCard.attachment.isUploading,

--- a/addons/mail/static/src/components/attachment_image/attachment_image.xml
+++ b/addons/mail/static/src/components/attachment_image/attachment_image.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.AttachmentImage" owl="1">
-        <div t-ref="root">
+        <div t-attf-class="{{ className }}" t-ref="root">
             <t t-if="attachmentImage">
                 <div class="o_AttachmentImage d-flex o-details-overlay position-relative"
                     t-att-class="{
                         'o-isUploading': attachmentImage.attachment.isUploading,
                     }"
-                    t-attf-class="{{ className }}"
                     t-att-title="attachmentImage.attachment.displayName ? attachmentImage.attachment.displayName : undefined"
                     t-att-data-id="attachmentImage.attachment.localId"
                     t-on-click="attachmentImage.onClickImage"


### PR DESCRIPTION
Before this commit, attachments in attachment box (chatter) had no
left padding.

Mistakenly introduced by https://github.com/odoo/odoo/pull/80060
which changes classname passing from parent component to child
component with `t-attf-class`. AttachmentCard and AttachmentImage
components did not `t-attf-class` not on root node, which caused
the broken style that this commit fixes.
