### PR TITLE
[FIX] account: fix destination account reset to default

### DIFF
--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -805,3 +805,18 @@ class TestAccountPayment(AccountTestInvoicingCommon):
             'available_partner_bank_ids': self.comp_bank_account2.ids,
             'partner_bank_id': self.comp_bank_account2.id,
         }])
+
+    def test_internal_transfer_custom_partner_bank_id(self):
+        """ Ensure partner_bank_id user choice is not systematically ignored by compute method. """
+        self.bank_journal_1.bank_account_id = self.comp_bank_account1
+
+        payment = self.env['account.payment'].create({
+            'journal_id': self.bank_journal_1.id,
+            'amount': 50.0,
+            'is_internal_transfer': True,
+            'payment_type': 'outbound',
+            'partner_bank_id': self.comp_bank_account2.id,
+        })
+        self.assertRecordValues(payment, [{
+            'partner_bank_id': self.comp_bank_account2.id,
+        }])


### PR DESCRIPTION
When creating an internal transfer, the destination account is reset by its compute method discarding any user choice.
Now, if a valid account is set, the compute method will leave it.
Bug appeared after https://github.com/odoo/odoo/commit/5b2eb004c92dc80e540373680d0ab6ab2f0af0f4.

Task: 2725228