### PR TITLE
[FIX] maintenance: `MemoryError` on compute

### DIFF
--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -433,12 +433,12 @@ class MaintenanceTeam(models.Model):
     @api.depends('request_ids.stage_id.done')
     def _compute_todo_requests(self):
         for team in self:
-            team.todo_request_ids = team.request_ids.filtered(lambda e: e.stage_id.done==False)
+            team.todo_request_ids = self.env['maintenance.request'].search([('maintenance_team_id', '=', team.id), ('stage_id.done', '=', False)])
             team.todo_request_count = len(team.todo_request_ids)
-            team.todo_request_count_date = len(team.todo_request_ids.filtered(lambda e: e.schedule_date != False))
-            team.todo_request_count_high_priority = len(team.todo_request_ids.filtered(lambda e: e.priority == '3'))
-            team.todo_request_count_block = len(team.todo_request_ids.filtered(lambda e: e.kanban_state == 'blocked'))
-            team.todo_request_count_unscheduled = len(team.todo_request_ids.filtered(lambda e: not e.schedule_date))
+            team.todo_request_count_date = self.env['maintenance.request'].search_count([('maintenance_team_id', '=', team.id), ('schedule_date', '!=', False)])
+            team.todo_request_count_high_priority = self.env['maintenance.request'].search_count([('maintenance_team_id', '=', team.id), ('priority', '=', '3')])
+            team.todo_request_count_block = self.env['maintenance.request'].search_count([('maintenance_team_id', '=', team.id), ('kanban_state', '=', 'blocked')])
+            team.todo_request_count_unscheduled = self.env['maintenance.request'].search_count([('maintenance_team_id', '=', team.id), ('schedule_date', '=', False)])
 
     @api.depends('equipment_ids')
     def _compute_equipment(self):


### PR DESCRIPTION
When computing the todo fields of maintenance requests, we could get a
`MemoryError` since we are fetching more fields that we actually need.

Here we rework the way the compute is done in order to avoid too much
prefetch.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
