### PR TITLE
[FIX] payment: Payments acquirers of not selected companies shown

### DIFF
--- a/addons/payment/security/payment_security.xml
+++ b/addons/payment/security/payment_security.xml
@@ -2,6 +2,12 @@
 <odoo>
     <data noupdate="1">
 
+        <record id="payment_acquirer_company_rule" model="ir.rule">
+            <field name="name">Access acquirers in own companies only</field>
+            <field name="model_id" ref="payment.model_payment_acquirer"/>
+            <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+        </record>
+
         <record id="payment_transaction_user_rule" model="ir.rule">
             <field name="name">Access own payment transaction only</field>
             <field name="model_id" ref="payment.model_payment_transaction"/>


### PR DESCRIPTION
The issue:
Payment acquirers cannot be restricted by company.

Expected behavior:
Payment acquirers can be restricted by company.

Steps to reproduce:

1. Go to the list of payment acquirers in website > Configuration >
Ecommerce > Payment acquirers or Accounting > Configuration >
Payments > Payment acquirers

2. Select the list view and alter a payment acquirers' company to an
inactive company.

I add a record rule to filter the results by selected company.

opw-2724217
