### PR TITLE
[FIX] product: help for field standard_price

### DIFF
--- a/addons/product/i18n/product.pot
+++ b/addons/product/i18n/product.pot
@@ -1125,7 +1125,7 @@ msgstr ""
 #: model:ir.model.fields,help:product.field_product_template__standard_price
 msgid ""
 "In Standard Price & AVCO: value of the product (automatically computed in AVCO).\n"
-"        In FIFO: value of the last unit that left the stock (automatically computed).\n"
+"        In FIFO: value of the next unit that will leave the stock (automatically computed).\n"
 "        Used to value the product when the purchase cost is not known (e.g. inventory adjustment).\n"
 "        Used to compute margins on sale orders."
 msgstr ""

--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -112,7 +112,7 @@ class ProductProduct(models.Model):
         digits='Product Price',
         groups="base.group_user",
         help="""In Standard Price & AVCO: value of the product (automatically computed in AVCO).
-        In FIFO: value of the last unit that left the stock (automatically computed).
+        In FIFO: value of the next unit that will leave the stock (automatically computed).
         Used to value the product when the purchase cost is not known (e.g. inventory adjustment).
         Used to compute margins on sale orders.""")
     volume = fields.Float('Volume', digits='Volume')

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -79,7 +79,7 @@ class ProductTemplate(models.Model):
         inverse='_set_standard_price', search='_search_standard_price',
         digits='Product Price', groups="base.group_user",
         help="""In Standard Price & AVCO: value of the product (automatically computed in AVCO).
-        In FIFO: value of the last unit that left the stock (automatically computed).
+        In FIFO: value of the next unit that will leave the stock (automatically computed).
         Used to value the product when the purchase cost is not known (e.g. inventory adjustment).
         Used to compute margins on sale orders.""")
 


### PR DESCRIPTION
Step to reproduce:
1) create a product with, the `Product Type` as `Storable Product` + a `Product Category` with a `Costing Method` set in `FIFO` mode and the Inventory Valuation in `Automated`.
2) create a Purchase Order for 1 unit of that product and set the unit price to 10.00. Confirm Order → Receive Products → Validate (the delivery) → Apply
3) create a second Purchase Order for 1 unit of the same product but set the unit price to a different price, like 20.00. Confirm Order → Receive Products → Validate (the delivery) → Apply
4) create a Sales Orders for 1 unit → Confirm → Smart button Delivery → Validate → Apply
5) check the cost on the product form of that product.
On the V13 it will be $10, so it's the last unit that left the stock
On V14 and upper, it will be $20, so the next product that will leave the stock.


The help popup for the field `standard_price` doesn't reflect the correct behavior. It's the standard price for the next unit instead of the last one.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
