### PR TITLE
[FIX] purchase_stock: traceback (insufficient rights) on manufacturing order creation

### DIFF
--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -314,7 +314,7 @@ class StockRule(models.Model):
         )
         if values.get('orderpoint_id'):
             procurement_date = fields.Date.to_date(values['date_planned']) - relativedelta(days=int(values['supplier'].delay))
-            delta_days = int(self.env['ir.config_parameter'].get_param('purchase_stock.delta_days_merge') or 0)
+            delta_days = int(self.env['ir.config_parameter'].sudo().get_param('purchase_stock.delta_days_merge') or 0)
             domain += (
                 ('date_order', '<=', datetime.combine(procurement_date + relativedelta(days=delta_days), datetime.max.time())),
                 ('date_order', '>=', datetime.combine(procurement_date - relativedelta(days=delta_days), datetime.min.time()))


### PR DESCRIPTION
Fix traceback (insufficient rights) on manufacturing order creation in some situations

Before this commit there is traceback if user without Administration/Settings role tries to create a manufacturing order and there are components to buy and there is purchase order for them already.

After this commit there is no traceback.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
