### PR TITLE
[FIX] web_tour: do this.$el check before calling _delegateEvents()

### DIFF
--- a/addons/web_tour/static/src/js/tip.js
+++ b/addons/web_tour/static/src/js/tip.js
@@ -165,13 +165,13 @@ var Tip = Widget.extend({
             this._setupAnchor($anchor, $altAnchor);
         }
         this._bind_anchor_events();
-        this._delegateEvents();
         if (!this.$el) {
             // Ideally this case should not happen but this is still possible,
             // as update may be called before the `start` method is called.
             // The `start` method is calling _updatePosition too anyway.
             return;
         }
+        this._delegateEvents();
         this._updatePosition(true);
     },
 


### PR DESCRIPTION


Description of the issue/feature this PR addresses:
TypeError: this.$el is undefined

Current behavior before PR:

Desired behavior after PR is merged:
After this commit, the arbitrary js error in Odoo will be fixed.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
