### PR TITLE
[FIX] maintenance: set noupdate for stages

### DIFF
--- a/addons/maintenance/data/maintenance_data.xml
+++ b/addons/maintenance/data/maintenance_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-<data>
+<data noupdate="1">
 
     <!-- Standard stages for Maintenance Request -->
     <record id="stage_0" model="maintenance.stage">


### PR DESCRIPTION
It's useless to trigger the udpate of the stages during module (or whole
DB) upgrade if these stages do not change. It's been the same since at
least 12.0. Updating the stage triggers a series of computes that may
end up in MemoryError during upgrade.
https://github.com/odoo/odoo/blob/7b3b623cf3359ac1eea537177f7f963e81403a01/addons/maintenance/models/maintenance.py#L434-L441

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
