### PR TITLE
[REV] l10n_be: remove duplicate tax

### DIFF
--- a/addons/l10n_be/data/account_fiscal_position_tax_template_data.xml
+++ b/addons/l10n_be/data/account_fiscal_position_tax_template_data.xml
@@ -33,7 +33,7 @@
         </record>
         <record id="afpttn_intracom_7" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fiscal_position_template_3"/>
-            <field name="tax_src_id" ref="attn_VAT-OUT-21-L"/>
+            <field name="tax_src_id" ref="attn_VAT-OUT-21-S"/>
             <field name="tax_dest_id" ref="attn_VAT-OUT-00-EU-S"/>
         </record>
         <record id="afpttn_intracom_8" model="account.fiscal.position.tax.template">
@@ -151,6 +151,11 @@
             <field name="tax_src_id" ref="attn_VAT-OUT-12-L"/>
             <field name="tax_dest_id" ref="attn_VAT-OUT-00-ROW"/>
         </record>
+        <record id="afpttn_extracom_7" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fiscal_position_template_2"/>
+            <field name="tax_src_id" ref="attn_VAT-OUT-21-S"/>
+            <field name="tax_dest_id" ref="attn_VAT-OUT-00-ROW"/>
+        </record>
         <record id="afpttn_extracom_8" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fiscal_position_template_2"/>
             <field name="tax_src_id" ref="attn_VAT-OUT-21-L"/>
@@ -244,6 +249,11 @@
         <record id="afpttn_cocontractant_6" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fiscal_position_template_4"/>
             <field name="tax_src_id" ref="attn_VAT-OUT-12-L"/>
+            <field name="tax_dest_id" ref="attn_VAT-OUT-00-CC"/>
+        </record>
+        <record id="afpttn_cocontractant_7" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fiscal_position_template_4"/>
+            <field name="tax_src_id" ref="attn_VAT-OUT-21-S"/>
             <field name="tax_dest_id" ref="attn_VAT-OUT-00-CC"/>
         </record>
         <record id="afpttn_cocontractant_8" model="account.fiscal.position.tax.template">

--- a/addons/l10n_be/data/account_tax_template_data.xml
+++ b/addons/l10n_be/data/account_tax_template_data.xml
@@ -42,6 +42,47 @@
             ]"/>
         </record>
 
+        <record id="attn_VAT-OUT-21-S" model="account.tax.template">
+            <field name="sequence">11</field>
+            <field name="description">TVA 21%</field>
+            <field name="name">21% S.</field>
+            <field name="price_include" eval="0"/>
+            <field name="amount">21</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">sale</field>
+            <field name="active" eval="False"/>
+            <field name="chart_template_id" ref="l10nbe_chart_template"/>
+            <field name="tax_group_id" ref="tax_group_tva_21"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_03')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('a451'),
+                    'plus_report_line_ids': [ref('tax_report_line_54')]
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_49')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('a451'),
+                    'plus_report_line_ids': [ref('tax_report_line_64')],
+                }),
+            ]"/>
+        </record>
+
         <record id="attn_VAT-OUT-12-S" model="account.tax.template">
             <field name="sequence">20</field>
             <field name="description">TVA 12%</field>


### PR DESCRIPTION
This reverts commit 11fd24856e436136236d67f01dd88acc00105e9b.

Removing the "21% S." tax made sense for Belgium,
but created an issue for the mapping of fiscal positions.
A task is being created to use the tax_scope instead (in master).

Issue: https://github.com/odoo/odoo/pull/77549#issuecomment-1000103421

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
