### PR TITLE
Remove old features `_sequence`/`format_column`/`deprecated` and refactor `_write`

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -60,8 +60,7 @@ class SaleOrder(models.Model):
         if value is not None:
             _logger.debug("Table '%s': setting default value of new column %s to %r",
                 self._table, column_name, value)
-            query = 'UPDATE "%s" SET "%s"=%s WHERE "%s" IS NULL' % (
-                self._table, column_name, field.column_format, column_name)
+            query = f'UPDATE "{self._table}" SET "{column_name}" = %s WHERE "{column_name}" IS NULL'
             self._cr.execute(query, (value,))
 
     @api.depends('picking_ids.date_done')

--- a/addons/website/models/ir_attachment.py
+++ b/addons/website/models/ir_attachment.py
@@ -12,8 +12,6 @@ class Attachment(models.Model):
 
     _inherit = "ir.attachment"
 
-    # related for backward compatibility with saas-6
-    website_url = fields.Char(string="Website URL", related='local_url', deprecated=True, readonly=False)
     key = fields.Char(help='Technical field used to resolve multiple attachments in a multi-website environment.')
     website_id = fields.Many2one('website')
 

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -170,7 +170,6 @@ class IrActionsActWindow(models.Model):
     _description = 'Action Window'
     _table = 'ir_act_window'
     _inherit = 'ir.actions.actions'
-    _sequence = 'ir_actions_id_seq'
     _order = 'name'
 
     @api.constrains('res_model', 'binding_model_id')
@@ -348,7 +347,6 @@ class IrActionsActUrl(models.Model):
     _description = 'Action URL'
     _table = 'ir_act_url'
     _inherit = 'ir.actions.actions'
-    _sequence = 'ir_actions_id_seq'
     _order = 'name'
 
     name = fields.Char(string='Action Name', translate=True)
@@ -386,7 +384,6 @@ class IrActionsServer(models.Model):
     _description = 'Server Actions'
     _table = 'ir_act_server'
     _inherit = 'ir.actions.actions'
-    _sequence = 'ir_actions_id_seq'
     _order = 'sequence,name'
 
     DEFAULT_PYTHON_CODE = """# Available variables:
@@ -662,7 +659,6 @@ class IrActionsServer(models.Model):
 class IrServerObjectLines(models.Model):
     _name = 'ir.server.object.lines'
     _description = 'Server Action value mapping'
-    _sequence = 'ir_actions_id_seq'
 
     server_id = fields.Many2one('ir.actions.server', string='Related Server Action', ondelete='cascade')
     col1 = fields.Many2one('ir.model.fields', string='Field', required=True, ondelete='cascade')
@@ -818,7 +814,6 @@ class IrActionsActClient(models.Model):
     _description = 'Client Action'
     _inherit = 'ir.actions.actions'
     _table = 'ir_act_client'
-    _sequence = 'ir_actions_id_seq'
     _order = 'name'
 
     name = fields.Char(string='Action Name', translate=True)

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -86,7 +86,6 @@ class IrActionsReport(models.Model):
     _description = 'Report Action'
     _inherit = 'ir.actions.actions'
     _table = 'ir_act_report_xml'
-    _sequence = 'ir_actions_id_seq'
     _order = 'name'
 
     name = fields.Char(translate=True)

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1568,7 +1568,7 @@ class TestOne2many(TransactionCase):
                         SELECT "res_partner_bank"."partner_id"
                         FROM "res_partner_bank"
                         WHERE ((
-                            "res_partner_bank"."id" IN (%s,%s,%s)
+                            "res_partner_bank"."id" IN %s
                         ) AND (
                             "res_partner_bank"."sanitized_acc_number"::text LIKE %s
                         ))

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -3388,7 +3388,7 @@ class TestFieldParametersValidation(common.TransactionCase):
 def insert(model, *fnames):
     """ Return the expected query string to INSERT the given columns. """
     columns = sorted(fnames + ('create_uid', 'create_date', 'write_uid', 'write_date'))
-    return 'INSERT INTO "{}" ("id", {}) VALUES (nextval(%s), {}) RETURNING id'.format(
+    return 'INSERT INTO "{}" ({}) VALUES ({}) RETURNING id'.format(
         model._table,
         ", ".join('"{}"'.format(column) for column in columns),
         ", ".join('%s' for column in columns),

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -3388,11 +3388,8 @@ class TestFieldParametersValidation(common.TransactionCase):
 def insert(model, *fnames):
     """ Return the expected query string to INSERT the given columns. """
     columns = sorted(fnames + ('create_uid', 'create_date', 'write_uid', 'write_date'))
-    return 'INSERT INTO "{}" ({}) VALUES ({}) RETURNING id'.format(
-        model._table,
-        ", ".join('"{}"'.format(column) for column in columns),
-        ", ".join('%s' for column in columns),
-    )
+    header = ", ".join(f'"{column}"' for column in columns)
+    return f'INSERT INTO "{model._table}" ({header}) VALUES %s RETURNING id'
 
 
 def update(model, *fnames):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -283,7 +283,6 @@ class Field(MetaField('DummyField', (object,), {})):
     states = None                       # set readonly and required depending on state
     groups = None                       # csv list of group xml ids
     change_default = False              # whether the field may trigger a "user-onchange"
-    deprecated = None                   # whether the field is deprecated
 
     related_field = None                # corresponding related field
     group_operator = None               # operator for aggregating values
@@ -460,8 +459,8 @@ class Field(MetaField('DummyField', (object,), {})):
 
         self.__dict__.update(attrs)
 
-        # prefetch only stored, column, non-manual and non-deprecated fields
-        if not (self.store and self.column_type) or self.manual or self.deprecated:
+        # prefetch only stored, column, non-manual fields
+        if not self.store or not self.column_type or self.manual:
             self.prefetch = False
 
         if not self.string and not self.related:
@@ -811,7 +810,6 @@ class Field(MetaField('DummyField', (object,), {})):
     _description_states = property(attrgetter('states'))
     _description_groups = property(attrgetter('groups'))
     _description_change_default = property(attrgetter('change_default'))
-    _description_deprecated = property(attrgetter('deprecated'))
     _description_group_operator = property(attrgetter('group_operator'))
 
     def _description_depends(self, env):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -238,7 +238,6 @@ class Field(MetaField('DummyField', (object,), {})):
     translate = False                   # whether the field is translated
 
     column_type = None                  # database column type (ident, spec)
-    column_format = '%s'                # placeholder for value in queries
     column_cast_from = ()               # column types that may be cast to this
     write_sequence = 0                  # field ordering for write()
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3378,8 +3378,6 @@ Fields:
                 field = self._fields[name]
                 if not field.column_type:
                     field.read(fetched)
-                if field.deprecated:
-                    _logger.warning('Field %s is deprecated: %s', field, field.deprecated)
 
         # possibly raise exception for the records that could not be read
         missing = self - fetched
@@ -3946,10 +3944,6 @@ Fields:
                 continue
             field = self._fields[name]
             assert field.store
-
-            if field.deprecated:
-                _logger.warning('Field %s is deprecated: %s', field, field.deprecated)
-
             assert field.column_type
             columns[name] = val
 
@@ -4816,10 +4810,6 @@ Fields:
                     blacklist.update(set(self.env[parent_model]._fields) - whitelist)
                 else:
                     blacklist_given_fields(self.env[parent_model])
-            # blacklist deprecated fields
-            for name, field in model._fields.items():
-                if field.deprecated:
-                    blacklist.add(name)
 
         blacklist_given_fields(self)
 


### PR DESCRIPTION
Several changes to simplify CRUD, to avoid maintain unused feature and to be able to make a clean bulk insert (PR: https://github.com/odoo/odoo/pull/80961)

### [REM] base: remove _sequence attribute of BaseModel

The `_sequence` was only used for the insertion of data in the DB for
the `id` value. But in Odoo, the `id` is always a `SERIAL`, then the
PostgreSQL fill already the value by the right SQL sequence. Then,
avoid doing the job of the DB by ourselves.
Sadly, we need to manage the case when we create an empty record to
always get a valid query.

### [REM] base: remove column_format of Field class

The `column_format` of the `Field` class was unused and create useless
noise in the ORM. Then remove it and simplify some flows.

### [REF] base: simplify the _write
Issue:
`_write` checked that the number of modified row in DB was equal to the
number of ids in the RecordSet (raise `MissingError` if not).
This behavior was only used by the ORM to retry
(with exists() on the RecordSet before) if the Missing Error raised.
Then it makes the job a second time (for no reason).

Then:
- Remove the check of number of row (and simplify the call of `_write`)
- Remove the useless return value (always `True`)
- Remove the `set(` before the `split_for_in_conditions`, it adds
randomness for nothing because the `_write` should be call without
duplicate id (even if it is not the case, we don't care).

### [REM] base: remove deprecated field attribute
It was only used one time on a unused field.
We don't want to keep useless fields anymore,
the migration is done for that.

odoo/upgrade#3194
task-2735546