### PR TITLE
[FIX] account: adequate template loading at first time

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3142,7 +3142,6 @@ class AccountMove(models.Model):
             custom_layout="mail.mail_notification_paynow",
             model_description=self.with_context(lang=lang).type_name,
             force_email=True,
-            wizard_opened=True
         )
         return {
             'name': _('Send Invoice'),

--- a/addons/account/wizard/account_invoice_send.py
+++ b/addons/account/wizard/account_invoice_send.py
@@ -93,8 +93,7 @@ class AccountInvoiceSend(models.TransientModel):
                 self.composer_id.composition_mode = 'comment' if len(res_ids) == 1 else 'mass_mail'
                 self.composer_id.template_id = self.template_id.id
                 self._compute_composition_mode()
-            if not self.env.context.get("wizard_opened"):
-                self.composer_id._onchange_template_id_wrapper()
+            self.composer_id._onchange_template_id_wrapper()
 
     @api.onchange('is_email')
     def _compute_invoice_without_email(self):


### PR DESCRIPTION
Steps to reproduce:
- install accounting (account_accountant)
- go to invoice
- click on "send and print"
-> template is not loaded directly

Solution:
- revert changes of commit #fc5812c327daab4 since the onchange is now called only once

OPW-2732687
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
