### PR TITLE
[FIX] website_blog: search query not consistent

### DIFF
--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -121,11 +121,20 @@ class WebsiteBlog(http.Controller):
             first_post = posts[0]
         posts = posts[offset:offset + self._blog_post_per_page]
 
+        url_args = dict()
+        if search:
+            url_args["search"] = search
+
+        if date_begin and date_end:
+            url_args["date_begin"] = date_begin
+            url_args["date_end"] = date_end
+
         pager = request.website.pager(
             url=request.httprequest.path.partition('/page/')[0],
             total=total,
             page=page,
             step=self._blog_post_per_page,
+            url_args=url_args,
         )
 
         if not blogs:


### PR DESCRIPTION
steps to reproduce:
- install blog
- create more than 12 articles with at least on word  (the one we will search for)
- Go to the "blog" menu of the website
- Go in the search field
- Search for the word in the created articles
-> Odoo removes the search criteria on the blog (Website) + number of results is inconsistent

OPW-2720355
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
