### PR TITLE
[FIX] sale_project : display SO stat button on task in mobile

### DIFF
--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -41,7 +41,7 @@
         <field name="inherit_id" ref="project.view_task_form2"/>
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
-                <button class="d-none d-md-inline oe_stat_button"
+                <button class="oe_stat_button"
                         type="object" name="action_view_so" icon="fa-dollar"
                         attrs="{'invisible': [('sale_order_id', '=', False)]}"
                         string="Sales Order"


### PR DESCRIPTION
Steps :
- In mobile, go to Task

Issue :
- "Sales Order" stat button is not displayed.

Cause :
- This button's classe are :
	- d-md-inline = displayed when size is medium+.
	- d-none = or else not displayed
- In the past, there was a field SO in the form,
	which made this button unnecessary and taking space.

Fix :
- Now that this field isn't present anymore, delete d-none part.

opw-2722535

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
