### PR TITLE
[FIX] stock: convert product description

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -11,6 +11,7 @@ from odoo.exceptions import UserError
 from odoo.osv import expression
 from odoo.tools import float_is_zero
 from odoo.tools.float_utils import float_round
+from odoo.tools.mail import html2plaintext, is_html_empty
 
 OPERATORS = {
     '<': py_operator.lt,
@@ -233,7 +234,7 @@ class Product(models.Model):
         """
         self.ensure_one()
         picking_code = picking_type_id.code
-        description = self.description or self.name
+        description = html2plaintext(self.description) if not is_html_empty(self.description) else self.name
         if picking_code == 'incoming':
             return self.description_pickingin or description
         if picking_code == 'outgoing':


### PR DESCRIPTION
In some cases, the SM description is incorrect

To reproduce the issue:
1. Create a product P
2. Create a receipt with 1 x P

Error: The description of the SM is incorrect: `<p><br></p>`. It should
be the name of P

Another example:
1. Create a product P:
    - Internal Notes: "Lorem Ipsum"
2. Create a receipt with 1 x P

Error: The description of the SM is incorrect: `<p>Lorem ipsum<br></p>`.
It should be "Lorem Ipsum"

Since [1], `product_template.description` is a HTML field.

[1] bea5790713020209e0527840b7dbc1ea4806b762

OPW-2732208