### PR TITLE
[FIX] survey: download certificate as portal user

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -8,7 +8,7 @@ import werkzeug
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 
-from odoo import fields, http, _
+from odoo import fields, http, SUPERUSER_ID, _
 from odoo.addons.base.models.ir_ui_view import keep_query
 from odoo.exceptions import UserError
 from odoo.http import request, content_disposition
@@ -640,7 +640,7 @@ class Survey(http.Controller):
         return request.render('survey.survey_page_statistics', template_values)
 
     def _generate_report(self, user_input, download=True):
-        report = request.env.ref('survey.certification_report').sudo()._render_qweb_pdf([user_input.id], data={'report_type': 'pdf'})[0]
+        report = request.env.ref('survey.certification_report').with_user(SUPERUSER_ID)._render_qweb_pdf([user_input.id], data={'report_type': 'pdf'})[0]
 
         report_content_disposition = content_disposition('Certification.pdf')
         if not download:


### PR DESCRIPTION
(:information_source: Backport from 55705215f22d556110a7ac5b130f892882e0e4e5)

### Current behavior
A portal user couldn't download a survey certificate

### Steps to reproduce
1. Install the Survey app and open it
2. Create a survey with a scoring and a certificate and copy the link
3. In an incognito tab, connect as portal and go to the survey
4. After completing the survey, try to download the certificate

### Solution
Change the call `sudo()` to `with_user(SUPERUSER_ID)`

### Note
This is a backport of a v15 commit (55705215f22d556110a7ac5b130f892882e0e4e5) as he hasn't been applied on v14. (Issue does **not** happen on v13)

OPW-2728436
