### PR TITLE
[FIX] account: fix reconciliation with 0% tax

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -291,6 +291,8 @@ class AccountReconcileModel(models.Model):
 
         new_aml_dicts = []
         for tax_res in res['taxes']:
+            if self.company_id.currency_id.is_zero(tax_res['amount']):
+                continue
             tax = self.env['account.tax'].browse(tax_res['id'])
             balance = tax_res['amount']
             name = ' '.join([x for x in [base_line_dict.get('name', ''), tax_res['name']] if x])


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Create a 0% Tax with a tax repartition line of 100%.
- Create a reconciliation model :
	- Type : "Manually create a write-off on clicked button".
	- Counterpart entries : aforementioned 0% tax.
- Create a Customer Invoice of 3300 on AR (debit).
- Create a Payment of 3000 on AR (credit).
- Open Manual reconciliation widget.
- Select both lines and apply this reconciliation model using the button.

Current behavior before PR:
- Two entries are created.

Desired behavior after PR is merged:
- Only one entry.

opw-2714472

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
