### PR TITLE
[REF] product: make related fields variant template overloadable

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -398,6 +398,10 @@ class ProductTemplate(models.Model):
             type_mapping = self._detailed_type_mapping()
             vals['type'] = type_mapping.get(vals['detailed_type'], vals['detailed_type'])
 
+    def _get_related_fields_variant_template(self):
+        """ Return a list of fields present on template and variants models and that are related"""
+        return ['barcode', 'default_code', 'standard_price', 'volume', 'weight', 'packaging_ids']
+
     @api.model_create_multi
     def create(self, vals_list):
         ''' Store the initial standard price in order to be able to retrieve the cost of a product template for a given date'''
@@ -410,19 +414,9 @@ class ProductTemplate(models.Model):
         # This is needed to set given values to first variant after creation
         for template, vals in zip(templates, vals_list):
             related_vals = {}
-            if vals.get('barcode'):
-                related_vals['barcode'] = vals['barcode']
-            if vals.get('default_code'):
-                related_vals['default_code'] = vals['default_code']
-            if vals.get('standard_price'):
-                related_vals['standard_price'] = vals['standard_price']
-            if vals.get('volume'):
-                related_vals['volume'] = vals['volume']
-            if vals.get('weight'):
-                related_vals['weight'] = vals['weight']
-            # Please do forward port
-            if vals.get('packaging_ids'):
-                related_vals['packaging_ids'] = vals['packaging_ids']
+            for field_name in self._get_related_fields_variant_template():
+                if vals.get(field_name):
+                    related_vals[field_name] = vals[field_name]
             if related_vals:
                 template.write(related_vals)
 


### PR DESCRIPTION
Trivial PR.

**Description of the issue/feature this PR addresses:**
add related fields (between product variant and template) requires to overload create function. See : https://github.com/OCA/product-attribute/pull/980/files#diff-65d363ea5642673a23b320a89bdd17c1d6e541fc51fd95a9d7fccac1b6fa90bbR83 

**Desired behavior after PR is merged:**
simply overload the new function ``_get_related_fields_variant_template``.

CC : @Mantux11 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
