### PR TITLE
[FIX] l10n_pe: demo: set l10n_latam_identification_type_id to 'RUC'

### DIFF
--- a/addons/l10n_pe/demo/demo_company.xml
+++ b/addons/l10n_pe/demo/demo_company.xml
@@ -11,6 +11,7 @@
         <field name="phone">+51 912 345 678</field>
         <field name="email">info@company.peexample.com</field>
         <field name="website">www.peexample.com</field>
+        <field name="l10n_latam_identification_type_id" ref="it_RUC"/>
     </record>
 
     <record id="demo_company_pe" model="res.company">

--- a/addons/l10n_pe/demo/demo_partner.xml
+++ b/addons/l10n_pe/demo/demo_partner.xml
@@ -6,5 +6,6 @@
         <field name="company_type">company</field>
         <field name="zip">150101</field>
         <field name="street2">Av. Pedro de Osma Nro. 434</field>
+        <field name="l10n_latam_identification_type_id" ref="it_RUC"/>
     </record>
 </odoo>


### PR DESCRIPTION
#### The issue:
When creating a fresh DB with demo data, the demo company and customer are created with l10n_latam_identification_type_id set to 'VAT' rather than 'RUC'.

This causes a problem when we create an invoice with the demo company and the demo customer and validate it: when the l10n_pe_edi module sends the invoice to the OSE, the OSE responds with the following error code:

`1007|El dato ingresado no cumple con el estandar - [...]
error: Error Factura (codigo: 1007): 1007
(nodo: "cbc:ID/schemeID" valor: "0")`

#### Some observations on how the issue occurs:
Interestingly, when you create a new company or partner using the UI, the `l10n_latam_identification_type_id` is automatically set to 'RUC'.
This is ensured by the `ResCompany.create()` and `ResPartner._onchange_country()` methods, see
https://github.com/odoo/odoo/blob/f84dbf63b9354a3c577589178a09c3ffb151cba3/addons/l10n_latam_base/models/res_company.py#L10 and
https://github.com/odoo/odoo/blob/f84dbf63b9354a3c577589178a09c3ffb151cba3/addons/l10n_latam_base/models/res_partner.py#L25

However, when the demo company is created, the `create()` method is called at the first `<field>` element, which is `name`, and so, `create()` does not set `l10n_latam_identification_type_id`.

And because the demo partner is created without the UI, the onchange is not called when the partner's country is set.

#### The solution:
Therefore it is necessary to explicitly set the `l10n_latam_identification_type_id` for both the demo company and the demo customer.