### PR TITLE
[FIX] payment: preserve type of all-digits transaction references

### DIFF
--- a/addons/payment/static/src/js/payment_form_mixin.js
+++ b/addons/payment/static/src/js/payment_form_mixin.js
@@ -292,7 +292,8 @@ odoo.define('payment.payment_form_mixin', require => {
         _prepareTransactionRouteParams: function (provider, paymentOptionId, flow) {
             return {
                 'payment_option_id': paymentOptionId,
-                'reference_prefix': this.txContext.referencePrefix,
+                'reference_prefix': this.txContext.referencePrefix !== undefined
+                    ? this.txContext.referencePrefix.toString() : null,
                 'amount': this.txContext.amount !== undefined
                     ? parseFloat(this.txContext.amount) : null,
                 'currency_id': this.txContext.currencyId


### PR DESCRIPTION
Before this commit, it was impossible to make a payment if the
transaction reference exclusively contained digits. This is because the
reference is extracted from the data-* attribute of the &lt;form/&gt; element
of the payment form and wrongly cast into an integer by jQuery before
being passed to the server. Indeed, as of jQuery 1.4.3, HTML5's
data-* attributes are automatically pulled into a jQuery's data object.

To reproduce the issue, remove the prefix from the sequence of the sales
orders and attempt to pay a quotation from a payment link.

This commit forces the reference to be cast into a string as it is the
variable type that the server expects, and it crashes if the reference
is an integer.

opw-2732448