### PR TITLE
[FIX] account: Don't enable 'reconcile' on liquidity account

### DIFF
--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -149,17 +149,26 @@ class AccountPaymentMethodLine(models.Model):
 
         return super(AccountPaymentMethodLine, unused_payment_method_lines).unlink()
 
-    def write(self, vals):
-        if 'payment_account_id' in vals:
-            account = self.env['account.account'].browse(vals['payment_account_id'])
-            if not account.reconcile:
-                account.reconcile = True
-        return super().write(vals)
-
     @api.model
+    def _auto_toggle_account_to_reconcile(self, account_id):
+        """ Automatically toggle the account to reconcile if allowed.
+
+        :param account_id: The id of an account.account.
+        """
+        account = self.env['account.account'].browse(account_id)
+        if not account.reconcile and account.internal_type != 'liquidity' and account.internal_group != 'off_balance':
+            account.reconcile = True
+
+    @api.model_create_multi
     def create(self, vals_list):
-        if 'payment_account_id' in vals_list:
-            account = self.env['account.account'].browse(vals_list['payment_account_id'])
-            if not account.reconcile:
-                account.reconcile = True
+        # OVERRIDE
+        for vals in vals_list:
+            if vals.get('payment_account_id'):
+                self._auto_toggle_account_to_reconcile(vals['payment_account_id'])
         return super().create(vals_list)
+
+    def write(self, vals):
+        # OVERRIDE
+        if vals.get('payment_account_id'):
+            self._auto_toggle_account_to_reconcile(vals['payment_account_id'])
+        return super().write(vals)


### PR DESCRIPTION
If the liquidity account becomes reconcile (not possible from the UI but possible when setting the account on a payment.method.line), the account is visible from the bank reconciliation widget and then, the user is able to reconcile a statement line with itself that is wrong.

issue: 2713163

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
