### PR TITLE
[IMP] mail: melt causal relations into identifying fields

### DIFF
--- a/addons/mail/static/src/models/media_preview/media_preview.js
+++ b/addons/mail/static/src/models/media_preview/media_preview.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import { attr } from '@mail/model/model_field';
+import { attr, one2one } from '@mail/model/model_field';
 import { registerModel } from '@mail/model/model_core';
 
 registerModel({
     name: 'MediaPreview',
-    identifyingFields: ['messaging'],
+    identifyingFields: ['welcomeView'],
     modelMethods: {
         /**
          * Iterates tracks of the provided MediaStream, calling the `stop`
@@ -171,6 +171,13 @@ registerModel({
          */
         videoStream: attr({
             default: null,
+        }),
+        /**
+         * States the welcome view containing this media preview.
+         */
+        welcomeView: one2one('WelcomeView', {
+            inverse: 'mediaPreview',
+            readonly: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/welcome_view/welcome_view.js
+++ b/addons/mail/static/src/models/welcome_view/welcome_view.js
@@ -11,7 +11,7 @@ const getNextGuestNameInputId = (function () {
 
 registerModel({
     name: 'WelcomeView',
-    identifyingFields: ['messaging'],
+    identifyingFields: ['discussPublicView'],
     recordMethods: {
         /**
          * Updates guest if needed then displays the thread view instead of the
@@ -184,6 +184,7 @@ registerModel({
          */
         mediaPreview: one2one('MediaPreview', {
             compute: '_computeMediaPreview',
+            inverse: 'welcomeView',
             isCausal: true,
             readonly: true,
         }),


### PR DESCRIPTION
With the idea of maybe merging the concepts of causal relations and identifying fields, change the identifying fields so that heir inverses are the only fields with `isCausal: true`.