### PR TITLE
[IMP] *: improve report security

### DIFF
--- a/addons/hr_timesheet/report/hr_timesheet_report_view.xml
+++ b/addons/hr_timesheet/report/hr_timesheet_report_view.xml
@@ -154,18 +154,17 @@
         <menuitem id="menu_timesheets_reports"
             name="Reporting"
             parent="timesheet_menu_root"
-            groups="hr_timesheet.group_timesheet_manager"
             sequence="99"/>
 
         <menuitem id="menu_timesheets_reports_timesheet"
             name="Timesheets"
             parent="menu_timesheets_reports"
-            groups="hr_timesheet.group_timesheet_manager"
             sequence="10"/>
 
         <menuitem id="menu_hr_activity_analysis"
             parent="menu_timesheets_reports_timesheet"
             action="act_hr_timesheet_report"
+            groups="hr_timesheet.group_hr_timesheet_approver"
             name="By Employee"
             sequence="10"/>
 

--- a/addons/hr_timesheet_attendance/models/__init__.py
+++ b/addons/hr_timesheet_attendance/models/__init__.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding:utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
-from . import report
+from . import ir_ui_menu

--- a/addons/hr_timesheet_attendance/models/ir_ui_menu.py
+++ b/addons/hr_timesheet_attendance/models/ir_ui_menu.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrUiMenu(models.Model):
+    _inherit = 'ir.ui.menu'
+
+    def _load_menus_blacklist(self):
+        res = super()._load_menus_blacklist()
+        if not (self.env.user.has_group('hr_attendance.group_hr_attendance_user') and self.env.user.has_group('hr_timesheet.group_hr_timesheet_user')):
+            res.append(self.env.ref('hr_timesheet_attendance.menu_hr_timesheet_attendance_report').id)
+        return res

--- a/addons/hr_timesheet_attendance/security/hr_timesheet_attendance_report_security.xml
+++ b/addons/hr_timesheet_attendance/security/hr_timesheet_attendance_report_security.xml
@@ -5,4 +5,30 @@
         <field name="model_id" ref="model_hr_timesheet_attendance_report"/>
         <field name="domain_force"> ['|', ('company_id', 'in', company_ids), ('company_id', '=', False)]</field>
     </record>
+
+    <record id="hr_timesheet_attendance_report_rule_user" model="ir.rule">
+        <field name="name">Timesheet attendance Report: User</field>
+        <field name="model_id" ref="model_hr_timesheet_attendance_report"/>
+        <field name="domain_force">[('user_id', '=', user.id)]</field>
+        <field name="groups" eval="[(4, ref('hr_timesheet.group_hr_timesheet_user'))]"/>
+    </record>
+
+    <record id="hr_timesheet_attendance_report_rule_approver" model="ir.rule">
+        <field name="name">Timesheet attendance Report: Approver</field>
+        <field name="model_id" ref="model_hr_timesheet_attendance_report"/>
+        <field name="domain_force">[
+            ('project_id', '!=', False),
+            '|',
+                ('project_id.privacy_visibility', '!=', 'followers'),
+                ('project_id.message_partner_ids', 'in', [user.partner_id.id])
+        ]</field>
+        <field name="groups" eval="[(4, ref('hr_timesheet.group_hr_timesheet_approver'))]"/>
+    </record>
+
+    <record id="hr_timesheet_attendance_report_rule_manager" model="ir.rule">
+        <field name="name">Timesheet attendance Report: Administrator</field>
+        <field name="model_id" ref="model_hr_timesheet_attendance_report"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('hr_timesheet.group_timesheet_manager'))]"/>
+    </record>
 </odoo>

--- a/addons/project/models/__init__.py
+++ b/addons/project/models/__init__.py
@@ -14,3 +14,4 @@ from . import project_update
 from . import res_config_settings
 from . import res_partner
 from . import digest
+from . import ir_ui_menu

--- a/addons/project/models/ir_ui_menu.py
+++ b/addons/project/models/ir_ui_menu.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrUiMenu(models.Model):
+    _inherit = 'ir.ui.menu'
+
+    def _load_menus_blacklist(self):
+        res = super()._load_menus_blacklist()
+        if not self.env.user.has_group('project.group_project_manager'):
+            res.append(self.env.ref('project.rating_rating_menu_project').id)
+        return res

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -764,7 +764,7 @@ class Project(models.Model):
                 'show': self.rating_active and self.rating_count > 0,
                 'sequence': 15,
             })
-        if self.user_has_groups('project.group_project_manager'):
+        if self.user_has_groups('project.group_project_user'):
             buttons.append({
                 'icon': 'area-chart',
                 'text': _lt('Burndown Chart'),

--- a/addons/project/report/project_task_burndown_chart_report.py
+++ b/addons/project/report/project_task_burndown_chart_report.py
@@ -14,6 +14,7 @@ class ReportProjectTaskBurndownChart(models.Model):
     _auto = False
     _order = 'date'
 
+    task_id = fields.Many2one('project.task', readonly=True)
     project_id = fields.Many2one('project.project', readonly=True)
     display_project_id = fields.Many2one('project.project', readonly=True)
     stage_id = fields.Many2one('project.task.type', readonly=True)

--- a/addons/project/security/ir.model.access.csv
+++ b/addons/project/security/ir.model.access.csv
@@ -9,6 +9,7 @@ access_project_task_type_manager,project.task.type manager,model_project_task_ty
 access_project_task_type_portal,task_type_portal,project.model_project_task_type,base.group_portal,1,0,0,0
 access_project_task,project.task,model_project_task,project.group_project_user,1,1,1,1
 access_report_project_task_user,report.project.task.user,model_report_project_task_user,project.group_project_manager,1,1,1,1
+access_report_project_task_user_project_user,report.project.task.user.project.user,model_report_project_task_user,project.group_project_user,1,0,0,0
 access_partner_task_user,base.res.partner user,base.model_res_partner,project.group_project_user,1,0,0,0
 access_task_on_partner,project.task on partners,model_project_task,base.group_user,1,0,0,0
 access_task_portal,task_portal,project.model_project_task,base.group_portal,1,0,0,0
@@ -28,6 +29,7 @@ access_project_delete_wizard,access_project_delete_wizard,model_project_delete_w
 access_project_task_type_delete_wizard,project.task.type.delete.wizard,model_project_task_type_delete_wizard,project.group_project_manager,1,1,1,1
 access_project_task_recurrence,project.task.recurrence,model_project_task_recurrence,project.group_project_user,1,1,1,1
 project.access_project_task_burndown_chart_report,access_project_task_burndown_chart_report,project.model_project_task_burndown_chart_report,project.group_project_manager,1,1,1,1
+project.access_project_task_burndown_chart_report_user,access_project_task_burndown_chart_report_user,project.model_project_task_burndown_chart_report,project.group_project_user,1,0,0,0
 access_project_update_user,project.update.user,model_project_update,base.group_user,1,0,0,0
 access_project_update_portal,project.update.portal,model_project_update,base.group_portal,1,0,0,0
 access_project_update_project_user,project.update.project.user,model_project_update,project.group_project_user,1,1,1,1

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -231,11 +231,48 @@
         <field name="groups" eval="[(4,ref('base.group_user'))]"/>
     </record>
 
+    <record model="ir.rule" id="report_project_task_user_rule">
+        <field name="name">Tasks Analysis: project visibility User</field>
+        <field name="model_id" ref="model_report_project_task_user"/>
+        <field name="domain_force">[
+        '|',
+            ('project_id.privacy_visibility', '!=', 'followers'),
+            '|',
+                ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                '|',
+                    ('task_id.message_partner_ids', 'in', [user.partner_id.id]),
+                    ('user_ids', 'in', user.id),
+        ]</field>
+        <field name="groups" eval="[(4,ref('project.group_project_user'))]"/>
+    </record>
+
+    <record model="ir.rule" id="report_project_task_manager_rule">
+        <field name="name">Tasks Analysis: project visibility Manager</field>
+        <field name="model_id" ref="model_report_project_task_user"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
+    </record>
+
     <record id="update_visibility_project_admin" model="ir.rule">
         <field name="name">Project updates : Project user can see all project updates</field>
         <field name="model_id" ref="project.model_project_update"/>
         <field name="domain_force">[(1, '=', 1)]</field>
         <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
+    </record>
+
+    <record model="ir.rule" id="burndown_chart_project_user_rule">
+        <field name="name">Burndown chart: project visibility User</field>
+        <field name="model_id" ref="model_project_task_burndown_chart_report"/>
+        <field name="domain_force">[
+        '|',
+            ('project_id.privacy_visibility', '!=', 'followers'),
+            '|',
+                ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                '|',
+                    ('task_id.message_partner_ids', 'in', [user.partner_id.id]),
+                    ('user_ids', 'in', user.id),
+        ]</field>
+        <field name="groups" eval="[(4,ref('project.group_project_user'))]"/>
     </record>
 
 </data>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -353,7 +353,7 @@
                                 <field name="last_update_status" readonly="1" widget="status_with_color" options="{'color_field': 'last_update_color', 'no_quick_edit': 1}"/>
                             </div>
                         </button>
-                        <button name="%(action_project_task_burndown_chart_report)d" type="action" class="oe_stat_button" icon="fa-area-chart" groups="project.group_project_manager">
+                        <button name="%(action_project_task_burndown_chart_report)d" type="action" class="oe_stat_button" icon="fa-area-chart" groups="project.group_project_user">
                             <span class="o_stat_text">
                                 Burndown Chart
                             </span>
@@ -409,7 +409,6 @@
                                     <div name="alias_def" colspan="2" attrs="{'invisible': [('alias_domain', '=', False)]}">
                                         <!-- Always display the whole alias in edit mode. It depends in read only -->
                                         <field name="alias_enabled" invisible="1"/>
-                                        <span class="oe_read_only" attrs="{'invisible': [('alias_name', '!=', False)]}">Create tasks by sending an email to </span>
                                         <span class="font-weight-bold oe_read_only" attrs="{'invisible': [('alias_name', '=', False)]}">Create tasks by sending an email to </span>
                                         <span class="font-weight-bold oe_edit_only">Create tasks by sending an email to </span>
                                             <field name="alias_value" class="oe_read_only d-inline" readonly="1" widget="email" attrs="{'invisible':  [('alias_name', '=', False)]}" />
@@ -704,14 +703,14 @@
                                                     <a name="action_view_tasks" type="object">Tasks</a>
                                                 </div>
                                             </div>
-                                            <div class="col-6 o_kanban_card_manage_section o_kanban_manage_reporting" groups="project.group_project_manager">
-                                                <div role="menuitem" class="o_kanban_card_manage_title">
+                                            <div class="col-6 o_kanban_card_manage_section o_kanban_manage_reporting">
+                                                <div role="menuitem" class="o_kanban_card_manage_title" groups="project.group_project_user">
                                                     <span>Reporting</span>
                                                 </div>
-                                                <div role="menuitem">
+                                                <div role="menuitem" groups="project.group_project_user">
                                                     <a name="action_view_tasks_analysis" type="object">Tasks Analysis</a>
                                                 </div>
-                                                <div role="menuitem" name="project_burndown_menu">
+                                                <div role="menuitem" name="project_burndown_menu" groups="project.group_project_user">
                                                     <a name="%(action_project_task_burndown_chart_report)d" type="action">Burndown Chart</a>
                                                 </div>
                                             </div>
@@ -1458,7 +1457,6 @@
 
         <!-- Reporting menus -->
         <menuitem id="menu_project_report" name="Reporting"
-            groups="project.group_project_manager"
             parent="menu_main_pm" sequence="99"/>
 
         <menuitem id="menu_project_report_task_analysis"
@@ -1495,7 +1493,7 @@
                     <field name="id"/>
                 </xpath>
                 <xpath expr="//div[hasclass('o_kanban_manage_view')]" position="inside">
-                    <div role="menuitem" groups="project.group_project_manager">
+                    <div role="menuitem" groups="project.group_project_user">
                         <a name="%(project.project_update_all_action)d" type="action" t-attf-context="{'active_id': #{record.id.raw_value}}">Project Updates</a>
                     </div>
                 </xpath>

--- a/addons/project/views/rating_views.xml
+++ b/addons/project/views/rating_views.xml
@@ -151,7 +151,7 @@
         <field name="name">Ratings</field>
         <field name="res_model">rating.rating</field>
         <field name="view_mode">kanban,tree,graph,pivot,form</field>
-        <field name="domain">[('consumed','=',True), ('parent_res_model','=','project.project')]</field>
+        <field name="domain">[('consumed','=',True), ('parent_res_model','=','project.project'), ('parent_res_id', '=', active_id)]</field>
         <field name="search_view_id" ref="rating_rating_view_search_project"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">

--- a/addons/sale_stock/tests/test_create_perf.py
+++ b/addons/sale_stock/tests/test_create_perf.py
@@ -165,5 +165,5 @@ class TestPERF(common.TransactionCase):
         } for i in range(self.ENTITIES)]
 
         # 1592 locally, 1593 in nightly runbot, 1954 sometimes
-        with self.assertQueryCount(admin=1594):
+        with self.assertQueryCount(admin=1593):
             self.env["sale.order"].create(vals_list)

--- a/addons/sale_timesheet/report/timesheets_analysis_report.py
+++ b/addons/sale_timesheet/report/timesheets_analysis_report.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, api
+
+class TimesheetsAnalysisReport(models.Model):
+
+    _inherit = "timesheets.analysis.report"
+    _auto = False
+
+    so_line = fields.Many2one("sale.order.line", string="SO line", readonly=True)
+    timesheet_invoice_type = fields.Selection([
+        ("billable_time", "Billed on Timesheets"),
+        ("billable_fixed", "Billed at a Fixed price"),
+        ("non_billable", "Non Billable Tasks"),
+        ("timesheet_revenues", "Timesheet Revenues"),
+        ("service_revenues", "Service Revenues"),
+        ("other_revenues", "Other Revenues"),
+        ("other_costs", "Other Costs")], string="Billable Type",
+            readonly=True)
+    timesheet_revenues = fields.Float("Timesheet Revenues", readonly=True, help="Number of hours spent multiplied by the unit price per hour/day.")
+    margin = fields.Float("Margin", readonly=True, help="Timesheets revenues minus the costs")
+
+    billable_time = fields.Float("Billable Time", readonly=True, help="Number of hours/days linked to a SOL.")
+    non_billable_time = fields.Float("Non Billable Time", readonly=True, help="Number of hours/days not linked to a SOL.")
+    billable_time_percentage = fields.Float("Billable Time %", readonly=True, help="Sum of hours/days linked to a SOL vs the total number of hours/days spent.", group_operator="avg")
+    non_billable_time_percentage = fields.Float("Non Billable Time %", readonly=True, help="Sum of hours/days not linked to a SOL vs the total number of hours/days spent.", group_operator="avg")
+
+    @api.model
+    def _select(self):
+        return super()._select() + """,
+            A.so_line AS so_line,
+            A.timesheet_invoice_type AS timesheet_invoice_type,
+            (timesheet_revenues - A.amount) AS margin,
+            timesheet_revenues, billable_time, billable_time_percentage,
+            (A.unit_amount - billable_time) AS non_billable_time,
+            (100 - billable_time_percentage) AS non_billable_time_percentage
+        """
+
+    def _from(self):
+        return """
+            FROM
+            (
+                """ + super()._select() + """,
+                    so_line, timesheet_invoice_type,
+                    (-1 * A.unit_amount * A.amount) AS timesheet_revenues,
+                    CASE WHEN order_id IS NULL THEN 0 ELSE unit_amount END AS billable_time,
+                    CASE WHEN order_id IS NULL THEN 0 ELSE unit_amount END AS billable_time_percentage
+                FROM account_analytic_line A
+            ) A
+        """


### PR DESCRIPTION
\* hr_timesheet_{attendance}, project, rating, sale_timesheet

The goal of this task is therefore to let all users access the reporting menus, while making sure they can only see data available with their access right level and nothing more.

- removed the 'admin' group on the reporting menu items so that 'users' can
  access these menus.
- 'timesheet / attendance' menu should only show if user has access for both
  the attendance and timesheet.
- Project/User should access 'Task Analysis' report And Added rule for user.
- customer ratings: only show ratings which has access of their project/task.
- ratings: user should not able to edit ratings.

task-2467564
Co-authored-by: Priyanka Kakadiya <pka@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
