### PR TITLE
Remove dead code / unused functions

### DIFF
--- a/addons/digest/controllers/portal.py
+++ b/addons/digest/controllers/portal.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import hmac
 
 from werkzeug.exceptions import Forbidden, NotFound
 from werkzeug.urls import url_encode
 
 from odoo import _
 from odoo.http import Controller, request, route
-from odoo.tools import consteq
 
 
 class DigestController(Controller):
@@ -18,7 +18,7 @@ class DigestController(Controller):
         # new route parameters
         if digest_sudo and token and user_id:
             correct_token = digest_sudo._get_unsubscribe_token(int(user_id))
-            if not consteq(correct_token, token):
+            if not hmac.compare_digest(correct_token, token):
                 raise NotFound()
             digest_sudo._action_unsubscribe_users(request.env['res.users'].sudo().browse(int(user_id)))
         # old route was given without any token or user_id but only for auth users

--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+import hmac
 import logging
 
 from werkzeug.urls import url_encode
@@ -8,7 +8,6 @@ from werkzeug.urls import url_encode
 from odoo import http
 from odoo.exceptions import AccessError
 from odoo.http import request
-from odoo.tools import consteq
 
 _logger = logging.getLogger(__name__)
 
@@ -27,7 +26,7 @@ class MailController(http.Controller):
         params = dict(request.params)
         params.pop('token', '')
         valid_token = request.env['mail.thread']._notify_encode_link(base_link, params)
-        return consteq(valid_token, str(token))
+        return hmac.compare_digest(valid_token, str(token))
 
     @classmethod
     def _check_token_and_record_or_redirect(cls, model, res_id, token):

--- a/addons/mail/models/mail_guest.py
+++ b/addons/mail/models/mail_guest.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import hmac
 
 import pytz
 import uuid
 
-from odoo.tools import consteq
 from odoo import _, api, fields, models
 from odoo.addons.base.models.res_partner import _tz_get
 from odoo.exceptions import UserError
@@ -37,7 +37,7 @@ class MailGuest(models.Model):
         if not guest_id or not guest_access_token:
             return self.env['mail.guest']
         guest = self.env['mail.guest'].browse(int(guest_id)).sudo().exists()
-        if not guest or not guest.access_token or not consteq(guest.access_token, guest_access_token):
+        if not guest or not guest.access_token or not hmac.compare_digest(guest.access_token, guest_access_token):
             return self.env['mail.guest']
         if not guest.timezone:
             timezone = self._get_timezone_from_request(request)

--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -201,7 +201,7 @@ class MassMailController(http.Controller):
         if not token or not user_id:
             raise werkzeug.exceptions.NotFound()
         user_id = int(user_id)
-        correct_token = consteq(token, request.env['mailing.mailing']._get_unsubscribe_token(user_id))
+        correct_token = hmac.compare_digest(token, request.env['mailing.mailing']._get_unsubscribe_token(user_id))
         user = request.env['res.users'].sudo().browse(user_id)
         if correct_token and user.has_group('mass_mailing.group_mass_mailing_user'):
             request.env['ir.config_parameter'].sudo().set_param('mass_mailing.mass_mailing_reports', False)

--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+import hmac
 import logging
 import pprint
 import re
@@ -11,7 +11,7 @@ from dateutil import relativedelta
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-from odoo.tools import consteq, format_amount, ustr
+from odoo.tools import format_amount, ustr
 from odoo.tools.misc import hmac as hmac_tool
 
 from odoo.addons.payment import utils as payment_utils
@@ -783,7 +783,7 @@ class PaymentTransaction(models.Model):
                 continue  # Skip transactions with unset (or not properly defined) callbacks
 
             valid_callback_hash = self._generate_callback_hash(model_sudo.id, res_id, method)
-            if not consteq(ustr(valid_callback_hash), callback_hash):
+            if not hmac.compare_digest(ustr(valid_callback_hash), callback_hash):
                 _logger.warning(
                     "invalid callback signature for transaction with reference %s", tx.reference
                 )

--- a/addons/payment/utils.py
+++ b/addons/payment/utils.py
@@ -1,8 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import hmac
 
 from odoo import fields
 from odoo.http import request
-from odoo.tools import consteq, float_round, ustr
+from odoo.tools import float_round, ustr
 from odoo.tools.misc import hmac as hmac_tool
 
 
@@ -37,7 +38,7 @@ def check_access_token(access_token, *values):
     :rtype: bool
     """
     authentic_token = generate_access_token(*values)
-    return access_token and consteq(ustr(access_token), authentic_token)
+    return access_token and hmac.compare_digest(ustr(access_token), authentic_token)
 
 
 # Transaction values formatting

--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -7,12 +7,9 @@ import logging
 import pprint
 from datetime import datetime
 
-import werkzeug
-
 from odoo import http
 from odoo.exceptions import ValidationError
 from odoo.http import request
-from odoo.tools import consteq
 
 _logger = logging.getLogger(__name__)
 
@@ -166,7 +163,7 @@ class StripeController(http.Controller):
             signed_payload.encode('utf-8'),
             hashlib.sha256
         ).hexdigest()
-        if not consteq(received_signature, expected_signature):
+        if not hmac.compare_digest(received_signature, expected_signature):
             _logger.warning("ignored event with invalid signature")
             return False
 

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
-import functools
+import hmac
 import json
 import logging
 import math
@@ -13,7 +13,6 @@ from werkzeug import urls
 from odoo import fields as odoo_fields, http, tools, _, SUPERUSER_ID
 from odoo.exceptions import ValidationError, AccessError, MissingError, UserError, AccessDenied
 from odoo.http import content_disposition, Controller, request, route
-from odoo.tools import consteq
 
 # --------------------------------------------------
 # Misc tools
@@ -393,7 +392,7 @@ class CustomerPortal(Controller):
             document.check_access_rights('read')
             document.check_access_rule('read')
         except AccessError:
-            if not access_token or not document_sudo.access_token or not consteq(document_sudo.access_token, access_token):
+            if not access_token or not document_sudo.access_token or not hmac.compare_digest(document_sudo.access_token, access_token):
                 raise
         return document_sudo
 

--- a/addons/sale_stock/controllers/portal.py
+++ b/addons/sale_stock/controllers/portal.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import hmac
 
 from odoo import exceptions, SUPERUSER_ID
 from odoo.addons.sale.controllers.portal import CustomerPortal
 from odoo.http import request, route
-from odoo.tools import consteq
 
 
 class SaleStockPortal(CustomerPortal):
@@ -16,7 +16,7 @@ class SaleStockPortal(CustomerPortal):
             picking.check_access_rights('read')
             picking.check_access_rule('read')
         except exceptions.AccessError:
-            if not access_token or not consteq(picking_sudo.sale_id.access_token, access_token):
+            if not access_token or not hmac.compare_digest(picking_sudo.sale_id.access_token, access_token):
                 raise
         return picking_sudo
 

--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from operator import attrgetter
 from re import findall as regex_findall
 from re import split as regex_split
 
-from odoo.tools.misc import attrgetter
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 

--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import collections
+import contextlib
 import json
 import itertools
 import operator
@@ -366,7 +367,7 @@ class SurveyQuestion(models.Model):
 
         if self.validation_required:
             # Answer is not in the right range
-            with tools.ignore(Exception):
+            with contextlib.suppress(Exception):
                 if not (self.validation_min_float_value <= floatanswer <= self.validation_max_float_value):
                     return {self.id: self.validation_error_msg}
         return {}

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import base64
+import contextlib
 import hashlib
 import io
 import itertools
@@ -147,7 +148,7 @@ class IrAttachment(models.Model):
         if not os.path.exists(full_path):
             dirname = os.path.dirname(full_path)
             if not os.path.isdir(dirname):
-                with tools.ignore(OSError):
+                with contextlib.suppress(OSError):
                     os.makedirs(dirname)
             open(full_path, 'ab').close()
 
@@ -199,7 +200,7 @@ class IrAttachment(models.Model):
                         removed += 1
                     except (OSError, IOError):
                         _logger.info("_file_gc could not unlink %s", self._full_path(fname), exc_info=True)
-                with tools.ignore(OSError):
+                with contextlib.suppress(OSError):
                     os.unlink(filepath)
 
         # commit to release the lock

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -4,12 +4,11 @@
 #----------------------------------------------------------
 import base64
 import hashlib
+import hmac
 import logging
 import mimetypes
 import os
 import re
-import sys
-import traceback
 
 import werkzeug
 import werkzeug.exceptions
@@ -20,7 +19,7 @@ import odoo
 from odoo import api, http, models, tools, SUPERUSER_ID
 from odoo.exceptions import AccessDenied, AccessError, MissingError
 from odoo.http import request, content_disposition, Response
-from odoo.tools import consteq, pycompat
+from odoo.tools import pycompat
 from odoo.tools.mimetypes import guess_mimetype
 from odoo.modules.module import get_resource_path, get_module_path
 
@@ -314,9 +313,9 @@ class IrHttp(models.AbstractModel):
         try:
             if model == 'ir.attachment':
                 record_sudo = record.sudo()
-                if access_token and not consteq(record_sudo.access_token or '', access_token):
+                if access_token and not hmac.compare_digest(record_sudo.access_token or '', access_token):
                     return None, 403
-                elif (access_token and consteq(record_sudo.access_token or '', access_token)):
+                elif (access_token and hmac.compare_digest(record_sudo.access_token or '', access_token)):
                     record = record_sudo
                 elif record_sudo.public:
                     record = record_sudo

--- a/odoo/addons/base/tests/test_func.py
+++ b/odoo/addons/base/tests/test_func.py
@@ -5,23 +5,7 @@ import functools
 
 from odoo.tests.common import BaseCase
 from odoo.tools import frozendict
-from odoo.tools.func import compose
 from odoo import Command
-
-
-class TestCompose(BaseCase):
-    def test_basic(self):
-        str_add = compose(str, lambda a, b: a + b)
-        self.assertEqual(str_add(1, 2), "3")
-
-    def test_decorator(self):
-        """ ensure compose() can be partially applied as a decorator
-        """
-        @functools.partial(compose, str)
-        def mul(a, b):
-            return a * b
-
-        self.assertEqual(mul(5, 42), u"210")
 
 
 class TestFrozendict(BaseCase):

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -19,7 +19,7 @@ import psycopg2
 import odoo
 from .. import SUPERUSER_ID
 from odoo.sql_db import TestCursor
-from odoo.tools import (config, existing_tables, ignore,
+from odoo.tools import (config, existing_tables,
                         lazy_classproperty, lazy_property, sql,
                         Collector, OrderedSet)
 from odoo.tools.lru import LRU

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -6,7 +6,7 @@
 """
 from collections import defaultdict, deque
 from collections.abc import Mapping
-from contextlib import closing, contextmanager
+from contextlib import closing, contextmanager, suppress
 from functools import partial
 from operator import attrgetter
 import logging
@@ -336,7 +336,7 @@ class Registry(Mapping):
             for field in Model._fields.values():
                 # dependencies of custom fields may not exist; ignore that case
                 exceptions = (Exception,) if field.base_field.manual else ()
-                with ignore(*exceptions):
+                with suppress(*exceptions):
                     dependencies[field] = OrderedSet(field.resolve_depends(self))
 
         # determine transitive dependencies

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+import contextlib
 import logging
 import logging.handlers
 import os
@@ -35,7 +35,7 @@ class PostgreSQLHandler(logging.Handler):
         dbname = tools.config['log_db'] if tools.config['log_db'] and tools.config['log_db'] != '%d' else ct_db
         if not dbname:
             return
-        with tools.ignore(Exception), tools.mute_logger('odoo.sql_db'), sql_db.db_connect(dbname, allow_uri=True).cursor() as cr:
+        with contextlib.suppress(Exception), tools.mute_logger('odoo.sql_db'), sql_db.db_connect(dbname, allow_uri=True).cursor() as cr:
             # preclude risks of deadlocks
             cr.execute("SET LOCAL statement_timeout = 1000")
             msg = tools.ustr(record.msg)

--- a/odoo/service/security.py
+++ b/odoo/service/security.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import hmac
 
 import odoo
 import odoo.exceptions
@@ -15,6 +16,6 @@ def compute_session_token(session, env):
 def check_session(session, env):
     self = env['res.users'].browse(session.uid)
     expected = self._compute_session_token(session.sid)
-    if expected and odoo.tools.misc.consteq(expected, session.session_token):
+    if expected and hmac.compare_digest(expected, session.session_token):
         return True
     return False

--- a/odoo/tools/func.py
+++ b/odoo/tools/func.py
@@ -6,7 +6,6 @@ __all__ = ['synchronized', 'lazy_classproperty', 'lazy_property',
 
 from functools import wraps
 from inspect import getsourcefile
-from json import JSONEncoder
 
 
 class lazy_property(object):
@@ -60,7 +59,6 @@ def conditional(condition, decorator):
         return decorator
     else:
         return lambda fn: fn
-
 def synchronized(lock_attr='_lock'):
     def decorator(func):
         @wraps(func)
@@ -92,21 +90,6 @@ def frame_codeinfo(fframe, back=0):
         return fname, lineno
     except Exception:
         return "<unknown>", ''
-
-def compose(a, b):
-    """ Composes the callables ``a`` and ``b``. ``compose(a, b)(*args)`` is
-    equivalent to ``a(b(*args))``.
-
-    Can be used as a decorator by partially applying ``a``::
-
-         @partial(compose, a)
-         def b():
-            ...
-    """
-    @wraps(b)
-    def wrapper(*args, **kwargs):
-        return a(b(*args, **kwargs))
-    return wrapper
 
 
 class _ClassProperty(property):

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -35,7 +35,6 @@ from operator import itemgetter
 import babel
 import babel.dates
 import markupsafe
-import passlib.utils
 import pytz
 import werkzeug.utils
 from lxml import etree
@@ -1510,12 +1509,10 @@ def format_duration(value):
     return '%02d:%02d' % (hours, minutes)
 
 
-def _consteq(str1, str2):
-    """ Constant-time string comparison. Suitable to compare bytestrings of fixed,
-        known length only, because length difference is optimized. """
-    return len(str1) == len(str2) and sum(ord(x)^ord(y) for x, y in zip(str1, str2)) == 0
+def consteq(s1, s2):
+    warnings.warn("`odoo.tools.consteq` is replaced by `hmac.compare_digest`", DeprecationWarning, stacklevel=2)
+    return hmac_lib.compare_digest(s1, s2)
 
-consteq = getattr(passlib.utils, 'consteq', _consteq)
 
 # forbid globals entirely: str/unicode, int/long, float, bool, tuple, list, dict, None
 class Unpickler(pickle_.Unpickler, object):

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -7,6 +7,7 @@ Miscellaneous tools used by OpenERP.
 """
 import cProfile
 import collections
+import contextlib
 import datetime
 import hmac as hmac_lib
 import hashlib
@@ -23,9 +24,9 @@ import time
 import traceback
 import types
 import unicodedata
+import warnings
 from collections import OrderedDict
 from collections.abc import Iterable, Mapping, MutableMapping, MutableSet
-from contextlib import contextmanager
 from difflib import HtmlDiff
 from functools import wraps
 from itertools import islice, groupby as itergroupby
@@ -1234,12 +1235,9 @@ class Reverse(object):
     def __le__(self, other): return self.val >= other.val
     def __lt__(self, other): return self.val > other.val
 
-@contextmanager
 def ignore(*exc):
-    try:
-        yield
-    except exc:
-        pass
+    warnings.warn("`odoo.tools.ignore` is replaced by `contextlib.suppress`", DeprecationWarning, stacklevel=2)
+    return contextlib.suppress(*exc)
 
 html_escape = markupsafe.escape
 

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -683,33 +683,6 @@ class unquote(str):
     def __repr__(self):
         return self
 
-class UnquoteEvalContext(defaultdict):
-    """Defaultdict-based evaluation context that returns
-       an ``unquote`` string for any missing name used during
-       the evaluation.
-       Mostly useful for evaluating OpenERP domains/contexts that
-       may refer to names that are unknown at the time of eval,
-       so that when the context/domain is converted back to a string,
-       the original names are preserved.
-
-       **Warning**: using an ``UnquoteEvalContext`` as context for ``eval()`` or
-       ``safe_eval()`` will shadow the builtins, which may cause other
-       failures, depending on what is evaluated.
-
-       Example (notice that ``section_id`` is preserved in the final
-       result) :
-
-       >>> context_str = "{'default_user_id': uid, 'default_section_id': section_id}"
-       >>> eval(context_str, UnquoteEvalContext(uid=1))
-       {'default_user_id': 1, 'default_section_id': section_id}
-
-       """
-    def __init__(self, *args, **kwargs):
-        super(UnquoteEvalContext, self).__init__(None, *args, **kwargs)
-
-    def __missing__(self, key):
-        return unquote(key)
-
 
 class mute_logger(logging.Handler):
     """Temporary suppress the logging.

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -355,9 +355,6 @@ except ImportError:
     xlsxwriter = None
 
 
-def to_xml(s):
-    return s.replace('&','&amp;').replace('<','&lt;').replace('>','&gt;')
-
 def get_iso_codes(lang):
     if lang.find('_') != -1:
         if lang.split('_')[0] == lang.split('_')[1].lower():

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -11,10 +11,8 @@ import contextlib
 import datetime
 import hmac as hmac_lib
 import hashlib
-import io
 import itertools
 import os
-import pickle as pickle_
 import re
 import socket
 import subprocess
@@ -22,7 +20,6 @@ import sys
 import threading
 import time
 import traceback
-import types
 import unicodedata
 import warnings
 from collections import OrderedDict
@@ -1496,28 +1493,6 @@ def format_duration(value):
 def consteq(s1, s2):
     warnings.warn("`odoo.tools.consteq` is replaced by `hmac.compare_digest`", DeprecationWarning, stacklevel=2)
     return hmac_lib.compare_digest(s1, s2)
-
-
-# forbid globals entirely: str/unicode, int/long, float, bool, tuple, list, dict, None
-class Unpickler(pickle_.Unpickler, object):
-    find_global = None # Python 2
-    find_class = None # Python 3
-def _pickle_load(stream, encoding='ASCII', errors=False):
-    if sys.version_info[0] == 3:
-        unpickler = Unpickler(stream, encoding=encoding)
-    else:
-        unpickler = Unpickler(stream)
-    try:
-        return unpickler.load()
-    except Exception:
-        _logger.warning('Failed unpickling data, returning default: %r',
-                        errors, exc_info=True)
-        return errors
-pickle = types.ModuleType(__name__ + '.pickle')
-pickle.load = _pickle_load
-pickle.loads = lambda text, encoding='ASCII': _pickle_load(io.BytesIO(text), encoding=encoding)
-pickle.dump = pickle_.dump
-pickle.dumps = pickle_.dumps
 
 
 class DotDict(dict):

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -665,22 +665,6 @@ def split_every(n, iterable, piece_maker=tuple):
         yield piece
         piece = piece_maker(islice(iterator, n))
 
-# port of python 2.6's attrgetter with support for dotted notation
-def resolve_attr(obj, attr):
-    for name in attr.split("."):
-        obj = getattr(obj, name)
-    return obj
-
-def attrgetter(*items):
-    if len(items) == 1:
-        attr = items[0]
-        def g(obj):
-            return resolve_attr(obj, attr)
-    else:
-        def g(obj):
-            return tuple(resolve_attr(obj, attr) for attr in items)
-    return g
-
 def discardattr(obj, key):
     """ Perform a ``delattr(obj, key)`` but without crashing if ``key`` is not present. """
     try:

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -458,19 +458,6 @@ def logged(f):
 
     return wrapper
 
-class profile(object):
-    def __init__(self, fname=None):
-        self.fname = fname
-
-    def __call__(self, f):
-        @wraps(f)
-        def wrapper(*args, **kwargs):
-            profile = cProfile.Profile()
-            result = profile.runcall(f, *args, **kwargs)
-            profile.dump_stats(self.fname or ("%s.cprof" % (f.__name__,)))
-            return result
-
-        return wrapper
 
 def detect_ip_addr():
     """Try a very crude method to figure out a valid external

--- a/odoo/tools/osutil.py
+++ b/odoo/tools/osutil.py
@@ -4,16 +4,12 @@
 """
 Some functions related to the os and os.path module
 """
-import logging
 import os
 import re
-import tempfile
 import zipfile
-
 from contextlib import contextmanager
-from os.path import join as opj
 
-_logger = logging.getLogger(__name__)
+from odoo.release import nt_service_name
 
 WINDOWS_RESERVED = re.compile(r'''
     ^
@@ -54,34 +50,6 @@ def clean_filename(name, replacement=''):
         return "Untitled"
     return re.sub(r'[^\w_.()\[\] -]+', replacement, name).lstrip('.-') or "Untitled"
 
-def listdir(dir, recursive=False):
-    """Allow to recursively get the file listing following symlinks, returns
-    paths relative to the provided `dir` except completely broken if the symlink
-    it follows leaves `dir`...
-    """
-    if not recursive:
-        _logger.getChild('listdir').warning("Deprecated: just call os.listdir...")
-    dir = os.path.normpath(dir)
-    if not recursive:
-        return os.listdir(dir)
-
-    res = []
-    for root, _, files in os.walk(dir, followlinks=True):
-        r = os.path.relpath(root, dir)
-        # FIXME: what should happen if root is outside dir?
-        yield from (opj(r, f) for f in files)
-    return res
-
-def walksymlinks(top, topdown=True, onerror=None):
-    _logger.getChild('walksymlinks').warning("Deprecated: use os.walk(followlinks=True) instead")
-    return os.walk(top, topdown=topdown, onerror=onerror, followlinks=True)
-
-@contextmanager
-def tempdir():
-    _logger.getChild('tempdir').warning("Deprecated: use tempfile.TemporaryDirectory")
-    with tempfile.TemporaryDirectory() as d:
-        yield d
-
 def zip_dir(path, stream, include_dir=True, fnct_sort=None):      # TODO add ignore list
     """
     : param fnct_sort : Function to be passed to "key" parameter of built-in
@@ -94,7 +62,7 @@ def zip_dir(path, stream, include_dir=True, fnct_sort=None):      # TODO add ign
         len_prefix += 1
 
     with zipfile.ZipFile(stream, 'w', compression=zipfile.ZIP_DEFLATED, allowZip64=True) as zipf:
-        for dirpath, dirnames, filenames in os.walk(path):
+        for dirpath, _, filenames in os.walk(path):
             filenames = sorted(filenames, key=fnct_sort)
             for fname in filenames:
                 bname, ext = os.path.splitext(fname)
@@ -106,49 +74,11 @@ def zip_dir(path, stream, include_dir=True, fnct_sort=None):      # TODO add ign
 
 
 if os.name != 'nt':
-    getppid = os.getppid
-    is_running_as_nt_service = lambda: False
+    def is_running_as_nt_service():
+        return False
 else:
-    import ctypes
     import win32service as ws
     import win32serviceutil as wsu
-
-    # based on http://mail.python.org/pipermail/python-win32/2007-June/006174.html
-    _TH32CS_SNAPPROCESS = 0x00000002
-    class _PROCESSENTRY32(ctypes.Structure):
-        _fields_ = [("dwSize", ctypes.c_ulong),
-                    ("cntUsage", ctypes.c_ulong),
-                    ("th32ProcessID", ctypes.c_ulong),
-                    ("th32DefaultHeapID", ctypes.c_ulong),
-                    ("th32ModuleID", ctypes.c_ulong),
-                    ("cntThreads", ctypes.c_ulong),
-                    ("th32ParentProcessID", ctypes.c_ulong),
-                    ("pcPriClassBase", ctypes.c_ulong),
-                    ("dwFlags", ctypes.c_ulong),
-                    ("szExeFile", ctypes.c_char * 260)]
-
-    def getppid():
-        CreateToolhelp32Snapshot = ctypes.windll.kernel32.CreateToolhelp32Snapshot
-        Process32First = ctypes.windll.kernel32.Process32First
-        Process32Next = ctypes.windll.kernel32.Process32Next
-        CloseHandle = ctypes.windll.kernel32.CloseHandle
-        hProcessSnap = CreateToolhelp32Snapshot(_TH32CS_SNAPPROCESS, 0)
-        current_pid = os.getpid()
-        try:
-            pe32 = _PROCESSENTRY32()
-            pe32.dwSize = ctypes.sizeof(_PROCESSENTRY32)
-            if not Process32First(hProcessSnap, ctypes.byref(pe32)):
-                raise OSError('Failed getting first process.')
-            while True:
-                if pe32.th32ProcessID == current_pid:
-                    return pe32.th32ParentProcessID
-                if not Process32Next(hProcessSnap, ctypes.byref(pe32)):
-                    return None
-        finally:
-            CloseHandle(hProcessSnap)
-
-    from contextlib import contextmanager
-    from odoo.release import nt_service_name
 
     def is_running_as_nt_service():
         @contextmanager
@@ -159,13 +89,9 @@ else:
                 ws.CloseServiceHandle(srv)
 
         try:
-            with close_srv(ws.OpenSCManager(None, None, ws.SC_MANAGER_ALL_ACCESS)) as hscm:
-                with close_srv(wsu.SmartOpenService(hscm, nt_service_name, ws.SERVICE_ALL_ACCESS)) as hs:
-                    info = ws.QueryServiceStatusEx(hs)
-                    return info['ProcessId'] == getppid()
+            with close_srv(ws.OpenSCManager(None, None, ws.SC_MANAGER_ALL_ACCESS)) as hscm,\
+                 close_srv(wsu.SmartOpenService(hscm, nt_service_name, ws.SERVICE_ALL_ACCESS)) as hs:
+                     info = ws.QueryServiceStatusEx(hs)
+                     return info['ProcessId'] == os.getppid()
         except Exception:
             return False
-
-if __name__ == '__main__':
-    from pprint import pprint as pp
-    pp(listdir('../report', True))

--- a/odoo/tools/osutil.py
+++ b/odoo/tools/osutil.py
@@ -91,7 +91,7 @@ else:
         try:
             with close_srv(ws.OpenSCManager(None, None, ws.SC_MANAGER_ALL_ACCESS)) as hscm,\
                  close_srv(wsu.SmartOpenService(hscm, nt_service_name, ws.SERVICE_ALL_ACCESS)) as hs:
-                     info = ws.QueryServiceStatusEx(hs)
-                     return info['ProcessId'] == os.getppid()
+                    info = ws.QueryServiceStatusEx(hs)
+                    return info['ProcessId'] == os.getppid()
         except Exception:
             return False

--- a/odoo/tools/osutil.py
+++ b/odoo/tools/osutil.py
@@ -89,9 +89,9 @@ else:
                 ws.CloseServiceHandle(srv)
 
         try:
-            with close_srv(ws.OpenSCManager(None, None, ws.SC_MANAGER_ALL_ACCESS)) as hscm,\
+            with close_srv(ws.OpenSCManager(None, None, ws.SC_MANAGER_ALL_ACCESS)) as hscm, \
                  close_srv(wsu.SmartOpenService(hscm, nt_service_name, ws.SERVICE_ALL_ACCESS)) as hs:
-                    info = ws.QueryServiceStatusEx(hs)
-                    return info['ProcessId'] == os.getppid()
+                info = ws.QueryServiceStatusEx(hs)
+                return info['ProcessId'] == os.getppid()
         except Exception:
             return False

--- a/rules/removed.sem
+++ b/rules/removed.sem
@@ -1,0 +1,32 @@
+rules:
+
+- id: use-contextlib-suppress
+  languages:
+  - python
+  message: Use contextlib.suppress over odoo.tools.misc.ignore.
+  pattern-either:
+    - pattern: odoo.tools.misc.ignore($X)
+    - pattern: odoo.tools.ignore($X)
+  fix: contextlib.suppress($X)
+  severity: ERROR
+
+- id: use-hmac-compare-digest
+  languages:
+  - python
+  message: hmac.compare_digest is the standard stdlib version
+  pattern-either:
+    - pattern: odoo.tools.consteq($X, $Y)
+    - pattern: odoo.tools.misc.consteq($X, $Y)
+    - pattern: passlib.utils.consteq($X, $Y)
+  fix: hmac.compare_digest($X, $Y)
+  severity: ERROR
+
+- id: use-operator-attrgetter
+  languages:
+  - python
+  message: attrgetter port with support for dotted notation has been removed
+  pattern-either:
+    - pattern: odoo.tools.attrgetter($X)
+    - pattern: odoo.tools.misc.attrgetter($X)
+  fix: operator.attrgetter($X)
+  severity: ERROR

--- a/rules/removed.sem
+++ b/rules/removed.sem
@@ -30,3 +30,12 @@ rules:
     - pattern: odoo.tools.misc.attrgetter($X)
   fix: operator.attrgetter($X)
   severity: ERROR
+
+- id: use-markupsafe
+  languages: [python]
+  severity: ERROR
+  message: to_xml is nonsense, use markupsafe.escape
+  pattern-either:
+    - pattern: odoo.tools.to_xml($X)
+    - pattern: odoo.tools.misc.to_xml($X)
+  fix: markupsafe.escape($X)


### PR DESCRIPTION
Extracted from #73535.

These functions are either unused (and not useful), or (now) duplicates of the standard library or an existing dependency.

wrt notes on the previous:

- the functions which were actually used internally have been reprecated rather than immediately removed, under the assumption that they might be used externally & co, they should be removed after odoo 16 has been released
- `logged` is considered potentially useful for dev / debugging (while profile is not a big gain and has lots of alternatives), so left in
- `dumpstacks`'s parameters are mandated by `signal.signal`

/cc @ryv-odoo 