### PR TITLE
[FIX] project: `MemoryError` on _compute_attached_docs_count

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -151,15 +151,21 @@ class Project(models.Model):
     _check_company_auto = True
 
     def _compute_attached_docs_count(self):
-        Attachment = self.env['ir.attachment']
+        self.env.cr.execute(
+            """
+            SELECT coalesce(task.project_id, project.id), count(*)
+              FROM ir_attachment attachment
+              LEFT JOIN project_task task ON attachment.res_model = 'project.task' AND task.id = attachment.res_id
+              LEFT JOIN project_project project ON attachment.res_model = 'project.project' AND project.id = attachment.res_id
+             WHERE project.id IN %(project_ids)s
+                OR task.project_id IN %(project_ids)s
+             GROUP BY coalesce(task.project_id, project.id)
+            """,
+            {"project_ids": tuple(self.ids)}
+        )
+        docs_count = dict(self.env.cr.fetchall())
         for project in self:
-            project.doc_count = Attachment.search_count([
-                '|',
-                '&',
-                ('res_model', '=', 'project.project'), ('res_id', '=', project.id),
-                '&',
-                ('res_model', '=', 'project.task'), ('res_id', 'in', project.task_ids.ids)
-            ])
+            project.doc_count = docs_count.get(project.id, 0)
 
     def _compute_task_count(self):
         task_data = self.env['project.task'].read_group(


### PR DESCRIPTION
When there are multiple projects and many tasks the compute of
project.project.doc_count may raise a `MemoryError` on access to the
projects kanban view.

This issue may appear since the addition on 642fb2e of docs_count field
to the kanban view `view_project_kanban`.
https://github.com/odoo/odoo/blob/136808203545eb5d7056d941f3fc250f2871f95b/addons/project/views/project_views.xml#L613
This provokes too much information to be prefetched by the ORM, in
particular the `description` fields of the tasks which may be big (e.g.
contain embedded images).

This issue was observed during upg-101057

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
