### PR TITLE
[FIX] web_editor,website_forum,web_unsplash: portal image in forum post

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/document_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/document_selector.js
@@ -51,11 +51,14 @@ export class DocumentSelector extends FileSelector {
             const linkEl = document.createElement('a');
             let href = `/web/content/${attachment.id}?unique=${attachment.checksum}&dowload=true`;
             if (!attachment.public) {
-                const [accessToken] = await orm.call(
-                    'ir.attachment',
-                    'generate_access_token',
-                    [attachment.id],
-                );
+                let accessToken = attachment.access_token;
+                if (!accessToken) {
+                    [accessToken] = await orm.call(
+                        'ir.attachment',
+                        'generate_access_token',
+                        [attachment.id],
+                    );
+                }
                 href += `&access_token=${accessToken}`;
             }
             linkEl.href = href;

--- a/addons/web_editor/static/src/components/media_dialog/image_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/image_selector.js
@@ -239,11 +239,14 @@ export class ImageSelector extends FileSelector {
             const imageEl = document.createElement('img');
             let src = attachment.image_src;
             if (!attachment.public) {
-                const [accessToken] = await orm.call(
-                    'ir.attachment',
-                    'generate_access_token',
-                    [attachment.id],
-                );
+                let accessToken = attachment.access_token;
+                if (!accessToken) {
+                    [accessToken] = await orm.call(
+                        'ir.attachment',
+                        'generate_access_token',
+                        [attachment.id],
+                    );
+                }
                 src += `?access_token=${accessToken}`;
             }
             imageEl.src = src;

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -6,7 +6,6 @@ const { MediaDialogWrapper } = require('@web_editor/components/media_dialog/medi
 const { saveVideos, videoSpecificClasses } = require('@web_editor/components/media_dialog/video_selector');
 const dom = require('web.dom');
 const core = require('web.core');
-const session = require('web.session');
 const Widget = require('web.Widget');
 const Dialog = require('web.Dialog');
 const customColors = require('web_editor.custom_colors');
@@ -107,7 +106,6 @@ const Wysiwyg = Widget.extend({
         const self = this;
 
         var options = this._editorOptions();
-        this.options.isInternalUser = await session.user_has_group('base.group_user');
 
         this.$editable = this.$editable || this.$el;
         if (options.value) {
@@ -1212,7 +1210,7 @@ const Wysiwyg = Widget.extend({
         // selection when the modal is closed.
         const restoreSelection = preserveCursor(this.odooEditor.document);
 
-        const $editable = $(OdooEditorLib.closestElement(range.startContainer, '.o_editable'));
+        const $editable = $(OdooEditorLib.closestElement(range.startContainer, '.o_editable') || this.odooEditor.editable);
         const model = $editable.data('oe-model');
         const field = $editable.data('oe-field');
         const type = $editable.data('oe-type');
@@ -1876,30 +1874,34 @@ const Wysiwyg = Widget.extend({
                     this.odooEditor.execCommand('setTag', 'pre');
                 },
             },
-            {
-                groupName: 'Navigation',
-                title: 'Link',
-                description: 'Add a link.',
-                fontawesome: 'fa-link',
-                callback: () => {
-                    this.toggleLinkTools({forceDialog: true});
-                },
-            },
-            {
-                groupName: 'Navigation',
-                title: 'Button',
-                description: 'Add a button.',
-                fontawesome: 'fa-link',
-                callback: () => {
-                    this.toggleLinkTools({forceDialog: true});
-                    // Force the button style after the link modal is open.
-                    setTimeout(() => {
-                        $(".o_link_dialog .link-style[value=primary]").click();
-                    }, 150);
-                },
-            },
         ];
-        if (options.isInternalUser) {
+        if (options.allowCommandLink) {
+            commands.push(
+                {
+                    groupName: 'Navigation',
+                    title: 'Link',
+                    description: 'Add a link.',
+                    fontawesome: 'fa-link',
+                    callback: () => {
+                        this.toggleLinkTools({forceDialog: true});
+                    },
+                },
+                {
+                    groupName: 'Navigation',
+                    title: 'Button',
+                    description: 'Add a button.',
+                    fontawesome: 'fa-link',
+                    callback: () => {
+                        this.toggleLinkTools({forceDialog: true});
+                        // Force the button style after the link modal is open.
+                        setTimeout(() => {
+                            $(".o_link_dialog .link-style[value=primary]").click();
+                        }, 150);
+                    },
+                },
+            );
+        }
+        if (options.allowCommandImage) {
             commands.push({
                 groupName: 'Medias',
                 title: 'Image',

--- a/addons/web_editor/tests/test_controller.py
+++ b/addons/web_editor/tests/test_controller.py
@@ -2,16 +2,38 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import binascii
-
-from odoo.tools.json import scriptsafe as json_safe
-from odoo.addons.http_routing.models.ir_http import slug
+import json
 
 import odoo.tests
-from odoo.tests.common import HttpCase
+from odoo.tests.common import HttpCase, new_test_user
+from odoo.tools.json import scriptsafe as json_safe
 
+from odoo.addons.http_routing.models.ir_http import slug
 
 @odoo.tests.tagged('-at_install', 'post_install')
 class TestController(HttpCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        portal_user = new_test_user(cls.env, login='portal_user', groups='base.group_portal')
+        cls.portal = portal_user.login
+        admin_user = new_test_user(cls.env, login='admin_user', groups='base.group_user,base.group_system')
+        cls.admin = admin_user.login
+        cls.headers = {"Content-Type": "application/json"}
+        cls.pixel = 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs='
+
+    def _build_payload(self, params=None):
+        """
+        Helper to properly build jsonrpc payload
+        """
+        return {
+            "jsonrpc": "2.0",
+            "method": "call",
+            "id": 0,
+            "params": params or {},
+        }
+
     def test_01_upload_document(self):
         self.authenticate('admin', 'admin')
         # Upload document.
@@ -115,3 +137,16 @@ class TestController(HttpCase):
         self.assertEqual(attachment_id, response['result']['original']['id'], "Wrong id")
         self.assertEqual(image_src, response['result']['original']['image_src'], "Wrong image_src")
         self.assertEqual(mimetype, response['result']['original']['mimetype'], "Wrong mimetype")
+
+    def test_04_admin_attachment(self):
+        self.authenticate(self.admin, self.admin)
+        payload = self._build_payload({"name": "pixel", "data": self.pixel, "is_image": True})
+        response = self.url_open('/web_editor/attachment/add_data', data=json.dumps(payload), headers=self.headers)
+        self.assertEqual(200, response.status_code)
+        attachment = self.env['ir.attachment'].search([('name', '=', 'pixel')])
+        self.assertTrue(attachment)
+
+        domain = [('name', '=', 'pixel')]
+        result = attachment.search_read(domain)
+        self.assertTrue(len(result), "No attachment fetched")
+        self.assertEqual(result[0]['id'], attachment.id)

--- a/addons/web_unsplash/models/res_users.py
+++ b/addons/web_unsplash/models/res_users.py
@@ -6,12 +6,10 @@ from odoo import models
 class ResUsers(models.Model):
     _inherit = 'res.users'
 
-    def _has_unsplash_key_rights(self, mode='write'):
+    def _can_manage_unsplash_settings(self):
         self.ensure_one()
         # Website has no dependency to web_unsplash, we cannot warranty the order of the execution
         # of the overwrite done in 5ef8300.
         # So to avoid to create a new module bridge, with a lot of code, we prefer to make a check
         # here for website's user.
-        assert mode in ('read', 'write')
-        website_group_required = (mode == 'write') and 'website.group_website_designer' or 'website.group_website_publisher'
-        return self.has_group('base.group_erp_manager') or self.has_group(website_group_required)
+        return self.has_group('base.group_erp_manager') or self.has_group('website.group_website_publisher')

--- a/addons/web_unsplash/static/src/components/media_dialog/image_selector.js
+++ b/addons/web_unsplash/static/src/components/media_dialog/image_selector.js
@@ -45,6 +45,7 @@ patch(ImageSelector.prototype, 'image_selector_unsplash', {
         this.state.isFetchingUnsplash = false;
         this.state.isMaxed = false;
         this.state.unsplashError = null;
+        this.state.useUnsplash = true;
 
         this.errorMessages = {
             'key_not_found': {
@@ -134,8 +135,12 @@ patch(ImageSelector.prototype, 'image_selector_unsplash', {
             return { isMaxed, records };
         } catch (e) {
             this.state.isFetchingUnsplash = false;
-            this.state.unsplashError = e;
-            return { records: [], isMaxed: false };
+            if (e === 'no_access') {
+                this.state.useUnsplash = false;
+            } else {
+                this.state.unsplashError = e;
+            }
+            return { records: [], isMaxed: true };
         }
     },
 

--- a/addons/web_unsplash/static/src/components/media_dialog/image_selector.xml
+++ b/addons/web_unsplash/static/src/components/media_dialog/image_selector.xml
@@ -73,7 +73,13 @@
 
 <t t-inherit="web_editor.FileSelectorControlPanel" t-inherit-mode="extension">
     <xpath expr="//option[@value='media-library']" position="after">
-        <option t-att-selected="props.searchService === 'unsplash'" value="unsplash">Photos (via Unsplash)</option>
+        <option t-if="props.useUnsplash" t-att-selected="props.searchService === 'unsplash'" value="unsplash">Photos (via Unsplash)</option>
+    </xpath>
+</t>
+
+<t t-inherit="web_editor.FileSelector" t-inherit-mode="extension">
+    <xpath expr="//FileSelectorControlPanel" position="attributes">
+        <attribute name="useUnsplash">state.useUnsplash</attribute>
     </xpath>
 </t>
 </templates>

--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -137,11 +137,9 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                 resizable: true,
                 userGeneratedContent: true,
             };
-            if (!hasFullEdit) {
-                options.plugins = {
-                    LinkPlugin: false,
-                    MediaPlugin: false,
-                };
+            if (hasFullEdit) {
+                options.allowCommandLink = true;
+                options.allowCommandImage = true;
             }
             wysiwygLoader.loadFromTextarea(self, $textarea[0], options).then(wysiwyg => {
                 if (!hasFullEdit) {

--- a/addons/website_forum/tests/__init__.py
+++ b/addons/website_forum/tests/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from . import common
+from . import test_controller
 from . import test_forum
 from . import test_forum_process

--- a/addons/website_forum/tests/test_controller.py
+++ b/addons/website_forum/tests/test_controller.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+from odoo.tests.common import HttpCase, new_test_user
+
+
+class TestController(HttpCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        portal_user = new_test_user(cls.env, login='portal_user', groups='base.group_portal')
+        cls.portal = portal_user.login
+        admin_user = new_test_user(cls.env, login='admin_user', groups='base.group_user,base.group_system')
+        cls.admin = admin_user.login
+        cls.headers = {"Content-Type": "application/json"}
+        cls.pixel = 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs='
+
+    def _build_payload(self, params=None):
+        """
+        Helper to properly build jsonrpc payload
+        """
+        return {
+            "jsonrpc": "2.0",
+            "method": "call",
+            "id": 0,
+            "params": params or {},
+        }
+
+    def test_01_portal_attachment(self):
+        self.authenticate(self.portal, self.portal)
+        payload = self._build_payload({"name": "pixel", "data": self.pixel, "is_image": True, "res_model": "forum.post"})
+        response = self.url_open('/web_editor/attachment/add_data', data=json.dumps(payload), headers=self.headers, timeout=60000)
+        self.assertEqual(200, response.status_code)
+        attachment = self.env['ir.attachment'].search([('name', '=', 'pixel')])
+        self.assertTrue(attachment)
+
+    def test_02_admin_attachment(self):
+        self.authenticate(self.admin, self.admin)
+        payload = self._build_payload({"name": "pixel", "data": self.pixel, "is_image": True, "res_model": "forum.post"})
+        response = self.url_open('/web_editor/attachment/add_data', data=json.dumps(payload), headers=self.headers)
+        self.assertEqual(200, response.status_code)
+        attachment = self.env['ir.attachment'].search([('name', '=', 'pixel')])
+        self.assertTrue(attachment)
+
+        attachment = self.env['ir.attachment'].create([{'name': 'test_pixel', 'public': True, 'res_id': False,
+                                                        'mimetype': 'text/plain', 'res_model': 'forum.post',
+                                                        'raw': self.pixel, 'website_id': 1}])
+        domain = [('name', '=', 'test_pixel')]
+        result = attachment.search_read(domain)
+        self.assertTrue(len(result), "No attachment fetched")
+        self.assertEqual(result[0]['id'], attachment.id)


### PR DESCRIPTION
[RDE] Edit: Let's not forget to remove the /image command in stable (the real bugfix).

A portal user cannot insert an image to a forum post

Steps to reproduce:
1. Install the Forum app
2. Connect as portal
3. Go to the forum and create a new post
4. Type '/image' and try to insert an image
5. An Access Error is raised preventing the portal user from inserting
an image

Solution:
Hide the /image and /link commands if it is specified in options.plugins
If an access error is raised when fetching attachments, we catch the
error silently and return an empty list.
Call create and search_read with sudo to allow access to portal users
if he has the rights.
Provide the res_model when creating attachment to check access.
Allow any user to use unsplash in the image widget and hide the unsplash
configurator for users with no unsplash rights.
In 15.0, [this PR] removes the `/image` command for portal users.

[this PR]: https://github.com/odoo/odoo/pull/89250

opw-2648770
task-2811325