### PR TITLE
[IMP] account: display access button in notification emails for users and customers

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2642,6 +2642,19 @@ class AccountMove(models.Model):
         action['res_id'] = self.copy().id
         return action
 
+    def _notify_get_groups(self, msg_vals=None):
+        """ Give access button to users and portal customer as portal is integrated
+        in account. Customer and portal group have probably no right to see
+        the document so they don't have the access button. """
+        groups = super(AccountMove, self)._notify_get_groups(msg_vals=msg_vals)
+
+        self.ensure_one()
+        if self.type != 'entry':
+            for group_name, _group_method, group_data in groups:
+                if group_name == 'portal_customer':
+                    group_data['has_button_access'] = True
+
+        return groups
 
 class AccountMoveLine(models.Model):
     _name = "account.move.line"


### PR DESCRIPTION
If applied, this PR will enable `button_access` for all `users` and `portal_customer`s, letting them access the documents directly. The button "View Journal Entries" will appear on the notification email, and by clicking this the user will be directed to the portal page of the invoice/refund . All `users` and `portal_customer`s subscribed to the thread should be able to see this button.

A following refactor by TDE (https://github.com/odoo/odoo/pull/82167) has addressed this problem in master (for 15.2).
For stable versions, in this PR, we agreed to keep changes limited to the accounting scope.

Ticket link: https://www.odoo.com/web#id=2645653&model=project.task

opw-2645653