### PR TITLE
[FIX] mail: _get_recipient_data return groups for pids

### DIFF
--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -173,10 +173,13 @@ ORDER BY pid, cid, notif
                 query_pid = """
 SELECT partner.id as pid, NULL::int AS cid,
     partner.active as active, partner.partner_share as pshare, NULL as ctype,
-    users.notification_type AS notif, NULL AS groups
+    users.notification_type AS notif, array_agg(groups.id) AS groups
 FROM res_partner partner
-LEFT JOIN res_users users ON users.partner_id = partner.id AND users.active
-WHERE partner.id IN %s"""
+    LEFT JOIN res_users users ON users.partner_id = partner.id AND users.active
+    LEFT JOIN res_groups_users_rel groups_rel ON groups_rel.uid = users.id
+    LEFT JOIN res_groups groups ON groups.id = groups_rel.gid
+WHERE partner.id IN %s
+GROUP BY partner.id, users.notification_type"""
                 params.append(tuple(pids))
             if cids:
                 query_cid = """


### PR DESCRIPTION
Step to reproduce:
- Go to a project with visibility set on 'Invited portal users and all internal users'
- Go a task
- Send an follow invitation to Marc Demo (an internal user)

Intended behavior:
The mail has a 'View task button'

Current behavior:
No view task button

This behaviour is due to the function _get_recipient_data which is supposed to return groups when given pids but doesn't.

See _get_recipient_data docstring.

opw-2727410

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
