### PR TITLE
[FIX] hr_contract: Working Schedule Calendar Mismatch Interface Eror

### DIFF
--- a/addons/hr_contract/static/src/scss/calendar_mismatch.scss
+++ b/addons/hr_contract/static/src/scss/calendar_mismatch.scss
@@ -7,6 +7,8 @@
         display: block;
         height: 0;
         opacity: 0;
+        position: relative;
+        z-index: -1;
     }
 
     .o_calendar_warning:hover + .o_calendar_warning_tooltip {
@@ -14,5 +16,6 @@
         height: auto;
         opacity: 1;
         transition: opacity 0.5s linear;
+        position: static;
     }
 }


### PR DESCRIPTION
.o_calendar_warning_tooltip that applies to the field resource_calendar_id on contract form view caused the right-after selection field unclickable. Here is demonstration demo video:
https://watch.screencastify.com/v/LXnmmyWkKzRzHxD3LnTM

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
