### PR TITLE
[FIX] mail: typo in action_save_as_template

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -338,8 +338,7 @@ class MailComposer(models.TransientModel):
             template = self.env['mail.template'].create(values)
 
             if record.attachment_ids:
-                # transfer pending attachments to the new template
-                attachments = self.env['ir.attachment'].sudo().browse(record.attachment_ids).filtered(
+                attachments = self.env['ir.attachment'].sudo().browse(record.attachment_ids.ids).filtered(
                     lambda a: a.res_model == 'mail.compose.message' and a.create_uid.id == self._uid)
                 if attachments:
                     attachments.write({'res_model': template._name, 'res_id': template.id})


### PR DESCRIPTION
Traceback on the ticket:
https://pastebin.com/mCAFJVWG

A browse should take an id or a list of ids as parameter.
```python
record = env['mail.compose.message'].browse(1)
attachments = env['ir.attachment'].sudo().browse(record.attachment_ids)
print(attachments)
attachments = env['ir.attachment'].sudo().browse(record.attachment_ids.ids)
print(attachments)
```

OPW-2728748