### PR TITLE
[FIX] mrp: adapt the expected duration of WO

### DIFF
--- a/addons/mrp/wizard/change_production_qty.py
+++ b/addons/mrp/wizard/change_production_qty.py
@@ -81,7 +81,7 @@ class ChangeProductionQty(models.TransientModel):
             operation_bom_qty = {}
             for bom, bom_data in boms:
                 for operation in bom.routing_id.operation_ids:
-                    operation_bom_qty[operation.id] = bom_data['qty']
+                    operation_bom_qty[operation.id] = bom.product_qty * bom_data['qty']
             finished_moves_modification = self._update_finished_moves(production, production.product_qty - qty_produced, old_production_qty)
             production._log_downside_manufactured_quantity(finished_moves_modification)
             moves = production.move_raw_ids.filtered(lambda x: x.state not in ('done', 'cancel'))


### PR DESCRIPTION
On a MO, if the user changes the quantity to produce, the expected
duration of the related WO will be incorrect

To reproduce the issue:
1. In Settings, enable "Work Orders"
2. Create two products P_finished, P_compo
3. Create a routing R with one operation:
    - Work Center:
        - Time Efficiency: 100
        - Capacity: 1
        - Time before: 0
        - Time after: 0
    - Duration computation: Manual
    - Default duration: 60
4. Create a bill of materials:
    - Product: P_finished
    - Quantity: 4
    - Routing: R
    - Components:
        - 1 x P_compo
5. Create a manufacturing order MO for 4 x P_finished
6. Mark it as todo and Plan it
    - The work order is created and the expected duration (in Time
Tracking) is 240 minutes (4 x 60)
7. Update the quantity to produce: 8

Error: On the work order, the expected duration is now 120 minutes, it
should be 480.

When saving the new quantity, it recomputes the expected duration like
this:
https://github.com/odoo/odoo/blob/ec0206fdd3ced42c44e737e4afc6f07f2fe2a7e9/addons/mrp/wizard/change_production_qty.py#L92-L95
where `operation_bom_qty[operation.id]` comes from the result of
`mrp_bom.explode`:
https://github.com/odoo/odoo/blob/ec0206fdd3ced42c44e737e4afc6f07f2fe2a7e9/addons/mrp/wizard/change_production_qty.py#L57
https://github.com/odoo/odoo/blob/ec0206fdd3ced42c44e737e4afc6f07f2fe2a7e9/addons/mrp/wizard/change_production_qty.py#L82-L84
But here is the issue: the factor given to `explode` is used as a
quantity for the found boms (the factor is `quantity` in the method):
https://github.com/odoo/odoo/blob/9e7d7fe86e4b6cc625974da7e2eb4b6044c13448/addons/mrp/models/mrp_bom.py#L261
Therefore, when computing the expected duration, it uses the factor
instead of the total quantity. This explains why the duration becomes
120: the user sets the quantity to 8, thus the factor is 2, therefore
`2 x 60 = 120 minutes`

OPW-2596320