### PR TITLE
[FIX] project: prevent html editor fixed size

### DIFF
--- a/addons/project/static/src/css/project.css
+++ b/addons/project/static/src/css/project.css
@@ -15,10 +15,6 @@
 }
 .o_form_project_tasks .o_wysiwyg_resizer {
   border: 0;
-  margin: 0 0px -40px 0px;
-}
-.o_form_project_tasks .o_form_sheet, .o_form_project_tasks .oe_form_field_html, .o_form_project_tasks .o_wysiwyg_wrapper {
-  margin-bottom: 0 !important;
 }
 
 .o_kanban_project_tasks .oe_kanban_align.badge {

--- a/addons/project/static/src/js/project_form.js
+++ b/addons/project/static/src/js/project_form.js
@@ -3,29 +3,12 @@
 import Dialog from 'web.Dialog';
 import FormView from 'web.FormView';
 import FormController from 'web.FormController';
-import { bus, _t } from 'web.core';
+import FormRenderer from 'web.FormRenderer';
+import { _t } from 'web.core';
 import { device } from 'web.config';
 import viewRegistry from 'web.view_registry';
 
 const ProjectFormController = FormController.extend({
-    on_attach_callback() {
-        this._super(...arguments);
-        if (!device.isMobile) {
-            bus.on("DOM_updated", this, this._onDomUpdated);
-        }
-    },
-    _onDomUpdated() {
-        const $editable = this.$el.find('.note-editable');
-        if ($editable.length) {
-            const resizerHeight = this.$el.find('.o_wysiwyg_resizer').outerHeight();
-            const newHeight = window.innerHeight - $editable.offset().top - resizerHeight - 1;
-            $editable.outerHeight(newHeight);
-        }
-    },
-    on_detach_callback() {
-        this._super(...arguments);
-        bus.off('DOM_updated', this._onDomUpdated);
-    },
     _getActionMenuItems(state) {
         if (!this.archiveEnabled || !state.data['recurrence_id']) {
             return this._super(...arguments);
@@ -112,10 +95,48 @@ const ProjectFormController = FormController.extend({
     }
 });
 
-export const ProjectFormView = FormView.extend({
+export const FormHtmlFieldExpanderMixin = {
+    bottomDistance: 0,
+    fieldQuerySelector: '.o_xxl_form_view .oe_form_field.oe_form_field_html',
+    on_attach_callback() {
+        this._super(...arguments);
+        this._fixDescriptionHeight();
+    },
+    _fixDescriptionHeight() {
+        if (device.isMobile) return;
+
+        const descriptionField = this.el.querySelector(this.fieldQuerySelector);
+        if (descriptionField) {
+            const editor = descriptionField.querySelector('.note-editable')
+            const elementToResize = editor || descriptionField
+            const minHeight = document.documentElement.clientHeight - elementToResize.getBoundingClientRect().top - this.bottomDistance;
+            elementToResize.style.minHeight = `${minHeight}px`
+        }
+    },
+    _updateView() {
+        this._super(...arguments);
+        this._fixDescriptionHeight();
+    },
+}
+
+const FormDescriptionExpanderRenderer = FormRenderer.extend(Object.assign({}, FormHtmlFieldExpanderMixin, {
+    // 58px is the sum of the top margin of o_form_sheet 12 px + the bottom padding of o_form_sheet 24px
+    // + 5px margin bottom (o_field_widget) + 1px border + the bottom padding of tab-pane 16 px.
+    bottomDistance: 58,
+}));
+
+export const FormDescriptionExpanderView = FormView.extend({
     config: Object.assign({}, FormView.prototype.config, {
+        Renderer: FormDescriptionExpanderRenderer,
+    }),
+})
+
+export const ProjectFormView = FormDescriptionExpanderView.extend({
+    config: Object.assign({}, FormDescriptionExpanderView.prototype.config, {
         Controller: ProjectFormController,
     }),
 });
 
 viewRegistry.add('project_form', ProjectFormView);
+
+viewRegistry.add('form_description_expander', FormDescriptionExpanderView)

--- a/addons/project/static/src/scss/project_form.scss
+++ b/addons/project/static/src/scss/project_form.scss
@@ -13,17 +13,9 @@
     padding: $o-horizontal-padding $o-horizontal-padding;
 }
 
-.o_form_view.o_form_project_update:not(.o_form_readonly), .o_form_view.o_form_project_update:not(.o_form_readonly) .o_form_sheet {
-    padding-bottom: 0;
-    margin-bottom: 0;
-}
-
 .o_project_update_description {
     .note-editable, .o_wysiwyg_resizer {
         border: 0;
-    }
-    &.oe_form_field_html, .o_wysiwyg_wrapper {
-        margin-bottom: 0;
     }
     &.oe_form_field_html .o_readonly {
         padding: $o-horizontal-padding $o-horizontal-padding;

--- a/addons/project/views/project_update_views.xml
+++ b/addons/project/views/project_update_views.xml
@@ -15,7 +15,7 @@
         <field name="name">project.update.view.form</field>
         <field name="model">project.update</field>
         <field name="arch" type="xml">
-            <form string="Project Update" class="o_form_project_update">
+            <form string="Project Update" class="o_form_project_update" js_class="form_description_expander">
                 <sheet>
                     <div class="oe_title">
                         <h1>
@@ -37,7 +37,7 @@
                     <separator/>
                     <notebook>
                         <page string="Description" name="description">
-                            <field name="description" widget="html_with_action" nolabel="1" class="o_project_update_description"/>
+                            <field name="description" widget="html_with_action" nolabel="1" class="o_project_update_description" options="{'resizable': false}"/>
                         </page>
                     </notebook>
                 </sheet>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -282,7 +282,7 @@
             <field name="name">project.project.form</field>
             <field name="model">project.project</field>
             <field name="arch" type="xml">
-                <form string="Project" class="o_form_project_project" delete="0">
+                <form string="Project" class="o_form_project_project" delete="0" js_class="form_description_expander">
                     <header>
                         <button name="%(project.project_share_wizard_action)d" string="Share Readonly" type="action" class="oe_highlight" groups="project.group_project_manager"
                         attrs="{'invisible': [('privacy_visibility', '!=', 'portal')]}" context="{'default_access_mode': 'read'}"/>
@@ -403,7 +403,7 @@
                     </group>
                     <notebook>
                         <page name="description" string="Description">
-                            <field name="description"/>
+                            <field name="description" options="{'resizable': false}"/>
                         </page>
                         <page name="settings" string="Settings">
                             <group>
@@ -938,7 +938,7 @@
                     </group>
                     <notebook>
                         <page name="description_page" string="Description">
-                            <field name="description" type="html" options="{'collaborative': true}"/>
+                            <field name="description" type="html" options="{'collaborative': true, 'resizable': false}"/>
                         </page>
                         <page name="sub_tasks_page" string="Sub-tasks" attrs="{'invisible': [('allow_subtasks', '=', False)]}">
                             <field name="child_ids" context="{'default_project_id': project_id if not parent_id or not display_project_id else display_project_id, 'default_user_ids': user_ids, 'default_parent_id': id, 'default_partner_id': partner_id}" widget="subtasks_one2many">


### PR DESCRIPTION
Prior this commit, the description field of both project.project and project.task
were displayed with the resizable bar and were displayed with a calculated height
which prevented to see the whole field.

After this commit, the resizable option is set to false which displays the whole
field content without the resizable bar.

task-2735599

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
