### PR TITLE
[FIX] mass_mailing: fix preview prepend when sending test email

### DIFF
--- a/addons/mass_mailing/wizard/mailing_mailing_test.py
+++ b/addons/mass_mailing/wizard/mailing_mailing_test.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from markupsafe import Markup
+
 from odoo import _, fields, models, tools
 
 
@@ -39,7 +41,7 @@ class TestMassMailing(models.TransientModel):
             # Returns a proper error if there is a syntax error with Qweb
             body = mailing._render_field('body_html', record.ids, post_process=True)[record.id]
             preview = mailing._render_field('preview', record.ids, post_process=True)[record.id]
-            full_body = mailing._prepend_preview(body, preview)
+            full_body = mailing._prepend_preview(Markup(body), preview)
             subject = mailing._render_field('subject', record.ids)[record.id]
         else:
             full_body = mailing._prepend_preview(mailing.body_html, mailing.preview)


### PR DESCRIPTION
- Go to Email Marketing and create a new one
- Select any template
- In Settings tab, set a Preview Text
- Send a test
The content of the received test email is a text with the html code of the email body.

When sending the test email, the body is retrieved with "render_field" method, which
does not return a Markup object but a simple string.
Then "_prepend_preview" method prepends preview (Markup) to body (str).

opw-2686316




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
