### PR TITLE
[FIX] product,stock*: wrong barcode type use on report

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -561,6 +561,48 @@ class ProductProduct(models.Model):
             return _('Products: ') + self.env['product.category'].browse(self._context['categ_id']).name
         return res
 
+    @api.model
+    def get_barcode_check_digit(self, numeric_barcode):
+        """ Computes and returns the barcode check digit. The used algorithm
+        follows the GTIN specifications and can be used by all compatible
+        barcode nomenclature, like as EAN-8, EAN-12 (UPC-A) or EAN-13.
+        https://www.gs1.org/sites/default/files/docs/barcodes/GS1_General_Specifications.pdf
+        https://www.gs1.org/services/how-calculate-check-digit-manually
+        :param numeric_barcode: the barcode to verify/recompute the check digit
+        :type numeric_barcode: str
+        :return: the number corresponding to the right check digit
+        :rtype: int
+        """
+        # Multiply value of each position by
+        # N1  N2  N3  N4  N5  N6  N7  N8  N9  N10 N11 N12 N13 N14 N15 N16 N17 N18
+        # x3  X1  x3  x1  x3  x1  x3  x1  x3  x1  x3  x1  x3  x1  x3  x1  x3  CHECKSUM
+        oddsum = evensum = total = 0
+        code = numeric_barcode[-2::-1]  # Remove the check digit and reverse the barcode.
+        # The CHECKSUM digit is removed because it will be recomputed and it must not interfer with
+        # the computation. Also, the barcode is inverted, so the barcode length doesn't matter.
+        # Otherwise, the digits' group (even or odd) could be different according to the barcode length.
+        for i, digit in enumerate(code):
+            if i % 2 == 0:
+                evensum += int(digit)
+            else:
+                oddsum += int(digit)
+        total = evensum * 3 + oddsum
+        return (10 - total % 10) % 10
+
+    @api.model
+    def check_encoding(self, barcode, encoding):
+        """ Checks if the given barcode is correctly encoded.
+        :return: True if the barcode string is encoded with the provided encoding.
+        """
+        if encoding == "any":
+            return True
+        barcode_sizes = {
+            'ean8': 8,
+            'ean13': 13,
+            'upca': 12,
+        }
+        return len(barcode) == barcode_sizes[encoding] and re.match(r"^\d+$", barcode) and self.get_barcode_check_digit(barcode) == int(barcode[-1])
+
     def open_pricelist_rules(self):
         self.ensure_one()
         domain = ['|',

--- a/addons/product/report/product_packaging.xml
+++ b/addons/product/report/product_packaging.xml
@@ -29,8 +29,8 @@
                                   <t t-if="packaging.barcode">
                                     <tr>
                                     <td style="text-align: center; vertical-align: middle;" class="col-5">
-                                        <img alt="Barcode" t-if="len(packaging.barcode) == 13" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', packaging.barcode, 600, 150)" style="width:100%;height:20%;"/>
-                                        <img alt="Barcode" t-elif="len(packaging.barcode) == 8" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN8', packaging.barcode, 600, 150)" style="width:100%;height:20%;"/>
+                                        <img alt="Barcode" t-if="packaging.product_id.check_encoding(packaging.barcode, 'ean13')" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', packaging.barcode, 600, 150)" style="width:100%;height:20%;"/>
+                                        <img alt="Barcode" t-elif="packaging.product_id.check_encoding(packaging.barcode, 'ean8')" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN8', packaging.barcode, 600, 150)" style="width:100%;height:20%;"/>
                                         <img alt="Barcode" t-else="" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('Code128', packaging.barcode, 600, 150)" style="width:100%;height:20%;"/>
                                         <span t-field="packaging.barcode"/>
                                     </td>

--- a/addons/product/report/product_product_templates.xml
+++ b/addons/product/report/product_product_templates.xml
@@ -18,8 +18,8 @@
                     <tr>
                         <td class="text-center align-middle" style="height: 6rem">
                             <t t-if="product.barcode">
-                                <img alt="Barcode" t-if="len(product.barcode) == 13" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', quote_plus(product.barcode or ''), 600, 150)" style="width:100%;height::4rem;"/>
-                                <img alt="Barcode" t-elif="len(product.barcode) == 8" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN8', quote_plus(product.barcode or ''), 600, 150)" style="width:100%;height::4rem;"/>
+                                <img alt="Barcode" t-if="product.check_encoding(product.barcode, 'ean13')" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', quote_plus(product.barcode or ''), 600, 150)" style="width:100%;height::4rem;"/>
+                                <img alt="Barcode" t-elif="product.check_encoding(product.barcode, 'ean8')" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN8', quote_plus(product.barcode or ''), 600, 150)" style="width:100%;height::4rem;"/>
                                 <img alt="Barcode" t-else="" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('Code128', quote_plus(product.barcode or ''), 600, 150)" style="width:100%;height::4rem;"/>
                                 <span t-field="product.barcode"/>
                             </t>
@@ -53,8 +53,8 @@
                     <tr>
                         <td class="text-center align-middle" style="height: 6rem;">
                             <t t-if="product.barcode">
-                                <img alt="Barcode" t-if="len(product.barcode) == 13" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', quote_plus(product.barcode or ''), 600, 150)" style="width:100%;height:4rem;"/>
-                                <img alt="Barcode" t-elif="len(product.barcode) == 8" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN8', quote_plus(product.barcode or ''), 600, 150)" style="width:100%;height:4rem;"/>
+                                <img alt="Barcode" t-if="product.check_encoding(product.barcode, 'ean13')" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', quote_plus(product.barcode or ''), 600, 150)" style="width:100%;height:4rem;"/>
+                                <img alt="Barcode" t-elif="product.check_encoding(product.barcode, 'ean8')" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN8', quote_plus(product.barcode or ''), 600, 150)" style="width:100%;height:4rem;"/>
                                 <img alt="Barcode" t-else="" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('Code128', quote_plus(product.barcode or ''), 600, 150)" style="width:100%;height:4rem"/>
                                 <span t-field="product.barcode"/>
                             </t>

--- a/addons/product/tests/test_product_attribute_value_config.py
+++ b/addons/product/tests/test_product_attribute_value_config.py
@@ -505,8 +505,16 @@ class TestProductAttributeValueConfig(TestProductAttributeValueSetup):
         # It should be about instantaneous, 0.5 to avoid false positives
         self.assertLess(elapsed, 0.5)
 
+    def test_check_encoding_barcode(self):
+        self.assertTrue(self.env['product.product'].check_encoding('90311017', 'ean8'))
+        self.assertFalse(self.env['product.product'].check_encoding('90311011', 'ean8'))
 
+        self.assertTrue(self.env['product.product'].check_encoding('725272730706', 'upca'))
+        self.assertFalse(self.env['product.product'].check_encoding('725272730700', 'upca'))
 
+        self.assertTrue(self.env['product.product'].check_encoding('2234567890004', 'ean13'))
+        self.assertTrue(self.env['product.product'].check_encoding('2109876543210', 'ean13'))
+        self.assertFalse(self.env['product.product'].check_encoding('2234567890000', 'ean13'))
 
     def test_get_closest_possible_combinations(self):
         computer_ssd_256 = self._get_product_template_attribute_value(self.ssd_256)

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -119,10 +119,9 @@
                                                 <td class="text-center" t-if="has_barcode">
                                                     <t t-if="product_barcode != move.product_id.barcode">
                                                         <span t-if="move.product_id and move.product_id.barcode">
-                                                            <img t-if="len(move.product_id.barcode) == 13" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s&amp;quiet=%s' % ('EAN13', move.product_id.barcode, 400, 100, 0)" style="height:35px" alt="Barcode"/>
-                                                            <img t-elif="len(move.product_id.barcode) == 8" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s&amp;quiet=%s' % ('EAN8', move.product_id.barcode, 400, 100, 0)" style="height:35px" alt="Barcode"/>
+                                                            <img t-if="move.product_id.check_encoding(move.product_id.barcode, 'ean13')" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s&amp;quiet=%s' % ('EAN13', move.product_id.barcode, 400, 100, 0)" style="height:35px" alt="Barcode"/>
+                                                            <img t-elif="move.product_id.check_encoding(move.product_id.barcode, 'ean8')" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s&amp;quiet=%s' % ('EAN8', move.product_id.barcode, 400, 100, 0)" style="height:35px" alt="Barcode"/>
                                                             <img t-else="" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s&amp;quiet=%s' % ('Code128', move.product_id.barcode, 400, 100, 0)" style="height:35px" alt="Barcode"/>
-
                                                         </span>
                                                         <t t-set="product_barcode" t-value="move.product_id.barcode"/>
                                                     </t>

--- a/addons/stock_picking_batch/report/report_picking_batch.xml
+++ b/addons/stock_picking_batch/report/report_picking_batch.xml
@@ -100,10 +100,9 @@
                                             </td>
                                             <td width="15%" class="text-center" t-if="has_barcode">
                                                 <span t-if="move_operation.product_id and move_operation.product_id.barcode">
-                                                    <img t-if="len(move_operation.product_id.barcode) == 13" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', move_operation.product_id.barcode, 600, 100)" style="width:100%;height:35px" alt="Barcode"/>
-                                                    <img t-elif="len(move_operation.product_id.barcode) == 8" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN8', move_operation.product_id.barcode, 600, 100)" style="width:100%;height:35px" alt="Barcode"/>
+                                                    <img t-if="move_operation.product_id.check_encoding(move_operation.product_id.barcode, 'ean13')" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', move_operation.product_id.barcode, 600, 100)" style="width:100%;height:35px" alt="Barcode"/>
+                                                    <img t-elif="move_operation.product_id.check_encoding(move_operation.product_id.barcode, 'ean8')" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN8', move_operation.product_id.barcode, 600, 100)" style="width:100%;height:35px" alt="Barcode"/>
                                                     <img t-else="" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('Code128', move_operation.product_id.barcode, 600, 100)" style="width:100%;height:35px" alt="Barcode"/>
-
                                                 </span>
                                             </td>
                                             <td t-if="has_package" width="15%">


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:
Create 2 products with respectively barcodes 07010022 and 07010023 print labels for these products.

Result:
- barcodes on the labels are 07010022 and 07010023 (OK)
- barcode image on the labels are the same, when you read it with
a scanner, it says  07010026 -> not consistent

For the moment, the barcode type is selected according only to its length. So we don't verify if the checksum in EAN correspond to what the user uses in his barcode.

# Desired behavior after PR is merged:

With this commit, the preferred type for a barcode is “EAN8” or “EAN13” but if the checksum doesn't correspond, it's using “code128”.

opw-2719022

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
