### PR TITLE
[IMP] packaging: debian nginx and certbot config

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: odoo
 Section: net
 Priority: optional
 Maintainer: Odoo S.A. <info@odoo.com>
-Uploaders: Aaron Bohy <aab@odoo.com>, Simon Lejeune <sle@odoo.com>
+Uploaders: Christophe Monniez <moc@odoo.com>
 Build-Depends: debhelper-compat (= 12), dh-python, python3, rsync, python3-setuptools
 Standards-Version: 4.5.0
 Homepage: http://www.odoo.com/
@@ -15,6 +15,7 @@ Depends:
  ${misc:Depends},
  ${python3:Depends},
  adduser,
+ debconf (>= 1.5.61),
 # support for multilingual fonts
  fonts-dejavu-core | fonts-freefont-ttf | fonts-freefont-otf | fonts-noto-core,
  fonts-inconsolata,
@@ -55,6 +56,7 @@ Depends:
  python3-xlsxwriter,
  python3-xlrd,
  python3-zeep,
+ ucf,
 Pre-Depends: ${misc:Pre-Depends}
 Conflicts: tinyerp-server, openerp-server, openerp-web, openerp
 Replaces: tinyerp-server, openerp-server, openerp-web, openerp
@@ -62,6 +64,10 @@ Recommends:
  ${python3:Recommends},
  postgresql,
  python3-ldap,
+Suggests:
+ nginx,
+ certbot,
+ python3-certbot-nginx,
 Description: Open Source Apps To Grow Your Business
  Odoo, formerly known as OpenERP, is a suite of open-source business apps
  written in Python and released under the LGPLv3 license. This suite of

--- a/debian/dirs
+++ b/debian/dirs
@@ -1,0 +1,1 @@
+etc/odoo

--- a/debian/install
+++ b/debian/install
@@ -1,2 +1,3 @@
-debian/odoo.conf /etc/odoo
-README.md /usr/share/doc/odoo
+debian/odoo.conf usr/share/doc/odoo
+README.md usr/share/doc/odoo
+debian/odoo-nginx-site.conf usr/share/doc/odoo

--- a/debian/odoo-nginx-site.conf
+++ b/debian/odoo-nginx-site.conf
@@ -1,0 +1,40 @@
+#odoo server
+upstream odoo {
+ server 127.0.0.1:8069;
+}
+upstream odoochat {
+ server 127.0.0.1:8072;
+}
+
+server {
+ listen 80;
+ server_name odoo.mycompany.com;
+ proxy_read_timeout 720s;
+ proxy_connect_timeout 720s;
+ proxy_send_timeout 720s;
+
+ # Add Headers for odoo proxy mode
+ proxy_set_header X-Forwarded-Host $host;
+ proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+ proxy_set_header X-Forwarded-Proto $scheme;
+ proxy_set_header X-Real-IP $remote_addr;
+
+ # log
+ access_log /var/log/nginx/odoo.access.log;
+ error_log /var/log/nginx/odoo.error.log;
+
+ # Redirect longpoll requests to odoo longpolling port
+ location /longpolling {
+ proxy_pass http://odoochat;
+ }
+
+ # Redirect requests to odoo backend server
+ location / {
+   proxy_redirect off;
+   proxy_pass http://odoo;
+ }
+
+ # common gzip
+ gzip_types text/css text/scss text/plain text/xml application/xml application/json application/javascript;
+ gzip on;
+}

--- a/debian/odoo.service
+++ b/debian/odoo.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Odoo Open Source ERP and CRM
-After=network.target
+After=network.target postgresql.service
 
 [Service]
 Type=simple

--- a/debian/odoo.templates
+++ b/debian/odoo.templates
@@ -1,0 +1,11 @@
+Template: odoo-nginx/server_name
+Type: string
+Default: foo.bar.com
+Description: Server name for nginx configuration
+ This is what nginx will listen for to handle requests for the Odoo server.
+
+Template: odoo-certbot/email
+Type: string
+Default: email@example.com
+Description: Email address
+ This address is used to register let's encrypt certificate.

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,15 +1,96 @@
 #!/bin/sh
 
 set -e
+. /usr/share/debconf/confmodule
 
 ODOO_CONFIGURATION_FILE=/etc/odoo/odoo.conf
 ODOO_GROUP="odoo"
 ODOO_DATA_DIR=/var/lib/odoo
 ODOO_LOG_DIR=/var/log/odoo
 ODOO_USER="odoo"
+NGINX_ODOO_FILE=/etc/nginx/sites-available/odoo-deb.conf
+TEMPODOOCONF=$(mktemp -t odoo.conf.XXXXXXXXXX)
+
+configure_nginx() {
+    # compute available CPU's and FQDN
+    NBWORKERS=$(($(nproc)*2+1))
+
+    # update odoo configuration file
+    # setting number of workers
+    if ! grep -q workers "$TEMPODOOCONF" ; then
+        echo "workers = $NBWORKERS" >> "$TEMPODOOCONF"
+    else
+        sed -i -e "s/workers \?= \?[[:digit:]]\+/workers = $NBWORKERS/" "$TEMPODOOCONF"
+    fi
+
+    # setting proxy_mode
+    if ! grep -q proxy_mode "$TEMPODOOCONF" ; then
+            echo "proxy_mode = True" >> "$TEMPODOOCONF"
+        else
+            sed -i -e "s/proxy_mode \?= \?False/proxy_mode = True/" "$TEMPODOOCONF"
+    fi
+
+    # update odoo nginx configuration file
+    tempnginxconf=$(mktemp -t odoo-nginx.conf.XXXXXXXXXX)
+    if [ -e "$NGINX_ODOO_FILE" ]; then
+        cat  "$NGINX_ODOO_FILE" > "$tempnginxconf"
+    else
+        cat /usr/share/doc/odoo/odoo-nginx-site.conf > "$tempnginxconf"
+    fi
+
+    db_get odoo-nginx/server_name || true
+    if [ -n "$RET"  ] && [ "$RET" = "foo.bar.com" ]; then
+        FQDN=$(hostname --fqdn)
+        db_set odoo-nginx/server_name "${FQDN}"
+    fi
+
+    db_input high odoo-nginx/server_name || true
+    db_go || true
+
+    db_get odoo-nginx/server_name || true
+    if [ -n "$RET"  ]; then
+        SERVERNAME=$RET
+        sed -i -e "s/server_name odoo.mycompany.com/server_name ${SERVERNAME}/g" "$tempnginxconf"
+    fi
+
+    ucf --debconf-ok --three-way "$tempnginxconf" "$NGINX_ODOO_FILE"
+    ucfr odoo "$NGINX_ODOO_FILE"
+    rm -f "$tempnginxconf"
+
+    # enable the odoo site
+    ln -fs $NGINX_ODOO_FILE /etc/nginx/sites-enabled/
+    # reload nginx
+    if [ -d /run/systemd/system ]; then
+        deb-systemd-invoke reload nginx > /dev/null || true
+    fi
+
+    # let'sencrypt
+    if dpkg -s certbot python3-certbot-nginx > /dev/null 2>&1 && [ ! -e "/etc/letsencrypt/live/${SERVERNAME}" ]; then
+        db_input high odoo-certbot/email || true
+        db_go || true
+        db_get odoo-certbot/email || true
+        if [ -n "$RET"  ]; then
+            certbot -n -q --nginx --agree-tos -m "$RET" -d "${SERVERNAME}"
+        fi
+    fi;
+}
 
 case "${1}" in
-    configure)
+    configure | reconfigure)
+        if [ -e "$ODOO_CONFIGURATION_FILE" ]; then
+            cat  "$ODOO_CONFIGURATION_FILE" > "$TEMPODOOCONF"
+        else
+            cat /usr/share/doc/odoo/odoo.conf > "$TEMPODOOCONF"
+        fi
+        # configure nginx if installed
+        if dpkg -s nginx > /dev/null 2>&1; then
+            configure_nginx
+        fi;
+
+        ucf --debconf-ok --three-way "$TEMPODOOCONF" "$ODOO_CONFIGURATION_FILE"
+        ucfr odoo "$ODOO_CONFIGURATION_FILE"
+        rm -f "$TEMPODOOCONF"
+
         if ! getent passwd | grep -q "^odoo:"; then
             adduser --system --home $ODOO_DATA_DIR --quiet --group $ODOO_USER
         fi


### PR DESCRIPTION
When a user installs the Odoo Debian package for the first time, it can
be tedious to configure the webserver as a reverse proxy and manage ssl
certificates.

With this commit, when the `nginx` package is installed, a basic
configuration file for Odoo is installed. The user will be prompted for
the domain name to use.

Also, if the `certbot` and `python3-certbot-nginx` packages are
installed, a `Let's Encrypt` certificate will be automatically obtained.
The user will be prompted for an email address.

Also, with this commit, the `/etc/odoo/odoo.conf` and
`/etc/nginx/sites-available/odoo/conf` files are managed by ucf.
It means that the user changes to those files will be preserved during
upgrades.
