### PR TITLE
[IMP] core: deduplicate `@locked` and `@synchronized`, use in Registry

### DIFF
--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -9,7 +9,6 @@ the ORM does, in fact.
 """
 
 from contextlib import contextmanager
-from functools import wraps
 import itertools
 import logging
 import time
@@ -24,6 +23,8 @@ from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT, ISOLATION_LEVEL_READ
 from psycopg2.pool import PoolError
 from psycopg2.sql import SQL, Identifier
 from werkzeug import urls
+
+from .tools.func import frame_codeinfo, locked
 
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
 
@@ -43,7 +44,6 @@ psycopg2.extensions.register_type(psycopg2.extensions.new_type((700, 701, 1700,)
 
 
 from . import tools
-from .tools.func import frame_codeinfo
 
 from .tools import parse_version as pv
 if pv(psycopg2.__version__) < pv('2.7'):
@@ -654,6 +654,7 @@ class PsycoConnection(psycopg2.extensions.connection):
     def lobject(*args, **kwargs):
         pass
 
+
 class ConnectionPool(object):
     """ The pool of connections to database(s)
 
@@ -663,17 +664,6 @@ class ConnectionPool(object):
         The connections are *not* automatically closed. Only a close_db()
         can trigger that.
     """
-
-    def locked(fun):
-        @wraps(fun)
-        def _locked(self, *args, **kwargs):
-            self._lock.acquire()
-            try:
-                return fun(self, *args, **kwargs)
-            finally:
-                self._lock.release()
-        return _locked
-
     def __init__(self, maxconn=64):
         self._connections = []
         self._maxconn = max(maxconn, 1)

--- a/odoo/tools/func.py
+++ b/odoo/tools/func.py
@@ -8,6 +8,7 @@ from functools import wraps
 from inspect import getsourcefile
 from json import JSONEncoder
 
+from decorator import decorator
 
 class lazy_property(object):
     """ Decorator for a lazy property of an object, i.e., an object attribute
@@ -62,17 +63,12 @@ def conditional(condition, decorator):
         return lambda fn: fn
 
 def synchronized(lock_attr='_lock'):
-    def decorator(func):
-        @wraps(func)
-        def wrapper(self, *args, **kwargs):
-            lock = getattr(self, lock_attr)
-            try:
-                lock.acquire()
-                return func(self, *args, **kwargs)
-            finally:
-                lock.release()
-        return wrapper
-    return decorator
+    @decorator
+    def locked(func, inst, *args, **kwargs):
+        with getattr(inst, lock_attr):
+            return func(inst, *args, **kwargs)
+    return locked
+locked = synchronized()
 
 def frame_codeinfo(fframe, back=0):
     """ Return a (filename, line) pair for a previous frame .

--- a/odoo/tools/lru.py
+++ b/odoo/tools/lru.py
@@ -2,7 +2,7 @@
 import collections
 import threading
 
-from .func import synchronized
+from .func import locked
 
 __all__ = ['LRU']
 
@@ -19,7 +19,7 @@ class LRU(object):
         for key, value in pairs:
             self[key] = value
 
-    @synchronized()
+    @locked
     def __contains__(self, obj):
         return obj in self.d
 
@@ -29,31 +29,31 @@ class LRU(object):
         except KeyError:
             return val
 
-    @synchronized()
+    @locked
     def __getitem__(self, obj):
         a = self.d[obj]
         self.d.move_to_end(obj, last=False)
         return a
 
-    @synchronized()
+    @locked
     def __setitem__(self, obj, val):
         self.d[obj] = val
         self.d.move_to_end(obj, last=False)
         while len(self.d) > self.count:
             self.d.popitem(last=True)
 
-    @synchronized()
+    @locked
     def __delitem__(self, obj):
         del self.d[obj]
 
-    @synchronized()
+    @locked
     def __len__(self):
         return len(self.d)
 
-    @synchronized()
+    @locked
     def pop(self,key):
         return self.d.pop(key)
 
-    @synchronized()
+    @locked
     def clear(self):
         self.d.clear()


### PR DESCRIPTION
It's not entirely clear whether `@synchronized` is even useful, but keep it for now. `locked` is just the default instance of `@synchronised`.

- rewrite `@synchronized` using `decorator`, don't fold everything into a single call as there's a potential for parametric conflict
- remove the independent `locked` in `sql_db.py`
- convert `lru` to `locked`
- move `Registry` over to `locked` where applicable
