### PR TITLE
[FIX] web: Command Palette FooterComponent

### DIFF
--- a/addons/web/static/src/core/commands/command_palette.js
+++ b/addons/web/static/src/core/commands/command_palette.js
@@ -37,7 +37,7 @@ const FUZZY_NAMESPACES = ["default"];
  * @typedef {{
  *  categoriesByNamespace?: {[namespace]: string[]};
  *  emptyMessageByNamespace?: {[namespace]: string};
- *  footerComponent?: Component;
+ *  FooterComponent?: Component;
  *  placeholder?: string;
  *  providers: Provider[];
  *  searchValue?: string;
@@ -84,7 +84,7 @@ export class CommandPalette extends Component {
         /**
          * @type {{ commands: CommandItem[],
          *          emptyMessage: string,
-         *          footerComponent: Component,
+         *          FooterComponent: Component,
          *          placeholder: string,
          *          searchValue: string,
          *          selectedCommand: CommandItem }}
@@ -132,7 +132,7 @@ export class CommandPalette extends Component {
         this.emptyMessageByNamespace = config.emptyMessageByNamespace || {};
         this.providersByNamespace = result;
 
-        this.state.footerComponent = config.footerComponent;
+        this.state.FooterComponent = config.FooterComponent;
 
         this.state.placeholder = config.placeholder || DEFAULT_PLACEHOLDER.toString();
 

--- a/addons/web/static/src/core/commands/command_palette.xml
+++ b/addons/web/static/src/core/commands/command_palette.xml
@@ -28,8 +28,8 @@
         </t>
       </div>
 
-      <div t-if="state.footerComponent" class="o_command_palette_footer">
-        <t t-component="state.footerComponent"/>
+      <div t-if="state.FooterComponent" class="o_command_palette_footer">
+        <t t-component="state.FooterComponent"/>
       </div>
 
     </div>

--- a/addons/web/static/src/core/commands/command_service.js
+++ b/addons/web/static/src/core/commands/command_service.js
@@ -93,7 +93,7 @@ export const commandService = {
                 {
                     categoriesByNamespace,
                     emptyMessageByNamespace,
-                    footerComponent: DefaultFooter,
+                    FooterComponent: DefaultFooter,
                     placeholder: env._t("Search for a command..."),
                     providers: commandProviderRegistry.getAll(),
                 },

--- a/addons/web/static/tests/core/commands/command_palette_tests.js
+++ b/addons/web/static/tests/core/commands/command_palette_tests.js
@@ -26,8 +26,8 @@ let target;
 let testComponent;
 const serviceRegistry = registry.category("services");
 
-class footerComponent extends Component {}
-footerComponent.template = xml`<span>My footer</span>`;
+class FooterComponent extends Component {}
+FooterComponent.template = xml`<span>My footer</span>`;
 
 class TestComponent extends Component {
     get DialogContainer() {
@@ -154,7 +154,7 @@ QUnit.test("add a footer", async (assert) => {
     testComponent = await mount(TestComponent, { env, target });
     const config = {
         providers: [],
-        footerComponent,
+        FooterComponent,
     };
     env.services.dialog.add(CommandPaletteDialog, {
         config,
@@ -963,7 +963,7 @@ QUnit.test("multi level command", async (assert) => {
     ];
     const config = {
         emptyMessageByNamespace,
-        footerComponent,
+        FooterComponent,
         placeholder: "placeholder test",
         providers,
     };


### PR DESCRIPTION
This commit solves a naming error introduced by commit 1e1b45ea62a180f01204be232677d28675a7e6ff, the name of a component always starts with a capital letter.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
