### PR TITLE
[FIX] account : No cash journal

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -6073,6 +6073,13 @@ msgid ""
 msgstr ""
 
 #. module: point_of_sale
+#: code:addons/point_of_sale/models/account_journal.py:0
+#, python-format
+msgid ""
+"This journal is associated with a payment method. You cannot modify its type"
+msgstr ""
+
+#. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/ChromeWidgets/DebugWidget.js:0
 #, python-format

--- a/addons/point_of_sale/models/account_journal.py
+++ b/addons/point_of_sale/models/account_journal.py
@@ -1,10 +1,16 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 # Copyright (C) 2004-2008 PC Solutions (<http://pcsol.be>). All Rights Reserved
-from odoo import fields, models, api
-
+from odoo import fields, models, api, _
+from odoo.exceptions import ValidationError
 
 class AccountJournal(models.Model):
     _inherit = 'account.journal'
 
     pos_payment_method_ids = fields.One2many('pos.payment.method', 'journal_id', string='Point of Sale Payment Methods')
+
+    @api.constrains('type')
+    def _check_type(self):
+        methods = self.env['pos.payment.method'].sudo().search([("journal_id", "=", self.id)])
+        if methods:
+            raise ValidationError(_("This journal is associated with a payment method. You cannot modify its type"))


### PR DESCRIPTION
Current behavior:
When changing the type of a payment journal used in a cash payment method you couldn't close a PoS that used this payment method

Steps to reproduce:
- Point of Sale > Configuration > Payment Methods
- Select 'Cash' payment method, go to journal 'Cash', edit the type to 'Bank'
- Go to a Pos session, then try to close it.

opw-2732933

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
