### PR TITLE
[FIX] fetchmail: pop server without message no error

### DIFF
--- a/addons/fetchmail/models/fetchmail.py
+++ b/addons/fetchmail/models/fetchmail.py
@@ -183,6 +183,7 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
                 try:
                     while True:
                         failed_in_loop = 0
+                        num = 0
                         pop_server = server.connect()
                         (num_messages, total_size) = pop_server.stat()
                         pop_server.list()


### PR DESCRIPTION

In 72cd8d076 there was an improvement for removing infinite loop in POP
mail server, but if there was no message to fetch, you can get an error:

UnboundLocalError: local variable 'num' referenced  before assignment

because `num` is not set when logging stats of fetching mails.

`num` should be set to 0 by default, we don't want to have it unset or
use a value from a previous loop.

opw-2724216
