### PR TITLE
[FIX] stock_picking_batch: compute the state of all the batches

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -94,7 +94,7 @@ class StockPickingBatch(models.Model):
         batchs = self.filtered(lambda batch: batch.state not in ['cancel', 'done'])
         for batch in batchs:
             if not batch.picking_ids:
-                return
+                continue
             # Cancels automatically the batch picking if all its transfers are cancelled.
             if all(picking.state == 'cancel' for picking in batch.picking_ids):
                 batch.state = 'cancel'


### PR DESCRIPTION
Steps to reproduce the bug:
- Create two batches, one with picking and one without
- Try to compute their state together with an RPC call

Problem:
If the first has no picking, the second batch does not compute state because we use `”return”` instead of `”continue”`

opw-2725988



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
