### PR TITLE
[FIX] sale_purchase: copied purchase is linked with the SO

### DIFF
--- a/addons/sale_purchase/models/purchase_order.py
+++ b/addons/sale_purchase/models/purchase_order.py
@@ -71,4 +71,4 @@ class PurchaseOrderLine(models.Model):
     _inherit = 'purchase.order.line'
 
     sale_order_id = fields.Many2one(related='sale_line_id.order_id', string="Sale Order", store=True, readonly=True)
-    sale_line_id = fields.Many2one('sale.order.line', string="Origin Sale Item", index=True)
+    sale_line_id = fields.Many2one('sale.order.line', string="Origin Sale Item", index=True, copy=False)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- create an SO with dropshipping, confirm. It create a PO 1
- copy PO 1
--> Issue PO 2 is linked with the SO


@amoyaux 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
