### PR TITLE
[FIX] sale_{mrp,stock}, stock_account: pass data through context

### DIFF
--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -28,7 +28,7 @@ class AccountMoveLine(models.Model):
                     prod_moves = moves.filtered(lambda m: m.product_id == product)
                     prod_qty_invoiced = factor * qty_invoiced
                     prod_qty_to_invoice = factor * qty_to_invoice
-                    average_price_unit += factor * product.with_context(force_company=self.company_id.id)._compute_average_price(prod_qty_invoiced, prod_qty_to_invoice, prod_moves, is_returned=is_line_reversing)
+                    average_price_unit += factor * product.with_context(force_company=self.company_id.id, is_returned=is_line_reversing)._compute_average_price(prod_qty_invoiced, prod_qty_to_invoice, prod_moves)
                 price_unit = average_price_unit / bom.product_qty or price_unit
                 price_unit = self.product_id.uom_id._compute_price(price_unit, self.product_uom_id)
         return price_unit

--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -120,7 +120,7 @@ class AccountMoveLine(models.Model):
             posted_invoice_lines = so_line.invoice_lines.filtered(lambda l: l.move_id.state == 'posted' and bool(l.move_id.reversed_entry_id) == is_line_reversing)
             qty_invoiced = sum([x.product_uom_id._compute_quantity(x.quantity, x.product_id.uom_id) for x in posted_invoice_lines])
 
-            average_price_unit = self.product_id.with_context(force_company=self.company_id.id)._compute_average_price(qty_invoiced, qty_to_invoice, so_line.move_ids, is_returned=is_line_reversing)
+            average_price_unit = self.product_id.with_context(force_company=self.company_id.id, is_returned=is_line_reversing)._compute_average_price(qty_invoiced, qty_to_invoice, so_line.move_ids)
             price_unit = average_price_unit or price_unit
             price_unit = self.product_id.uom_id.with_context(force_company=self.company_id.id)._compute_price(price_unit, self.product_uom_id)
         return price_unit

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -601,7 +601,7 @@ class ProductProduct(models.Model):
             return price or 0.0
         return self.uom_id._compute_price(price, uom)
 
-    def _compute_average_price(self, qty_invoiced, qty_to_invoice, stock_moves, is_returned=False):
+    def _compute_average_price(self, qty_invoiced, qty_to_invoice, stock_moves):
         """Go over the valuation layers of `stock_moves` to value `qty_to_invoice` while taking
         care of ignoring `qty_invoiced`. If `qty_to_invoice` is greater than what's possible to
         value with the valuation layers, use the product's standard price.
@@ -609,13 +609,15 @@ class ProductProduct(models.Model):
         :param qty_invoiced: quantity already invoiced
         :param qty_to_invoice: quantity to invoice
         :param stock_moves: recordset of `stock.move`
-        :param is_returned: if True, consider the incoming moves
         :returns: the anglo saxon price unit
         :rtype: float
         """
         self.ensure_one()
         if not qty_to_invoice:
             return 0.0
+
+        # if True, consider the incoming moves
+        is_returned = self.env.context.get('is_returned', False)
 
         returned_quantities = defaultdict(float)
         for move in stock_moves:


### PR DESCRIPTION
[1] adds a parameter to the method `_compute_average_price`, which is
not a stable change.

[1] ff9828cc7021daff08225b0b98e69803c4d42c2f