### PR TITLE
[IMP] account,project: allow to filter based on id on portal

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from ast import literal_eval
+
 from odoo import http, _
 from odoo.osv import expression
 from odoo.addons.portal.controllers.portal import CustomerPortal, pager as portal_pager
@@ -79,6 +81,10 @@ class PortalAccount(CustomerPortal):
         if not filterby:
             filterby = 'all'
         domain += searchbar_filters[filterby]['domain']
+
+        # filter based on id
+        if kw.get('invoice_ids', False):
+            domain += [('id', 'in', literal_eval(kw.get('invoice_ids')))]
 
         if date_begin and date_end:
             domain += [('create_date', '>', date_begin), ('create_date', '<=', date_end)]

--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from ast import literal_eval
-
 from odoo import http, _
 from odoo.osv import expression
 from odoo.addons.portal.controllers.portal import CustomerPortal, pager as portal_pager
@@ -81,10 +79,6 @@ class PortalAccount(CustomerPortal):
         if not filterby:
             filterby = 'all'
         domain += searchbar_filters[filterby]['domain']
-
-        # filter based on id
-        if kw.get('invoice_ids', False):
-            domain += [('id', 'in', literal_eval(kw.get('invoice_ids')))]
 
         if date_begin and date_end:
             domain += [('create_date', '>', date_begin), ('create_date', '<=', date_end)]

--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from ast import literal_eval
 from collections import OrderedDict
 from operator import itemgetter
 from markupsafe import Markup
@@ -331,6 +332,10 @@ class ProjectCustomerPortal(CustomerPortal):
         if not sortby:
             sortby = 'date'
         order = searchbar_sortings[sortby]['order']
+
+        # Filter based on id
+        if kw.get('task_ids'):
+            domain += [('id', 'in', literal_eval(kw.get('task_ids')))]
 
         # default group by value
         if not groupby:

--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from ast import literal_eval
 from collections import OrderedDict
 from operator import itemgetter
 from markupsafe import Markup
@@ -332,10 +331,6 @@ class ProjectCustomerPortal(CustomerPortal):
         if not sortby:
             sortby = 'date'
         order = searchbar_sortings[sortby]['order']
-
-        # Filter based on id
-        if kw.get('task_ids'):
-            domain += [('id', 'in', literal_eval(kw.get('task_ids')))]
 
         # default group by value
         if not groupby:


### PR DESCRIPTION
Currently, it's not possible to filter the portal record based on id of the record.

so in this commit, allow to pass the invoice ids and task ids and display the filtered record based on that.

task-2722488
