### PR TITLE
[FIX] hr_holidays: actually compute state for both validation

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -76,7 +76,7 @@ class HolidaysRequest(models.Model):
         lt = LeaveType.search([('valid', '=', True)], limit=1)
 
         defaults['holiday_status_id'] = lt.id if lt else defaults.get('holiday_status_id')
-        defaults['state'] = 'confirm' if lt and lt.validation_type != 'no_validation' else 'draft'
+        defaults['state'] = 'confirm'
         return defaults
 
     def _default_employee(self):


### PR DESCRIPTION
Step to reproduce:
- Change the validation type of the hr.leave.type with id 1 (hlt1) to no_validation
- Create a new time off request with a time off type different from hlt1

Current Behaviour:
- Time off state is 'draft'

Behaviour After PR:
- Default time off state is always correctly computed. 
- 'no_validation' does not need to be set to draft as it's modified afterward.
(https://github.com/odoo/odoo/blob/13.0/addons/hr_holidays/models/hr_leave.py#L675-L676)

opw-2713600

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
