### PR TITLE
Adapt Owl imports for Owl Next

### DIFF
--- a/addons/account/static/src/js/account_resequence_field.js
+++ b/addons/account/static/src/js/account_resequence_field.js
@@ -1,10 +1,10 @@
 odoo.define('account.ShowResequenceRenderer', function (require) {
 "use strict";
 
-const { Component } = owl;
-const { useState } = owl.hooks;
 const AbstractFieldOwl = require('web.AbstractFieldOwl');
 const field_registry = require('web.field_registry_owl');
+
+const { Component } = owl;
 
 class ChangeLine extends Component { }
 ChangeLine.template = 'account.ResequenceChangeLine';

--- a/addons/account/static/src/js/grouped_view_widget.js
+++ b/addons/account/static/src/js/grouped_view_widget.js
@@ -1,10 +1,10 @@
 odoo.define('account.ShowGroupedList', function (require) {
 "use strict";
 
-const { Component } = owl;
-const { useState } = owl.hooks;
 const AbstractFieldOwl = require('web.AbstractFieldOwl');
 const field_registry = require('web.field_registry_owl');
+
+const { Component } = owl;
 
 class ListItem extends Component { }
 ListItem.template = 'account.GroupedItemTemplate';

--- a/addons/account/static/src/js/tax_totals.js
+++ b/addons/account/static/src/js/tax_totals.js
@@ -1,12 +1,12 @@
 /** @odoo-module alias=account.tax_group_owl **/
 "use strict";
 
-const { Component } = owl;
-const { useState, useRef } = owl.hooks;
 import session from 'web.session';
 import AbstractFieldOwl from 'web.AbstractFieldOwl';
 import fieldUtils from 'web.field_utils';
 import field_registry from 'web.field_registry_owl';
+
+const { Component, useRef, useState } = owl;
 
 /**
     A line of some TaxTotalsComponent, giving the values of a tax group.

--- a/addons/base_automation/static/tests/base_automation_error_dialog.js
+++ b/addons/base_automation/static/tests/base_automation_error_dialog.js
@@ -18,6 +18,7 @@ import { DialogContainer } from "@web/core/dialog/dialog_container";
 import { getFixture } from "@web/../tests/helpers/utils";
 import { nextTick } from "@web/../tests/helpers/utils";
 
+const { mount } = owl;
 const serviceRegistry = registry.category("services");
 
 QUnit.module("base_automation", {}, function () {
@@ -79,7 +80,7 @@ QUnit.module("base_automation", {}, function () {
 
         const env = await makeTestEnv();
         const { Component: Container, props } = registry.category("main_components").get("DialogContainer");
-        const dialogContainer = await owl.mount(Container, { target: getFixture(), env, props });
+        const dialogContainer = await mount(Container, { target: getFixture(), env, props });
 
         const errorEvent = new PromiseRejectionEvent("error", { reason: {
             message: error,
@@ -114,7 +115,7 @@ QUnit.module("base_automation", {}, function () {
 
         const env = await makeTestEnv();
         const { Component: Container, props } = registry.category("main_components").get("DialogContainer");
-        const dialogContainer = await owl.mount(Container, { target: getFixture(), env, props });
+        const dialogContainer = await mount(Container, { target: getFixture(), env, props });
 
         const errorEvent = new PromiseRejectionEvent("error", { reason: {
             message: error,

--- a/addons/bus/static/src/js/services/assets_watchdog_service.js
+++ b/addons/bus/static/src/js/services/assets_watchdog_service.js
@@ -4,6 +4,8 @@ import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
 
+const { Component } = owl;
+
 export const assetsWatchdogService = {
     dependencies: ["notification"],
 
@@ -12,7 +14,7 @@ export const assetsWatchdogService = {
         let bundleNotifTimerID = null;
 
         env.bus.on("WEB_CLIENT_READY", null, async () => {
-            const legacyEnv = owl.Component.env;
+            const legacyEnv = Component.env;
             legacyEnv.services.bus_service.onNotification(this, onNotification);
             legacyEnv.services.bus_service.startPolling();
         });

--- a/addons/bus/static/tests/bus_tests.js
+++ b/addons/bus/static/tests/bus_tests.js
@@ -12,6 +12,7 @@ const { ConnectionLostError } = require("@web/core/network/rpc_service");
 const { patchWithCleanup, nextTick } = require("@web/../tests/helpers/utils");
 const { createWebClient } =  require('@web/../tests/webclient/helpers');
 
+const { Component } = owl;
 
 var LocalStorageServiceMock;
 
@@ -114,7 +115,7 @@ QUnit.module('Bus', {
             },
             legacyParams: { serviceRegistry: legacyRegistry },
         });
-        busService = owl.Component.env.services.bus_service;
+        busService = Component.env.services.bus_service;
         busService.startPolling();
         // Give longpolling bus a tick to try to restart polling
         await nextTick();

--- a/addons/calendar/static/src/js/services/calendar_notification_service.js
+++ b/addons/calendar/static/src/js/services/calendar_notification_service.js
@@ -4,6 +4,8 @@ import { browser } from "@web/core/browser/browser";
 import { ConnectionLostError } from "@web/core/network/rpc_service";
 import { registry } from "@web/core/registry";
 
+const { Component } = owl;
+
 export const calendarNotificationService = {
     dependencies: ["action", "notification", "rpc"],
 
@@ -13,7 +15,7 @@ export const calendarNotificationService = {
         const displayedNotifications = new Set();
 
         env.bus.on("WEB_CLIENT_READY", null, async () => {
-            const legacyEnv = owl.Component.env;
+            const legacyEnv = Component.env;
             legacyEnv.services.bus_service.onNotification(this, (notifications) => {
                 for (const { payload, type } of notifications) {
                     if (type === "calendar.alarm") {

--- a/addons/hr/static/tests/standalone_m2o_avatar_employee_tests.js
+++ b/addons/hr/static/tests/standalone_m2o_avatar_employee_tests.js
@@ -1,6 +1,5 @@
 /** @odoo-module **/
 
-    const { xml } = owl.tags;
 
     import AbstractRendererOwl from 'web.AbstractRendererOwl';
     import BasicView from "web.BasicView";
@@ -9,6 +8,8 @@
     import { createView } from 'web.test_utils';
 
     import StandaloneM2OAvatarEmployee from '@hr/js/standalone_m2o_avatar_employee';
+
+    const { xml } = owl;
 
     function getHtmlRenderer(html) {
         return BasicRenderer.extend({

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.js
@@ -1,11 +1,13 @@
 /* @odoo-module */
 
-export class TimeOffCardPopover extends owl.Component {}
+const { Component } = owl;
+
+export class TimeOffCardPopover extends Component {}
 
 TimeOffCardPopover.template = 'hr_holidays.TimeOffCardPopover';
 TimeOffCardPopover.props = ['allocated', 'approved', 'planned', 'left'];
 
-export class TimeOffCard extends owl.Component {}
+export class TimeOffCard extends Component {}
 
 TimeOffCard.components = { TimeOffCardPopover };
 TimeOffCard.template = 'hr_holidays.TimeOffCard';

--- a/addons/hr_holidays/static/src/dashboard/time_off_dashboard.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_dashboard.js
@@ -2,7 +2,9 @@
 
 import { TimeOffCard } from './time_off_card';
 
-export class TimeOffDashboard extends owl.Component {}
+const { Component } = owl;
+
+export class TimeOffDashboard extends Component {}
 
 TimeOffDashboard.components = { TimeOffCard };
 TimeOffDashboard.template = 'hr_holidays.TimeOffDashboard';

--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -80,6 +80,7 @@ Help your customers with this chat, and analyse their feedback.
             'web/static/lib/qweb/qweb2.js',
             # Odoo JS Framework
             'web/static/lib/owl/owl.js',
+            'web/static/src/owl_next_adapter.js',
             'web/static/src/legacy/js/promise_extension.js',
             'web/static/src/boot.js',
             'web/static/src/core/assets.js',

--- a/addons/mail/static/src/component_hooks/use_component_to_model/use_component_to_model.js
+++ b/addons/mail/static/src/component_hooks/use_component_to_model/use_component_to_model.js
@@ -2,7 +2,7 @@
 
 import { clear } from '@mail/model/model_field_command';
 
-const { onWillUpdateProps, useComponent } = owl.hooks;
+const { onWillUpdateProps, useComponent } = owl;
 
 /**
  * This hook provides support for saving the reference of the component directly

--- a/addons/mail/static/src/component_hooks/use_drag_visible_dropzone/use_drag_visible_dropzone.js
+++ b/addons/mail/static/src/component_hooks/use_drag_visible_dropzone/use_drag_visible_dropzone.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-const { useState, onMounted, onWillUnmount } = owl.hooks;
+const { onMounted, onWillUnmount, useState } = owl;
 
 /**
  * This hook handle the visibility of the dropzone based on drag & drop events.

--- a/addons/mail/static/src/component_hooks/use_models/use_models.js
+++ b/addons/mail/static/src/component_hooks/use_models/use_models.js
@@ -2,7 +2,7 @@
 
 import { Listener } from '@mail/model/model_listener';
 
-const { useComponent } = owl.hooks;
+const { useComponent } = owl;
 
 /**
  * This hook provides support for automatically re-rendering when used records

--- a/addons/mail/static/src/component_hooks/use_ref_to_model/use_ref_to_model.js
+++ b/addons/mail/static/src/component_hooks/use_ref_to_model/use_ref_to_model.js
@@ -2,7 +2,7 @@
 
 import { clear } from '@mail/model/model_field_command';
 
-const { onWillUpdateProps, useComponent, useRef } = owl.hooks;
+const { onWillUpdateProps, useComponent, useRef } = owl;
 
 /**
  * This hook provides support for saving the result of useRef directly into the

--- a/addons/mail/static/src/component_hooks/use_rendered_values/use_rendered_values.js
+++ b/addons/mail/static/src/component_hooks/use_rendered_values/use_rendered_values.js
@@ -2,8 +2,7 @@
 
 import { Listener } from '@mail/model/model_listener';
 
-const { Component } = owl;
-const { onMounted, onPatched } = owl.hooks;
+const { Component, onMounted, onPatched } = owl;
 
 /**
  * This hooks provides support for accessing the values returned by the given

--- a/addons/mail/static/src/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props.js
+++ b/addons/mail/static/src/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props.js
@@ -1,8 +1,7 @@
 /** @odoo-module **/
 'use strict';
 
-const { Component } = owl;
-const { onPatched } = owl.hooks;
+const { Component, onPatched } = owl;
 
 /**
  * Shallow compares props `a` and `b`.

--- a/addons/mail/static/src/component_hooks/use_update/use_update.js
+++ b/addons/mail/static/src/component_hooks/use_update/use_update.js
@@ -2,7 +2,7 @@
 
 import { Listener } from '@mail/model/model_listener';
 
-const { onMounted, onPatched, useComponent } = owl.hooks;
+const { onMounted, onPatched, useComponent } = owl;
 
 /**
  * This hook provides support for executing code after update (render or patch).

--- a/addons/mail/static/src/component_hooks/use_update_to_model/use_update_to_model.js
+++ b/addons/mail/static/src/component_hooks/use_update_to_model/use_update_to_model.js
@@ -2,7 +2,7 @@
 
 import { useUpdate } from '@mail/component_hooks/use_update/use_update';
 
-const { useComponent } = owl.hooks;
+const { useComponent } = owl;
 
 /**
  * This hook provides support for binding the onMounted/onPatched hooks to the

--- a/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover.js
+++ b/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover.js
@@ -4,8 +4,7 @@ import { useComponentToModel } from '@mail/component_hooks/use_component_to_mode
 import { useRefToModel } from '@mail/component_hooks/use_ref_to_model/use_ref_to_model';
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component } = owl;
-const { onMounted, useRef } = owl.hooks;
+const { Component, onMounted, useRef } = owl;
 
 export class ActivityMarkDonePopover extends Component {
 

--- a/addons/mail/static/src/components/attachment_card/attachment_card.js
+++ b/addons/mail/static/src/components/attachment_card/attachment_card.js
@@ -2,6 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 import { useComponentToModel } from '@mail/component_hooks/use_component_to_model/use_component_to_model';
+
 const { Component } = owl;
 
 export class AttachmentCard extends Component {

--- a/addons/mail/static/src/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog.js
+++ b/addons/mail/static/src/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog.js
@@ -4,7 +4,7 @@ import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
 import Dialog from 'web.OwlDialog';
 
-const { Component } = owl;
+const { Component, escape } = owl;
 
 export class AttachmentDeleteConfirmDialog extends Component {
 
@@ -25,7 +25,7 @@ export class AttachmentDeleteConfirmDialog extends Component {
     getBody() {
         return _.str.sprintf(
             this.env._t(`Do you really want to delete "%s"?`),
-            owl.utils.escape(this.attachment.displayName)
+            escape(this.attachment.displayName)
         );
     }
 

--- a/addons/mail/static/src/components/attachment_image/attachment_image.js
+++ b/addons/mail/static/src/components/attachment_image/attachment_image.js
@@ -2,6 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 import { useComponentToModel } from '@mail/component_hooks/use_component_to_model/use_component_to_model';
+
 const { Component } = owl;
 
 export class AttachmentImage extends Component {

--- a/addons/mail/static/src/components/attachment_viewer/attachment_viewer.js
+++ b/addons/mail/static/src/components/attachment_viewer/attachment_viewer.js
@@ -7,8 +7,7 @@ import { link } from '@mail/model/model_field_command';
 
 import { hidePDFJSButtons } from '@web/legacy/js/libs/pdfjs';
 
-const { Component } = owl;
-const { onMounted, onPatched, onWillUnmount, useRef } = owl.hooks;
+const { Component, onMounted, onPatched, onWillUnmount, useRef } = owl;
 
 const MIN_SCALE = 0.5;
 const SCROLL_ZOOM_STEP = 0.1;

--- a/addons/mail/static/src/components/autocomplete_input/autocomplete_input.js
+++ b/addons/mail/static/src/components/autocomplete_input/autocomplete_input.js
@@ -2,8 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component } = owl;
-const { onMounted, onWillUnmount } = owl.hooks;
+const { Component, onMounted, onWillUnmount } = owl;
 
 export class AutocompleteInput extends Component {
 

--- a/addons/mail/static/src/components/chat_window/chat_window.js
+++ b/addons/mail/static/src/components/chat_window/chat_window.js
@@ -4,8 +4,7 @@ import { registerMessagingComponent } from '@mail/utils/messaging_component';
 import { useUpdate } from '@mail/component_hooks/use_update/use_update';
 import { isEventHandled } from '@mail/utils/utils';
 
-const { Component } = owl;
-const { useRef } = owl.hooks;
+const { Component, useRef } = owl;
 
 export class ChatWindow extends Component {
 

--- a/addons/mail/static/src/components/chat_window_hidden_menu/chat_window_hidden_menu.js
+++ b/addons/mail/static/src/components/chat_window_hidden_menu/chat_window_hidden_menu.js
@@ -2,8 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component } = owl;
-const { onMounted, onPatched, onWillUnmount, useRef } = owl.hooks;
+const { Component, onMounted, onPatched, onWillUnmount, useRef } = owl;
 
 export class ChatWindowHiddenMenu extends Component {
 

--- a/addons/mail/static/src/components/chatter/chatter.js
+++ b/addons/mail/static/src/components/chatter/chatter.js
@@ -4,8 +4,7 @@ import { registerMessagingComponent } from '@mail/utils/messaging_component';
 import { useComponentToModel } from '@mail/component_hooks/use_component_to_model/use_component_to_model';
 import { useUpdate } from '@mail/component_hooks/use_update/use_update';
 
-const { Component } = owl;
-const { useRef } = owl.hooks;
+const { Component, useRef } = owl;
 
 export class Chatter extends Component {
 

--- a/addons/mail/static/src/components/chatter_container/chatter_container.js
+++ b/addons/mail/static/src/components/chatter_container/chatter_container.js
@@ -3,8 +3,7 @@
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 import { clear } from '@mail/model/model_field_command';
 
-const { Component } = owl;
-const { onWillUpdateProps } = owl.hooks;
+const { Component, onWillUpdateProps } = owl;
 
 const getChatterNextTemporaryId = (function () {
     let tmpId = 0;

--- a/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.js
+++ b/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.js
@@ -6,8 +6,7 @@ import { useUpdate } from '@mail/component_hooks/use_update/use_update';
 import { FormViewDialog } from 'web.view_dialogs';
 import { ComponentAdapter } from 'web.OwlCompatibility';
 
-const { Component } = owl;
-const { useRef } = owl.hooks;
+const { Component, useRef } = owl;
 
 class FormViewDialogComponentAdapter extends ComponentAdapter {
 

--- a/addons/mail/static/src/components/composer_suggested_recipient_list/composer_suggested_recipient_list.js
+++ b/addons/mail/static/src/components/composer_suggested_recipient_list/composer_suggested_recipient_list.js
@@ -2,8 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component } = owl;
-const { useState } = owl.hooks;
+const { Component, useState } = owl;
 
 export class ComposerSuggestedRecipientList extends Component {
 

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.js
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.js
@@ -5,8 +5,7 @@ import { registerMessagingComponent } from '@mail/utils/messaging_component';
 import { useUpdate } from '@mail/component_hooks/use_update/use_update';
 import { markEventHandled } from '@mail/utils/utils';
 
-const { Component } = owl;
-const { useRef } = owl.hooks;
+const { Component, useRef } = owl;
 
 export class ComposerTextInput extends Component {
 

--- a/addons/mail/static/src/components/dialog/dialog.js
+++ b/addons/mail/static/src/components/dialog/dialog.js
@@ -2,8 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component } = owl;
-const { onMounted, onWillUnmount } = owl.hooks;
+const { Component, onMounted, onWillUnmount } = owl;
 
 export class Dialog extends Component {
 

--- a/addons/mail/static/src/components/dialog_manager/dialog_manager.js
+++ b/addons/mail/static/src/components/dialog_manager/dialog_manager.js
@@ -2,8 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component } = owl;
-const { onMounted, onPatched } = owl.hooks;
+const { Component, onMounted, onPatched } = owl;
 
 export class DialogManager extends Component {
 

--- a/addons/mail/static/src/components/discuss/discuss.js
+++ b/addons/mail/static/src/components/discuss/discuss.js
@@ -3,8 +3,7 @@
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 import { useUpdate } from '@mail/component_hooks/use_update/use_update';
 
-const { Component } = owl;
-const { onWillUnmount } = owl.hooks;
+const { Component, onWillUnmount } = owl;
 
 export class Discuss extends Component {
 

--- a/addons/mail/static/src/components/discuss_sidebar/discuss_sidebar.js
+++ b/addons/mail/static/src/components/discuss_sidebar/discuss_sidebar.js
@@ -3,8 +3,7 @@
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 import { useUpdate } from '@mail/component_hooks/use_update/use_update';
 
-const { Component } = owl;
-const { useRef } = owl.hooks;
+const { Component, useRef } = owl;
 
 export class DiscussSidebar extends Component {
 

--- a/addons/mail/static/src/components/follow_button/follow_button.js
+++ b/addons/mail/static/src/components/follow_button/follow_button.js
@@ -2,8 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component } = owl;
-const { useState } = owl.hooks;
+const { Component, useState } = owl;
 
 export class FollowButton extends Component {
 

--- a/addons/mail/static/src/components/follower_list_menu/follower_list_menu.js
+++ b/addons/mail/static/src/components/follower_list_menu/follower_list_menu.js
@@ -2,8 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component } = owl;
-const { onMounted, onWillUnmount, useRef, useState } = owl.hooks;
+const { Component, onMounted, onWillUnmount, useRef, useState } = owl;
 
 export class FollowerListMenu extends Component {
 

--- a/addons/mail/static/src/components/media_preview/media_preview.js
+++ b/addons/mail/static/src/components/media_preview/media_preview.js
@@ -3,7 +3,9 @@
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 import { useRefToModel } from '@mail/component_hooks/use_ref_to_model/use_ref_to_model';
 
-export class MediaPreview extends owl.Component {
+const { Component } = owl;
+
+export class MediaPreview extends Component {
 
     /**
      * @override

--- a/addons/mail/static/src/components/message/message.js
+++ b/addons/mail/static/src/components/message/message.js
@@ -10,8 +10,7 @@ import { _lt } from 'web.core';
 import { format } from 'web.field_utils';
 import { getLangDatetimeFormat } from 'web.time';
 
-const { Component, useState } = owl;
-const { onWillUnmount, useRef } = owl.hooks;
+const { Component, onWillUnmount, useRef, useState } = owl;
 
 const READ_MORE = _lt("Read More");
 const READ_LESS = _lt("Read Less");

--- a/addons/mail/static/src/components/message_list/message_list.js
+++ b/addons/mail/static/src/components/message_list/message_list.js
@@ -5,8 +5,7 @@ import { useComponentToModel } from '@mail/component_hooks/use_component_to_mode
 import { useRenderedValues } from '@mail/component_hooks/use_rendered_values/use_rendered_values';
 import { useUpdate } from '@mail/component_hooks/use_update/use_update';
 
-const { Component } = owl;
-const { onWillPatch, useRef } = owl.hooks;
+const { Component, onWillPatch, useRef } = owl;
 
 export class MessageList extends Component {
 

--- a/addons/mail/static/src/components/message_reaction_group/message_reaction_group.js
+++ b/addons/mail/static/src/components/message_reaction_group/message_reaction_group.js
@@ -1,7 +1,8 @@
 /** @odoo-module **/
 
-const { Component } = owl;
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
+
+const { Component } = owl;
 
 export class MessageReactionGroup extends Component {
 

--- a/addons/mail/static/src/components/messaging_menu/messaging_menu.js
+++ b/addons/mail/static/src/components/messaging_menu/messaging_menu.js
@@ -2,8 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component } = owl;
-const { onMounted, onWillUnmount } = owl.hooks;
+const { Component, onMounted, onWillUnmount } = owl;
 
 export class MessagingMenu extends Component {
 

--- a/addons/mail/static/src/components/messaging_menu_container/messaging_menu_container.js
+++ b/addons/mail/static/src/components/messaging_menu_container/messaging_menu_container.js
@@ -13,7 +13,7 @@ export class MessagingMenuContainer extends Component {
     setup() {
         // for now, the legacy env is needed for internal functions such as
         // `useModels` to work
-        this.env = owl.Component.env;
+        this.env = Component.env;
         useModels();
         super.setup();
     }

--- a/addons/mail/static/src/components/notification_group/notification_group.js
+++ b/addons/mail/static/src/components/notification_group/notification_group.js
@@ -2,8 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component } = owl;
-const { useRef } = owl.hooks;
+const { Component, useRef } = owl;
 
 export class NotificationGroup extends Component {
 

--- a/addons/mail/static/src/components/notification_list/notification_list.js
+++ b/addons/mail/static/src/components/notification_list/notification_list.js
@@ -2,8 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component } = owl;
-const { onMounted } = owl.hooks;
+const { Component, onMounted } = owl;
 
 export class NotificationList extends Component {
 

--- a/addons/mail/static/src/components/rtc_activity_notice_container/rtc_activity_notice_container.js
+++ b/addons/mail/static/src/components/rtc_activity_notice_container/rtc_activity_notice_container.js
@@ -13,7 +13,7 @@ export class RtcActivityNoticeContainer extends Component {
     setup() {
         // for now, the legacy env is needed for internal functions such as
         // `useModels` to work
-        this.env = owl.Component.env;
+        this.env = Component.env;
         useModels();
         super.setup();
     }

--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.js
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.js
@@ -2,8 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component } = owl;
-const { useRef } = owl.hooks;
+const { Component, useRef } = owl;
 
 export class RtcCallParticipantCard extends Component {
 

--- a/addons/mail/static/src/components/rtc_call_viewer/rtc_call_viewer.js
+++ b/addons/mail/static/src/components/rtc_call_viewer/rtc_call_viewer.js
@@ -5,8 +5,7 @@ import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
 import Dialog from 'web.OwlDialog';
 
-const { Component, useState } = owl;
-const { useRef } = owl.hooks;
+const { Component, useRef, useState } = owl;
 
 const components = {
     Dialog,

--- a/addons/mail/static/src/components/rtc_configuration_menu/rtc_configuration_menu.js
+++ b/addons/mail/static/src/components/rtc_configuration_menu/rtc_configuration_menu.js
@@ -4,8 +4,7 @@ import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
 import { browser } from "@web/core/browser/browser";
 
-const { Component } = owl;
-const { onWillStart, useState } = owl.hooks;
+const { Component, onWillStart, useState } = owl;
 
 export class RtcConfigurationMenu extends Component {
 

--- a/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.js
+++ b/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.js
@@ -4,8 +4,7 @@ import * as mailUtils from '@mail/js/utils';
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component } = owl;
-const { useRef } = owl.hooks;
+const { Component, useRef } = owl;
 
 export class ThreadNeedactionPreview extends Component {
 

--- a/addons/mail/static/src/components/thread_preview/thread_preview.js
+++ b/addons/mail/static/src/components/thread_preview/thread_preview.js
@@ -4,8 +4,7 @@ import * as mailUtils from '@mail/js/utils';
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component } = owl;
-const { useRef } = owl.hooks;
+const { Component, useRef } = owl;
 
 export class ThreadPreview extends Component {
 

--- a/addons/mail/static/src/components/welcome_view/welcome_view.js
+++ b/addons/mail/static/src/components/welcome_view/welcome_view.js
@@ -4,7 +4,9 @@ import { registerMessagingComponent } from '@mail/utils/messaging_component';
 import { useRefToModel } from '@mail/component_hooks/use_ref_to_model/use_ref_to_model';
 import { useUpdateToModel } from '@mail/component_hooks/use_update_to_model/use_update_to_model';
 
-export class WelcomeView extends owl.Component {
+const { Component } = owl;
+
+export class WelcomeView extends Component {
 
     /**
      * @override

--- a/addons/mail/static/src/js/core/translation.js
+++ b/addons/mail/static/src/js/core/translation.js
@@ -2,17 +2,19 @@
 
 import { TranslationDataBase } from 'web.translation';
 
+const { Component } = owl;
+
 TranslationDataBase.include({
     /**
      * @override
      */
     set_bundle() {
         const res = this._super(...arguments);
-        if (owl.Component.env.services && owl.Component.env.services.messaging) {
+        if (Component.env.services && Component.env.services.messaging) {
             // During boot `env.services` might not even be set yet, in this
             // case this can safely be ignored as messaging will then load
             // locale information during its initialization.
-            owl.Component.env.services.messaging.get().then(messaging => {
+            Component.env.services.messaging.get().then(messaging => {
                 // Update messaging locale whenever the translation bundle changes.
                 // In particular if messaging is created before the end of the
                 // `load_translations` RPC, the default values have to be

--- a/addons/mail/static/src/js/utils.js
+++ b/addons/mail/static/src/js/utils.js
@@ -2,6 +2,8 @@
 
 import core from 'web.core';
 
+const { escape } = owl;
+
 var _t = core._t;
 
 /**
@@ -146,7 +148,7 @@ function parseEmail(text) {
  */
 function escapeAndCompactTextContent(content) {
     //Removing unwanted extra spaces from message
-    let value = owl.utils.escape(content).trim();
+    let value = escape(content).trim();
     value = value.replace(/(\r|\n){2,}/g, '<br/><br/>');
     value = value.replace(/(\r|\n)/g, '<br/>');
 

--- a/addons/mail/static/src/js/views/activity/activity_renderer.js
+++ b/addons/mail/static/src/js/views/activity/activity_renderer.js
@@ -11,9 +11,9 @@ import QWeb from 'web.QWeb';
 import session from 'web.session';
 import utils from 'web.utils';
 
+const { useState } = owl;
 const _t = core._t;
 
-const { useState } = owl.hooks;
 
 /**
  * Owl Component Adapter for ActivityRecord which is KanbanRecord (Odoo Widget)

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -8,6 +8,8 @@ import { OnChange } from '@mail/model/model_onchange';
 import { addLink, escapeAndCompactTextContent, parseAndTransform } from '@mail/js/utils';
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
+const { escape } = owl;
+
 registerModel({
     name: 'ComposerView',
     identifyingFields: [['threadView', 'messageViewInEditing', 'chatter']],
@@ -722,7 +724,7 @@ registerModel({
             const mentions = [];
             for (const partner of this.composer.mentionedPartners) {
                 const placeholder = `@-mention-partner-${partner.id}`;
-                const text = `@${owl.utils.escape(partner.name)}`;
+                const text = `@${escape(partner.name)}`;
                 mentions.push({
                     class: 'o_mail_redirect',
                     id: partner.id,
@@ -734,7 +736,7 @@ registerModel({
             }
             for (const channel of this.composer.mentionedChannels) {
                 const placeholder = `#-mention-channel-${channel.id}`;
-                const text = `#${owl.utils.escape(channel.name)}`;
+                const text = `#${escape(channel.name)}`;
                 mentions.push({
                     class: 'o_channel_redirect',
                     id: channel.id,

--- a/addons/mail/static/src/models/discuss/discuss.js
+++ b/addons/mail/static/src/models/discuss/discuss.js
@@ -4,6 +4,8 @@ import { registerModel } from '@mail/model/model_core';
 import { attr, many2one, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace, link, unlink } from '@mail/model/model_field_command';
 
+const { escape } = owl;
+
 registerModel({
     name: 'Discuss',
     identifyingFields: ['messaging'],
@@ -64,14 +66,14 @@ registerModel({
             this.update({ addingChannelValue: req.term });
             const threads = await this.messaging.models['Thread'].searchChannelsToOpen({ limit: 10, searchTerm: req.term });
             const items = threads.map((thread) => {
-                const escapedName = owl.utils.escape(thread.name);
+                const escapedName = escape(thread.name);
                 return {
                     id: thread.id,
                     label: escapedName,
                     value: escapedName,
                 };
             });
-            const escapedValue = owl.utils.escape(req.term);
+            const escapedValue = escape(req.term);
             // XDU FIXME could use a component but be careful with owl's
             // renderToString https://github.com/odoo/owl/issues/708
             items.push({
@@ -107,7 +109,7 @@ registerModel({
          * @param {function} res
          */
         handleAddChatAutocompleteSource(req, res) {
-            const value = owl.utils.escape(req.term);
+            const value = escape(req.term);
             this.messaging.models['Partner'].imSearch({
                 callback: partners => {
                     const suggestions = partners.map(partner => {

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -6,7 +6,7 @@ import { OnChange } from '@mail/model/model_onchange';
 import { insertAndReplace, link, unlink } from '@mail/model/model_field_command';
 import { makeDeferred } from '@mail/utils/deferred/deferred';
 
-const { EventBus } = owl.core;
+const { EventBus } = owl;
 
 registerModel({
     name: 'Messaging',
@@ -171,7 +171,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {owl.EventBus}
+         * @returns {EventBus}
          */
         _computeMessagingBus() {
             if (this.messagingBus) {

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -7,6 +7,7 @@ import { htmlToTextContentInline } from '@mail/js/utils';
 import { str_to_datetime } from 'web.time';
 import { Markup } from 'web.utils';
 
+const { escape } = owl;
 const PREVIEW_MSG_MAX_SIZE = 350; // optimal for native English speakers
 
 registerModel({
@@ -692,7 +693,7 @@ registerModel({
                     notificationTitle = author.nameOrDisplayName;
                 }
             }
-            const notificationContent = owl.utils.escape(
+            const notificationContent = escape(
                 htmlToTextContentInline(message.body).substr(0, PREVIEW_MSG_MAX_SIZE)
             );
             this.env.services['bus_service'].sendNotification({

--- a/addons/mail/static/src/models/popover_view/popover_view.js
+++ b/addons/mail/static/src/models/popover_view/popover_view.js
@@ -4,6 +4,8 @@ import { registerModel } from '@mail/model/model_core';
 import { attr, one2one } from '@mail/model/model_field';
 import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
 
+const { Ref } = owl;
+
 registerModel({
     name: 'PopoverView',
     identifyingFields: [['composerViewOwnerAsEmoji', 'messageActionListOwnerAsReaction', 'threadViewTopbarOwnerAsInvite']],
@@ -28,7 +30,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {owl.Ref}
+         * @returns {Ref}
          */
         _computeAnchorRef() {
             if (this.threadViewTopbarOwnerAsInvite) {

--- a/addons/mail/static/src/public/discuss_public_boot.js
+++ b/addons/mail/static/src/public/discuss_public_boot.js
@@ -24,20 +24,22 @@ import {
 } from '@web/legacy/utils';
 import * as legacySession from 'web.session';
 
-owl.Component.env = legacyEnv;
+const { Component, config, mount, whenReady } = owl;
+
+Component.env = legacyEnv;
 
 (async function boot() {
-    await owl.utils.whenReady();
-    owl.config.mode = owl.Component.env.isDebug() ? 'dev' : 'prod';
-    AbstractService.prototype.deployServices(owl.Component.env);
+    await whenReady();
+    config.mode = Component.env.isDebug() ? 'dev' : 'prod';
+    AbstractService.prototype.deployServices(Component.env);
     const serviceRegistry = registry.category('services');
-    serviceRegistry.add('legacy_rpc', makeLegacyRpcService(owl.Component.env));
-    serviceRegistry.add('legacy_session', makeLegacySessionService(owl.Component.env, legacySession));
-    serviceRegistry.add('legacy_notification', makeLegacyNotificationService(owl.Component.env));
-    serviceRegistry.add('legacy_crash_manager', makeLegacyCrashManagerService(owl.Component.env));
-    serviceRegistry.add('legacy_dialog_mapping', makeLegacyDialogMappingService(owl.Component.env));
+    serviceRegistry.add('legacy_rpc', makeLegacyRpcService(Component.env));
+    serviceRegistry.add('legacy_session', makeLegacySessionService(Component.env, legacySession));
+    serviceRegistry.add('legacy_notification', makeLegacyNotificationService(Component.env));
+    serviceRegistry.add('legacy_crash_manager', makeLegacyCrashManagerService(Component.env));
+    serviceRegistry.add('legacy_dialog_mapping', makeLegacyDialogMappingService(Component.env));
     await legacySession.is_bound;
-    owl.Component.env.qweb.addTemplates(legacySession.owlTemplates);
+    Component.env.qweb.addTemplates(legacySession.owlTemplates);
     Object.assign(odoo, {
         info: {
             db: session.db,
@@ -53,19 +55,19 @@ owl.Component.env = legacyEnv;
         odoo.loadTemplatesPromise.then(processTemplates),
     ]);
     env.qweb.addTemplates(templates);
-    mapLegacyEnvToWowlEnv(owl.Component.env, env);
+    mapLegacyEnvToWowlEnv(Component.env, env);
     odoo.isReady = true;
     legacyServiceRegistry.add('messaging', MessagingService.extend({
         messagingValues: {
             autofetchPartnerImStatus: false,
         },
     }));
-    await owl.mount(MainComponentsContainer, { env, target: document.body });
+    await mount(MainComponentsContainer, { env, target: document.body });
     createAndMountDiscussPublicView();
 })();
 
 async function createAndMountDiscussPublicView() {
-    const messaging = await owl.Component.env.services.messaging.get();
+    const messaging = await Component.env.services.messaging.get();
     // needed by the attachment viewer
     const DialogManager = getMessagingComponent('DialogManager');
     const dialogManagerComponent = new DialogManager(null, {});

--- a/addons/mail/static/src/public/root_widget.js
+++ b/addons/mail/static/src/public/root_widget.js
@@ -4,6 +4,8 @@
  */
 odoo.define("root.widget", function (require) {
     const { ComponentAdapter } = require("web.OwlCompatibility");
+
     const { Component } = owl;
+
     return new ComponentAdapter(null, { Component });
 });

--- a/addons/mail/static/src/utils/messaging_component.js
+++ b/addons/mail/static/src/utils/messaging_component.js
@@ -3,7 +3,7 @@
 import { useModels } from "@mail/component_hooks/use_models/use_models";
 import { useShouldUpdateBasedOnProps } from "@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props";
 
-const { useRef } = owl.hooks;
+const { useRef } = owl;
 
 const componentRegistry = {};
 

--- a/addons/mail/static/src/utils/test_utils.js
+++ b/addons/mail/static/src/utils/test_utils.js
@@ -29,13 +29,12 @@ import { createWebClient, getActionManagerServerData } from "@web/../tests/webcl
 
 import LegacyRegistry from "web.Registry";
 
+const { Component, EventBus } = owl;
 const {
     addMockEnvironment,
     patch: legacyPatch,
     unpatch: legacyUnpatch,
 } = mock;
-const { Component } = owl;
-const { EventBus } = owl.core;
 
 //------------------------------------------------------------------------------
 // Private
@@ -163,7 +162,7 @@ function _useDiscuss(callbacks, { afterNextRender }) {
  * @returns {Promise}
  */
 function nextAnimationFrame() {
-    const requestAnimationFrame = owl.Component.scheduler.requestAnimationFrame;
+    const requestAnimationFrame = Component.scheduler.requestAnimationFrame;
     return new Promise(function (resolve) {
         setTimeout(() => requestAnimationFrame(() => resolve()));
     });
@@ -178,10 +177,10 @@ function nextAnimationFrame() {
  * @returns {Promise}
  */
 const afterNextRender = (function () {
-    const stop = owl.Component.scheduler.stop;
+    const stop = Component.scheduler.stop;
     const stopPromises = [];
 
-    owl.Component.scheduler.stop = function () {
+    Component.scheduler.stop = function () {
         const wasRunning = this.isRunning;
         stop.call(this);
         if (wasRunning) {
@@ -201,7 +200,7 @@ const afterNextRender = (function () {
         const timeoutProm = new Promise((resolve, reject) => {
             timeoutNoRender = setTimeout(() => {
                 let error = startError;
-                if (owl.Component.scheduler.isRunning) {
+                if (Component.scheduler.isRunning) {
                     error = stopError;
                 }
                 console.error(error);
@@ -222,7 +221,7 @@ const afterNextRender = (function () {
         await funcRes;
         // Wait one more frame to make sure no new render has been queued.
         await nextAnimationFrame();
-        if (owl.Component.scheduler.isRunning) {
+        if (Component.scheduler.isRunning) {
             await afterNextRender(() => {}, timeoutDelay);
         }
     }

--- a/addons/mail/static/src/webclient/commands/mail_providers.js
+++ b/addons/mail/static/src/webclient/commands/mail_providers.js
@@ -3,8 +3,7 @@
 import { _lt } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-const { Component } = owl;
-const { xml } = owl.tags;
+const { Component, xml } = owl;
 
 class DialogCommand extends Component {}
 DialogCommand.template = xml`

--- a/addons/mail/static/src/widgets/form_renderer/form_renderer.js
+++ b/addons/mail/static/src/widgets/form_renderer/form_renderer.js
@@ -5,6 +5,8 @@ import { getMessagingComponent } from "@mail/utils/messaging_component";
 import FormRenderer from 'web.FormRenderer';
 import { ComponentWrapper } from 'web.OwlCompatibility';
 
+const { Component } = owl;
+
 class ChatterContainerWrapperComponent extends ComponentWrapper {}
 
 /**
@@ -37,7 +39,7 @@ FormRenderer.include({
         this.off('o_attachments_changed', this);
         this.off('o_chatter_rendered', this);
         this.off('o_message_posted', this);
-        owl.Component.env.bus.off('Thread:promptAddFollower-closed', this);
+        Component.env.bus.off('Thread:promptAddFollower-closed', this);
     },
 
     //--------------------------------------------------------------------------
@@ -76,7 +78,7 @@ FormRenderer.include({
             this.on('o_attachments_changed', this, ev => this.trigger_up('reload', { keepChanges: true }));
         }
         if (this.chatterFields.hasRecordReloadOnFollowersUpdate) {
-            owl.Component.env.bus.on('Thread:promptAddFollower-closed', this, ev => this.trigger_up('reload', { keepChanges: true }));
+            Component.env.bus.on('Thread:promptAddFollower-closed', this, ev => this.trigger_up('reload', { keepChanges: true }));
         }
     },
     /**

--- a/addons/mail/static/tests/tours/mail_full_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_full_composer_test_tour.js
@@ -7,6 +7,8 @@ import {
 
 import tour from 'web_tour.tour';
 
+const { Component } = owl;
+
 /**
  * This tour depends on data created by python test in charge of launching it.
  * It is not intended to work when launched from interface. It is needed to test
@@ -31,7 +33,7 @@ tour.register('mail/static/tests/tours/mail_full_composer_test_tour.js', {
             contentType: 'text/plain',
             name: 'text.txt',
         });
-        const messaging = await window.owl.Component.env.services.messaging.get();
+        const messaging = await Component.env.services.messaging.get();
         const uploaders = messaging.models['FileUploader'].all();
         inputFiles(
             uploaders[0].fileInput,

--- a/addons/point_of_sale/static/src/js/Chrome.js
+++ b/addons/point_of_sale/static/src/js/Chrome.js
@@ -1,8 +1,6 @@
 odoo.define('point_of_sale.Chrome', function(require) {
     'use strict';
 
-    const { useState, useRef, useContext, useExternalListener } = owl.hooks;
-    const { debounce } = owl.utils;
     const { loadCSS } = require('web.ajax');
     const { useListener } = require('web.custom_hooks');
     const { BarcodeEvents } = require('barcodes.BarcodeEvents');
@@ -22,6 +20,8 @@ odoo.define('point_of_sale.Chrome', function(require) {
     // when we create an instance of one of the classes,
     // we instantiate the extended one.
     const models = require('point_of_sale.models');
+
+    const { debounce, useContext, useExternalListener, useRef, useState } = owl;
 
     /**
      * Chrome is the root component of the PoS App.

--- a/addons/point_of_sale/static/src/js/ChromeWidgets/ClientScreenButton.js
+++ b/addons/point_of_sale/static/src/js/ChromeWidgets/ClientScreenButton.js
@@ -1,9 +1,10 @@
 odoo.define('point_of_sale.ClientScreenButton', function(require) {
     'use strict';
 
-    const { useState } = owl;
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
+
+    const { useState } = owl;
 
     // Formerly ClientScreenWidget
     class ClientScreenButton extends PosComponent {

--- a/addons/point_of_sale/static/src/js/ChromeWidgets/DebugWidget.js
+++ b/addons/point_of_sale/static/src/js/ChromeWidgets/DebugWidget.js
@@ -1,13 +1,13 @@
 odoo.define('point_of_sale.DebugWidget', function (require) {
     'use strict';
 
-    const { useState } = owl;
-    const { useRef } = owl.hooks;
     const { getFileAsText } = require('point_of_sale.utils');
     const { parse } = require('web.field_utils');
     const NumberBuffer = require('point_of_sale.NumberBuffer');
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
+
+    const { useRef, useState } = owl;
 
     class DebugWidget extends PosComponent {
         constructor() {

--- a/addons/point_of_sale/static/src/js/ChromeWidgets/ProxyStatus.js
+++ b/addons/point_of_sale/static/src/js/ChromeWidgets/ProxyStatus.js
@@ -1,9 +1,10 @@
 odoo.define('point_of_sale.ProxyStatus', function(require) {
     'use strict';
 
-    const { useState } = owl;
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
+
+    const { useState } = owl;
 
     // Previously ProxyStatusWidget
     class ProxyStatus extends PosComponent {

--- a/addons/point_of_sale/static/src/js/ChromeWidgets/SyncNotification.js
+++ b/addons/point_of_sale/static/src/js/ChromeWidgets/SyncNotification.js
@@ -1,9 +1,10 @@
 odoo.define('point_of_sale.SyncNotification', function(require) {
     'use strict';
 
-    const { useState } = owl;
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
+
+    const { useState } = owl;
 
     // Previously SynchNotificationWidget
     class SyncNotification extends PosComponent {

--- a/addons/point_of_sale/static/src/js/Gui.js
+++ b/addons/point_of_sale/static/src/js/Gui.js
@@ -1,9 +1,11 @@
 odoo.define('point_of_sale.Gui', function (require) {
     'use strict';
 
+    const { Component, component } = owl;
+
     /**
      * This module bridges the data classes (such as those defined in
-     * models.js) to the view (owl.Component) but not vice versa.
+     * models.js) to the view (Component) but not vice versa.
      *
      * The idea is to be able to perform side-effects to the user interface
      * during calculation. Think of console.log during times we want to see
@@ -29,7 +31,7 @@ odoo.define('point_of_sale.Gui', function (require) {
     /**
      * Call this when the user interface is ready. Provide the component
      * that will be used to control the ui.
-     * @param {owl.component} component component having the ui methods.
+     * @param {component} component component having the ui methods.
      */
     const configureGui = ({ component }) => {
         config.component = component;

--- a/addons/point_of_sale/static/src/js/Misc/AbstractReceiptScreen.js
+++ b/addons/point_of_sale/static/src/js/Misc/AbstractReceiptScreen.js
@@ -1,10 +1,11 @@
 odoo.define('point_of_sale.AbstractReceiptScreen', function (require) {
     'use strict';
 
-    const { useRef } = owl.hooks;
     const { nextFrame } = require('point_of_sale.utils');
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
+
+    const { useRef } = owl;
 
     /**
      * This relies on the assumption that there is a reference to

--- a/addons/point_of_sale/static/src/js/Misc/Draggable.js
+++ b/addons/point_of_sale/static/src/js/Misc/Draggable.js
@@ -1,10 +1,11 @@
 odoo.define('point_of_sale.Draggable', function(require) {
     'use strict';
 
-    const { useExternalListener } = owl.hooks;
     const { useListener } = require('web.custom_hooks');
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
+
+    const { useExternalListener } = owl;
 
     /**
      * Wrap an element or a component with { position: absolute } to make it

--- a/addons/point_of_sale/static/src/js/Misc/NumberBuffer.js
+++ b/addons/point_of_sale/static/src/js/Misc/NumberBuffer.js
@@ -1,15 +1,13 @@
 odoo.define('point_of_sale.NumberBuffer', function(require) {
     'use strict';
 
-    const { Component } = owl;
-    const { EventBus } = owl.core;
-    const { onMounted, onWillUnmount, useExternalListener } = owl.hooks;
     const { useListener } = require('web.custom_hooks');
     const { parse } = require('web.field_utils');
     const { BarcodeEvents } = require('barcodes.BarcodeEvents');
     const { _t } = require('web.core');
     const { Gui } = require('point_of_sale.Gui');
 
+    const { Component, EventBus, onMounted, onWillUnmount, useExternalListener } = owl;
     const INPUT_KEYS = new Set(
         ['Delete', 'Backspace', '+1', '+2', '+5', '+10', '+20', '+50'].concat('0123456789+-.,'.split(''))
     );

--- a/addons/point_of_sale/static/src/js/Misc/SearchBar.js
+++ b/addons/point_of_sale/static/src/js/Misc/SearchBar.js
@@ -1,10 +1,11 @@
 odoo.define('point_of_sale.SearchBar', function (require) {
     'use strict';
 
-    const { useState, useExternalListener } = owl.hooks;
     const { useListener } = require('web.custom_hooks');
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
+
+    const { useExternalListener, useState } = owl;
 
     /**
      * This is a simple configurable search bar component. It has search fields

--- a/addons/point_of_sale/static/src/js/PopupControllerMixin.js
+++ b/addons/point_of_sale/static/src/js/PopupControllerMixin.js
@@ -1,8 +1,9 @@
 odoo.define('point_of_sale.PopupControllerMixin', function(require) {
     'use strict';
 
-    const { useState } = owl;
     const { useListener } = require('web.custom_hooks');
+
+    const { useState } = owl;
 
     /**
      * Allows the component declared with this mixin the ability show popup dynamically,

--- a/addons/point_of_sale/static/src/js/Popups/AbstractAwaitablePopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/AbstractAwaitablePopup.js
@@ -1,8 +1,9 @@
 odoo.define('point_of_sale.AbstractAwaitablePopup', function (require) {
     'use strict';
 
-    const { useExternalListener } = owl.hooks;
     const PosComponent = require('point_of_sale.PosComponent');
+
+    const { useExternalListener, xml } = owl;
 
     /**
      * Implement this abstract class by extending it like so:
@@ -12,7 +13,7 @@ odoo.define('point_of_sale.AbstractAwaitablePopup', function (require) {
      *     return 'result';
      *   }
      * }
-     * ConcretePopup.template = owl.tags.xml`
+     * ConcretePopup.template = xml`
      *   <div>
      *     <button t-on-click="confirm">Okay</button>
      *     <button t-on-click="cancel">Cancel</button>

--- a/addons/point_of_sale/static/src/js/Popups/CashMovePopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/CashMovePopup.js
@@ -6,15 +6,17 @@ odoo.define('point_of_sale.CashMovePopup', function (require) {
     const { _t } = require('web.core');
     const { parse } = require('web.field_utils');
 
+    const { useRef, useState } = owl;
+
     class CashMovePopup extends AbstractAwaitablePopup {
         setup() {
-            this.state = owl.hooks.useState({
+            this.state = useState({
                 inputType: '', // '' | 'in' | 'out'
                 inputAmount: '',
                 inputReason: '',
                 inputHasError: false,
             });
-            this.inputAmountRef = owl.hooks.useRef('input-amount-ref');
+            this.inputAmountRef = useRef('input-amount-ref');
         }
         confirm() {
             try {

--- a/addons/point_of_sale/static/src/js/Popups/CashOpeningPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/CashOpeningPopup.js
@@ -1,10 +1,10 @@
 odoo.define('point_of_sale.CashOpeningPopup', function(require) {
     'use strict';
 
-    const { useState, useRef } = owl.hooks;
     const AbstractAwaitablePopup = require('point_of_sale.AbstractAwaitablePopup');
     const Registries = require('point_of_sale.Registries');
 
+    const { useRef, useState } = owl;
 
     class CashOpeningPopup extends AbstractAwaitablePopup {
         constructor() {

--- a/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
@@ -1,11 +1,12 @@
 odoo.define('point_of_sale.ClosePosPopup', function(require) {
     'use strict';
 
-    const { useState, useRef } = owl.hooks;
     const AbstractAwaitablePopup = require('point_of_sale.AbstractAwaitablePopup');
     const Registries = require('point_of_sale.Registries');
     const { identifyError } = require('point_of_sale.utils');
     const { ConnectionLostError, ConnectionAbortedError} = require('@web/core/network/rpc_service')
+
+    const { useRef, useState } = owl;
 
     /**
      * This popup needs to be self-dependent because it needs to be called from different place.

--- a/addons/point_of_sale/static/src/js/Popups/EditListPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/EditListPopup.js
@@ -1,11 +1,12 @@
 odoo.define('point_of_sale.EditListPopup', function(require) {
     'use strict';
 
-    const { useState } = owl.hooks;
     const AbstractAwaitablePopup = require('point_of_sale.AbstractAwaitablePopup');
     const Registries = require('point_of_sale.Registries');
     const { useAutoFocusToLast } = require('point_of_sale.custom_hooks');
     const { _lt } = require('@web/core/l10n/translation');
+
+    const { useState } = owl;
 
     /**
      * Given a array of { id, text }, we show the user this popup to be able to modify this given array.

--- a/addons/point_of_sale/static/src/js/Popups/MoneyDetailsPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/MoneyDetailsPopup.js
@@ -1,9 +1,10 @@
 odoo.define('point_of_sale.MoneyDetailsPopup', function(require) {
     'use strict';
 
-    const { useState } = owl.hooks;
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
+
+    const { useState } = owl;
 
     /**
      * Even if this component has a "confirm and cancel"-like buttons, this should not be an AbstractAwaitablePopup.

--- a/addons/point_of_sale/static/src/js/Popups/NumberPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/NumberPopup.js
@@ -3,11 +3,12 @@ odoo.define('point_of_sale.NumberPopup', function(require) {
     var core = require('web.core');
     var _t = core._t;
 
-    const { useState } = owl;
     const AbstractAwaitablePopup = require('point_of_sale.AbstractAwaitablePopup');
     const NumberBuffer = require('point_of_sale.NumberBuffer');
     const { useListener } = require('web.custom_hooks');
     const Registries = require('point_of_sale.Registries');
+
+    const { useState } = owl;
 
     // formerly NumberPopupWidget
     class NumberPopup extends AbstractAwaitablePopup {

--- a/addons/point_of_sale/static/src/js/Popups/ProductConfiguratorPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ProductConfiguratorPopup.js
@@ -1,10 +1,11 @@
 odoo.define('point_of_sale.ProductConfiguratorPopup', function(require) {
     'use strict';
 
-    const { useState, useSubEnv } = owl.hooks;
     const PosComponent = require('point_of_sale.PosComponent');
     const AbstractAwaitablePopup = require('point_of_sale.AbstractAwaitablePopup');
     const Registries = require('point_of_sale.Registries');
+
+    const { useState, useSubEnv } = owl;
 
     class ProductConfiguratorPopup extends AbstractAwaitablePopup {
         constructor() {

--- a/addons/point_of_sale/static/src/js/Popups/SelectionPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/SelectionPopup.js
@@ -1,10 +1,11 @@
 odoo.define('point_of_sale.SelectionPopup', function (require) {
     'use strict';
 
-    const { useState } = owl.hooks;
     const AbstractAwaitablePopup = require('point_of_sale.AbstractAwaitablePopup');
     const Registries = require('point_of_sale.Registries');
     const { _lt } = require('@web/core/l10n/translation');
+
+    const { useState } = owl;
 
     // formerly SelectionPopupWidget
     class SelectionPopup extends AbstractAwaitablePopup {

--- a/addons/point_of_sale/static/src/js/Popups/TextAreaPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/TextAreaPopup.js
@@ -1,10 +1,11 @@
 odoo.define('point_of_sale.TextAreaPopup', function(require) {
     'use strict';
 
-    const { useState, useRef } = owl.hooks;
     const AbstractAwaitablePopup = require('point_of_sale.AbstractAwaitablePopup');
     const Registries = require('point_of_sale.Registries');
     const { _lt } = require('@web/core/l10n/translation');
+
+    const { useRef, useState } = owl;
 
     // formerly TextAreaPopupWidget
     // IMPROVEMENT: This code is very similar to TextInputPopup.

--- a/addons/point_of_sale/static/src/js/Popups/TextInputPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/TextInputPopup.js
@@ -1,10 +1,11 @@
 odoo.define('point_of_sale.TextInputPopup', function(require) {
     'use strict';
 
-    const { useState, useRef } = owl.hooks;
     const AbstractAwaitablePopup = require('point_of_sale.AbstractAwaitablePopup');
     const Registries = require('point_of_sale.Registries');
     const { _lt } = require('@web/core/l10n/translation');
+
+    const { useRef, useState } = owl;
 
     // formerly TextInputPopupWidget
     class TextInputPopup extends AbstractAwaitablePopup {

--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -1,10 +1,11 @@
 odoo.define('point_of_sale.ClientListScreen', function(require) {
     'use strict';
 
-    const { debounce } = owl.utils;
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
     const { useListener } = require('web.custom_hooks');
+
+    const { Observer, debounce } = owl;
 
     /**
      * Render this screen using `showTempScreen` to select client.
@@ -31,7 +32,7 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
             // We are not using useState here because the object
             // passed to useState converts the object and its contents
             // to Observer proxy. Not sure of the side-effects of making
-            // a persistent object, such as pos, into owl.Observer. But it
+            // a persistent object, such as pos, into Observer. But it
             // is better to be safe.
             this.state = {
                 query: null,

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/OrderWidget.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/OrderWidget.js
@@ -1,11 +1,12 @@
 odoo.define('point_of_sale.OrderWidget', function(require) {
     'use strict';
 
-    const { useState, useRef, onPatched } = owl.hooks;
     const { useListener } = require('web.custom_hooks');
     const { onChangeOrder } = require('point_of_sale.custom_hooks');
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
+
+    const { onPatched, useRef, useState } = owl;
 
     class OrderWidget extends PosComponent {
         constructor() {

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -8,8 +8,9 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
     const Registries = require('point_of_sale.Registries');
     const { onChangeOrder, useBarcodeReader } = require('point_of_sale.custom_hooks');
     const { isConnectionError, posbus } = require('point_of_sale.utils');
-    const { useState, onMounted } = owl.hooks;
     const { parse } = require('web.field_utils');
+
+    const { onMounted, useState } = owl;
 
     class ProductScreen extends ControlButtonsMixin(PosComponent) {
         constructor() {

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductsWidget.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductsWidget.js
@@ -1,10 +1,11 @@
 odoo.define('point_of_sale.ProductsWidget', function(require) {
     'use strict';
 
-    const { useState } = owl.hooks;
     const PosComponent = require('point_of_sale.PosComponent');
     const { useListener } = require('web.custom_hooks');
     const Registries = require('point_of_sale.Registries');
+
+    const { useState } = owl;
 
     class ProductsWidget extends PosComponent {
         /**

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductsWidgetControlPanel.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductsWidgetControlPanel.js
@@ -1,13 +1,13 @@
 odoo.define('point_of_sale.ProductsWidgetControlPanel', function(require) {
     'use strict';
 
-    const { useRef } = owl.hooks;
-    const { debounce } = owl.utils;
     const { identifyError } = require('point_of_sale.utils');
     const { ConnectionLostError, ConnectionAbortedError } = require('@web/core/network/rpc_service');
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
     const { posbus } = require('point_of_sale.utils');
+
+    const { debounce, useRef } = owl;
 
     class ProductsWidgetControlPanel extends PosComponent {
         constructor() {

--- a/addons/point_of_sale/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
@@ -3,11 +3,11 @@ odoo.define('point_of_sale.ReceiptScreen', function (require) {
 
     const { Printer } = require('point_of_sale.Printer');
     const { is_email } = require('web.utils');
-    const { useRef, useContext } = owl.hooks;
     const { useErrorHandlers, onChangeOrder } = require('point_of_sale.custom_hooks');
     const Registries = require('point_of_sale.Registries');
     const AbstractReceiptScreen = require('point_of_sale.AbstractReceiptScreen');
 
+    const { useContext, useRef } = owl;
     const ReceiptScreen = (AbstractReceiptScreen) => {
         class ReceiptScreen extends AbstractReceiptScreen {
             constructor() {

--- a/addons/point_of_sale/static/src/js/Screens/ScaleScreen/ScaleScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ScaleScreen/ScaleScreen.js
@@ -1,10 +1,11 @@
 odoo.define('point_of_sale.ScaleScreen', function(require) {
     'use strict';
 
-    const { useState, useExternalListener } = owl.hooks;
     const PosComponent = require('point_of_sale.PosComponent');
     const { round_precision: round_pr } = require('web.utils');
     const Registries = require('point_of_sale.Registries');
+
+    const { useExternalListener, useState } = owl;
 
     class ScaleScreen extends PosComponent {
         /**

--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -1,7 +1,6 @@
 odoo.define('point_of_sale.TicketScreen', function (require) {
     'use strict';
 
-    const { useState } = owl.hooks;
     const models = require('point_of_sale.models');
     const Registries = require('point_of_sale.Registries');
     const IndependentToOrderScreen = require('point_of_sale.IndependentToOrderScreen');
@@ -10,6 +9,7 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
     const { posbus } = require('point_of_sale.utils');
     const { parse } = require('web.field_utils');
 
+    const { useState } = owl;
 
     class TicketScreen extends IndependentToOrderScreen {
         constructor() {

--- a/addons/point_of_sale/static/src/js/chrome_adapter.js
+++ b/addons/point_of_sale/static/src/js/chrome_adapter.js
@@ -6,13 +6,14 @@ import Chrome from "point_of_sale.Chrome";
 import Registries from "point_of_sale.Registries";
 import { configureGui } from "point_of_sale.Gui";
 import { useBus } from "@web/core/utils/hooks";
-const { Component } = owl;
 import { registry } from "@web/core/registry";
+
+const { Component, debounce, onMounted, useRef, xml } = owl;
 
 function setupResponsivePlugin(env) {
     const isMobile = () => window.innerWidth <= 768;
     env.isMobile = isMobile();
-    const updateEnv = owl.utils.debounce(() => {
+    const updateEnv = debounce(() => {
         if (env.isMobile !== isMobile()) {
             env.isMobile = !env.isMobile;
             env.qweb.forceUpdate();
@@ -26,12 +27,12 @@ export class ChromeAdapter extends Component {
         this.PosChrome = Registries.Component.get(Chrome);
         this.legacyActionManager = useService("legacy_action_manager");
 
-        this.env = owl.Component.env;
+        this.env = Component.env;
         useBus(this.env.qweb, "update", () => this.render());
         setupResponsivePlugin(this.env);
 
-        const chrome = owl.hooks.useRef("chrome");
-        owl.hooks.onMounted(async () => {
+        const chrome = useRef("chrome");
+        onMounted(async () => {
             // Add the pos error handler when the chrome component is available.
             registry.category('error_handlers').add(
                 'posErrorHandler',
@@ -52,4 +53,4 @@ export class ChromeAdapter extends Component {
         });
     }
 }
-ChromeAdapter.template = owl.tags.xml`<PosChrome t-ref="chrome" webClient="legacyActionManager"/>`;
+ChromeAdapter.template = xml`<PosChrome t-ref="chrome" webClient="legacyActionManager"/>`;

--- a/addons/point_of_sale/static/src/js/custom_hooks.js
+++ b/addons/point_of_sale/static/src/js/custom_hooks.js
@@ -1,8 +1,7 @@
 odoo.define('point_of_sale.custom_hooks', function (require) {
     'use strict';
 
-    const { Component } = owl;
-    const { onMounted, onPatched, onWillUnmount } = owl.hooks;
+    const { Component, onMounted, onPatched, onWillUnmount } = owl;
 
     /**
      * Introduce error handlers in the component.

--- a/addons/point_of_sale/static/src/js/main.js
+++ b/addons/point_of_sale/static/src/js/main.js
@@ -6,14 +6,16 @@ import { ChromeAdapter } from "@point_of_sale/js/chrome_adapter";
 import Registries from "point_of_sale.Registries";
 import { registry } from "@web/core/registry";
 
+const { Component, Portal, xml } = owl;
+
 // For consistency's sake, we should trigger"WEB_CLIENT_READY" on the bus when PosApp is mounted
 // But we can't since mail and some other poll react on that cue, and we don't want those services started
-class PosApp extends owl.Component {
+class PosApp extends Component {
     setup() {
         this.Components = registry.category("main_components").getEntries();
     }
 }
-PosApp.template = owl.tags.xml`
+PosApp.template = xml`
   <body>
     <ChromeAdapter />
     <div>
@@ -26,7 +28,7 @@ PosApp.template = owl.tags.xml`
 PosApp.components = { ChromeAdapter };
 
 function startPosApp() {
-    Registries.Component.add(owl.misc.Portal);
+    Registries.Component.add(Portal);
     Registries.Component.freeze();
     startWebClient(PosApp);
 }

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2,7 +2,6 @@
 odoo.define('point_of_sale.models', function (require) {
 "use strict";
 
-const { Context } = owl;
 var BarcodeParser = require('barcodes.BarcodeParser');
 var BarcodeReader = require('point_of_sale.BarcodeReader');
 var PosDB = require('point_of_sale.DB');
@@ -14,6 +13,8 @@ var field_utils = require('web.field_utils');
 var time = require('web.time');
 var utils = require('web.utils');
 var { Gui } = require('point_of_sale.Gui');
+
+const { Context } = owl;
 
 var QWeb = core.qweb;
 var _t = core._t;

--- a/addons/point_of_sale/static/src/js/utils.js
+++ b/addons/point_of_sale/static/src/js/utils.js
@@ -1,8 +1,9 @@
 odoo.define('point_of_sale.utils', function (require) {
     'use strict';
 
-    const { EventBus } = owl.core;
     const { ConnectionAbortedError, ConnectionLostError } = require('@web/core/network/rpc_service');
+
+    const { EventBus } = owl;
 
     function getFileAsText(file) {
         return new Promise((resolve, reject) => {

--- a/addons/point_of_sale/static/tests/unit/helpers/test_env.js
+++ b/addons/point_of_sale/static/tests/unit/helpers/test_env.js
@@ -13,7 +13,9 @@ odoo.define('point_of_sale.test_env', async function (require) {
     const models = require('point_of_sale.models');
     const Registries = require('point_of_sale.Registries');
 
-    Registries.Component.add(owl.misc.Portal);
+    const { Portal } = owl;
+
+    Registries.Component.add(Portal);
 
     await env.session.is_bound;
     const pos = new models.PosModel({

--- a/addons/point_of_sale/static/tests/unit/test_ChromeWidgets.js
+++ b/addons/point_of_sale/static/tests/unit/test_ChromeWidgets.js
@@ -5,7 +5,8 @@ odoo.define('point_of_sale.tests.ChromeWidgets', function (require) {
     const PopupControllerMixin = require('point_of_sale.PopupControllerMixin');
     const testUtils = require('web.test_utils');
     const makePosTestEnv = require('point_of_sale.test_env');
-    const { xml } = owl.tags;
+
+    const { xml } = owl;
 
     QUnit.module('unit tests for Chrome Widgets', {});
 

--- a/addons/point_of_sale/static/tests/unit/test_NumberBuffer.js
+++ b/addons/point_of_sale/static/tests/unit/test_NumberBuffer.js
@@ -1,11 +1,11 @@
 odoo.define('point_of_sale.tests.NumberBuffer', function(require) {
     'use strict';
 
-    const { Component, useState } = owl;
-    const { xml } = owl.tags;
     const NumberBuffer = require('point_of_sale.NumberBuffer');
     const makeTestEnvironment = require('web.test_env');
     const testUtils = require('web.test_utils');
+
+    const { Component, useState, xml } = owl;
 
     QUnit.module('unit tests for NumberBuffer', {
         before() {},

--- a/addons/point_of_sale/static/tests/unit/test_PaymentScreen.js
+++ b/addons/point_of_sale/static/tests/unit/test_PaymentScreen.js
@@ -6,8 +6,8 @@ odoo.define('point_of_sale.tests.PaymentScreen', function (require) {
     const { useListener } = require('web.custom_hooks');
     const testUtils = require('web.test_utils');
     const makePosTestEnv = require('point_of_sale.test_env');
-    const { xml } = owl.tags;
-    const { useState } = owl;
+
+    const { useState, xml } = owl;
 
     QUnit.module('unit tests for PaymentScreen components', {});
 

--- a/addons/point_of_sale/static/tests/unit/test_ProductScreen.js
+++ b/addons/point_of_sale/static/tests/unit/test_ProductScreen.js
@@ -6,8 +6,8 @@ odoo.define('point_of_sale.tests.ProductScreen', function (require) {
     const { useListener } = require('web.custom_hooks');
     const testUtils = require('web.test_utils');
     const makePosTestEnv = require('point_of_sale.test_env');
-    const { xml } = owl.tags;
-    const { useState } = owl;
+
+    const { useState, xml } = owl;
 
     QUnit.module('unit tests for ProductScreen components', {});
 

--- a/addons/point_of_sale/static/tests/unit/test_popups.js
+++ b/addons/point_of_sale/static/tests/unit/test_popups.js
@@ -6,7 +6,8 @@ odoo.define('point_of_sale.test_popups', function(require) {
     const PosComponent = require('point_of_sale.PosComponent');
     const PopupControllerMixin = require('point_of_sale.PopupControllerMixin');
     const makePosTestEnv = require('point_of_sale.test_env');
-    const { xml } = owl.tags;
+
+    const { xml } = owl;
 
     QUnit.module('unit tests for Popups', {
         before() {

--- a/addons/pos_gift_card/static/src/js/GiftCardPopup.js
+++ b/addons/pos_gift_card/static/src/js/GiftCardPopup.js
@@ -1,9 +1,10 @@
 odoo.define("pos_gift_card.GiftCardPopup", function (require) {
   "use strict";
 
-  const { useState, useRef } = owl.hooks;
   const AbstractAwaitablePopup = require("point_of_sale.AbstractAwaitablePopup");
   const Registries = require("point_of_sale.Registries");
+
+  const { useState } = owl;
 
   class GiftCardPopup extends AbstractAwaitablePopup {
     constructor() {

--- a/addons/pos_hr/static/src/js/HeaderLockButton.js
+++ b/addons/pos_hr/static/src/js/HeaderLockButton.js
@@ -3,6 +3,7 @@ odoo.define('point_of_sale.HeaderLockButton', function(require) {
 
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
+
     const { useState } = owl;
 
     class HeaderLockButton extends PosComponent {

--- a/addons/pos_mercury/static/src/js/PaymentTransactionPopup.js
+++ b/addons/pos_mercury/static/src/js/PaymentTransactionPopup.js
@@ -1,10 +1,11 @@
 odoo.define('pos_mercury.PaymentTransactionPopup', function(require) {
     'use strict';
 
-    const { useState } = owl.hooks;
     const AbstractAwaitablePopup = require('point_of_sale.AbstractAwaitablePopup');
     const Registries = require('point_of_sale.Registries');
     const { _lt } = require('@web/core/l10n/translation');
+
+    const { useState } = owl;
 
     class PaymentTransactionPopup extends AbstractAwaitablePopup {
         constructor() {

--- a/addons/pos_restaurant/static/src/js/Resizeable.js
+++ b/addons/pos_restaurant/static/src/js/Resizeable.js
@@ -1,10 +1,11 @@
 odoo.define('pos_restaurant.Resizeable', function(require) {
     'use strict';
 
-    const { useExternalListener } = owl.hooks;
     const { useListener } = require('web.custom_hooks');
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
+
+    const { useExternalListener } = owl;
 
     class Resizeable extends PosComponent {
         constructor() {

--- a/addons/pos_restaurant/static/src/js/Screens/FloorScreen/EditBar.js
+++ b/addons/pos_restaurant/static/src/js/Screens/FloorScreen/EditBar.js
@@ -3,7 +3,8 @@ odoo.define('pos_restaurant.EditBar', function(require) {
 
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
-    const { useState } = owl.hooks;
+
+    const { useState } = owl;
 
     class EditBar extends PosComponent {
         constructor() {

--- a/addons/pos_restaurant/static/src/js/Screens/FloorScreen/EditableTable.js
+++ b/addons/pos_restaurant/static/src/js/Screens/FloorScreen/EditableTable.js
@@ -1,10 +1,11 @@
 odoo.define('pos_restaurant.EditableTable', function(require) {
     'use strict';
 
-    const { onPatched, onMounted } = owl.hooks;
     const { useListener } = require('web.custom_hooks');
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
+
+    const { onMounted, onPatched } = owl;
 
     class EditableTable extends PosComponent {
         constructor() {

--- a/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
@@ -1,12 +1,12 @@
 odoo.define('pos_restaurant.FloorScreen', function (require) {
     'use strict';
 
-    const { debounce } = owl.utils;
     const PosComponent = require('point_of_sale.PosComponent');
-    const { useState, useRef } = owl.hooks;
     const { useListener } = require('web.custom_hooks');
     const Registries = require('point_of_sale.Registries');
     const { posbus } = require('point_of_sale.utils');
+
+    const { debounce, useRef, useState } = owl;
 
     class FloorScreen extends PosComponent {
         /**

--- a/addons/pos_restaurant/static/src/js/Screens/SplitBillScreen/SplitBillScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/SplitBillScreen/SplitBillScreen.js
@@ -2,10 +2,11 @@ odoo.define('pos_restaurant.SplitBillScreen', function(require) {
     'use strict';
 
     const PosComponent = require('point_of_sale.PosComponent');
-    const { useState } = owl.hooks;
     const { useListener } = require('web.custom_hooks');
     const models = require('point_of_sale.models');
     const Registries = require('point_of_sale.Registries');
+
+    const { useState } = owl;
 
     class SplitBillScreen extends PosComponent {
         constructor() {

--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -7,7 +7,8 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
     const { useAutofocus } = require('web.custom_hooks');
     const { posbus } = require('point_of_sale.utils');
     const { parse } = require('web.field_utils');
-    const { useState, useContext } = owl.hooks;
+
+    const { useContext, useState } = owl;
 
     const PosResTicketScreen = (TicketScreen) =>
         class extends TicketScreen {

--- a/addons/pos_restaurant/static/src/js/Screens/TipScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TipScreen.js
@@ -4,7 +4,8 @@ odoo.define('pos_restaurant.TipScreen', function (require) {
     const Registries = require('point_of_sale.Registries');
     const PosComponent = require('point_of_sale.PosComponent');
     const { parse } = require('web.field_utils');
-    const { useContext } = owl.hooks;
+
+    const { useContext } = owl;
 
     class TipScreen extends PosComponent {
         constructor() {

--- a/addons/pos_restaurant/static/tests/unit/test_FloorScreen.js
+++ b/addons/pos_restaurant/static/tests/unit/test_FloorScreen.js
@@ -5,8 +5,8 @@ odoo.define('pos_restaurant.tests.FloorScreen', function (require) {
     const { useListener } = require('web.custom_hooks');
     const testUtils = require('web.test_utils');
     const makePosTestEnv = require('point_of_sale.test_env');
-    const { xml } = owl.tags;
-    const { useRef } = owl.hooks;
+
+    const { useRef, xml } = owl;
 
     QUnit.module('FloorScreen components', {});
 

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/MobileSaleOrderManagementScreen.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/MobileSaleOrderManagementScreen.js
@@ -2,7 +2,8 @@ odoo.define('point_of_sale.MobileSaleOrderManagementScreen', function (require) 
     const SaleOrderManagementScreen = require('pos_sale.SaleOrderManagementScreen');
     const Registries = require('point_of_sale.Registries');
     const { useListener } = require('web.custom_hooks');
-    const { useState } = owl.hooks;
+
+    const { useState } = owl;
 
     const MobileSaleOrderManagementScreen = (SaleOrderManagementScreen) => {
         class MobileSaleOrderManagementScreen extends SaleOrderManagementScreen {

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderFetcher.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderFetcher.js
@@ -1,10 +1,11 @@
 odoo.define('pos_sale.SaleOrderFetcher', function (require) {
     'use strict';
 
-    const { EventBus } = owl.core;
     const { Gui } = require('point_of_sale.Gui');
     const { isConnectionError } = require('point_of_sale.utils');
     const models = require('point_of_sale.models');
+
+    const { EventBus } = owl;
 
     class SaleOrderFetcher extends EventBus {
         constructor() {

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderList.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderList.js
@@ -1,10 +1,11 @@
 odoo.define('pos_sale.SaleOrderList', function (require) {
     'use strict';
 
-    const { useState } = owl.hooks;
     const { useListener } = require('web.custom_hooks');
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
+
+    const { useState } = owl;
 
     /**
      * @props {models.Order} [initHighlightedOrder] initially highligted order

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementControlPanel.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementControlPanel.js
@@ -1,12 +1,13 @@
 odoo.define('pos_sale.SaleOrderManagementControlPanel', function (require) {
     'use strict';
 
-    const { useContext } = owl.hooks;
     const { useAutofocus, useListener } = require('web.custom_hooks');
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
     const SaleOrderFetcher = require('pos_sale.SaleOrderFetcher');
     const contexts = require('point_of_sale.PosContext');
+
+    const { useContext } = owl;
 
     // NOTE: These are constants so that they are only instantiated once
     // and they can be used efficiently by the OrderManagementControlPanel.

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
@@ -3,7 +3,6 @@ odoo.define('pos_sale.SaleOrderManagementScreen', function (require) {
 
     const { sprintf } = require('web.utils');
     const { parse } = require('web.field_utils');
-    const { useContext } = owl.hooks;
     const { useListener } = require('web.custom_hooks');
     const ControlButtonsMixin = require('point_of_sale.ControlButtonsMixin');
     const NumberBuffer = require('point_of_sale.NumberBuffer');
@@ -12,6 +11,8 @@ odoo.define('pos_sale.SaleOrderManagementScreen', function (require) {
     const IndependentToOrderScreen = require('point_of_sale.IndependentToOrderScreen');
     const contexts = require('point_of_sale.PosContext');
     const models = require('point_of_sale.models');
+
+    const { useContext } = owl;
 
     class SaleOrderManagementScreen extends ControlButtonsMixin(IndependentToOrderScreen) {
         constructor() {

--- a/addons/project/static/src/js/right_panel/project_right_panel.js
+++ b/addons/project/static/src/js/right_panel/project_right_panel.js
@@ -2,9 +2,10 @@
 
 import { AddMilestone, OpenMilestone } from '@project/js/right_panel/project_utils';
 import { formatFloat } from "@web/fields/formatters";
-const { useState } = owl.hooks;
 
-export default class ProjectRightPanel extends owl.Component {
+const { Component, useState } = owl;
+
+export default class ProjectRightPanel extends Component {
     constructor() {
         super(...arguments);
         this.context = this.props.action.context;

--- a/addons/project/static/src/js/right_panel/project_utils.js
+++ b/addons/project/static/src/js/right_panel/project_utils.js
@@ -4,9 +4,10 @@ import { _lt } from 'web.core';
 import fieldUtils from 'web.field_utils';
 import { ComponentAdapter } from 'web.OwlCompatibility';
 import { FormViewDialog } from 'web.view_dialogs';
-const { useState, useRef } = owl.hooks;
 
-class MilestoneComponent extends owl.Component {
+const { Component, useRef, useState } = owl;
+
+class MilestoneComponent extends Component {
     constructor() {
         super(...arguments);
         this.contextValue = Object.assign({}, {

--- a/addons/snailmail/static/src/components/snailmail_error_dialog/snailmail_error_dialog.js
+++ b/addons/snailmail/static/src/components/snailmail_error_dialog/snailmail_error_dialog.js
@@ -5,7 +5,6 @@ import { registerMessagingComponent } from '@mail/utils/messaging_component';
 import Dialog from 'web.OwlDialog';
 
 const { Component } = owl;
-const { useRef } = owl.hooks;
 
 class SnailmailErrorDialog extends Component {
 

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -356,6 +356,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/lib/underscore.string/lib/underscore.string.js',
             'web/static/lib/moment/moment.js',
             'web/static/lib/owl/owl.js',
+            'web/static/src/owl_next_adapter.js',
             'web/static/src/legacy/js/component_extension.js',
             'web/static/lib/jquery/jquery.js',
             'web/static/lib/jquery.ui/jquery-ui.js',

--- a/addons/web/static/src/core/assets.js
+++ b/addons/web/static/src/core/assets.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-const { useEnv, onWillStart } = owl.hooks;
 import { memoize } from "./utils/functions";
 import { browser } from "./browser/browser";
 
-class AssetsLoadingError extends Error {
-}
+const { onWillStart, useEnv } = owl;
+
+class AssetsLoadingError extends Error {}
 
 //------------------------------------------------------------------------------
 // Types
@@ -116,7 +116,6 @@ export const loadBundleTemplates = memoize(async function loadBundleTemplates(na
     return processTemplates(templates);
 });
 
-
 /**
  * Loads the content definition of a bundle
  * @param {string} name the bundleName of the bundle as declared in the manifest.
@@ -145,18 +144,22 @@ export async function loadBundle(name, options) {
         bundlesCache[name].templates = loadBundleTemplates(name);
     }
 
-    if (css && !bundlesCache[name].css || js && !bundlesCache[name].js) {
+    if ((css && !bundlesCache[name].css) || (js && !bundlesCache[name].js)) {
         // we only load the bundle info (that is an RPC) if JS or CSS is requested on the bundle,
         // and if it has not yet been requested.
         /** @type BundleInfo[] */
         const bundleInfo = await loadBundleDefinition(name);
 
         if (options.js) {
-            bundlesCache[name].js = Promise.all(bundleInfo.filter((i) => i.type === "script").map((i) => loadJS(i.src)));
+            bundlesCache[name].js = Promise.all(
+                bundleInfo.filter((i) => i.type === "script").map((i) => loadJS(i.src))
+            );
         }
 
         if (options.css) {
-            bundlesCache[name].css = Promise.all(bundleInfo.filter((i) => i.type === "link").map((i) => loadCSS(i.src)));
+            bundlesCache[name].css = Promise.all(
+                bundleInfo.filter((i) => i.type === "link").map((i) => loadCSS(i.src))
+            );
         }
     }
 

--- a/addons/web/static/src/core/commands/command_palette.js
+++ b/addons/web/static/src/core/commands/command_palette.js
@@ -8,8 +8,7 @@ import { fuzzyLookup } from "@web/core/utils/search";
 import { debounce } from "@web/core/utils/timing";
 import { _lt } from "@web/core/l10n/translation";
 
-const { Component, hooks } = owl;
-const { onWillStart, useRef, useState } = hooks;
+const { Component, onWillStart, useRef, useState } = owl;
 
 const DEFAULT_PLACEHOLDER = _lt("Search...");
 const DEFAULT_EMPTY_MESSAGE = _lt("No result found");
@@ -21,7 +20,7 @@ const FUZZY_NAMESPACES = ["default"];
 
 /**
  * @typedef {Command & {
- *  Component?: owl.Component;
+ *  Component?: Component;
  *  props?: object;
  * }} CommandItem
  */

--- a/addons/web/static/src/core/commands/command_palette_dialog.js
+++ b/addons/web/static/src/core/commands/command_palette_dialog.js
@@ -3,8 +3,7 @@
 import { Dialog } from "@web/core/dialog/dialog";
 import { CommandPalette } from "./command_palette";
 
-const { hooks } = owl;
-const { useExternalListener } = hooks;
+const { useExternalListener } = owl;
 
 /**
  * @typedef {import("./command_service").Command} Command

--- a/addons/web/static/src/core/commands/command_service.js
+++ b/addons/web/static/src/core/commands/command_service.js
@@ -2,9 +2,8 @@
 
 import { registry } from "@web/core/registry";
 import { CommandPaletteDialog } from "./command_palette_dialog";
-const { Component } = owl;
 
-const { xml } = owl.tags;
+const { Component, xml } = owl;
 
 /**
  * @typedef {import("./command_palette").CommandPaletteConfig} CommandPaletteConfig

--- a/addons/web/static/src/core/datepicker/datepicker.js
+++ b/addons/web/static/src/core/datepicker/datepicker.js
@@ -4,9 +4,8 @@ import { localization } from "@web/core/l10n/localization";
 import { registry } from "@web/core/registry";
 import { useAutofocus } from "@web/core/utils/hooks";
 
-const { Component, hooks } = owl;
+const { Component, useExternalListener, useRef, useState } = owl;
 const { DateTime } = luxon;
-const { useExternalListener, useRef, useState } = hooks;
 
 const formatters = registry.category("formatters");
 const parsers = registry.category("parsers");

--- a/addons/web/static/src/core/debug/debug_context.js
+++ b/addons/web/static/src/core/debug/debug_context.js
@@ -4,7 +4,7 @@ import { registry } from "../registry";
 import { memoize } from "../utils/functions";
 import { useEffect } from "@web/core/utils/hooks";
 
-const { useEnv, useSubEnv } = owl.hooks;
+const { useEnv, useSubEnv } = owl;
 const debugRegistry = registry.category("debug");
 
 const getAccessRights = memoize(async function getAccessRights(orm) {

--- a/addons/web/static/src/core/debug/profiling/profiling_service.js
+++ b/addons/web/static/src/core/debug/profiling/profiling_service.js
@@ -4,7 +4,7 @@ import { registry } from "@web/core/registry";
 import { ProfilingItem } from "./profiling_item";
 import { session } from "@web/session";
 
-const { core } = owl;
+const { EventBus } = owl;
 
 const profilingService = {
     dependencies: ["orm"],
@@ -17,7 +17,7 @@ const profilingService = {
                 return Boolean(state.session);
             },
         };
-        const bus = new core.EventBus();
+        const bus = new EventBus();
 
         let recordingIcon = null;
         function updateDebugIcon() {
@@ -46,7 +46,8 @@ const profilingService = {
                 params
             );
             const resp = await orm.call("ir.profile", "set_profiling", [], kwargs);
-            if (resp.type) {  // most likely an "ir.actions.act_window"
+            if (resp.type) {
+                // most likely an "ir.actions.act_window"
                 env.services.action.doAction(resp);
             } else {
                 state.session = resp.session;

--- a/addons/web/static/src/core/dialog/dialog.js
+++ b/addons/web/static/src/core/dialog/dialog.js
@@ -3,8 +3,7 @@
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 import { useActiveElement } from "../ui/ui_service";
 
-const { Component, hooks } = owl;
-const { useRef, useSubEnv } = hooks;
+const { Component, useRef, useSubEnv, xml } = owl;
 
 export class Dialog extends Component {
     setup() {
@@ -46,5 +45,5 @@ Dialog.renderHeader = true;
 Dialog.size = "modal-lg";
 Dialog.technical = true;
 Dialog.title = "Odoo";
-Dialog.bodyTemplate = owl.tags.xml`<div/>`;
+Dialog.bodyTemplate = xml`<div/>`;
 Dialog.footerTemplate = "web.DialogFooterDefault";

--- a/addons/web/static/src/core/dialog/dialog_container.js
+++ b/addons/web/static/src/core/dialog/dialog_container.js
@@ -2,7 +2,7 @@
 
 import { ErrorHandler, NotUpdatable } from "../utils/components";
 
-const { Component, tags } = owl;
+const { Component, xml } = owl;
 
 export class DialogContainer extends Component {
     setup() {
@@ -23,7 +23,7 @@ export class DialogContainer extends Component {
     }
 }
 DialogContainer.components = { ErrorHandler, NotUpdatable };
-DialogContainer.template = tags.xml`
+DialogContainer.template = xml`
     <div class="o_dialog_container" t-att-class="{'modal-open': Object.keys(props.dialogs).length > 0}">
       <t t-foreach="Object.values(props.dialogs)" t-as="dialog" t-key="dialog.id">
         <NotUpdatable>

--- a/addons/web/static/src/core/dialog/dialog_service.js
+++ b/addons/web/static/src/core/dialog/dialog_service.js
@@ -4,8 +4,7 @@ import { registry } from "../registry";
 import { Dialog } from "./dialog";
 import { DialogContainer } from "./dialog_container";
 
-const { core } = owl;
-const { EventBus } = core;
+const { EventBus } = owl;
 
 /**
  *  @typedef {{

--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -5,9 +5,16 @@ import { usePosition } from "../position/position_hook";
 import { useDropdownNavigation } from "./dropdown_navigation_hook";
 import { localization } from "../l10n/localization";
 
-const { Component, core, hooks, useState, QWeb } = owl;
-const { EventBus } = core;
-const { onWillStart, useExternalListener, useRef, useSubEnv } = hooks;
+const {
+    Component,
+    EventBus,
+    QWeb,
+    onWillStart,
+    useExternalListener,
+    useRef,
+    useState,
+    useSubEnv,
+} = owl;
 
 const DIRECTION_CARET_CLASS = {
     bottom: "dropdown",

--- a/addons/web/static/src/core/dropdown/dropdown_item.js
+++ b/addons/web/static/src/core/dropdown/dropdown_item.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 import { DROPDOWN } from "./dropdown";
+
 const { Component, QWeb } = owl;
 
 /**

--- a/addons/web/static/src/core/dropdown/dropdown_navigation_hook.js
+++ b/addons/web/static/src/core/dropdown/dropdown_navigation_hook.js
@@ -5,6 +5,8 @@ import { browser } from "../browser/browser";
 import { localization } from "@web/core/l10n/localization";
 import { scrollTo } from "../utils/scrolling";
 
+const { useComponent, useRef } = owl;
+
 /**
  * @typedef {{
  *  el: HTMLElement,
@@ -17,9 +19,6 @@ import { scrollTo } from "../utils/scrolling";
  *  openSubDropdown: (immediate?:boolean)=>void,
  * }} MenuElement
  */
-
-const { hooks } = owl;
-const { useComponent, useRef } = hooks;
 
 const ACTIVE_MENU_ELEMENT_CLASS = "focus";
 const MENU_ELEMENTS_SELECTORS = [":scope > .dropdown-item", ":scope > .dropdown"];

--- a/addons/web/static/src/core/effects/effect_container.js
+++ b/addons/web/static/src/core/effects/effect_container.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-const { Component, tags } = owl;
+const { Component, xml } = owl;
 
 export class EffectContainer extends Component {
     setup() {
@@ -16,7 +16,7 @@ export class EffectContainer extends Component {
     }
 }
 
-EffectContainer.template = tags.xml`
+EffectContainer.template = xml`
   <div class="o_effects_manager">
     <t t-if="effect">
         <t t-component="effect.Component" t-props="effect.props" t-key="effect.id" close="() => this.removeEffect()"/>

--- a/addons/web/static/src/core/effects/effect_service.js
+++ b/addons/web/static/src/core/effects/effect_service.js
@@ -4,7 +4,7 @@ import { registry } from "../registry";
 import { EffectContainer } from "./effect_container";
 import { RainbowMan } from "./rainbow_man";
 
-const { EventBus } = owl.core;
+const { Component, EventBus } = owl;
 
 const effectRegistry = registry.category("effects");
 
@@ -32,7 +32,7 @@ const effectRegistry = registry.category("effects");
  *    'fast' will make rainbowman dissapear quickly
  *    'medium' and 'slow' will wait little longer before disappearing (can be used when options.message is longer)
  *    'no' will keep rainbowman on screen until user clicks anywhere outside rainbowman
- * @param {owl.Component} [params.Component]
+ * @param {Component} [params.Component]
  *    Custom Component class to instantiate inside the Rainbow Man
  * @param {Object} [params.props]
  *    If params.Component is given, its props can be passed with this argument

--- a/addons/web/static/src/core/effects/rainbow_man.js
+++ b/addons/web/static/src/core/effects/rainbow_man.js
@@ -3,7 +3,7 @@
 import { browser } from "@web/core/browser/browser";
 import { useEffect } from "@web/core/utils/hooks";
 
-const { Component, hooks } = owl;
+const { Component, useExternalListener } = owl;
 
 /**
  * @typedef Common
@@ -37,7 +37,7 @@ const { Component, hooks } = owl;
  */
 export class RainbowMan extends Component {
     setup() {
-        hooks.useExternalListener(document.body, "click", this.closeRainbowMan);
+        useExternalListener(document.body, "click", this.closeRainbowMan);
         this.delay = RainbowMan.rainbowFadeouts[this.props.fadeout];
         if (this.delay) {
             useEffect(

--- a/addons/web/static/src/core/errors/error_dialogs.js
+++ b/addons/web/static/src/core/errors/error_dialogs.js
@@ -7,8 +7,7 @@ import { registry } from "../registry";
 import { useService } from "@web/core/utils/hooks";
 import { capitalize } from "../utils/strings";
 
-const { hooks } = owl;
-const { useState } = hooks;
+const { useState } = owl;
 
 export const odooExceptionTitleMap = new Map(
     Object.entries({

--- a/addons/web/static/src/core/file_input/file_input.js
+++ b/addons/web/static/src/core/file_input/file_input.js
@@ -2,8 +2,7 @@
 
 import { useService } from "@web/core/utils/hooks";
 
-const { Component, hooks, QWeb } = owl;
-const { useRef } = hooks;
+const { Component, QWeb, useRef } = owl;
 
 /**
  * Custom file input

--- a/addons/web/static/src/core/l10n/localization_service.js
+++ b/addons/web/static/src/core/l10n/localization_service.js
@@ -7,11 +7,13 @@ import { localization } from "./localization";
 import { translatedTerms, _t } from "./translation";
 import { session } from "@web/session";
 
+const { config } = owl;
+
 export const localizationService = {
     dependencies: ["user"],
     start: async (env, { user }) => {
         // add "data-toolip" to the list of translatable attributes in owl templates
-        owl.config.translatableAttributes.push("data-tooltip");
+        config.translatableAttributes.push("data-tooltip");
 
         const cacheHashes = session.cache_hashes || {};
         const translationsHash = cacheHashes.translations || new Date().getTime().toString();

--- a/addons/web/static/src/core/main_components_container.js
+++ b/addons/web/static/src/core/main_components_container.js
@@ -2,7 +2,7 @@
 import { registry } from "./registry";
 import { NotUpdatable, ErrorHandler } from "./utils/components";
 
-const { Component, tags } = owl;
+const { Component, xml } = owl;
 
 export class MainComponentsContainer extends Component {
     setup() {
@@ -24,7 +24,7 @@ export class MainComponentsContainer extends Component {
     }
 }
 
-MainComponentsContainer.template = tags.xml`
+MainComponentsContainer.template = xml`
 <div>
     <t t-foreach="Components" t-as="C" t-key="C[0]">
         <NotUpdatable>

--- a/addons/web/static/src/core/notifications/notification.js
+++ b/addons/web/static/src/core/notifications/notification.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-const { Component, hooks } = owl;
+const { Component, onWillUnmount } = owl;
 
 export class Notification extends Component {
     setup() {
         if (this.props.onClose) {
-            hooks.onWillUnmount(() => this.props.onClose());
+            onWillUnmount(() => this.props.onClose());
         }
     }
 
@@ -40,13 +40,13 @@ Notification.props = {
             return (
                 typeof m === "string" || (typeof m === "object" && typeof m.toString === "function")
             );
-        }
+        },
     },
     title: { type: [String, Boolean, { toString: Function }], optional: true },
     type: {
         type: String,
         optional: true,
-        validate: (t) => ["warning", "danger", "success", "info"].includes(t)
+        validate: (t) => ["warning", "danger", "success", "info"].includes(t),
     },
     messageIsHtml: { type: Boolean, optional: true },
     className: { type: String, optional: true },
@@ -58,15 +58,15 @@ Notification.props = {
                 name: { type: String },
                 icon: { type: String, optional: true },
                 primary: { type: Boolean, optional: true },
-                onClick: Function
-            }
-        }
+                onClick: Function,
+            },
+        },
     },
-    onClose: { type: Function, optional: true }
+    onClose: { type: Function, optional: true },
 };
 Notification.defaultProps = {
     buttons: [],
     className: "",
     messageIsHtml: false,
-    type: "warning"
+    type: "warning",
 };

--- a/addons/web/static/src/core/notifications/notification_container.js
+++ b/addons/web/static/src/core/notifications/notification_container.js
@@ -2,7 +2,7 @@
 
 import { Notification } from "./notification";
 
-const { Component, tags } = owl;
+const { Component, xml } = owl;
 
 export class NotificationContainer extends Component {
     setup() {
@@ -12,7 +12,7 @@ export class NotificationContainer extends Component {
     }
 }
 
-NotificationContainer.template = tags.xml`
+NotificationContainer.template = xml`
     <div class="o_notification_manager">
         <t t-foreach="props.notifications" t-as="notification" t-key="notification.id">
             <Notification

--- a/addons/web/static/src/core/notifications/notification_service.js
+++ b/addons/web/static/src/core/notifications/notification_service.js
@@ -4,7 +4,7 @@ import { browser } from "../browser/browser";
 import { registry } from "../registry";
 import { NotificationContainer } from "./notification_container";
 
-const { EventBus } = owl.core;
+const { EventBus } = owl;
 
 const AUTOCLOSE_DELAY = 4000;
 

--- a/addons/web/static/src/core/pager/pager.js
+++ b/addons/web/static/src/core/pager/pager.js
@@ -2,8 +2,7 @@
 
 import { useAutofocus } from "../utils/hooks";
 
-const { Component } = owl;
-const { useExternalListener, useRef, useState } = owl.hooks;
+const { Component, useExternalListener, useRef, useState } = owl;
 
 /**
  * Pager

--- a/addons/web/static/src/core/popover/popover_container.js
+++ b/addons/web/static/src/core/popover/popover_container.js
@@ -2,9 +2,7 @@
 
 import { Popover } from "./popover";
 
-const { Component } = owl;
-const { useExternalListener, useState } = owl.hooks;
-const { xml } = owl.tags;
+const { Component, useExternalListener, useState, xml } = owl;
 
 class PopoverController extends Component {
     setup() {

--- a/addons/web/static/src/core/popover/popover_hook.js
+++ b/addons/web/static/src/core/popover/popover_hook.js
@@ -2,7 +2,7 @@
 
 import { useService } from "@web/core/utils/hooks";
 
-const { onWillUnmount, useComponent } = owl.hooks;
+const { onWillUnmount, useComponent } = owl;
 
 export function usePopover() {
     const removeFns = new Set();

--- a/addons/web/static/src/core/popover/popover_service.js
+++ b/addons/web/static/src/core/popover/popover_service.js
@@ -3,7 +3,7 @@
 import { registry } from "../registry";
 import { PopoverContainer } from "./popover_container";
 
-const { EventBus } = owl.core;
+const { EventBus } = owl;
 
 export const popoverService = {
     start() {

--- a/addons/web/static/src/core/position/position_hook.js
+++ b/addons/web/static/src/core/position/position_hook.js
@@ -3,7 +3,7 @@
 import { useEffect } from "@web/core/utils/hooks";
 import { throttleForAnimation } from "../utils/timing";
 
-const { onWillUnmount } = owl.hooks;
+const { onWillUnmount, useComponent, useExternalListener, useRef } = owl;
 
 /**
  * @typedef {{
@@ -54,9 +54,6 @@ const { onWillUnmount } = owl.hooks;
  *
  * @typedef {{ className: string, top: number, left: number }} PositioningSolution
  */
-
-const { hooks } = owl;
-const { useComponent, useExternalListener, useRef } = hooks;
 
 const POPPER_CLASS = "o-popper-position";
 /** @type DirectionFlipOrder */

--- a/addons/web/static/src/core/registry.js
+++ b/addons/web/static/src/core/registry.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
-const { core } = owl;
-const { EventBus } = core;
+const { EventBus } = owl;
 
 // -----------------------------------------------------------------------------
 // Errors

--- a/addons/web/static/src/core/ui/block_ui.js
+++ b/addons/web/static/src/core/ui/block_ui.js
@@ -2,7 +2,7 @@
 
 import { browser } from "@web/core/browser/browser";
 
-const { Component, tags, useState } = owl;
+const { Component, useState, xml } = owl;
 
 export class BlockUI extends Component {
     setup() {
@@ -70,7 +70,7 @@ export class BlockUI extends Component {
     }
 }
 
-BlockUI.template = tags.xml`
+BlockUI.template = xml`
     <div t-att-class="state.blockUI ? 'o_blockUI' : ''">
       <t t-if="state.blockUI">
         <div class="o_spinner">

--- a/addons/web/static/src/core/ui/ui_service.js
+++ b/addons/web/static/src/core/ui/ui_service.js
@@ -6,9 +6,7 @@ import { debounce } from "@web/core/utils/timing";
 import { BlockUI } from "./block_ui";
 import { browser } from "@web/core/browser/browser";
 
-const { Component, core, hooks } = owl;
-const { EventBus } = core;
-const { useRef } = hooks;
+const { Component, EventBus, useRef } = owl;
 
 export const SIZES = { XS: 0, VSM: 1, SM: 2, MD: 3, LG: 4, XL: 5, XXL: 6 };
 

--- a/addons/web/static/src/core/utils/components.js
+++ b/addons/web/static/src/core/utils/components.js
@@ -1,13 +1,13 @@
 /** @odoo-module **/
 
-const { Component, tags } = owl;
+const { Component, xml } = owl;
 
 export class NotUpdatable extends Component {
     shouldUpdate() {
         return false;
     }
 }
-NotUpdatable.template = tags.xml`<t t-slot="default" />`;
+NotUpdatable.template = xml`<t t-slot="default" />`;
 
 export class ErrorHandler extends Component {
     catchError(error) {
@@ -16,4 +16,4 @@ export class ErrorHandler extends Component {
         }
     }
 }
-ErrorHandler.template = tags.xml`<t t-slot="default" />`;
+ErrorHandler.template = xml`<t t-slot="default" />`;

--- a/addons/web/static/src/core/utils/hooks.js
+++ b/addons/web/static/src/core/utils/hooks.js
@@ -2,7 +2,7 @@
 
 import { SERVICES_METADATA } from "@web/env";
 
-const { onMounted, onWillPatch, onPatched, onWillUnmount, useComponent } = owl.hooks;
+const { onMounted, onPatched, onWillPatch, onWillUnmount, useComponent } = owl;
 
 /**
  * This file contains various custom hooks.

--- a/addons/web/static/src/env.js
+++ b/addons/web/static/src/env.js
@@ -2,6 +2,8 @@
 
 import { registry } from "./core/registry";
 
+const { EventBus, QWeb } = owl;
+
 // -----------------------------------------------------------------------------
 // Types
 // -----------------------------------------------------------------------------
@@ -9,8 +11,8 @@ import { registry } from "./core/registry";
 /**
  * @typedef {Object} OdooEnv
  * @property {Object} services
- * @property {owl.core.EventBus} bus
- * @property {owl.QWeb} qweb
+ * @property {EventBus} bus
+ * @property {QWeb} qweb
  * @property {string} debug
  * @property {(str: string) => string} _t
  * @property {boolean} [isSmall]
@@ -27,8 +29,8 @@ import { registry } from "./core/registry";
  */
 export function makeEnv() {
     return {
-        qweb: new owl.QWeb(),
-        bus: new owl.core.EventBus(),
+        qweb: new QWeb(),
+        bus: new EventBus(),
         services: {},
         debug: odoo.debug,
         _t: () => {

--- a/addons/web/static/src/fields/fields.js
+++ b/addons/web/static/src/fields/fields.js
@@ -5,7 +5,7 @@ import owlFieldRegistry from "web.field_registry_owl";
 import { ComponentAdapter } from "web.OwlCompatibility";
 import { useEffect } from "@web/core/utils/hooks";
 
-const { Component, tags, hooks } = owl;
+const { Component, useRef, xml } = owl;
 
 const fieldRegistry = registry.category("fields");
 
@@ -36,12 +36,12 @@ class Field extends Component {
 
     setup() {
         const { record, type, name } = this.props;
-        this.fieldRef = hooks.useRef("fieldRef");
+        this.fieldRef = useRef("fieldRef");
         this.FieldComponent = Field.getTangibleField({ record, type, name }).FieldClass;
     }
 }
 
-Field.template = tags.xml/* xml */ `
+Field.template = xml/* xml */ `
     <t t-component="FieldComponent" t-props="props" class="o-field" t-key="props.record.id" t-ref="fieldRef"/>
 `;
 
@@ -77,7 +77,7 @@ class FieldSupportsLegacy extends Field {
             this.renderId++;
         });
         if (!this.FieldComponent) {
-            this.env = owl.Component.env;
+            this.env = Component.env;
             const { record, type, name } = this.props;
             const { FieldClass, isOwlLegacy, isLegacy } = FieldSupportsLegacy.getTangibleField({
                 record,
@@ -104,7 +104,7 @@ class FieldSupportsLegacy extends Field {
         return [fieldName, record];
     }
 }
-FieldSupportsLegacy.template = tags.xml/* xml */ `<t>
+FieldSupportsLegacy.template = xml/* xml */ `<t>
     <t t-if="!isOwlLegacy and !isLegacy" t-call="${Field.template}" />
     <t t-elif="isOwlLegacy" t-component="FieldComponent" t-props="legacyProps" />
     <t t-elif="isLegacy" t-component="ComponentAdapter" widgetArgs="widgetArgs" Component="FieldComponent" t-key="renderId" />

--- a/addons/web/static/src/legacy/action_adapters.js
+++ b/addons/web/static/src/legacy/action_adapters.js
@@ -11,9 +11,9 @@ import { ViewNotFoundError } from "../webclient/actions/action_service";
 import { cleanDomFromBootstrap, wrapSuccessOrFail } from "./utils";
 import { mapDoActionOptionAPI } from "./backend_utils";
 
-const { Component, tags, hooks } = owl;
+const { Component, onMounted, useExternalListener, xml } = owl;
 
-const warningDialogBodyTemplate = tags.xml`<t t-esc="props.message"/>`;
+const warningDialogBodyTemplate = xml`<t t-esc="props.message"/>`;
 
 class ActionAdapter extends ComponentAdapter {
     setup() {
@@ -56,7 +56,7 @@ class ActionAdapter extends ComponentAdapter {
             },
             () => []
         );
-        hooks.useExternalListener(window, "click", () => {
+        useExternalListener(window, "click", () => {
             cleanDomFromBootstrap();
         });
     }
@@ -168,7 +168,7 @@ export class ClientActionAdapter extends ActionAdapter {
     setup() {
         super.setup();
         useDebugCategory("action", { action: this.props.widgetArgs[0] });
-        owl.hooks.onMounted(() => {
+        onMounted(() => {
             const action = this.props.widgetArgs[0];
             if ("params" in action) {
                 const newState = {};

--- a/addons/web/static/src/legacy/debug_manager.js
+++ b/addons/web/static/src/legacy/debug_manager.js
@@ -6,8 +6,7 @@ import { formatDateTime, parseDateTime } from "@web/core/l10n/dates";
 import { formatMany2one } from "@web/fields/formatters";
 import { registry } from "@web/core/registry";
 
-const { hooks } = owl;
-const { useState } = hooks;
+const { useState } = owl;
 
 const debugRegistry = registry.category("debug");
 

--- a/addons/web/static/src/legacy/js/chrome/abstract_action.js
+++ b/addons/web/static/src/legacy/js/chrome/abstract_action.js
@@ -13,6 +13,7 @@ import ControlPanel from "web.ControlPanel";
 import Widget from "web.Widget";
 import { ComponentWrapper } from "web.OwlCompatibility";
 
+const { Component } = owl;
 const AbstractAction = Widget.extend(ActionMixin, {
     config: {
         ControlPanel: ControlPanel,
@@ -78,7 +79,7 @@ const AbstractAction = Widget.extend(ActionMixin, {
         this.searchModelConfig = {
             context: Object.assign({}, action.context),
             domain: action.domain || [],
-            env: owl.Component.env,
+            env: Component.env,
             searchMenuTypes: this.searchMenuTypes,
         };
         this.extensions = {};

--- a/addons/web/static/src/legacy/js/common_env.js
+++ b/addons/web/static/src/legacy/js/common_env.js
@@ -25,6 +25,7 @@ odoo.define("web.commonEnv", function (require) {
     const { _t } = require("web.translation");
     const utils = require("web.utils");
 
+    const { QWeb } = owl;
     const browser = {
         clearInterval: window.clearInterval.bind(window),
         clearTimeout: window.clearTimeout.bind(window),
@@ -49,7 +50,7 @@ odoo.define("web.commonEnv", function (require) {
         bus,
         device,
         isDebug,
-        qweb: new owl.QWeb({ translateFn: _t }),
+        qweb: new QWeb({ translateFn: _t }),
         services: {
             ajaxJsonRPC() {
                 return jsonRpc(...arguments);

--- a/addons/web/static/src/legacy/js/component_extension.js
+++ b/addons/web/static/src/legacy/js/component_extension.js
@@ -1,4 +1,7 @@
 (function () {
+
+    const { Component } = owl;
+
     /**
      * Symbol used in ComponentWrapper to redirect Owl events to Odoo legacy
      * events.
@@ -9,7 +12,7 @@
      * Add a new method to owl Components to ensure that no performed RPC is
      * resolved/rejected when the component is destroyed.
      */
-    owl.Component.prototype.rpc = function () {
+    Component.prototype.rpc = function () {
         return new Promise((resolve, reject) => {
             return this.env.services.rpc(...arguments)
                 .then(result => {
@@ -26,14 +29,14 @@
     };
 
     /**
-     * Patch owl.Component.__trigger method to call a hook that adds a listener
+     * Patch Component.__trigger method to call a hook that adds a listener
      * for the triggered event just before triggering it. This is useful if
      * there are legacy widgets in the ancestors. In that case, there would be
      * a widgetSymbol key in the environment, corresponding to the hook to call
      * (see ComponentWrapper).
      */
-    const originalTrigger = owl.Component.prototype.__trigger;
-    owl.Component.prototype.__trigger = function (component, evType, payload) {
+    const originalTrigger = Component.prototype.__trigger;
+    Component.prototype.__trigger = function (component, evType, payload) {
         if (this.env[odoo.widgetSymbol]) {
             this.env[odoo.widgetSymbol](evType);
         }

--- a/addons/web/static/src/legacy/js/components/custom_file_input.js
+++ b/addons/web/static/src/legacy/js/components/custom_file_input.js
@@ -1,8 +1,7 @@
 odoo.define('web.CustomFileInput', function (require) {
     "use strict";
 
-    const { Component, hooks } = owl;
-    const { useRef } = hooks;
+    const { Component, useRef } = owl;
 
     /**
      * Custom file input

--- a/addons/web/static/src/legacy/js/components/datepicker.js
+++ b/addons/web/static/src/legacy/js/components/datepicker.js
@@ -5,8 +5,7 @@ odoo.define('web.DatePickerOwl', function (require) {
     const time = require('web.time');
     const { useAutofocus } = require('web.custom_hooks');
 
-    const { Component, hooks } = owl;
-    const { useExternalListener, useRef, useState } = hooks;
+    const { Component, useExternalListener, useRef, useState } = owl;
 
     let datePickerId = 0;
 

--- a/addons/web/static/src/legacy/js/components/dropdown_menu.js
+++ b/addons/web/static/src/legacy/js/components/dropdown_menu.js
@@ -4,8 +4,7 @@ odoo.define('web.DropdownMenu', function (require) {
     const { _t } = require('web.core');
     const DropdownMenuItem = require('web.DropdownMenuItem');
 
-    const { Component, hooks } = owl;
-    const { useExternalListener, useRef, useState } = hooks;
+    const { Component, useExternalListener, useRef, useState } = owl;
 
     /**
      * Dropdown menu

--- a/addons/web/static/src/legacy/js/components/dropdown_menu_item.js
+++ b/addons/web/static/src/legacy/js/components/dropdown_menu_item.js
@@ -3,8 +3,7 @@ odoo.define('web.DropdownMenuItem', function (require) {
 
     const { useListener } = require('web.custom_hooks');
 
-    const { Component, hooks } = owl;
-    const { useExternalListener, useRef, useState } = hooks;
+    const { Component, useExternalListener, useRef, useState } = owl;
 
     /**
      * Dropdown menu item

--- a/addons/web/static/src/legacy/js/components/pager.js
+++ b/addons/web/static/src/legacy/js/components/pager.js
@@ -3,8 +3,7 @@ odoo.define('web.Pager', function (require) {
 
     const { useAutofocus } = require('web.custom_hooks');
 
-    const { Component, hooks } = owl;
-    const { useState } = hooks;
+    const { Component, useState } = owl;
 
     /**
      * Pager

--- a/addons/web/static/src/legacy/js/control_panel/control_panel.js
+++ b/addons/web/static/src/legacy/js/control_panel/control_panel.js
@@ -11,8 +11,7 @@ odoo.define('web.ControlPanel', function (require) {
     const SearchBar = require('web.SearchBar');
     const { useModel } = require('web.Model');
 
-    const { Component, hooks } = owl;
-    const { useRef, useSubEnv } = hooks;
+    const { Component, useRef, useSubEnv } = owl;
 
     /**
      * TODO: remove this whole mechanism as soon as `cp_content` is completely removed.

--- a/addons/web/static/src/legacy/js/control_panel/custom_favorite_item.js
+++ b/addons/web/static/src/legacy/js/control_panel/custom_favorite_item.js
@@ -5,8 +5,7 @@ odoo.define('web.CustomFavoriteItem', function (require) {
     const { useAutofocus } = require('web.custom_hooks');
     const { useModel } = require('web.Model');
 
-    const { Component, hooks, useState } = owl;
-    const { useRef } = hooks;
+    const { Component, useRef, useState } = owl;
 
     let favoriteId = 0;
 

--- a/addons/web/static/src/legacy/js/control_panel/custom_filter_item.js
+++ b/addons/web/static/src/legacy/js/control_panel/custom_filter_item.js
@@ -7,8 +7,7 @@ odoo.define('web.CustomFilterItem', function (require) {
     const field_utils = require('web.field_utils');
     const { useModel } = require('web.Model');
 
-    const { Component, hooks } = owl;
-    const { useState } = hooks;
+    const { Component, useState } = owl;
 
     /**
      * Filter generator menu

--- a/addons/web/static/src/legacy/js/control_panel/custom_group_by_item.js
+++ b/addons/web/static/src/legacy/js/control_panel/custom_group_by_item.js
@@ -3,8 +3,7 @@ odoo.define('web.CustomGroupByItem', function (require) {
 
     const { useModel } = require('web.Model');
 
-    const { Component, hooks } = owl;
-    const { useState } = hooks;
+    const { Component, useState } = owl;
 
     class CustomGroupByItem extends Component {
         constructor() {

--- a/addons/web/static/src/legacy/js/control_panel/favorite_menu.js
+++ b/addons/web/static/src/legacy/js/control_panel/favorite_menu.js
@@ -5,6 +5,7 @@ odoo.define('web.FavoriteMenu', function (require) {
     const { FACET_ICONS } = require("web.searchUtils");
     const Registry = require('web.Registry');
     const { useModel } = require('web.Model');
+
     const { Component, useState } = owl;
 
     /**

--- a/addons/web/static/src/legacy/js/control_panel/search_bar.js
+++ b/addons/web/static/src/legacy/js/control_panel/search_bar.js
@@ -7,9 +7,8 @@ odoo.define('web.SearchBar', function (require) {
     const { useModel } = require('web.Model');
     const { fuzzyTest } = require('@web/core/utils/search');
 
+    const { Component, useExternalListener, useRef, useState } = owl;
     const CHAR_FIELDS = ['char', 'html', 'many2many', 'many2one', 'one2many', 'text'];
-    const { Component, hooks } = owl;
-    const { useExternalListener, useRef, useState } = hooks;
 
     let sourceId = 0;
 

--- a/addons/web/static/src/legacy/js/core/custom_hooks.js
+++ b/addons/web/static/src/legacy/js/core/custom_hooks.js
@@ -1,8 +1,9 @@
 odoo.define('web.custom_hooks', function (require) {
     "use strict";
 
-    const { Component } = owl;
     const { useEffect } = require("@web/core/utils/hooks");
+
+    const { Component } = owl;
 
     /**
      * Focus a given selector as soon as it appears in the DOM and if it was not

--- a/addons/web/static/src/legacy/js/core/owl_dialog.js
+++ b/addons/web/static/src/legacy/js/core/owl_dialog.js
@@ -1,9 +1,7 @@
 odoo.define('web.OwlDialog', function (require) {
     "use strict";
 
-    const { Component, hooks, misc } = owl;
-    const { Portal } = misc;
-    const { useRef } = hooks;
+    const { Component, Portal, useRef } = owl;
     const SIZE_CLASSES = {
         'extra-large': 'modal-xl',
         'large': 'modal-lg',

--- a/addons/web/static/src/legacy/js/core/popover.js
+++ b/addons/web/static/src/legacy/js/core/popover.js
@@ -1,9 +1,7 @@
 odoo.define('web.Popover', function (require) {
     'use strict';
 
-    const { Component, hooks, misc, QWeb } = owl;
-    const { Portal } = misc;
-    const { useRef, useState } = hooks;
+    const { Component, Portal, QWeb, useRef, useState } = owl;
 
     /**
      * Popover

--- a/addons/web/static/src/legacy/js/core/utils.js
+++ b/addons/web/static/src/legacy/js/core/utils.js
@@ -10,6 +10,8 @@ odoo.define('web.utils', function (require) {
 var translation = require('web.translation');
 var cookieUtils = require('web.utils.cookies');
 
+const { Component } = owl;
+
 var _t = translation._t;
 var id = -1;
 
@@ -581,12 +583,12 @@ var utils = Object.assign({
         return (/^\d+(\.\d*)? [^0-9]+$/).test(v);
     },
     /**
-     * Checks if a class is an extension of owl.Component.
+     * Checks if a class is an extension of Component.
      *
      * @param {any} value A class reference
      */
     isComponent: function (value) {
-        return value.prototype instanceof owl.Component;
+        return value.prototype instanceof Component;
     },
     /**
      * Checks if a keyboard event concerns

--- a/addons/web/static/src/legacy/js/fields/abstract_field_owl.js
+++ b/addons/web/static/src/legacy/js/fields/abstract_field_owl.js
@@ -5,6 +5,8 @@ odoo.define('web.AbstractFieldOwl', function (require) {
     const { useListener } = require('web.custom_hooks');
     const { useEffect } = require("@web/core/utils/hooks");
 
+    const { Component } = owl;
+
     /**
      * This file defines the Owl version of the AbstractField. Specific fields
      * written in Owl should override this component.
@@ -44,7 +46,7 @@ odoo.define('web.AbstractFieldOwl', function (require) {
      *
      * @module web.AbstractFieldOwl
      */
-    class AbstractField extends owl.Component {
+    class AbstractField extends Component {
         /**
          * Abstract field class
          *

--- a/addons/web/static/src/legacy/js/fields/field_registry.js
+++ b/addons/web/static/src/legacy/js/fields/field_registry.js
@@ -3,9 +3,11 @@ odoo.define('web.field_registry', function (require) {
 
     const Registry = require('web.Registry');
 
+    const { Component } = owl;
+
     return new Registry(
         null,
-        (value) => !(value.prototype instanceof owl.Component)
+        (value) => !(value.prototype instanceof Component)
     );
 });
 
@@ -17,7 +19,6 @@ var basic_fields = require('web.basic_fields');
 var relational_fields = require('web.relational_fields');
 var registry = require('web.field_registry');
 var special_fields = require('web.special_fields');
-
 
 // Basic fields
 registry

--- a/addons/web/static/src/legacy/js/fields/field_registry_owl.js
+++ b/addons/web/static/src/legacy/js/fields/field_registry_owl.js
@@ -3,9 +3,11 @@ odoo.define('web.field_registry_owl', function (require) {
 
     const Registry = require('web.Registry');
 
+    const { Component } = owl;
+
     return new Registry(
         null,
-        (value) => value.prototype instanceof owl.Component
+        (value) => value.prototype instanceof Component
     );
 });
 

--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -29,7 +29,8 @@ var ListRenderer = require('web.ListRenderer');
 const { ComponentWrapper, WidgetAdapterMixin } = require('web.OwlCompatibility');
 const { sprintf, toBoolElse } = require("web.utils");
 
-const { escape } = owl.utils;
+const { escape } = owl;
+
 var _t = core._t;
 var _lt = core._lt;
 var qweb = core.qweb;

--- a/addons/web/static/src/legacy/js/model.js
+++ b/addons/web/static/src/legacy/js/model.js
@@ -4,8 +4,7 @@ odoo.define("web.Model", function (require) {
     const { groupBy, partitionBy } = require("web.utils");
     const Registry = require("web.Registry");
 
-    const { Component, core } = owl;
-    const { EventBus, Observer } = core;
+    const { Component, EventBus, Observer } = owl;
     const isNotNull = (val) => val !== null && val !== undefined;
 
     /**

--- a/addons/web/static/src/legacy/js/owl_compatibility.js
+++ b/addons/web/static/src/legacy/js/owl_compatibility.js
@@ -1,6 +1,8 @@
 odoo.define('web.OwlCompatibility', function () {
     "use strict";
 
+    const { Component, useRef, useSubEnv, xml } = owl;
+
     /**
      * This file defines the necessary tools for the transition phase where Odoo
      * legacy widgets and Owl components will coexist. There are two possible
@@ -9,15 +11,12 @@ odoo.define('web.OwlCompatibility', function () {
      *  2) A legacy widget has to instantiate Owl components
      */
 
-    const { Component, hooks, tags } = owl;
-    const { useRef, useSubEnv } = hooks;
-    const { xml } = tags;
 
     const widgetSymbol = odoo.widgetSymbol;
     const children = new WeakMap(); // associates legacy widgets with their Owl children
 
-    const templateForLegacy = tags.xml`<div/>`;
-    const templateForOwl = tags.xml`<t t-component="props.Component" t-props="childProps" />`;
+    const templateForLegacy = xml`<div/>`;
+    const templateForOwl = xml`<t t-component="props.Component" t-props="childProps" />`;
     /**
      * Case 1) An Owl component has to instantiate legacy widgets
      * ----------------------------------------------------------

--- a/addons/web/static/src/legacy/js/public/public_root.js
+++ b/addons/web/static/src/legacy/js/public/public_root.js
@@ -26,6 +26,7 @@ import { loadBundleTemplates } from "@web/core/assets";
 import { makeEnv, startServices } from "@web/env";
 import { MainComponentsContainer } from "@web/core/main_components_container";
 const serviceRegistry = registry.category("services");
+const { Component, config, mount, whenReady } = owl;
 
 // Load localizations outside the PublicRoot to not wait for DOM ready (but
 // wait for them in PublicRoot)
@@ -352,13 +353,12 @@ export const PublicRoot = publicWidget.RootWidget.extend({
     },
 });
 
-const { Component, mount } = owl;
 
 /**
  * Configure Owl with the public env
  */
-owl.config.mode = legacyEnv.isDebug() ? "dev" : "prod";
-owl.Component.env = legacyEnv;
+config.mode = legacyEnv.isDebug() ? "dev" : "prod";
+Component.env = legacyEnv;
 
 /**
  * This widget is important, because the tour manager needs a root widget in
@@ -376,7 +376,7 @@ export async function createPublicRoot(RootWidget) {
     serviceRegistry.add("legacy_notification", makeLegacyNotificationService(legacyEnv));
     serviceRegistry.add("legacy_dialog_mapping", makeLegacyDialogMappingService(legacyEnv));
     serviceRegistry.add("legacy_rainbowman_service", makeLegacyRainbowManService(legacyEnv));
-    await Promise.all([owl.utils.whenReady(), session.is_bound]);
+    await Promise.all([whenReady(), session.is_bound]);
 
     const wowlEnv = makeEnv();
     wowlEnv.qweb.addTemplates(await loadBundleTemplates("web.assets_frontend"));

--- a/addons/web/static/src/legacy/js/views/abstract_controller.js
+++ b/addons/web/static/src/legacy/js/views/abstract_controller.js
@@ -18,6 +18,7 @@ import { ComponentWrapper } from 'web.OwlCompatibility';
 import mvc from 'web.mvc';
 import session from 'web.session';
 
+const { Component } = owl;
 
 var AbstractController = mvc.Controller.extend(ActionMixin, {
     custom_events: _.extend({}, ActionMixin.custom_events, {
@@ -121,7 +122,7 @@ var AbstractController = mvc.Controller.extend(ActionMixin, {
         if (this.withControlPanel) {
             this.searchModel.on('get-controller-query-params', this, this._onGetOwnedQueryParams);
         }
-        if (!(this.renderer instanceof owl.Component)) {
+        if (!(this.renderer instanceof Component)) {
             this.renderer.on_attach_callback();
         }
     },
@@ -134,7 +135,7 @@ var AbstractController = mvc.Controller.extend(ActionMixin, {
         if (this.withControlPanel) {
             this.searchModel.off('get-controller-query-params', this);
         }
-        if (!(this.renderer instanceof owl.Component)) {
+        if (!(this.renderer instanceof Component)) {
             this.renderer.on_detach_callback();
         }
     },
@@ -361,7 +362,7 @@ var AbstractController = mvc.Controller.extend(ActionMixin, {
      * @private
      */
     _startRenderer: function () {
-        if (this.renderer instanceof owl.Component) {
+        if (this.renderer instanceof Component) {
             return this.renderer.mount(this.$('.o_content')[0]);
         }
         return this.renderer.appendTo(this.$('.o_content'));
@@ -448,7 +449,7 @@ var AbstractController = mvc.Controller.extend(ActionMixin, {
      * @return {Promise}
      */
     _updateRendererState(state, params = {}) {
-        if (this.renderer instanceof owl.Component) {
+        if (this.renderer instanceof Component) {
             return this.renderer.update(state);
         }
         return this.renderer.updateState(state, params);

--- a/addons/web/static/src/legacy/js/views/abstract_renderer.js
+++ b/addons/web/static/src/legacy/js/views/abstract_renderer.js
@@ -8,6 +8,8 @@
 
 import * as mvc from 'web.mvc';
 
+const { Component } = owl;
+
 // Renderers may display sample data when there is no real data to display. In
 // this case the data is displayed with opacity and can't be clicked. Moreover,
 // we also want to prevent the user from accessing DOM elements with TAB
@@ -155,8 +157,8 @@ export default mvc.Renderer.extend({
         const template = document.createElement('template');
         // FIXME: retrieve owl qweb instance via the env set on Component s.t.
         // it also works in the tests (importing 'web.env' wouldn't). This
-        // won't be necessary as soon as this will be written in owl.
-        const owlQWeb = owl.Component.env.qweb;
+        // won't be necessary as soon as this will be written in 
+        const owlQWeb = Component.env.qweb;
         template.innerHTML = owlQWeb.renderToString(templateName, context);
         this.el.append(template.content.firstChild);
     },

--- a/addons/web/static/src/legacy/js/views/abstract_renderer_owl.js
+++ b/addons/web/static/src/legacy/js/views/abstract_renderer_owl.js
@@ -1,5 +1,7 @@
 /** @odoo-module alias=web.AbstractRendererOwl **/
 
+const { Component } = owl;
+
 // Renderers may display sample data when there is no real data to display. In
 // this case the data is displayed with opacity and can't be clicked. Moreover,
 // we also want to prevent the user from accessing DOM elements with TAB
@@ -11,7 +13,7 @@ const FOCUSABLE_ELEMENTS = [
     '[tabindex="0"]'
 ].map((sel) => `:scope ${sel}`).join(', ');
 
-class AbstractRenderer extends owl.Component {
+class AbstractRenderer extends Component {
 
     constructor() {
         super(...arguments);

--- a/addons/web/static/src/legacy/js/views/basic/basic_renderer.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_renderer.js
@@ -20,6 +20,8 @@ const { WidgetAdapterMixin } = require('web.OwlCompatibility');
 const FieldWrapper = require('web.FieldWrapper');
 const WidgetWrapper = require("web.WidgetWrapper");
 
+const { Component } = owl;
+
 var qweb = core.qweb;
 const _t = core._t;
 
@@ -730,7 +732,7 @@ var BasicRenderer = AbstractRenderer.extend(WidgetAdapterMixin, {
         // Initialize and register the widget
         // Readonly status is known as the modifiers have just been registered
         var Widget = record.fieldsInfo[this.viewType][fieldName].Widget;
-        const legacy = !(Widget.prototype instanceof owl.Component);
+        const legacy = !(Widget.prototype instanceof Component);
         const widgetOptions = {
             // Distinct readonly from renderer and readonly from modifier,
             // renderer can be readonly while modifier not.
@@ -809,7 +811,7 @@ var BasicRenderer = AbstractRenderer.extend(WidgetAdapterMixin, {
     _renderWidget: function (record, node) {
         const name = node.attrs.name;
         const Widget = widgetRegistryOwl.get(name) || widgetRegistry.get(name);
-        const legacy = !(Widget.prototype instanceof owl.Component);
+        const legacy = !(Widget.prototype instanceof Component);
         let widget;
         if (legacy) {
             widget = new Widget(this, record, node, { mode: this.mode });

--- a/addons/web/static/src/legacy/js/views/basic/basic_view.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_view.js
@@ -21,6 +21,8 @@ var utils = require('web.utils');
 const widgetRegistry = require('web.widget_registry');
 const widgetRegistryOwl = require('web.widgetRegistry');
 
+const { Component } = owl;
+
 var BasicView = AbstractView.extend({
     config: _.extend({}, AbstractView.prototype.config, {
         Model: BasicModel,
@@ -418,7 +420,7 @@ var BasicView = AbstractView.extend({
         // custom widget may have fieldDependencies so add it to fields of fields_view
         if (node.tag === 'widget') {
             const Widget = widgetRegistryOwl.get(node.attrs.name) || widgetRegistry.get(node.attrs.name);
-            const legacy = !(Widget.prototype instanceof owl.Component);
+            const legacy = !(Widget.prototype instanceof Component);
             let deps;
             if (legacy && Widget.prototype.fieldDependencies) {
                 deps = Widget.prototype.fieldDependencies;

--- a/addons/web/static/src/legacy/js/views/basic/widget_registry.js
+++ b/addons/web/static/src/legacy/js/views/basic/widget_registry.js
@@ -33,5 +33,7 @@ odoo.define('web.widget_registry', function (require) {
 
     var Registry = require('web.Registry');
 
-    return new Registry(null, (value) => !(value.prototype instanceof owl.Component));
+    const { Component } = owl;
+
+    return new Registry(null, (value) => !(value.prototype instanceof Component));
 });

--- a/addons/web/static/src/legacy/js/views/basic/widget_registry_owl.js
+++ b/addons/web/static/src/legacy/js/views/basic/widget_registry_owl.js
@@ -20,5 +20,7 @@ odoo.define("web.widgetRegistry", function (require) {
 
     const Registry = require("web.Registry");
 
-    return new Registry(null, (value) => value.prototype instanceof owl.Component);
+    const { Component } = owl;
+
+    return new Registry(null, (value) => value.prototype instanceof Component);
 });

--- a/addons/web/static/src/legacy/js/views/graph/graph_renderer.js
+++ b/addons/web/static/src/legacy/js/views/graph/graph_renderer.js
@@ -5,7 +5,6 @@ odoo.define("web/static/src/js/views/graph/graph_renderer", function (require) {
     const { DateClasses } = require("web.dataComparisonUtils");
     const fieldUtils = require("web.field_utils");
     const { sortBy } = require("web.utils");
-
     const {
         COLORS,
         DEFAULT_BG,
@@ -17,7 +16,8 @@ odoo.define("web/static/src/js/views/graph/graph_renderer", function (require) {
         shortenLabel,
     } = require("web/static/src/js/views/graph/graph_utils");
 
-    const { useRef } = owl.hooks;
+    const { useRef } = owl;
+
     class GraphRenderer extends AbstractRenderer {
         constructor() {
             super(...arguments);

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_record.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_record.js
@@ -24,6 +24,8 @@ var QWeb = core.qweb;
 var KANBAN_RECORD_COLORS = require('web.basic_fields').FieldColorPicker.prototype.RECORD_COLORS;
 var NB_KANBAN_RECORD_COLORS = KANBAN_RECORD_COLORS.length;
 
+const { Component } = owl;
+
 var KanbanRecord = Widget.extend(WidgetAdapterMixin, {
     events: {
         'click .oe_kanban_action': '_onKanbanActionClicked',
@@ -369,7 +371,7 @@ var KanbanRecord = Widget.extend(WidgetAdapterMixin, {
 
             const name = $field.attr('name');
             const Widget = widgetRegistryOwl.get(name) || widgetRegistry.get(name);
-            const legacy = !(Widget.prototype instanceof owl.Component);
+            const legacy = !(Widget.prototype instanceof Component);
             let widget;
             if (legacy) {
                 widget = new Widget(self, self.state, options);

--- a/addons/web/static/src/legacy/js/views/pivot/pivot_renderer.js
+++ b/addons/web/static/src/legacy/js/views/pivot/pivot_renderer.js
@@ -5,8 +5,7 @@
     import field_utils from 'web.field_utils';
     import { DEFAULT_INTERVAL, INTERVAL_OPTIONS, getIntervalOptions } from 'web.searchUtils';
 
-    const { Component, hooks } = owl;
-    const { useExternalListener, useState } = hooks;
+    const { Component, useExternalListener, useState } = owl;
 
     class PivotCustomGroupByItem extends Component {
         constructor() {

--- a/addons/web/static/src/legacy/js/views/search_panel.js
+++ b/addons/web/static/src/legacy/js/views/search_panel.js
@@ -2,8 +2,7 @@
 
     import { Model, useModel } from "web.Model";
 
-    const { Component, hooks } = owl;
-    const { useState, useSubEnv } = hooks;
+    const { Component, useState, useSubEnv } = owl;
 
     /**
      * Search panel

--- a/addons/web/static/src/legacy/js/widgets/week_days.js
+++ b/addons/web/static/src/legacy/js/widgets/week_days.js
@@ -4,10 +4,11 @@ odoo.define('web.WeekDays', function (require) {
     const CustomCheckbox = require('web.CustomCheckbox');
     const Registry = require('web.widgetRegistry');
     const utils = require('web.utils');
-    const { useState } = owl.hooks;
+
+    const { Component, useState } = owl;
 
 
-    class WeekDays extends owl.Component {
+    class WeekDays extends Component {
         constructor(parent) {
             super(...arguments);
             this.parent = parent;

--- a/addons/web/static/src/legacy/legacy_client_actions.js
+++ b/addons/web/static/src/legacy/legacy_client_actions.js
@@ -9,10 +9,10 @@ import { useSetupAction } from "../webclient/actions/action_hook";
 import { ClientActionAdapter } from "./action_adapters";
 import { breadcrumbsToLegacy } from "./backend_utils";
 
-const { Component, hooks, tags } = owl;
+const { Component, useRef, xml } = owl;
 const actionRegistry = registry.category("actions");
 
-const legacyClientActionTemplate = tags.xml`
+const legacyClientActionTemplate = xml`
     <ClientActionAdapter Component="Widget" widgetArgs="widgetArgs" widget="widget"
                          onReverseBreadcrumb="onReverseBreadcrumb" t-ref="controller"
                          t-on-scrollTo.stop="onScrollTo"/>`;
@@ -25,7 +25,7 @@ function registerClientAction(name, action) {
         class Action extends Component {
             constructor() {
                 super(...arguments);
-                this.controllerRef = hooks.useRef("controller");
+                this.controllerRef = useRef("controller");
                 this.Widget = action;
                 const options = {};
                 for (const key in this.props) {

--- a/addons/web/static/src/legacy/legacy_setup.js
+++ b/addons/web/static/src/legacy/legacy_setup.js
@@ -16,15 +16,14 @@ import * as legacyEnv from "web.env";
 import * as session from "web.session";
 import * as makeLegacyWebClientService from "web.pseudo_web_client";
 
-const { Component, config, utils } = owl;
-const { whenReady } = utils;
+const { Component, config, whenReady } = owl;
 
 let legacySetupResolver;
 export const legacySetupProm = new Promise((resolve) => {
     legacySetupResolver = resolve;
 });
 
-// build the legacy env and set it on owl.Component (this was done in main.js,
+// build the legacy env and set it on Component (this was done in main.js,
 // with the starting of the webclient)
 (async () => {
     config.mode = legacyEnv.isDebug() ? "dev" : "prod";

--- a/addons/web/static/src/legacy/legacy_views.js
+++ b/addons/web/static/src/legacy/legacy_views.js
@@ -1,5 +1,4 @@
 /** @odoo-module **/
-const { Component, hooks, tags } = owl;
 
 import { useService } from "@web/core/utils/hooks";
 import { useSetupAction } from "../webclient/actions/action_hook";
@@ -16,6 +15,7 @@ import { setScrollPosition } from "../core/utils/scrolling";
 import { registry } from "@web/core/registry";
 import { loadPublicAsset } from "@web/core/assets";
 
+const { Component, useRef, xml } = owl;
 const viewRegistry = registry.category("views");
 
 function getJsClassWidget(fieldsInfo) {
@@ -24,7 +24,7 @@ function getJsClassWidget(fieldsInfo) {
     return legacyViewRegistry.get(key);
 }
 
-const legacyViewTemplate = tags.xml`
+const legacyViewTemplate = xml`
     <ViewAdapter Component="Widget" View="View" viewInfo="viewInfo" viewParams="viewParams"
                  widget="widget" onReverseBreadcrumb="onReverseBreadcrumb" t-ref="controller"
                  t-on-scrollTo.stop="onScrollTo"/>`;
@@ -36,7 +36,7 @@ function registerView(name, LegacyView) {
         constructor() {
             super(...arguments);
             this.vm = useService("view");
-            this.controllerRef = hooks.useRef("controller");
+            this.controllerRef = useRef("controller");
             this.Widget = Widget; // fool the ComponentAdapter with a simple Widget
             this.View = LegacyView;
             this.viewInfo = {};

--- a/addons/web/static/src/legacy/systray_menu_item.js
+++ b/addons/web/static/src/legacy/systray_menu_item.js
@@ -4,7 +4,7 @@ import { ComponentAdapter } from "web.OwlCompatibility";
 import * as legacySystrayMenu from "web.SystrayMenu";
 import { registry } from "../core/registry";
 
-const { Component, tags } = owl;
+const { Component, xml } = owl;
 const systrayRegistry = registry.category("systray");
 
 class SystrayItemAdapter extends ComponentAdapter {
@@ -20,7 +20,7 @@ const legacySystrayMenuItems = legacySystrayMenu.Items;
 const convertedItems = [];
 let id = 1;
 
-const legacySystrayItemTemplate = tags.xml`<SystrayItemAdapter Component="Widget" />`;
+const legacySystrayItemTemplate = xml`<SystrayItemAdapter Component="Widget" />`;
 
 function addSystrayItem(Widget) {
     const name = `_legacy_systray_item_${id++}`;

--- a/addons/web/static/src/owl_next_adapter.js
+++ b/addons/web/static/src/owl_next_adapter.js
@@ -1,0 +1,34 @@
+(() => {
+    /**
+     * This file converts the imports of Owl variables from v1 to v2
+     *
+     * In the previous version: imports were grouped in subkeys under the
+     * global `owl` object. In the newer, all imports are top-level.
+     *
+     * Any call to the previous subkeys will throw an error to help
+     * devs adapt to the new system.
+     */
+
+    // These are the old subkeys used to group exports
+    const ROOT_KEYS = ["core", "router", "utils", "tags", "misc", "hooks"];
+
+    for (const key of ROOT_KEYS) {
+        if (!Object.getOwnPropertyDescriptor(owl, key).value) {
+            // This means that the key has already been transformed
+            continue;
+        }
+        for (const subKey in owl[key]) {
+            owl[subKey] = owl[key][subKey];
+        }
+        // TODO: uncomment the code below as soon as o_spreadsheet ugprades to Owl v2
+        // delete owl[key];
+        // Object.defineProperty(owl, key, {
+        //     get() {
+        //         throw new Error(
+        //             `Deprecated Owl import: ${key}. All properties under this key are now directly available from the global 'owl' object.`
+        //         );
+        //     },
+        //     set() {},
+        // });
+    }
+})();

--- a/addons/web/static/src/search/favorite_menu/custom_favorite_item.js
+++ b/addons/web/static/src/search/favorite_menu/custom_favorite_item.js
@@ -3,8 +3,7 @@
 import { registry } from "@web/core/registry";
 import { useAutofocus, useService } from "@web/core/utils/hooks";
 
-const { Component, hooks } = owl;
-const { useRef, useState } = hooks;
+const { Component, useRef, useState } = owl;
 
 const favoriteMenuRegistry = registry.category("favoriteMenu");
 

--- a/addons/web/static/src/search/favorite_menu/favorite_menu.js
+++ b/addons/web/static/src/search/favorite_menu/favorite_menu.js
@@ -6,9 +6,8 @@ import { registry } from "@web/core/registry";
 import { useBus } from "@web/core/utils/hooks";
 import { useService } from "@web/core/utils/hooks";
 
-const favoriteMenuRegistry = registry.category("favoriteMenu");
-
 const { Component } = owl;
+const favoriteMenuRegistry = registry.category("favoriteMenu");
 
 export class FavoriteMenu extends Component {
     setup() {

--- a/addons/web/static/src/search/filter_menu/custom_filter_item.js
+++ b/addons/web/static/src/search/filter_menu/custom_filter_item.js
@@ -6,8 +6,7 @@ import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
 import { _lt } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-const { Component, hooks } = owl;
-const { useState } = hooks;
+const { Component, useState } = owl;
 
 const { DateTime } = luxon;
 

--- a/addons/web/static/src/search/group_by_menu/custom_group_by_item.js
+++ b/addons/web/static/src/search/group_by_menu/custom_group_by_item.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
-const { Component, hooks } = owl;
-const { useState } = hooks;
+const { Component, useState } = owl;
 
 export class CustomGroupByItem extends Component {
     setup() {

--- a/addons/web/static/src/search/pager_hook.js
+++ b/addons/web/static/src/search/pager_hook.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-const { useEnv, useSubEnv } = owl.hooks;
+const { useEnv, useSubEnv } = owl;
 
 /**
  * @typedef PagerUpdateParams

--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -7,8 +7,7 @@ import { KeepLast } from "@web/core/utils/concurrency";
 import { useAutofocus, useBus, useService } from "@web/core/utils/hooks";
 import { fuzzyTest } from "@web/core/utils/search";
 
-const { Component, hooks } = owl;
-const { useExternalListener, useRef, useState } = hooks;
+const { Component, useExternalListener, useRef, useState } = owl;
 const parsers = registry.category("parsers");
 
 const CHAR_FIELDS = ["char", "html", "many2many", "many2one", "one2many", "text"];

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -17,8 +17,8 @@ import {
 } from "./utils/dates";
 import { FACET_ICONS } from "./utils/misc";
 
+const { EventBus } = owl;
 const { DateTime } = luxon;
-const EventBus = owl.core.EventBus;
 
 /**
  * @typedef {Object} ComparisonDomain

--- a/addons/web/static/src/search/search_panel/search_panel.js
+++ b/addons/web/static/src/search/search_panel/search_panel.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
-const { Component, hooks } = owl;
-const { useState } = hooks;
+const { Component, useState } = owl;
 
 /**
  * Search panel

--- a/addons/web/static/src/search/with_search/with_search.js
+++ b/addons/web/static/src/search/with_search/with_search.js
@@ -4,8 +4,7 @@ import { useBus, useService } from "@web/core/utils/hooks";
 import { SearchModel } from "@web/search/search_model";
 import { CallbackRecorder, useSetupAction } from "@web/webclient/actions/action_hook";
 
-const { Component, hooks } = owl;
-const { useSubEnv } = hooks;
+const { Component, useSubEnv } = owl;
 
 export const SEARCH_KEYS = ["comparison", "context", "domain", "groupBy", "orderBy"];
 const OTHER_SEARCH_KEYS = ["irFilters", "searchViewArch", "searchViewFields", "searchViewId"];

--- a/addons/web/static/src/start.js
+++ b/addons/web/static/src/start.js
@@ -6,8 +6,7 @@ import { mapLegacyEnvToWowlEnv } from "./legacy/utils";
 import { processTemplates } from "./core/assets";
 import { session } from "@web/session";
 
-const { mount, utils } = owl;
-const { whenReady } = utils;
+const { Component, mount, whenReady } = owl;
 
 /**
  * Function to start a webclient.
@@ -15,7 +14,7 @@ const { whenReady } = utils;
  * It's meant to be webclient flexible so we can have a subclass of
  * webclient in enterprise with added features.
  *
- * @param {owl.Component} Webclient
+ * @param {Component} Webclient
  */
 export async function startWebClient(Webclient) {
     odoo.info = {

--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -5,7 +5,7 @@ import { Dialog } from "@web/core/dialog/dialog";
 import { editModelDebug } from "@web/core/debug/debug_utils";
 import { registry } from "@web/core/registry";
 
-const { tags } = owl;
+const { xml } = owl;
 
 const debugRegistry = registry.category("debug");
 
@@ -14,7 +14,7 @@ FieldViewGetDialog.props = Object.assign({}, Dialog.props, {
     arch: { type: String },
     close: Function,
 });
-FieldViewGetDialog.bodyTemplate = tags.xml`<pre t-esc="props.arch"/>`;
+FieldViewGetDialog.bodyTemplate = xml`<pre t-esc="props.arch"/>`;
 FieldViewGetDialog.title = _lt("Fields View Get");
 
 function viewSeparator() {

--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -8,8 +8,7 @@ import { sortBy } from "@web/core/utils/arrays";
 import { useAssets } from "@web/core/assets";
 import { useEffect } from "@web/core/utils/hooks";
 
-const { Component, hooks } = owl;
-const { useRef } = hooks;
+const { Component, useRef } = owl;
 
 const NO_DATA = _lt("No data");
 

--- a/addons/web/static/src/views/graph/graph_view.js
+++ b/addons/web/static/src/views/graph/graph_view.js
@@ -12,9 +12,8 @@ import { GraphArchParser } from "./graph_arch_parser";
 import { GraphModel } from "./graph_model";
 import { GraphRenderer } from "./graph_renderer";
 
-const viewRegistry = registry.category("views");
-
 const { Component } = owl;
+const viewRegistry = registry.category("views");
 
 export class GraphView extends Component {
     setup() {

--- a/addons/web/static/src/views/helpers/model.js
+++ b/addons/web/static/src/views/helpers/model.js
@@ -5,9 +5,7 @@ import { useBus, useService } from "@web/core/utils/hooks";
 import { buildSampleORM } from "@web/views/helpers/sample_server";
 import { useSetupView } from "@web/views/helpers/view_hook";
 
-const { core, hooks } = owl;
-const { EventBus } = core;
-const { onWillStart, onWillUpdateProps, useComponent } = hooks;
+const { EventBus, onWillStart, onWillUpdateProps, useComponent } = owl;
 
 /**
  * @typedef {import("@web/search/search_model").SearchParams} SearchParams

--- a/addons/web/static/src/views/helpers/view_hook.js
+++ b/addons/web/static/src/views/helpers/view_hook.js
@@ -6,7 +6,7 @@ import { registry } from "@web/core/registry";
 import { useListener, useService } from "@web/core/utils/hooks";
 import { evaluateExpr } from "@web/core/py_js/py";
 
-const { useComponent } = owl.hooks;
+const { useComponent, xml } = owl;
 
 export function useSetupView(params) {
     const component = useComponent();
@@ -30,7 +30,7 @@ export function useViewArch(arch, params = {}) {
 
     const { compile, extract } = params;
     if (!("template" in processedArch) && compile) {
-        processedArch.template = owl.tags.xml`${compile(arch)}`;
+        processedArch.template = xml`${compile(arch)}`;
     }
     if (!("extracted" in processedArch) && extract) {
         processedArch.extracted = extract(arch);
@@ -54,7 +54,7 @@ export function useViewArch(arch, params = {}) {
  */
 export function useActionLinks({ resModel, reload }) {
     const selector = `a[type="action"]`;
-    const component = owl.hooks.useComponent();
+    const component = useComponent();
     const keepLast = component.env.keepLast;
 
     const orm = useService("orm");

--- a/addons/web/static/src/views/onboarding_banner.js
+++ b/addons/web/static/src/views/onboarding_banner.js
@@ -4,7 +4,9 @@ import { loadAssets } from "@web/core/assets";
 import { useService } from "@web/core/utils/hooks";
 import { useActionLinks } from "@web/views/helpers/view_hook";
 
-export class OnboardingBanner extends owl.Component {
+const { Component, xml } = owl;
+
+export class OnboardingBanner extends Component {
     setup() {
         this.rpc = useService("rpc");
         this.user = useService("user");
@@ -48,5 +50,5 @@ export class OnboardingBanner extends owl.Component {
     }
 }
 
-OnboardingBanner.template = owl.tags.xml`<div class="w-100" t-raw="bannerHTML" />`;
+OnboardingBanner.template = xml`<div class="w-100" t-raw="bannerHTML" />`;
 OnboardingBanner.props = {};

--- a/addons/web/static/src/views/pivot/pivot_view.js
+++ b/addons/web/static/src/views/pivot/pivot_view.js
@@ -12,9 +12,8 @@ import { PivotArchParser } from "@web/views/pivot/pivot_arch_parser";
 import { PivotModel } from "@web/views/pivot/pivot_model";
 import { PivotRenderer } from "@web/views/pivot/pivot_renderer";
 
-const viewRegistry = registry.category("views");
-
 const { Component } = owl;
+const viewRegistry = registry.category("views");
 
 export class PivotView extends Component {
     setup() {

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -9,10 +9,8 @@ import { WithSearch } from "@web/search/with_search/with_search";
 import { useActionLinks } from "@web/views/helpers/view_hook";
 import { extractLayoutComponents } from "@web/views/layout";
 
+const { Component, useSubEnv } = owl;
 const viewRegistry = registry.category("views");
-
-const { Component, hooks } = owl;
-const { useSubEnv } = hooks;
 
 /** @typedef {Object} Config
  *  @property {integer|false} actionId

--- a/addons/web/static/src/webclient/actions/action_container.js
+++ b/addons/web/static/src/webclient/actions/action_container.js
@@ -2,7 +2,7 @@
 
 import { ActionDialog } from "./action_dialog";
 
-const { Component, tags } = owl;
+const { Component, xml } = owl;
 
 // -----------------------------------------------------------------------------
 // ActionContainer (Component)
@@ -22,7 +22,7 @@ export class ActionContainer extends Component {
     }
 }
 ActionContainer.components = { ActionDialog };
-ActionContainer.template = tags.xml`
+ActionContainer.template = xml`
     <t t-name="web.ActionContainer">
       <div class="o_action_manager">
         <t t-if="info.Component" t-component="info.Component" t-props="info.componentProps" t-key="info.id"/>

--- a/addons/web/static/src/webclient/actions/action_dialog.js
+++ b/addons/web/static/src/webclient/actions/action_dialog.js
@@ -5,7 +5,7 @@ import { DebugMenu } from "@web/core/debug/debug_menu";
 import { useOwnDebugContext } from "@web/core/debug/debug_context";
 import { useEffect } from "@web/core/utils/hooks";
 
-const { hooks } = owl;
+const { useRef } = owl;
 
 const LEGACY_SIZE_CLASSES = {
     "extra-large": "modal-xl",
@@ -20,7 +20,7 @@ class ActionDialog extends Dialog {
     setup() {
         super.setup();
         useOwnDebugContext();
-        this.actionRef = hooks.useRef("actionRef");
+        this.actionRef = useRef("actionRef");
         const actionProps = this.props && this.props.actionProps;
         const action = actionProps && actionProps.action;
         this.actionType = action && action.type;

--- a/addons/web/static/src/webclient/actions/action_hook.js
+++ b/addons/web/static/src/webclient/actions/action_hook.js
@@ -3,7 +3,7 @@
 import { getScrollPosition, setScrollPosition } from "@web/core/utils/scrolling";
 import { useEffect } from "@web/core/utils/hooks";
 
-const { useComponent } = owl.hooks;
+const { useComponent } = owl;
 
 // -----------------------------------------------------------------------------
 // Action hook

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -14,8 +14,7 @@ import { View } from "@web/views/view";
 import { ActionDialog } from "./action_dialog";
 import { CallbackRecorder } from "./action_hook";
 
-const { Component, hooks, tags } = owl;
-const { useRef, useSubEnv } = hooks;
+const { Component, useRef, useSubEnv, xml } = owl;
 
 const actionHandlersRegistry = registry.category("action_handlers");
 const actionRegistry = registry.category("actions");
@@ -74,7 +73,7 @@ export class InvalidButtonParamsError extends Error {}
 const CTX_KEY_REGEX = /^(?:(?:default_|search_default_|show_).+|.+_view_ref|group_by|group_by_no_leaf|active_id|active_ids|orderedBy)$/;
 
 // only register this template once for all dynamic classes ControllerComponent
-const ControllerComponentTemplate = tags.xml`<t t-component="Component" t-props="props"
+const ControllerComponentTemplate = xml`<t t-component="Component" t-props="props"
     t-ref="component"
     t-on-history-back="onHistoryBack"/>`;
 
@@ -988,7 +987,7 @@ function makeActionManager(env) {
         const controller = {
             jsId: `controller_${++id}`,
             // for historical reasons, the report Component is a client action,
-            // but there's no need to keep this when it will be converted to owl.
+            // but there's no need to keep this when it will be converted to
             Component: actionRegistry.get("report.client_action"),
             action,
             ..._getActionInfo(action, props),

--- a/addons/web/static/src/webclient/actions/client_actions.js
+++ b/addons/web/static/src/webclient/actions/client_actions.js
@@ -4,8 +4,7 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { sprintf } from "@web/core/utils/strings";
 
-const { utils, Component } = owl;
-const { escape } = utils;
+const { Component, escape, xml } = owl;
 
 export const displayNotificationAction = (env, action) => {
     const params = action.params || {};
@@ -39,6 +38,6 @@ class InvalidAction extends Component {
         this.notification.add(message, { type: "danger" });
     }
 }
-InvalidAction.template = owl.tags.xml`<div class="o_invalid_action"></div>`;
+InvalidAction.template = xml`<div class="o_invalid_action"></div>`;
 
 registry.category("actions").add("invalid_action", InvalidAction);

--- a/addons/web/static/src/webclient/clickbot/clickbot_loader.js
+++ b/addons/web/static/src/webclient/clickbot/clickbot_loader.js
@@ -2,7 +2,7 @@
 
 import { registry } from "../../core/registry";
 
-const { loadJS } = owl.utils;
+const { loadJS } = owl;
 
 export default async function startClickEverywhere(xmlId, appsMenusOnly) {
     await loadJS("web/static/src/webclient/clickbot/clickbot.js");

--- a/addons/web/static/src/webclient/debug_items.js
+++ b/addons/web/static/src/webclient/debug_items.js
@@ -5,6 +5,8 @@ import { browser } from "@web/core/browser/browser";
 import dialogs from "web.view_dialogs";
 import { ComponentAdapter } from "web.OwlCompatibility";
 
+const { Component } = owl;
+
 function runJSTestsItem({ env }) {
     const runTestsURL = browser.location.origin + "/web/tests?debug=assets";
     return {
@@ -53,7 +55,7 @@ export function openViewItem({ env }) {
         type: "item",
         description: env._t("Open View"),
         callback: () => {
-            const adapterParent = new ComponentAdapter(null, { Component: owl.Component });
+            const adapterParent = new ComponentAdapter(null, { Component: Component });
             const selectCreateDialog = new dialogs.SelectCreateDialog(adapterParent, {
                 res_model: "ir.ui.view",
                 title: env._t("Select a view"),

--- a/addons/web/static/src/webclient/navbar/navbar.js
+++ b/addons/web/static/src/webclient/navbar/navbar.js
@@ -7,8 +7,7 @@ import { registry } from "@web/core/registry";
 import { debounce } from "@web/core/utils/timing";
 import { ErrorHandler, NotUpdatable } from "@web/core/utils/components";
 
-const { Component, hooks } = owl;
-const { useExternalListener, useRef } = hooks;
+const { Component, useExternalListener, useRef } = owl;
 const systrayRegistry = registry.category("systray");
 
 const getBoundingClientRect = Element.prototype.getBoundingClientRect;

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
@@ -5,8 +5,7 @@ import { registry } from "@web/core/registry";
 import { browser } from "@web/core/browser/browser";
 import { symmetricalDifference } from "@web/core/utils/arrays";
 
-const { Component, hooks } = owl;
-const { useState } = hooks;
+const { Component, useState } = owl;
 
 export class SwitchCompanyMenu extends Component {
     setup() {

--- a/addons/web/static/src/webclient/webclient.js
+++ b/addons/web/static/src/webclient/webclient.js
@@ -11,8 +11,7 @@ import { registry } from "@web/core/registry";
 import { DebugMenu } from "@web/core/debug/debug_menu";
 import { localization } from "@web/core/l10n/localization";
 
-const { Component, hooks } = owl;
-const { useExternalListener } = hooks;
+const { Component, useExternalListener } = owl;
 
 export class WebClient extends Component {
     setup() {

--- a/addons/web/static/tests/core/checkbox_tests.js
+++ b/addons/web/static/tests/core/checkbox_tests.js
@@ -7,8 +7,7 @@ import { makeTestEnv } from "../helpers/mock_env";
 import { makeFakeLocalizationService } from "../helpers/mock_services";
 import { getFixture, patchWithCleanup } from "../helpers/utils";
 
-const { Component, mount, tags } = owl;
-const { xml } = tags;
+const { Component, mount, xml } = owl;
 const serviceRegistry = registry.category("services");
 
 let env;

--- a/addons/web/static/tests/core/commands/command_palette_tests.js
+++ b/addons/web/static/tests/core/commands/command_palette_tests.js
@@ -18,8 +18,7 @@ import {
 } from "../../helpers/utils";
 import { editSearchBar } from "./command_service_tests";
 
-const { Component, mount, tags } = owl;
-const { xml } = tags;
+const { Component, mount, xml } = owl;
 
 let env;
 let target;

--- a/addons/web/static/tests/core/commands/command_service_tests.js
+++ b/addons/web/static/tests/core/commands/command_service_tests.js
@@ -13,8 +13,7 @@ import testUtils from "web.test_utils";
 import { clearRegistryWithCleanup, makeTestEnv } from "../../helpers/mock_env";
 import { click, getFixture, nextTick, patchWithCleanup, triggerHotkey } from "../../helpers/utils";
 
-const { Component, mount, tags } = owl;
-const { xml } = tags;
+const { Component, mount, xml } = owl;
 
 let env;
 let target;

--- a/addons/web/static/tests/core/datepicker_tests.js
+++ b/addons/web/static/tests/core/datepicker_tests.js
@@ -8,9 +8,8 @@ import { makeTestEnv } from "../helpers/mock_env";
 import { makeFakeLocalizationService } from "../helpers/mock_services";
 import { click, getFixture, triggerEvent } from "../helpers/utils";
 
+const { Component, mount, xml } = owl;
 const { DateTime } = luxon;
-const { Component, mount, tags } = owl;
-const { xml } = tags;
 const serviceRegistry = registry.category("services");
 
 /**

--- a/addons/web/static/tests/core/debug/debug_manager_tests.js
+++ b/addons/web/static/tests/core/debug/debug_manager_tests.js
@@ -23,8 +23,7 @@ import { createWebClient, doAction, getActionManagerServerData } from "../../web
 import { openViewItem } from "@web/webclient/debug_items";
 import { editSearchView, editView } from "@web/views/debug_items";
 
-const { Component, mount, tags } = owl;
-const { xml } = tags;
+const { Component, mount, xml } = owl;
 
 export class DebugMenuParent extends Component {
     setup() {

--- a/addons/web/static/tests/core/dialog_service_tests.js
+++ b/addons/web/static/tests/core/dialog_service_tests.js
@@ -13,7 +13,7 @@ import { makeFakeLocalizationService, makeFakeRPCService } from "../helpers/mock
 import { click, getFixture, makeDeferred, nextTick, patchWithCleanup } from "../helpers/utils";
 import { Dialog } from "../../src/core/dialog/dialog";
 
-const { Component, mount, tags } = owl;
+const { Component, mount, xml } = owl;
 
 let env;
 let target;
@@ -26,7 +26,7 @@ class PseudoWebClient extends Component {
         this.Components = mainComponentRegistry.getEntries();
     }
 }
-PseudoWebClient.template = tags.xml`
+PseudoWebClient.template = xml`
         <div>
             <div>
                 <t t-foreach="Components" t-as="C" t-key="C[0]">

--- a/addons/web/static/tests/core/dialog_tests.js
+++ b/addons/web/static/tests/core/dialog_tests.js
@@ -6,11 +6,10 @@ import { uiService } from "@web/core/ui/ui_service";
 import { hotkeyService } from "@web/core/hotkeys/hotkey_service";
 import { Dialog } from "@web/core/dialog/dialog";
 import { makeTestEnv } from "../helpers/mock_env";
-import { click, getFixture, nextTick } from "../helpers/utils";
+import { click, getFixture } from "../helpers/utils";
 import { makeFakeDialogService } from "../helpers/mock_services";
 
-const { hooks, mount } = owl;
-const { useRef, useState } = hooks;
+const { Component, mount, useState, xml } = owl;
 const serviceRegistry = registry.category("services");
 let parent;
 let target;
@@ -36,7 +35,7 @@ class SimpleDialog extends Dialog {
         });
     }
 }
-SimpleDialog.bodyTemplate = owl.tags.xml`<t t-slot="default"/>`;
+SimpleDialog.bodyTemplate = xml`<t t-slot="default"/>`;
 
 QUnit.module("Components", (hooks) => {
     hooks.beforeEach(async () => {
@@ -58,7 +57,7 @@ QUnit.module("Components", (hooks) => {
         assert.expect(8);
         class Parent extends Dialog {}
         Parent.title = "Wow(l) Effect";
-        Parent.bodyTemplate = owl.tags.xml`
+        Parent.bodyTemplate = xml`
             <t>
                 Hello!
             </t>
@@ -89,8 +88,8 @@ QUnit.module("Components", (hooks) => {
 
     QUnit.test("simple rendering with two dialogs", async function (assert) {
         assert.expect(3);
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
               <div>
                   <SimpleDialog title="'First Title'">
                       Hello!
@@ -118,13 +117,13 @@ QUnit.module("Components", (hooks) => {
         assert.expect(3);
         const env = await makeTestEnv();
         class MyDialog extends SimpleDialog {}
-        class Parent extends owl.Component {
+        class Parent extends Component {
             close() {
                 assert.step("close");
             }
         }
 
-        Parent.template = owl.tags.xml`
+        Parent.template = xml`
             <MyDialog close="close">
                 Hello!
             </MyDialog>
@@ -142,13 +141,13 @@ QUnit.module("Components", (hooks) => {
             const env = await makeTestEnv();
             assert.expect(3);
             class MyDialog extends SimpleDialog {}
-            class Parent extends owl.Component {
+            class Parent extends Component {
                 close() {
                     assert.step("close");
                 }
             }
 
-            Parent.template = owl.tags.xml`
+            Parent.template = xml`
                 <MyDialog close="close">
                     Hello!
                 </MyDialog>
@@ -164,13 +163,13 @@ QUnit.module("Components", (hooks) => {
     QUnit.test("render custom footer buttons is possible", async function (assert) {
         assert.expect(2);
         class SimpleButtonsDialog extends Dialog {}
-        SimpleButtonsDialog.footerTemplate = owl.tags.xml`
+        SimpleButtonsDialog.footerTemplate = xml`
             <div>
                 <button class="btn btn-primary">The First Button</button>
                 <button class="btn btn-primary">The Second Button</button>
             </div>
           `;
-        class Parent extends owl.Component {
+        class Parent extends Component {
             constructor() {
                 super(...arguments);
                 this.state = useState({
@@ -178,7 +177,7 @@ QUnit.module("Components", (hooks) => {
                 });
             }
         }
-        Parent.template = owl.tags.xml`
+        Parent.template = xml`
               <div>
                   <SimpleButtonsDialog/>
               </div>
@@ -192,22 +191,22 @@ QUnit.module("Components", (hooks) => {
 
     QUnit.test("embed an arbitrary component in a dialog is possible", async function (assert) {
         assert.expect(6);
-        class SubComponent extends owl.Component {
+        class SubComponent extends Component {
             _onClick() {
                 assert.step("subcomponent-clicked");
                 this.trigger("subcomponent-clicked");
             }
         }
-        SubComponent.template = owl.tags.xml`
+        SubComponent.template = xml`
               <div class="o_subcomponent" t-esc="props.text" t-on-click="_onClick"/>
           `;
-        class Parent extends owl.Component {
+        class Parent extends Component {
             _onSubcomponentClicked() {
                 assert.step("message received by parent");
             }
         }
         Parent.components = { SimpleDialog, SubComponent };
-        Parent.template = owl.tags.xml`
+        Parent.template = xml`
               <SimpleDialog>
                   <SubComponent text="'Wow(l) Effect'" t-on-subcomponent-clicked="_onSubcomponentClicked"/>
               </SimpleDialog>
@@ -223,8 +222,8 @@ QUnit.module("Components", (hooks) => {
 
     QUnit.test("dialog without header/footer", async function (assert) {
         assert.expect(4);
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
               <SimpleDialog renderHeader="false" renderFooter="false"/>
           `;
         const env = await makeTestEnv();
@@ -238,8 +237,8 @@ QUnit.module("Components", (hooks) => {
 
     QUnit.test("dialog size can be chosen", async function (assert) {
         assert.expect(5);
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
       <div>
         <SimpleDialog contentClass="'xl'" size="'modal-xl'"/>
         <SimpleDialog contentClass="'lg'"/>
@@ -270,8 +269,8 @@ QUnit.module("Components", (hooks) => {
 
     QUnit.test("dialog can be rendered on fullscreen", async function (assert) {
         assert.expect(2);
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
               <div><SimpleDialog fullscreen="true"/></div>
           `;
         Parent.components = { SimpleDialog };
@@ -283,7 +282,7 @@ QUnit.module("Components", (hooks) => {
 
     QUnit.test("can be the UI active element", async function (assert) {
         assert.expect(3);
-        class Parent extends owl.Component {
+        class Parent extends Component {
             setup() {
                 this.ui = useService("ui");
                 this.modalRef = { el: null };
@@ -302,7 +301,7 @@ QUnit.module("Components", (hooks) => {
             }
         }
         const env = await makeTestEnv();
-        Parent.template = owl.tags.xml`<div><SimpleDialog modalRef="modalRef"/></div>`;
+        Parent.template = xml`<div><SimpleDialog modalRef="modalRef"/></div>`;
         Parent.components = { SimpleDialog };
         parent = await mount(Parent, { env, target });
 

--- a/addons/web/static/tests/core/dropdown_tests.js
+++ b/addons/web/static/tests/core/dropdown_tests.js
@@ -18,7 +18,7 @@ import {
     triggerHotkey,
 } from "../helpers/utils";
 
-const { mount } = owl;
+const { Component, mount, xml } = owl;
 const serviceRegistry = registry.category("services");
 
 let env;
@@ -40,8 +40,8 @@ QUnit.module("Components", ({ beforeEach }) => {
     QUnit.module("Dropdown");
 
     QUnit.test("can be rendered", async (assert) => {
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`<Dropdown/>`;
+        class Parent extends Component {}
+        Parent.template = xml`<Dropdown/>`;
         env = await makeTestEnv();
         parent = await mount(Parent, { env, target });
         assert.strictEqual(
@@ -53,16 +53,16 @@ QUnit.module("Components", ({ beforeEach }) => {
     });
 
     QUnit.test("DropdownItem can be rendered as <span/>", async (assert) => {
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`<DropdownItem>coucou</DropdownItem>`;
+        class Parent extends Component {}
+        Parent.template = xml`<DropdownItem>coucou</DropdownItem>`;
         env = await makeTestEnv();
         parent = await mount(Parent, { env, target });
         assert.strictEqual(parent.el.outerHTML, '<span class="dropdown-item">coucou</span>');
     });
 
     QUnit.test("DropdownItem (with href prop) can be rendered as <a/>", async (assert) => {
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`<DropdownItem href="'#'">coucou</DropdownItem>`;
+        class Parent extends Component {}
+        Parent.template = xml`<DropdownItem href="'#'">coucou</DropdownItem>`;
         env = await makeTestEnv();
         parent = await mount(Parent, { env, target });
         assert.strictEqual(parent.el.outerHTML, '<a href="#" class="dropdown-item">coucou</a>');
@@ -81,8 +81,8 @@ QUnit.module("Components", ({ beforeEach }) => {
                 assert.ok(href !== null ? ev.defaultPrevented : !ev.defaultPrevented);
             },
         });
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
             <Dropdown>
                 <DropdownItem class="link" href="'#'"/>
                 <DropdownItem class="nolink" />
@@ -100,8 +100,8 @@ QUnit.module("Components", ({ beforeEach }) => {
     });
 
     QUnit.test("can be styled", async (assert) => {
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
         <Dropdown class="one" togglerClass="'two'" menuClass="'three'">
             <DropdownItem class="four" />
         </Dropdown>
@@ -121,7 +121,7 @@ QUnit.module("Components", ({ beforeEach }) => {
     QUnit.test("menu can be toggled", async (assert) => {
         assert.expect(5);
         const beforeOpenProm = makeDeferred();
-        class Parent extends owl.Component {
+        class Parent extends Component {
             constructor() {
                 super(...arguments);
                 this.beforeOpen = () => {
@@ -130,7 +130,7 @@ QUnit.module("Components", ({ beforeEach }) => {
                 };
             }
         }
-        Parent.template = owl.tags.xml`<Dropdown beforeOpen="beforeOpen"/>`;
+        Parent.template = xml`<Dropdown beforeOpen="beforeOpen"/>`;
         env = await makeTestEnv();
         parent = await mount(Parent, { env, target });
         await click(parent.el, "button.dropdown-toggle");
@@ -145,7 +145,7 @@ QUnit.module("Components", ({ beforeEach }) => {
 
     QUnit.test("initial open state can be true", async (assert) => {
         assert.expect(3);
-        class Parent extends owl.Component {
+        class Parent extends Component {
             constructor() {
                 super(...arguments);
                 this.beforeOpen = () => {
@@ -153,7 +153,7 @@ QUnit.module("Components", ({ beforeEach }) => {
                 };
             }
         }
-        Parent.template = owl.tags.xml`<Dropdown startOpen="true" beforeOpen="beforeOpen"/>`;
+        Parent.template = xml`<Dropdown startOpen="true" beforeOpen="beforeOpen"/>`;
         env = await makeTestEnv();
         parent = await mount(Parent, { env, target });
         assert.verifySteps(["beforeOpen"]);
@@ -161,8 +161,8 @@ QUnit.module("Components", ({ beforeEach }) => {
     });
 
     QUnit.test("close on outside click", async (assert) => {
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
         <div>
           <div class="outside">outside</div>
           <Dropdown/>
@@ -177,8 +177,8 @@ QUnit.module("Components", ({ beforeEach }) => {
     });
 
     QUnit.test("close on item selection", async (assert) => {
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
         <Dropdown>
             <DropdownItem/>
         </Dropdown>
@@ -191,12 +191,12 @@ QUnit.module("Components", ({ beforeEach }) => {
     });
 
     QUnit.test("payload received on item selection", async (assert) => {
-        class Parent extends owl.Component {
+        class Parent extends Component {
             onItemSelected(value) {
                 assert.equal(value, 42);
             }
         }
-        Parent.template = owl.tags.xml`
+        Parent.template = xml`
         <Dropdown>
             <DropdownItem onSelected="() => onItemSelected(42)"/>
         </Dropdown>
@@ -208,8 +208,8 @@ QUnit.module("Components", ({ beforeEach }) => {
     });
 
     QUnit.test("multi-level dropdown: can be rendered and toggled", async (assert) => {
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
         <Dropdown>
             <Dropdown>
                 <Dropdown/>
@@ -225,8 +225,8 @@ QUnit.module("Components", ({ beforeEach }) => {
     });
 
     QUnit.test("multi-level dropdown: initial open state can be true", async (assert) => {
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
         <Dropdown startOpen="true">
             <Dropdown startOpen="true">
                 <Dropdown startOpen="true"/>
@@ -239,8 +239,8 @@ QUnit.module("Components", ({ beforeEach }) => {
     });
 
     QUnit.test("multi-level dropdown: close on outside click", async (assert) => {
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
         <div>
           <div class="outside">outside</div>
           <Dropdown>
@@ -261,8 +261,8 @@ QUnit.module("Components", ({ beforeEach }) => {
     });
 
     QUnit.test("multi-level dropdown: close on item selection", async (assert) => {
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
         <Dropdown>
             <Dropdown>
                 <DropdownItem/>
@@ -285,8 +285,8 @@ QUnit.module("Components", ({ beforeEach }) => {
     });
 
     QUnit.test("multi-level dropdown: parent closing modes on item selection", async (assert) => {
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
         <Dropdown>
             <Dropdown>
                 <DropdownItem class="item1" parentClosingMode="'none'" />
@@ -343,7 +343,7 @@ QUnit.module("Components", ({ beforeEach }) => {
             </t>
         </Dropdown>
     `;
-        class Parent extends owl.Component {
+        class Parent extends Component {
             constructor() {
                 super(...arguments);
                 this.name = "foo";
@@ -406,7 +406,7 @@ QUnit.module("Components", ({ beforeEach }) => {
         async (assert) => {
             assert.expect(13);
             const beforeOpenProm = makeDeferred();
-            class Parent extends owl.Component {
+            class Parent extends Component {
                 constructor() {
                     super(...arguments);
                     this.beforeOpen = () => {
@@ -415,7 +415,7 @@ QUnit.module("Components", ({ beforeEach }) => {
                     };
                 }
             }
-            Parent.template = owl.tags.xml`
+            Parent.template = xml`
         <div>
           <Dropdown class="one" />
           <Dropdown class="two" beforeOpen="beforeOpen"/>
@@ -463,8 +463,8 @@ QUnit.module("Components", ({ beforeEach }) => {
     QUnit.test(
         "siblings dropdowns: when non-sibling is open, other must not be toggled on mouse-enter",
         async (assert) => {
-            class Parent extends owl.Component {}
-            Parent.template = owl.tags.xml`
+            class Parent extends Component {}
+            Parent.template = xml`
         <div>
           <div><Dropdown class="foo" /></div>
           <Dropdown class="bar1" />
@@ -488,8 +488,8 @@ QUnit.module("Components", ({ beforeEach }) => {
     QUnit.test(
         "siblings dropdowns: when one is open, then non-sibling toggled, siblings must not be toggled on mouse-enter",
         async (assert) => {
-            class Parent extends owl.Component {}
-            Parent.template = owl.tags.xml`
+            class Parent extends Component {}
+            Parent.template = xml`
         <div>
           <div><Dropdown class="foo" /></div>
           <Dropdown class="bar1" />
@@ -515,8 +515,8 @@ QUnit.module("Components", ({ beforeEach }) => {
 
     QUnit.test("siblings dropdowns with manualOnly props", async (assert) => {
         assert.expect(7);
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
         <div>
           <Dropdown class="one" manualOnly="true"/>
           <Dropdown class="two" manualOnly="true"/>
@@ -548,12 +548,12 @@ QUnit.module("Components", ({ beforeEach }) => {
 
     QUnit.test("dropdowns keynav", async (assert) => {
         assert.expect(26);
-        class Parent extends owl.Component {
+        class Parent extends Component {
             onItemSelected(value) {
                 assert.step(value.toString());
             }
         }
-        Parent.template = owl.tags.xml`
+        Parent.template = xml`
         <Dropdown hotkey="'m'">
             <DropdownItem class="item1" onSelected="() => onItemSelected(1)">item1</DropdownItem>
             <DropdownItem class="item2" hotkey="'2'" onSelected="() => onItemSelected(2)">item2</DropdownItem>
@@ -640,8 +640,8 @@ QUnit.module("Components", ({ beforeEach }) => {
     });
 
     QUnit.test("props toggler='parent'", async (assert) => {
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
             <div>
                 <div class="my_custom_toggler">
                     Click Me
@@ -664,12 +664,12 @@ QUnit.module("Components", ({ beforeEach }) => {
 
     QUnit.test("multi-level dropdown: keynav", async (assert) => {
         assert.expect(125);
-        class Parent extends owl.Component {
+        class Parent extends Component {
             onItemSelected(value) {
                 assert.step(value);
             }
         }
-        Parent.template = owl.tags.xml`
+        Parent.template = xml`
             <Dropdown class="first" hotkey="'1'">
                 <DropdownItem class="first-first" onSelected="() => onItemSelected('first-first')">O</DropdownItem>
                 <Dropdown class="second">
@@ -763,8 +763,8 @@ QUnit.module("Components", ({ beforeEach }) => {
 
     QUnit.test("multi-level dropdown: keynav when rtl direction", async (assert) => {
         assert.expect(10);
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
             <Dropdown class="first" hotkey="'1'">
                 <DropdownItem class="first-first">O</DropdownItem>
                 <Dropdown class="second">
@@ -809,8 +809,8 @@ QUnit.module("Components", ({ beforeEach }) => {
         "multi-level dropdown: mouseentering a dropdown item should close any subdropdown",
         async (assert) => {
             assert.expect(4);
-            class Parent extends owl.Component {}
-            Parent.template = owl.tags.xml`
+            class Parent extends Component {}
+            Parent.template = xml`
                 <Dropdown togglerClass="'main'">
                     <Dropdown togglerClass="'sub'" />
                     <DropdownItem class="item" />
@@ -836,8 +836,8 @@ QUnit.module("Components", ({ beforeEach }) => {
 
     QUnit.test("multi-level dropdown: unsubscribe all keynav when root close", async (assert) => {
         assert.expect(14);
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`
+        class Parent extends Component {}
+        Parent.template = xml`
             <Dropdown togglerClass="'first'">
                 <Dropdown togglerClass="'second'">
                     <Dropdown togglerClass="'third'"/>
@@ -898,8 +898,8 @@ QUnit.module("Components", ({ beforeEach }) => {
     QUnit.test("Dropdown with a tooltip", async (assert) => {
         assert.expect(1);
 
-        class Parent extends owl.Component {}
-        Parent.template = owl.tags.xml`<Dropdown tooltip="'My tooltip'"></Dropdown>`;
+        class Parent extends Component {}
+        Parent.template = xml`<Dropdown tooltip="'My tooltip'"></Dropdown>`;
 
         env = await makeTestEnv();
         parent = await mount(Parent, { env, target });

--- a/addons/web/static/tests/core/effects/effect_service_tests.js
+++ b/addons/web/static/tests/core/effects/effect_service_tests.js
@@ -10,7 +10,7 @@ import { makeFakeLocalizationService } from "../../helpers/mock_services";
 import { click, getFixture, mockTimeout, nextTick, patchWithCleanup } from "../../helpers/utils";
 import { registerCleanup } from "../../helpers/cleanup";
 
-const { Component, mount, tags } = owl;
+const { Component, mount, xml } = owl;
 const serviceRegistry = registry.category("services");
 const mainComponentRegistry = registry.category("main_components");
 
@@ -20,7 +20,7 @@ class Parent extends Component {
         this.NotificationContainer = mainComponentRegistry.get("NotificationContainer");
     }
 }
-Parent.template = tags.xml`
+Parent.template = xml`
     <div>
       <t t-component="EffectContainer.Component" t-props="EffectContainer.props" />
       <t t-component="NotificationContainer.Component" t-props="NotificationContainer.props" />
@@ -131,7 +131,7 @@ QUnit.module("Effect Service", (hooks) => {
                 assert.deepEqual(this.props, props, "should have received these props");
             }
         }
-        Custom.template = tags.xml`<div class="custom">foo is <t t-esc="props.foo"/></div>`;
+        Custom.template = xml`<div class="custom">foo is <t t-esc="props.foo"/></div>`;
 
         const parent = await makeParent();
         parent.env.services.effect.add({ Component: Custom, props });

--- a/addons/web/static/tests/core/errors/error_dialogs_tests.js
+++ b/addons/web/static/tests/core/errors/error_dialogs_tests.js
@@ -16,7 +16,8 @@ import { makeTestEnv } from "../../helpers/mock_env";
 import { makeFakeDialogService, makeFakeLocalizationService } from "../../helpers/mock_services";
 import { click, getFixture, nextTick, patchWithCleanup } from "../../helpers/utils";
 
-const { Component, mount, tags } = owl;
+const { Component, mount, xml } = owl;
+
 let target;
 let env;
 let parent;
@@ -47,7 +48,7 @@ QUnit.test("ErrorDialog with traceback", async (assert) => {
         }
     }
     Parent.components = { ErrorDialog };
-    Parent.template = tags.xml`<ErrorDialog traceback="traceback" name="name" message="message" data="data"/>`;
+    Parent.template = xml`<ErrorDialog traceback="traceback" name="name" message="message" data="data"/>`;
     assert.containsNone(target, ".o_dialog");
     env = await makeTestEnv();
     parent = await mount(Parent, { env, target });
@@ -99,7 +100,7 @@ QUnit.test("Client ErrorDialog with traceback", async (assert) => {
         }
     }
     Parent.components = { ClientErrorDialog };
-    Parent.template = tags.xml`<ClientErrorDialog traceback="traceback" name="name" message="message" data="data"/>`;
+    Parent.template = xml`<ClientErrorDialog traceback="traceback" name="name" message="message" data="data"/>`;
     assert.containsNone(target, ".o_dialog");
     env = await makeTestEnv();
     parent = await mount(Parent, { env, target });
@@ -171,7 +172,7 @@ QUnit.test("button clipboard copy error traceback", async (assert) => {
         }
     }
     Parent.components = { ErrorDialog };
-    Parent.template = tags.xml`<ErrorDialog traceback="traceback" name="name" message="message" data="data"/>`;
+    Parent.template = xml`<ErrorDialog traceback="traceback" name="name" message="message" data="data"/>`;
     parent = await mount(Parent, { env, target });
     const clipboardButton = target.querySelector(".fa-clipboard");
     click(clipboardButton);
@@ -189,7 +190,7 @@ QUnit.test("WarningDialog", async (assert) => {
         }
     }
     Parent.components = { WarningDialog };
-    Parent.template = tags.xml`<WarningDialog exceptionName="name" message="message" data="data"/>`;
+    Parent.template = xml`<WarningDialog exceptionName="name" message="message" data="data"/>`;
     assert.containsNone(target, ".o_dialog");
     env = await makeTestEnv();
     parent = await mount(Parent, { env, target });
@@ -221,7 +222,7 @@ QUnit.test("RedirectWarningDialog", async (assert) => {
         }
     }
     Parent.components = { RedirectWarningDialog: CloseRedirectWarningDialog };
-    Parent.template = tags.xml`<RedirectWarningDialog data="data" close="close"/>`;
+    Parent.template = xml`<RedirectWarningDialog data="data" close="close"/>`;
     const faceActionService = {
         name: "action",
         start() {
@@ -255,7 +256,7 @@ QUnit.test("Error504Dialog", async (assert) => {
     assert.expect(5);
     class Parent extends Component {}
     Parent.components = { Error504Dialog };
-    Parent.template = tags.xml`<Error504Dialog/>`;
+    Parent.template = xml`<Error504Dialog/>`;
     assert.containsNone(target, ".o_dialog");
     env = await makeTestEnv();
     parent = await mount(Parent, { env, target });
@@ -272,7 +273,7 @@ QUnit.test("SessionExpiredDialog", async (assert) => {
     assert.expect(7);
     class Parent extends Component {}
     Parent.components = { SessionExpiredDialog };
-    Parent.template = tags.xml`<SessionExpiredDialog/>`;
+    Parent.template = xml`<SessionExpiredDialog/>`;
     patchWithCleanup(browser, {
         location: {
             reload() {

--- a/addons/web/static/tests/core/errors/error_service_tests.js
+++ b/addons/web/static/tests/core/errors/error_service_tests.js
@@ -21,7 +21,7 @@ import {
 } from "../../helpers/mock_services";
 import { makeDeferred, nextTick, patchWithCleanup } from "../../helpers/utils";
 
-const { Component, tags } = owl;
+const { Component, xml } = owl;
 const errorDialogRegistry = registry.category("error_dialogs");
 const errorHandlerRegistry = registry.category("error_handlers");
 const serviceRegistry = registry.category("services");
@@ -84,7 +84,7 @@ QUnit.test(
     async (assert) => {
         assert.expect(2);
         class CustomDialog extends Component {}
-        CustomDialog.template = tags.xml`<RPCErrorDialog title="'Strange Error'"/>`;
+        CustomDialog.template = xml`<RPCErrorDialog title="'Strange Error'"/>`;
         CustomDialog.components = { RPCErrorDialog };
         const error = new RPCError();
         error.code = 701;
@@ -120,10 +120,10 @@ QUnit.test(
     async (assert) => {
         assert.expect(2);
         class CustomDialog extends Component {}
-        CustomDialog.template = tags.xml`<RPCErrorDialog title="'Strange Error'"/>`;
+        CustomDialog.template = xml`<RPCErrorDialog title="'Strange Error'"/>`;
         CustomDialog.components = { RPCErrorDialog };
         class NormalDialog extends Component {}
-        NormalDialog.template = tags.xml`<RPCErrorDialog title="'Normal Error'"/>`;
+        NormalDialog.template = xml`<RPCErrorDialog title="'Normal Error'"/>`;
         NormalDialog.components = { RPCErrorDialog };
         const error = new RPCError();
         error.code = 701;

--- a/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
+++ b/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
@@ -8,8 +8,7 @@ import { hotkeyService } from "@web/core/hotkeys/hotkey_service";
 import { makeTestEnv } from "../../helpers/mock_env";
 import { getFixture, nextTick, patchWithCleanup, triggerHotkey } from "../../helpers/utils";
 
-const { Component, mount, tags } = owl;
-const { xml } = tags;
+const { Component, mount, xml } = owl;
 const serviceRegistry = registry.category("services");
 
 let env;

--- a/addons/web/static/tests/core/l10n/translation_tests.js
+++ b/addons/web/static/tests/core/l10n/translation_tests.js
@@ -11,17 +11,17 @@ import { makeFakeLocalizationService } from "@web/../tests/helpers/mock_services
 import { getFixture, patchWithCleanup } from "@web/../tests/helpers/utils";
 import { registerCleanup } from "@web/../tests/helpers/cleanup";
 
-const { mount } = owl;
+const { Component, mount, xml } = owl;
 
 const terms = { Hello: "Bonjour" };
 const serviceRegistry = registry.category("services");
-class TestComponent extends owl.Component {}
+class TestComponent extends Component {}
 
 QUnit.module("Translations");
 
 QUnit.test("can translate a text node", async (assert) => {
     assert.expect(1);
-    TestComponent.template = owl.tags.xml`<div>Hello</div>`;
+    TestComponent.template = xml`<div>Hello</div>`;
     serviceRegistry.add("localization", makeFakeLocalizationService());
     const env = await makeTestEnv();
     patch(translatedTerms, "add translations", terms);
@@ -34,7 +34,7 @@ QUnit.test("can translate a text node", async (assert) => {
 QUnit.test("can lazy translate", async (assert) => {
     assert.expect(3);
 
-    TestComponent.template = owl.tags.xml`<div><t t-esc="constructor.someLazyText" /></div>`;
+    TestComponent.template = xml`<div><t t-esc="constructor.someLazyText" /></div>`;
     TestComponent.someLazyText = _lt("Hello");
     assert.strictEqual(TestComponent.someLazyText.toString(), "Hello");
     assert.strictEqual(TestComponent.someLazyText.valueOf(), "Hello");
@@ -50,7 +50,7 @@ QUnit.test("can lazy translate", async (assert) => {
 
 QUnit.test("_t is in env", async (assert) => {
     assert.expect(1);
-    TestComponent.template = owl.tags.xml`<div><t t-esc="env._t('Hello')"/></div>`;
+    TestComponent.template = xml`<div><t t-esc="env._t('Hello')"/></div>`;
     serviceRegistry.add("localization", makeFakeLocalizationService());
     const env = await makeTestEnv();
     patch(translatedTerms, "add translations", terms);
@@ -66,7 +66,7 @@ QUnit.test("luxon is configured in the correct lang", async (assert) => {
         luxon.Settings.defaultLocale = defaultLocale;
     });
     patchWithCleanup(session, {
-        user_context: {...session.user_context, lang: "fr_BE"},
+        user_context: { ...session.user_context, lang: "fr_BE" },
     });
     patchWithCleanup(browser, {
         fetch() {

--- a/addons/web/static/tests/core/main_components_container_tests.js
+++ b/addons/web/static/tests/core/main_components_container_tests.js
@@ -5,9 +5,7 @@ import { clearRegistryWithCleanup, makeTestEnv } from "../helpers/mock_env";
 import { patch, unpatch } from "@web/core/utils/patch";
 import { getFixture, nextTick } from "../helpers/utils";
 
-const { mount, Component } = owl;
-const { useState } = owl.hooks;
-const { xml } = owl.tags;
+const { Component, mount, useState, xml } = owl;
 const mainComponentsRegistry = registry.category("main_components");
 let container;
 let target;

--- a/addons/web/static/tests/core/network/rpc_service_tests.js
+++ b/addons/web/static/tests/core/network/rpc_service_tests.js
@@ -11,8 +11,7 @@ import { makeMockXHR } from "../../helpers/mock_services";
 import { getFixture, makeDeferred, nextTick, patchWithCleanup } from "../../helpers/utils";
 import { registerCleanup } from "../../helpers/cleanup";
 
-const { Component, mount, tags } = owl;
-const { xml } = tags;
+const { Component, mount, xml } = owl;
 
 let isXHRMocked = false;
 const serviceRegistry = registry.category("services");

--- a/addons/web/static/tests/core/orm_service_tests.js
+++ b/addons/web/static/tests/core/orm_service_tests.js
@@ -6,8 +6,7 @@ import { useService } from "@web/core/utils/hooks";
 import { makeTestEnv } from "../helpers/mock_env";
 import { getFixture } from "../helpers/utils";
 
-const { Component, mount, tags } = owl;
-const { xml } = tags;
+const { Component, mount, xml } = owl;
 const serviceRegistry = registry.category("services");
 
 QUnit.module("ORM Service", {

--- a/addons/web/static/tests/core/pager_tests.js
+++ b/addons/web/static/tests/core/pager_tests.js
@@ -11,9 +11,7 @@ import {
     triggerEvents,
 } from "../helpers/utils";
 
-const { Component, mount } = owl;
-const { useState } = owl.hooks;
-const { xml } = owl.tags;
+const { Component, mount, useState, xml } = owl;
 
 class PagerController extends Component {
     setup() {

--- a/addons/web/static/tests/core/popover/popover_hook_tests.js
+++ b/addons/web/static/tests/core/popover/popover_hook_tests.js
@@ -7,8 +7,7 @@ import { registerCleanup } from "../../helpers/cleanup";
 import { clearRegistryWithCleanup, makeTestEnv } from "../../helpers/mock_env";
 import { getFixture, nextTick } from "../../helpers/utils";
 
-const { Component, mount } = owl;
-const { xml } = owl.tags;
+const { Component, mount, xml } = owl;
 
 let env;
 let fixture;

--- a/addons/web/static/tests/core/popover/popover_service_tests.js
+++ b/addons/web/static/tests/core/popover/popover_service_tests.js
@@ -6,8 +6,7 @@ import { registerCleanup } from "../../helpers/cleanup";
 import { clearRegistryWithCleanup, makeTestEnv } from "../../helpers/mock_env";
 import { click, getFixture, nextTick } from "../../helpers/utils";
 
-const { Component, mount } = owl;
-const { xml } = owl.tags;
+const { Component, mount, xml } = owl;
 
 let env;
 let fixture;

--- a/addons/web/static/tests/core/position_hook_tests.js
+++ b/addons/web/static/tests/core/position_hook_tests.js
@@ -11,8 +11,8 @@ import {
     triggerEvent,
 } from "../helpers/utils";
 
-const { Component, mount, tags } = owl;
-const { css, xml } = tags;
+const { Component, css, mount, xml } = owl;
+
 let container;
 let reference;
 

--- a/addons/web/static/tests/core/router_service_tests.js
+++ b/addons/web/static/tests/core/router_service_tests.js
@@ -6,9 +6,11 @@ import { makeTestEnv } from "../helpers/mock_env";
 import { makeFakeRouterService } from "../helpers/mock_services";
 import { nextTick, patchWithCleanup } from "../helpers/utils";
 
+const { EventBus } = owl;
+
 async function createRouter(params = {}) {
     const env = params.env || {};
-    env.bus = env.bus || new owl.core.EventBus();
+    env.bus = env.bus || new EventBus();
     if (params.onPushState) {
         const originalPushState = browser.history.pushState;
         const onPushState = params.onPushState;

--- a/addons/web/static/tests/core/scroller_service_tests.js
+++ b/addons/web/static/tests/core/scroller_service_tests.js
@@ -7,7 +7,7 @@ import { registerCleanup } from "../helpers/cleanup";
 import { makeTestEnv } from "../helpers/mock_env";
 import { click, getFixture, nextTick } from "../helpers/utils";
 
-const { Component, mount, tags } = owl;
+const { Component, mount, xml } = owl;
 const serviceRegistry = registry.category("services");
 
 let env;
@@ -28,7 +28,7 @@ QUnit.test("Ignore empty hrefs", async (assert) => {
     assert.expect(1);
 
     class MyComponent extends Component {}
-    MyComponent.template = tags.xml/* xml */ `
+    MyComponent.template = xml/* xml */ `
         <div class="my_component">
             <a href="#" class="inactive_link">This link does nothing</a>
             <button class="btn btn-secondary">
@@ -68,7 +68,7 @@ QUnit.test("Simple rendering with a scroll", async (assert) => {
     target.append(scrollableParent);
 
     class MyComponent extends Component {}
-    MyComponent.template = tags.xml/* xml */ `
+    MyComponent.template = xml/* xml */ `
         <div class="o_content">
             <a href="#scrollToHere"  class="btn btn-primary">sroll to ...</a>
             <p>
@@ -122,7 +122,7 @@ QUnit.test("Rendering with multiple anchors and scrolls", async (assert) => {
     target.append(scrollableParent);
 
     class MyComponent extends Component {}
-    MyComponent.template = tags.xml/* xml */ `
+    MyComponent.template = xml/* xml */ `
         <div class="o_content">
             <h2 id="anchor3">ANCHOR 3</h2>
             <a href="#anchor1" class="link1">sroll to ...</a>
@@ -196,7 +196,7 @@ QUnit.test("clicking anchor when no scrollable", async (assert) => {
     target.append(scrollableParent);
 
     class MyComponent extends Component {}
-    MyComponent.template = tags.xml/* xml */ `
+    MyComponent.template = xml/* xml */ `
         <div class="o_content">
             <a href="#scrollToHere"  class="btn btn-primary">scroll to ...</a>
             <div class="active-container">
@@ -234,7 +234,7 @@ QUnit.test("clicking anchor when multi levels scrollables", async (assert) => {
     target.append(scrollableParent);
 
     class MyComponent extends Component {}
-    MyComponent.template = tags.xml/* xml */ `
+    MyComponent.template = xml/* xml */ `
         <div class="o_content scrollable-1">
             <a href="#scroll1"  class="btn1 btn btn-primary">go to level 2 anchor</a>
             <div>
@@ -329,7 +329,7 @@ QUnit.test("Simple scroll to HTML elements", async (assert) => {
     target.append(scrollableParent);
 
     class MyComponent extends Component {}
-    MyComponent.template = tags.xml/* xml */ `
+    MyComponent.template = xml/* xml */ `
         <div class="o_content">
             <p>
                 Aliquam convallis sollicitudin purus. 

--- a/addons/web/static/tests/core/tooltip/tooltip_hook_tests.js
+++ b/addons/web/static/tests/core/tooltip/tooltip_hook_tests.js
@@ -9,8 +9,7 @@ import { registerCleanup } from "../../helpers/cleanup";
 import { clearRegistryWithCleanup, makeTestEnv } from "../../helpers/mock_env";
 import { getFixture, nextTick, patchWithCleanup, triggerEvent } from "../../helpers/utils";
 
-const { Component, mount, useState } = owl;
-const { xml } = owl.tags;
+const { Component, mount, useState, xml } = owl;
 
 const mainComponents = registry.category("main_components");
 

--- a/addons/web/static/tests/core/ui_service_tests.js
+++ b/addons/web/static/tests/core/ui_service_tests.js
@@ -6,7 +6,7 @@ import { makeTestEnv } from "../helpers/mock_env";
 import { makeFakeLocalizationService } from "../helpers/mock_services";
 import { getFixture, nextTick } from "../helpers/utils";
 
-const { Component, mount } = owl;
+const { Component, mount, xml } = owl;
 const serviceRegistry = registry.category("services");
 
 let target;
@@ -71,7 +71,7 @@ QUnit.test("a component can be the active element", async (assert) => {
             useActiveElement();
         }
     }
-    MyComponent.template = owl.tags.xml`<div/>`;
+    MyComponent.template = xml`<div/>`;
 
     const env = await makeTestEnv({ ...baseConfig });
     const ui = env.services.ui;
@@ -91,7 +91,7 @@ QUnit.test("a component can be the  UI active element: with t-ref delegation", a
             useActiveElement("delegatedRef");
         }
     }
-    MyComponent.template = owl.tags.xml`
+    MyComponent.template = xml`
     <div>
       <h1>My Component</h1>
       <div id="owner" t-ref="delegatedRef"/>

--- a/addons/web/static/tests/core/utils/component_tests.js
+++ b/addons/web/static/tests/core/utils/component_tests.js
@@ -4,7 +4,7 @@ import { NotUpdatable, ErrorHandler } from "@web/core/utils/components";
 import { makeTestEnv } from "../../helpers/mock_env";
 import { getFixture } from "../../helpers/utils";
 
-const { Component, mount } = owl;
+const { Component, mount, xml } = owl;
 
 QUnit.module("utils", () => {
     QUnit.module("components");
@@ -18,9 +18,9 @@ QUnit.module("utils", () => {
                 assert.step("willupdateprops");
             }
         }
-        Child.template = owl.tags.xml`<div>hey</div>`;
+        Child.template = xml`<div>hey</div>`;
         class Parent extends Component {}
-        Parent.template = owl.tags.xml`
+        Parent.template = xml`
           <div>
             <Child/>
             <NotUpdatable><Child/></NotUpdatable>
@@ -38,7 +38,7 @@ QUnit.module("utils", () => {
 
     QUnit.test("ErrorHandler component", async function (assert) {
         class Boom extends Component {}
-        Boom.template = owl.tags.xml`<div><t t-esc="this.will.throw"/></div>`;
+        Boom.template = xml`<div><t t-esc="this.will.throw"/></div>`;
 
         class Parent extends Component {
             setup() {
@@ -49,7 +49,7 @@ QUnit.module("utils", () => {
                 this.render();
             }
         }
-        Parent.template = owl.tags.xml`
+        Parent.template = xml`
         <div>
           <t t-if="flag">
             <ErrorHandler onError="() => this.handleError()">

--- a/addons/web/static/tests/core/utils/hooks_tests.js
+++ b/addons/web/static/tests/core/utils/hooks_tests.js
@@ -1,13 +1,20 @@
 /** @odoo-module **/
 
 import { uiService } from "@web/core/ui/ui_service";
-import { useAutofocus, useBus, useEffect, useListener, useService, onDestroyed } from "@web/core/utils/hooks";
+import {
+    useAutofocus,
+    useBus,
+    useEffect,
+    useListener,
+    useService,
+    onDestroyed,
+} from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 import { makeTestEnv } from "../../helpers/mock_env";
 import { click, getFixture, nextTick } from "../../helpers/utils";
 import { registerCleanup } from "../../helpers/cleanup";
 
-const { Component, mount, tags, useState } = owl;
+const { Component, mount, useState, xml } = owl;
 const serviceRegistry = registry.category("services");
 
 QUnit.module("utils", () => {
@@ -20,7 +27,7 @@ QUnit.module("utils", () => {
                     useAutofocus();
                 }
             }
-            MyComponent.template = tags.xml`
+            MyComponent.template = xml`
                 <span>
                     <input type="text" autofocus="" />
                 </span>
@@ -49,7 +56,7 @@ QUnit.module("utils", () => {
                     this.showInput = true;
                 }
             }
-            MyComponent.template = tags.xml`
+            MyComponent.template = xml`
                 <span>
                     <input t-if="showInput" type="text" autofocus="" />
                 </span>
@@ -90,7 +97,7 @@ QUnit.module("utils", () => {
                     assert.step("callback");
                 }
             }
-            MyComponent.template = tags.xml`<div/>`;
+            MyComponent.template = xml`<div/>`;
 
             const env = await makeTestEnv();
             const target = getFixture();
@@ -131,7 +138,7 @@ QUnit.module("utils", () => {
                         });
                     }
                 }
-                MyComponent.template = tags.xml`<div/>`;
+                MyComponent.template = xml`<div/>`;
 
                 const env = await makeTestEnv();
                 const target = getFixture();
@@ -193,7 +200,7 @@ QUnit.module("utils", () => {
                         );
                     }
                 }
-                MyComponent.template = tags.xml`<div/>`;
+                MyComponent.template = xml`<div/>`;
 
                 const env = await makeTestEnv();
                 const target = getFixture();
@@ -270,7 +277,7 @@ QUnit.module("utils", () => {
                         );
                     }
                 }
-                MyComponent.template = tags.xml`<div t-esc="state.value"/>`;
+                MyComponent.template = xml`<div t-esc="state.value"/>`;
 
                 const env = await makeTestEnv();
                 const target = getFixture();
@@ -307,7 +314,7 @@ QUnit.module("utils", () => {
                     useListener("click", () => assert.step("click"));
                 }
             }
-            MyComponent.template = tags.xml`<button>Click Me</button>`;
+            MyComponent.template = xml`<button>Click Me</button>`;
 
             const env = await makeTestEnv();
             const target = getFixture();
@@ -327,7 +334,7 @@ QUnit.module("utils", () => {
                     useListener("click", "button", () => assert.step("click"));
                 }
             }
-            MyComponent.template = tags.xml`
+            MyComponent.template = xml`
                 <div>
                     <button t-if="flag">Click Here</button>
                     <button t-else="">
@@ -360,7 +367,7 @@ QUnit.module("utils", () => {
                     useListener("click", "button", () => assert.step("click"), { capture: true });
                 }
             }
-            MyComponent.template = tags.xml`
+            MyComponent.template = xml`
                 <div>
                     <button t-if="flag">Click Here</button>
                     <button t-else="">
@@ -394,7 +401,7 @@ QUnit.module("utils", () => {
                     useService("toy_service");
                 }
             }
-            MyComponent.template = tags.xml`<div/>`;
+            MyComponent.template = xml`<div/>`;
 
             const env = await makeTestEnv();
             const target = getFixture();
@@ -411,7 +418,7 @@ QUnit.module("utils", () => {
                     this.toyService = useService("toy_service");
                 }
             }
-            MyComponent.template = tags.xml`<div/>`;
+            MyComponent.template = xml`<div/>`;
 
             serviceRegistry.add("toy_service", {
                 name: "toy_service",
@@ -437,10 +444,10 @@ QUnit.module("utils", () => {
                     onDestroyed(() => assert.step("onDestroyed"));
                 }
             }
-            MyComponent.template = tags.xml`<div/>`;
+            MyComponent.template = xml`<div/>`;
 
             const target = getFixture();
-            const component = await owl.mount(MyComponent, {target});
+            const component = await mount(MyComponent, { target });
             assert.verifySteps([]);
             component.destroy();
             assert.verifySteps(["onDestroyed"]);

--- a/addons/web/static/tests/legacy/component_extension_tests.js
+++ b/addons/web/static/tests/legacy/component_extension_tests.js
@@ -4,9 +4,9 @@ odoo.define('web.component_extension_tests', function (require) {
     const makeTestEnvironment = require("web.test_env");
     const testUtils = require("web.test_utils");
 
-    const { Component, tags } = owl;
-    const { xml } = tags;
     const { useListener } = require('web.custom_hooks');
+
+    const { Component, xml } = owl;
 
     QUnit.module("web", function () {
         QUnit.module("Component Extension");

--- a/addons/web/static/tests/legacy/components/dropdown_menu_tests.js
+++ b/addons/web/static/tests/legacy/components/dropdown_menu_tests.js
@@ -4,6 +4,7 @@ odoo.define('web.dropdown_menu_tests', function (require) {
     const DropdownMenu = require('web.DropdownMenu');
     const testUtils = require('web.test_utils');
 
+    const { Component, useState, xml } = owl;
     const { createComponent } = testUtils;
 
     QUnit.module('Components', {
@@ -358,14 +359,14 @@ odoo.define('web.dropdown_menu_tests', function (require) {
             assert.expect(7);
 
             const props = { items: this.items };
-            class Parent extends owl.Component {
+            class Parent extends Component {
                 constructor() {
                     super(...arguments);
-                    this.state = owl.useState(props);
+                    this.state = useState(props);
                 }
             }
             Parent.components = { DropdownMenu };
-            Parent.template = owl.tags.xml`
+            Parent.template = xml`
                 <div>
                     <DropdownMenu class="first" title="'First'" items="state.items"/>
                     <DropdownMenu class="second" title="'Second'" items="state.items"/>
@@ -405,14 +406,14 @@ odoo.define('web.dropdown_menu_tests', function (require) {
             assert.expect(5);
 
             const items = this.items;
-            class Parent extends owl.Component {
+            class Parent extends Component {
                 constructor() {
                     super(...arguments);
                     this.items = items;
                 }
             }
             Parent.components = { DropdownMenu };
-            Parent.template = owl.tags.xml`
+            Parent.template = xml`
                 <div>
                     <DropdownMenu class="first" title="'First'" items="items"/>
                 </div>`;

--- a/addons/web/static/tests/legacy/core/owl_dialog_tests.js
+++ b/addons/web/static/tests/legacy/core/owl_dialog_tests.js
@@ -14,9 +14,8 @@ odoo.define('web.owl_dialog_tests', function (require) {
     const { getFixture, nextTick, patchWithCleanup } = require("@web/../tests/helpers/utils");
     const { createWebClient, doAction } = require("@web/../tests/webclient/helpers");
 
-    const { Component, tags, useState, mount } = owl;
+    const { Component, mount, useState, xml } = owl;
     const EscapeKey = { key: 'Escape', keyCode: 27, which: 27 };
-    const { xml } = tags;
 
     QUnit.module('core', {}, function () {
         QUnit.module('OwlDialog');
@@ -283,7 +282,7 @@ odoo.define('web.owl_dialog_tests', function (require) {
 
             let id = 1;
             // OwlDialog env
-            class OwlDialogWrapper extends owl.Component {
+            class OwlDialogWrapper extends Component {
                 setup() {
                     this.env = legacyEnv;
                 }

--- a/addons/web/static/tests/legacy/core/popover_tests.js
+++ b/addons/web/static/tests/legacy/core/popover_tests.js
@@ -6,9 +6,7 @@ odoo.define('web.popover_tests', function (require) {
     const testUtils = require('web.test_utils');
     const { useEffect } = require("@web/core/utils/hooks");
 
-    const { Component, tags, hooks } = owl;
-    const { useRef, useState } = hooks;
-    const { xml } = tags;
+    const { Component, useRef, useState, xml } = owl;
 
     QUnit.module('core', {}, function () {
         QUnit.module('Popover');

--- a/addons/web/static/tests/legacy/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields/field_one2many_tests.js
@@ -24,6 +24,8 @@ const { FieldOne2Many } = relationalFields;
 const AbstractFieldOwl = require('web.AbstractFieldOwl');
 const fieldRegistryOwl = require('web.field_registry_owl');
 
+const { onMounted, onWillUnmount, xml } = owl;
+
 QUnit.module('fields', {}, function () {
 
     QUnit.module('relational_fields', {
@@ -9650,10 +9652,10 @@ QUnit.module('fields', {}, function () {
             patch(ControlPanel.prototype, 'cp_patch_mock', {
                 setup() {
                     this._super(...arguments);
-                    owl.hooks.onMounted(() => {
+                    onMounted(() => {
                         assert.step('mounted');
                     });
-                    owl.hooks.onWillUnmount(() => {
+                    onWillUnmount(() => {
                         assert.step('willUnmount');
                     });
                 },
@@ -9881,7 +9883,7 @@ QUnit.module('fields', {}, function () {
 
         QUnit.test("Editable list's field widgets call on_attach_callback on row update", async function (assert) {
             // We use here a badge widget (owl component, does have a on_attach_callback method) and check its decoration
-            // is properly managed in this scenario.       
+            // is properly managed in this scenario.
             assert.expect(3);
 
             this.data.partner.records[0].p = [1, 2];
@@ -10036,11 +10038,11 @@ QUnit.module('fields', {}, function () {
                 setup() {
                     super.setup();
                     const ID = testInst++;
-                    owl.hooks.onMounted(() => {
+                    onMounted(() => {
                         assert.step(`mounted ${ID}`);
                     });
 
-                    owl.hooks.onWillUnmount(() => {
+                    onWillUnmount(() => {
                         assert.step(`willUnmount ${ID}`);
                     });
                 }
@@ -10049,7 +10051,7 @@ QUnit.module('fields', {}, function () {
                 }
             }
 
-            TestField.template = owl.tags.xml`<span>test</span>`;
+            TestField.template = xml`<span>test</span>`;
             fieldRegistryOwl.add('test_field', TestField);
 
             const def = testUtils.makeTestPromise();

--- a/addons/web/static/tests/legacy/helpers/test_env.js
+++ b/addons/web/static/tests/legacy/helpers/test_env.js
@@ -6,6 +6,8 @@ odoo.define('web.test_env', async function (require) {
     const session = require('web.session');
     const { registerCleanup } = require("@web/../tests/helpers/cleanup");
 
+    const { Component, QWeb } = owl;
+
     let qweb;
 
     /**
@@ -21,7 +23,7 @@ odoo.define('web.test_env', async function (require) {
         if (!qweb) {
             // avoid parsing templates at every test because it takes a lot of
             // time and they never change
-            qweb = new owl.QWeb({ templates: session.owlTemplates });
+            qweb = new QWeb({ templates: session.owlTemplates });
         }
         registerCleanup(() => {
             qweb.subscriptions = {};
@@ -98,10 +100,10 @@ odoo.define('web.test_env', async function (require) {
     }
 
     /**
-     * Before each test, we want owl.Component.env to be a fresh test environment.
+     * Before each test, we want Component.env to be a fresh test environment.
      */
     QUnit.on('OdooBeforeTestHook', function () {
-        owl.Component.env = makeTestEnvironment();
+        Component.env = makeTestEnvironment();
     });
 
     return makeTestEnvironment;

--- a/addons/web/static/tests/legacy/helpers/test_utils_create.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_create.js
@@ -21,9 +21,7 @@ odoo.define('web.test_utils_create', function (require) {
     const testUtilsMock = require('web.test_utils_mock');
     const Widget = require('web.Widget');
 
-    const { Component } = owl;
-    const { useRef, useState } = owl.hooks;
-    const { xml } = owl.tags;
+    const { Component, useRef, useState, xml } = owl;
 
     /**
      * Similar as createView, but specific for calendar views. Some calendar

--- a/addons/web/static/tests/legacy/helpers/test_utils_dom.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_dom.js
@@ -4,6 +4,8 @@ odoo.define('web.test_utils_dom', function (require) {
     const concurrency = require('web.concurrency');
     const Widget = require('web.Widget');
 
+    const { Component } = owl;
+
     /**
      * DOM Test Utils
      *
@@ -368,7 +370,7 @@ odoo.define('web.test_utils_dom', function (require) {
      */
     function getNode(target) {
         let nodes;
-        if (target instanceof owl.Component || target instanceof Widget) {
+        if (target instanceof Component || target instanceof Widget) {
             nodes = [target.el];
         } else if (typeof target === 'string') {
             nodes = document.querySelectorAll(target);

--- a/addons/web/static/tests/legacy/helpers/test_utils_mock.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_mock.js
@@ -24,6 +24,7 @@ const RamStorage = require('web.RamStorage');
 const session = require('web.session');
 const { patchDate } = require("@web/../tests/helpers/utils");
 
+const { Component } = owl;
 const DebouncedField = basic_fields.DebouncedField;
 
 
@@ -541,8 +542,8 @@ async function addMockEnvironment(widget, params) {
     if (!('mockSRC' in params)) { // redirect src rpcs to the mock server
         params.mockSRC = true;
     }
-    const cleanUp = await addMockEnvironmentOwl(owl.Component, params, mockServer);
-    const env = owl.Component.env;
+    const cleanUp = await addMockEnvironmentOwl(Component, params, mockServer);
+    const env = Component.env;
 
     // ensure to clean up everything when the widget will be destroyed
     const destroy = widget.destroy;

--- a/addons/web/static/tests/legacy/owl_compatibility_tests.js
+++ b/addons/web/static/tests/legacy/owl_compatibility_tests.js
@@ -10,12 +10,11 @@ odoo.define('web.OwlCompatibilityTests', function (require) {
     const testUtils = require('web.test_utils');
     const Widget = require('web.Widget');
 
+    const { Component, useState, xml } = owl;
     const makeTestPromise = testUtils.makeTestPromise;
     const nextTick = testUtils.nextTick;
     const addMockEnvironmentOwl = testUtils.mock.addMockEnvironmentOwl;
 
-    const { Component, tags, useState } = owl;
-    const { xml } = tags;
 
     // from Owl internal status enum
     const ISMOUNTED = 3; 

--- a/addons/web/static/tests/legacy/views/abstract_controller_tests.js
+++ b/addons/web/static/tests/legacy/views/abstract_controller_tests.js
@@ -1,7 +1,6 @@
 odoo.define("base.abstract_controller_tests", function (require) {
 "use strict";
 
-const { xml } = owl.tags;
 
 var testUtils = require("web.test_utils");
 var createView = testUtils.createView;
@@ -9,6 +8,8 @@ var BasicView = require("web.BasicView");
 var BasicRenderer = require("web.BasicRenderer");
 const AbstractRenderer = require('web.AbstractRendererOwl');
 const RendererWrapper = require('web.RendererWrapper');
+
+const { xml } = owl;
 
 function getHtmlRenderer(html) {
     return BasicRenderer.extend({

--- a/addons/web/static/tests/legacy/views/basic_view_tests.js
+++ b/addons/web/static/tests/legacy/views/basic_view_tests.js
@@ -5,7 +5,8 @@ odoo.define('web.basic_view_tests', function (require) {
     const BasicRenderer = require("web.BasicRenderer");
     const testUtils = require('web.test_utils');
     const widgetRegistryOwl = require('web.widgetRegistry');
-    const { xml } = owl.tags;
+
+    const { Component, xml } = owl;
 
     const createView = testUtils.createView;
 
@@ -42,7 +43,7 @@ odoo.define('web.basic_view_tests', function (require) {
                 })
             });
 
-            class MyWidget extends owl.Component {}
+            class MyWidget extends Component {}
             MyWidget.fieldDependencies = {
                 foo: { type: 'char' },
                 bar: { type: 'boolean' },

--- a/addons/web/static/tests/legacy/views/form_tests.js
+++ b/addons/web/static/tests/legacy/views/form_tests.js
@@ -31,6 +31,8 @@ const { mapLegacyEnvToWowlEnv } = require("@web/legacy/utils");
 const { registry } = require("@web/core/registry");
 const { scrollerService } = require("@web/core/scroller_service");
 
+const { Component, xml } = owl;
+
 let serverData;
 QUnit.module('Views', {
     beforeEach: async function () {
@@ -8346,12 +8348,12 @@ QUnit.module('Views', {
     QUnit.test('basic support for widgets (being Owl Components)', async function (assert) {
         assert.expect(1);
 
-        class MyComponent extends owl.Component {
+        class MyComponent extends Component {
             get value() {
                 return JSON.stringify(this.props.record.data);
             }
         }
-        MyComponent.template = owl.tags.xml`<div t-esc="value"/>`;
+        MyComponent.template = xml`<div t-esc="value"/>`;
         widgetRegistryOwl.add('test', MyComponent);
 
         const form = await createView({

--- a/addons/web/static/tests/legacy/views/kanban_tests.js
+++ b/addons/web/static/tests/legacy/views/kanban_tests.js
@@ -20,6 +20,8 @@ var nextTick = testUtils.nextTick;
  const cpHelpers = require('@web/../tests/search/helpers');
 var createView = testUtils.createView;
 
+ const { Component, xml } = owl;
+
 QUnit.module('Views', {
     before: function () {
         this._initialKanbanProgressBarAnimate = KanbanColumnProgressBar.prototype.ANIMATE;
@@ -6172,12 +6174,12 @@ QUnit.module('Views', {
     QUnit.test('basic support for widgets (being Owl Components)', async function (assert) {
         assert.expect(1);
 
-        class MyComponent extends owl.Component {
+        class MyComponent extends Component {
             get value() {
                 return JSON.stringify(this.props.record.data);
             }
         }
-        MyComponent.template = owl.tags.xml`<div t-esc="value"/>`;
+        MyComponent.template = xml`<div t-esc="value"/>`;
         widgetRegistryOwl.add('test', MyComponent);
 
         const kanban = await createView({

--- a/addons/web/static/tests/legacy/views/list_tests.js
+++ b/addons/web/static/tests/legacy/views/list_tests.js
@@ -1,32 +1,33 @@
 odoo.define('web.list_tests', function (require) {
 "use strict";
 
-var AbstractFieldOwl = require('web.AbstractFieldOwl');
-var AbstractStorageService = require('web.AbstractStorageService');
-var BasicModel = require('web.BasicModel');
-var core = require('web.core');
+const AbstractFieldOwl = require('web.AbstractFieldOwl');
+const AbstractStorageService = require('web.AbstractStorageService');
+const BasicModel = require('web.BasicModel');
+const core = require('web.core');
 const Domain = require('web.Domain')
-var basicFields = require('web.basic_fields');
-var fieldRegistry = require('web.field_registry');
-var fieldRegistryOwl = require('web.field_registry_owl');
-var FormView = require('web.FormView');
-var ListRenderer = require('web.ListRenderer');
-var ListView = require('web.ListView');
-var mixins = require('web.mixins');
-var RamStorage = require('web.RamStorage');
-var testUtils = require('web.test_utils');
+const basicFields = require('web.basic_fields');
+const fieldRegistry = require('web.field_registry');
+const fieldRegistryOwl = require('web.field_registry_owl');
+const FormView = require('web.FormView');
+const ListRenderer = require('web.ListRenderer');
+const ListView = require('web.ListView');
+const mixins = require('web.mixins');
+const RamStorage = require('web.RamStorage');
+const testUtils = require('web.test_utils');
 const { patch, unpatch } = require('web.utils');
-var widgetRegistry = require('web.widget_registry');
+const widgetRegistry = require('web.widget_registry');
 const widgetRegistryOwl = require('web.widgetRegistry');
-var Widget = require('web.Widget');
-
-
-var _t = core._t;
+const Widget = require('web.Widget');
+const ControlPanel = require('web.ControlPanel');
+const ListController = require('web.ListController');
 const cpHelpers = require('@web/../tests/search/helpers');
-var createView = testUtils.createView;
-
 const { click, legacyExtraNextTick } = require("@web/../tests/helpers/utils");
 const { createWebClient, doAction, loadState } = require('@web/../tests/webclient/helpers');
+
+const { Component, xml } = owl;
+const createView = testUtils.createView;
+const _t = core._t;
 
 let serverData;
 
@@ -9303,12 +9304,12 @@ QUnit.module('Views', {
     QUnit.test('basic support for widgets (being Owl Components)', async function (assert) {
         assert.expect(1);
 
-        class MyComponent extends owl.Component {
+        class MyComponent extends Component {
             get value() {
                 return JSON.stringify(this.props.record.data);
             }
         }
-        MyComponent.template = owl.tags.xml`<div t-esc="value"/>`;
+        MyComponent.template = xml`<div t-esc="value"/>`;
         widgetRegistryOwl.add('test', MyComponent);
 
         const list = await createView({
@@ -12129,7 +12130,7 @@ QUnit.module('Views', {
                 willUnmountCalls++;
             }
         }
-        MyField.template = owl.tags.xml`<span>Hello World</span>`;
+        MyField.template = xml`<span>Hello World</span>`;
         fieldRegistryOwl.add('my_owl_field', MyField);
 
         const list = await createView({
@@ -12270,8 +12271,6 @@ QUnit.module('Views', {
     });
 
     QUnit.test("update control panel while list view is mounting", async function (assert) {
-        const ControlPanel = require('web.ControlPanel');
-        const ListController = require('web.ListController');
 
         let mountedCounterCall = 0;
 

--- a/addons/web/static/tests/legacy/views/state_mapping_tests.js
+++ b/addons/web/static/tests/legacy/views/state_mapping_tests.js
@@ -25,6 +25,7 @@ import { mock } from "web.test_utils";
 import legacyViewRegistry from "web.view_registry";
 import { browser } from "@web/core/browser/browser";
 
+const { Component, xml } = owl;
 const serviceRegistry = registry.category("services");
 const viewRegistry = registry.category("views");
 const searchModelRegistry = registry.category("search_models");
@@ -75,13 +76,13 @@ QUnit.module("Views", (hooks) => {
         setupControlPanelServiceRegistry();
         serviceRegistry.add("dialog", dialogService);
 
-        class ToyView extends owl.Component {}
+        class ToyView extends Component {}
         ToyView.components = { ControlPanel };
         ToyView.display_name = _lt("Toy view");
         ToyView.icon = "fab fa-android";
         ToyView.multiRecord = true;
         ToyView.searchMenuTypes = ["filter", "groupBy", "comparison", "favorite"];
-        ToyView.template = owl.tags.xml`
+        ToyView.template = xml`
             <div class="o_toy_view">
                 <ControlPanel />
             </div>

--- a/addons/web/static/tests/qunit.js
+++ b/addons/web/static/tests/qunit.js
@@ -113,7 +113,7 @@
      * - is unique
      * - has the given attribute with the proper value
      *
-     * @param {Widget|jQuery|HTMLElement|owl.Component} w
+     * @param {Widget|jQuery|HTMLElement|Component} w
      * @param {string} attr
      * @param {string} value
      * @param {string} [msg]
@@ -363,12 +363,12 @@
         }
     });
     const oldError = QUnit.onError;
-    QUnit.onError = err => {
-        if (err.message === 'ResizeObserver loop limit exceeded') {
+    QUnit.onError = (err) => {
+        if (err.message === "ResizeObserver loop limit exceeded") {
             return true;
         }
         return oldError(err);
-    }
+    };
 
     // -----------------------------------------------------------------------------
     // Add sort button

--- a/addons/web/static/tests/search/custom_favorite_item_tests.js
+++ b/addons/web/static/tests/search/custom_favorite_item_tests.js
@@ -20,6 +20,7 @@ import {
     validateSearch,
 } from "./helpers";
 
+const { Component, xml } = owl;
 const serviceRegistry = registry.category("services");
 
 /**
@@ -159,7 +160,7 @@ QUnit.module("Search", (hooks) => {
     QUnit.test("save filter", async function (assert) {
         assert.expect(1);
 
-        class TestComponent extends owl.Component {
+        class TestComponent extends Component {
             setup() {
                 useSetupAction({
                     getContext: () => {
@@ -169,7 +170,7 @@ QUnit.module("Search", (hooks) => {
             }
         }
         TestComponent.components = { FavoriteMenu };
-        TestComponent.template = owl.tags.xml`<div><FavoriteMenu/></div>`;
+        TestComponent.template = xml`<div><FavoriteMenu/></div>`;
 
         const comp = await makeWithSearch({
             serverData,

--- a/addons/web/static/tests/search/favorite_menu_tests.js
+++ b/addons/web/static/tests/search/favorite_menu_tests.js
@@ -19,6 +19,7 @@ import {
     toggleMenuItem,
 } from "./helpers";
 
+const { Component, xml } = owl;
 const serviceRegistry = registry.category("services");
 const viewRegistry = registry.category("views");
 const favoriteMenuRegistry = registry.category("favoriteMenu");
@@ -129,7 +130,7 @@ QUnit.module("Search", (hooks) => {
         async function (assert) {
             assert.expect(7);
 
-            class ToyView extends owl.Component {
+            class ToyView extends Component {
                 setup() {
                     assert.deepEqual(this.props.domain, [["foo", "=", "qsdf"]]);
                 }
@@ -138,7 +139,7 @@ QUnit.module("Search", (hooks) => {
                 }
             }
             ToyView.components = { FavoriteMenu, SearchBar };
-            ToyView.template = owl.tags.xml`
+            ToyView.template = xml`
                 <div>
                     <SearchBar/>
                     <FavoriteMenu/>

--- a/addons/web/static/tests/search/helpers.js
+++ b/addons/web/static/tests/search/helpers.js
@@ -13,10 +13,9 @@ import { registerCleanup } from "../helpers/cleanup";
 import { makeTestEnv } from "../helpers/mock_env";
 import { click, getFixture, mouseEnter, triggerEvent } from "../helpers/utils";
 
+const { Component, mount } = owl;
 const serviceRegistry = registry.category("services");
 const favoriteMenuRegistry = registry.category("favoriteMenu");
-
-const { Component, mount } = owl;
 
 export const setupControlPanelServiceRegistry = () => {
     serviceRegistry.add("action", actionService);

--- a/addons/web/static/tests/search/pager_hook_tests.js
+++ b/addons/web/static/tests/search/pager_hook_tests.js
@@ -5,9 +5,7 @@ import { usePager } from "@web/search/pager_hook";
 import { click } from "../helpers/utils";
 import { makeWithSearch, setupControlPanelServiceRegistry } from "./helpers";
 
-const { Component } = owl;
-const { useState } = owl.hooks;
-const { xml } = owl.tags;
+const { Component, useState, xml } = owl;
 
 let serverData;
 QUnit.module("Search", (hooks) => {

--- a/addons/web/static/tests/search/search_model_tests.js
+++ b/addons/web/static/tests/search/search_model_tests.js
@@ -4,8 +4,7 @@ import { patchDate } from "@web/../tests/helpers/utils";
 import { makeWithSearch, setupControlPanelServiceRegistry } from "./helpers";
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
 
-const { Component, tags } = owl;
-const { xml } = tags;
+const { Component, xml } = owl;
 
 class TestComponent extends Component {}
 TestComponent.template = xml`<div class="o_test_component"/>`;

--- a/addons/web/static/tests/search/search_panel_tests.js
+++ b/addons/web/static/tests/search/search_panel_tests.js
@@ -15,8 +15,7 @@ import { FilterMenu } from "@web/search/filter_menu/filter_menu";
 import { GroupByMenu } from "@web/search/group_by_menu/group_by_menu";
 import { SearchPanel } from "@web/search/search_panel/search_panel";
 
-const { Component, tags } = owl;
-const { xml } = tags;
+const { Component, xml } = owl;
 
 const serviceRegistry = registry.category("services");
 

--- a/addons/web/static/tests/search/with_search_tests.js
+++ b/addons/web/static/tests/search/with_search_tests.js
@@ -17,9 +17,7 @@ import {
     toggleMenuItem,
 } from "./helpers";
 
-const { Component, hooks, mount, tags } = owl;
-const { useState } = hooks;
-const { xml } = tags;
+const { Component, mount, useState, xml } = owl;
 
 const serviceRegistry = registry.category("services");
 

--- a/addons/web/static/tests/setup.js
+++ b/addons/web/static/tests/setup.js
@@ -11,10 +11,10 @@ import { prepareRegistriesWithCleanup } from "./helpers/mock_env";
 import { session as sessionInfo } from "@web/session";
 import { prepareLegacyRegistriesWithCleanup } from "./helpers/legacy_env_utils";
 
-const { whenReady, loadFile } = owl.utils;
+const { QWeb, config, loadFile, whenReady } = owl;
 
-owl.config.enableTransitions = false;
-owl.QWeb.dev = true;
+config.enableTransitions = false;
+QWeb.dev = true;
 
 function stringifyObjectValues(obj, properties) {
     let res = "";

--- a/addons/web/static/tests/views/helpers.js
+++ b/addons/web/static/tests/views/helpers.js
@@ -7,7 +7,7 @@ import { getDefaultConfig, View } from "@web/views/view";
 import { _fieldsViewGet } from "../helpers/mock_server";
 import { addLegacyMockEnvironment } from "../webclient/helpers";
 
-const { mount } = owl;
+const { Component, mount } = owl;
 
 /**
  * @typedef {{
@@ -21,7 +21,7 @@ const { mount } = owl;
 
 /**
  * @param {MakeViewParams} params
- * @returns {owl.Component}
+ * @returns {Component}
  */
 export const makeView = async (params) => {
     const props = { ...params };

--- a/addons/web/static/tests/views/layout_tests.js
+++ b/addons/web/static/tests/views/layout_tests.js
@@ -8,9 +8,7 @@ import { Layout } from "@web/views/layout";
 import { getDefaultConfig } from "@web/views/view";
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
 
-const { Component, hooks, mount, tags } = owl;
-const { xml } = tags;
-const { useSubEnv } = hooks;
+const { Component, mount, useSubEnv, xml } = owl;
 
 const serviceRegistry = registry.category("services");
 

--- a/addons/web/static/tests/views/view_tests.js
+++ b/addons/web/static/tests/views/view_tests.js
@@ -15,9 +15,7 @@ import { OnboardingBanner } from "@web/views/onboarding_banner";
 import { View } from "@web/views/view";
 import { actionService } from "@web/webclient/actions/action_service";
 
-const { Component, mount, hooks, tags } = owl;
-const { useState } = hooks;
-const { xml } = tags;
+const { Component, mount, useState, xml } = owl;
 
 const serviceRegistry = registry.category("services");
 const viewRegistry = registry.category("views");

--- a/addons/web/static/tests/webclient/actions/client_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/client_action_tests.js
@@ -9,7 +9,7 @@ import { registerCleanup } from "../../helpers/cleanup";
 import { click, legacyExtraNextTick, patchWithCleanup } from "../../helpers/utils";
 import { createWebClient, doAction, getActionManagerServerData } from "./../helpers";
 
-const { Component, tags } = owl;
+const { Component, xml } = owl;
 
 let serverData;
 const actionRegistry = registry.category("actions");
@@ -98,7 +98,7 @@ QUnit.module("ActionManager", (hooks) => {
     QUnit.test("can execute client actions from tag name", async function (assert) {
         assert.expect(4);
         class ClientAction extends Component {}
-        ClientAction.template = tags.xml`<div class="o_client_action_test">Hello World</div>`;
+        ClientAction.template = xml`<div class="o_client_action_test">Hello World</div>`;
         actionRegistry.add("HelloWorldTest", ClientAction);
 
         const mockRPC = async function (route, args) {
@@ -230,7 +230,7 @@ QUnit.module("ActionManager", (hooks) => {
     QUnit.test("action can use a custom control panel (legacy)", async function (assert) {
         assert.expect(1);
         class CustomControlPanel extends Component {}
-        CustomControlPanel.template = tags.xml`
+        CustomControlPanel.template = xml`
         <div class="custom-control-panel">My custom control panel</div>
       `;
         const ClientAction = AbstractAction.extend({
@@ -344,7 +344,7 @@ QUnit.module("ActionManager", (hooks) => {
                 this.env.config.setDisplayName(this.breadcrumbTitle);
             }
         }
-        ClientAction.template = tags.xml`<div class="my_owl_action" t-on-click="onClick">owl client action</div>`;
+        ClientAction.template = xml`<div class="my_owl_action" t-on-click="onClick">owl client action</div>`;
         actionRegistry.add("OwlClientAction", ClientAction);
         const webClient = await createWebClient({ serverData });
         await doAction(webClient, 8);
@@ -365,7 +365,7 @@ QUnit.module("ActionManager", (hooks) => {
                 assert.strictEqual(this.props.division, "bell");
             }
         }
-        ClientAction.template = tags.xml`<div class="my_owl_action"></div>`;
+        ClientAction.template = xml`<div class="my_owl_action"></div>`;
         actionRegistry.add("OwlClientAction", ClientAction);
         const webClient = await createWebClient({ serverData });
         await doAction(webClient, "OwlClientAction", {

--- a/addons/web/static/tests/webclient/actions/concurrency_tests.js
+++ b/addons/web/static/tests/webclient/actions/concurrency_tests.js
@@ -10,7 +10,7 @@ import testUtils from "web.test_utils";
 import { useSetupView } from "@web/views/helpers/view_hook";
 import * as cpHelpers from "@web/../tests/search/helpers";
 
-const { Component, tags } = owl;
+const { Component, xml } = owl;
 const actionRegistry = registry.category("actions");
 
 let serverData;
@@ -484,7 +484,7 @@ QUnit.module("ActionManager", (hooks) => {
                     return slowWillStartDef;
                 }
             }
-            ClientAction.template = tags.xml`<div class="client_action">ClientAction</div>`;
+            ClientAction.template = xml`<div class="client_action">ClientAction</div>`;
             actionRegistry.add("slowAction", ClientAction);
             const webClient = await createWebClient({ serverData });
             doAction(webClient, "slowAction");
@@ -650,7 +650,7 @@ QUnit.module("ActionManager", (hooks) => {
         ToyView.icon = "fab fa-android";
         ToyView.multiRecord = true;
         ToyView.searchMenuTypes = ["filter"];
-        ToyView.template = owl.tags.xml`
+        ToyView.template = xml`
             <div class="o_toy_view">
                 <ControlPanel />
             </div>

--- a/addons/web/static/tests/webclient/actions/error_handling_tests.js
+++ b/addons/web/static/tests/webclient/actions/error_handling_tests.js
@@ -6,7 +6,7 @@ import { registerCleanup } from "../../helpers/cleanup";
 import { click, nextTick, patchWithCleanup } from "../../helpers/utils";
 import { errorService } from "@web/core/errors/error_service";
 
-const { Component, tags } = owl;
+const { Component, xml } = owl;
 
 let serverData;
 const actionRegistry = registry.category("actions");
@@ -21,7 +21,7 @@ QUnit.module("ActionManager", (hooks) => {
     QUnit.test("error in a client action (at rendering)", async function (assert) {
         assert.expect(4);
         class Boom extends Component {}
-        Boom.template = tags.xml`<div><t t-esc="a.b.c"/></div>`;
+        Boom.template = xml`<div><t t-esc="a.b.c"/></div>`;
         actionRegistry.add("Boom", Boom);
 
         const webClient = await createWebClient({ serverData });
@@ -60,7 +60,7 @@ QUnit.module("ActionManager", (hooks) => {
                 this.render();
             }
         }
-        Boom.template = tags.xml`
+        Boom.template = xml`
             <div>
                 <t t-if="boom" t-esc="a.b.c"/>
                 <button t-else="" class="my_button" t-on-click="onClick">Click Me</button>

--- a/addons/web/static/tests/webclient/actions/load_state_tests.js
+++ b/addons/web/static/tests/webclient/actions/load_state_tests.js
@@ -26,7 +26,7 @@ import {
 } from "./../helpers";
 import { errorService } from "@web/core/errors/error_service";
 
-const { Component, mount, tags } = owl;
+const { Component, mount, xml } = owl;
 
 let serverData;
 
@@ -181,7 +181,7 @@ QUnit.module("ActionManager", (hooks) => {
     QUnit.test("properly load client actions", async function (assert) {
         assert.expect(3);
         class ClientAction extends Component {}
-        ClientAction.template = tags.xml`<div class="o_client_action_test">Hello World</div>`;
+        ClientAction.template = xml`<div class="o_client_action_test">Hello World</div>`;
         actionRegistry.add("HelloWorldTest", ClientAction);
         const mockRPC = async function (route, args) {
             assert.step((args && args.method) || route);
@@ -942,12 +942,12 @@ QUnit.module("ActionManager", (hooks) => {
 
             serverData.views = {
                 ...serverData.views,
-                "partner,false,search":`
+                "partner,false,search": `
                     <search>
                         <filter name="filter" string="Filter" domain="[('foo', '=', 'yop')]"/>
                     </search>
                 `,
-            }
+            };
 
             const webClient = await createWebClient({ serverData });
 
@@ -1021,7 +1021,7 @@ QUnit.module("ActionManager", (hooks) => {
                 browser.location.hash = "#action=__test__client__action__&menu_id=1";
             }
         }
-        MyAction.template = tags.xml`<div class="not-here" />`;
+        MyAction.template = xml`<div class="not-here" />`;
         registry.category("actions").add("myAction", MyAction);
 
         browser.location.hash = "#action=myAction";
@@ -1052,7 +1052,7 @@ QUnit.module("ActionManager", (hooks) => {
                 window.dispatchEvent(new HashChangeEvent("hashchange", { newURL }));
             }
         }
-        MyAction.template = tags.xml`<div class="not-here" />`;
+        MyAction.template = xml`<div class="not-here" />`;
         registry.category("actions").add("myAction", MyAction);
 
         browser.location.hash = "#action=myAction";

--- a/addons/web/static/tests/webclient/actions/push_state_tests.js
+++ b/addons/web/static/tests/webclient/actions/push_state_tests.js
@@ -7,7 +7,7 @@ import testUtils from "web.test_utils";
 import { click, legacyExtraNextTick, nextTick, patchWithCleanup } from "../../helpers/utils";
 import { createWebClient, doAction, getActionManagerServerData } from "./../helpers";
 
-const { Component, tags } = owl;
+const { Component, xml } = owl;
 
 let serverData;
 const actionRegistry = registry.category("actions");
@@ -77,7 +77,7 @@ QUnit.module("ActionManager", (hooks) => {
                 this.router.pushState({ arbitrary: "actionPushed" });
             }
         }
-        ClientActionPushes.template = tags.xml`
+        ClientActionPushes.template = xml`
       <div class="test_client_action" t-on-click="_actionPushState">
         ClientAction_<t t-esc="props.params and props.params.description" />
       </div>`;
@@ -106,7 +106,7 @@ QUnit.module("ActionManager", (hooks) => {
                 this.router.pushState({ arbitrary: "actionPushed" });
             }
         }
-        ClientActionPushes.template = tags.xml`
+        ClientActionPushes.template = xml`
       <div class="test_client_action" t-on-click="_actionPushState">
         ClientAction_<t t-esc="props.params and props.params.description" />
       </div>`;
@@ -136,7 +136,7 @@ QUnit.module("ActionManager", (hooks) => {
                 this.router.pushState({ arbitrary: "actionPushed" });
             }
         }
-        ClientActionPushes.template = tags.xml`
+        ClientActionPushes.template = xml`
       <div class="test_client_action" t-on-click="_actionPushState">
         ClientAction_<t t-esc="props.params and props.params.description" />
       </div>`;

--- a/addons/web/static/tests/webclient/actions/target_tests.js
+++ b/addons/web/static/tests/webclient/actions/target_tests.js
@@ -11,6 +11,8 @@ import { errorService } from "@web/core/errors/error_service";
 import { useService } from "@web/core/utils/hooks";
 import { ClientErrorDialog } from "@web/core/errors/error_dialogs";
 
+const { Component, xml } = owl;
+
 let serverData;
 
 QUnit.module("ActionManager", (hooks) => {
@@ -340,19 +342,19 @@ QUnit.module("ActionManager", (hooks) => {
             onUnhandledRejection: () => {},
         });
 
-        class ErrorClientAction extends owl.Component {
+        class ErrorClientAction extends Component {
             setup() {
                 throw new Error("my error");
             }
         }
-        ErrorClientAction.template = owl.tags.xml`<div/>`;
+        ErrorClientAction.template = xml`<div/>`;
         registry.category("actions").add("failing", ErrorClientAction);
 
-        class ClientActionTargetNew extends owl.Component {}
-        ClientActionTargetNew.template = owl.tags.xml`<div class="my_action_new" />`;
+        class ClientActionTargetNew extends Component {}
+        ClientActionTargetNew.template = xml`<div class="my_action_new" />`;
         registry.category("actions").add("clientActionNew", ClientActionTargetNew);
 
-        class ClientAction extends owl.Component {
+        class ClientAction extends Component {
             setup() {
                 this.action = useService("action");
             }
@@ -367,7 +369,7 @@ QUnit.module("ActionManager", (hooks) => {
                 }
             }
         }
-        ClientAction.template = owl.tags.xml`<div class="my_action" t-on-click="onClick" />`;
+        ClientAction.template = xml`<div class="my_action" t-on-click="onClick" />`;
         registry.category("actions").add("clientAction", ClientAction);
 
         const errorDialogOpened = makeDeferred();

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -25,6 +25,8 @@ import { WarningDialog } from "@web/core/errors/error_dialogs";
 import { makeFakeUserService } from "@web/../tests/helpers/mock_services";
 import * as cpHelpers from "@web/../tests/search/helpers";
 
+const { onMounted } = owl;
+
 let serverData;
 const serviceRegistry = registry.category("services");
 
@@ -2348,7 +2350,7 @@ QUnit.module("ActionManager", (hooks) => {
         class WarningDialogWait extends WarningDialog {
             setup() {
                 super.setup();
-                owl.hooks.onMounted(() => warningOpened.resolve());
+                onMounted(() => warningOpened.resolve());
             }
         }
 

--- a/addons/web/static/tests/webclient/helpers.js
+++ b/addons/web/static/tests/webclient/helpers.js
@@ -47,7 +47,7 @@ import { ClientActionAdapter, ViewAdapter } from "@web/legacy/action_adapters";
 import { commandService } from "@web/core/commands/command_service";
 import { CustomFavoriteItem } from "@web/search/favorite_menu/custom_favorite_item";
 
-const { Component, mount, tags } = owl;
+const { Component, mount, xml } = owl;
 
 const actionRegistry = registry.category("actions");
 const serviceRegistry = registry.category("services");
@@ -192,7 +192,7 @@ export function addLegacyMockEnvironment(env, legacyParams = {}) {
     registerCleanup(() => (debouncedField.prototype.DEBOUNCE = initialDebouncedVal));
 
     if (legacyParams.withLegacyMockServer) {
-        const adapter = new ComponentAdapter(null, { Component: owl.Component });
+        const adapter = new ComponentAdapter(null, { Component: Component });
         adapter.env = legacyEnv;
         const W = Widget.extend({ do_push_state() {} });
         const widget = new W(adapter);
@@ -308,7 +308,7 @@ export async function loadState(env, state) {
 export function getActionManagerServerData() {
     // additional basic client action
     class TestClientAction extends Component {}
-    TestClientAction.template = tags.xml`
+    TestClientAction.template = xml`
       <div class="test_client_action">
         ClientAction_<t t-esc="props.action.params?.description"/>
       </div>`;

--- a/addons/web/static/tests/webclient/navbar_tests.js
+++ b/addons/web/static/tests/webclient/navbar_tests.js
@@ -11,8 +11,7 @@ import { NavBar } from "@web/webclient/navbar/navbar";
 import { clearRegistryWithCleanup, makeTestEnv } from "../helpers/mock_env";
 import { click, getFixture, nextTick, patchWithCleanup, makeDeferred } from "../helpers/utils";
 
-const { Component, mount, tags } = owl;
-const { xml } = tags;
+const { Component, mount, xml } = owl;
 const systrayRegistry = registry.category("systray");
 const serviceRegistry = registry.category("services");
 
@@ -427,7 +426,10 @@ QUnit.test("Do not execute adapt when navbar is destroyed", async (assert) => {
     let prom = makeDeferred();
 
     patchWithCleanup(browser, {
-        setTimeout: async (handler, delay, ...args) => { await prom; return handler(...args); },
+        setTimeout: async (handler, delay, ...args) => {
+            await prom;
+            return handler(...args);
+        },
         clearTimeout: () => {},
     });
     class MyNavbar extends NavBar {

--- a/addons/web/static/tests/webclient/webclient_tests.js
+++ b/addons/web/static/tests/webclient/webclient_tests.js
@@ -15,8 +15,7 @@ import { fakeTitleService } from "../helpers/mock_services";
 import { getFixture, patchWithCleanup, triggerEvent } from "../helpers/utils";
 import { session } from "@web/session";
 
-const { Component, tags, mount } = owl;
-const { xml } = tags;
+const { Component, mount, xml } = owl;
 const mainComponentRegistry = registry.category("main_components");
 const serviceRegistry = registry.category("services");
 

--- a/addons/web/tooling/types/qunit.d.ts
+++ b/addons/web/tooling/types/qunit.d.ts
@@ -1,4 +1,7 @@
 // Type definitions for QUnit v2.9.2
+
+const { Component } = owl;
+
 // Project: http://qunitjs.com/
 // Definitions by: James Bracy <https://github.com/waratuman>
 //                 Mike North <https://github.com/mike-north>
@@ -55,7 +58,7 @@ interface Assert {
      * - is unique
      * - has the given attribute with the proper value
      *
-     * @param {Widget|jQuery|HTMLElement|owl.Component} target
+     * @param {Widget|jQuery|HTMLElement|Component} target
      */
     hasAttrValue(target: HTMLElement, attr: string, value: string, msg?: string): void;
   

--- a/addons/website/static/src/components/configurator/configurator.js
+++ b/addons/website/static/src/components/configurator/configurator.js
@@ -9,10 +9,7 @@ import {_t, _lt} from 'web.core';
 import {svgToPNG} from 'website.utils';
 import {useService} from "@web/core/utils/hooks";
 
-const {Component, Store, mount, QWeb} = owl;
-const {useDispatch, useStore, useGetters, useRef} = owl.hooks;
-const {Router, RouteComponent} = owl.router;
-const {whenReady} = owl.utils;
+const { Component, QWeb, RouteComponent, Router, Store, loadFile, mount, useDispatch, useGetters, useRef, useStore, whenReady } = owl;
 
 const WEBSITE_TYPES = {
     1: {id: 1, label: _lt("a business website"), name: 'business'},
@@ -671,8 +668,8 @@ async function makeEnvironment() {
     });
     await session.is_bound;
     const qweb = new QWeb({translateFn: _t});
-    const loaderTemplate = await owl.utils.loadFile('/website/static/src/xml/theme_preview.xml');
-    const configuratorTemplates = await owl.utils.loadFile('/website/static/src/components/configurator/configurator.xml');
+    const loaderTemplate = await loadFile('/website/static/src/xml/theme_preview.xml');
+    const configuratorTemplates = await loadFile('/website/static/src/components/configurator/configurator.xml');
     qweb.addTemplates(loaderTemplate);
     qweb.addTemplates(configuratorTemplates);
 

--- a/addons/website/static/src/js/menu/debug_menu.js
+++ b/addons/website/static/src/js/menu/debug_menu.js
@@ -3,6 +3,7 @@ import { registry } from "@web/core/registry";
 import { DebugMenuBasic } from "@web/core/debug/debug_menu_basic";
 import { createDebugContext } from "@web/core/debug/debug_context";
 
+const { mount } = owl;
 const debugMenuService = {
     dependencies: ["localization", "orm"],
     start(env) {
@@ -10,7 +11,7 @@ const debugMenuService = {
             const systray = document.querySelector('.o_menu_systray');
             if (systray) {
                 Object.assign(env, createDebugContext(env, {categories: ["default"]}));
-                owl.mount(DebugMenuBasic, {
+                mount(DebugMenuBasic, {
                     target: systray,
                     position: 'first-child',
                     env,


### PR DESCRIPTION
Adaptation of all imports from the Owl library to the next version.

In the next version of Owl, all exported terms are directly available from the top level object `owl`. This PR aims to adapt existing imports to this new system. This is done by importing any Owl variable used in files at the top, after the `import` | `require` statements.

Enterprise: https://github.com/odoo/enterprise/pull/23609

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
