### PR TITLE
[FIX] account: Fix wrong st line account in pos box

### DIFF
--- a/addons/account/wizard/pos_box.py
+++ b/addons/account/wizard/pos_box.py
@@ -33,7 +33,6 @@ class CashBox(models.TransientModel):
             if record.state == 'confirm':
                 raise UserError(_("You cannot put/take money in/out for a bank statement which is closed."))
             values = box._calculate_values_for_statement_line(record)
-            values["counterpart_account_id"] = record.journal_id.company_id.transfer_account_id.id
             self.env['account.bank.statement.line'].sudo().create(values)
 
 


### PR DESCRIPTION
If money is withdrawn, we can't tell if it's a transfert to the bank account or if some money has been withdrawn to pay an invoice or some expense.
We then assign the suspense account in order for the accountant to go through the reconciliation widget process in order to dispatch/assign the amount to the right account(s).
This allows all the accounting process to go smoothly without any needs for the accountant to manually create a miscellaneous entry.

Introduced by:
PR: https://github.com/odoo/odoo/pull/82123
commit: https://github.com/odoo/odoo/commit/336656e0e9677ccb2f43935b6f267fa83ed153df

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
