### PR TITLE
[FIX] l10n_fr_fec: prevent error for non-french vat

### DIFF
--- a/addons/l10n_fr_fec/i18n/fr.po
+++ b/addons/l10n_fr_fec/i18n/fr.po
@@ -86,6 +86,12 @@ msgid "Missing VAT number for company %s"
 msgstr "Numéro de TVA manquant sur la société %s"
 
 #. module: l10n_fr_fec
+#: code:addons/l10n_fr_fec/wizard/fec.py:98
+#, python-format
+msgid "Invalid VAT number for company %s"
+msgstr "Numéro de TVA invalide sur la société %s"
+
+#. module: l10n_fr_fec
 #: view:account.fr.fec:0
 msgid "Cancel"
 msgstr "Annuler"

--- a/addons/l10n_fr_fec/i18n/l10n_fr_fec.pot
+++ b/addons/l10n_fr_fec/i18n/l10n_fr_fec.pot
@@ -229,6 +229,12 @@ msgid "Missing VAT number for company %s"
 msgstr ""
 
 #. module: l10n_fr_fec
+#: code:addons/l10n_fr_fec/wizard/account_fr_fec.py:98
+#, python-format
+msgid "Invalid VAT number for company %s"
+msgstr ""
+
+#. module: l10n_fr_fec
 #: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
 msgid "Montantdevise"
 msgstr ""


### PR DESCRIPTION
As the FEC can be downloaded by non-french companies, the length of a given vat number might be different than the french's vat. Currently, if the vat length was lower than 13, it raised an error.

For french companies -> include the SIREN in the name of the FEC file (legal requirement)
For non french companies -> include the complete vat number in the FEC file
