### PR TITLE
[FIX] l10n_it_stock_ddt: take care of uom in price calculation

### DIFF
--- a/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
+++ b/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
@@ -119,7 +119,7 @@
                                         <span t-field="move.product_uom" groups="uom.group_uom"/>
                                     </td>
                                     <td>
-                                        <t t-set="lst_price" t-value="move.product_id.lst_price * move.quantity_done"/>
+                                        <t t-set="lst_price" t-value="move.product_id.lst_price * move.product_qty"/>
                                         <span t-esc="lst_price"  t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
                                         <t t-set="total_value" t-value="total_value + lst_price"/>
                                     </td>


### PR DESCRIPTION
When multiplying price by quantity we need to have the quantity
in the standard uom.  This was introduced by the changes in
PR #78184

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
