### PR TITLE
[IMP] expression: handle False for many2many list domains

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -59,6 +59,10 @@ class TestExpression(SavepointCaseWithUserDemo):
         with_a_or_with_b = self._search(partners, ['|', ('category_id', 'in', [cat_a.id]), ('category_id', 'in', [cat_b.id])])
         self.assertEqual(a + b + ab, with_a_or_with_b, "Search for category_id contains cat_a or contains cat_b failed.")
 
+        # Partners with categories.
+        with_cat = partners.search([('category_id', 'not in', [False])])
+        self.assertTrue(with_a_or_with_b <= with_cat, "Search for with any category failed.")
+
         # If we change the OR in AND...
         with_a_and_b = self._search(partners, [('category_id', 'in', [cat_a.id]), ('category_id', 'in', [cat_b.id])])
         self.assertEqual(ab, with_a_and_b, "Search for category_id contains cat_a and cat_b failed.")
@@ -67,6 +71,10 @@ class TestExpression(SavepointCaseWithUserDemo):
         without_a_or_b = self._search(partners, [('category_id', 'not in', [cat_a.id, cat_b.id])])
         self.assertFalse(without_a_or_b & (a + b + ab), "Search for category_id doesn't contain cat_a or cat_b failed (1).")
         self.assertTrue(c in without_a_or_b, "Search for category_id doesn't contain cat_a or cat_b failed (2).")
+
+        # Partners without categories.
+        without_cat = partners.search([('category_id', 'in', [False])])
+        self.assertTrue(without_cat <= without_a_or_b, "Search for without any category failed.")
 
         # Show that `doesn't contain list` is really `doesn't contain element and doesn't contain element`.
         without_a_and_without_b = self._search(partners, [('category_id', 'not in', [cat_a.id]), ('category_id', 'not in', [cat_b.id])])

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -853,7 +853,10 @@ class expression(object):
                         # rewrite condition in terms of ids2
                         subop = 'not inselect' if operator in NEGATIVE_TERM_OPERATORS else 'inselect'
                         subquery = 'SELECT "%s" FROM "%s" WHERE "%s" IN %%s' % (rel_id1, rel_table, rel_id2)
+                        check_null = False in ids2
                         ids2 = tuple(it for it in ids2 if it) or (None,)
+                        if check_null:
+                            subquery += ' OR "%s" is null' % rel_id2
                         push(('id', subop, (subquery, [ids2])), model, alias, internal=True)
 
                 else:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

`[('field', 'in', [False, id1, id2])]` should be the same as `['|', ('field', '=', False)]), ('field', 'in', [id1, id2])]` when field is a many2many.

**Current behavior before PR:**

`[('field', 'in', [False, id1, id2])]` is treated as `[('field', 'in', [id1, id2])]` which doesn't makes sense to me. (to me this PR is a FIX, but I know you prefer calling it an IMP...)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr