### PR TITLE
mass_mailing: show media modal when fullcreen

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_renderer.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_renderer.js
@@ -434,6 +434,7 @@ var BasicRenderer = AbstractRenderer.extend(WidgetAdapterMixin, {
      */
     _getTooltipOptions: function (widget) {
         return {
+            template: '<div class="tooltip tooltip-field-info" role="tooltip"><div class="arrow"></div><div class="tooltip-inner"></div></div>',
             title: function () {
                 let help = widget.attrs.help || widget.field.help || '';
                 if (session.display_switch_company_menu && widget.field.company_dependent) {

--- a/addons/web/static/tests/helpers/cleanup.js
+++ b/addons/web/static/tests/helpers/cleanup.js
@@ -51,6 +51,8 @@ const validElements = [
     { tagName: "DIV", attr: "class", value: "o_notification_manager" },
     { tagName: "DIV", attr: "class", value: "tooltip fade bs-tooltip-auto" },
     { tagName: "DIV", attr: "class", value: "tooltip fade bs-tooltip-auto show" },
+    { tagName: "DIV", attr: "class", value: "tooltip tooltip-field-info fade bs-tooltip-auto" },
+    { tagName: "DIV", attr: "class", value: "tooltip tooltip-field-info fade bs-tooltip-auto show" },
     { tagName: "SPAN", attr: "class", value: "select2-hidden-accessible" },
 
     // Due to a Document Kanban bug (already present in 12.0)

--- a/addons/web_editor/static/src/scss/web_editor.backend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.backend.scss
@@ -59,7 +59,7 @@
         z-index: 1001 !important;
         border: 0;
     }
-    > :not(.modal):not(.modal-backdrop) {
+    .tooltip-field-info {
         display: none;
     }
     .o_form_fullscreen_ancestor {


### PR DESCRIPTION
Whenever the user clicked on the fullscreen in mass_maliing, then
trying to show the media modal was not possible as the div that
contains it was hidden.

Task-2731907




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
