### PR TITLE
[FIX] website_slides: Fix join course link

### DIFF
--- a/addons/website_slides/views/website_slides_templates_utils.xml
+++ b/addons/website_slides/views/website_slides_templates_utils.xml
@@ -75,7 +75,7 @@
 </template>
 
 <template id="join_course_link" name="Join Course Link">
-    <a class="o_wslides_js_course_join_link" href="#"
+    <a class="o_wslides_js_course_join_link" href="#" t-att-data-channel-enroll="slide.channel_id.enroll"
        t-att-data-channel-id="slide.channel_id.id">
         Join Course
     </a> to download resources


### PR DESCRIPTION
The "Join course" link with additional resources was broken

Task-2735494