### PR TITLE
14.0 account dashboard optimization avd

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -507,6 +507,7 @@ class AccountBankStatementLine(models.Model):
     # == Business fields ==
     move_id = fields.Many2one(
         comodel_name='account.move',
+        auto_join=True,
         string='Journal Entry', required=True, readonly=True, ondelete='cascade',
         check_company=True)
     statement_id = fields.Many2one(

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -39,6 +39,14 @@ class AccountMove(models.Model):
     _check_company_auto = True
     _sequence_index = "journal_id"
 
+    def init(self):
+        self.env.cr.execute("""
+            CREATE INDEX IF NOT EXISTS account_move_to_check_idx
+            ON account_move(journal_id) WHERE to_check = true;
+            CREATE INDEX IF NOT EXISTS account_move_payment_idx
+            ON account_move(journal_id, state, payment_state, move_type, date);
+        """)
+
     @property
     def _sequence_monthly_regex(self):
         return self.journal_id.sequence_override_regex or super()._sequence_monthly_regex


### PR DESCRIPTION
This PR contains two commits cherry-picked from #66924.

From #66924 discussions, it is currently blocked because commit 37c3719
uses tools.ormcache and thus awaits al's validation. 

There are currently two tickets in the support perf pipe that are about
slow Accounting Dashboard opening. According to a local benchmark
(that can be found below), merging these two commits is sufficient
to have a good enough speed-up that would allow to close the
two aforementioned tickets.

Moreover these two commits can be safely deployed to stable.

#### speedup

Customer DB, 65 cash/bank account_journal, 30k account_bank_statement_line,
330k account_move.

- account_journal._get_last_bank_statement (state = "posted") avg time: `119 ms -> 7 ms`.
- account_journal_dashboard._kanban_dashboard (33 journals) avg time: `7.5s -> 1.06s`.
- Accounting App search_read: `12.20s -> 3.40s`.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
