### PR TITLE
Show client name if exist

### DIFF
--- a/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
@@ -43,6 +43,15 @@
                 </t>
             </div>
             <br /><br />
+            <!-- Client name is exists -->
+            	<t t-if="receipt.client">
+                	<t>
+                		<div>---------------------------------------</div>
+                	</t>
+                <div><strong><h2><u>Client:</u> <t t-esc="receipt.client.name" /></h2></strong></div>
+                </t>
+            </div>
+            <br/>
 
             <!-- Orderlines -->
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This modification shows the client name, if a client is selected it shows it's name, else; the line is invisible.

Current behavior before PR:
No client name is visible in the ticket receipt.

Desired behavior after PR is merged:
Client name is visible and printable

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
