### PR TITLE
[Master] Print client name in POS receipt if selected

### DIFF
--- a/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
@@ -43,7 +43,15 @@
                 </t>
             </div>
             <br /><br />
-
+            
+            <!-- Client name if exists -->
+            	<t t-if="receipt.client">
+                	<t>
+                		<div>---------------------------------------</div>
+                	</t>
+                <div><strong><h2><u>Client:</u> <t t-esc="receipt.client.name" /></h2></strong></div>
+                </t>
+        
             <!-- Orderlines -->
 
             <div class="orderlines">


### PR DESCRIPTION
Description of the issue/feature this PR addresses / Current behavior before PR:
If a client is selected, his name will not be add to the POS receipt.

Desired behavior after PR is merged:
If a client is selected, his name will be add to the POS receipt and will be printed.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
