### PR TITLE
shipping / invoice partner_id domain restriction on invoice

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -769,7 +769,7 @@
                                     <label for="partner_id" string="Vendor" style="font-weight:bold;"
                                            attrs="{'invisible': [('move_type', 'not in', ('in_invoice', 'in_refund', 'in_receipt'))]}"/>
                                 </div>
-                                <field name="partner_id" widget="res_partner_many2one" nolabel="1"
+                                <field name="partner_id" domain="['|', ('type', '=', 'invoice'), ('parent_id', '=', None)]" widget="res_partner_many2one" nolabel="1"
                                        context="{
                                             'res_partner_search_mode': (context.get('default_move_type', 'entry') in ('out_invoice', 'out_refund', 'out_receipt') and 'customer') or (context.get('default_move_type', 'entry') in ('in_invoice', 'in_refund', 'in_receipt') and 'supplier') or False,
                                             'show_address': 1, 'default_is_company': True, 'show_vat': True}"

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -1227,6 +1227,7 @@
                 <data>
                     <xpath expr="//field[@name='partner_id']" position="after">
                        <field name="partner_shipping_id"
+                              domain="['|', ('type', '=', 'delivery'), ('parent_id', '=', None)]"
                               groups="sale.group_delivery_invoice_address"
                               attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund', 'out_receipt'))]}"/>
                    </xpath>

--- a/doc/cla/corporate/strongblue.md
+++ b/doc/cla/corporate/strongblue.md
@@ -1,0 +1,15 @@
+Strasbourg, France, 25/11/2021
+
+Strong Blue Conseil & Télécom SASU agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Arnaud Willem arnaud@strong.blue https://github.com/a-willem
+
+List of contributors:
+
+Arnaud Willem arnaud@strong.blue https://github.com/a-willem


### PR DESCRIPTION
…n invoice

Description of the issue/feature this PR addresses:

When creating an invoice with separate partner invoicing address and shipping address, the search widget for shipping address looks up through all partners and contacts : when working through large partner sets, this can be fastidious.

This PR adresses shipping address lookups and general / invoicing partner lookups for various fields in the invoice creation form.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
