### PR TITLE
[IMP] fleet: reorder/reword fuel types

### DIFF
--- a/addons/fleet/i18n/fleet.pot
+++ b/addons/fleet/i18n/fleet.pot
@@ -995,12 +995,6 @@ msgid "Fuel Used by the vehicle"
 msgstr ""
 
 #. module: fleet
-#: model:ir.model.fields.selection,name:fleet.selection__fleet_vehicle__fuel_type__full_hybrid_gasoline
-#: model:ir.model.fields.selection,name:fleet.selection__fleet_vehicle_model__default_fuel_type__full_hybrid_gasoline
-msgid "Full Hybrid Gasoline"
-msgstr ""
-
-#. module: fleet
 #: model_terms:ir.ui.view,arch_db:fleet.fleet_vehicle_log_contract_view_search
 #: model_terms:ir.ui.view,arch_db:fleet.fleet_vehicle_view_search
 msgid "Future Activities"
@@ -1088,7 +1082,13 @@ msgstr ""
 #. module: fleet
 #: model:ir.model.fields.selection,name:fleet.selection__fleet_vehicle__fuel_type__hybrid
 #: model:ir.model.fields.selection,name:fleet.selection__fleet_vehicle_model__default_fuel_type__hybrid
-msgid "Hybrid"
+msgid "Hybrid Diesel"
+msgstr ""
+
+#. module: fleet
+#: model:ir.model.fields.selection,name:fleet.selection__fleet_vehicle__fuel_type__full_hybrid_gasoline
+#: model:ir.model.fields.selection,name:fleet.selection__fleet_vehicle_model__default_fuel_type__full_hybrid_gasoline
+msgid "Hybrid Gasoline"
 msgstr ""
 
 #. module: fleet

--- a/addons/fleet/models/fleet_vehicle_model.py
+++ b/addons/fleet/models/fleet_vehicle_model.py
@@ -5,10 +5,16 @@ from odoo import _, api, fields, models
 
 
 FUEL_TYPES = [
-    ('gasoline', 'Gasoline'), ('diesel', 'Diesel'), ('lpg', 'LPG'),
-    ('electric', 'Electric'), ('hybrid', 'Hybrid'), ('plug_in_hybrid_diesel', 'Plug-in Hybrid Diesel'),
-    ('plug_in_hybrid_gasoline', 'Plug-in Hybrid Gasoline'), ('full_hybrid_gasoline', 'Full Hybrid Gasoline'),
-    ('cng', 'CNG'), ('hydrogen', 'Hydrogen'),
+    ('diesel', 'Diesel'),
+    ('gasoline', 'Gasoline'),
+    ('hybrid', 'Hybrid Diesel'),
+    ('full_hybrid_gasoline', 'Hybrid Gasoline'),
+    ('plug_in_hybrid_diesel', 'Plug-in Hybrid Diesel'),
+    ('plug_in_hybrid_gasoline', 'Plug-in Hybrid Gasoline'),
+    ('cng', 'CNG'),
+    ('lpg', 'LPG'),
+    ('hydrogen', 'Hydrogen'),
+    ('electric', 'Electric'),
 ]
 
 class FleetVehicleModel(models.Model):


### PR DESCRIPTION
There was some confusion about all the types of hybrid vehicles.
Also changes the order in which they are displayed.

TaskId-2629318

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
