### PR TITLE
[FIX] odoo: Related selection field not properly setup

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2416,7 +2416,7 @@ class Selection(Field):
         raise ValueError("Wrong value for %s: %r" % (self, value))
 
     def convert_to_export(self, value, record):
-        if not isinstance(self.selection, list):
+        if not isinstance(self.selection, list) and not callable(self.selection):
             # FIXME: this reproduces an existing buggy behavior!
             return value if value else ''
         for item in self._description_selection(record.env):


### PR DESCRIPTION
Steps to  reproduce the issue:

- Go to Accounting -> Customers -> Payments
- Export the table in XLS

Bug:

The field Status was exported with the value instead of the name
The field Status is a related selection field from move_id (account.move)

opw:2715414