### PR TITLE
[FIX] payment_authorize : accept american express CVC

### DIFF
--- a/addons/payment_authorize/views/payment_authorize_templates.xml
+++ b/addons/payment_authorize/views/payment_authorize_templates.xml
@@ -17,7 +17,7 @@
                 </div>
                 <div class="col-sm-4 form-group">
                     <label t-attf-for="o_authorize_code_{{acquirer_id}}">Card Code</label>
-                    <input type="number" t-attf-id="o_authorize_code_{{acquirer_id}}" max="999" class="form-control"/>
+                    <input type="number" t-attf-id="o_authorize_code_{{acquirer_id}}" max="9999" class="form-control"/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
American Express CVC code are 4-digit numbers

Current Behaviour:
Authorize currently only accept numbers up to 999.

Behaviour after PR:
Authorize accept number up to 9999

opw-2727511

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
