### PR TITLE
[FIX] web_editor: properly save history step when pasting text

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2781,6 +2781,7 @@ export class OdooEditor extends EventTarget {
                     }
                 }
             }
+            this.historyStep();
         }
     }
     /**


### PR DESCRIPTION
Before this commit, when trying to paste an url, the editor was
properly creating a link but did not create a step in the history.
So when the user hit enter just after the paste, the last link
insertion was reverted.

Task-2720366






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
