### PR TITLE
[FIX] base: incorrect UserError initialisation

### DIFF
--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -384,8 +384,8 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
             or super()._valid_field_parameter(field, name)
         )
 
-    def copy(self, values):
-        raise UserError(_("Cannot duplicate configuration!"), "")
+    def copy(self, default=None):
+        raise UserError(_("Cannot duplicate configuration!"))
 
     @api.model
     def fields_view_get(self, view_id=None, view_type='form',


### PR DESCRIPTION
Apparently a migration error in
0fd773a486fbc1aeef7f00ec5eab3eaf0e4c6a9d, probably never noticed
because nobody ever tries to copy config objects since there's a
bespoke widget, and it's specifically forbidden.

Also fix the signature of the method itself to match the normal one.

Moved over from #73535