### PR TITLE
[FIX] l10n_ar: currency rate on post method

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -188,7 +188,7 @@ class AccountMove(models.Model):
                 rec.l10n_ar_currency_rate = 1.0
             elif not rec.l10n_ar_currency_rate:
                 rec.l10n_ar_currency_rate = rec.currency_id._convert(
-                    1.0, rec.company_id.currency_id, rec.company_id, rec.invoice_date or fields.Date.today(), round=False)
+                    1.0, rec.company_id.currency_id, rec.company_id, rec.date, round=False)
 
         # We make validations here and not with a constraint because we want validation before sending electronic
         # data on l10n_ar_edi

--- a/doc/cla/corporate/adhoc.md
+++ b/doc/cla/corporate/adhoc.md
@@ -17,3 +17,4 @@ Katherine Zaoral kz@adhoc.com.ar https://github.com/zaoral
 Valentino Defelice vd@adhoc.com.ar https://github.com/ValentinoDefelice
 Bruno Zanotti bz@adhoc.com.ar https://github.com/Bruno-Zanotti
 Pablo Santiago Paez Sheridan pp@adhoc.com.ar https://github.com/PabloPaezSheridan
+Augusto Weiss awe@adhoc.com.ar https://github.com/augusto-weiss


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The currency rate could be different if the invoice date is different that the accounting date

Steps to reproduce:
1- Install l10n_ar
2- Create two different currency rate for foreign currency (i.e: Dollar) with also different Date
3- Create an invoice setting the currency as foreign currency (i.e: Dollar)

Current behavior before PR:
In page "Journal Items" could see that each account line use the currency rate defined by the accounting date, however the currency rate filed (which is not visible) is defined by the invoice date.

Desired behavior after PR is merged:
Use always the accounting date to set the currency rate



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
