### PR TITLE
[FIX] website_slides: Fix lesson fullscreen template

### DIFF
--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -144,7 +144,7 @@
                                     <i class="fa fa-link mr-2"/><span t-esc="link.name"/>
                                 </a>
                                 <span t-else="" class="o_wslides_fs_slide_link text-600">
-                                    <i class="fa fa-link mr-2"/><span t-esc="resource.name"/>
+                                    <i class="fa fa-link mr-2"/><span t-esc="link.name"/>
                                 </span>
                             </li>
                             <t t-set="resources" t-value="slide.slide_resource_ids.filtered(lambda res: res.resource_type == 'file')"/>


### PR DESCRIPTION
A variable was inadvertently renamed which broke the fullscreen rendering of
lessons with links.

Task-2735020
Introduced in 63285ce0, part of odoo/odoo#75646
