### PR TITLE
[IMP] flake8 base config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,14 +47,13 @@ requires =
   python3-zeep
 
 [flake8]
-exclude =
+extend-exclude =
   .git,
   .tx,
-  addons,
   debian,
   doc,
   setup,
-select =
+extend-select =
   RST
 rst-directives =
   function,


### PR DESCRIPTION
The usage of `select=RST` apparently broke all local flake8 uses (which might
be implicit e.g. used for linting in the simpler editors). Always excluding
"addons" probably causes a similar problem.

Remove the exclusion of "addons", and use "extend-select" for the selection of
RST errors. This should play better with local configuration, or the lack of
configuration (thus flake8 defaults). This means the exclusion of addons and
the "blanking" of the default errors selection will have to be done in the CI 
configuration, but that probably makes sense.
