### PR TITLE
[FIX] l10n_latam_invoice_document: refund doc type

### DIFF
--- a/addons/l10n_latam_invoice_document/wizards/account_move_reversal.py
+++ b/addons/l10n_latam_invoice_document/wizards/account_move_reversal.py
@@ -35,7 +35,6 @@ class AccountMoveReversal(models.TransientModel):
     @api.depends('move_ids')
     def _compute_document_type(self):
         self.l10n_latam_available_document_type_ids = False
-        self.l10n_latam_document_type_id = False
         self.l10n_latam_use_documents = False
         for record in self:
             if len(record.move_ids) > 1:
@@ -52,7 +51,8 @@ class AccountMoveReversal(models.TransientModel):
                     'partner_id': record.move_ids.partner_id.id,
                     'company_id': record.move_ids.company_id.id,
                 })
-                record.l10n_latam_document_type_id = refund.l10n_latam_document_type_id
+                if record.l10n_latam_document_type_id not in refund.l10n_latam_available_document_type_ids._origin:
+                    record.l10n_latam_document_type_id = refund.l10n_latam_document_type_id
                 record.l10n_latam_available_document_type_ids = refund.l10n_latam_available_document_type_ids
 
     def _prepare_default_reversal(self, move):
@@ -60,7 +60,7 @@ class AccountMoveReversal(models.TransientModel):
         the wizard """
         res = super()._prepare_default_reversal(move)
         res.update({
-            'l10n_latam_document_type_id': self.l10n_latam_document_type_id.id,
+            'l10n_latam_document_type_id': self._context.get('l10n_latam_document_type_id', self.l10n_latam_document_type_id.id),
             'l10n_latam_document_number': self.l10n_latam_document_number,
         })
         return res

--- a/addons/l10n_latam_invoice_document/wizards/account_move_reversal_view.xml
+++ b/addons/l10n_latam_invoice_document/wizards/account_move_reversal_view.xml
@@ -15,6 +15,9 @@
                 <field name="l10n_latam_document_type_id" attrs="{'invisible': ['|', ('l10n_latam_use_documents', '=', False), ('refund_method', '=', 'refund')], 'required': [('l10n_latam_use_documents', '=', True), ('refund_method', '!=', 'refund')]}" options="{'no_open': True, 'no_create': True}"/>
                 <field name="l10n_latam_document_number" attrs="{'invisible': ['|', '|', ('l10n_latam_use_documents', '=', False), ('l10n_latam_manual_document_number', '=', False), ('refund_method', '=', 'refund')], 'required': [('l10n_latam_manual_document_number', '=', True), ('l10n_latam_use_documents', '=', True), ('refund_method', '!=', 'refund')]}"/>
             </field>
+            <button name="reverse_moves" position="attributes">
+                <attribute name="context">{'l10n_latam_document_type_id': l10n_latam_document_type_id}</attribute>
+            </button>
         </field>
     </record>
 


### PR DESCRIPTION
Prior to this change, if the user use a full refund option and choose a document type different than default one, the default document type was use regardless of the choosen one.

This was broken on this commit https://github.com/odoo/odoo/commit/dfd01b8c5c7e1177f37bf199790a0732a61eed78#diff-1369ca152be95632086495cfcfbd54a0d18d893c2389670ff1d516f1596f3e0d

The fix include two parts:
1. as l10n_latam_document_type_id is not stored, it's change is not saved and sended to to backend, we send it in the context. If there is no key on the context we get it from computed value (for eg refund created by python code)
2. Fix also to choose and available document type.

This should be FP only till v15, on master this should be applied https://github.com/odoo/odoo/pull/79529/files

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
