### PR TITLE
[FIX] stock_picking_batch: Correctly skip records when computing state

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -94,7 +94,7 @@ class StockPickingBatch(models.Model):
         batchs = self.filtered(lambda batch: batch.state not in ['cancel', 'done'])
         for batch in batchs:
             if not batch.picking_ids:
-                return
+                continue
             # Cancels automatically the batch picking if all its transfers are cancelled.
             if all(picking.state == 'cancel' for picking in batch.picking_ids):
                 batch.state = 'cancel'


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In _compute_state if a batch doesn't have picking ids it stops processing all batches.

Current behavior before PR:
Halts loop computing state and returns early.

Desired behavior after PR is merged:
Skips the record and continues computing state for other batches.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
