### PR TITLE
[FIX] project: allow parent task being a subtask in task form

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1022,7 +1022,7 @@
                             <group>
                                 <group>
                                     <field name="analytic_account_id" groups="analytic.group_analytic_accounting" context="{'default_partner_id': partner_id}"/>
-                                    <field name="parent_id" domain="[('parent_id', '=', False)]" attrs="{'invisible': [('allow_subtasks', '=', False)]}" groups="base.group_no_one"/>
+                                    <field name="parent_id" attrs="{'invisible': [('allow_subtasks', '=', False)]}" groups="base.group_no_one"/>
                                     <field name="analytic_tag_ids" groups="analytic.group_analytic_tags" widget="many2many_tags"/>
                                     <field name="sequence" groups="base.group_no_one"/>
                                     <field name="email_from" invisible="1"/>


### PR DESCRIPTION
Before this commit:

    - From the task form, it was not possible to select a parent task
      that is itself a subtask and thus creating multiple level of
      subtasks.

After this commit:

    - From the task form, it will be possible to select a parent task
      that is itself a subtask and thus creating multiple level of
      subtasks.

task-2703632

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
