### PR TITLE
[IMP] sale_*: clean order line name computation

### DIFF
--- a/addons/event_booth_sale/models/sale_order_line.py
+++ b/addons/event_booth_sale/models/sale_order_line.py
@@ -68,7 +68,7 @@ class SaleOrderLine(models.Model):
     def _compute_name(self):
         """Override to add the compute dependency.
 
-        The custom name logic can be found below in get_sale_order_line_multiline_description_sale.
+        The custom name logic can be found below in _get_sale_order_line_multiline_description_sale.
         """
         super()._compute_name()
 
@@ -85,13 +85,10 @@ class SaleOrderLine(models.Model):
                 so_line.event_booth_ids.action_set_paid()
         return True
 
-    def get_sale_order_line_multiline_description_sale(self, product):
+    def _get_sale_order_line_multiline_description_sale(self):
         if self.event_booth_pending_ids:
-            booths = self.event_booth_pending_ids.with_context(
-                lang=self.order_id.partner_id.lang,
-            )
-            return booths._get_booth_multiline_description()
-        return super(SaleOrderLine, self).get_sale_order_line_multiline_description_sale(product)
+            return self.event_booth_pending_ids._get_booth_multiline_description()
+        return super()._get_sale_order_line_multiline_description_sale()
 
     def _get_display_price(self):
         if self.event_booth_pending_ids and self.event_id:

--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -146,7 +146,7 @@ class SaleOrderLine(models.Model):
     def _compute_name(self):
         """Override to add the compute dependency.
 
-        The custom name logic can be found below in get_sale_order_line_multiline_description_sale.
+        The custom name logic can be found below in _get_sale_order_line_multiline_description_sale.
         """
         super()._compute_name()
 
@@ -160,20 +160,16 @@ class SaleOrderLine(models.Model):
     def _unlink_associated_registrations(self):
         self.env['event.registration'].search([('sale_order_line_id', 'in', self.ids)]).unlink()
 
-    def get_sale_order_line_multiline_description_sale(self, product):
+    def _get_sale_order_line_multiline_description_sale(self):
         """ We override this method because we decided that:
                 The default description of a sales order line containing a ticket must be different than the default description when no ticket is present.
                 So in that case we use the description computed from the ticket, instead of the description computed from the product.
                 We need this override to be defined here in sales order line (and not in product) because here is the only place where the event_ticket_id is referenced.
         """
         if self.event_ticket_id:
-            ticket = self.event_ticket_id.with_context(
-                lang=self.order_id.partner_id.lang,
-            )
-
-            return ticket._get_ticket_multiline_description() + self._get_sale_order_line_multiline_description_variants()
+            return self.event_ticket_id._get_ticket_multiline_description() + self._get_sale_order_line_multiline_description_variants()
         else:
-            return super(SaleOrderLine, self).get_sale_order_line_multiline_description_sale(product)
+            return super()._get_sale_order_line_multiline_description_sale()
 
     def _get_display_price(self):
         if self.event_ticket_id and self.event_id:

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -620,8 +620,7 @@ class SaleOrderLine(models.Model):
         for line in self:
             if not line.product_id:
                 continue
-            product = line.product_id.with_context(lang=line.order_partner_id.lang)
-            line.name = line.get_sale_order_line_multiline_description_sale(product)
+            line.name = line.with_context(lang=line.order_partner_id.lang)._get_sale_order_line_multiline_description_sale()
 
     @api.depends('product_id')
     def _compute_custom_attribute_values(self):
@@ -876,7 +875,7 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         return False
 
-    def get_sale_order_line_multiline_description_sale(self, product):
+    def _get_sale_order_line_multiline_description_sale(self):
         """ Compute a default multiline description for this sales order line.
 
         In most cases the product description is enough but sometimes we need to append information that only
@@ -886,7 +885,8 @@ class SaleOrderLine(models.Model):
         - in event_sale we need to know specifically the sales order line as well as the product to generate the name:
           the product is not sufficient because we also need to know the event_id and the event_ticket_id (both which belong to the sale order line).
         """
-        return product.get_product_multiline_description_sale() + self._get_sale_order_line_multiline_description_variants()
+        self.ensure_one()
+        return self.product_id.get_product_multiline_description_sale() + self._get_sale_order_line_multiline_description_variants()
 
     def _get_sale_order_line_multiline_description_variants(self):
         """When using no_variant attributes or is_custom values, the product

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -7,18 +7,20 @@ from odoo import api, models, fields, _
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    name_short = fields.Char(compute="_compute_name_short")
-
     linked_line_id = fields.Many2one('sale.order.line', string='Linked Order Line', domain="[('order_id', '!=', order_id)]", ondelete='cascade')
     option_line_ids = fields.One2many('sale.order.line', 'linked_line_id', string='Options Linked')
 
-    def get_sale_order_line_multiline_description_sale(self, product):
-        description = super(SaleOrderLine, self).get_sale_order_line_multiline_description_sale(product)
-        if self.linked_line_id:
-            description += "\n" + _("Option for: %s", self.linked_line_id.product_id.display_name)
-        if self.option_line_ids:
-            description += "\n" + '\n'.join([_("Option: %s", option_line.product_id.display_name) for option_line in self.option_line_ids])
-        return description
+    name_short = fields.Char(compute="_compute_name_short")
+
+    #=== COMPUTE METHODS ===#
+
+    @api.depends('linked_line_id', 'option_line_ids')
+    def _compute_name(self):
+        """Override to add the compute dependency.
+
+        The custom name logic can be found below in _get_sale_order_line_multiline_description_sale.
+        """
+        super()._compute_name()
 
     @api.depends('product_id.display_name')
     def _compute_name_short(self):
@@ -27,6 +29,19 @@ class SaleOrderLine(models.Model):
         """
         for record in self:
             record.name_short = record.product_id.with_context(display_default_code=False).display_name
+
+    #=== BUSINESS METHODS ===#
+
+    def _get_sale_order_line_multiline_description_sale(self):
+        description = super()._get_sale_order_line_multiline_description_sale()
+        if self.linked_line_id:
+            description += "\n" + _("Option for: %s", self.linked_line_id.product_id.display_name)
+        if self.option_line_ids:
+            description += "\n" + '\n'.join([
+                _("Option: %s", option_line.product_id.display_name)
+                for option_line in self.option_line_ids
+            ])
+        return description
 
     def get_description_following_lines(self):
         return self.name.splitlines()[1:]


### PR DESCRIPTION
* make sure full content is translated in partner language
* drop useless product param (use line product_id field instead)
* delegate order lines name computation to computes for ecommerce carts

COM PR: https://github.com/odoo/odoo/pull/82620
Enterprise PR: https://github.com/odoo/enterprise/pull/23432

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
