### PR TITLE
Literals cleanups

### DIFF
--- a/addons/account/models/account_analytic_line.py
+++ b/addons/account/models/account_analytic_line.py
@@ -38,7 +38,7 @@ class AccountAnalyticAccount(models.Model):
             ('analytic_account_id', 'in', self.ids)
         ]
         groups = self.env['account.move.line'].read_group(domain, ['move_id:count_distinct'], ['analytic_account_id'])
-        moves_count_mapping = dict((g['analytic_account_id'][0], g['move_id']) for g in groups)
+        moves_count_mapping = {g['analytic_account_id'][0]: g['move_id'] for g in groups}
         for account in self:
             account.invoice_count = moves_count_mapping.get(account.id, 0)
 
@@ -51,7 +51,7 @@ class AccountAnalyticAccount(models.Model):
             ('analytic_account_id', 'in', self.ids)
         ]
         groups = self.env['account.move.line'].read_group(domain, ['move_id:count_distinct'], ['analytic_account_id'])
-        moves_count_mapping = dict((g['analytic_account_id'][0], g['move_id']) for g in groups)
+        moves_count_mapping = {g['analytic_account_id'][0]: g['move_id'] for g in groups}
         for account in self:
             account.vendor_bill_count = moves_count_mapping.get(account.id, 0)
 

--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -1234,9 +1234,9 @@ class AccountBankStatementLine(models.Model):
         # Assign partner if needed (for example, when reconciling a statement
         # line with no partner, with an invoice; assign the partner of this invoice)
         if not self.partner_id:
-            rec_overview_partners = set(overview['counterpart_line'].partner_id.id
+            rec_overview_partners = {overview['counterpart_line'].partner_id.id
                                         for overview in reconciliation_overview
-                                        if overview.get('counterpart_line'))
+                                        if overview.get('counterpart_line')}
             if len(rec_overview_partners) == 1 and rec_overview_partners != {False}:
                 self.line_ids.write({'partner_id': rec_overview_partners.pop()})
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3151,22 +3151,22 @@ class AccountMove(models.Model):
         if not lang:
             lang = get_lang(self.env).code
         compose_form = self.env.ref('account.account_invoice_send_wizard_form', raise_if_not_found=False)
-        ctx = dict(
-            default_model='account.move',
-            default_res_id=self.id,
+        ctx = {
+            'default_model': 'account.move',
+            'default_res_id': self.id,
             # For the sake of consistency we need a default_res_model if
             # default_res_id is set. Not renaming default_model as it can
             # create many side-effects.
-            default_res_model='account.move',
-            default_use_template=bool(template),
-            default_template_id=template and template.id or False,
-            default_composition_mode='comment',
-            mark_invoice_as_sent=True,
-            default_email_layout_xmlid="mail.mail_notification_paynow",
-            model_description=self.with_context(lang=lang).type_name,
-            force_email=True,
-            wizard_opened=True
-        )
+            'default_res_model': 'account.move',
+            'default_use_template': bool(template),
+            'default_template_id': template and template.id or False,
+            'default_composition_mode': 'comment',
+            'mark_invoice_as_sent': True,
+            'default_email_layout_xmlid': "mail.mail_notification_paynow",
+            'model_description': self.with_context(lang=lang).type_name,
+            'force_email': True,
+            'wizard_opened': True
+        }
         return {
             'name': _('Send Invoice'),
             'type': 'ir.actions.act_window',

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2897,7 +2897,7 @@ class AccountMove(models.Model):
         move._compute_name()  # because the name is given, we need to recompute in case it is the first invoice of the journal
 
         # Assign followers.
-        all_followers_ids = set(partner.id for partner in followers + senders + partners if is_internal_partner(partner))
+        all_followers_ids = {partner.id for partner in followers + senders + partners if is_internal_partner(partner)}
         move.message_subscribe(list(all_followers_ids))
         return move
 

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -601,7 +601,7 @@ class AccountPayment(models.Model):
         ''', {
             'payment_ids': tuple(stored_payments.ids)
         })
-        query_res = dict((payment_id, statement_ids) for payment_id, statement_ids in self._cr.fetchall())
+        query_res = {payment_id: statement_ids for payment_id, statement_ids in self._cr.fetchall()}
 
         for pay in self:
             statement_ids = query_res.get(pay.id, [])

--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -819,7 +819,7 @@ class AccountReconcileModel(models.Model):
         candidates, priorities = self._filter_candidates(candidates, aml_ids_to_exclude, reconciled_amls_ids)
 
         st_line_currency = st_line.foreign_currency_id or st_line.currency_id
-        candidate_currencies = set(candidate['aml_currency_id'] for candidate in candidates)
+        candidate_currencies = {candidate['aml_currency_id'] for candidate in candidates}
         kept_candidates = candidates
         if candidate_currencies == {st_line_currency.id}:
             kept_candidates = []

--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -283,7 +283,7 @@ class AccountReconcileModel(models.Model):
 
     def _compute_number_entries(self):
         data = self.env['account.move.line'].read_group([('reconcile_model_id', 'in', self.ids)], ['reconcile_model_id'], 'reconcile_model_id')
-        mapped_data = dict([(d['reconcile_model_id'][0], d['reconcile_model_id_count']) for d in data])
+        mapped_data = {d['reconcile_model_id'][0]: d['reconcile_model_id_count'] for d in data}
         for model in self:
             model.number_entries = mapped_data.get(model.id, 0)
 

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -646,7 +646,7 @@ class AccountChartTemplate(models.Model):
         for template, vals in template_vals:
             module, name = template_xmlids[template.id].split('.', 1)
             xml_id = "%s.%s_%s" % (module, company.id, name)
-            data_list.append(dict(xml_id=xml_id, values=vals, noupdate=True))
+            data_list.append({'xml_id': xml_id, 'values': vals, 'noupdate': True})
         return self.env[model]._load_records(data_list)
 
     @api.model
@@ -666,11 +666,11 @@ class AccountChartTemplate(models.Model):
                 account_xml_id = data['xml_id'] + '_liquidity_transfer'
                 if not self.env.ref(account_xml_id, raise_if_not_found=False):
                     account_vals = record._prepare_transfer_account_template()
-                    account_data_list.append(dict(
-                        xml_id=account_xml_id,
-                        values=account_vals,
-                        noupdate=data.get('noupdate'),
-                    ))
+                    account_data_list.append({
+                        'xml_id': account_xml_id,
+                        'values': account_vals,
+                        'noupdate': data.get('noupdate')
+                    })
         self.env['account.account.template']._load_records(account_data_list, update)
         return records
 

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -492,7 +492,7 @@ class ResPartner(models.Model):
 
     def _compute_bank_count(self):
         bank_data = self.env['res.partner.bank'].read_group([('partner_id', 'in', self.ids)], ['partner_id'], ['partner_id'])
-        mapped_data = dict([(bank['partner_id'][0], bank['partner_id_count']) for bank in bank_data])
+        mapped_data = {bank['partner_id'][0]: bank['partner_id_count'] for bank in bank_data}
         for partner in self:
             partner.bank_account_count = mapped_data.get(partner.id, 0)
 

--- a/addons/account/tests/test_templates_consistency.py
+++ b/addons/account/tests/test_templates_consistency.py
@@ -29,7 +29,7 @@ class AccountingTestTemplConsistency(TransactionCase):
         extra_domain = [('name', 'not in', exceptions)] if exceptions else []
         from_fields = self.get_model_fields(model_from, extra_domain=extra_domain).filtered_domain([('modules', '=', 'account')])
 
-        to_fields_set = set([f.name for f in self.get_model_fields(model_to)])
+        to_fields_set = {f.name for f in self.get_model_fields(model_to)}
         for field in from_fields:
             assert field.name in to_fields_set,\
                 'Missing field "%s" from "%s" in model "%s".' % (field.name, model_from, model_to)

--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -109,7 +109,7 @@ class AutomaticEntryWizard(models.TransientModel):
     @api.model
     def default_get(self, fields):
         res = super().default_get(fields)
-        if not set(fields) & set(['move_line_ids', 'company_id']):
+        if not set(fields) & {'move_line_ids', 'company_id'}:
             return res
 
         if self.env.context.get('active_model') != 'account.move.line' or not self.env.context.get('active_ids'):

--- a/addons/account/wizard/account_invoice_send.py
+++ b/addons/account/wizard/account_invoice_send.py
@@ -64,7 +64,7 @@ class AccountInvoiceSend(models.TransientModel):
 
                 # Get the move types of all selected moves and see if there is more than one of them.
                 # If so, we'll display a warning on the next window about it.
-                move_types_set = set(m.type_name for m in moves)
+                move_types_set = {m.type_name for m in moves}
 
                 if len(move_types_set) > 1:
                     move_types = ', '.join(move_types_set)

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -126,7 +126,7 @@ class AccountPaymentRegister(models.TransientModel):
         :param batch_result:    A batch returned by '_get_batches'.
         :return:                A string representing a communication to be set on payment.
         '''
-        labels = set(line.name or line.move_id.ref or line.move_id.name for line in batch_result['lines'])
+        labels = {line.name or line.move_id.ref or line.move_id.name for line in batch_result['lines']}
         return ' '.join(sorted(labels))
 
     @api.model

--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -178,7 +178,7 @@ class AccountEdiDocument(models.Model):
 
         documents.edi_format_id.ensure_one()  # All account.edi.document of a job should have the same edi_format_id
         documents.move_id.company_id.ensure_one()  # All account.edi.document of a job should be from the same company
-        if len(set(doc.state for doc in documents)) != 1:
+        if len({doc.state for doc in documents}) != 1:
             raise ValueError('All account.edi.document of a job should have the same state')
 
         edi_format = documents.edi_format_id

--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -66,7 +66,7 @@ class AccountMove(models.Model):
                 move.edi_error_message = error_doc.error
                 move.edi_blocking_level = error_doc.blocking_level
             else:
-                error_levels = set([doc.blocking_level for doc in move.edi_document_ids])
+                error_levels = {doc.blocking_level for doc in move.edi_document_ids}
                 if 'error' in error_levels:
                     move.edi_error_message = str(move.edi_error_count) + _(" Electronic invoicing error(s)")
                     move.edi_blocking_level = 'error'

--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -59,13 +59,13 @@ class OAuthLogin(Home):
         for provider in providers:
             return_url = request.httprequest.url_root + 'auth_oauth/signin'
             state = self.get_state(provider)
-            params = dict(
-                response_type='token',
-                client_id=provider['client_id'],
-                redirect_uri=return_url,
-                scope=provider['scope'],
-                state=json.dumps(state),
-            )
+            params = {
+                'response_type': 'token',
+                'client_id': provider['client_id'],
+                'redirect_uri': return_url,
+                'scope': provider['scope'],
+                'state': json.dumps(state)
+            }
             provider['auth_link'] = "%s?%s" % (provider['auth_endpoint'], werkzeug.urls.url_encode(params))
         return providers
 
@@ -73,11 +73,11 @@ class OAuthLogin(Home):
         redirect = request.params.get('redirect') or 'web'
         if not redirect.startswith(('//', 'http://', 'https://')):
             redirect = '%s%s' % (request.httprequest.url_root, redirect[1:] if redirect[0] == '/' else redirect)
-        state = dict(
-            d=request.session.db,
-            p=provider['id'],
-            r=werkzeug.urls.url_quote_plus(redirect),
-        )
+        state = {
+            'd': request.session.db,
+            'p': provider['id'],
+            'r': werkzeug.urls.url_quote_plus(redirect)
+        }
         token = request.params.get('token')
         if token:
             state['t'] = token

--- a/addons/auth_signup/models/res_partner.py
+++ b/addons/auth_signup/models/res_partner.py
@@ -58,7 +58,7 @@ class ResPartner(models.Model):
 
             route = 'login'
             # the parameters to encode for the query
-            query = dict(db=self.env.cr.dbname)
+            query = {'db': self.env.cr.dbname}
             signup_type = self.env.context.get('signup_force_type_in_url', partner.sudo().signup_type or '')
             if signup_type:
                 route = 'reset_password' if signup_type == 'reset' else signup_type
@@ -73,7 +73,7 @@ class ResPartner(models.Model):
             if url:
                 query['redirect'] = url
             else:
-                fragment = dict()
+                fragment = {}
                 base = '/web#'
                 if action == '/mail/view':
                     base = '/mail/view?'

--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -47,7 +47,7 @@ class IrModule(models.Model):
         unmet_dependencies = set(terp['depends']).difference(installed_mods)
 
         if unmet_dependencies:
-            if (unmet_dependencies == set(['web_studio']) and
+            if (unmet_dependencies == {'web_studio'} and
                     _is_studio_custom(path)):
                 err = _("Studio customizations require Studio")
             else:

--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -60,11 +60,11 @@ class IrModule(models.Model):
 
         mod = known_mods_names.get(module)
         if mod:
-            mod.write(dict(state='installed', **values))
+            mod.write({'state': 'installed', **values})
             mode = 'update' if not force else 'init'
         else:
             assert terp.get('installable', True), "Module not installable"
-            self.create(dict(name=module, state='installed', imported=True, **values))
+            self.create({'name': module, 'state': 'installed', 'imported': True, **values})
             mode = 'init'
 
         for kind in ['data', 'init_xml', 'update_xml']:
@@ -93,13 +93,13 @@ class IrModule(models.Model):
                     if not isinstance(url_path, str):
                         url_path = url_path.decode(sys.getfilesystemencoding())
                     filename = os.path.split(url_path)[1]
-                    values = dict(
-                        name=filename,
-                        url=url_path,
-                        res_model='ir.ui.view',
-                        type='binary',
-                        datas=data,
-                    )
+                    values = {
+                        'name': filename,
+                        'url': url_path,
+                        'res_model': 'ir.ui.view',
+                        'type': 'binary',
+                        'datas': data
+                    }
                     attachment = IrAttachment.search([('url', '=', url_path), ('type', '=', 'binary'), ('res_model', '=', 'ir.ui.view')])
                     if attachment:
                         attachment.write(values)
@@ -155,7 +155,7 @@ class IrModule(models.Model):
             raise UserError(_('Only zip files are supported.'))
 
         success = []
-        errors = dict()
+        errors = {}
         module_names = []
         with zipfile.ZipFile(module_file, "r") as z:
             for zf in z.filelist:

--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -316,10 +316,10 @@ class ResPartner(models.Model):
 
     # Mexican VAT verification, contributed by Vauxoo
     # and Panos Christeas <p_christ@hol.gr>
-    __check_vat_mx_re = re.compile(br"(?P<primeras>[A-Za-z\xd1\xf1&]{3,4})" \
-                                   br"[ \-_]?" \
-                                   br"(?P<ano>[0-9]{2})(?P<mes>[01][0-9])(?P<dia>[0-3][0-9])" \
-                                   br"[ \-_]?" \
+    __check_vat_mx_re = re.compile(br"(?P<primeras>[A-Za-z\xd1\xf1&]{3,4})"
+                                   br"[ \-_]?"
+                                   br"(?P<ano>[0-9]{2})(?P<mes>[01][0-9])(?P<dia>[0-3][0-9])"
+                                   br"[ \-_]?"
                                    br"(?P<code>[A-Za-z0-9&\xd1\xf1]{3})$")
 
     def check_vat_mx(self, vat):

--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -137,7 +137,7 @@ class ImDispatch(object):
 
         # immediatly returns in peek mode
         if options.get('peek'):
-            return dict(notifications=notifications, channels=channels)
+            return {'notifications': notifications, 'channels': channels}
 
         # or wait for future ones
         if not notifications:

--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -172,7 +172,7 @@ class AlarmManager(models.AbstractModel):
         if not events_by_alarm:
             return
 
-        event_ids = list(set(event_id for event_ids in events_by_alarm.values() for event_id in event_ids))
+        event_ids = {event_id for event_ids in events_by_alarm.values() for event_id in event_ids}
         events = self.env['calendar.event'].browse(event_ids)
         attendees = events.attendee_ids.filtered(lambda a: a.state != 'declined')
         alarms = self.env['calendar.alarm'].browse(events_by_alarm.keys())

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -568,7 +568,7 @@ class Meeting(models.Model):
     @api.model
     def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
         groupby = [groupby] if isinstance(groupby, str) else groupby
-        grouped_fields = set(group_field.split(':')[0] for group_field in groupby)
+        grouped_fields = {group_field.split(':')[0] for group_field in groupby}
         private_fields = grouped_fields - self._get_public_fields()
         if not self.env.su and private_fields:
             # display public and confidential events

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -636,7 +636,7 @@ class Meeting(models.Model):
         attendee_commands += [[2, attendee.id] for attendee in attendees_to_unlink]  # Removes and delete
 
         attendee_commands += [
-            [0, 0, dict(partner_id=partner_id)]
+            [0, 0, {'partner_id': partner_id}]
             for partner_id in added_partner_ids
         ]
         return attendee_commands
@@ -665,15 +665,15 @@ class Meeting(models.Model):
         template_id = self.env['ir.model.data']._xmlid_to_res_id('calendar.calendar_template_meeting_update', raise_if_not_found=False)
         # The mail is sent with datetime corresponding to the sending user TZ
         composition_mode = self.env.context.get('composition_mode', 'comment')
-        compose_ctx = dict(
-            default_composition_mode=composition_mode,
-            default_model='calendar.event',
-            default_res_ids=self.ids,
-            default_use_template=bool(template_id),
-            default_template_id=template_id,
-            default_partner_ids=self.partner_ids.ids,
-            mail_tz=self.env.user.tz,
-        )
+        compose_ctx = {
+            'default_composition_mode': composition_mode,
+            'default_model': 'calendar.event',
+            'default_res_ids': self.ids,
+            'default_use_template': bool(template_id),
+            'default_template_id': template_id,
+            'default_partner_ids': self.partner_ids.ids,
+            'mail_tz': self.env.user.tz
+        }
         return {
             'type': 'ir.actions.act_window',
             'name': _('Contact Attendees'),

--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -489,10 +489,10 @@ class RecurrenceRule(models.Model):
     def _get_rrule(self, dtstart=None):
         self.ensure_one()
         freq = self.rrule_type
-        rrule_params = dict(
-            dtstart=dtstart,
-            interval=self.interval,
-        )
+        rrule_params = {
+            'dtstart': dtstart,
+            'interval': self.interval
+        }
         if freq == 'monthly' and self.month_by == 'date':  # e.g. every 15th of the month
             rrule_params['bymonthday'] = self.day
         elif freq == 'monthly' and self.month_by == 'day':  # e.g. every 2nd Monday in the month

--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -195,7 +195,7 @@ class RecurrenceRule(models.Model):
 
         synced_events = self.calendar_event_ids.filtered(lambda e: e._range() in ranges)
 
-        existing_ranges = set(event._range() for event in synced_events)
+        existing_ranges = {event._range() for event in synced_events}
         ranges_to_create = (event_range for event_range in ranges if event_range not in existing_ranges)
         return synced_events, ranges_to_create
 
@@ -214,7 +214,7 @@ class RecurrenceRule(models.Model):
             event = recurrence.base_event_id or recurrence._get_first_event(include_outliers=False)
             duration = event.stop - event.start
             if specific_values_creation:
-                ranges = set([(x[1], x[2]) for x in specific_values_creation if x[0] == recurrence.id])
+                ranges = {(x[1], x[2]) for x in specific_values_creation if x[0] == recurrence.id}
             else:
                 ranges = recurrence._range_calculation(event, duration)
 
@@ -403,7 +403,7 @@ class RecurrenceRule(models.Model):
         self.ensure_one()
         original_count = self.end_type == 'count' and self.count
         ranges = set(self._get_ranges(event.start, duration))
-        future_events = set((x, y) for x, y in ranges if x.date() >= event.start.date() and y.date() >= event.start.date())
+        future_events = {(x, y) for x, y in ranges if x.date() >= event.start.date() and y.date() >= event.start.date()}
         if original_count and len(future_events) < original_count:
             # Rise count number because some past values will be dismissed.
             self.count = (2*original_count) - len(future_events)
@@ -411,7 +411,7 @@ class RecurrenceRule(models.Model):
             # We set back the occurrence number to its original value
             self.count = original_count
         # Remove ranges of events occurring in the past
-        ranges = set((x, y) for x, y in ranges if x.date() >= event.start.date() and y.date() >= event.start.date())
+        ranges = {(x, y) for x, y in ranges if x.date() >= event.start.date() and y.date() >= event.start.date()}
         return ranges
 
 

--- a/addons/calendar_sms/models/calendar_alarm_manager.py
+++ b/addons/calendar_sms/models/calendar_alarm_manager.py
@@ -16,7 +16,7 @@ class AlarmManager(models.AbstractModel):
         if not events_by_alarm:
             return
 
-        event_ids = list(set(event_id for event_ids in events_by_alarm.values() for event_id in event_ids))
+        event_ids = {event_id for event_ids in events_by_alarm.values() for event_id in event_ids}
         events = self.env['calendar.event'].browse(event_ids)
         alarms = self.env['calendar.alarm'].browse(events_by_alarm.keys())
         for event in events:

--- a/addons/coupon/models/coupon.py
+++ b/addons/coupon/models/coupon.py
@@ -59,16 +59,16 @@ class Coupon(models.Model):
         self.ensure_one()
         default_template = self._get_default_template()
         compose_form = self.env.ref('mail.email_compose_message_wizard_form', False)
-        ctx = dict(
-            default_model='coupon.coupon',
-            default_res_id=self.id,
-            default_use_template=bool(default_template),
-            default_template_id=default_template and default_template.id,
-            default_composition_mode='comment',
-            default_email_layout_xmlid='mail.mail_notification_light',
-            mark_coupon_as_sent=True,
-            force_email=True,
-        )
+        ctx = {
+            'default_model': 'coupon.coupon',
+            'default_res_id': self.id,
+            'default_use_template': bool(default_template),
+            'default_template_id': default_template and default_template.id,
+            'default_composition_mode': 'comment',
+            'default_email_layout_xmlid': 'mail.mail_notification_light',
+            'mark_coupon_as_sent': True,
+            'force_email': True
+        }
         return {
             'name': _('Compose Email'),
             'type': 'ir.actions.act_window',

--- a/addons/coupon/models/coupon_program.py
+++ b/addons/coupon/models/coupon_program.py
@@ -64,7 +64,7 @@ class CouponProgram(models.Model):
     @api.depends('coupon_ids')
     def _compute_coupon_count(self):
         coupon_data = self.env['coupon.coupon'].read_group([('program_id', 'in', self.ids)], ['program_id'], ['program_id'])
-        mapped_data = dict([(m['program_id'][0], m['program_id_count']) for m in coupon_data])
+        mapped_data = {m['program_id'][0]: m['program_id_count'] for m in coupon_data}
         for program in self:
             program.coupon_count = mapped_data.get(program.id, 0)
 

--- a/addons/coupon/wizard/coupon_generate.py
+++ b/addons/coupon/wizard/coupon_generate.py
@@ -34,8 +34,8 @@ class CouponGenerate(models.TransientModel):
             for partner in self.env['res.partner'].search(ast.literal_eval(self.partners_domain)):
                 vals.update({'partner_id': partner.id, 'state': 'sent' if partner.email else 'new'})
                 coupon = self.env['coupon.coupon'].create(vals)
-                context = dict(lang=partner.lang)
-                subject = _('%s, a coupon has been generated for you') % (partner.name)
+                context = {'lang': partner.lang}
+                subject = _('%s, a coupon has been generated for you') % partner.name
                 del context
                 if self.template_id:
                     email_values = {'email_from': self.env.user.email or '', 'subject': subject}

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -397,10 +397,10 @@ class Lead(models.Model):
         one if set. """
         # prepare cache
         lang_codes = [code for code in self.mapped('partner_id.lang') if code]
-        lang_id_by_code = dict(
-            (code, self.env['res.lang']._lang_get_id(code))
+        lang_id_by_code = {
+            code: self.env['res.lang']._lang_get_id(code)
             for code in lang_codes
-        )
+        }
         for lead in self.filtered('partner_id'):
             lead.lang_id = lang_id_by_code.get(lead.partner_id.lang, False)
 
@@ -496,7 +496,7 @@ class Lead(models.Model):
             ], ['opportunity_id'], ['opportunity_id'])
             mapped_data = {m['opportunity_id'][0]: m['opportunity_id_count'] for m in meeting_data}
         else:
-            mapped_data = dict()
+            mapped_data = {}
         for lead in self:
             lead.calendar_event_count = mapped_data.get(lead.id, 0)
 
@@ -769,7 +769,7 @@ class Lead(models.Model):
             ['res_id'],
             orderby='date_deadline ASC'
         )
-        my_lead_mapping = dict((item['res_id'], item['date_deadline']) for item in my_lead_activities)
+        my_lead_mapping = {item['res_id']: item['date_deadline'] for item in my_lead_activities}
         my_lead_ids = list(my_lead_mapping.keys())
         my_lead_domain = expression.AND([[('id', 'in', my_lead_ids)], args])
         my_lead_order = ', '.join(item for item in order_items if 'my_activity_date_deadline' not in item)
@@ -1967,8 +1967,8 @@ class Lead(models.Model):
         # each value probability must be computed only with their own variable related total count
         # special case: for lead for which team_id is not in frequency table or lead with no team_id,
         # we consider all the records, independently from team_id (this is why we add a result[-1])
-        result = dict((team_id, dict((field, dict(won_total=0, lost_total=0)) for field in leads_fields)) for team_id in frequency_team_ids)
-        result[-1] = dict((field, dict(won_total=0, lost_total=0)) for field in leads_fields)
+        result = {team_id: {field: {'won_total': 0, 'lost_total': 0} for field in leads_fields} for team_id in frequency_team_ids}
+        result[-1] = {field: {'won_total': 0, 'lost_total': 0} for field in leads_fields}
         for frequency in frequencies:
             field = frequency['variable']
             value = frequency['value']
@@ -2223,9 +2223,9 @@ class Lead(models.Model):
 
         # split leads values by team_id
         # get current frequencies related to the target leads
-        leads_frequency_values_by_team = dict((team_id, []) for team_id in team_ids)
+        leads_frequency_values_by_team = {team_id: [] for team_id in team_ids}
         leads_pls_fields = set()  # ensure to keep each field unique (can have multiple tag_id leads_values_dict)
-        for lead_id, values in leads_values_dict.items():
+        for values in leads_values_dict.values():
             team_id = values.get('team_id', 0)  # If team_id is unset, consider it as team 0
             lead_frequency_values = {'count': 1}
             for field, value in values['values']:
@@ -2257,7 +2257,7 @@ class Lead(models.Model):
             for frequency in existing_frequencies:
                 team_id = frequency['team_id'][0] if frequency.get('team_id') else 0
                 if team_id not in existing_frequencies_by_team:
-                    existing_frequencies_by_team[team_id] = dict((field, {}) for field in leads_pls_fields)
+                    existing_frequencies_by_team[team_id] = {field: {} for field in leads_pls_fields}
 
                 existing_frequencies_by_team[team_id][frequency['variable']][frequency['value']] = {
                     'frequency_id': frequency['id'],
@@ -2359,7 +2359,7 @@ class Lead(models.Model):
         """new state is used when getting frequencies for leads that are changing to lost or won.
         Stays none if we are checking frequencies for leads already won or lost."""
         pls_fields = leads_pls_fields.copy()
-        frequencies = dict((field, {}) for field in pls_fields)
+        frequencies = {field: {} for field in pls_fields}
 
         stage_ids = self.env['crm.stage'].search_read([], ['sequence', 'name', 'id'], order='sequence')
         stage_sequences = {stage['id']: stage['sequence'] for stage in stage_ids}

--- a/addons/crm/models/crm_lost_reason.py
+++ b/addons/crm/models/crm_lost_reason.py
@@ -18,7 +18,7 @@ class LostReason(models.Model):
             ['lost_reason_id'],
             ['lost_reason_id']
         )
-        mapped_data = dict((data['lost_reason_id'][0], data['lost_reason_id_count']) for data in lead_data)
+        mapped_data = {data['lost_reason_id'][0]: data['lost_reason_id_count'] for data in lead_data}
         for reason in self:
             reason.leads_count = mapped_data.get(reason.id, 0)
 

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -268,7 +268,7 @@ class Team(models.Model):
         # on singleton record set, do not bother doing a specific message per team)
         log_action = _("Lead Assignment requested by %(user_name)s", user_name=self.env.user.name)
         log_message = "<p>%s<br /><br />%s</p>" % (log_action, html_message)
-        self._message_log_batch(bodies=dict((team.id, log_message) for team in self))
+        self._message_log_batch(bodies={team.id: log_message for team in self})
 
         return {
             'type': 'ir.actions.client',
@@ -449,10 +449,10 @@ class Team(models.Model):
 
         # leads
         max_create_dt = fields.Datetime.now() - datetime.timedelta(hours=BUNDLE_HOURS_DELAY)
-        duplicates_lead_cache = dict()
+        duplicates_lead_cache = {}
 
         # teams data
-        teams_data, population, weights = dict(), list(), list()
+        teams_data, population, weights = {}, [], []
         for team in self:
             if not team.assignment_max:
                 continue
@@ -488,7 +488,7 @@ class Team(models.Model):
             self._cr.commit()
 
         # assignment process data
-        global_data = dict(assigned=set(), merged=set(), duplicates=set())
+        global_data = {'assigned': set(), 'merged': set(), 'duplicates': set()}
         leads_done_ids, lead_unlink_ids, counter = set(), set(), 0
         while population:
             counter += 1
@@ -547,12 +547,12 @@ class Team(models.Model):
           and fetch information in it instead;
         """
         self.ensure_one()
-        duplicates_cache = duplicates_cache if duplicates_cache is not None else dict()
+        duplicates_cache = duplicates_cache if duplicates_cache is not None else {}
 
         # classify leads
         leads_assigned = self.env['crm.lead']  # direct team assign
         leads_done_ids, leads_merged_ids, leads_dup_ids = set(), set(), set()  # classification
-        leads_dups_dict = dict()  # lead -> its duplicate
+        leads_dups_dict = {}  # lead -> its duplicate
         for lead in leads:
             if lead.id not in leads_done_ids:
 

--- a/addons/crm/models/crm_team_member.py
+++ b/addons/crm/models/crm_team_member.py
@@ -120,7 +120,7 @@ class TeamMember(models.Model):
                 _('Leads team allocation should be done for at least 0.2 or maximum 30 work days, not %.2f.', work_days)
             )
 
-        members_data, population, weights = dict(), list(), list()
+        members_data, population, weights = {}, [], []
         members = self.filtered(lambda member: not member.assignment_optout and member.assignment_max > 0)
         if not members:
             return members_data
@@ -189,10 +189,10 @@ class TeamMember(models.Model):
         if auto_commit:
             self._cr.commit()
         # log results and return
-        result_data = dict(
-            (member_info["team_member"], {"assigned": member_info["assigned"]})
-            for member_id, member_info in members_data.items()
-        )
+        result_data = {
+            member_info["team_member"]: {"assigned": member_info["assigned"]}
+            for member_info in members_data.values()
+        }
         _logger.info('Assigned %s leads to %s salesmen', len(leads_done_ids), len(members))
         for member, member_info in result_data.items():
             _logger.info('-> member %s: assigned %d leads (%s)', member.id, len(member_info["assigned"]), member_info["assigned"])

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -52,7 +52,7 @@ class TestCRMLead(TestCrmCommon):
         # address
         self.assertLeadAddress(lead, False, False, False, False, self.env['res.country.state'], self.country_ref)
         # other contact fields
-        for fname in set(PARTNER_FIELDS_TO_SYNC) - set(['function', 'lang']):
+        for fname in set(PARTNER_FIELDS_TO_SYNC) - {'function', 'lang'}:
             self.assertEqual(lead[fname], self.contact_1[fname], 'No user input -> take from contact for field %s' % fname)
         self.assertEqual(lead.function, 'Parmesan Rappeur', 'User input should take over partner value')
         self.assertEqual(lead.lang_id, self.lang_fr)

--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -177,7 +177,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
             })
             mass_convert.action_mass_convert()
 
-        self.assertEqual(set(test_leads.mapped('type')), set(['opportunity']))
+        self.assertEqual(set(test_leads.mapped('type')), {'opportunity'})
         self.assertEqual(len(test_leads.partner_id), len(test_leads))
         # TDE FIXME: strange
         # self.assertEqual(test_leads.team_id, self.sales_team_convert | self.sales_team_1)

--- a/addons/crm_iap_mine/models/crm_iap_lead_helpers.py
+++ b/addons/crm_iap_mine/models/crm_iap_lead_helpers.py
@@ -19,9 +19,9 @@ class CRMHelpers(models.Model):
         iap_account = self.env['iap.account'].search([('service_name', '=', service_name)], limit=1)
         # Get the email address of the creators of the records
         res = self.env[model_name].search_read([], ['create_uid'])
-        uids = set(r['create_uid'][0] for r in res if r.get('create_uid'))
+        uids = {r['create_uid'][0] for r in res if r.get('create_uid')}
         res = self.env['res.users'].search_read([('id', 'in', list(uids))], ['email'])
-        emails = set(r['email'] for r in res if r.get('email'))
+        emails = {r['email'] for r in res if r.get('email')}
 
         email_values = {
             'email_to': ','.join(emails)

--- a/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
+++ b/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
@@ -104,9 +104,9 @@ class CRMLeadMiningRequest(models.Model):
                 ['lead_mining_request_id'], ['lead_mining_request_id'])
         else:
             leads_data = []
-        mapped_data = dict(
-            (m['lead_mining_request_id'][0], m['lead_mining_request_id_count'])
-            for m in leads_data)
+        mapped_data = {
+            m['lead_mining_request_id'][0]: m['lead_mining_request_id_count']
+            for m in leads_data}
         for request in self:
             request.lead_count = mapped_data.get(request.id, 0)
 

--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -208,16 +208,14 @@ class Digest(models.Model):
         self.ensure_one()
         digest_fields = self._get_kpi_fields()
         invalid_fields = []
-        kpis = [
-            dict(kpi_name=field_name,
-                 kpi_fullname=self.env['ir.model.fields']._get(self._name, field_name).field_description,
-                 kpi_action=False,
-                 kpi_col1=dict(),
-                 kpi_col2=dict(),
-                 kpi_col3=dict(),
-                 )
-            for field_name in digest_fields
-        ]
+        kpis = [{
+            'kpi_name': field_name,
+            'kpi_fullname': self.env['ir.model.fields']._get(self._name, field_name).field_description,
+            'kpi_action': False,
+            'kpi_col1': {},
+            'kpi_col2': {},
+            'kpi_col3': {}
+        } for field_name in digest_fields]
         kpis_actions = self._compute_kpis_actions(company, user)
 
         for col_index, (tf_name, tf) in enumerate(self._compute_timeframes(company)):

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -220,8 +220,8 @@ class EventEvent(models.Model):
             'open': 'seats_reserved',
             'done': 'seats_used',
         }
-        base_vals = dict((fname, 0) for fname in state_field.values())
-        results = dict((event_id, dict(base_vals)) for event_id in self.ids)
+        base_vals = dict.fromkeys(state_field.values(), 0)
+        results = {event_id: dict(base_vals) for event_id in self.ids}
         if self.ids:
             query = """ SELECT event_id, state, count(event_id)
                         FROM event_registration

--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -189,7 +189,7 @@ class EventMailScheduler(models.Model):
             ex_s = exception_to_unicode(exception)
             try:
                 event, template = scheduler.event_id, scheduler.template_ref
-                emails = list(set([event.organizer_id.email, event.user_id.email, template.write_uid.email]))
+                emails = list({event.organizer_id.email, event.user_id.email, template.write_uid.email})
                 subject = _("WARNING: Event Scheduler Error for event: %s", event.name)
                 body = _("""Event Scheduler for:
   - Event: %(event_name)s (%(event_id)s)

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -118,7 +118,7 @@ class EventRegistration(models.Model):
             contact_id = partner.address_get().get('contact', False)
             if contact_id:
                 contact = self.env['res.partner'].browse(contact_id)
-                return dict((fname, contact[fname]) for fname in fnames if contact[fname])
+                return {fname: contact[fname] for fname in fnames if contact[fname]}
         return {}
 
     # ------------------------------------------------------------
@@ -209,14 +209,14 @@ class EventRegistration(models.Model):
         self.ensure_one()
         template = self.env.ref('event.event_registration_mail_template_badge')
         compose_form = self.env.ref('mail.email_compose_message_wizard_form')
-        ctx = dict(
-            default_model='event.registration',
-            default_res_id=self.id,
-            default_use_template=bool(template),
-            default_template_id=template.id,
-            default_composition_mode='comment',
-            default_email_layout_xmlid="mail.mail_notification_light",
-        )
+        ctx = {
+            'default_model': 'event.registration',
+            'default_res_id': self.id,
+            'default_use_template': bool(template),
+            'default_template_id': template.id,
+            'default_composition_mode': 'comment',
+            'default_email_layout_xmlid': "mail.mail_notification_light"
+        }
         return {
             'name': _('Compose Email'),
             'type': 'ir.actions.act_window',

--- a/addons/event/tests/test_event_internals.py
+++ b/addons/event/tests/test_event_internals.py
@@ -221,14 +221,14 @@ class TestEventData(TestEventInternalsCommon):
         # verify that mail is linked to the registration
         self.assertEqual(
             set(mail.mapped('mail_registration_ids.registration_id.id')),
-            set([registration.id])
+            {registration.id}
         )
         # start test scenario
         event_form = Form(event)
         # verify that mail is linked to the event in the form
         self.assertEqual(
             set(map(lambda m: m.get('id', None), event_form.event_mail_ids._records)),
-            set([mail.id])
+            {mail.id}
         )
         # switch to an event_type with a mail template which should be computed
         event_form.event_type_id = event_type_mails
@@ -247,7 +247,7 @@ class TestEventData(TestEventInternalsCommon):
         # verify that the mail linked to the registration was kept, and the other removed
         self.assertEqual(
             set(map(lambda m: m.get('id', None), event_form.event_mail_ids._records)),
-            set([mail.id])
+            {mail.id}
         )
 
     @users('user_eventmanager')
@@ -322,21 +322,21 @@ class TestEventData(TestEventInternalsCommon):
         # verify that the ticket is linked to the event in the form
         self.assertEqual(
             set(map(lambda m: m.get('name', None), event_form.event_ticket_ids._records)),
-            set(['Registration Ticket'])
+            {'Registration Ticket'}
         )
         # switch to an event_type with a ticket template which should be computed
         event_form.event_type_id = event_type_tickets
         # verify that both tickets are computed
         self.assertEqual(
             set(map(lambda m: m.get('name', None), event_form.event_ticket_ids._records)),
-            set(['Registration Ticket', 'Default Ticket'])
+            {'Registration Ticket', 'Default Ticket'}
         )
         # switch back to an event_type without default tickets
         event_form.event_type_id = event_type_default
         # verify that the ticket linked to the registration was kept, and the other removed
         self.assertEqual(
             set(map(lambda m: m.get('name', None), event_form.event_ticket_ids._records)),
-            set(['Registration Ticket'])
+            {'Registration Ticket'}
         )
 
     @users('user_eventmanager')

--- a/addons/event_booth/models/event_booth.py
+++ b/addons/event_booth/models/event_booth.py
@@ -80,10 +80,10 @@ class EventBooth(models.Model):
         to_confirm = self.filtered(lambda booth: booth.state == 'available')
         wpartner = {}
         if 'state' in vals or 'partner_id' in vals:
-            wpartner = dict(
-                (booth, booth.partner_id.ids)
+            wpartner = {
+                booth: booth.partner_id.ids
                 for booth in self.filtered(lambda booth: booth.partner_id)
-            )
+            }
 
         res = super(EventBooth, self).write(vals)
 

--- a/addons/event_booth/models/event_event.py
+++ b/addons/event_booth/models/event_event.py
@@ -57,8 +57,8 @@ class Event(models.Model):
             [('event_id', 'in', self.ids)],
             ['event_id', 'state'], ['event_id', 'state'], lazy=False
         )
-        elements_total_count = dict()
-        elements_available_count = dict()
+        elements_total_count = {}
+        elements_available_count = {}
         for element in elements:
             event_id = element['event_id'][0]
             if element['state'] == 'available':

--- a/addons/event_booth/tests/test_event_internals.py
+++ b/addons/event_booth/tests/test_event_internals.py
@@ -83,7 +83,7 @@ class TestEventData(TestEventBoothCommon):
         self.assertEqual(event.event_booth_count, 3)
         self.assertEqual(
             set(r['name'] for r in event.event_booth_ids),
-            set(('Custom Standard Booth 2', 'Standard Booth', 'Premium Booth')),
+            {'Custom Standard Booth 2', 'Standard Booth', 'Premium Booth'},
             'Should keep booths with reservation, remove unused ones and add type ones'
         )
         self.assertEqual(event.event_booth_count_available, 2)

--- a/addons/event_booth_sale/models/sale_order.py
+++ b/addons/event_booth_sale/models/sale_order.py
@@ -17,9 +17,9 @@ class SaleOrder(models.Model):
                 [('sale_order_id', 'in', self.ids)],
                 ['sale_order_id'], ['sale_order_id']
             )
-            slot_mapped = dict((data['sale_order_id'][0], data['sale_order_id_count']) for data in slot_data)
+            slot_mapped = {data['sale_order_id'][0]: data['sale_order_id_count'] for data in slot_data}
         else:
-            slot_mapped = dict()
+            slot_mapped = {}
         for so in self:
             so.event_booth_count = slot_mapped.get(so.id, 0)
 

--- a/addons/event_booth_sale/tests/test_event_internals.py
+++ b/addons/event_booth_sale/tests/test_event_internals.py
@@ -87,7 +87,7 @@ class TestEventData(TestEventBoothSaleCommon):
         self.assertEqual(event.event_booth_count, 3)
         self.assertEqual(
             set(r['name'] for r in event.event_booth_ids),
-            set(('Custom Standard Booth 2', 'Standard Booth', 'Premium Booth')),
+            {'Custom Standard Booth 2', 'Standard Booth', 'Premium Booth'},
             'Should keep booths with reservation, remove unused ones and add type ones'
         )
         self.assertEqual(event.event_booth_count_available, 2)

--- a/addons/event_crm/models/event_lead_rule.py
+++ b/addons/event_crm/models/event_lead_rule.py
@@ -153,7 +153,7 @@ class EventLeadRule(models.Model):
 
         # second: check registrations matching rules (in batch)
         new_registrations = self.env['event.registration']
-        rule_to_new_regs = dict()
+        rule_to_new_regs = {}
         for rule in self:
             new_for_rule = registrations.filtered(lambda reg: reg not in rule_to_existing_regs[rule])
             rule_registrations = rule._filter_registrations(new_for_rule)

--- a/addons/event_crm/models/event_registration.py
+++ b/addons/event_crm/models/event_registration.py
@@ -115,10 +115,10 @@ class EventRegistration(models.Model):
             # if partner has been updated -> update registration contact information
             # as they are computed (and therefore not given to write values)
             if 'partner_id' in new_vals:
-                new_vals.update(**dict(
+                new_vals.update(
                     (field, registration[field])
                     for field in self._get_lead_contact_fields()
-                    if field != 'partner_id')
+                    if field != 'partner_id'
                 )
 
             lead_values = {}
@@ -262,11 +262,10 @@ class EventRegistration(models.Model):
 
         Tracked values are therefore the union of those two field sets. """
         tracked_fields = list(set(self._get_lead_contact_fields()) or set(self._get_lead_description_fields()))
-        return dict(
-            (registration.id,
-             dict((field, self._convert_value(registration[field], field)) for field in tracked_fields)
-            ) for registration in self
-        )
+        return {
+            registration.id: {field: self._convert_value(registration[field], field) for field in tracked_fields}
+            for registration in self
+        }
 
     def _get_lead_grouping(self, rules, rule_to_new_regs):
         """ Perform grouping of registrations in order to enable order-based
@@ -295,11 +294,11 @@ class EventRegistration(models.Model):
         for registration in self:
             event_to_reg_ids[registration.event_id] += registration
 
-        return dict(
-            (rule, [(False, event, (registrations & rule_to_new_regs[rule]).sorted('id'))
-                    for event, registrations in event_to_reg_ids.items()])
+        return {
+            rule: [(False, event, (registrations & rule_to_new_regs[rule]).sorted('id'))
+                    for event, registrations in event_to_reg_ids.items()]
             for rule in rules
-        )
+        }
 
     # ------------------------------------------------------------
     # TOOLS

--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -158,19 +158,19 @@ class TestEventSale(TestEventSaleCommon):
         self.assertEqual(len(ticket2_new_reg), 1)
         self.assertEqual(
             set(ticket1_new_reg.mapped('name')),
-            set(['ManualEntry1', 'ManualEntry2'])
+            {'ManualEntry1', 'ManualEntry2'}
         )
         self.assertEqual(
             set(ticket1_new_reg.mapped('email')),
-            set(['manual.email.1@test.example.com', 'manual.email.2@test.example.com'])
+            {'manual.email.1@test.example.com', 'manual.email.2@test.example.com'}
         )
         self.assertEqual(
             set(ticket1_new_reg.mapped('phone')),
-            set(['+32456111111', self.event_customer.phone])
+            {'+32456111111', self.event_customer.phone}
         )
         self.assertEqual(
             set(ticket1_new_reg.mapped('mobile')),
-            set(['+32456222222', self.event_customer.mobile])
+            {'+32456222222', self.event_customer.mobile}
         )
         for field in ['name', 'email', 'phone', 'mobile']:
             self.assertEqual(ticket2_new_reg[field], self.event_customer[field])

--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -115,7 +115,7 @@ class FleetVehicle(models.Model):
         '''
         Copies all the related fields from the model to the vehicle
         '''
-        model_values = dict()
+        model_values = {}
         for vehicle in self.filtered('model_id'):
             if vehicle.model_id.id in model_values:
                 write_vals = model_values[vehicle.model_id.id]

--- a/addons/gamification/models/gamification_challenge.py
+++ b/addons/gamification/models/gamification_challenge.py
@@ -144,10 +144,7 @@ class Challenge(models.Model):
               GROUP BY gamification_challenge_id
             """
             self.env.cr.execute(query, [tuple(self.ids)])
-            mapped_data = dict(
-                (challenge_id, user_count)
-                for challenge_id, user_count in self.env.cr.fetchall()
-            )
+            mapped_data = dict(self.env.cr.fetchall())
         for challenge in self:
             challenge.user_count = mapped_data.get(challenge.id, 0)
 

--- a/addons/gamification/models/gamification_karma_rank.py
+++ b/addons/gamification/models/gamification_karma_rank.py
@@ -28,7 +28,7 @@ class KarmaRank(models.Model):
     @api.depends('user_ids')
     def _compute_rank_users_count(self):
         requests_data = self.env['res.users'].read_group([('rank_id', '!=', False)], ['rank_id'], ['rank_id'])
-        requests_mapped_data = dict((data['rank_id'][0], data['rank_id_count']) for data in requests_data)
+        requests_mapped_data = {data['rank_id'][0]: data['rank_id_count'] for data in requests_data}
         for rank in self:
             rank.rank_users_count = requests_mapped_data.get(rank.id, 0)
 

--- a/addons/hr/models/hr_department.py
+++ b/addons/hr/models/hr_department.py
@@ -44,7 +44,7 @@ class Department(models.Model):
 
     def _compute_total_employee(self):
         emp_data = self.env['hr.employee'].read_group([('department_id', 'in', self.ids)], ['department_id'], ['department_id'])
-        result = dict((data['department_id'][0], data['department_id_count']) for data in emp_data)
+        result = {data['department_id'][0]: data['department_id_count'] for data in emp_data}
         for department in self:
             department.total_employee = result.get(department.id, 0)
 

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -267,10 +267,7 @@ class HrEmployeePrivate(models.Model):
             self.tz = self.resource_calendar_id.tz
 
     def _sync_user(self, user, employee_has_image=False):
-        vals = dict(
-            work_email=user.email,
-            user_id=user.id,
-        )
+        vals = {'work_email': user.email, 'user_id': user.id}
         if not employee_has_image:
             vals['image_1920'] = user.image_1920
         if user.tz:

--- a/addons/hr/models/hr_job.py
+++ b/addons/hr/models/hr_job.py
@@ -39,7 +39,7 @@ class Job(models.Model):
     @api.depends('no_of_recruitment', 'employee_ids.job_id', 'employee_ids.active')
     def _compute_employees(self):
         employee_data = self.env['hr.employee'].read_group([('job_id', 'in', self.ids)], ['job_id'], ['job_id'])
-        result = dict((data['job_id'][0], data['job_id_count']) for data in employee_data)
+        result = {data['job_id'][0]: data['job_id_count'] for data in employee_data}
         for job in self:
             job.no_of_employee = result.get(job.id, 0)
             job.expected_employees = result.get(job.id, 0) + job.no_of_recruitment

--- a/addons/hr/models/mail_channel.py
+++ b/addons/hr/models/mail_channel.py
@@ -17,7 +17,7 @@ class Channel(models.Model):
         for channel in self:
             new_members[channel.id] = list(
                 set(new_members[channel.id]) |
-                set((channel.subscription_department_ids.member_ids.user_id.partner_id - channel.channel_partner_ids).ids)
+                {(channel.subscription_department_ids.member_ids.user_id.partner_id - channel.channel_partner_ids).ids}
             )
         return new_members
 

--- a/addons/hr/models/mail_channel.py
+++ b/addons/hr/models/mail_channel.py
@@ -17,7 +17,7 @@ class Channel(models.Model):
         for channel in self:
             new_members[channel.id] = list(
                 set(new_members[channel.id]) |
-                {(channel.subscription_department_ids.member_ids.user_id.partner_id - channel.channel_partner_ids).ids}
+                set((channel.subscription_department_ids.member_ids.user_id.partner_id - channel.channel_partner_ids).ids)
             )
         return new_members
 

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -235,8 +235,8 @@ class User(models.Model):
 
     def action_create_employee(self):
         self.ensure_one()
-        self.env['hr.employee'].create(dict(
-            name=self.name,
-            company_id=self.env.company.id,
+        self.env['hr.employee'].create({
+            'name': self.name,
+            'company_id': self.env.company.id,
             **self.env['hr.employee']._sync_user(self)
-        ))
+        })

--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -39,7 +39,7 @@ class Employee(models.Model):
     def _compute_contracts_count(self):
         # read_group as sudo, since contract count is displayed on form view
         contract_data = self.env['hr.contract'].sudo().read_group([('employee_id', 'in', self.ids)], ['employee_id'], ['employee_id'])
-        result = dict((data['employee_id'][0], data['employee_id_count']) for data in contract_data)
+        result = {data['employee_id'][0]: data['employee_id_count'] for data in contract_data}
         for employee in self:
             employee.contracts_count = result.get(employee.id, 0)
 

--- a/addons/hr_expense/models/hr_department.py
+++ b/addons/hr_expense/models/hr_department.py
@@ -9,7 +9,7 @@ class HrDepartment(models.Model):
 
     def _compute_expense_sheets_to_approve(self):
         expense_sheet_data = self.env['hr.expense.sheet'].read_group([('department_id', 'in', self.ids), ('state', '=', 'submit')], ['department_id'], ['department_id'])
-        result = dict((data['department_id'][0], data['department_id_count']) for data in expense_sheet_data)
+        result = {data['department_id'][0]: data['department_id_count'] for data in expense_sheet_data}
         for department in self:
             department.expense_sheets_to_approve_count = result.get(department.id, 0)
 

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -193,7 +193,7 @@ class HrExpense(models.Model):
 
     def _compute_attachment_number(self):
         attachment_data = self.env['ir.attachment'].read_group([('res_model', '=', 'hr.expense'), ('res_id', 'in', self.ids)], ['res_id'], ['res_id'])
-        attachment = dict((data['res_id'], data['res_id_count']) for data in attachment_data)
+        attachment = {data['res_id']: data['res_id_count'] for data in attachment_data}
         for expense in self:
             expense.attachment_number = attachment.get(expense._origin.id, 0)
 

--- a/addons/hr_fleet/models/fleet_vehicle_assignation_log.py
+++ b/addons/hr_fleet/models/fleet_vehicle_assignation_log.py
@@ -22,7 +22,7 @@ class FleetVehicleAssignationLog(models.Model):
         attachment_data = self.env['ir.attachment'].read_group([
             ('res_model', '=', 'fleet.vehicle.assignation.log'),
             ('res_id', 'in', self.ids)], ['res_id'], ['res_id'])
-        attachment = dict((data['res_id'], data['res_id_count']) for data in attachment_data)
+        attachment = {data['res_id']: data['res_id_count'] for data in attachment_data}
         for doc in self:
             doc.attachment_number = attachment.get(doc.id, 0)
 

--- a/addons/hr_holidays/models/hr_department.py
+++ b/addons/hr_holidays/models/hr_department.py
@@ -38,9 +38,9 @@ class Department(models.Model):
              ('date_from', '<=', today_end), ('date_to', '>=', today_start)],
             ['department_id'], ['department_id'])
 
-        res_leave = dict((data['department_id'][0], data['department_id_count']) for data in leave_data)
-        res_allocation = dict((data['department_id'][0], data['department_id_count']) for data in allocation_data)
-        res_absence = dict((data['department_id'][0], data['department_id_count']) for data in absence_data)
+        res_leave = {data['department_id'][0]: data['department_id_count'] for data in leave_data}
+        res_allocation = {data['department_id'][0]: data['department_id_count'] for data in allocation_data}
+        res_absence = {data['department_id'][0]: data['department_id_count'] for data in absence_data}
 
         for department in self:
             department.leave_to_approve_count = res_leave.get(department.id, 0)

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -359,7 +359,7 @@ class HolidaysType(models.Model):
             ['holiday_status_id'],
             ['holiday_status_id'],
         )
-        grouped_dict = dict((data['holiday_status_id'][0], data['holiday_status_id_count']) for data in grouped_res)
+        grouped_dict = {data['holiday_status_id'][0]: data['holiday_status_id_count'] for data in grouped_res}
         for allocation in self:
             allocation.allocation_count = grouped_dict.get(allocation.id, 0)
 
@@ -377,13 +377,13 @@ class HolidaysType(models.Model):
             ['holiday_status_id'],
             ['holiday_status_id'],
         )
-        grouped_dict = dict((data['holiday_status_id'][0], data['holiday_status_id_count']) for data in grouped_res)
+        grouped_dict = {data['holiday_status_id'][0]: data['holiday_status_id_count'] for data in grouped_res}
         for allocation in self:
             allocation.group_days_leave = grouped_dict.get(allocation.id, 0)
 
     def _compute_accrual_count(self):
         accrual_allocations = self.env['hr.leave.accrual.plan'].read_group([('time_off_type_id', 'in', self.ids)], ['time_off_type_id'], ['time_off_type_id'])
-        mapped_data = dict((data['time_off_type_id'][0], data['time_off_type_id_count']) for data in accrual_allocations)
+        mapped_data = {data['time_off_type_id'][0]: data['time_off_type_id_count'] for data in accrual_allocations}
         for leave_type in self:
             leave_type.accrual_count = mapped_data.get(leave_type.id, 0)
 

--- a/addons/hr_org_chart/controllers/hr_org_chart.py
+++ b/addons/hr_org_chart/controllers/hr_org_chart.py
@@ -32,16 +32,16 @@ class HrOrgChartController(http.Controller):
 
     def _prepare_employee_data(self, employee):
         job = employee.sudo().job_id
-        return dict(
-            id=employee.id,
-            name=employee.name,
-            link='/mail/view?model=%s&res_id=%s' % ('hr.employee.public', employee.id,),
-            job_id=job.id,
-            job_name=job.name or '',
-            job_title=employee.job_title or '',
-            direct_sub_count=len(employee.child_ids),
-            indirect_sub_count=employee.child_all_count,
-        )
+        return {
+            'id': employee.id,
+            'name': employee.name,
+            'link': '/mail/view?model=%s&res_id=%s' % ('hr.employee.public', employee.id,),
+            'job_id': job.id,
+            'job_name': job.name or '',
+            'job_title': employee.job_title or '',
+            'direct_sub_count': len(employee.child_ids),
+            'indirect_sub_count': employee.child_all_count
+        }
 
     @http.route('/hr/get_redirect_model', type='json', auth='user')
     def get_redirect_model(self):
@@ -65,16 +65,16 @@ class HrOrgChartController(http.Controller):
             ancestors += current.parent_id
             current = current.parent_id
 
-        values = dict(
-            self=self._prepare_employee_data(employee),
-            managers=[
+        values = {
+            'self': self._prepare_employee_data(employee),
+            'managers': [
                 self._prepare_employee_data(ancestor)
                 for idx, ancestor in enumerate(ancestors)
                 if idx < self._managers_level
             ],
-            managers_more=len(ancestors) > self._managers_level,
-            children=[self._prepare_employee_data(child) for child in employee.child_ids],
-        )
+            'managers_more': len(ancestors) > self._managers_level,
+            'children': [self._prepare_employee_data(child) for child in employee.child_ids]
+        }
         values['managers'].reverse()
         return values
 

--- a/addons/hr_presence/models/hr_employee.py
+++ b/addons/hr_presence/models/hr_employee.py
@@ -179,15 +179,15 @@ Do not hesitate to contact your manager or the human resource department.""")
             raise UserError(_("There is no professional email address for this employee."))
         template = self.env.ref('hr_presence.mail_template_presence', False)
         compose_form = self.env.ref('mail.email_compose_message_wizard_form', False)
-        ctx = dict(
-            default_model="hr.employee",
-            default_res_id=self.id,
-            default_use_template=bool(template),
-            default_template_id=template.id,
-            default_composition_mode='comment',
-            default_is_log=True,
-            default_email_layout_xmlid='mail.mail_notification_light',
-        )
+        ctx = {
+            'default_model': "hr.employee",
+            'default_res_id': self.id,
+            'default_use_template': bool(template),
+            'default_template_id': template.id,
+            'default_composition_mode': 'comment',
+            'default_is_log': True,
+            'default_email_layout_xmlid': 'mail.mail_notification_light'
+        }
         return {
             'name': _('Compose Email'),
             'type': 'ir.actions.act_window',

--- a/addons/hr_recruitment/models/hr_department.py
+++ b/addons/hr_recruitment/models/hr_department.py
@@ -17,7 +17,7 @@ class HrDepartment(models.Model):
         applicant_data = self.env['hr.applicant'].read_group(
             [('department_id', 'in', self.ids), ('stage_id.sequence', '<=', '1')],
             ['department_id'], ['department_id'])
-        result = dict((data['department_id'][0], data['department_id_count']) for data in applicant_data)
+        result = {data['department_id'][0]: data['department_id_count'] for data in applicant_data}
         for department in self:
             department.new_applicant_count = result.get(department.id, 0)
 
@@ -25,8 +25,8 @@ class HrDepartment(models.Model):
         job_data = self.env['hr.job'].read_group(
             [('department_id', 'in', self.ids)],
             ['no_of_hired_employee', 'no_of_recruitment', 'department_id'], ['department_id'])
-        new_emp = dict((data['department_id'][0], data['no_of_hired_employee']) for data in job_data)
-        expected_emp = dict((data['department_id'][0], data['no_of_recruitment']) for data in job_data)
+        new_emp = {data['department_id'][0]: data['no_of_hired_employee'] for data in job_data}
+        expected_emp = {data['department_id'][0]: data['no_of_recruitment'] for data in job_data}
         for department in self:
             department.new_hired_employee = new_emp.get(department.id, 0)
             department.expected_employee = expected_emp.get(department.id, 0)

--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -61,7 +61,7 @@ class Job(models.Model):
 
     def _compute_document_ids(self):
         applicants = self.mapped('application_ids').filtered(lambda self: not self.emp_id)
-        app_to_job = dict((applicant.id, applicant.job_id.id) for applicant in applicants)
+        app_to_job = {applicant.id: applicant.job_id.id for applicant in applicants}
         attachments = self.env['ir.attachment'].search([
             '|',
             '&', ('res_model', '=', 'hr.job'), ('res_id', 'in', self.ids),
@@ -79,13 +79,13 @@ class Job(models.Model):
 
     def _compute_all_application_count(self):
         read_group_result = self.env['hr.applicant'].with_context(active_test=False).read_group([('job_id', 'in', self.ids)], ['job_id'], ['job_id'])
-        result = dict((data['job_id'][0], data['job_id_count']) for data in read_group_result)
+        result = {data['job_id'][0]: data['job_id_count'] for data in read_group_result}
         for job in self:
             job.all_application_count = result.get(job.id, 0)
 
     def _compute_application_count(self):
         read_group_result = self.env['hr.applicant'].read_group([('job_id', 'in', self.ids)], ['job_id'], ['job_id'])
-        result = dict((data['job_id'][0], data['job_id_count']) for data in read_group_result)
+        result = {data['job_id'][0]: data['job_id_count'] for data in read_group_result}
         for job in self:
             job.application_count = result.get(job.id, 0)
 

--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -87,7 +87,7 @@ class RecruitmentStage(models.Model):
     @api.depends('hired_stage')
     def _compute_is_warning_visible(self):
         applicant_data = self.env['hr.applicant'].read_group([('stage_id', 'in', self.ids)], ['stage_id'], 'stage_id')
-        applicants = dict((data['stage_id'][0], data['stage_id_count']) for data in applicant_data)
+        applicants = {data['stage_id'][0]: data['stage_id_count'] for data in applicant_data}
         for stage in self:
             if stage._origin.hired_stage and not stage.hired_stage and applicants.get(stage._origin.id):
                 stage.is_warning_visible = True
@@ -225,9 +225,9 @@ class Applicant(models.Model):
             }
             self.env.cr.execute(query_str, where_clause_params)
 
-            application_data_mapped = dict((data['l_email_from'], data['count']) for data in self.env.cr.dictfetchall())
+            application_data_mapped = dict(self.env.cr.fetchall())
         else:
-            application_data_mapped = dict()
+            application_data_mapped = {}
         for applicant in applicants:
             applicant.application_count = application_data_mapped.get(applicant.email_from.lower(), 1) - 1
         (self - applicants).application_count = False
@@ -261,7 +261,7 @@ class Applicant(models.Model):
         read_group_res = self.env['ir.attachment'].read_group(
             [('res_model', '=', 'hr.applicant'), ('res_id', 'in', self.ids)],
             ['res_id'], ['res_id'])
-        attach_data = dict((res['res_id'], res['res_id_count']) for res in read_group_res)
+        attach_data = {res['res_id']: res['res_id_count'] for res in read_group_res}
         for record in self:
             record.attachment_number = attach_data.get(record.id, 0)
 
@@ -598,7 +598,7 @@ class Applicant(models.Model):
 
     def reset_applicant(self):
         """ Reinsert the applicant into the recruitment pipe in the first stage"""
-        default_stage = dict()
+        default_stage = {}
         for job_id in self.mapped('job_id'):
             default_stage[job_id.id] = self.env['hr.recruitment.stage'].search(
                 ['|',

--- a/addons/hr_recruitment_survey/tests/test_recruitment_survey.py
+++ b/addons/hr_recruitment_survey/tests/test_recruitment_survey.py
@@ -58,7 +58,7 @@ class TestRecruitmentSurvey(common.SingleTransactionCase):
         self.assertEqual(self.job_sysadmin.response_id, answers)
         self.assertEqual(
             set(answers.mapped('email')),
-            set([self.job_sysadmin.email_from]))
+            {self.job_sysadmin.email_from})
 
     def test_print_survey(self):
         # We ensure that response is False because we don't know test order

--- a/addons/hr_timesheet/controllers/portal.py
+++ b/addons/hr_timesheet/controllers/portal.py
@@ -139,11 +139,11 @@ class TimesheetCustomerPortal(CustomerPortal):
             if field:
                 if groupby == 'date':
                     time_data = Timesheet_sudo.read_group(domain, ['date', 'unit_amount:sum'], ['date:day'])
-                    mapped_time = dict([(datetime.strptime(m['date:day'], '%d %b %Y').date(), m['unit_amount']) for m in time_data])
+                    mapped_time = {datetime.strptime(m['date:day'], '%d %b %Y').date(): m['unit_amount'] for m in time_data}
                     grouped_timesheets = [(Timesheet_sudo.concat(*g), mapped_time[k]) for k, g in groupbyelem(timesheets, itemgetter('date'))]
                 else:
-                    time_data = time_data = Timesheet_sudo.read_group(domain, [field, 'unit_amount:sum'], [field])
-                    mapped_time = dict([(m[field][0] if m[field] else False, m['unit_amount']) for m in time_data])
+                    time_data = Timesheet_sudo.read_group(domain, [field, 'unit_amount:sum'], [field])
+                    mapped_time = {m[field][0] if m[field] else False: m['unit_amount'] for m in time_data}
                     grouped_timesheets = [(Timesheet_sudo.concat(*g), mapped_time[k.id]) for k, g in groupbyelem(timesheets, itemgetter(field))]
                 return timesheets, grouped_timesheets
 

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -166,7 +166,7 @@ class AccountAnalyticLine(models.Model):
         # custom inheretied view stored in database. Even if normally, no xpath can be done on
         # 'string' attribute.
         for node in doc.xpath("//field[@name='unit_amount'][@widget='timesheet_uom'][not(@string)]"):
-            node.set('string', _('%s Spent') % (re.sub(r'[\(\)]', '', encoding_uom.name or '')))
+            node.set('string', _('%s Spent') % (re.sub(r'[()]', '', encoding_uom.name or '')))
         return etree.tostring(doc, encoding='unicode')
 
     @api.model

--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -556,10 +556,7 @@ class IrHttp(models.AbstractModel):
     def _get_exception_code_values(cls, exception):
         """ Return a tuple with the error code following by the values matching the exception"""
         code = 500  # default code
-        values = dict(
-            exception=exception,
-            traceback=traceback.format_exc(),
-        )
+        values = {'exception': exception, 'traceback': traceback.format_exc()}
         if isinstance(exception, exceptions.UserError):
             values['error_message'] = exception.args[0]
             code = 400

--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver.py
@@ -126,7 +126,7 @@ class PrinterDriver(Driver):
                     break
         elif device.get('device-make-and-model'):
             device_model = device['device-make-and-model']
-        return re.sub("\(.*?\)", "", device_model).strip()
+        return re.sub(r"\(.*?\)", "", device_model).strip()
 
     @classmethod
     def get_status(cls):

--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver.py
@@ -126,7 +126,7 @@ class PrinterDriver(Driver):
                     break
         elif device.get('device-make-and-model'):
             device_model = device['device-make-and-model']
-        return re.sub("[\(].*?[\)]", "", device_model).strip()
+        return re.sub("\(.*?\)", "", device_model).strip()
 
     @classmethod
     def get_status(cls):

--- a/addons/hw_escpos/escpos/printer.py
+++ b/addons/hw_escpos/escpos/printer.py
@@ -34,7 +34,7 @@ class Usb(Escpos):
         # pyusb dropped the 'interface' parameter from usb.Device.write() at 1.0.0b2
         # https://github.com/pyusb/pyusb/commit/20cd8c1f79b24082ec999c022b56c3febedc0964#diff-b5a4f98a864952f0f55d569dd14695b7L293
         if usb.version_info < (1, 0, 0) or (usb.version_info == (1, 0, 0) and usb.version_info[3] in ("a1", "a2", "a3", "b1")):
-            self.write_kwargs = dict(interface=self.interface)
+            self.write_kwargs = {'interface': self.interface}
         else:
             self.write_kwargs = {}
 

--- a/addons/iap/tools/iap_tools.py
+++ b/addons/iap/tools/iap_tools.py
@@ -38,7 +38,7 @@ BaseCase.setUp = setUp
 # Tools globals
 #----------------------------------------------------------
 
-_MAIL_DOMAIN_BLACKLIST = set([
+_MAIL_DOMAIN_BLACKLIST = {
     # Top 100 email providers on SaaS at 2020-10
     'gmail.com', 'hotmail.com', 'yahoo.com', 'qq.com', 'outlook.com', '163.com', 'yahoo.fr', 'live.com', 'hotmail.fr', 'icloud.com', '126.com',
     'me.com', 'free.fr', 'ymail.com', 'msn.com', 'mail.com', 'orange.fr', 'aol.com', 'wanadoo.fr', 'live.fr', 'mail.ru', 'yahoo.co.in',
@@ -65,13 +65,13 @@ _MAIL_DOMAIN_BLACKLIST = set([
     'prisme.ch', 'bbox.fr', 'orbitalu.com', 'netcourrier.com', 'iinet.net.au',
     # Dummy entries
     'example.com',
-])
+}
 
 # List of country codes for which we should offer state filtering when mining new leads.
 # See crm.iap.lead.mining.request#_compute_available_state_ids() or task-2471703 for more details.
-_STATES_FILTER_COUNTRIES_WHITELIST = set([
+_STATES_FILTER_COUNTRIES_WHITELIST = {
     'AR', 'AU', 'BR', 'CA', 'IN', 'MY', 'MX', 'NZ', 'AE', 'US'
-])
+}
 
 #----------------------------------------------------------
 # Helpers for both clients and proxy

--- a/addons/im_livechat/models/mail_channel.py
+++ b/addons/im_livechat/models/mail_channel.py
@@ -52,7 +52,7 @@ class MailChannel(models.Model):
             :rtype : list(dict)
         """
         channel_infos = super().channel_info()
-        channel_infos_dict = dict((c['id'], c) for c in channel_infos)
+        channel_infos_dict = {c['id']: c for c in channel_infos}
         for channel in self:
             # add the last message date
             if channel.channel_type == 'livechat':

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -71,9 +71,9 @@ class AccountMove(models.Model):
         """ Method to get the concept of the invoice considering the type of the products on the invoice """
         self.ensure_one()
         invoice_lines = self.invoice_line_ids.filtered(lambda x: not x.display_type)
-        product_types = set([x.product_id.type for x in invoice_lines if x.product_id])
-        consumable = set(['consu', 'product'])
-        service = set(['service'])
+        product_types = {x.product_id.type for x in invoice_lines if x.product_id}
+        consumable = {'consu', 'product'}
+        service = {'service'}
         # on expo invoice you can mix services and products
         expo_invoice = self.l10n_latam_document_type_id.code in ['19', '20', '21']
 

--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -150,7 +150,7 @@ class AccountMove(models.Model):
         pdf_name = re.sub(r'\W+', '', self.name) + '.pdf'
 
         # tax map for 0% taxes which have no tax_line_id
-        tax_map = dict()
+        tax_map = {}
         for line in self.line_ids:
             for tax in line.tax_ids:
                 if tax.amount == 0.0:

--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -66,7 +66,7 @@ class LinkTracker(models.Model):
             )
             mapped_data = {m['link_id'][0]: m['link_id_count'] for m in clicks_data}
         else:
-            mapped_data = dict()
+            mapped_data = {}
         for tracker in self:
             tracker.count = mapped_data.get(tracker.id, 0)
 
@@ -297,7 +297,7 @@ class LinkTrackerClick(models.Model):
     country_id = fields.Many2one('res.country', 'Country')
 
     def _prepare_click_values_from_route(self, **route_values):
-        click_values = dict((fname, route_values[fname]) for fname in self._fields if fname in route_values)
+        click_values = {fname: route_values[fname] for fname in self._fields if fname in route_values}
         if not click_values.get('country_id') and route_values.get('country_code'):
             click_values['country_id'] = self.env['res.country'].search([('code', '=', route_values['country_code'])], limit=1).id
         return click_values

--- a/addons/lunch/models/lunch_order.py
+++ b/addons/lunch/models/lunch_order.py
@@ -244,7 +244,7 @@ class LunchOrder(models.Model):
             return
         notified_users = set()
         # (company, lang): (subject, body)
-        translate_cache = dict()
+        translate_cache = {}
         for order in self:
             user = order.user_id
             if user in notified_users:

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -565,7 +565,7 @@ class MailActivity(models.Model):
 
     def activity_format(self):
         activities = self.read()
-        mail_template_ids = set([template_id for activity in activities for template_id in activity["mail_template_ids"]])
+        mail_template_ids = {template_id for activity in activities for template_id in activity["mail_template_ids"]}
         mail_template_info = self.env["mail.template"].browse(mail_template_ids).read(['id', 'name'])
         mail_template_dict = dict([(mail_template['id'], mail_template) for mail_template in mail_template_info])
         for activity in activities:

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -206,7 +206,7 @@ class MailActivity(models.Model):
 
         # fall back on related document access right checks. Use the same as defined for mail.thread
         # if available; otherwise fall back on read for read, write for other operations.
-        activity_to_documents = dict()
+        activity_to_documents = {}
         for activity in remaining_sudo:
             # write / unlink: if not updating self or assigned, limit to automated activities to avoid
             # updating other people's activities. As unlinking a document bypasses access rights checks
@@ -356,7 +356,7 @@ class MailActivity(models.Model):
             self._cr.execute("""
                 SELECT DISTINCT activity.id, activity.res_model, activity.res_id
                 FROM "%s" activity
-                WHERE activity.id = ANY (%%(ids)s) AND activity.res_id != 0""" % self._table, dict(ids=list(sub_ids)))
+                WHERE activity.id = ANY (%%(ids)s) AND activity.res_id != 0""" % self._table, {'ids': list(sub_ids)})
             activities_to_check += self._cr.dictfetchall()
 
         activity_to_documents = {}
@@ -437,11 +437,11 @@ class MailActivity(models.Model):
                 activity = activity.with_context(lang=activity.user_id.lang)
             model_description = self.env['ir.model']._get(activity.res_model).display_name
             body = body_template._render(
-                dict(
-                    activity=activity,
-                    model_description=model_description,
-                    access_link=self.env['mail.thread']._notify_get_action_link('view', model=activity.res_model, res_id=activity.res_id),
-                ),
+                {
+                    'activity': activity,
+                    'model_description': model_description,
+                    'access_link': self.env['mail.thread']._notify_get_action_link('view', model=activity.res_model, res_id=activity.res_id)
+                },
                 engine='ir.qweb',
                 minimal_qcontext=True
             )
@@ -567,7 +567,7 @@ class MailActivity(models.Model):
         activities = self.read()
         mail_template_ids = {template_id for activity in activities for template_id in activity["mail_template_ids"]}
         mail_template_info = self.env["mail.template"].browse(mail_template_ids).read(['id', 'name'])
-        mail_template_dict = dict([(mail_template['id'], mail_template) for mail_template in mail_template_info])
+        mail_template_dict = {mail_template['id']: mail_template for mail_template in mail_template_info}
         for activity in activities:
             activity['mail_template_ids'] = [mail_template_dict[mail_template_id] for mail_template_id in activity['mail_template_ids']]
         return activities

--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -435,7 +435,7 @@ class MailActivityMixin(models.AbstractModel):
         if self.env.context.get('mail_activity_automation_skip'):
             return False
 
-        render_context = render_context or dict()
+        render_context = render_context or {}
         if isinstance(views_or_xmlid, str):
             views = self.env.ref(views_or_xmlid, raise_if_not_found=False)
         else:

--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -273,10 +273,10 @@ class Channel(models.Model):
 
     def _subscribe_users_automatically_get_members(self):
         """ Return new members per channel ID """
-        return dict(
-            (channel.id, (channel.group_ids.users.partner_id - channel.channel_partner_ids).ids)
+        return {
+            channel.id: (channel.group_ids.users.partner_id - channel.channel_partner_ids).ids
             for channel in self
-        )
+        }
 
     def action_unfollow(self):
         return self._action_unfollow(self.env.user.partner_id)
@@ -731,7 +731,7 @@ class Channel(models.Model):
             return []
         channel_infos = []
         rtc_sessions_by_channel = self.sudo().rtc_session_ids._mail_rtc_session_format_by_channel()
-        channel_last_message_ids = dict((r['id'], r['message_id']) for r in self._channel_last_message_ids())
+        channel_last_message_ids = {r['id']: r['message_id'] for r in self._channel_last_message_ids()}
         all_needed_members_domain = expression.OR([
             [('channel_id.channel_type', '!=', 'channel')],
             [('rtc_inviting_session_id', '!=', False)],
@@ -1130,7 +1130,7 @@ class Channel(models.Model):
         if not self:
             return []
         channels_last_message_ids = self._channel_last_message_ids()
-        channels_preview = dict((r['message_id'], r) for r in channels_last_message_ids)
+        channels_preview = {r['message_id']: r for r in channels_last_message_ids}
         last_messages = self.env['mail.message'].browse(channels_preview).message_format()
         for message in last_messages:
             channel = channels_preview[message['id']]

--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -259,13 +259,13 @@ GROUP BY fol.id%s%s""" % (
         :return: see ``_add_followers``
         """
         if not partner_ids:
-            return dict(), dict()
+            return {}, {}
 
         default, _, external = self.env['mail.message.subtype'].default_subtypes(res_model)
         if partner_ids and customer_ids is None:
             customer_ids = self.env['res.partner'].sudo().search([('id', 'in', partner_ids), ('partner_share', '=', True)]).ids
 
-        p_stypes = dict((pid, external.ids if pid in customer_ids else default.ids) for pid in partner_ids)
+        p_stypes = {pid: external.ids if pid in customer_ids else default.ids for pid in partner_ids}
 
         return self._add_followers(res_model, res_ids, partner_ids, p_stypes, check_existing=check_existing, existing_policy=existing_policy)
 
@@ -299,7 +299,7 @@ GROUP BY fol.id%s%s""" % (
           * update: gives an update dict allowing to add missing subtypes (no subtype removal);
         """
         _res_ids = res_ids or [0]
-        data_fols, doc_pids = dict(), dict((i, set()) for i in _res_ids)
+        data_fols, doc_pids = {}, {i: set() for i in _res_ids}
 
         if check_existing and res_ids:
             for fid, rid, pid, sids in self._get_subscription_data([(res_model, res_ids)], partner_ids or None):
@@ -311,7 +311,7 @@ GROUP BY fol.id%s%s""" % (
             if existing_policy == 'force':
                 self.sudo().browse(data_fols.keys()).unlink()
 
-        new, update = dict(), dict()
+        new, update = {}, {}
         for res_id in _res_ids:
             for partner_id in set(partner_ids or []):
                 if partner_id not in doc_pids[res_id]:

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -283,7 +283,7 @@ class Message(models.Model):
             return ids
 
         pid = self.env.user.partner_id.id
-        author_ids, partner_ids, allowed_ids = set([]), set([]), set([])
+        author_ids, partner_ids, allowed_ids = set(), set(), set()
         model_ids = {}
 
         # check read access rights before checking the actual rules on the given ids
@@ -324,7 +324,7 @@ class Message(models.Model):
     def _find_allowed_model_wise(self, doc_model, doc_dict):
         doc_ids = list(doc_dict)
         allowed_doc_ids = self.env[doc_model].with_context(active_test=False).search([('id', 'in', doc_ids)]).ids
-        return set([message_id for allowed_doc_id in allowed_doc_ids for message_id in doc_dict[allowed_doc_id]])
+        return {message_id for allowed_doc_id in allowed_doc_ids for message_id in doc_dict[allowed_doc_id]}
 
     @api.model
     def _find_allowed_doc_ids(self, model_ids):

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -300,7 +300,7 @@ class Message(models.Model):
                 ON partner_rel.mail_message_id = m.id AND partner_rel.res_partner_id = %%(pid)s
                 LEFT JOIN "mail_notification" needaction_rel
                 ON needaction_rel.mail_message_id = m.id AND needaction_rel.res_partner_id = %%(pid)s
-                WHERE m.id = ANY (%%(ids)s)""" % self._table, dict(pid=pid, ids=list(sub_ids)))
+                WHERE m.id = ANY (%%(ids)s)""" % self._table, {'pid': pid, 'ids': list(sub_ids)})
             for msg_id, rmod, rid, author_id, message_type, partner_id in self._cr.fetchall():
                 if author_id == pid:
                     author_ids.add(msg_id)
@@ -391,7 +391,7 @@ class Message(models.Model):
                 )
 
         # Read mail_message.ids to have their values
-        message_values = dict((message_id, {}) for message_id in self.ids)
+        message_values = {message_id: {} for message_id in self.ids}
 
         self.flush(['model', 'res_id', 'author_id', 'parent_id', 'message_type', 'partner_ids'])
         self.env['mail.notification'].flush(['mail_message_id', 'res_partner_id'])
@@ -406,7 +406,7 @@ class Message(models.Model):
                 ON partner_rel.mail_message_id = m.id AND partner_rel.res_partner_id = %%(pid)s
                 LEFT JOIN "mail_notification" needaction_rel
                 ON needaction_rel.mail_message_id = m.id AND needaction_rel.res_partner_id = %%(pid)s
-                WHERE m.id = ANY (%%(ids)s)""" % self._table, dict(pid=self.env.user.partner_id.id, ids=self.ids))
+                WHERE m.id = ANY (%%(ids)s)""" % self._table, {'pid': self.env.user.partner_id.id, 'ids': self.ids})
             for mid, rmod, rid, author_id, parent_id, partner_id, message_type in self._cr.fetchall():
                 message_values[mid] = {
                     'model': rmod,
@@ -426,7 +426,7 @@ class Message(models.Model):
                 ON partner_rel.mail_message_id = m.id AND partner_rel.res_partner_id = %%(pid)s
                 LEFT JOIN "mail_notification" needaction_rel
                 ON needaction_rel.mail_message_id = m.id AND needaction_rel.res_partner_id = %%(pid)s
-                WHERE m.id = ANY (%%(ids)s)""" % self._table, dict(pid=self.env.user.partner_id.id, uid=self.env.user.id, ids=self.ids))
+                WHERE m.id = ANY (%%(ids)s)""" % self._table, {'pid': self.env.user.partner_id.id, 'uid': self.env.user.id, 'ids': self.ids})
             for mid, rmod, rid, author_id, parent_id, partner_id, message_type in self._cr.fetchall():
                 message_values[mid] = {
                     'model': rmod,

--- a/addons/mail/models/mail_message_subtype.py
+++ b/addons/mail/models/mail_message_subtype.py
@@ -74,9 +74,9 @@ class MailMessageSubtype(models.Model):
           * parent: dict(parent subtype id, child subtype id), i.e. {task_new.id: new.id}
           * relation: dict(parent_model, relation_fields), i.e. {'project.project': ['project_id']}
         """
-        child_ids, def_ids = list(), list()
-        all_int_ids = list()
-        parent, relation = dict(), dict()
+        child_ids, def_ids = [], []
+        all_int_ids = []
+        parent, relation = {}, {}
         subtypes = self.sudo().search([
             '|', '|', ('res_model', '=', False),
             ('res_model', '=', model_name),

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -181,8 +181,8 @@ class MailTemplate(models.Model):
             res_ids = [res_ids]
             multi_mode = False
 
-        results = dict()
-        for lang, (template, template_res_ids) in self._classify_per_lang(res_ids).items():
+        results = {}
+        for template, template_res_ids in self._classify_per_lang(res_ids).values():
             for field in fields:
                 generated_field_values = template._render_field(
                     field, template_res_ids,
@@ -190,7 +190,7 @@ class MailTemplate(models.Model):
                     post_process=(field == 'body_html')
                 )
                 for res_id, field_value in generated_field_values.items():
-                    results.setdefault(res_id, dict())[field] = field_value
+                    results.setdefault(res_id, {})[field] = field_value
             # compute recipients
             if any(field in fields for field in ['email_to', 'partner_to', 'email_cc']):
                 results = template.generate_recipients(results, template_res_ids)
@@ -295,7 +295,7 @@ class MailTemplate(models.Model):
                     model = model.with_context(lang=lang)
 
                 template_ctx = {
-                    'message': self.env['mail.message'].sudo().new(dict(body=values['body_html'], record_name=record.display_name)),
+                    'message': self.env['mail.message'].sudo().new({'body': values['body_html'], 'record_name': record.display_name}),
                     'model_description': model.display_name,
                     'company': 'company_id' in record and record['company_id'] or self.env.company,
                     'record': record,

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1392,7 +1392,8 @@ class MailThread(models.AbstractModel):
         msg_dict['cc'] = ','.join(email_cc_list) if email_cc_list else email_cc
         # Delivered-To is a safe bet in most modern MTAs, but we have to fallback on To + Cc values
         # for all the odd MTAs out there, as there is no standard header for the envelope's `rcpt_to` value.
-        msg_dict['recipients'] = ','.join(set(formatted_email
+        msg_dict['recipients'] = ','.join({
+            formatted_email
             for address in [
                 tools.decode_message_header(message, 'Delivered-To'),
                 tools.decode_message_header(message, 'To'),
@@ -1400,15 +1401,16 @@ class MailThread(models.AbstractModel):
                 tools.decode_message_header(message, 'Resent-To'),
                 tools.decode_message_header(message, 'Resent-Cc')
             ] if address
-            for formatted_email in tools.email_split_and_format(address))
-        )
-        msg_dict['to'] = ','.join(set(formatted_email
+            for formatted_email in tools.email_split_and_format(address)
+        })
+        msg_dict['to'] = ','.join({
+            formatted_email
             for address in [
                 tools.decode_message_header(message, 'Delivered-To'),
                 tools.decode_message_header(message, 'To')
             ] if address
-            for formatted_email in tools.email_split_and_format(address))
-        )
+            for formatted_email in tools.email_split_and_format(address)
+        })
         partner_ids = [x.id for x in self._mail_find_partner_from_emails(tools.email_split(msg_dict['recipients']), records=self) if x]
         msg_dict['partner_ids'] = partner_ids
         # compute references to find if email_message is a reply to an existing thread
@@ -2581,7 +2583,7 @@ class MailThread(models.AbstractModel):
             return True
 
         partner_ids = partner_ids or []
-        adding_current = set(partner_ids) == set([self.env.user.partner_id.id])
+        adding_current = set(partner_ids) == {self.env.user.partner_id.id}
         customer_ids = [] if adding_current else None
 
         if partner_ids and adding_current:
@@ -2634,7 +2636,7 @@ class MailThread(models.AbstractModel):
         # not necessary for computation, but saves an access right check
         if not partner_ids:
             return True
-        if set(partner_ids) == set([self.env.user.partner_id.id]):
+        if set(partner_ids) == {self.env.user.partner_id.id}:
             self.check_access_rights('read')
             self.check_access_rule('read')
         else:

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -124,13 +124,13 @@ class BaseModel(models.AbstractModel):
 
         alias_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
         result = dict.fromkeys(_res_ids, False)
-        result_email = dict()
-        doc_names = doc_names if doc_names else dict()
+        result_email = {}
+        doc_names = doc_names or {}
 
         if alias_domain:
             if model and res_ids:
                 if not doc_names:
-                    doc_names = dict((rec.id, rec.display_name) for rec in _records)
+                    doc_names = {rec.id: rec.display_name for rec in _records}
 
                 mail_aliases = self.env['mail.alias'].sudo().search([
                     ('alias_parent_model_id.model', '=', model),
@@ -145,7 +145,7 @@ class BaseModel(models.AbstractModel):
             if left_ids:
                 catchall = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.alias")
                 if catchall:
-                    result_email.update(dict((rid, '%s@%s' % (catchall, alias_domain)) for rid in left_ids))
+                    result_email.update((rid, '%s@%s' % (catchall, alias_domain)) for rid in left_ids)
 
             # compute name of reply-to - TDE tocheck: quotes and stuff like that
             company_name = company.name if company else self.env.company.name
@@ -155,7 +155,7 @@ class BaseModel(models.AbstractModel):
 
         left_ids = set(_res_ids) - set(result_email)
         if left_ids:
-            result.update(dict((res_id, default) for res_id in left_ids))
+            result.update((res_id, default) for res_id in left_ids)
 
         return result
 

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -104,7 +104,7 @@ class Partner(models.Model):
     # ------------------------------------------------------------
 
     def mail_partner_format(self):
-        partners_format = dict()
+        partners_format = {}
         for partner in self:
             internal_users = partner.user_ids - partner.user_ids.filtered('share')
             main_user = internal_users[0] if len(internal_users) > 0 else partner.user_ids[0] if len(partner.user_ids) > 0 else self.env['res.users']

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -220,7 +220,7 @@ class MockEmail(common.BaseCase):
           ``build_email``;
         """
         for sent_email in self._mails:
-            if set(sent_email['email_to']) == set([email_to]):
+            if set(sent_email['email_to']) == {email_to}:
                 break
         else:
             raise AssertionError('sent mail not found for email_to %s' % (email_to))
@@ -818,7 +818,7 @@ class MailCase(MockEmail):
         bus_notifs = self.env['bus.bus'].sudo().search([('channel', 'in', [json_dump(channel) for channel in channels])])
         if check_unique:
             self.assertEqual(len(bus_notifs), len(channels))
-        self.assertEqual(set(bus_notifs.mapped('channel')), set([json_dump(channel) for channel in channels]))
+        self.assertEqual(set(bus_notifs.mapped('channel')), {json_dump(channel) for channel in channels})
 
         notif_messages = [n.message for n in bus_notifs]
 

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -77,7 +77,7 @@ class MailComposer(models.TransientModel):
 
         if 'active_domain' in self._context:  # not context.get() because we want to keep global [] domains
             result['active_domain'] = '%s' % self._context.get('active_domain')
-        if result.get('composition_mode') == 'comment' and (set(fields) & set(['model', 'res_id', 'partner_ids', 'record_name', 'subject'])):
+        if result.get('composition_mode') == 'comment' and (set(fields) & {'model', 'res_id', 'partner_ids', 'record_name', 'subject'}):
             result.update(self.get_record_data(result))
 
         # when being in new mode, create_uid is not granted -> ACLs issue may arise

--- a/addons/mail/wizard/mail_resend_cancel.py
+++ b/addons/mail/wizard/mail_resend_cancel.py
@@ -30,7 +30,7 @@ class MailResendCancel(models.TransientModel):
                             """, (wizard.model, author_id))
             res = self._cr.fetchall()
             notif_ids = [row[0] for row in res]
-            messages_ids = list(set([row[1] for row in res]))
+            messages_ids = list({[row[1] for row in res]})
             if notif_ids:
                 self.env["mail.notification"].browse(notif_ids).sudo().write({'notification_status': 'canceled'})
                 self.env["mail.message"].browse(messages_ids)._notify_message_notification_update()

--- a/addons/mail_group/models/mail_group.py
+++ b/addons/mail_group/models/mail_group.py
@@ -285,7 +285,7 @@ class MailGroup(models.Model):
         self.ensure_one()
         # First create the <mail.message>
         Mailthread = self.env['mail.thread']
-        values = dict((key, val) for key, val in kwargs.items() if key in self.env['mail.message']._fields)
+        values = {key: val for key, val in kwargs.items() if key in self.env['mail.message']._fields}
         author_id, email_from = Mailthread._message_compute_author(author_id, email_from, raise_exception=True)
 
         values.update({

--- a/addons/mail_group/tests/test_mail_group_moderation.py
+++ b/addons/mail_group/tests/test_mail_group_moderation.py
@@ -45,7 +45,7 @@ class TestMailGroupModeration(TestMailListCommon):
         mail_group_2 = self.env['mail.group'].browse(self.test_group_2.ids)
         self.assertEqual(
             set(mail_group.moderation_rule_ids.mapped('email')),
-            set(['banned_member@test.com'])
+            {'banned_member@test.com'}
         )
 
         moderation_1, moderation_2, moderation_3 = self.env['mail.group.moderation'].create([{
@@ -64,7 +64,7 @@ class TestMailGroupModeration(TestMailListCommon):
 
         self.assertEqual(
             set(mail_group.moderation_rule_ids.mapped('email')),
-            set(['banned_member@test.com', 'std@test.com', 'xss@test.com'])
+            {'banned_member@test.com', 'std@test.com', 'xss@test.com'}
         )
 
         message_1, message_2, message_3 = self.env['mail.group.message'].create([{
@@ -87,7 +87,7 @@ class TestMailGroupModeration(TestMailListCommon):
         self.assertEqual(len(mail_group.moderation_rule_ids), 4, "Should have created only one moderation rule")
         self.assertEqual(
             set(mail_group.moderation_rule_ids.mapped('email')),
-            set(['banned_member@test.com', 'std@test.com', 'xss@test.com', 'bob@test.com'])
+            {'banned_member@test.com', 'std@test.com', 'xss@test.com', 'bob@test.com'}
         )
         self.assertEqual(moderation_1.status, 'allow')
         self.assertEqual(moderation_2.status, 'allow', 'Should have write on the existing moderation rule')

--- a/addons/mail_plugin/controllers/mail_plugin.py
+++ b/addons/mail_plugin/controllers/mail_plugin.py
@@ -293,7 +293,7 @@ class MailPluginController(http.Controller):
 
         fields_list = ['id', 'name', 'phone', 'mobile', 'email', 'website']
 
-        company_values = dict((fname, company[fname]) for fname in fields_list)
+        company_values = {fname: company[fname] for fname in fields_list}
         company_values['address'] = {'street': company.street,
                                      'city': company.city,
                                      'zip': company.zip,
@@ -362,7 +362,7 @@ class MailPluginController(http.Controller):
 
         fields_list = ['id', 'name', 'email', 'phone', 'mobile', 'is_company']
 
-        partner_values = dict((fname, partner[fname]) for fname in fields_list)
+        partner_values = {fname: partner[fname] for fname in fields_list}
         partner_values['image'] = partner.image_128
         partner_values['title'] = partner.function
         partner_values['enrichment_info'] = None

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -53,13 +53,13 @@ class MaintenanceEquipmentCategory(models.Model):
 
     def _compute_equipment_count(self):
         equipment_data = self.env['maintenance.equipment'].read_group([('category_id', 'in', self.ids)], ['category_id'], ['category_id'])
-        mapped_data = dict([(m['category_id'][0], m['category_id_count']) for m in equipment_data])
+        mapped_data = {m['category_id'][0]: m['category_id_count'] for m in equipment_data}
         for category in self:
             category.equipment_count = mapped_data.get(category.id, 0)
 
     def _compute_maintenance_count(self):
         maintenance_data = self.env['maintenance.request'].read_group([('category_id', 'in', self.ids)], ['category_id'], ['category_id'])
-        mapped_data = dict([(m['category_id'][0], m['category_id_count']) for m in maintenance_data])
+        mapped_data = {m['category_id'][0]: m['category_id_count'] for m in maintenance_data}
         for category in self:
             category.maintenance_count = mapped_data.get(category.id, 0)
 

--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -47,9 +47,9 @@ class MassMailController(http.Controller):
                 # TODO DBE Fixme : Optimise the following to get real opt_out and opt_in
                 opt_out_list_ids = subscription_list_ids.filtered(lambda rel: rel.opt_out).mapped('list_id')
                 opt_in_list_ids = subscription_list_ids.filtered(lambda rel: not rel.opt_out).mapped('list_id')
-                opt_out_list_ids = set([list.id for list in opt_out_list_ids if list not in opt_in_list_ids])
+                opt_out_list_ids = {list.id for list in opt_out_list_ids if list not in opt_in_list_ids}
 
-                unique_list_ids = set([list.list_id.id for list in subscription_list_ids])
+                unique_list_ids = {list.list_id.id for list in subscription_list_ids}
                 list_ids = request.env['mailing.list'].sudo().browse(unique_list_ids)
                 unsubscribed_list = ', '.join(str(list.name) for list in mailing.contact_list_ids if list.is_public)
                 return request.render('mass_mailing.page_unsubscribe', {

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -227,7 +227,7 @@ class MassMailing(models.Model):
             GROUP BY stats.mass_mailing_id
         """, [tuple(self.ids) or (None,)])
         mass_mailing_data = self.env.cr.dictfetchall()
-        mapped_data = dict([(m['id'], 100 * m['nb_clicks'] / m['nb_mails']) for m in mass_mailing_data])
+        mapped_data = {m['id']: 100 * m['nb_clicks'] / m['nb_mails'] for m in mass_mailing_data}
         for mass_mailing in self:
             mass_mailing.clicks_ratio = mapped_data.get(mass_mailing.id, 0)
 
@@ -733,7 +733,7 @@ class MassMailing(models.Model):
         }
 
     def _get_default_ab_testing_campaign_values(self, values=None):
-        values = values or dict()
+        values = values or {}
         return {
             'ab_testing_schedule_datetime': values.get('ab_testing_schedule_datetime') or self.ab_testing_schedule_datetime,
             'ab_testing_winner_selection': values.get('ab_testing_winner_selection') or self.ab_testing_winner_selection,

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -823,7 +823,7 @@ class MassMailing(models.Model):
         query = query % {'target': target._table, 'mail_field': mail_field}
         params = {'mailing_id': self.id, 'mailing_campaign_id': self.campaign_id.id, 'target_model': self.mailing_model_real}
         self._cr.execute(query, params)
-        seen_list = set(m[0] for m in self._cr.fetchall())
+        seen_list = {m[0] for m in self._cr.fetchall()}
         _logger.info(
             "Mass-mailing %s has already reached %s %s emails", self, len(seen_list), target._name)
         return seen_list
@@ -845,7 +845,7 @@ class MassMailing(models.Model):
             if self.campaign_id and self.ab_testing_enabled:
                 already_mailed = self.campaign_id._get_mailing_recipients()[self.campaign_id.id]
             else:
-                already_mailed = set([])
+                already_mailed = set()
             remaining = set(res_ids).difference(already_mailed)
             if topick > len(remaining) or (len(remaining) > 0 and topick == 0):
                 topick = len(remaining)

--- a/addons/mass_mailing/models/mailing_list.py
+++ b/addons/mass_mailing/models/mailing_list.py
@@ -242,7 +242,7 @@ class MassMailingList(models.Model):
         subscriptions = self.subscription_ids if self else mailing.contact_list_ids.subscription_ids
         opt_out_contacts = subscriptions.filtered(lambda rel: rel.opt_out).mapped('contact_id.email_normalized')
         opt_in_contacts = subscriptions.filtered(lambda rel: not rel.opt_out).mapped('contact_id.email_normalized')
-        opt_out = set(c for c in opt_out_contacts if c not in opt_in_contacts)
+        opt_out = opt_out_contacts - opt_in_contacts
         return opt_out
 
     # ------------------------------------------------------

--- a/addons/mass_mailing/models/mailing_list.py
+++ b/addons/mass_mailing/models/mailing_list.py
@@ -240,10 +240,9 @@ class MassMailingList(models.Model):
         opted in and the other one opted out, send the mail anyway. """
         # TODO DBE Fixme : Optimize the following to get real opt_out and opt_in
         subscriptions = self.subscription_ids if self else mailing.contact_list_ids.subscription_ids
-        opt_out_contacts = subscriptions.filtered(lambda rel: rel.opt_out).mapped('contact_id.email_normalized')
-        opt_in_contacts = subscriptions.filtered(lambda rel: not rel.opt_out).mapped('contact_id.email_normalized')
-        opt_out = opt_out_contacts - opt_in_contacts
-        return opt_out
+        opt_out_contacts = set(subscriptions.filtered(lambda rel: rel.opt_out).mapped('contact_id.email_normalized'))
+        opt_in_contacts = set(subscriptions.filtered(lambda rel: not rel.opt_out).mapped('contact_id.email_normalized'))
+        return opt_out_contacts - opt_in_contacts
 
     # ------------------------------------------------------
     # UTILITY

--- a/addons/mass_mailing/models/utm_campaign.py
+++ b/addons/mass_mailing/models/utm_campaign.py
@@ -63,8 +63,8 @@ class UtmCampaign(models.Model):
                     ab_testing_mapped_data.setdefault(data['campaign_id'][0], []).append(data['__count'])
                 mapped_data.setdefault(data['campaign_id'][0], []).append(data['__count'])
         else:
-            mapped_data = dict()
-            ab_testing_mapped_data = dict()
+            mapped_data = {}
+            ab_testing_mapped_data = {}
         for campaign in self:
             campaign.mailing_mail_count = sum(mapped_data.get(campaign.id, []))
             campaign.ab_testing_mailings_count = sum(ab_testing_mapped_data.get(campaign.id, []))

--- a/addons/mass_mailing_event_track/models/event_event.py
+++ b/addons/mass_mailing_event_track/models/event_event.py
@@ -8,15 +8,15 @@ class Event(models.Model):
     _inherit = "event.event"
 
     def action_mass_mailing_track_speakers(self):
-        mass_mailing_action = dict(
-            name='Mass Mail Attendees',
-            type='ir.actions.act_window',
-            res_model='mailing.mailing',
-            view_mode='form',
-            target='current',
-            context=dict(
-                default_mailing_model_id=self.env.ref('website_event_track.model_event_track').id,
-                default_mailing_domain=repr([('event_id', 'in', self.ids), ('stage_id.is_cancel', '!=', True)]),
-            ),
-        )
+        mass_mailing_action = {
+            'name': 'Mass Mail Attendees',
+            'type': 'ir.actions.act_window',
+            'res_model': 'mailing.mailing',
+            'view_mode': 'form',
+            'target': 'current',
+            'context': {
+                'default_mailing_model_id': self.env.ref('website_event_track.model_event_track').id,
+                'default_mailing_domain': repr([('event_id', 'in', self.ids), ('stage_id.is_cancel', '!=', True)])
+            }
+        }
         return mass_mailing_action

--- a/addons/mass_mailing_slides/models/slide_channel.py
+++ b/addons/mass_mailing_slides/models/slide_channel.py
@@ -9,15 +9,15 @@ class Course(models.Model):
 
     def action_mass_mailing_attendees(self):
         domain = repr([('slide_channel_ids', 'in', self.ids)])
-        mass_mailing_action = dict(
-            name=_('Mass Mail Course Members'),
-            type='ir.actions.act_window',
-            res_model='mailing.mailing',
-            view_mode='form',
-            target='current',
-            context=dict(
-                default_mailing_model_id=self.env.ref('base.model_res_partner').id,
-                default_mailing_domain=domain,
-            ),
-        )
+        mass_mailing_action = {
+            'name': _('Mass Mail Course Members'),
+            'type': 'ir.actions.act_window',
+            'res_model': 'mailing.mailing',
+            'view_mode': 'form',
+            'target': 'current',
+            'context': {
+                'default_mailing_model_id': self.env.ref('base.model_res_partner').id,
+                'default_mailing_domain': domain
+            }
+        }
         return mass_mailing_action

--- a/addons/mass_mailing_sms/models/mailing_list.py
+++ b/addons/mass_mailing_sms/models/mailing_list.py
@@ -62,4 +62,4 @@ class MailingList(models.Model):
         subscriptions = self.subscription_ids if self else mailing.contact_list_ids.subscription_ids
         opt_out_contacts = subscriptions.filtered(lambda sub: sub.opt_out).mapped('contact_id')
         opt_in_contacts = subscriptions.filtered(lambda sub: not sub.opt_out).mapped('contact_id')
-        return list(set(c.id for c in opt_out_contacts if c not in opt_in_contacts))
+        return (opt_out_contacts - opt_in_contacts).ids

--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -359,7 +359,7 @@ class Mailing(models.Model):
 
     def _get_default_ab_testing_campaign_values(self, values=None):
         campaign_values = super()._get_default_ab_testing_campaign_values(values)
-        values = values or dict()
+        values = values or {}
         if self.mailing_type == 'sms':
             sms_subject = values.get('sms_subject') or self.sms_subject
             if sms_subject:

--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -217,8 +217,8 @@ class Mailing(models.Model):
         params = {'mailing_id': self.id, 'target_model': self.mailing_model_real}
         self._cr.execute(query, params)
         query_res = self._cr.fetchall()
-        seen_list = set(number for item in query_res for number in item[1:] if number)
-        seen_ids = set(item[0] for item in query_res)
+        seen_list = {number for item in query_res for number in item[1:] if number}
+        seen_ids = {item[0] for item in query_res}
         _logger.info("Mass SMS %s targets %s: already reached %s SMS", self, target._name, len(seen_list))
         return list(seen_ids), list(seen_list)
 

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -185,7 +185,7 @@ class MicrosoftSync(models.AbstractModel):
 
         microsoft_ids = [x.seriesMasterId for x in recurrents]
         recurrences = self.env['calendar.recurrence'].search([('microsoft_id', 'in', microsoft_ids)])
-        for recurrent_master_id in set([x.seriesMasterId for x in recurrents]):
+        for recurrent_master_id in {x.seriesMasterId for x in recurrents}:
             recurrence_id = recurrences.filtered(lambda ev: ev.microsoft_id == recurrent_master_id)
             to_update = recurrents.filter(lambda e: e.seriesMasterId == recurrent_master_id)
             for recurrent_event in to_update:

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -283,12 +283,12 @@ class MrpBom(models.Model):
 
         boms_done = [(self, {'qty': quantity, 'product': product, 'original_qty': quantity, 'parent_line': False})]
         lines_done = []
-        V |= set([product.product_tmpl_id.id])
+        V |= {product.product_tmpl_id.id}
 
         bom_lines = []
         for bom_line in self.bom_line_ids:
             product_id = bom_line.product_id
-            V |= set([product_id.product_tmpl_id.id])
+            V |= {product_id.product_tmpl_id.id}
             graph[product.product_tmpl_id.id].append(product_id.product_tmpl_id.id)
             bom_lines.append((bom_line, product, quantity, False))
             product_ids.add(product_id.id)
@@ -313,7 +313,7 @@ class MrpBom(models.Model):
                     graph[current_line.product_id.product_tmpl_id.id].append(bom_line.product_id.product_tmpl_id.id)
                     if bom_line.product_id.product_tmpl_id.id in V and check_cycle(bom_line.product_id.product_tmpl_id.id, {key: False for  key in V}, {key: False for  key in V}, graph):
                         raise UserError(_('Recursion error!  A product with a Bill of Material should not have itself in its BoM or child BoMs!'))
-                    V |= set([bom_line.product_id.product_tmpl_id.id])
+                    V |= {bom_line.product_id.product_tmpl_id.id}
                     if not bom_line.product_id in product_boms:
                         product_ids.add(bom_line.product_id.id)
                 boms_done.append((bom, {'qty': converted_line_quantity, 'product': current_product, 'original_qty': quantity, 'parent_line': current_line}))

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -506,7 +506,7 @@ class MrpProduction(models.Model):
 
     def _compute_scrap_move_count(self):
         data = self.env['stock.scrap'].read_group([('production_id', 'in', self.ids)], ['production_id'], ['production_id'])
-        count_data = dict((item['production_id'][0], item['production_id_count']) for item in data)
+        count_data = {item['production_id'][0]: item['production_id_count'] for item in data}
         for production in self:
             production.scrap_count = count_data.get(production.id, 0)
 

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1872,7 +1872,7 @@ class MrpProduction(models.Model):
             if not lot_ids:
                 continue
             lot_components.setdefault(move.product_id, set()).update(lot_ids)
-        multiple_lot_components = set([p for p, l in lot_components.items() if len(l) != 1])
+        multiple_lot_components = {p for p, l in lot_components.items() if len(l) != 1}
         action = self.env["ir.actions.actions"]._for_xml_id("mrp.act_assign_serial_numbers_production")
         action['context'] = {
             'default_production_id': self.id,

--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -85,7 +85,7 @@ class MrpRoutingWorkcenter(models.Model):
         data = self.env['mrp.workorder'].read_group([
             ('operation_id', 'in', self.ids),
             ('state', '=', 'done')], ['operation_id'], ['operation_id'])
-        count_data = dict((item['operation_id'][0], item['operation_id_count']) for item in data)
+        count_data = {item['operation_id'][0]: item['operation_id_count'] for item in data}
         for operation in self:
             operation.workorder_count = count_data.get(operation.id, 0)
 

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -89,7 +89,7 @@ class MrpWorkcenter(models.Model):
         data = MrpWorkorder.read_group(
             [('workcenter_id', 'in', self.ids), ('state', 'in', ('pending', 'waiting', 'ready')), ('date_planned_start', '<', datetime.datetime.now().strftime('%Y-%m-%d'))],
             ['workcenter_id'], ['workcenter_id'])
-        count_data = dict((item['workcenter_id'][0], item['workcenter_id_count']) for item in data)
+        count_data = {item['workcenter_id'][0]: item['workcenter_id_count'] for item in data}
         # Count All, Pending, Ready, Progress Workorder
         res = MrpWorkorder.read_group(
             [('workcenter_id', 'in', self.ids)],
@@ -135,7 +135,7 @@ class MrpWorkcenter(models.Model):
             ('date_end', '!=', False),
             ('loss_type', '!=', 'productive')],
             ['duration', 'workcenter_id'], ['workcenter_id'], lazy=False)
-        count_data = dict((item['workcenter_id'][0], item['duration']) for item in data)
+        count_data = {item['workcenter_id'][0]: item['duration'] for item in data}
         for workcenter in self:
             workcenter.blocked_time = count_data.get(workcenter.id, 0.0) / 60.0
 
@@ -147,7 +147,7 @@ class MrpWorkcenter(models.Model):
             ('date_end', '!=', False),
             ('loss_type', '=', 'productive')],
             ['duration', 'workcenter_id'], ['workcenter_id'], lazy=False)
-        count_data = dict((item['workcenter_id'][0], item['duration']) for item in data)
+        count_data = {item['workcenter_id'][0]: item['duration'] for item in data}
         for workcenter in self:
             workcenter.productive_time = count_data.get(workcenter.id, 0.0) / 60.0
 
@@ -164,8 +164,8 @@ class MrpWorkcenter(models.Model):
             ('date_start', '>=', fields.Datetime.to_string(datetime.datetime.now() - relativedelta.relativedelta(months=1))),
             ('workcenter_id', 'in', self.ids),
             ('state', '=', 'done')], ['duration_expected', 'workcenter_id', 'duration'], ['workcenter_id'], lazy=False)
-        duration_expected = dict((data['workcenter_id'][0], data['duration_expected']) for data in wo_data)
-        duration = dict((data['workcenter_id'][0], data['duration']) for data in wo_data)
+        duration_expected = {data['workcenter_id'][0]: data['duration_expected'] for data in wo_data}
+        duration = {data['workcenter_id'][0]: data['duration'] for data in wo_data}
         for workcenter in self:
             if duration.get(workcenter.id):
                 workcenter.performance = 100 * duration_expected.get(workcenter.id, 0.0) / duration[workcenter.id]

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -169,11 +169,13 @@ class MrpWorkorder(models.Model):
             [('next_work_order_id', 'in', self.ids)],
             ['ids:array_agg(id)', 'date_planned_start:max', 'date_planned_finished:max'],
             ['next_work_order_id'])
-        previous_wo_dict = dict([(x['next_work_order_id'][0], {
-            'id': x['ids'][0],
-            'date_planned_start': x['date_planned_start'],
-            'date_planned_finished': x['date_planned_finished']})
-            for x in previous_wo_data])
+        previous_wo_dict = {
+            x['next_work_order_id'][0]: {
+                'id': x['ids'][0],
+                'date_planned_start': x['date_planned_start'],
+                'date_planned_finished': x['date_planned_finished']
+            } for x in previous_wo_data
+        }
         if self.ids:
             conflicted_dict = self._get_conflicted_workorder_ids()
         for wo in self:
@@ -367,7 +369,7 @@ class MrpWorkorder(models.Model):
 
     def _compute_scrap_move_count(self):
         data = self.env['stock.scrap'].read_group([('workorder_id', 'in', self.ids)], ['workorder_id'], ['workorder_id'])
-        count_data = dict((item['workorder_id'][0], item['workorder_id_count']) for item in data)
+        count_data = {item['workorder_id'][0]: item['workorder_id_count'] for item in data}
         for workorder in self:
             workorder.scrap_count = count_data.get(workorder.id, 0)
 

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -147,7 +147,7 @@ class ProductProduct(models.Model):
         #TODO: state = done?
         domain = [('state', '=', 'done'), ('product_id', 'in', self.ids), ('date_planned_start', '>', date_from)]
         read_group_res = self.env['mrp.production'].read_group(domain, ['product_id', 'product_uom_qty'], ['product_id'])
-        mapped_data = dict([(data['product_id'][0], data['product_uom_qty']) for data in read_group_res])
+        mapped_data = {data['product_id'][0]: data['product_uom_qty'] for data in read_group_res}
         for product in self:
             if not product.id:
                 product.mrp_product_qty = 0.0

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -31,7 +31,7 @@ class ProductTemplate(models.Model):
     def _compute_is_kits(self):
         domain = [('product_tmpl_id', 'in', self.ids), ('type', '=', 'phantom')]
         bom_mapping = self.env['mrp.bom'].search_read(domain, ['product_tmpl_id'])
-        kits_ids = set(b['product_tmpl_id'][0] for b in bom_mapping)
+        kits_ids = {b['product_tmpl_id'][0] for b in bom_mapping}
         for template in self:
             template.is_kits = (template.id in kits_ids)
 
@@ -97,8 +97,8 @@ class ProductProduct(models.Model):
                             '&', ('product_id', '=', False),
                                  ('product_tmpl_id', 'in', self.product_tmpl_id.ids)]
         bom_mapping = self.env['mrp.bom'].search_read(domain, ['product_tmpl_id', 'product_id'])
-        kits_template_ids = set([])
-        kits_product_ids = set([])
+        kits_template_ids = set()
+        kits_product_ids = set()
         for bom_data in bom_mapping:
             if bom_data['product_id']:
                 kits_product_ids.add(bom_data['product_id'][0])

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -11,13 +11,13 @@ class TestBoM(TestMrpCommon):
 
     def test_01_explode(self):
         boms, lines = self.bom_1.explode(self.product_4, 3)
-        self.assertEqual(set([bom[0].id for bom in boms]), set(self.bom_1.ids))
-        self.assertEqual(set([line[0].id for line in lines]), set(self.bom_1.bom_line_ids.ids))
+        self.assertEqual({bom[0].id for bom in boms}, set(self.bom_1.ids))
+        self.assertEqual({line[0].id for line in lines}, set(self.bom_1.bom_line_ids.ids))
 
         boms, lines = self.bom_3.explode(self.product_6, 3)
-        self.assertEqual(set([bom[0].id for bom in boms]), set((self.bom_2 | self.bom_3).ids))
+        self.assertEqual({bom[0].id for bom in boms}, set((self.bom_2 | self.bom_3).ids))
         self.assertEqual(
-            set([line[0].id for line in lines]),
+            {line[0].id for line in lines},
             set((self.bom_2 | self.bom_3).mapped('bom_line_ids').filtered(lambda line: not line.child_bom_id or line.child_bom_id.type != 'phantom').ids))
 
     def test_10_variants(self):
@@ -199,13 +199,13 @@ class TestBoM(TestMrpCommon):
 
         # check product > product_tmpl
         boms, lines = test_bom_2.explode(self.product_7_1, 4)
-        self.assertEqual(set((test_bom_2 | self.bom_2).ids), set([b[0].id for b in boms]))
+        self.assertEqual(set((test_bom_2 | self.bom_2).ids), {b[0].id for b in boms})
         self.assertEqual(set((test_bom_2_l1 | test_bom_2_l4 | self.bom_2.bom_line_ids).ids), set([l[0].id for l in lines]))
 
         # check sequence priority
         test_bom_1.write({'sequence': 1})
         boms, lines = test_bom_2.explode(self.product_7_1, 4)
-        self.assertEqual(set((test_bom_2 | test_bom_1).ids), set([b[0].id for b in boms]))
+        self.assertEqual(set((test_bom_2 | test_bom_1).ids), {b[0].id for b in boms})
         self.assertEqual(set((test_bom_2_l1 | test_bom_2_l4 | test_bom_1.bom_line_ids).ids), set([l[0].id for l in lines]))
 
         # check with another picking_type
@@ -213,7 +213,7 @@ class TestBoM(TestMrpCommon):
         self.bom_2.write({'picking_type_id': tmp_picking_type.id})
         test_bom_2.write({'picking_type_id': tmp_picking_type.id})
         boms, lines = test_bom_2.explode(self.product_7_1, 4)
-        self.assertEqual(set((test_bom_2 | self.bom_2).ids), set([b[0].id for b in boms]))
+        self.assertEqual(set((test_bom_2 | self.bom_2).ids), {b[0].id for b in boms})
         self.assertEqual(set((test_bom_2_l1 | test_bom_2_l4 | self.bom_2.bom_line_ids).ids), set([l[0].id for l in lines]))
 
         #check recursion

--- a/addons/mrp/tests/test_traceability.py
+++ b/addons/mrp/tests/test_traceability.py
@@ -298,9 +298,9 @@ class TestTraceability(TestMrpCommon):
         mo = mo | mo_backorder
         raw_move_lines = mo.move_raw_ids.mapped('move_line_ids')
         raw_line_raw_1_lot_1 = raw_move_lines.filtered(lambda ml: ml.lot_id.name == 'Raw_1_lot_1')
-        self.assertEqual(set(raw_line_raw_1_lot_1.produce_line_ids.lot_id.mapped('name')), set(['Final_lot_1', 'Byproduct_1_lot_1', 'Byproduct_2_lot_1']))
+        self.assertEqual(set(raw_line_raw_1_lot_1.produce_line_ids.lot_id.mapped('name')), {'Final_lot_1', 'Byproduct_1_lot_1', 'Byproduct_2_lot_1'})
         raw_line_raw_2_lot_1 = raw_move_lines.filtered(lambda ml: ml.lot_id.name == 'Raw_2_lot_1')
-        self.assertEqual(set(raw_line_raw_2_lot_1.produce_line_ids.lot_id.mapped('name')), set(['Final_lot_1', 'Byproduct_1_lot_1', 'Byproduct_2_lot_1']))
+        self.assertEqual(set(raw_line_raw_2_lot_1.produce_line_ids.lot_id.mapped('name')), {'Final_lot_1', 'Byproduct_1_lot_1', 'Byproduct_2_lot_1'})
 
         finished_move_lines = mo.move_finished_ids.mapped('move_line_ids')
         finished_move_line_lot_1 = finished_move_lines.filtered(lambda ml: ml.lot_id.name == 'Final_lot_1')

--- a/addons/payment/models/account_payment_method.py
+++ b/addons/payment/models/account_payment_method.py
@@ -25,7 +25,7 @@ class AccountPaymentMethodLine(models.Model):
         ])
 
         # Make sure to pick the active acquirer, if any.
-        acquirers_map = dict()
+        acquirers_map = {}
         for acquirer in acquirers:
             current_value = acquirers_map.get((acquirer.provider, acquirer.company_id), False)
             if current_value and current_value.state != 'disabled':

--- a/addons/payment/models/payment_token.py
+++ b/addons/payment/models/payment_token.py
@@ -57,7 +57,7 @@ class PaymentToken(models.Model):
         :return: The dict of acquirer-specific create values
         :rtype: dict
         """
-        return dict()
+        return {}
 
     def write(self, values):
         """ Delegate the handling of active state switch to dedicated methods.

--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -236,7 +236,7 @@ class PaymentTransaction(models.Model):
         :return: The dict of acquirer-specific create values
         :rtype: dict
         """
-        return dict()
+        return {}
 
     #=== ACTION METHODS ===#
 
@@ -510,7 +510,7 @@ class PaymentTransaction(models.Model):
         :return: The dict of acquirer-specific processing values
         :rtype: dict
         """
-        return dict()
+        return {}
 
     def _get_specific_rendering_values(self, processing_values):
         """ Return a dict of acquirer-specific values used to render the redirect form.
@@ -523,7 +523,7 @@ class PaymentTransaction(models.Model):
         :return: The dict of acquirer-specific rendering values
         :rtype: dict
         """
-        return dict()
+        return {}
 
     def _send_payment_request(self):
         """ Request the provider of the acquirer handling the transaction to execute the payment.

--- a/addons/payment_sips/models/payment_transaction.py
+++ b/addons/payment_sips/models/payment_transaction.py
@@ -70,7 +70,7 @@ class PaymentTransaction(models.Model):
             'transactionReference': self.reference,
             'statementReference': self.reference,
             'keyVersion': self.acquirer_id.sips_key_version,
-            'returnContext': json.dumps(dict(reference=self.reference)),
+            'returnContext': json.dumps({'reference': self.reference}),
         }
         api_url = self.acquirer_id.sips_prod_url if self.acquirer_id.state == 'enabled' \
             else self.acquirer_id.sips_test_url

--- a/addons/payment_sips/tests/test_sips.py
+++ b/addons/payment_sips/tests/test_sips.py
@@ -53,9 +53,9 @@ class SipsTest(SipsCommon):
         return_url = self._build_url(SipsController._return_url)
         notify_url = self._build_url(SipsController._notify_url)
         self.assertEqual(form_inputs['Data'],
-            f'amount=111111|currencyCode=978|merchantId=dummy_mid|normalReturnUrl={return_url}|' \
-            f'automaticResponseUrl={notify_url}|transactionReference={self.reference}|' \
-            f'statementReference={self.reference}|keyVersion={self.sips.sips_key_version}|' \
+            f'amount=111111|currencyCode=978|merchantId=dummy_mid|normalReturnUrl={return_url}|'
+            f'automaticResponseUrl={notify_url}|transactionReference={self.reference}|'
+            f'statementReference={self.reference}|keyVersion={self.sips.sips_key_version}|'
             f'returnContext={json.dumps(dict(reference=self.reference))}'
         )
         self.assertEqual(form_inputs['Seal'],

--- a/addons/point_of_sale/models/account_tax.py
+++ b/addons/point_of_sale/models/account_tax.py
@@ -8,16 +8,16 @@ class AccountTax(models.Model):
     _inherit = 'account.tax'
 
     def write(self, vals):
-        forbidden_fields = set([
+        forbidden_fields = {
             'amount_type', 'amount', 'type_tax_use', 'tax_group_id', 'price_include',
             'include_base_amount', 'is_base_affected',
-        ])
+        }
         if forbidden_fields & set(vals.keys()):
             tax_ids = self.env['pos.order.line'].sudo().search([
                 ('order_id.session_id.state', '!=', 'closed')
             ]).read(['tax_ids'])
             # Flatten the list of taxes, see https://stackoverflow.com/questions/952914
-            tax_ids = set([i for sl in [t['tax_ids'] for t in tax_ids] for i in sl])
+            tax_ids = {i for sl in [t['tax_ids'] for t in tax_ids] for i in sl}
             if tax_ids & set(self.ids):
                 raise UserError(_(
                     'It is forbidden to modify a tax used in a POS order not posted. '

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1213,7 +1213,7 @@ class PosSession(models.Model):
 
     def _get_sale_vals(self, key, amount, amount_converted):
         account_id, sign, tax_keys, base_tag_ids = key
-        tax_ids = set(tax[0] for tax in tax_keys)
+        tax_ids = {tax[0] for tax in tax_keys}
         applied_taxes = self.env['account.tax'].browse(tax_ids)
         title = 'Sales' if sign == 1 else 'Refund'
         name = '%s untaxed' % title

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -129,7 +129,7 @@ class PosSession(models.Model):
     @api.depends('order_ids.payment_ids.amount')
     def _compute_total_payments_amount(self):
         result = self.env['pos.payment'].read_group([('session_id', 'in', self.ids)], ['amount'], ['session_id'])
-        session_amount_map = dict((data['session_id'][0], data['amount']) for data in result)
+        session_amount_map = {data['session_id'][0]: data['amount'] for data in result}
         for session in self:
             session.total_payments_amount = session_amount_map.get(session.id) or 0
 

--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -82,13 +82,13 @@ def _message_post_helper(res_model, res_id, message, token='', _hash=False, pid=
         partner = request.env['res.partner'].sudo().browse(author_id)
         email_from = partner.email_formatted if partner.email else None
 
-    message_post_args = dict(
-        body=message,
-        message_type=kw.pop('message_type', "comment"),
-        subtype_xmlid=kw.pop('subtype_xmlid', "mail.mt_comment"),
-        author_id=author_id,
+    message_post_args = {
+        'body': message,
+        'message_type': kw.pop('message_type', "comment"),
+        'subtype_xmlid': kw.pop('subtype_xmlid', "mail.mt_comment"),
+        'author_id': author_id,
         **kw
-    )
+    }
 
     # This is necessary as mail.message checks the presence
     # of the key to compute its default email from

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -341,7 +341,7 @@ class CustomerPortal(Controller):
         return attachment_sudo.unlink()
 
     def details_form_validate(self, data):
-        error = dict()
+        error = {}
         error_message = []
 
         # Validation

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -190,7 +190,7 @@ class CustomerPortal(Controller):
             if not error:
                 values = {key: post[key] for key in self.MANDATORY_BILLING_FIELDS}
                 values.update({key: post[key] for key in self.OPTIONAL_BILLING_FIELDS if key in post})
-                for field in set(['country_id', 'state_id']) & set(values.keys()):
+                for field in {'country_id', 'state_id'} & set(values.keys()):
                     try:
                         values[field] = int(values[field])
                     except:

--- a/addons/portal_rating/models/mail_message.py
+++ b/addons/portal_rating/models/mail_message.py
@@ -22,7 +22,7 @@ class MailMessage(models.Model):
         if self._context.get('rating_include'):
             infos = ["id", "publisher_comment", "publisher_id", "publisher_datetime", "message_id"]
             related_rating = self.env['rating.rating'].sudo().search([('message_id', 'in', self.ids)]).read(infos)
-            mid_rating_tree = dict((rating['message_id'][0], rating) for rating in related_rating)
+            mid_rating_tree = {rating['message_id'][0]: rating for rating in related_rating}
             for vals in vals_list:
                 vals["rating"] = mid_rating_tree.get(vals['id'], {})
         return vals_list

--- a/addons/pos_adyen/models/pos_payment_method.py
+++ b/addons/pos_adyen/models/pos_payment_method.py
@@ -45,7 +45,7 @@ class PosPaymentMethod(models.Model):
         }
 
     def _is_write_forbidden(self, fields):
-        whitelisted_fields = set(('adyen_latest_response', 'adyen_latest_diagnosis'))
+        whitelisted_fields = {'adyen_latest_response', 'adyen_latest_diagnosis'}
         return super(PosPaymentMethod, self)._is_write_forbidden(fields - whitelisted_fields)
 
     def _adyen_diagnosis_request_data(self, pos_config_name):

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -44,7 +44,7 @@ class PosConfig(models.Model):
         domain = [('state', '=', 'draft'), ('table_id', 'in', tables.ids)]
 
         order_stats = self.env['pos.order'].read_group(domain, ['table_id'], 'table_id')
-        orders_map = dict((s['table_id'][0], s['table_id_count']) for s in order_stats)
+        orders_map = {s['table_id'][0]: s['table_id_count'] for s in order_stats}
 
         result = []
         for table in tables:

--- a/addons/pos_sale/models/crm_team.py
+++ b/addons/pos_sale/models/crm_team.py
@@ -23,7 +23,7 @@ class CrmTeam(models.Model):
             ('session_id.state', '=', 'opened'),
             ('config_id.crm_team_id', 'in', self.ids),
         ], ['price_total:sum', 'config_id'], ['config_id'])
-        rg_results = dict((d['config_id'][0], d['price_total']) for d in data)
+        rg_results = {d['config_id'][0]: d['price_total'] for d in data}
         for team in self:
             team.pos_order_amount_total = sum([
                 rg_results.get(config.id, 0.0)

--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -40,7 +40,7 @@ class ProductCategory(models.Model):
 
     def _compute_product_count(self):
         read_group_res = self.env['product.template'].read_group([('categ_id', 'child_of', self.ids)], ['categ_id'], ['categ_id'])
-        group_data = dict((data['categ_id'][0], data['categ_id_count']) for data in read_group_res)
+        group_data = {data['categ_id'][0]: data['categ_id_count'] for data in read_group_res}
         for categ in self:
             product_count = 0
             for sub_categ_id in categ.search([('id', 'child_of', categ.ids)]).ids:

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -550,13 +550,13 @@ class PricelistItem(models.Model):
                 # Ensure item consistency for later searches.
                 applied_on = values['applied_on']
                 if applied_on == '3_global':
-                    values.update(dict(product_id=None, product_tmpl_id=None, categ_id=None))
+                    values.update(product_id=None, product_tmpl_id=None, categ_id=None)
                 elif applied_on == '2_product_category':
-                    values.update(dict(product_id=None, product_tmpl_id=None))
+                    values.update(product_id=None, product_tmpl_id=None)
                 elif applied_on == '1_product':
-                    values.update(dict(product_id=None, categ_id=None))
+                    values.update(product_id=None, categ_id=None)
                 elif applied_on == '0_product_variant':
-                    values.update(dict(categ_id=None))
+                    values.update(categ_id=None)
         return super(PricelistItem, self).create(vals_list)
 
     def write(self, values):
@@ -564,13 +564,13 @@ class PricelistItem(models.Model):
             # Ensure item consistency for later searches.
             applied_on = values['applied_on']
             if applied_on == '3_global':
-                values.update(dict(product_id=None, product_tmpl_id=None, categ_id=None))
+                values.update(product_id=None, product_tmpl_id=None, categ_id=None)
             elif applied_on == '2_product_category':
-                values.update(dict(product_id=None, product_tmpl_id=None))
+                values.update(product_id=None, product_tmpl_id=None)
             elif applied_on == '1_product':
-                values.update(dict(product_id=None, categ_id=None))
+                values.update(product_id=None, categ_id=None)
             elif applied_on == '0_product_variant':
-                values.update(dict(categ_id=None))
+                values.update(categ_id=None)
         res = super(PricelistItem, self).write(values)
         # When the pricelist changes we need the product.template price
         # to be invalided and recomputed.

--- a/addons/product/tests/test_seller.py
+++ b/addons/product/tests/test_seller.py
@@ -48,20 +48,20 @@ class TestSeller(TransactionCase):
         names = self.product_consu.with_context(
             partner_id=self.asustec.id,
         ).name_get()
-        ref = set([x[1] for x in names])
+        ref = {x[1] for x in names}
         self.assertEqual(len(names), 3, "3 vendor references should have been found")
         self.assertEqual(ref, {'[A] Boudin', '[B] Boudin', '[NO] Boudin'}, "Incorrect vendor reference list")
         names = self.product_consu.with_context(
             partner_id=self.asustec.id,
             company_id=company_a.id,
         ).name_get()
-        ref = set([x[1] for x in names])
+        ref = {x[1] for x in names}
         self.assertEqual(len(names), 2, "2 vendor references should have been found")
         self.assertEqual(ref, {'[A] Boudin', '[NO] Boudin'}, "Incorrect vendor reference list")
         names = self.product_consu.with_context(
             partner_id=self.asustec.id,
             company_id=company_b.id,
         ).name_get()
-        ref = set([x[1] for x in names])
+        ref = {x[1] for x in names}
         self.assertEqual(len(names), 2, "2 vendor references should have been found")
         self.assertEqual(ref, {'[B] Boudin', '[NO] Boudin'}, "Incorrect vendor reference list")

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -109,7 +109,7 @@ class ProjectTaskType(models.Model):
         # retrieves all the projects with a least 1 task in that stage
         # a task can be in a stage even if the project is not assigned to the stage
         readgroup = self.with_context(active_test=False).env['project.task'].read_group([('stage_id', 'in', self.ids)], ['project_id'], ['project_id'])
-        project_ids = list(set([project['project_id'][0] for project in readgroup] + self.project_ids.ids))
+        project_ids = list({project['project_id'][0] for project in readgroup}.union(self.project_ids.ids))
 
         wizard = self.with_context(project_ids=project_ids).env['project.task.type.delete.wizard'].create({
             'project_ids': project_ids,

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1643,7 +1643,7 @@ class Task(models.Model):
         is_portal_user = self.env.user.has_group('base.group_portal')
         if is_portal_user:
             self.check_access_rights('create')
-        default_stage = dict()
+        default_stage = {}
         for vals in vals_list:
             if is_portal_user:
                 self._ensure_fields_are_accessible(vals.keys(), operation='write', check_group_user=False)
@@ -1902,7 +1902,7 @@ class Task(models.Model):
                 subtype = self.env['ir.model.data']._xmlid_to_res_id('project.mt_task_dependency_change')
                 # We want to include the original subtype message coming from the child task
                 # for example when the stage changes the message in the chatter starts with 'Stage Changed'
-                child_subtype = self._track_subtype(dict((col_name, initial_values[col_name]) for col_name in changes))
+                child_subtype = self._track_subtype({col_name: initial_values[col_name] for col_name in changes})
                 child_subtype_info = child_subtype.description or child_subtype.name if child_subtype else False
                 # NOTE: the subtype does not have a description on purpose, otherwise the description would be put
                 #  at the end of the message instead of at the top, we use the name here

--- a/addons/project/tests/test_access_rights.py
+++ b/addons/project/tests/test_access_rights.py
@@ -262,7 +262,7 @@ class TestPortalProject(TestProjectPortalCommon):
         pigs.with_user(self.user_projectuser).read(['user_id'])
         # Test: all project tasks visible
         tasks = self.env['project.task'].with_user(self.user_projectuser).search([('project_id', '=', pigs.id)])
-        test_task_ids = set([self.task_1.id, self.task_2.id, self.task_3.id, self.task_4.id, self.task_5.id, self.task_6.id])
+        test_task_ids = {self.task_1.id, self.task_2.id, self.task_3.id, self.task_4.id, self.task_5.id, self.task_6.id}
         self.assertEqual(set(tasks.ids), test_task_ids,
                          'access rights: project user cannot see all tasks of an employees project')
         # Do: Bert reads project -> crash, no group

--- a/addons/project_purchase/models/project.py
+++ b/addons/project_purchase/models/project.py
@@ -15,7 +15,7 @@ class Project(models.Model):
             ('account_analytic_id', '!=', False),
             ('account_analytic_id', 'in', self.analytic_account_id.ids)
         ], ['account_analytic_id', 'order_id:count_distinct'], ['account_analytic_id'])
-        mapped_data = dict([(data['account_analytic_id'][0], data['order_id']) for data in purchase_orders_data])
+        mapped_data = {data['account_analytic_id'][0]: data['order_id'] for data in purchase_orders_data}
         for project in self:
             project.purchase_orders_count = mapped_data.get(project.analytic_account_id.id, 0)
 

--- a/addons/purchase/models/product.py
+++ b/addons/purchase/models/product.py
@@ -62,7 +62,7 @@ class ProductProduct(models.Model):
             ('order_id.date_approve', '>=', date_from)
         ]
         order_lines = self.env['purchase.order.line'].read_group(domain, ['product_id', 'product_uom_qty'], ['product_id'])
-        purchased_data = dict([(data['product_id'][0], data['product_uom_qty']) for data in order_lines])
+        purchased_data = {data['product_id'][0]: data['product_uom_qty'] for data in order_lines}
         for product in self:
             if not product.id:
                 product.purchased_product_qty = 0.0

--- a/addons/purchase_product_matrix/models/purchase.py
+++ b/addons/purchase_product_matrix/models/purchase.py
@@ -111,7 +111,7 @@ class PurchaseOrder(models.Model):
                 res = False
                 if new_lines:
                     # Add new PO lines
-                    self.update(dict(order_line=new_lines))
+                    self.update({'order_line': new_lines})
 
                 # Recompute prices for new/modified lines:
                 for line in self.order_line.filtered(lambda line: line.product_id.id in product_ids):

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -88,7 +88,7 @@ class StockRule(models.Model):
             procurements, rules = zip(*procurements_rules)
 
             # Get the set of procurement origin for the current domain.
-            origins = set([p.origin for p in procurements])
+            origins = {p.origin for p in procurements}
             # Check if a PO exists for the current domain.
             po = self.env['purchase.order'].sudo().search([dom for dom in domain], limit=1)
             company_id = procurements[0].company_id

--- a/addons/rating/models/mail_message.py
+++ b/addons/rating/models/mail_message.py
@@ -15,7 +15,7 @@ class MailMessage(models.Model):
     @api.depends('rating_ids', 'rating_ids.rating')
     def _compute_rating_value(self):
         ratings = self.env['rating.rating'].search([('message_id', 'in', self.ids), ('consumed', '=', True)], order='create_date DESC')
-        mapping = dict((r.message_id.id, r.rating) for r in ratings)
+        mapping = {r.message_id.id: r.rating for r in ratings}
         for message in self:
             message.rating_value = mapping.get(message.id, 0.0)
 

--- a/addons/rating/models/rating_mixin.py
+++ b/addons/rating/models/rating_mixin.py
@@ -52,7 +52,7 @@ class RatingParentMixin(models.AbstractModel):
 
         # get repartition of grades per parent id
         default_grades = {'great': 0, 'okay': 0, 'bad': 0}
-        grades_per_parent = dict((parent_id, dict(default_grades)) for parent_id in self.ids)  # map: {parent_id: {'great': 0, 'bad': 0, 'ok': 0}}
+        grades_per_parent = {parent_id: dict(default_grades) for parent_id in self.ids}
         rating_scores_per_parent = defaultdict(int)  # contains the total of the rating values per record
         for item in data:
             parent_id = item['parent_res_id']

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -466,7 +466,7 @@ class Repair(models.Model):
         repairs.mapped('operations').filtered(lambda op: op.type == 'add').write({'invoiced': True})
         repairs.mapped('fees_lines').write({'invoiced': True})
 
-        return dict((repair.id, repair.invoice_id.id) for repair in repairs)
+        return {repair.id: repair.invoice_id.id for repair in repairs}
 
     def action_created_invoice(self):
         self.ensure_one()

--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -1053,7 +1053,7 @@ class ResourceResource(models.Model):
         resource_calendar_validity_intervals = {}
         calendar_resources = defaultdict(lambda: self.env['resource.resource'])
         resource_work_intervals = defaultdict(Intervals)
-        calendar_work_intervals = dict()
+        calendar_work_intervals = {}
 
         resource_calendar_validity_intervals = self._get_calendars_validity_within_period(start, end)
         for resource in self:

--- a/addons/sale/models/crm_team.py
+++ b/addons/sale/models/crm_team.py
@@ -88,7 +88,7 @@ class CrmTeam(models.Model):
         params = [tuple(self.ids), fields.Date.to_string(today.replace(day=1)), fields.Date.to_string(today)]
         self._cr.execute(query, params)
 
-        data_map = dict((v[0], v[1]) for v in self._cr.fetchall())
+        data_map = dict(self._cr.fetchall())
         for team in self:
             team.invoiced = data_map.get(team.id, 0.0)
 

--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -358,7 +358,7 @@ class SaleOrder(models.Model):
                     value_found = False
                     for line in lines:
                         # Case 1.
-                        if not len(set(line.tax_id.mapped('id')).symmetric_difference(set([v[1] for v in value['tax_id']]))):
+                        if not set(line.tax_id.mapped('id')).symmetric_difference(v[1] for v in value['tax_id']):
                             value_found = True
                             # Working on Case 3.
                             lines_to_remove -= line

--- a/addons/sale_expense/models/sale_order.py
+++ b/addons/sale_expense/models/sale_order.py
@@ -23,6 +23,6 @@ class SaleOrder(models.Model):
     @api.depends('expense_ids')
     def _compute_expense_count(self):
         expense_data = self.env['hr.expense'].read_group([('sale_order_id', 'in', self.ids)], ['sale_order_id'], ['sale_order_id'])
-        mapped_data = dict([(item['sale_order_id'][0], item['sale_order_id_count']) for item in expense_data])
+        mapped_data = {item['sale_order_id'][0]: item['sale_order_id_count'] for item in expense_data}
         for sale_order in self:
             sale_order.expense_count = mapped_data.get(sale_order.id, 0)

--- a/addons/sale_mrp/models/sale.py
+++ b/addons/sale_mrp/models/sale.py
@@ -15,7 +15,7 @@ class SaleOrder(models.Model):
     @api.depends('procurement_group_id.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids')
     def _compute_mrp_production_count(self):
         data = self.env['procurement.group'].read_group([('sale_id', 'in', self.ids)], ['ids:array_agg(id)'], ['sale_id'])
-        mrp_count = dict()
+        mrp_count = {}
         for item in data:
             procurement_groups = self.env['procurement.group'].browse(item['ids'])
             mrp_count[item['sale_id'][0]] = len(

--- a/addons/sale_product_matrix/models/sale_order.py
+++ b/addons/sale_product_matrix/models/sale_order.py
@@ -114,7 +114,7 @@ class SaleOrder(models.Model):
                     ))
             if new_lines:
                 # Add new SO lines
-                self.update(dict(order_line=new_lines))
+                self.update({'order_line': new_lines})
 
     def _get_matrix(self, product_template):
         """Return the matrix of the given product, updated with current SOLines quantities.

--- a/addons/sale_purchase/models/sale_order.py
+++ b/addons/sale_purchase/models/sale_order.py
@@ -88,7 +88,7 @@ class SaleOrderLine(models.Model):
     @api.depends('purchase_line_ids')
     def _compute_purchase_count(self):
         database_data = self.env['purchase.order.line'].sudo().read_group([('sale_line_id', 'in', self.ids)], ['sale_line_id'], ['sale_line_id'])
-        mapped_data = dict([(db['sale_line_id'][0], db['sale_line_id_count']) for db in database_data])
+        mapped_data = {db['sale_line_id'][0]: db['sale_line_id_count'] for db in database_data}
         for line in self:
             line.purchase_line_count = mapped_data.get(line.id, 0)
 

--- a/addons/sale_timesheet/models/account_move.py
+++ b/addons/sale_timesheet/models/account_move.py
@@ -32,7 +32,7 @@ class AccountMove(models.Model):
     @api.depends('timesheet_ids')
     def _compute_timesheet_count(self):
         timesheet_data = self.env['account.analytic.line'].read_group([('timesheet_invoice_id', 'in', self.ids)], ['timesheet_invoice_id'], ['timesheet_invoice_id'])
-        mapped_data = dict([(t['timesheet_invoice_id'][0], t['timesheet_invoice_id_count']) for t in timesheet_data])
+        mapped_data = {t['timesheet_invoice_id'][0]: t['timesheet_invoice_id_count'] for t in timesheet_data}
         for invoice in self:
             invoice.timesheet_count = mapped_data.get(invoice.id, 0)
 

--- a/addons/sale_timesheet/wizard/project_create_sale_order.py
+++ b/addons/sale_timesheet/wizard/project_create_sale_order.py
@@ -188,7 +188,7 @@ class ProjectCreateSalesOrder(models.TransientModel):
         task_id = self.env['project.task'].search([('project_id', '=', self.project_id.id)], order='create_date DESC', limit=1).id
         project_id = self.project_id.id
 
-        lines_already_present = dict([(l.employee_id.id, l) for l in self.project_id.sale_line_employee_ids])
+        lines_already_present = {l.employee_id.id: l for l in self.project_id.sale_line_employee_ids}
 
         non_billable_tasks = self.project_id.tasks.filtered(lambda task: not task.sale_line_id)
 

--- a/addons/sales_team/models/crm_team_member.py
+++ b/addons/sales_team/models/crm_team_member.py
@@ -54,10 +54,10 @@ class CrmTeamMember(models.Model):
         ])
         duplicates = self.env['crm.team.member']
 
-        active_records = dict(
-            (membership.user_id.id, membership.crm_team_id.id)
+        active_records = {
+            membership.user_id.id: membership.crm_team_id.id
             for membership in self if membership.active
-        )
+        }
         for membership in self:
             potential = existing.filtered(lambda m: m.user_id == membership.user_id and \
                 m.crm_team_id == membership.crm_team_id and m.id != membership.id
@@ -174,7 +174,7 @@ class CrmTeamMember(models.Model):
         is_membership_multi = self.env['ir.config_parameter'].sudo().get_param('sales_team.membership_multi', False)
         if not is_membership_multi and values.get('active'):
             self._synchronize_memberships([
-                dict(user_id=membership.user_id.id, crm_team_id=membership.crm_team_id.id)
+                {'user_id': membership.user_id.id, 'crm_team_id': membership.crm_team_id.id}
                 for membership in self
             ])
         return super(CrmTeamMember, self).write(values)

--- a/addons/sales_team/tests/test_sales_team_membership.py
+++ b/addons/sales_team/tests/test_sales_team_membership.py
@@ -69,7 +69,7 @@ class TestMembership(TestSalesCommon):
         self.assertFalse(memberships.filtered(lambda m: m.crm_team_id == sales_team_1).active)
         new_team_memberships = memberships.filtered(lambda m: m.crm_team_id == new_team)
         self.assertEqual(len(new_team_memberships), 2)  # subscribed, removed, then subscribed again
-        self.assertTrue(set(new_team_memberships.mapped('active')), set([False, True]))
+        self.assertTrue(set(new_team_memberships.mapped('active')), {False, True})
 
         # still avoid duplicated team / user entries
         with self.assertRaises(exceptions.UserError):

--- a/addons/sms/wizard/sms_cancel.py
+++ b/addons/sms/wizard/sms_cancel.py
@@ -30,7 +30,7 @@ WHERE notif.notification_type = 'sms' IS TRUE AND notif.notification_status IN (
     AND msg.author_id = %s """, (wizard.model, author_id))
             res = self._cr.fetchall()
             notif_ids = [row[0] for row in res]
-            message_ids = list(set([row[1] for row in res]))
+            message_ids = list({row[1] for row in res})
             if notif_ids:
                 self.env['mail.notification'].browse(notif_ids).sudo().write({'notification_status': 'canceled'})
             if message_ids:

--- a/addons/sms/wizard/sms_resend.py
+++ b/addons/sms/wizard/sms_resend.py
@@ -86,7 +86,7 @@ class SMSResend(models.TransientModel):
         if to_resend_ids:
             record = self.env[self.mail_message_id.model].browse(self.mail_message_id.res_id)
 
-            sms_pid_to_number = dict((r.partner_id.id, r.sms_number) for  r in self.recipient_ids if r.resend and r.partner_id)
+            sms_pid_to_number = {r.partner_id.id: r.sms_number for r in self.recipient_ids if r.resend and r.partner_id}
             pids = list(sms_pid_to_number.keys())
             numbers = [r.sms_number for r in self.recipient_ids if r.resend and not r.partner_id]
 

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -163,17 +163,17 @@ class Product(models.Model):
         Quant = self.env['stock.quant'].with_context(active_test=False)
         domain_move_in_todo = [('state', 'in', ('waiting', 'confirmed', 'assigned', 'partially_available'))] + domain_move_in
         domain_move_out_todo = [('state', 'in', ('waiting', 'confirmed', 'assigned', 'partially_available'))] + domain_move_out
-        moves_in_res = dict((item['product_id'][0], item['product_qty']) for item in Move.read_group(domain_move_in_todo, ['product_id', 'product_qty'], ['product_id'], orderby='id'))
-        moves_out_res = dict((item['product_id'][0], item['product_qty']) for item in Move.read_group(domain_move_out_todo, ['product_id', 'product_qty'], ['product_id'], orderby='id'))
-        quants_res = dict((item['product_id'][0], (item['quantity'], item['reserved_quantity'])) for item in Quant.read_group(domain_quant, ['product_id', 'quantity', 'reserved_quantity'], ['product_id'], orderby='id'))
+        moves_in_res = {item['product_id'][0]: item['product_qty'] for item in Move.read_group(domain_move_in_todo, ['product_id', 'product_qty'], ['product_id'], orderby='id')}
+        moves_out_res = {item['product_id'][0]: item['product_qty'] for item in Move.read_group(domain_move_out_todo, ['product_id', 'product_qty'], ['product_id'], orderby='id')}
+        quants_res = {item['product_id'][0]: (item['quantity'], item['reserved_quantity']) for item in Quant.read_group(domain_quant, ['product_id', 'quantity', 'reserved_quantity'], ['product_id'], orderby='id')}
         if dates_in_the_past:
             # Calculate the moves that were done before now to calculate back in time (as most questions will be recent ones)
             domain_move_in_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_in_done
             domain_move_out_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_out_done
-            moves_in_res_past = dict((item['product_id'][0], item['product_qty']) for item in Move.read_group(domain_move_in_done, ['product_id', 'product_qty'], ['product_id'], orderby='id'))
-            moves_out_res_past = dict((item['product_id'][0], item['product_qty']) for item in Move.read_group(domain_move_out_done, ['product_id', 'product_qty'], ['product_id'], orderby='id'))
+            moves_in_res_past = {item['product_id'][0]: item['product_qty'] for item in Move.read_group(domain_move_in_done, ['product_id', 'product_qty'], ['product_id'], orderby='id')}
+            moves_out_res_past = {item['product_id'][0]: item['product_qty'] for item in Move.read_group(domain_move_out_done, ['product_id', 'product_qty'], ['product_id'], orderby='id')}
 
-        res = dict()
+        res = {}
         for product in self.with_context(prefetch_fields=False):
             origin_product_id = product._origin.id
             product_id = product.id

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -137,7 +137,7 @@ class Location(models.Model):
         view_by_wh = OrderedDict((wh.view_location_id.id, wh.id) for wh in warehouses)
         self.warehouse_id = False
         for loc in self:
-            path = set(int(loc_id) for loc_id in loc.parent_path.split('/')[:-1])
+            path = {int(loc_id) for loc_id in loc.parent_path.split('/')[:-1]}
             for view_location_id in view_by_wh:
                 if view_location_id in path:
                     loc.warehouse_id = view_by_wh[view_location_id]

--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -199,7 +199,7 @@ class StockLot(models.Model):
         ]
         move_lines = self.env['stock.move.line'].search(domain)
         if delivery_by_lot is None:
-            delivery_by_lot = dict()
+            delivery_by_lot = {}
         for lot in self:
             delivery_ids = set()
             if lot.id in lot_path:

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1428,7 +1428,7 @@ class StockMove(models.Model):
                 grouped_move_lines_out[k] = sum(self.env['stock.move.line'].concat(*g).mapped('reserved_qty'))
             available_move_lines = {key: grouped_move_lines_in[key] - grouped_move_lines_out.get(key, 0) for key in grouped_move_lines_in}
             # pop key if the quantity available amount to 0
-            return dict((k, v) for k, v in available_move_lines.items() if v)
+            return {k: v for k, v in available_move_lines.items() if v}
 
         StockMove = self.env['stock.move']
         assigned_moves_ids = OrderedSet()

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -290,7 +290,7 @@ class StockWarehouseOrderpoint(models.Model):
 
     def _get_lead_days_values(self):
         self.ensure_one()
-        return dict()
+        return {}
 
     def _get_product_context(self):
         """Used to call `virtual_available` when running an orderpoint."""

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -237,7 +237,7 @@ class Warehouse(models.Model):
                     # routes, rules, picking types and locations (e.g the reception
                     # steps). The purpose is to write on it in order to let the
                     # write method set the correct field to active or archive.
-                    depends = set([])
+                    depends = set()
                     for rule_item in warehouse._get_global_route_rules_values().values():
                         for depend in rule_item.get('depends', []):
                             depends.add(depend)

--- a/addons/stock/tests/test_stock_flow.py
+++ b/addons/stock/tests/test_stock_flow.py
@@ -401,7 +401,7 @@ class TestStockFlow(TestStockCommon):
         # Check product D done quantity must be 5.0 and 3.0
         movesD = self.MoveObj.search([('product_id', '=', self.productD.id), ('picking_id', '=', back_order_in.id)])
         d_done_qty = [move.product_uom_qty for move in movesD]
-        self.assertEqual(set(d_done_qty), set([8.0]), 'Wrong quantity of moves product D.')
+        self.assertEqual(set(d_done_qty), {8.0}, 'Wrong quantity of moves product D.')
         # Check no back order is created.
         self.assertFalse(self.PickingObj.search([('backorder_id', '=', back_order_in.id)]), "Should not create any back order.")
 

--- a/addons/stock/tests/test_wise_operator.py
+++ b/addons/stock/tests/test_wise_operator.py
@@ -138,9 +138,7 @@ class TestWiseOperator(TransactionCase):
         pack_ids2 = delivery_order_wise2.move_line_ids
 
         self.assertEqual(pack_ids1.location_id.id, self.shelf2.id)
-        self.assertEqual(set(pack_ids2.mapped('location_id.id')), set([
-            self.shelf1.id,
-            self.shelf2.id]))
+        self.assertEqual(set(pack_ids2.mapped('location_id.id')), {self.shelf1.id, self.shelf2.id})
 
         # put the move lines from delivery_order_wise2 into delivery_order_wise1
         for pack_id2 in pack_ids2:
@@ -150,9 +148,10 @@ class TestWiseOperator(TransactionCase):
         new_move_lines = delivery_order_wise1.move_line_ids.filtered(lambda p: p.qty_done)
         self.assertEqual(sum(new_move_lines.mapped('reserved_qty')), 0)
         self.assertEqual(sum(new_move_lines.mapped('qty_done')), 5)
-        self.assertEqual(set(new_move_lines.mapped('location_id.id')), set([
+        self.assertEqual(set(new_move_lines.mapped('location_id.id')), {
             self.shelf1.id,
-            self.shelf2.id]))
+            self.shelf2.id
+        })
 
         # put the move line from delivery_order_wise1 into delivery_order_wise2
         new_pack_id2 = pack_ids1.copy(default={'picking_id': delivery_order_wise2.id, 'move_id': move2.id})

--- a/addons/survey/models/res_partner.py
+++ b/addons/survey/models/res_partner.py
@@ -16,7 +16,7 @@ class ResPartner(models.Model):
             [('partner_id', 'in', self.ids), ('scoring_success', '=', True)],
             ['partner_id'], 'partner_id'
         )
-        data = dict((res['partner_id'][0], res['partner_id_count']) for res in read_group_res)
+        data = {res['partner_id'][0]: res['partner_id_count'] for res in read_group_res}
         for partner in self:
             partner.certifications_count = data.get(partner.id, 0)
 

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -34,12 +34,12 @@ class Survey(models.Model):
         for digits_count in range(4, 10):
             range_lower_bound = 1 * (10 ** (digits_count - 1))
             range_upper_bound = (range_lower_bound * 10) - 1
-            code_candidates = set([str(random.randint(range_lower_bound, range_upper_bound)) for i in range(20)])
+            code_candidates = {str(random.randint(range_lower_bound, range_upper_bound)) for i in range(20)}
             colliding_codes = self.sudo().search_read(
                 [('session_code', 'in', list(code_candidates))],
                 ['session_code']
             )
-            code_candidates -= set([colliding_code['session_code'] for colliding_code in colliding_codes])
+            code_candidates -= {colliding_code['session_code'] for colliding_code in colliding_codes}
             if code_candidates:
                 return list(code_candidates)[0]
 

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -189,7 +189,7 @@ class Survey(models.Model):
             'answer_count': 0, 'answer_done_count': 0, 'success_count': 0,
             'answer_score_avg': 0.0, 'success_ratio': 0.0
         }
-        stat = dict((cid, dict(default_vals, answer_score_avg_total=0.0)) for cid in self.ids)
+        stat = {cid: dict(default_vals, answer_score_avg_total=0.0) for cid in self.ids}
         UserInput = self.env['survey.user_input']
         base_domain = ['&', ('survey_id', 'in', self.ids), ('test_entry', '!=', True)]
 

--- a/addons/survey/models/survey_user_input.py
+++ b/addons/survey/models/survey_user_input.py
@@ -394,9 +394,7 @@ class SurveyUserInput(models.Model):
                 }]
             }
         }"""
-        res = dict((user_input, {
-            'by_section': {}
-        }) for user_input in self)
+        res = {user_input: {'by_section': {}} for user_input in self}
 
         scored_questions = self.mapped('predefined_question_ids').filtered(lambda question: question.is_scored_question)
 

--- a/addons/survey/tests/test_survey_invite.py
+++ b/addons/survey/tests/test_survey_invite.py
@@ -68,9 +68,9 @@ class TestSurveyInvite(common.TestSurveyCommon):
         self.assertEqual(len(answers), 1)
         self.assertEqual(
             set(answers.mapped('email')),
-            set([self.customer.email]))
+            {self.customer.email})
         self.assertEqual(answers.mapped('partner_id'), self.customer)
-        self.assertEqual(set(answers.mapped('deadline')), set([deadline]))
+        self.assertEqual(set(answers.mapped('deadline')), {deadline})
 
     @users('survey_manager')
     def test_survey_invite_authentication_nosignup(self):
@@ -96,7 +96,7 @@ class TestSurveyInvite(common.TestSurveyCommon):
         self.assertEqual(len(answers), 2)
         self.assertEqual(
             set(answers.mapped('email')),
-            set([self.user_emp.email, self.user_portal.email]))
+            {self.user_emp.email, self.user_portal.email})
         self.assertEqual(answers.mapped('partner_id'), self.user_emp.partner_id | self.user_portal.partner_id)
 
     @users('survey_manager')
@@ -122,7 +122,7 @@ class TestSurveyInvite(common.TestSurveyCommon):
         self.assertEqual(len(answers), 3)
         self.assertEqual(
             set(answers.mapped('email')),
-            set([self.customer.email, self.user_emp.email, self.user_portal.email]))
+            {self.customer.email, self.user_emp.email, self.user_portal.email})
         self.assertEqual(answers.mapped('partner_id'), self.customer | self.user_emp.partner_id | self.user_portal.partner_id)
 
     @users('survey_manager')
@@ -143,7 +143,7 @@ class TestSurveyInvite(common.TestSurveyCommon):
         self.assertEqual(len(answers), 3)
         self.assertEqual(
             set(answers.mapped('email')),
-            set(['test1@example.com', '"Raoulette Vignolette" <test2@example.com>', self.customer.email]))
+            {'test1@example.com', '"Raoulette Vignolette" <test2@example.com>', self.customer.email})
         self.assertEqual(answers.mapped('partner_id'), self.customer)
 
     @users('survey_manager')
@@ -164,7 +164,7 @@ class TestSurveyInvite(common.TestSurveyCommon):
         self.assertEqual(len(answers), 3)
         self.assertEqual(
             set(answers.mapped('email')),
-            set(['test1@example.com', '"Raoulette Vignolette" <test2@example.com>', self.customer.email]))
+            {'test1@example.com', '"Raoulette Vignolette" <test2@example.com>', self.customer.email})
         self.assertEqual(answers.mapped('partner_id'), self.customer)
 
     @users('survey_manager')
@@ -192,7 +192,7 @@ class TestSurveyInvite(common.TestSurveyCommon):
         self.assertEqual(len(answers), 1)
         self.assertEqual(
             set(answers.mapped('email')),
-            set([self.user_emp.email]))
+            {self.user_emp.email})
         self.assertEqual(answers.mapped('partner_id'), self.user_emp.partner_id)
 
     def test_survey_invite_token_by_email_nosignup(self):

--- a/addons/survey/wizard/survey_invite.py
+++ b/addons/survey/wizard/survey_invite.py
@@ -221,7 +221,7 @@ class SurveyInvite(models.TransientModel):
                 _logger.warning('QWeb template %s not found when sending survey mails. Sending without layout', email_layout_xmlid)
             else:
                 template_ctx = {
-                    'message': self.env['mail.message'].sudo().new(dict(body=mail_values['body_html'], record_name=self.survey_id.title)),
+                    'message': self.env['mail.message'].sudo().new({'body': mail_values['body_html'], 'record_name': self.survey_id.title}),
                     'model_description': self.env['ir.model']._get('survey.survey').display_name,
                     'company': self.env.company,
                 }

--- a/addons/test_event_full/tests/test_wevent_register.py
+++ b/addons/test_event_full/tests/test_wevent_register.py
@@ -25,15 +25,15 @@ class TestWEventRegister(TestWEventCommon):
         self.assertEqual(len(new_registrations), 2)
         self.assertEqual(
             set(new_registrations.mapped("name")),
-            set(["Raoulette Poiluchette", "Michel Tractopelle"])
+            {"Raoulette Poiluchette", "Michel Tractopelle"}
         )
         self.assertEqual(
             set(new_registrations.mapped("phone")),
-            set(["0456112233", "0456332211"])
+            {"0456112233", "0456332211"}
         )
         self.assertEqual(
             set(new_registrations.mapped("email")),
-            set(["raoulette@example.com", "michel@example.com"])
+            {"raoulette@example.com", "michel@example.com"}
         )
 
         # check visitor stored information

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -558,7 +558,7 @@ class TestComposerResultsComment(TestMailComposer):
         ])
         self.assertEqual(len(new_partners), 3)
         self.assertEqual(set(new_partners.mapped('email')),
-                         set(['test.to.1@test.example.com', 'test.to.2@test.example.com', 'test.cc.1@test.example.com'])
+                         {'test.to.1@test.example.com', 'test.to.2@test.example.com', 'test.cc.1@test.example.com'}
                         )
 
         # global outgoing: one mail.mail (all customer recipients, then all employee recipients)
@@ -605,9 +605,9 @@ class TestComposerResultsComment(TestMailComposer):
         # attachments are copied on message and linked to document
         self.assertEqual(
             set(message.attachment_ids.mapped('name')),
-            set(['00.txt', '01.txt', 'TestReport for %s.html' % self.test_record.name])
+            {'00.txt', '01.txt', 'TestReport for %s.html' % self.test_record.name}
         )
-        self.assertEqual(set(message.attachment_ids.mapped('res_model')), set([self.test_record._name]))
+        self.assertEqual(set(message.attachment_ids.mapped('res_model')), {self.test_record._name})
         self.assertEqual(set(message.attachment_ids.mapped('res_id')), set(self.test_record.ids))
         self.assertTrue(all(attach not in message.attachment_ids for attach in attachs), 'Should have copied attachments')
 

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -279,7 +279,7 @@ class TestMailgateway(TestMailCommon):
             self.assertIn('/web/image/%s' % attachment.id, message.body)
         self.assertEqual(
             set(message.attachment_ids.mapped('name')),
-            set(['rosaçée.gif', 'verte!µ.gif', 'orangée.gif']))
+            {'rosaçée.gif', 'verte!µ.gif', 'orangée.gif'})
 
     @mute_logger('odoo.addons.mail.models.mail_thread')
     def test_message_process_followers(self):

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -277,11 +277,11 @@ class TestMessagePost(TestMailCommon, TestRecipients):
 
         # message attachments
         self.assertEqual(len(msg.attachment_ids), 4)
-        self.assertEqual(set(msg.attachment_ids.mapped('res_model')), set([self.test_record._name]))
-        self.assertEqual(set(msg.attachment_ids.mapped('res_id')), set([self.test_record.id]))
-        self.assertEqual(set([base64.b64decode(x) for x in msg.attachment_ids.mapped('datas')]),
-                         set([b'migration test', _attachments[0][1], _attachments[1][1]]))
-        self.assertTrue(set([_attach_1.id, _attach_2.id]).issubset(msg.attachment_ids.ids),
+        self.assertEqual(set(msg.attachment_ids.mapped('res_model')), {self.test_record._name})
+        self.assertEqual(set(msg.attachment_ids.mapped('res_id')), {self.test_record.id})
+        self.assertEqual({base64.b64decode(x) for x in msg.attachment_ids.mapped('datas')},
+                         {b'migration test', _attachments[0][1], _attachments[1][1]})
+        self.assertTrue({_attach_1.id, _attach_2.id}.issubset(msg.attachment_ids.ids),
                         'message_post: mail.message attachments duplicated')
 
         # notification email attachments

--- a/addons/test_mail_full/tests/test_sms_sms.py
+++ b/addons/test_mail_full/tests/test_sms_sms.py
@@ -177,9 +177,9 @@ class TestSMSPost(TestMailFullCommon, MockLinkTracker):
         with self.assertRaises(exceptions.AccessError):
             with self.mockSMSGateway(sim_error='jsonrpc_exception'):
                 self.env['sms.sms'].browse(self.sms_all.ids).send(raise_exception=True)
-        self.assertEqual(set(self.sms_all.mapped('state')), set(['outgoing']))
+        self.assertEqual(set(self.sms_all.mapped('state')), {'outgoing'})
 
     def test_sms_send_raise_catch(self):
         with self.mockSMSGateway(sim_error='jsonrpc_exception'):
             self.env['sms.sms'].browse(self.sms_all.ids).send(raise_exception=False)
-        self.assertEqual(set(self.sms_all.mapped('state')), set(['error']))
+        self.assertEqual(set(self.sms_all.mapped('state')), {'error'})

--- a/addons/test_website/controllers/main.py
+++ b/addons/test_website/controllers/main.py
@@ -18,27 +18,27 @@ class WebsiteTest(Home):
 
     @http.route('/ignore_args/converteronly/<string:a>', type='http', auth="public", website=True, sitemap=False)
     def test_ignore_args_converter_only(self, a):
-        return request.make_response(json.dumps(dict(a=a, kw=None)))
+        return request.make_response(json.dumps({'a': a, 'kw': None}))
 
     @http.route('/ignore_args/none', type='http', auth="public", website=True, sitemap=False)
     def test_ignore_args_none(self):
-        return request.make_response(json.dumps(dict(a=None, kw=None)))
+        return request.make_response(json.dumps({'a': None, 'kw': None}))
 
     @http.route('/ignore_args/a', type='http', auth="public", website=True, sitemap=False)
     def test_ignore_args_a(self, a):
-        return request.make_response(json.dumps(dict(a=a, kw=None)))
+        return request.make_response(json.dumps({'a': a, 'kw': None}))
 
     @http.route('/ignore_args/kw', type='http', auth="public", website=True, sitemap=False)
     def test_ignore_args_kw(self, a, **kw):
-        return request.make_response(json.dumps(dict(a=a, kw=kw)))
+        return request.make_response(json.dumps({'a': a, 'kw': kw}))
 
     @http.route('/ignore_args/converter/<string:a>', type='http', auth="public", website=True, sitemap=False)
     def test_ignore_args_converter(self, a, b='youhou', **kw):
-        return request.make_response(json.dumps(dict(a=a, b=b, kw=kw)))
+        return request.make_response(json.dumps({'a': a, 'b': b, 'kw': kw}))
 
     @http.route('/ignore_args/converter/<string:a>/nokw', type='http', auth="public", website=True, sitemap=False)
     def test_ignore_args_converter_nokw(self, a, b='youhou'):
-        return request.make_response(json.dumps(dict(a=a, b=b)))
+        return request.make_response(json.dumps({'a': a, 'b': b}))
 
     @http.route('/multi_company_website', type='http', auth="public", website=True, sitemap=False)
     def test_company_context(self):

--- a/addons/transifex/models/ir_translation.py
+++ b/addons/transifex/models/ir_translation.py
@@ -46,7 +46,7 @@ class IrTranslation(models.Model):
             languages = self.env['res.lang'].with_context(active_test=False).search(
                 [('code', 'in', translation_languages)])
 
-            language_codes = dict((l.code, l.iso_code) for l in languages)
+            language_codes = {l.code: l.iso_code for l in languages}
 
             # .tx/config files contains the project reference
             # using ini files like '[odoo-master.website_sale]'

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1242,7 +1242,7 @@ class Session(http.Controller):
     @http.route('/web/session/modules', type='json', auth="user")
     def modules(self):
         # return all installed modules. Web client is smart enough to not load a module twice
-        return list(request.env.registry._init_modules | set([module.current_test] if module.current_test else []))
+        return list(request.env.registry._init_modules | {module.current_test} if module.current_test else set())
 
     @http.route('/web/session/save_session_action', type='json', auth="user")
     def save_session_action(self, the_action):

--- a/addons/web/static/src/core/assets.js
+++ b/addons/web/static/src/core/assets.js
@@ -129,6 +129,8 @@ const loadBundleDefinition = memoize(async function (bundleName) {
 
 const bundlesCache = {};
 
+const literal = {a: 'b'};
+const literal2 = {'a': 'b'};
 /**
  * Loads a bundle.
  *

--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -380,7 +380,7 @@ class Web_Editor(http.Controller):
         excluded_url_matcher = re.compile("^(.+/lib/.+)|(.+import_bootstrap.+\.scss)$")
 
         # First check the t-call-assets used in the related views
-        url_infos = dict()
+        url_infos = {}
         for v in views:
             for asset_call_node in etree.fromstring(v["arch"]).xpath("//t[@t-call-assets]"):
                 attr = asset_call_node.get(resources_type_info['t_call_assets_attribute'])

--- a/addons/website/controllers/backend.py
+++ b/addons/website/controllers/backend.py
@@ -34,10 +34,10 @@ class WebsiteBackend(http.Controller):
 
         if has_group_designer:
             if current_website.google_management_client_id and current_website.google_analytics_key:
-                dashboard_data['dashboards']['visits'] = dict(
-                    ga_client_id=current_website.google_management_client_id or '',
-                    ga_analytics_key=current_website.google_analytics_key or '',
-                )
+                dashboard_data['dashboards']['visits'] = {
+                    'ga_client_id': current_website.google_management_client_id or '',
+                    'ga_analytics_key': current_website.google_analytics_key or ''
+                }
         return dashboard_data
 
     @http.route('/website/dashboard/set_ga_data', type='json', auth='user')

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -159,7 +159,7 @@ class Website(Home):
     @http.route(['/website/country_infos/<model("res.country"):country>'], type='json', auth="public", methods=['POST'], website=True)
     def country_infos(self, country, **kw):
         fields = country.get_address_fields()
-        return dict(fields=fields, states=[(st.id, st.name, st.code) for st in country.state_ids], phone_code=country.phone_code)
+        return {'fields': fields, 'states': [(st.id, st.name, st.code) for st in country.state_ids], 'phone_code': country.phone_code}
 
     @http.route(['/robots.txt'], type='http', auth="public", website=True, sitemap=False)
     def robots(self, **kwargs):
@@ -300,8 +300,8 @@ class Website(Home):
         return {
             'matching_pages': sorted(matching_pages, key=lambda o: o['label']),
             'others': [
-                dict(title=_('Last modified pages'), values=matching_last_modified),
-                dict(title=_('Apps url'), values=suggested_controllers),
+                {'title': _('Last modified pages'), 'values': matching_last_modified},
+                {'title': _('Apps url'), 'values': suggested_controllers},
             ]
         }
 
@@ -586,7 +586,7 @@ class Website(Home):
             if request.env.ref(default_templ, False):
                 template = default_templ
 
-        template = template and dict(template=template) or {}
+        template = {'template': template} if template else {}
         page = request.env['website'].new_page(path, add_menu=add_menu, **template)
         url = page['url']
         if noredirect:

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -91,7 +91,7 @@ class Http(models.AbstractModel):
         logger.debug("_generate_routing_rules for website: %s", website_id)
         domain = [('redirect_type', 'in', ('308', '404')), '|', ('website_id', '=', False), ('website_id', '=', website_id)]
 
-        rewrites = dict([(x.url_from, x) for x in request.env['website.rewrite'].sudo().search(domain)])
+        rewrites = {x.url_from: x for x in request.env['website.rewrite'].sudo().search(domain)}
         cls._rewrite_len[website_id] = len(rewrites)
 
         for url, endpoint, routing in super(Http, cls)._generate_routing_rules(modules, converters):

--- a/addons/website/models/ir_qweb_fields.py
+++ b/addons/website/models/ir_qweb_fields.py
@@ -11,8 +11,8 @@ class Contact(models.AbstractModel):
     def get_available_options(self):
         options = super(Contact, self).get_available_options()
         options.update(
-            website_description=dict(type='boolean', string=_('Display the website description')),
-            UserBio=dict(type='boolean', string=_('Display the biography')),
-            badges=dict(type='boolean', string=_('Display the badges'))
+            website_description={'type': 'boolean', 'string': _('Display the website description')},
+            UserBio={'type': 'boolean', 'string': _('Display the biography')},
+            badges={'type': 'boolean', 'string': _('Display the badges')}
         )
         return options

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -460,14 +460,14 @@ class View(models.Model):
                     for comp in self.env.user.company_ids if comp != cur_company
                 ]
 
-            qcontext.update(dict(
+            qcontext.update(
                 main_object=self,
                 website=request.website,
                 is_view_active=request.website.is_view_active,
                 res_company=request.website.company_id.sudo(),
                 translatable=translatable,
                 editable=editable,
-            ))
+            )
 
         return qcontext
 

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -315,19 +315,20 @@ class Website(models.Model):
 
     @api.model
     def configurator_init(self):
-        r = dict()
         company = self.get_current_website().company_id
         configurator_features = self.env['website.configurator.feature'].search([])
-        r['features'] = [{
-            'id': feature.id,
-            'name': feature.name,
-            'description': feature.description,
-            'type': 'page' if feature.page_view_id else 'app',
-            'icon': feature.icon,
-            'website_config_preselection': feature.website_config_preselection,
-            'module_state': feature.module_id.state,
-        } for feature in configurator_features]
-        r['logo'] = False
+        r = {
+            'logo': False,
+            'features': [{
+                'id': feature.id,
+                'name': feature.name,
+                'description': feature.description,
+                'type': 'page' if feature.page_view_id else 'app',
+                'icon': feature.icon,
+                'website_config_preselection': feature.website_config_preselection,
+                'module_state': feature.module_id.state,
+            } for feature in configurator_features]
+        }
         if company.logo and company.logo != company._get_logo():
             r['logo'] = company.logo.decode('utf-8')
         try:
@@ -399,7 +400,7 @@ class Website(models.Model):
                     result = self.env['website'].new_page(
                         name=feature.name,
                         add_menu=add_menu,
-                        page_values=dict(url=feature.feature_url, is_published=True),
+                        page_values={'url': feature.feature_url, 'is_published': True},
                         menu_values=add_menu and {
                             'url': feature.feature_url,
                             'sequence': feature.menu_sequence,

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -179,7 +179,7 @@ class Page(models.Model):
             :param page_id : website.page identifier
         """
         page = self.browse(int(page_id))
-        copy_param = dict(name=page_name or page.name, website_id=self.env['website'].get_current_website().id)
+        copy_param = {'name': page_name or page.name, 'website_id': self.env['website'].get_current_website().id}
         if page_name:
             page_url = '/' + slugify(page_name, max_length=1024, path=True)
             copy_param['url'] = self.env['website'].get_unique_path(page_url)

--- a/addons/website/models/website_snippet_filter.py
+++ b/addons/website/models/website_snippet_filter.py
@@ -72,10 +72,10 @@ class WebsiteSnippetFilter(models.Model):
         if is_sample:
             records = self._prepare_sample(limit)
         View = self.env['ir.ui.view'].sudo().with_context(inherit_branding=False)
-        content = View._render_template(template_key, dict(
-            records=records,
-            is_sample=is_sample,
-        ))
+        content = View._render_template(template_key, {
+            'records': records,
+            'is_sample': is_sample
+        })
         return [etree.tostring(el, encoding='unicode') for el in html.fromstring('<root>%s</root>' % str(content)).getchildren()]
 
     def _prepare_values(self, limit=None, search_domain=None):

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -142,22 +142,18 @@ class WebsiteVisitor(models.Model):
         self.ensure_one()
         if not self._check_for_message_composer():
             raise UserError(_("There are no contact and/or no email linked to this visitor."))
-        visitor_composer_ctx = self._prepare_message_composer_context()
         compose_form = self.env.ref('mail.email_compose_message_wizard_form', False)
-        compose_ctx = dict(
-            default_use_template=False,
-            default_composition_mode='comment',
-        )
-        compose_ctx.update(**visitor_composer_ctx)
         return {
             'name': _('Contact Visitor'),
             'type': 'ir.actions.act_window',
-            'view_mode': 'form',
             'res_model': 'mail.compose.message',
-            'views': [(compose_form.id, 'form')],
-            'view_id': compose_form.id,
+            'views': [(compose_form and compose_form.id, 'form')],
             'target': 'new',
-            'context': compose_ctx,
+            'context': {
+                'default_use_template': False,
+                'default_composition_mode': 'comment',
+                **self._prepare_message_composer_context()
+            },
         }
 
     def _get_visitor_from_request(self, force_create=False):

--- a/addons/website/tests/test_disable_unused_snippets_assets.py
+++ b/addons/website/tests/test_disable_unused_snippets_assets.py
@@ -37,7 +37,7 @@ class TestDisableSnippetsAssets(TransactionCase):
         self.assertEqual(s_image_gallery_000.active, False)
         self.assertEqual(s_image_gallery_001.active, True)
 
-        unwanted_snippets_assets_changes = set(self.initial_active_snippets_assets) - set(self._get_active_snippets_assets()) - set([s_image_gallery_000.path])
+        unwanted_snippets_assets_changes = set(self.initial_active_snippets_assets) - set(self._get_active_snippets_assets()) - {s_image_gallery_000.path}
 
         # The vaccuum should not have activated/deactivated any other snippet asset than the original ones
         self.assertEqual(

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -216,7 +216,7 @@ class BlogPost(models.Model):
         for blog_post in self:
             blog_post.published_date = blog_post.post_date
             if not blog_post.published_date:
-                blog_post._write(dict(post_date=blog_post.create_date)) # dont trigger inverse function
+                blog_post._write({'post_date': blog_post.create_date}) # dont trigger inverse function
 
     def _check_for_publication(self, vals):
         if vals.get('is_published'):

--- a/addons/website_crm/models/website_visitor.py
+++ b/addons/website_crm/models/website_visitor.py
@@ -22,7 +22,7 @@ class WebsiteVisitor(models.Model):
 
         left_visitors = self.filtered(lambda visitor: not visitor.email or not visitor.mobile)
         leads = left_visitors.mapped('lead_ids').sorted('create_date', reverse=True)
-        visitor_to_lead_ids = dict((visitor.id, visitor.lead_ids.ids) for visitor in left_visitors)
+        visitor_to_lead_ids = {visitor.id: visitor.lead_ids.ids for visitor in left_visitors}
 
         for visitor in left_visitors:
             visitor_leads = leads.filtered(lambda lead: lead.id in visitor_to_lead_ids[visitor.id])

--- a/addons/website_crm_iap_reveal/tests/test_lead_reveal.py
+++ b/addons/website_crm_iap_reveal/tests/test_lead_reveal.py
@@ -93,7 +93,7 @@ class TestLeadMine(TestCrmCommon, MockIAPReveal):
             self.env['crm.reveal.view'].search([('reveal_ip', 'in', ['90.80.70.60', '90.80.70.61', '90.80.70.70'])]),
             self.test_views
         )
-        self.assertEqual(set(self.test_views.mapped('reveal_state')), set(['to_process']))
+        self.assertEqual(set(self.test_views.mapped('reveal_state')), {'to_process'})
 
     @users('user_sales_manager')
     def test_reveal_error_jsonrpc_exception(self):
@@ -112,7 +112,7 @@ class TestLeadMine(TestCrmCommon, MockIAPReveal):
             self.env['crm.reveal.view'].search([('reveal_ip', 'in', ['90.80.70.60', '90.80.70.61', '90.80.70.70'])]),
             self.test_views
         )
-        self.assertEqual(set(self.test_views.mapped('reveal_state')), set(['to_process']))
+        self.assertEqual(set(self.test_views.mapped('reveal_state')), {'to_process'})
 
     @users('user_sales_manager')
     def test_reveal_error_no_result(self):
@@ -130,7 +130,7 @@ class TestLeadMine(TestCrmCommon, MockIAPReveal):
             self.env['crm.reveal.view'].search([('reveal_ip', 'in', ['90.80.70.60', '90.80.70.61', '90.80.70.70'])]),
             self.test_views
         )
-        self.assertEqual(set(self.test_views.mapped('reveal_state')), set(['not_found']))
+        self.assertEqual(set(self.test_views.mapped('reveal_state')), {'not_found'})
 
     @users('user_sales_manager')
     def test_reveal(self):

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -204,10 +204,10 @@ class WebsiteEventController(http.Controller):
                 continue
             ticket_order[int(registration_items[1])] = int(value)
 
-        ticket_dict = dict((ticket.id, ticket) for ticket in request.env['event.event.ticket'].sudo().search([
+        ticket_dict = {ticket.id: ticket for ticket in request.env['event.event.ticket'].sudo().search([
             ('id', 'in', [tid for tid in ticket_order.keys() if tid]),
             ('event_id', '=', event.id)
-        ]))
+        ])}
 
         return [{
             'id': tid if ticket_dict.get(tid) else 0,
@@ -273,7 +273,7 @@ class WebsiteEventController(http.Controller):
             if counter == '0':
                 global_values[attr_name] = value
             else:
-                registrations.setdefault(counter, dict())[attr_name] = value
+                registrations.setdefault(counter, {})[attr_name] = value
         for key, value in global_values.items():
             for registration in registrations.values():
                 registration[key] = value

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -241,7 +241,7 @@ class Event(models.Model):
           'activated': subset of self having its menu currently set to True
           'deactivated': subset of self having its menu currently set to False
         } """
-        menus_state_by_field = dict()
+        menus_state_by_field = {}
         for fname in self._get_menu_update_fields():
             activated = self.filtered(lambda event: event[fname])
             menus_state_by_field[fname] = {
@@ -264,7 +264,7 @@ class Event(models.Model):
           'activated': subset of self having its menu toggled to True
           'deactivated': subset of self having its menu toggled to False
         } """
-        menus_update_by_field = dict()
+        menus_update_by_field = {}
         for fname in self._get_menu_update_fields():
             if fname in force_update:
                 menus_update_by_field[fname] = self

--- a/addons/website_event/models/website_menu.py
+++ b/addons/website_event/models/website_menu.py
@@ -25,6 +25,6 @@ class WebsiteMenu(models.Model):
         # update events
         for event, to_update in event_updates.items():
             if to_update:
-                event.write(dict((fname, False) for fname in to_update))
+                event.write(dict.fromkeys(to_update, False))
 
         return res

--- a/addons/website_event/models/website_visitor.py
+++ b/addons/website_event/models/website_visitor.py
@@ -29,11 +29,12 @@ class WebsiteVisitor(models.Model):
             read_group_res = self.env['event.registration'].read_group(
                 [('visitor_id', 'in', self.ids)],
                 ['visitor_id'], ['visitor_id'])
-            visitor_mapping = dict(
-                (item['visitor_id'][0], item['visitor_id_count'])
-                for item in read_group_res)
+            visitor_mapping = {
+                item['visitor_id'][0]: item['visitor_id_count']
+                for item in read_group_res
+            }
         else:
-            visitor_mapping = dict()
+            visitor_mapping = {}
         for visitor in self:
             visitor.event_registration_count = visitor_mapping.get(visitor.id) or 0
 

--- a/addons/website_event/tests/common.py
+++ b/addons/website_event/tests/common.py
@@ -35,7 +35,7 @@ class OnlineEventCase(EventCase):
         })
 
     def _get_menus(self):
-        return set(['Introduction', 'Location', 'Register', 'Community'])
+        return {'Introduction', 'Location', 'Register', 'Community'}
 
     def _assert_website_menus(self, event, menus_in=None, menus_out=None):
         self.assertTrue(event.menu_id)

--- a/addons/website_event_exhibitor/controllers/exhibitor.py
+++ b/addons/website_event_exhibitor/controllers/exhibitor.py
@@ -77,7 +77,7 @@ class ExhibitorController(WebsiteEventController):
         sponsor_types = sponsors_all.mapped('sponsor_type_id')
         sponsor_countries = sponsors_all.mapped('partner_id.country_id').sorted('name')
         # organize sponsors into categories to help display
-        sponsor_categories_dict = dict()
+        sponsor_categories_dict = {}
         sponsor_categories = []
         is_event_user = request.env.user.has_group('event.group_event_registration_desk')
         for sponsor in sponsors:

--- a/addons/website_event_exhibitor/models/event_event.py
+++ b/addons/website_event_exhibitor/models/event_event.py
@@ -21,7 +21,7 @@ class EventEvent(models.Model):
 
     def _compute_sponsor_count(self):
         data = self.env['event.sponsor'].read_group([], ['event_id'], ['event_id'])
-        result = dict((data['event_id'][0], data['event_id_count']) for data in data)
+        result = {data['event_id'][0]: data['event_id_count'] for data in data}
         for event in self:
             event.sponsor_count = result.get(event.id, 0)
 

--- a/addons/website_event_questions/tests/test_event_internals.py
+++ b/addons/website_event_questions/tests/test_event_internals.py
@@ -29,13 +29,13 @@ class TestEventData(TestEventQuestionCommon):
         self.assertEqual(event.specific_question_ids.title, 'Question1')
         self.assertEqual(
             set(event.specific_question_ids.mapped('answer_ids.name')),
-            set(['Q1-Answer1', 'Q1-Answer2']))
+            {'Q1-Answer1', 'Q1-Answer2'})
         self.assertEqual(len(event.general_question_ids), 2)
         self.assertEqual(event.general_question_ids[0].title, 'Question2')
         self.assertEqual(event.general_question_ids[1].title, 'Question3')
         self.assertEqual(
             set(event.general_question_ids[0].mapped('answer_ids.name')),
-            set(['Q2-Answer1', 'Q2-Answer2']))
+            {'Q2-Answer1', 'Q2-Answer2'})
 
     def test_process_attendees_form(self):
         event = self.env['event.event'].create({

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -121,11 +121,10 @@ class EventTrackController(http.Controller):
         # organize categories for display: announced, live, soon and day-based
         tracks_announced = tracks_sudo.filtered(lambda track: not track.date)
         tracks_wdate = tracks_sudo - tracks_announced
-        date_begin_tz_all = list(set(
+        date_begin_tz_all = sorted({
             dt.date()
             for dt in self._get_dt_in_event_tz(tracks_wdate.mapped('date'), event)
-        ))
-        date_begin_tz_all.sort()
+        })
         tracks_sudo_live = tracks_wdate.filtered(lambda track: track.is_track_live)
         tracks_sudo_soon = tracks_wdate.filtered(lambda track: not track.is_track_live and track.is_track_soon)
         tracks_by_day = []
@@ -201,8 +200,7 @@ class EventTrackController(http.Controller):
         ])
         tracks_sudo = request.env['event.track'].sudo().search(base_track_domain)
 
-        locations = list(set(track.location_id for track in tracks_sudo))
-        locations.sort(key=lambda x: x.id)
+        locations = sorted({track.location_id for track in tracks_sudo}, key=lambda x: x.id)
 
         # First split day by day (based on start time)
         time_slots_by_tracks = {track: self._split_track_by_days(track, local_tz) for track in tracks_sudo}
@@ -211,8 +209,7 @@ class EventTrackController(http.Controller):
         track_time_slots = set().union(*(time_slot.keys() for time_slot in [time_slots for time_slots in time_slots_by_tracks.values()]))
 
         # extract unique days
-        days = list(set(time_slot.date() for time_slot in track_time_slots))
-        days.sort()
+        days = sorted({time_slot.date() for time_slot in track_time_slots})
 
         # Create the dict that contains the tracks at the correct time_slots / locations coordinates
         tracks_by_days = dict.fromkeys(days, 0)

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -95,7 +95,7 @@ class EventTrackController(http.Controller):
             # Doing it this way allows to only get events who are tagged "age: 10-12" AND "activity: football".
             # Add another tag "age: 12-15" to the search and it would fetch the ones who are tagged:
             # ("age: 10-12" OR "age: 12-15") AND "activity: football
-            grouped_tags = dict()
+            grouped_tags = {}
             for search_tag in search_tags:
                 grouped_tags.setdefault(search_tag.category_id, list()).append(search_tag)
             search_domain_items = [
@@ -213,8 +213,8 @@ class EventTrackController(http.Controller):
 
         # Create the dict that contains the tracks at the correct time_slots / locations coordinates
         tracks_by_days = dict.fromkeys(days, 0)
-        time_slots_by_day = dict((day, dict(start=set(), end=set())) for day in days)
-        tracks_by_rounded_times = dict((time_slot, dict((location, {}) for location in locations)) for time_slot in track_time_slots)
+        time_slots_by_day = {day: {'start': set(), 'end': set()} for day in days}
+        tracks_by_rounded_times = {time_slot: {location: {} for location in locations} for time_slot in track_time_slots}
         for track, time_slots in time_slots_by_tracks.items():
             start_date = fields.Datetime.from_string(track.date).replace(tzinfo=pytz.utc).astimezone(local_tz)
             end_date = start_date + timedelta(hours=(track.duration or 0.25))
@@ -234,7 +234,7 @@ class EventTrackController(http.Controller):
                 tracks_by_days[day] += 1
 
         # split days into 15 minutes time slots
-        global_time_slots_by_day = dict((day, {}) for day in days)
+        global_time_slots_by_day = {day: {} for day in days}
         for day, time_slots in time_slots_by_day.items():
             start_time_slot = min(time_slots['start'])
             end_time_slot = max(time_slots['end'])

--- a/addons/website_event_track/models/event_event.py
+++ b/addons/website_event_track/models/event_event.py
@@ -25,7 +25,7 @@ class Event(models.Model):
 
     def _compute_track_count(self):
         data = self.env['event.track'].read_group([('stage_id.is_cancel', '!=', True)], ['event_id'], ['event_id'])
-        result = dict((data['event_id'][0], data['event_id_count']) for data in data)
+        result = {data['event_id'][0]: data['event_id_count'] for data in data}
         for event in self:
             event.track_count = result.get(event.id, 0)
 

--- a/addons/website_event_track/models/website_menu.py
+++ b/addons/website_event_track/models/website_menu.py
@@ -25,6 +25,6 @@ class WebsiteMenu(models.Model):
         # update events
         for event, to_update in event_updates.items():
             if to_update:
-                event.write(dict((fname, False) for fname in to_update))
+                event.write(dict.fromkeys(to_update, False))
 
         return res

--- a/addons/website_event_track/tests/test_event_menus.py
+++ b/addons/website_event_track/tests/test_event_menus.py
@@ -11,7 +11,7 @@ from odoo.tests.common import users
 class TestEventWebsiteTrack(OnlineEventCase):
 
     def _get_menus(self):
-        return super(TestEventWebsiteTrack, self)._get_menus() | set(['Talks', 'Agenda', 'Talk Proposals'])
+        return super(TestEventWebsiteTrack, self)._get_menus() | {'Talks', 'Agenda', 'Talk Proposals'}
 
     @users('user_eventmanager')
     def test_create_menu(self):

--- a/addons/website_forum/controllers/main.py
+++ b/addons/website_forum/controllers/main.py
@@ -29,10 +29,8 @@ class WebsiteForum(WebsiteProfile):
     def _prepare_user_values(self, **kwargs):
         values = super(WebsiteForum, self)._prepare_user_values(**kwargs)
         values['forum_welcome_message'] = request.httprequest.cookies.get('forum_welcome_message', False)
-        values.update({
-            'header': kwargs.get('header', dict()),
-            'searches': kwargs.get('searches', dict()),
-        })
+        values['header'] = kwargs.get('header', {})
+        values['searches'] = kwargs.get('searches', {})
         if kwargs.get('forum'):
             values['forum'] = kwargs.get('forum')
         elif kwargs.get('forum_id'):
@@ -152,25 +150,25 @@ class WebsiteForum(WebsiteProfile):
                                       url_args=url_args)
 
         values = self._prepare_user_values(forum=forum, searches=post, header={'ask_hide': not forum.active})
-        values.update({
-            'main_object': tag or forum,
-            'edit_in_backend': not tag,
-            'question_ids': question_ids,
-            'question_count': question_count,
-            'search_count': question_count,
-            'pager': pager,
-            'tag': tag,
-            'filters': filters,
-            'my': my,
-            'sorting': sorting,
-            'search': fuzzy_search_term or search,
-            'original_search': fuzzy_search_term and search,
-        })
+        values.update(
+            main_object=tag or forum,
+            edit_in_backend=not tag,
+            question_ids=question_ids,
+            question_count=question_count,
+            search_count=question_count,
+            pager=pager,
+            tag=tag,
+            filters=filters,
+            my=my,
+            sorting=sorting,
+            search=fuzzy_search_term or search,
+            original_search=fuzzy_search_term and search
+        )
         return request.render("website_forum.forum_index", values)
 
     @http.route(['''/forum/<model("forum.forum"):forum>/faq'''], type='http', auth="public", website=True, sitemap=True)
     def forum_faq(self, forum, **post):
-        values = self._prepare_user_values(forum=forum, searches=dict(), header={'is_guidelines': True}, **post)
+        values = self._prepare_user_values(forum=forum, searches={}, header={'is_guidelines': True}, **post)
         return request.render("website_forum.faq", values)
 
     @http.route(['/forum/<model("forum.forum"):forum>/faq/karma'], type='http', auth="public", website=True, sitemap=False)
@@ -378,7 +376,7 @@ class WebsiteForum(WebsiteProfile):
             return {'error': 'anonymous_user'}
 
         # set all answers to False, only one can be accepted
-        (post.parent_id.child_ids - post).write(dict(is_correct=False))
+        (post.parent_id.child_ids - post).write({'is_correct': False})
         post.is_correct = not post.is_correct
         return post.is_correct
 
@@ -392,7 +390,7 @@ class WebsiteForum(WebsiteProfile):
 
     @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/edit', type='http', auth="user", website=True)
     def post_edit(self, forum, post, **kwargs):
-        tags = [dict(id=tag.id, name=tag.name) for tag in post.tag_ids]
+        tags = [{'id': tag.id, 'name': tag.name} for tag in post.tag_ids]
         tags = json.dumps(tags)
         values = self._prepare_user_values(forum=forum)
         values.update({

--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -253,7 +253,7 @@ class Forum(models.Model):
     def get_tags_first_char(self):
         """ get set of first letter of forum tags """
         tags = self.env['forum.tag'].search([('forum_id', '=', self.id), ('posts_count', '>', 0)])
-        return sorted(set([tag.name[0].upper() for tag in tags if len(tag.name)]))
+        return sorted({tag.name[0].upper() for tag in tags if len(tag.name)})
 
     def go_to_website(self):
         self.ensure_one()

--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -431,7 +431,7 @@ class Post(models.Model):
 
     def _get_user_vote(self):
         votes = self.env['forum.post.vote'].search_read([('post_id', 'in', self._ids), ('user_id', '=', self._uid)], ['vote', 'post_id'])
-        mapped_vote = dict([(v['post_id'][0], v['vote']) for v in votes])
+        mapped_vote = {v['post_id'][0]: v['vote'] for v in votes}
         for vote in self:
             vote.user_vote = mapped_vote.get(vote.id, 0)
 

--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -40,24 +40,23 @@ class WebsiteHrRecruitment(http.Controller):
             if country_code:
                 countries_ = Country.search([('code', '=', country_code)])
                 country = countries_[0] if countries_ else None
-                if not any(j for j in jobs if j.address_id and j.address_id.country_id == country):
+                if not any(j.address_id.country_id == country for j in jobs):
                     country = False
 
         # Filter job / office for country
         if country and not kwargs.get('all_countries'):
-            jobs = [j for j in jobs if j.address_id is None or j.address_id.country_id and j.address_id.country_id.id == country.id]
-            offices = set(j.address_id for j in jobs if j.address_id is None or j.address_id.country_id and j.address_id.country_id.id == country.id)
-        else:
-            offices = set(j.address_id for j in jobs if j.address_id)
+            jobs = jobs.filtered(lambda j: j.address_id is None or j.address_id.country_id == country)
+        offices = jobs.address_id
 
         # Deduce departments and countries offices of those jobs
-        departments = set(j.department_id for j in jobs if j.department_id)
-        countries = set(o.country_id for o in offices if o.country_id)
+        departments = jobs.department_id
+        countries = offices.country_id
 
         if department:
-            jobs = [j for j in jobs if j.department_id and j.department_id.id == department.id]
-        if office_id and office_id in [x.id for x in offices]:
-            jobs = [j for j in jobs if j.address_id and j.address_id.id == office_id]
+            jobs = jobs.filtered(lambda j: j.department_id == department)
+
+        if office_id and office_id in offices.ids:
+            jobs = jobs.filtered(lambda j: j.address_id.id == office_id)
         else:
             office_id = False
 

--- a/addons/website_jitsi/models/chat_room_mixin.py
+++ b/addons/website_jitsi/models/chat_room_mixin.py
@@ -38,7 +38,7 @@ class ChatRoomMixin(models.AbstractModel):
             if any(values.get(fmatch[0]) for fmatch in self.ROOM_CONFIG_FIELDS) and not values.get('chat_room_id'):
                 if values.get('room_name'):
                     values['room_name'] = self._jitsi_sanitize_name(values['room_name'])
-                room_values = dict((fmatch[1], values[fmatch[0]]) for fmatch in self.ROOM_CONFIG_FIELDS if values.get(fmatch[0]))
+                room_values = {fmatch[1]: values[fmatch[0]] for fmatch in self.ROOM_CONFIG_FIELDS if values.get(fmatch[0])}
                 values['chat_room_id'] = self.env['chat.room'].create(room_values).id
         return super(ChatRoomMixin, self).create(values_list)
 
@@ -47,7 +47,7 @@ class ChatRoomMixin(models.AbstractModel):
             if values.get('room_name'):
                 values['room_name'] = self._jitsi_sanitize_name(values['room_name'])
             for document in self.filtered(lambda doc: not doc.chat_room_id):
-                room_values = dict((fmatch[1], values[fmatch[0]]) for fmatch in self.ROOM_CONFIG_FIELDS if values.get(fmatch[0]))
+                room_values = {fmatch[1]: values[fmatch[0]] for fmatch in self.ROOM_CONFIG_FIELDS if values.get(fmatch[0])}
                 document.chat_room_id = self.env['chat.room'].create(room_values).id
         return super(ChatRoomMixin, self).write(values)
 

--- a/addons/website_livechat/controllers/main.py
+++ b/addons/website_livechat/controllers/main.py
@@ -33,7 +33,7 @@ class WebsiteLivechat(LivechatController):
             percentage[grade] = round(repartition[grade] * 100.0 / sum(repartition.values()), 1) if sum(repartition.values()) else 0
 
         # filter only on the team users that worked on the last 100 ratings and get their detailed stat
-        ratings_per_partner = {partner_id: dict(great=0, okay=0, bad=0)
+        ratings_per_partner = {partner_id: {'great': 0, 'okay': 0, 'bad': 0}
                                for partner_id in ratings.mapped('rated_partner_id.id')}
         total_ratings_per_partner = dict.fromkeys(ratings.mapped('rated_partner_id.id'), 0)
         # keep 10 for backward compatibility

--- a/addons/website_livechat/models/mail_channel.py
+++ b/addons/website_livechat/models/mail_channel.py
@@ -28,7 +28,7 @@ class MailChannel(models.Model):
         at the top of the livechat channel discussion view in discuss module.
         """
         channel_infos = super().channel_info()
-        channel_infos_dict = dict((c['id'], c) for c in channel_infos)
+        channel_infos_dict = {c['id']: c for c in channel_infos}
         for channel in self:
             visitor = channel.livechat_visitor_id
             if visitor:

--- a/addons/website_membership/controllers/main.py
+++ b/addons/website_membership/controllers/main.py
@@ -99,7 +99,7 @@ class WebsiteMembership(http.Controller):
             count_members = MembershipLine.sudo().search_count(line_domain)
             if offset <= count_members:
                 membership_lines = MembershipLine.sudo().search(line_domain, offset, limit)
-        page_partner_ids = set(m.partner.id for m in membership_lines)
+        page_partner_ids = {m.partner.id for m in membership_lines}
 
         # get google maps localization of partners
         google_map_partner_ids = []

--- a/addons/website_payment/controllers/portal.py
+++ b/addons/website_payment/controllers/portal.py
@@ -25,7 +25,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
         kwargs['is_donation'] = True
         kwargs['currency_id'] = int(kwargs.get('currency_id', request.env.company.currency_id.id))
         kwargs['amount'] = float(kwargs.get('amount', 25))
-        kwargs['donation_options'] = kwargs.get('donation_options', json_safe.dumps(dict(customAmount="freeAmount")))
+        kwargs['donation_options'] = kwargs.get('donation_options', json_safe.dumps({'customAmount': "freeAmount"}))
 
         if request.env.user._is_public():
             kwargs['partner_id'] = request.env.user.partner_id.id

--- a/addons/website_profile/controllers/main.py
+++ b/addons/website_profile/controllers/main.py
@@ -253,7 +253,7 @@ class WebsiteProfile(http.Controller):
 
             max_position = max([user_data['karma_position'] for user_data in position_map.values()], default=1)
             for user in user_values:
-                user_data = position_map.get(user['id'], dict())
+                user_data = position_map.get(user['id'], {})
                 user['position'] = user_data.get('karma_position', max_position + 1)
                 user['karma_gain'] = user_data.get('karma_gain_total', 0)
             user_values.sort(key=itemgetter('position'))
@@ -284,7 +284,7 @@ class WebsiteProfile(http.Controller):
             position_map = self._get_user_tracking_karma_gain_position(position_domain, users.ids, group_by)
         else:
             position_results = users._get_karma_position(position_domain)
-            position_map = dict((user_data['user_id'], dict(user_data)) for user_data in position_results)
+            position_map = {user_data['user_id']: user_data for user_data in position_results}
         return position_map
 
     def _get_user_tracking_karma_gain_position(self, domain, user_ids, group_by):
@@ -298,7 +298,7 @@ class WebsiteProfile(http.Controller):
         else:
             from_date = None
         results = request.env['res.users'].browse(user_ids)._get_tracking_karma_gain_position(domain, from_date=from_date, to_date=to_date)
-        return dict((item['user_id'], dict(item)) for item in results)
+        return {item['user_id']: item for item in results}
 
     # User and validation
     # --------------------------------------------------

--- a/addons/website_sale/controllers/backend.py
+++ b/addons/website_sale/controllers/backend.py
@@ -25,16 +25,17 @@ class WebsiteSaleBackend(WebsiteBackend):
         datetime_from = datetime.combine(date_date_from, time.min)
         datetime_to = datetime.combine(date_date_to, time.max)
 
-        sales_values = dict(
-            graph=[],
-            best_sellers=[],
-            summary=dict(
-                order_count=0, order_carts_count=0, order_unpaid_count=0,
-                order_to_invoice_count=0, order_carts_abandoned_count=0,
-                payment_to_capture_count=0, total_sold=0,
-                order_per_day_ratio=0, order_sold_ratio=0, order_convertion_pctg=0,
-            )
-        )
+        sales_values = {
+            'graph': [],
+            'best_sellers': [],
+            'summary': {
+                'order_count': 0, 'order_carts_count': 0,
+                'order_unpaid_count': 0, 'order_to_invoice_count': 0,
+                'order_carts_abandoned_count': 0, 'payment_to_capture_count': 0,
+                'total_sold': 0, 'order_per_day_ratio': 0,
+                'order_sold_ratio': 0, 'order_convertion_pctg': 0
+            }
+        }
 
         results['dashboards']['sales'] = sales_values
 

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -685,7 +685,7 @@ class WebsiteSale(http.Controller):
         # mode: tuple ('new|edit', 'billing|shipping')
         # all_form_values: all values before preprocess
         # data: values after preprocess
-        error = dict()
+        error = {}
         error_message = []
 
         # Required fields from form
@@ -1181,13 +1181,13 @@ class WebsiteSale(http.Controller):
 
     @http.route(['/shop/country_infos/<model("res.country"):country>'], type='json', auth="public", methods=['POST'], website=True)
     def country_infos(self, country, mode, **kw):
-        return dict(
-            fields=country.get_address_fields(),
-            states=[(st.id, st.name, st.code) for st in country.get_website_sale_states(mode=mode)],
-            phone_code=country.phone_code,
-            zip_required=country.zip_required,
-            state_required=country.state_required,
-        )
+        return {
+            'fields': country.get_address_fields(),
+            'states': [(st.id, st.name, st.code) for st in country.get_website_sale_states(mode=mode)],
+            'phone_code': country.phone_code,
+            'zip_required': country.zip_required,
+            'state_required': country.state_required
+        }
 
     # --------------------------------------------------------------------------
     # Products Recently Viewed

--- a/addons/website_sale_comparison/controllers/main.py
+++ b/addons/website_sale_comparison/controllers/main.py
@@ -34,6 +34,6 @@ class WebsiteSaleProductComparison(WebsiteSale):
                     "website_sale_comparison.product_product",
                     {'product': prod, 'website': request.website}
                 ),
-                'product': dict(id=prod.id, name=prod.name, display_name=prod.display_name),
+                'product': {'id': prod.id, 'name': prod.name, 'display_name': prod.display_name},
             }
         return ret

--- a/addons/website_sale_digital/models/product.py
+++ b/addons/website_sale_digital/models/product.py
@@ -11,7 +11,7 @@ class ProductTemplate(models.Model):
 
     def _compute_attachment_count(self):
         attachment_data = self.env['ir.attachment'].read_group([('res_model', '=', self._name), ('res_id', 'in', self.ids), ('product_downloadable', '=', True)], ['res_id'], ['res_id'])
-        mapped_data = dict([(data['res_id'], data['res_id_count']) for data in attachment_data])
+        mapped_data = {data['res_id']: data['res_id_count'] for data in attachment_data}
         for product_template in self:
             product_template.attachment_count = mapped_data.get(product_template.id, 0)
 

--- a/addons/website_sale_slides/models/slide_channel.py
+++ b/addons/website_sale_slides/models/slide_channel.py
@@ -32,10 +32,10 @@ class Channel(models.Model):
             ('state', 'in', self.env['sale.report']._get_done_states()),
             ('product_id', 'in', self.product_id.ids),
         ]
-        rg_data = dict(
-            (item['product_id'][0], item['price_total'])
+        rg_data = {
+            item['product_id'][0]: item['price_total']
             for item in self.env['sale.report'].read_group(domain, ['product_id', 'price_total'], ['product_id'])
-        )
+        }
         for channel in self:
             channel.product_sale_revenues = rg_data.get(channel.product_id.id, 0)
 

--- a/addons/website_sale_stock_wishlist/models/product_wishlist.py
+++ b/addons/website_sale_stock_wishlist/models/product_wishlist.py
@@ -35,11 +35,11 @@ class ProductWishlist(models.Model):
             product = wishlist.with_context(website_id=wishlist.website_id.id).product_id
             if not product._is_sold_out():
                 body_html = tmpl._render({"wishlist": wishlist})
-                msg = self.env["mail.message"].sudo().new(dict(body=body_html, record_name=product.name))
+                msg = self.env["mail.message"].sudo().new({'body': body_html, 'record_name': product.name})
                 full_mail = self.env["mail.render.mixin"]._render_encapsulate(
                     "mail.mail_notification_light",
                     body_html,
-                    add_context=dict(message=msg, model_description=_("Wishlist")),
+                    add_context={'message': msg, 'model_description': _("Wishlist")},
                 )
                 mail_values = {
                     "subject": _("The product '%(product_name)s' is now available") % {'product_name': product.name},

--- a/addons/website_sale_wishlist/controllers/main.py
+++ b/addons/website_sale_wishlist/controllers/main.py
@@ -44,7 +44,7 @@ class WebsiteSaleWishlist(WebsiteSale):
         if not len(values):
             return request.redirect("/shop")
 
-        return request.render("website_sale_wishlist.product_wishlist", dict(wishes=values))
+        return request.render("website_sale_wishlist.product_wishlist", {'wishes': values})
 
     @http.route(['/shop/wishlist/remove/<model("product.wishlist"):wish>'], type='json', auth="public", website=True)
     def rm_from_wishlist(self, wish, **kw):

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -174,7 +174,7 @@ class WebsiteSlides(WebsiteProfile):
     def _get_channel_progress(self, channel, include_quiz=False):
         """ Replacement to user_progress. Both may exist in some transient state. """
         slides = request.env['slide.slide'].sudo().search([('channel_id', '=', channel.id)])
-        channel_progress = dict((sid, dict()) for sid in slides.ids)
+        channel_progress = {sid: {} for sid in slides.ids}
         if not request.env.user._is_public() and channel.is_member:
             slide_partners = request.env['slide.slide.partner'].sudo().search([
                 ('channel_id', '=', channel.id),
@@ -1127,7 +1127,7 @@ class WebsiteSlides(WebsiteProfile):
             if (file_size / 1024.0 / 1024.0) > 25:
                 return {'error': _('File is too big. File size cannot exceed 25MB')}
 
-        values = dict((fname, post[fname]) for fname in self._get_valid_slide_post_values() if post.get(fname))
+        values = {fname: post[fname] for fname in self._get_valid_slide_post_values() if post.get(fname)}
 
         # handle exception during creation of slide and sent error notification to the client
         # otherwise client slide create dialog box continue processing even server fail to create a slide

--- a/addons/website_slides/models/res_partner.py
+++ b/addons/website_slides/models/res_partner.py
@@ -42,7 +42,7 @@ class ResPartner(models.Model):
             [('partner_id', 'in', self.ids)],
             ['partner_id'], 'partner_id'
         )
-        data = dict((res['partner_id'][0], res['partner_id_count']) for res in read_group_res)
+        data = {res['partner_id'][0]: res['partner_id_count'] for res in read_group_res}
         for partner in self:
             partner.slide_channel_count = data.get(partner.id, 0)
 

--- a/addons/website_slides/models/slide_question.py
+++ b/addons/website_slides/models/slide_question.py
@@ -31,7 +31,7 @@ class SlideQuestion(models.Model):
     @api.depends('slide_id')
     def _compute_statistics(self):
         slide_partners = self.env['slide.slide.partner'].sudo().search([('slide_id', 'in', self.slide_id.ids)])
-        slide_stats = dict((s.slide_id.id, dict({'attempts_count': 0, 'attempts_unique': 0, 'done_count': 0})) for s in slide_partners)
+        slide_stats = {s.slide_id.id: {'attempts_count': 0, 'attempts_unique': 0, 'done_count': 0} for s in slide_partners}
 
         for slide_partner in slide_partners:
             slide_stats[slide_partner.slide_id.id]['attempts_count'] += slide_partner.quiz_attempts_count

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -297,7 +297,7 @@ class Slide(models.Model):
             ['slide_id'],
             groupby=['slide_id']
         )
-        mapped_data = dict((res['slide_id'][0], res['slide_id_count']) for res in read_group_res)
+        mapped_data = {res['slide_id'][0]: res['slide_id_count'] for res in read_group_res}
         for slide in self:
             slide.slide_views = mapped_data.get(slide.id, 0)
 
@@ -324,7 +324,7 @@ class Slide(models.Model):
         # Do not use dict.fromkeys(self.ids, dict()) otherwise it will use the same dictionnary for all keys.
         # Therefore, when updating the dict of one key, it updates the dict of all keys.
         keys = ['nbr_%s' % slide_category for slide_category in self.env['slide.slide']._fields['slide_category'].get_values(self.env)]
-        default_vals = dict((key, 0) for key in keys + ['total_slides'])
+        default_vals = dict.fromkeys(keys + ['total_slides'], 0)
 
         res = self.env['slide.slide'].read_group(
             [('is_published', '=', True), ('category_id', 'in', self.ids), ('is_category', '=', False)],
@@ -340,7 +340,7 @@ class Slide(models.Model):
         """ Compute statistics based on all existing slide categories """
         slide_categories = self.env['slide.slide']._fields['slide_category'].get_values(self.env)
         keys = ['nbr_%s' % slide_category for slide_category in slide_categories]
-        result = dict((cid, dict((key, 0) for key in keys + ['total_slides'])) for cid in self.ids)
+        result = {cid: dict.fromkeys(keys + ['total_slides'], 0) for cid in self.ids}
         for res_group in read_group_res:
             cid = res_group['category_id'][0]
             slide_category = res_group.get('slide_category')
@@ -879,7 +879,7 @@ class Slide(models.Model):
             ('slide_id', 'in', self.ids),
             ('partner_id', '=', target_partner.id)
         ])
-        slide_partners_map = dict((sp.slide_id.id, sp) for sp in slide_partners)
+        slide_partners_map = {sp.slide_id.id: sp for sp in slide_partners}
         for slide in self:
             if not slide.question_ids:
                 gains = [0]

--- a/addons/website_slides/wizard/slide_channel_invite.py
+++ b/addons/website_slides/wizard/slide_channel_invite.py
@@ -91,7 +91,7 @@ class SlideChannelInvite(models.TransientModel):
             else:
                 # could be great to use _notify_prepare_template_context someday
                 template_ctx = {
-                    'message': self.env['mail.message'].sudo().new(dict(body=mail_values['body_html'], record_name=self.channel_id.name)),
+                    'message': self.env['mail.message'].sudo().new({'body': mail_values['body_html'], 'record_name': self.channel_id.name}),
                     'model_description': self.env['ir.model']._get('slide.channel').display_name,
                     'record': slide_channel_partner,
                     'company': self.env.company,

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -153,13 +153,13 @@ class AssetsBundle(object):
                                                     extension='')
                 else:
                     href = attachment.url
-                attr = dict([
-                    ["type", "text/css"],
-                    ["rel", "stylesheet"],
-                    ["href", href],
-                    ['data-asset-bundle', self.name],
-                    ['data-asset-version', self.version],
-                ])
+                attr = {
+                    "type": "text/css",
+                    "rel": "stylesheet",
+                    "href": href,
+                    'data-asset-bundle': self.name,
+                    'data-asset-version': self.version,
+                }
                 response.append(("link", attr, None))
             if self.css_errors:
                 msg = '\n'.join(self.css_errors)
@@ -169,14 +169,14 @@ class AssetsBundle(object):
         if js and self.javascripts:
             js_attachment = self.js(is_minified=not is_debug_assets)
             src = self.get_debug_asset_url(name=js_attachment.name, extension='') if is_debug_assets else js_attachment[0].url
-            attr = dict([
-                ["async", "async" if async_load else None],
-                ["defer", "defer" if defer_load or lazy_load else None],
-                ["type", "text/javascript"],
-                ["data-src" if lazy_load else "src", src],
-                ['data-asset-bundle', self.name],
-                ['data-asset-version', self.version],
-            ])
+            attr = {
+                "async": "async" if async_load else None,
+                "defer": "defer" if defer_load or lazy_load else None,
+                "type": "text/javascript",
+                "data-src" if lazy_load else "src": src,
+                'data-asset-bundle': self.name,
+                'data-asset-version': self.version,
+            }
             response.append(("script", attr, None))
 
         return response
@@ -547,7 +547,7 @@ class AssetsBundle(object):
 
         for atype in asset_types:
             outdated = False
-            assets = dict((asset.html_url, asset) for asset in self.stylesheets if isinstance(asset, atype))
+            assets = {asset.html_url: asset for asset in self.stylesheets if isinstance(asset, atype)}
             if assets:
                 assets_domain = self._get_assets_domain_for_already_processed_css(assets)
                 attachments = self.env['ir.attachment'].sudo().search(assets_domain)
@@ -822,19 +822,19 @@ class JavascriptAsset(WebAsset):
 
     def to_node(self):
         if self.url:
-            return ("script", dict([
-                ["type", "text/javascript"],
-                ["src", self.html_url],
-                ['data-asset-bundle', self.bundle.name],
-                ['data-asset-version', self.bundle.version],
-            ]), None)
+            return ("script", {
+                "type": "text/javascript",
+                "src": self.html_url,
+                'data-asset-bundle': self.bundle.name,
+                'data-asset-version': self.bundle.version,
+            }, None)
         else:
-            return ("script", dict([
-                ["type", "text/javascript"],
-                ["charset", "utf-8"],
-                ['data-asset-bundle', self.bundle.name],
-                ['data-asset-version', self.bundle.version],
-            ]), self.with_header())
+            return ("script", {
+                "type": "text/javascript",
+                "charset": "utf-8",
+                'data-asset-bundle': self.bundle.name,
+                'data-asset-version': self.bundle.version,
+            }, self.with_header())
 
     def with_header(self, content=None, minimal=True):
         if minimal:
@@ -925,22 +925,22 @@ class StylesheetAsset(WebAsset):
 
     def to_node(self):
         if self.url:
-            attr = dict([
-                ["type", "text/css"],
-                ["rel", "stylesheet"],
-                ["href", self.html_url],
-                ["media", escape(to_text(self.media)) if self.media else None],
-                ['data-asset-bundle', self.bundle.name],
-                ['data-asset-version', self.bundle.version],
-            ])
+            attr = {
+                "type": "text/css",
+                "rel": "stylesheet",
+                "href": self.html_url,
+                "media": escape(to_text(self.media)) if self.media else None,
+                'data-asset-bundle': self.bundle.name,
+                'data-asset-version': self.bundle.version,
+            }
             return ("link", attr, None)
         else:
-            attr = dict([
-                ["type", "text/css"],
-                ["media", escape(to_text(self.media)) if self.media else None],
-                ['data-asset-bundle', self.bundle.name],
-                ['data-asset-version', self.bundle.version],
-            ])
+            attr = {
+                "type": "text/css",
+                "media": escape(to_text(self.media)) if self.media else None,
+                'data-asset-bundle': self.bundle.name,
+                'data-asset-version': self.bundle.version,
+            }
             return ("style", attr, self.with_header())
 
 

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -282,7 +282,7 @@ class IrActionsActWindow(models.Model):
     @tools.ormcache()
     def _existing(self):
         self._cr.execute("SELECT id FROM %s" % self._table)
-        return set(row[0] for row in self._cr.fetchall())
+        return {row[0] for row in self._cr.fetchall()}
 
 
     def _get_readable_fields(self):

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -781,7 +781,7 @@ class IrActionsReport(models.Model):
 
         save_in_attachment = OrderedDict()
         # Maps the streams in `save_in_attachment` back to the records they came from
-        stream_record = dict()
+        stream_record = {}
         if res_ids:
             # Dispatch the records by ones having an attachment and ones requesting a call to
             # wkhtmltopdf.

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -187,7 +187,7 @@ class IrAttachment(models.Model):
         for names in cr.split_for_in_conditions(checklist):
             # determine which files to keep among the checklist
             cr.execute("SELECT store_fname FROM ir_attachment WHERE store_fname IN %s", [names])
-            whitelist = set(row[0] for row in cr.fetchall())
+            whitelist = {row[0] for row in cr.fetchall()}
 
             # remove garbage files, and clean up checklist
             for fname in names:
@@ -481,7 +481,7 @@ class IrAttachment(models.Model):
         if not any(item[0] in ('id', 'res_field') for item in domain):
             domain.insert(0, ('res_field', '=', False))
         allowed_fields = self._read_group_allowed_fields()
-        fields_set = set(field.split(':')[0] for field in fields + groupby)
+        fields_set = {field.split(':')[0] for field in fields + groupby}
         if not self.env.is_system() and (not fields or fields_set.difference(allowed_fields)):
             raise AccessError(_("Sorry, you are not allowed to access these fields on attachments."))
         return super().read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)
@@ -588,7 +588,7 @@ class IrAttachment(models.Model):
         # database allowed it. Helps avoid errors when concurrent transactions
         # are deleting the same file, and some of the transactions are
         # rolled back by PostgreSQL (due to concurrent updates detection).
-        to_delete = set(attach.store_fname for attach in self if attach.store_fname)
+        to_delete = {attach.store_fname for attach in self if attach.store_fname}
         res = super(IrAttachment, self).unlink()
         for file_path in to_delete:
             self._file_delete(file_path)

--- a/odoo/addons/base/models/ir_fields.py
+++ b/odoo/addons/base/models/ir_fields.py
@@ -188,20 +188,20 @@ class IrFieldsConverter(models.AbstractModel):
     def _str_to_boolean(self, model, field, value):
         # all translatables used for booleans
         # potentially broken casefolding? What about locales?
-        trues = set(word.lower() for word in itertools.chain(
+        trues = {word.lower() for word in itertools.chain(
             [u'1', u"true", u"yes"], # don't use potentially translated values
             self._get_translations(['code'], u"true"),
             self._get_translations(['code'], u"yes"),
-        ))
+        )}
         if value.lower() in trues:
             return True, []
 
         # potentially broken casefolding? What about locales?
-        falses = set(word.lower() for word in itertools.chain(
+        falses = {word.lower() for word in itertools.chain(
             [u'', u"0", u"false", u"no"],
             self._get_translations(['code'], u"false"),
             self._get_translations(['code'], u"no"),
-        ))
+        )}
         if value.lower() in falses:
             return False, []
 

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -770,7 +770,7 @@ class Module(models.Model):
                 if not mod_path or not terp:
                     continue
                 state = "uninstalled" if terp.get('installable', True) else "uninstallable"
-                mod = self.create(dict(name=mod_name, state=state, **values))
+                mod = self.create({'name': mod_name, 'state': state, **values})
                 res[1] += 1
 
             mod._update_dependencies(terp.get('depends', []), terp.get('auto_install'))
@@ -884,7 +884,7 @@ class Module(models.Model):
         return tools.config.get('apps_server', 'https://apps.odoo.com/apps')
 
     def _update_dependencies(self, depends=None, auto_install_requirements=()):
-        existing = set(dep.name for dep in self.dependencies_id)
+        existing = {dep.name for dep in self.dependencies_id}
         needed = set(depends or [])
         for dep in (needed - existing):
             self._cr.execute('INSERT INTO ir_module_module_dependency (module_id, name) values (%s, %s)', (self.id, dep))
@@ -895,7 +895,7 @@ class Module(models.Model):
         self.invalidate_cache(['dependencies_id'], self.ids)
 
     def _update_exclusions(self, excludes=None):
-        existing = set(excl.name for excl in self.exclusion_ids)
+        existing = {excl.name for excl in self.exclusion_ids}
         needed = set(excludes or [])
         for name in (needed - existing):
             self._cr.execute('INSERT INTO ir_module_module_exclusion (module_id, name) VALUES (%s, %s)', (self.id, name))
@@ -1030,11 +1030,11 @@ class ModuleDependency(models.Model):
     @api.depends('name')
     def _compute_depend(self):
         # retrieve all modules corresponding to the dependency names
-        names = list(set(dep.name for dep in self))
+        names = list({dep.name for dep in self})
         mods = self.env['ir.module.module'].search([('name', 'in', names)])
 
         # index modules by name, and assign dependencies
-        name_mod = dict((mod.name, mod) for mod in mods)
+        name_mod = {mod.name: mod for mod in mods}
         for dep in self:
             dep.depend_id = name_mod.get(dep.name)
 
@@ -1067,7 +1067,7 @@ class ModuleExclusion(models.Model):
     @api.depends('name')
     def _compute_exclusion(self):
         # retrieve all modules corresponding to the exclusion names
-        names = list(set(excl.name for excl in self))
+        names = list({excl.name for excl in self})
         mods = self.env['ir.module.module'].search([('name', 'in', names)])
 
         # index modules by name, and assign dependencies

--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -149,9 +149,7 @@ class FloatConverter(models.AbstractModel):
     @api.model
     def get_available_options(self):
         options = super(FloatConverter, self).get_available_options()
-        options.update(
-            precision=dict(type='integer', string=_('Rounding precision')),
-        )
+        options['precision'] = {'type': 'integer', 'string': _('Rounding precision')}
         return options
 
     @api.model
@@ -194,9 +192,7 @@ class DateConverter(models.AbstractModel):
     @api.model
     def get_available_options(self):
         options = super(DateConverter, self).get_available_options()
-        options.update(
-            format=dict(type='string', string=_('Date format'))
-        )
+        options['format'] = {'type': 'string', 'string': _('Date format')}
         return options
 
     @api.model
@@ -213,11 +209,11 @@ class DateTimeConverter(models.AbstractModel):
     def get_available_options(self):
         options = super(DateTimeConverter, self).get_available_options()
         options.update(
-            format=dict(type='string', string=_('Pattern to format')),
-            tz_name=dict(type='char', string=_('Optional timezone name')),
-            time_only=dict(type='boolean', string=_('Display only the time')),
-            hide_seconds=dict(type='boolean', string=_('Hide seconds')),
-            date_only=dict(type='boolean', string=_('Display only the date')),
+            format={'type': 'string', 'string': _('Pattern to format')},
+            tz_name={'type': 'char', 'string': _('Optional timezone name')},
+            time_only={'type': 'boolean', 'string': _('Display only the time')},
+            hide_seconds={'type': 'boolean', 'string': _('Hide seconds')},
+            date_only={'type': 'boolean', 'string': _('Display only the date')},
         )
         return options
 
@@ -286,9 +282,7 @@ class SelectionConverter(models.AbstractModel):
     @api.model
     def get_available_options(self):
         options = super(SelectionConverter, self).get_available_options()
-        options.update(
-            selection=dict(type='selection', string=_('Selection'), description=_('By default the widget uses the field information'), required=True)
-        )
+        options['selection'] = {'type': 'selection', 'string': _('Selection'), 'description': _('By default the widget uses the field information'), 'required': True}
         return options
 
     @api.model
@@ -411,10 +405,10 @@ class MonetaryConverter(models.AbstractModel):
     def get_available_options(self):
         options = super(MonetaryConverter, self).get_available_options()
         options.update(
-            from_currency=dict(type='model', params='res.currency', string=_('Original currency')),
-            display_currency=dict(type='model', params='res.currency', string=_('Display currency'), required="value_to_html"),
-            date=dict(type='date', string=_('Date'), description=_('Date used for the original currency (only used for t-esc). by default use the current date.')),
-            company_id=dict(type='model', params='res.company', string=_('Company'), description=_('Company used for the original currency (only used for t-esc). By default use the user company')),
+            from_currency={'type': 'model', 'params': 'res.currency', 'string': _('Original currency')},
+            display_currency={'type': 'model', 'params': 'res.currency', 'string': _('Display currency'), 'required': "value_to_html"},
+            date={'type': 'date', 'string': _('Date'), 'description': _('Date used for the original currency (only used for t-esc). by default use the current date.')},
+            company_id={'type': 'model', 'params': 'res.company', 'string': _('Company'), 'description': _('Company used for the original currency (only used for t-esc). By default use the user company')},
         )
         return options
 
@@ -532,24 +526,24 @@ class DurationConverter(models.AbstractModel):
         options = super(DurationConverter, self).get_available_options()
         unit = [(value, str(label)) for value, label, ratio in TIMEDELTA_UNITS]
         options.update(
-            digital=dict(type="boolean", string=_('Digital formatting')),
-            unit=dict(type="selection", params=unit, string=_('Date unit'), description=_('Date unit used for comparison and formatting'), default_value='second', required=True),
-            round=dict(type="selection", params=unit, string=_('Rounding unit'), description=_("Date unit used for the rounding. The value must be smaller than 'hour' if you use the digital formatting."), default_value='second'),
-            format=dict(
-                type="selection",
-                params=[
+            digital={'type': "boolean", 'string': _('Digital formatting')},
+            unit={'type': "selection", 'params': unit, 'string': _('Date unit'), 'description': _('Date unit used for comparison and formatting'), 'default_value': 'second', 'required': True},
+            round={'type': "selection", 'params': unit, 'string': _('Rounding unit'), 'description': _("Date unit used for the rounding. The value must be smaller than 'hour' if you use the digital formatting."), 'default_value': 'second'},
+            format={
+                'type': "selection",
+                'params': [
                     ('long', _('Long')),
                     ('short', _('Short')),
                     ('narrow', _('Narrow'))],
-                string=_('Format'),
-                description=_("Formatting: long, short, narrow (not used for digital)"),
-                default_value='long'
-            ),
-            add_direction=dict(
-                type="boolean",
-                string=_("Add direction"),
-                description=_("Add directional information (not used for digital)")
-            ),
+                'string': _('Format'),
+                'description': _("Formatting: long, short, narrow (not used for digital)"),
+                'default_value': 'long'
+            },
+            add_direction={
+                'type': "boolean",
+                'string': _("Add direction"),
+                'description': _("Add directional information (not used for digital)")
+            },
         )
         return options
 
@@ -608,9 +602,7 @@ class RelativeDatetimeConverter(models.AbstractModel):
     @api.model
     def get_available_options(self):
         options = super(RelativeDatetimeConverter, self).get_available_options()
-        options.update(
-            now=dict(type='datetime', string=_('Reference date'), description=_('Date to compare with the field value, by default use the current date.'))
-        )
+        options['now'] = {'type': 'datetime', 'string': _('Reference date'), 'description': _('Date to compare with the field value, by default use the current date.')}
         return options
 
     @api.model
@@ -645,12 +637,12 @@ class BarcodeConverter(models.AbstractModel):
     def get_available_options(self):
         options = super(BarcodeConverter, self).get_available_options()
         options.update(
-            symbology=dict(type='string', string=_('Barcode symbology'), description=_('Barcode type, eg: UPCA, EAN13, Code128'), default_value='Code128'),
-            width=dict(type='integer', string=_('Width'), default_value=600),
-            height=dict(type='integer', string=_('Height'), default_value=100),
-            humanreadable=dict(type='integer', string=_('Human Readable'), default_value=0),
-            quiet=dict(type='integer', string='Quiet', default_value=1),
-            mask=dict(type='string', string='Mask', default_value='')
+            symbology={'type': 'string', 'string': _('Barcode symbology'), 'description': _('Barcode type, eg: UPCA, EAN13, Code128'), 'default_value': 'Code128'},
+            width={'type': 'integer', 'string': _('Width'), 'default_value': 600},
+            height={'type': 'integer', 'string': _('Height'), 'default_value': 100},
+            humanreadable={'type': 'integer', 'string': _('Human Readable'), 'default_value': 0},
+            quiet={'type': 'integer', 'string': 'Quiet', 'default_value': 1},
+            mask={'type': 'string', 'string': 'Mask', 'default_value': ''}
         )
         return options
 
@@ -690,18 +682,18 @@ class Contact(models.AbstractModel):
             {'field_name': 'email', 'label': _('Email'), 'default': True},
             {'field_name': 'vat', 'label': _('VAT')},
         ]
-        separator_params = dict(
-            type='selection',
-            selection=[[" ", _("Space")], [",", _("Comma")], ["-", _("Dash")], ["|", _("Vertical bar")], ["/", _("Slash")]],
-            placeholder=_('Linebreak'),
-        )
+        separator_params = {
+            'type': 'selection',
+            'selection': [[" ", _("Space")], [",", _("Comma")], ["-", _("Dash")], ["|", _("Vertical bar")], ["/", _("Slash")]],
+            'placeholder': _('Linebreak')
+        }
         options.update(
-            fields=dict(type='array', params=dict(type='selection', params=contact_fields), string=_('Displayed fields'), description=_('List of contact fields to display in the widget'), default_value=[param.get('field_name') for param in contact_fields if param.get('default')]),
-            separator=dict(type='selection', params=separator_params, string=_('Address separator'), description=_('Separator use to split the address from the display_name.'), default_value=False),
-            no_marker=dict(type='boolean', string=_('Hide badges'), description=_("Don't display the font awesome marker")),
-            no_tag_br=dict(type='boolean', string=_('Use comma'), description=_("Use comma instead of the <br> tag to display the address")),
-            phone_icons=dict(type='boolean', string=_('Display phone icons'), description=_("Display the phone icons even if no_marker is True")),
-            country_image=dict(type='boolean', string=_('Display country image'), description=_("Display the country image if the field is present on the record")),
+            fields={'type': 'array', 'params': {'type': 'selection', 'params': contact_fields}, 'string': _('Displayed fields'), 'description': _('List of contact fields to display in the widget'), 'default_value': [param.get('field_name') for param in contact_fields if param.get('default')]},
+            separator={'type': 'selection', 'params': separator_params, 'string': _('Address separator'), 'description': _('Separator use to split the address from the display_name.'), 'default_value': False},
+            no_marker={'type': 'boolean', 'string': _('Hide badges'), 'description': _("Don't display the font awesome marker")},
+            no_tag_br={'type': 'boolean', 'string': _('Use comma'), 'description': _("Use comma instead of the <br> tag to display the address")},
+            phone_icons={'type': 'boolean', 'string': _('Display phone icons'), 'description': _("Display the phone icons even if no_marker is True")},
+            country_image={'type': 'boolean', 'string': _('Display country image'), 'description': _("Display the country image if the field is present on the record")},
         )
         return options
 

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -320,7 +320,7 @@ actual arch.
 
     def _inverse_arch(self):
         for view in self:
-            data = dict(arch_db=view.arch)
+            data = {'arch_db': view.arch}
             if 'install_filename' in self._context:
                 # we store the relative path to the resource instead of the absolute path, if found
                 # (it will be missing e.g. when importing data-only modules using base_import_module)
@@ -1879,10 +1879,10 @@ actual arch.
             or any(self.is_node_branded(child) for child in node.iterdescendants())
 
     def _pop_view_branding(self, element):
-        distributed_branding = dict(
-            (attribute, element.attrib.pop(attribute))
+        distributed_branding = {
+            attribute: element.attrib.pop(attribute)
             for attribute in MOVABLE_BRANDING
-            if element.get(attribute))
+            if element.get(attribute)}
         return distributed_branding
 
     def distribute_branding(self, e, branding=None, parent_xpath='',
@@ -1971,7 +1971,7 @@ actual arch.
     def _render(self, values=None, engine='ir.qweb', minimal_qcontext=False, options=None):
         assert isinstance(self.id, int)
 
-        qcontext = dict() if minimal_qcontext else self._prepare_qcontext()
+        qcontext = {} if minimal_qcontext else self._prepare_qcontext()
         qcontext.update(values or {})
 
         return self.env[engine]._render(self.id, qcontext, **(options or {}))
@@ -1981,27 +1981,26 @@ actual arch.
         """ Returns the qcontext : rendering context with website specific value (required
             to render website layout template)
         """
-        qcontext = dict(
-            env=self.env,
-            user_id=self.env["res.users"].browse(self.env.user.id),
-            res_company=self.env.company.sudo(),
-            keep_query=keep_query,
-            request=request,  # might be unbound if we're not in an httprequest context
-            debug=request.session.debug if request else '',
-            test_mode_enabled=bool(config['test_enable'] or config['test_file']),
-            json=json_scriptsafe,
-            quote_plus=werkzeug.urls.url_quote_plus,
-            time=safe_eval.time,
-            datetime=safe_eval.datetime,
-            relativedelta=relativedelta,
-            xmlid=self.sudo().key,
-            viewid=self.id,
-            to_text=pycompat.to_text,
-            image_data_uri=image_data_uri,
-            # specific 'math' functions to ease rounding in templates and lessen controller marshmalling
-            floor=math.floor,
-            ceil=math.ceil,
-        )
+        qcontext = {
+            'env': self.env,
+            'user_id': self.env["res.users"].browse(self.env.user.id),
+            'res_company': self.env.company.sudo(),
+            'keep_query': keep_query,
+            'request': request,
+            'debug': request.session.debug if request else '',
+            'test_mode_enabled': bool(config['test_enable'] or config['test_file']),
+            'json': json_scriptsafe,
+            'quote_plus': werkzeug.urls.url_quote_plus,
+            'time': safe_eval.time,
+            'datetime': safe_eval.datetime,
+            'relativedelta': relativedelta,
+            'xmlid': self.sudo().key,
+            'viewid': self.id,
+            'to_text': pycompat.to_text,
+            'image_data_uri': image_data_uri,
+            'floor': math.floor,
+            'ceil': math.ceil
+        }
         return qcontext
 
     #------------------------------------------------------
@@ -2198,9 +2197,9 @@ class NameManager:
         self.available_fields = collections.defaultdict(dict)   # {field_name: field_info}
         self.available_actions = set()
         self.available_names = set()
-        self.mandatory_fields = dict()          # {field_name: use}
-        self.mandatory_parent_fields = dict()   # {field_name: use}
-        self.mandatory_names = dict()           # {name: use}
+        self.mandatory_fields = {}  # {field_name: use}
+        self.mandatory_parent_fields = {}  # {field_name: use}
+        self.mandatory_names = {}  # {name: use}
 
     @lazy_property
     def field_info(self):

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -115,8 +115,8 @@ class Company(models.Model):
         return ['street', 'street2', 'city', 'zip', 'state_id', 'country_id']
 
     def _get_company_address_update(self, partner):
-        return dict((fname, partner[fname])
-                    for fname in self._get_company_address_field_names())
+        return {fname: partner[fname]
+                    for fname in self._get_company_address_field_names()}
 
     def _compute_company_registry(self):
         # exists to allow overrides

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -874,7 +874,7 @@ class Partner(models.Model):
                                vat=unaccent('res_partner.vat'),)
 
             where_clause_params += [search_name]*3  # for email / display_name, reference
-            where_clause_params += [re.sub(r'[^a-zA-Z0-9\-\.]+', '', search_name) or None]  # for vat
+            where_clause_params += [re.sub(r'[^a-zA-Z0-9\-.]+', '', search_name) or None]  # for vat
             where_clause_params += [search_name]  # for order by
             if limit:
                 query += ' limit %s'

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -591,7 +591,7 @@ class Partner(models.Model):
             for partner in self:
                 if company_id and partner.user_ids:
                     company = self.env['res.company'].browse(company_id)
-                    companies = set(user.company_id for user in partner.user_ids)
+                    companies = partner.mapped('user_ids.company_id')
                     if len(companies) > 1 or company not in companies:
                         raise UserError(
                             ("The selected company is not compatible with the companies of the related user(s)"))
@@ -689,13 +689,13 @@ class Partner(models.Model):
         self.ensure_one()
         if self.company_name:
             # Create parent company
-            values = dict(name=self.company_name, is_company=True, vat=self.vat)
+            values = {'name': self.company_name, 'is_company': True, 'vat': self.vat}
             values.update(self._update_fields_values(self._address_fields()))
             new_company = self.create(values)
             # Set new company as my parent
             self.write({
                 'parent_id': new_company.id,
-                'child_ids': [Command.update(partner_id, dict(parent_id=new_company.id)) for partner_id in self.child_ids.ids]
+                'child_ids': [Command.update(partner_id, {'parent_id': new_company.id}) for partner_id in self.child_ids.ids]
             })
         return True
 

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -521,7 +521,7 @@ class Users(models.Model):
 
     @api.model
     def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
-        groupby_fields = {[groupby] if isinstance(groupby, str) else groupby}
+        groupby_fields = set([groupby] if isinstance(groupby, str) else groupby)
         if groupby_fields.intersection(USER_PRIVATE_FIELDS):
             raise AccessError(_("Invalid 'group by' parameter"))
         return super(Users, self).read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1086,7 +1086,7 @@ class GroupsImplied(models.Model):
                            FROM res_groups_users_rel r
                            JOIN group_imply i ON (r.gid = i.hid)
                           WHERE i.gid = %(gid)s
-                """, dict(gid=group.id))
+                """, {'gid': group.id})
             self._check_one_user_type()
         return res
 

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -521,7 +521,7 @@ class Users(models.Model):
 
     @api.model
     def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
-        groupby_fields = set([groupby] if isinstance(groupby, str) else groupby)
+        groupby_fields = {[groupby] if isinstance(groupby, str) else groupby}
         if groupby_fields.intersection(USER_PRIVATE_FIELDS):
             raise AccessError(_("Invalid 'group by' parameter"))
         return super(Users, self).read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)

--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -264,7 +264,7 @@ class TestAPI(SavepointCaseWithUserDemo):
         self.env.cache.check(self.env)
 
         # check recordsets
-        self.assertEqual(set(partner1.child_ids), set(children1) - set([child]))
+        self.assertEqual(set(partner1.child_ids), set(children1) - {child})
         self.assertEqual(set(partner2.child_ids), set(children2))
         self.env.cache.check(self.env)
 

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -545,11 +545,11 @@ class TestExpression(SavepointCaseWithUserDemo):
         self.assertEqual([p1,p2], res.ids, "o2m IN matches any on the right side")
         all_ids = self._search(Partner, []).ids
         res = self._search(Partner, [('user_ids', 'not in', u1a)])
-        self.assertEqual(set(all_ids) - set([p1]), set(res.ids), "o2m NOT IN matches none on the right side")
+        self.assertEqual(set(all_ids) - {p1}, set(res.ids), "o2m NOT IN matches none on the right side")
         res = self._search(Partner, [('user_ids', '!=', 'Dédé Boitaclou')])
-        self.assertEqual(set(all_ids) - set([p1]), set(res.ids), "o2m NOT IN matches none on the right side")
+        self.assertEqual(set(all_ids) - {p1}, set(res.ids), "o2m NOT IN matches none on the right side")
         res = self._search(Partner, [('user_ids', 'not in', [u1b, u2])])
-        self.assertEqual(set(all_ids) - set([p1,p2]), set(res.ids), "o2m NOT IN matches none on the right side")
+        self.assertEqual(set(all_ids) - {p1, p2}, set(res.ids), "o2m NOT IN matches none on the right side")
 
     def test_15_equivalent_one2many_2(self):
         Currency = self.env['res.currency']

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -1175,7 +1175,7 @@ class TestQWebStaticXml(TransactionCase):
             # so output is predictable & repeatable
             params = {} if param is None else json.loads(param.text, object_pairs_hook=collections.OrderedDict)
 
-            rec = re.compile(r'\>[ \n\t]*\<')
+            rec = re.compile(r'>[ \n\t]*<')
             result = doc.find('result[@id="{}"]'.format(template)).text
             self.assertEqual(
                 rec.sub('><', qweb._render(template, values=params, load=loader).strip()),

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -3040,7 +3040,7 @@ class TestValidationTools(common.BaseCase):
 
     def test_get_dict_asts(self):
         res = view_validation.get_dict_asts("{'test': False, 'required': [('model', '!=', False)], 'invisible': ['|', ('model', '=', parent.model or need_model), ('need_model', '=', False)]}")
-        self.assertEqual(set(res.keys()), set(['test', 'required', 'invisible']))
+        self.assertEqual(set(res.keys()), {'test', 'required', 'invisible'})
         self.assertIsInstance(res['test'], ast.NameConstant)
         self.assertIsInstance(res['required'], ast.List)
         self.assertIsInstance(res['invisible'], ast.List)

--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -251,7 +251,7 @@ class MergePartnerAutomatic(models.TransientModel):
             else:
                 return item
         # get all fields that are not computed or x2many
-        values = dict()
+        values = {}
         for column in model_fields:
             field = dst_partner._fields[column]
             if field.type not in ('many2many', 'one2many') and field.compute is None:
@@ -297,7 +297,7 @@ class MergePartnerAutomatic(models.TransientModel):
         if partner_ids & child_ids:
             raise UserError(_("You cannot merge a contact with one of his parent."))
 
-        if extra_checks and len(set(partner.email for partner in partner_ids)) > 1:
+        if extra_checks and len({partner.email for partner in partner_ids}) > 1:
             raise UserError(_("All contacts must have the same email. Only the Administrator can merge contacts with different emails."))
 
         # remove dst_partner from partners to merge

--- a/odoo/addons/test_impex/tests/test_load.py
+++ b/odoo/addons/test_impex/tests/test_load.py
@@ -918,7 +918,7 @@ class test_o2m(ImporterCase):
         self.assertEqual(len(result['ids']), 1)
 
         (b,) = self.browse()
-        self.assertEqual(set(values(b.value)), set([63, 64, 65, 66]))
+        self.assertEqual(set(values(b.value)), {63, 64, 65, 66})
 
     def test_multi_subfields(self):
         result = self.import_(['value/str', 'const', 'value/value'], [
@@ -931,7 +931,7 @@ class test_o2m(ImporterCase):
         self.assertEqual(len(result['ids']), 1)
 
         (b,) = self.browse()
-        self.assertEqual(set(values(b.value.sorted())), set([63, 64, 65, 66]))
+        self.assertEqual(set(values(b.value.sorted())), {63, 64, 65, 66})
         self.assertEqual(
             values(b.value.sorted(), 'str'),
             'this is the rhythm'.split())
@@ -959,7 +959,7 @@ class test_o2m(ImporterCase):
         [b] = self.browse()
         self.assertEqual(b.const, 42)
         # automatically forces link between core record and o2ms
-        self.assertEqual(set(values(b.value)), set([109, 262]))
+        self.assertEqual(set(values(b.value)), {109, 262})
         self.assertEqual(values(b.value, field='parent_id'), [b, b])
 
     def test_link(self):
@@ -994,7 +994,7 @@ class test_o2m(ImporterCase):
 
         [b] = self.browse()
         self.assertEqual(b.const, 42)
-        self.assertEqual(set(values(b.value)), set([1, 2]))
+        self.assertEqual(set(values(b.value)), {1, 2})
         self.assertEqual(values(b.value, field='parent_id'), [b, b])
 
     def test_o2m_repeated_with_xids(self):
@@ -1059,8 +1059,8 @@ class test_o2m_multiple(ImporterCase):
         self.assertEqual(len(result['ids']), 1)
 
         [b] = self.browse()
-        self.assertEqual(set(values(b.child1)), set([11, 12, 13, 14]))
-        self.assertEqual(set(values(b.child2)), set([21, 22, 23]))
+        self.assertEqual(set(values(b.child1)), {11, 12, 13, 14})
+        self.assertEqual(set(values(b.child2)), {21, 22, 23})
 
     def test_multi(self):
         result = self.import_(['const', 'child1/value', 'child2/value'], [
@@ -1075,8 +1075,8 @@ class test_o2m_multiple(ImporterCase):
         self.assertEqual(len(result['ids']), 1)
 
         [b] = self.browse()
-        self.assertEqual(set(values(b.child1)), set([11, 12, 13, 14]))
-        self.assertEqual(set(values(b.child2)), set([21, 22, 23]))
+        self.assertEqual(set(values(b.child1)), {11, 12, 13, 14})
+        self.assertEqual(set(values(b.child2)), {21, 22, 23})
 
     def test_multi_fullsplit(self):
         result = self.import_(['const', 'child1/value', 'child2/value'], [
@@ -1093,8 +1093,8 @@ class test_o2m_multiple(ImporterCase):
 
         [b] = self.browse()
         self.assertEqual(b.const, 5)
-        self.assertEqual(set(values(b.child1)), set([11, 12, 13, 14]))
-        self.assertEqual(set(values(b.child2)), set([21, 22, 23]))
+        self.assertEqual(set(values(b.child1)), {11, 12, 13, 14})
+        self.assertEqual(set(values(b.child2)), {21, 22, 23})
 
 
 class test_realworld(SavepointCaseWithUserDemo):

--- a/odoo/addons/test_populate/tests/test_populate.py
+++ b/odoo/addons/test_populate/tests/test_populate.py
@@ -116,7 +116,7 @@ class TestPopulateValidation(common.TransactionCase):
     def test_populate_factories(self):
         for model in self.env.values():
             factories = model._populate_factories() or []
-            factories_fields = set([field_name for field_name, factory in factories if not field_name.startswith('_')])
+            factories_fields = {field_name for field_name, factory in factories if not field_name.startswith('_')}
             missing = factories_fields - model._fields.keys()
             self.assertFalse(missing, 'Fields %s not found in model %s' % (missing, model._name))
 
@@ -147,7 +147,7 @@ class TestPopulateMissing(common.TransactionCase):
                         and field.store \
                         and field.name not in ('create_uid', 'write_uid', 'write_date', 'create_date', 'id') \
                         and field.type not in ('many2many', 'one2many')
-                electable_fields = set([key for key, field in model._fields.items() if is_electable(field)])
+                electable_fields = {key for key, field in model._fields.items() if is_electable(field)}
                 no_factory_fields = set(electable_fields - factories_fields)
                 if no_factory_fields:
                     _logger.info('Model %s has some undefined field: %s', model._name, no_factory_fields)

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1708,14 +1708,15 @@ class _String(Field):
                         ('res_id', 'in', real_recs._ids)
                     ]).unlink()
                 elif single_lang:
-                    records.env['ir.translation']._update_translations([dict(
-                        src=source_value,
-                        value=value,
-                        name=tname,
-                        lang=lang,
-                        type='model',
-                        state='translated',
-                        res_id=res_id) for res_id in real_recs._ids])
+                    records.env['ir.translation']._update_translations([{
+                        'src': source_value,
+                        'value': value,
+                        'name': tname,
+                        'lang': lang,
+                        'type': 'model',
+                        'state': 'translated',
+                        'res_id': res_id
+                    } for res_id in real_recs._ids])
                 else:
                     records.env['ir.translation']._set_ids(
                         tname, 'model', lang, real_recs._ids, value, source_value,
@@ -4034,7 +4035,7 @@ class Many2many(_RelationalMulti):
                 elif command[0] in (Command.CLEAR, Command.SET):
                     # new lines must no longer be linked to records
                     line_ids = command[2] if command[0] == Command.SET else ()
-                    line_ids = set(new(line_id) for line_id in line_ids)
+                    line_ids = {new(line_id) for line_id in line_ids}
                     for id_ in recs._ids:
                         new_relation[id_] = set(line_ids)
 

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -943,7 +943,7 @@ def _generate_routing_rules(modules, nodb_only, converters=None):
             members = inspect.getmembers(o, inspect.ismethod)
             for _, mv in members:
                 if hasattr(mv, 'routing'):
-                    routing = dict(type='http', auth='user', methods=None, routes=None)
+                    routing = {'type': 'http', 'auth': 'user', 'methods': None, 'routes': None}
                     methods_done = list()
                     # update routing attributes from subclasses(auth, methods...)
                     for claz in reversed(mv.__self__.__class__.mro()):
@@ -997,12 +997,12 @@ class OpenERPSession(sessions.Session):
         """
 
         wsgienv = request.httprequest.environ
-        env = dict(
-            interactive=True,
-            base_location=request.httprequest.url_root.rstrip('/'),
-            HTTP_HOST=wsgienv['HTTP_HOST'],
-            REMOTE_ADDR=wsgienv['REMOTE_ADDR'],
-        )
+        env = {
+            'interactive': True,
+            'base_location': request.httprequest.url_root.rstrip('/'),
+            'HTTP_HOST': wsgienv['HTTP_HOST'],
+            'REMOTE_ADDR': wsgienv['REMOTE_ADDR']
+        }
         uid = odoo.registry(db)['res.users'].authenticate(db, login, password, env)
         self.pre_uid = uid
 
@@ -1221,7 +1221,7 @@ class Response(werkzeug.wrappers.Response):
 
     def set_default(self, template=None, qcontext=None, uid=None):
         self.template = template
-        self.qcontext = qcontext or dict()
+        self.qcontext = qcontext or {}
         self.qcontext['response_template'] = self.template
         self.uid = uid
         # Support for Cross-Origin Resource Sharing
@@ -1556,7 +1556,7 @@ def db_filter(dbs, httprequest=None):
     elif odoo.tools.config['db_name']:
         # In case --db-filter is not provided and --database is passed, Odoo will
         # use the value of --database as a comma separated list of exposed databases.
-        exposed_dbs = set(db.strip() for db in odoo.tools.config['db_name'].split(','))
+        exposed_dbs = {db.strip() for db in odoo.tools.config['db_name'].split(',')}
         dbs = sorted(exposed_dbs.intersection(dbs))
     return dbs
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3141,7 +3141,7 @@ class BaseModel(metaclass=MetaModel):
                 description = self.env['ir.model']._get(self._name).name
                 if not self.env.user.has_group('base.group_no_one'):
                     raise AccessError(
-                        _('You do not have enough rights to access the fields "%(fields)s" on %(document_kind)s (%(document_model)s). '\
+                        _('You do not have enough rights to access the fields "%(fields)s" on %(document_kind)s (%(document_model)s). '
                           'Please contact your system administrator.\n\n(Operation: %(operation)s)') % {
                         'fields': ','.join(list(invalid_fields)),
                         'document_kind': description,

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1103,7 +1103,7 @@ class BaseModel(metaclass=MetaModel):
                 return
 
             data_list = [
-                dict(xml_id=xid, values=vals, info=info, noupdate=noupdate)
+                {'xml_id': xid, 'values': vals, 'info': info, 'noupdate': noupdate}
                 for xid, vals, info in batch
             ]
             batch.clear()
@@ -1255,7 +1255,7 @@ class BaseModel(metaclass=MetaModel):
                 only_o2m_values, itertools.islice(data, index + 1, None))
             # stitch record row back on for relational fields
             record_span = list(itertools.chain([row], record_span))
-            for relfield in set(fnames[0] for fnames in fields_ if is_relational(fnames[0])):
+            for relfield in {fnames[0] for fnames in fields_ if is_relational(fnames[0])}:
                 comodel = self.env[fields[relfield].comodel_name]
 
                 # get only cells for this sub-field, should be strictly
@@ -3406,10 +3406,10 @@ Fields:
             res = self.read(LOG_ACCESS_COLUMNS)
         else:
             res = [{'id': x} for x in self.ids]
-        xml_data = dict((x['res_id'], x) for x in IrModelData.search_read([('model', '=', self._name),
-                                                                           ('res_id', 'in', self.ids)],
-                                                                          ['res_id', 'noupdate', 'module', 'name'],
-                                                                          order='id DESC'))
+        xml_data = {x['res_id']: x for x in IrModelData.search_read(
+            [('model', '=', self._name), ('res_id', 'in', self.ids)],
+            ['res_id', 'noupdate', 'module', 'name'],
+            order='id DESC')}
         for r in res:
             value = xml_data.get(r['id'], {})
             r['xmlid'] = '%(module)s.%(name)s' % value if value else False
@@ -4794,7 +4794,7 @@ Fields:
 
         # build a black list of fields that should not be copied
         blacklist = set(MAGIC_COLUMNS + ['parent_path'])
-        whitelist = set(name for name, field in self._fields.items() if not field.inherited)
+        whitelist = {name for name, field in self._fields.items() if not field.inherited}
 
         def blacklist_given_fields(model):
             # blacklist the fields that are given by inheritance
@@ -6343,7 +6343,7 @@ Fields:
                 return (
                     len(self[name]) != len(record[name])
                     or (
-                        set(line_snapshot["<record>"].id for line_snapshot in self[name])
+                        {line_snapshot["<record>"].id for line_snapshot in self[name]}
                         != set(record[name]._ids)
                     )
                     or any(
@@ -6550,12 +6550,12 @@ Fields:
             title, message, type = warnings.pop()
             if not type:
                 type = 'dialog'
-            result['warning'] = dict(title=title, message=message, type=type)
+            result['warning'] = {'title': title, 'message': message, 'type': type}
         elif len(warnings) > 1:
             # concatenate warning titles and messages
             title = _("Warnings")
             message = '\n\n'.join([warn_title + '\n\n' + warn_message for warn_title, warn_message, warn_type in warnings])
-            result['warning'] = dict(title=title, message=message, type='dialog')
+            result['warning'] = {'title': title, 'message': message, 'type': 'dialog'}
 
         return result
 
@@ -6842,7 +6842,7 @@ def convert_pgerror_unique(model, fields, info, e):
     }
 
 def convert_pgerror_constraint(model, fields, info, e):
-    sql_constraints = dict([(('%s_%s') % (e.diag.table_name, x[0]), x) for x in model._sql_constraints])
+    sql_constraints = {('%s_%s') % (e.diag.table_name, x[0]): x for x in model._sql_constraints}
     if e.diag.constraint_name in sql_constraints.keys():
         return {'message': "'%s'" % sql_constraints[e.diag.constraint_name][2]}
     return {'message': tools.ustr(e)}

--- a/odoo/modules/graph.py
+++ b/odoo/modules/graph.py
@@ -65,7 +65,7 @@ class Graph(dict):
                 _logger.warning('module %s: not installable, skipped', module)
 
         dependencies = dict([(p, info['depends']) for p, info in packages])
-        current, later = set([p for p, info in packages]), set()
+        current, later = {p for p, info in packages}, set()
 
         while packages and current > later:
             package, info = packages[0]

--- a/odoo/modules/graph.py
+++ b/odoo/modules/graph.py
@@ -64,7 +64,7 @@ class Graph(dict):
             elif module != 'studio_customization':
                 _logger.warning('module %s: not installable, skipped', module)
 
-        dependencies = dict([(p, info['depends']) for p, info in packages])
+        dependencies = {p: info['depends'] for p, info in packages}
         current, later = {p for p, info in packages}, set()
 
         while packages and current > later:

--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -384,7 +384,7 @@ def list_dbs(force=False):
         return res
 
     chosen_template = odoo.tools.config['db_template']
-    templates_list = tuple(set(['postgres', chosen_template]))
+    templates_list = tuple({'postgres', chosen_template})
     db = odoo.sql_db.db_connect('postgres')
     with closing(db.cursor()) as cr:
         try:

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -269,7 +269,7 @@ class FSWatcherInotify(FSWatcherBase):
 
     def run(self):
         _logger.info('AutoReload watcher running with inotify')
-        dir_creation_events = set(('IN_MOVED_TO', 'IN_CREATE'))
+        dir_creation_events = {'IN_MOVED_TO', 'IN_CREATE'}
         while self.started:
             for event in self.watcher.event_gen(timeout_s=0, yield_nones=False):
                 (_, type_names, path, filename) = event

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -472,7 +472,7 @@ class Cursor(BaseCursor):
             self._cnx.leaked = True
         else:
             chosen_template = tools.config['db_template']
-            templates_list = tuple(set(['template0', 'template1', 'postgres', chosen_template]))
+            templates_list = tuple({'template0', 'template1', 'postgres', chosen_template})
             keep_in_pool = self.dbname not in templates_list
             self.__pool.give_back(self._cnx, keep_in_pool=keep_in_pool)
 

--- a/odoo/tools/cloc.py
+++ b/odoo/tools/cloc.py
@@ -129,7 +129,7 @@ class Cloc(object):
     def count_modules(self, env):
         # Exclude standard addons paths
         exclude_heuristic = [odoo.modules.get_module_path(m, display_warning=False) for m in STANDARD_MODULES]
-        exclude_path = set([os.path.dirname(os.path.realpath(m)) for m in exclude_heuristic if m])
+        exclude_path = {os.path.dirname(os.path.realpath(m)) for m in exclude_heuristic if m}
 
         domain = [('state', '=', 'installed')]
         # if base_import_module is present

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -416,7 +416,7 @@ class configmanager(object):
             old_rcfilepath = os.path.expanduser('~/.openerp_serverrc')
 
             die(os.path.isfile(rcfilepath) and os.path.isfile(old_rcfilepath),
-                "Found '.odoorc' and '.openerp_serverrc' in your path. Please keep only one of "\
+                "Found '.odoorc' and '.openerp_serverrc' in your path. Please keep only one of "
                 "them, preferably '.odoorc'.")
 
             if not os.path.isfile(rcfilepath) and os.path.isfile(old_rcfilepath):

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -80,10 +80,10 @@ class configmanager(object):
         }
 
         # Not exposed in the configuration file.
-        self.blacklist_for_save = set([
+        self.blacklist_for_save = {
             'publisher_warranty_url', 'load_language', 'root_path',
             'init', 'save', 'config', 'update', 'stop_after_init', 'dev_mode', 'shell_interface'
-        ])
+        }
 
         # dictionary mapping option destination (keys in self.options) to MyOptions.
         self.casts = {}

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -58,7 +58,7 @@ def _deduplicate_loggers(loggers):
     # there are no duplicates within the output sequence
     return (
         '{}:{}'.format(logger, level)
-        for logger, level in dict(it.split(':') for it in loggers).items()
+        for logger, level in dict(it.split(':') for it in loggers).items()  # nosemgrep
     )
 
 class configmanager(object):
@@ -91,10 +91,10 @@ class configmanager(object):
         self.misc = {}
         self.config_file = fname
 
-        self._LOGLEVELS = dict([
-            (getattr(loglevels, 'LOG_%s' % x), getattr(logging, x))
+        self._LOGLEVELS = {
+            getattr(loglevels, 'LOG_%s' % x): getattr(logging, x)
             for x in ('CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET')
-        ])
+        }
 
         version = "%s %s" % (release.description, release.version)
         self.parser = parser = optparse.OptionParser(version=version, option_class=MyOption)

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -387,7 +387,7 @@ form: module.record_id""" % (xml_id,)
             # Some domains contain references that are only valid at runtime at
             # client-side, so in that case we keep the original domain string
             # as it is. We also log it, just in case.
-            _logger.debug('Domain value (%s) for element with id "%s" does not parse '\
+            _logger.debug('Domain value (%s) for element with id "%s" does not parse '
                 'at server-side, keeping original string, in case it\'s meant for client side only',
                 domain, xml_id or 'n/a', exc_info=True)
         res = {

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -315,7 +315,7 @@ form: module.record_id""" % (xml_id,)
             res['paperformat_id'] = pf_id
 
         xid = self.make_xml_id(xml_id)
-        data = dict(xml_id=xid, values=res, noupdate=self.noupdate)
+        data = {'xml_id': xid, 'values': res, 'noupdate': self.noupdate}
         report = self.env['ir.actions.report']._load_records([data], self.mode == 'update')
         self.idref[xml_id] = report.id
 
@@ -423,7 +423,7 @@ form: module.record_id""" % (xml_id,)
             if views is not None:
                 res['binding_view_types'] = views
         xid = self.make_xml_id(xml_id)
-        data = dict(xml_id=xid, values=res, noupdate=self.noupdate)
+        data = {'xml_id': xid, 'values': res, 'noupdate': self.noupdate}
         self.env['ir.actions.act_window']._load_records([data], self.mode == 'update')
 
     def _tag_menuitem(self, rec, parent=None):
@@ -587,7 +587,7 @@ form: module.record_id""" % (xml_id,)
         if extra_vals:
             res.update(extra_vals)
 
-        data = dict(xml_id=xid, values=res, noupdate=self.noupdate)
+        data = {'xml_id': xid, 'values': res, 'noupdate': self.noupdate}
         record = model._load_records([data], self.mode == 'update')
         if rec_id:
             self.idref[rec_id] = record.id

--- a/odoo/tools/js_transpiler.py
+++ b/odoo/tools/js_transpiler.py
@@ -414,7 +414,7 @@ IMPORT_LEGACY_DEFAULT_RE = re.compile(r"""
     import\s+                                           # import
     (?P<identifier>\w+)\s*                              # default variable name
     from\s*                                             # from
-    (?P<path>(?P<quote>["'`])([^@\."'`][^"'`]*)(?P=quote))  # legacy alias file ("addon_name.module_name" or "some/path")
+    (?P<path>(?P<quote>["'`])([^@."'`][^"'`]*)(?P=quote))  # legacy alias file ("addon_name.module_name" or "some/path")
     """, re.MULTILINE | re.VERBOSE)
 
 
@@ -576,7 +576,7 @@ def relative_path_to_module_path(url, path_rel):
 
 ODOO_MODULE_RE = re.compile(r"""
     \s*                                       # some starting space
-    \/(\*|\/).*\s*                            # // or /*
+    /(\*|/).*\s*                            # // or /*
     @odoo-module                              # @odoo-module
     (\s+alias=(?P<alias>[\w.]+))?             # alias=web.AbstractAction (optional)
     (\s+default=(?P<default>False|false|0))?  # default=False or false or 0 (optional)

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -138,14 +138,14 @@ class _Cleaner(clean.Cleaner):
                 sibling.set('data-o-mail-quote', '1')
 
         # html signature (-- <br />blah)
-        signature_begin = re.compile(r"((?:(?:^|\n)[-]{2}[\s]?$))")
+        signature_begin = re.compile(r"((?:^|\n)[-]{2}[\s]?$)")
         if el.text and el.find('br') is not None and re.search(signature_begin, el.text):
             el.set('data-o-mail-quote', '1')
             if el.getparent() is not None:
                 el.getparent().set('data-o-mail-quote-container', '1')
 
         # text-based quotes (>, >>) and signatures (-- Signature)
-        text_complete_regex = re.compile(r"((?:\n[>]+[^\n\r]*)+|(?:(?:^|\n)[-]{2}[\s]?[\r\n]{1,2}[\s\S]+))")
+        text_complete_regex = re.compile(r"((?:\n[>]+[^\n\r]*)+|(?:^|\n)[-]{2}[\s]?[\r\n]{1,2}[\s\S]+)")
         if not el.get('data-o-mail-quote'):
             _tag_matching_regex_in_text(text_complete_regex, el, 'span', {'data-o-mail-quote': '1'})
 
@@ -279,15 +279,15 @@ def is_html_empty(html_content):
     """
     if not html_content:
         return True
-    tag_re = re.compile(r'\<\s*\/?(?:p|div|span|br|b|i|font)(?:(?=\s+\w*)[^/>]*|\s*)/?\s*\>')
-    return not bool(re.sub(tag_re, '', html_content).strip())
+    tag_re = re.compile(r'<\s*/?(?:p|div|span|br|b|i|font)(?:(?=\s+\w*)[^/>]*|\s*)/?\s*>')
+    return not bool(tag_re.sub('', html_content).strip())
 
 def html_keep_url(text):
     """ Transform the url into clickable link with <a/> tag """
     idx = 0
     final = ''
-    link_tags = re.compile(r"""(?<!["'])((ftp|http|https):\/\/(\w+:{0,1}\w*@)?([^\s<"']+)(:[0-9]+)?(\/|\/([^\s<"']))?)(?![^\s<"']*["']|[^\s<"']*</a>)""")
-    for item in re.finditer(link_tags, text):
+    link_tags = re.compile(r"""(?<!["'])((ftp|http|https)://(\w+:?\w*@)?([^\s<"']+)(:[0-9]+)?(/([^\s<"'])?)?)(?![^\s<"']*["']|[^\s<"']*</a>)""")
+    for item in link_tags.finditer(text):
         final += text[idx:item.start()]
         final += '<a href="%s" target="_blank" rel="noreferrer noopener">%s</a>' % (item.group(0), item.group(0))
         idx = item.end()

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -866,7 +866,7 @@ def stripped_sys_argv(*strip_args):
     """Return sys.argv with some arguments stripped, suitable for reexecution or subprocesses"""
     strip_args = sorted(set(strip_args) | {'-s', '--save', '-u', '--update', '-i', '--init', '--i18n-overwrite'})
     assert all(config.parser.has_option(s) for s in strip_args)
-    takes_value = dict((s, config.parser.get_option(s).takes_value()) for s in strip_args)
+    takes_value = {s: config.parser.get_option(s).takes_value() for s in strip_args}
 
     longs, shorts = list(tuple(y) for _, y in itergroupby(strip_args, lambda x: x.startswith('--')))
     longs_eq = tuple(l + '=' for l in longs if takes_value[l])

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -864,7 +864,7 @@ class CountingStream(object):
 
 def stripped_sys_argv(*strip_args):
     """Return sys.argv with some arguments stripped, suitable for reexecution or subprocesses"""
-    strip_args = sorted(set(strip_args) | set(['-s', '--save', '-u', '--update', '-i', '--init', '--i18n-overwrite']))
+    strip_args = sorted(set(strip_args) | {'-s', '--save', '-u', '--update', '-i', '--init', '--i18n-overwrite'})
     assert all(config.parser.has_option(s) for s in strip_args)
     takes_value = dict((s, config.parser.get_option(s).takes_value()) for s in strip_args)
 

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -723,7 +723,7 @@ class PoFileWriter:
     def write_rows(self, rows):
         # we now group the translations by source. That means one translation per source.
         grouped_rows = {}
-        modules = set([])
+        modules = set()
         for module, type, name, res_id, src, trad, comments in rows:
             row = grouped_rows.setdefault(src, {})
             row.setdefault('modules', set()).add(module)

--- a/rules/literals.sem
+++ b/rules/literals.sem
@@ -10,3 +10,22 @@ rules:
     severity: WARNING
     message: Use a set literal or comprehension
     pattern: set([...])
+
+  - id: dict-literals
+    languages: [python]
+    severity: WARNING
+    message: Use a dict literal or comprehension
+    pattern-either:
+      - pattern: dict()
+      - pattern: dict([...])
+      - patterns:
+        - pattern: dict(...)
+        - pattern-not: dict($POSITIONAL, ...)
+
+  - id: dict-update # way too many hits, holy crap
+    languages: [] # [python]
+    severity: WARNING
+    message: dict.update has the same signature as dict()
+    pattern-either:
+        - pattern: $X.update(dict(...))
+        - pattern: $X.update({...})

--- a/rules/literals.sem
+++ b/rules/literals.sem
@@ -1,0 +1,12 @@
+rules:
+  - id: set-empty
+    languages: [python]
+    severity: ERROR
+    message: an empty set does not need a parameter
+    pattern: set([])
+    fix: set()
+  - id: set-literals
+    languages: [python]
+    severity: WARNING
+    message: Use a set literal or comprehension
+    pattern: set([...])


### PR DESCRIPTION
* cleans up unecessary `set()` calls, by replacing them with set literals or set comprehensions
* cleans up unnecessary `dict()` calls, by replacing them with dict literals or dict comprehensions, or the odd `dict.fromkeys`
* cleans up a few regex (unnecessary escapes) and implicit string concatenations (unnecessary continuations)

Originally partially in #73535  but that PR is too large and unfocused, so breaking it up into more specific cleanups (and also more complete thus this one being twice the size of that one),