### PR TITLE
[FIX] l10n_de, stock: Germany delivery slip layout

### DIFF
--- a/addons/l10n_de/report/din5008_report.xml
+++ b/addons/l10n_de/report/din5008_report.xml
@@ -99,6 +99,31 @@
                             </t>
                         </tr>
                     </table>
+                    <div>
+                        <div t-if="o.move_ids_without_package and o.move_ids_without_package[0].partner_id and o.move_ids_without_package[0].partner_id.id != o.partner_id.id">
+                            <span><strong>Delivery Address:</strong></span>
+                            <div t-field="o.move_ids_without_package[0].partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;, &quot;phone&quot;], &quot;no_marker&quot;: True, &quot;phone_icons&quot;: True}"/>
+                        </div>
+                        <div t-if="o.picking_type_id.code != 'internal' and (not o.move_ids_without_package or not o.move_ids_without_package[0].partner_id) and o.picking_type_id.warehouse_id.partner_id">
+                            <span><strong>Warehouse Address:</strong></span>
+                            <div t-field="o.picking_type_id.warehouse_id.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;, &quot;phone&quot;], &quot;no_marker&quot;: True, &quot;phone_icons&quot;: True}"/>
+                        </div>
+                    </div>
+                    <div>
+                        <div t-if="o.picking_type_id.code=='incoming' and partner">
+                            <span><strong>Vendor Address:</strong></span>
+                        </div>
+                        <div t-if="o.picking_type_id.code=='internal' and partner">
+                            <span><strong>Warehouse Address:</strong></span>
+                        </div>
+                        <div t-if="o.picking_type_id.code=='outgoing' and partner">
+                            <span><strong>Customer Address:</strong></span>
+                        </div>
+                        <div t-if="partner" name="partner_header">
+                            <div t-field="partner.self" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;, &quot;phone&quot;], &quot;no_marker&quot;: True, &quot;phone_icons&quot;: True}"/>
+                            <p t-if="partner.sudo().vat"><t t-esc="o.company_id.country_id.vat_label or 'Tax ID'"/>: <span t-field="partner.sudo().vat"/></p>
+                        </div>
+                    </div>
                     <h2>
                         <span t-if="not o and not docs"><t t-esc="company.l10n_de_document_title"/></span>
                         <span t-else="">

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -7,6 +7,7 @@
                 <t t-set="partner" t-value="o.partner_id or (o.move_lines and o.move_lines[0].partner_id) or False"/>
 
                 <div class="page">
+                    <t t-if="o.company_id.country_id.id != 57">
                     <div class="row">
                         <div class="col-6" name="div_outgoing_address">
                             <div t-if="o.move_ids_without_package and o.move_ids_without_package[0].partner_id and o.move_ids_without_package[0].partner_id.id != o.partner_id.id">
@@ -37,6 +38,7 @@
                             </div>
                         </div>
                     </div>
+                    </t>
                     <h2>
                         <span t-field="o.name"/>
                     </h2>


### PR DESCRIPTION
Current behavior:
Customer address was not at the good place on the germany delivery slip

Steps to reproduce:
- Get in a German company
- Create a SO
- Go in the delivery and print delivery slip

opw-2715851

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
