### PR TITLE
[FIX] mail: _get_recipient_data return groups for pids

### DIFF
--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -8,6 +8,7 @@ from odoo.addons.test_mail.tests import common
 from odoo.addons.test_mail.tests.common import mail_new_test_user
 from odoo.tests import tagged
 from odoo.tools.misc import mute_logger
+from odoo.tests.common import users
 
 
 @tagged('mail_followers')
@@ -146,6 +147,18 @@ class BaseFollowersTest(common.BaseFunctionalTest):
             partner_ids=[self.user_employee.partner_id.id, self.user_admin.partner_id.id],
             channel_ids=[self.channel_listen.id]
         )
+
+    @users('employee')
+    def test_recipients_fetch_pids_only(self):
+        """ Test that _get_recipient_data correctly fetch groups for additional pids
+        """
+        users = self.user_admin + self.user_employee + self.user_portal
+        recipient_data = self.env['mail.followers']._get_recipient_data(self.env['mail.thread'], False, False, pids=users.partner_id.ids)
+        groups = {pid: set(groups) for pid, _, _, _, _, _, groups in recipient_data}
+
+        self.assertEqual(groups[self.user_admin.partner_id.id], set(self.user_admin.groups_id.ids), "User Admin groups are not correctly fetched")
+        self.assertEqual(groups[self.user_employee.partner_id.id], set(self.user_employee.groups_id.ids), "User Employee groups are not correctly fetched")
+        self.assertEqual(groups[self.user_portal.partner_id.id], set(self.user_portal.groups_id.ids), "User Portal groups are not correctly fetched")
 
 
 @tagged('mail_followers')


### PR DESCRIPTION
Step to reproduce:
- Go to a project with visibility set on 'Invited portal users and all internal users'
- Go a task
- Send an follow invitation to Marc Demo (an internal user)

Intended behavior:
The mail has a 'View task button'

Current behavior:
No view task button

This behaviour is due to the function _get_recipient_data which is supposed to return groups when given pids but doesn't.

See _get_recipient_data docstring.

opw-2727410


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
