### PR TITLE
[FIX] l10n_it_edi_sdicoop : forbid negative qties in ita invoices

### DIFF
--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -102,6 +102,9 @@ class AccountEdiFormat(models.Model):
             if not invoice_line.display_type and len(invoice_line.tax_ids) != 1:
                 raise UserError(_("You must select one and only one tax by line."))
 
+        if any(line.quantity < 0 for line in invoice.invoice_line_ids):
+            errors.append(_("All quantities should be positive."))
+
         for tax_line in invoice.line_ids.filtered(lambda line: line.tax_line_id):
             if not tax_line.tax_line_id.l10n_it_kind_exoneration and tax_line.tax_line_id.amount == 0:
                 errors.append(_("%s has an amount of 0.0, you must indicate the kind of exoneration.", tax_line.name))


### PR DESCRIPTION
Steps :
- Install l10n_it_edi_sdicoop
- Create an invoice with a line with a negative qty.

Issue :
- Error : File non valido

Fix :
- Forbid negative qties.

opw-2699722

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
