### PR TITLE
[FIX] sale : Show SO with archived customer

### DIFF
--- a/addons/sale/views/res_partner_views.xml
+++ b/addons/sale/views/res_partner_views.xml
@@ -4,7 +4,7 @@
             <field name="name">Quotations and Sales</field>
             <field name="res_model">sale.order</field>
             <field name="view_mode">tree,form,graph</field>
-            <field name="context">{'search_default_partner_id': active_id, 'default_partner_id': active_id}</field>
+            <field name="context">{'search_default_partner_id': active_id, 'default_partner_id': active_id, 'active_test': False}</field>
             <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">


### PR DESCRIPTION
Current behavior:
When archiving a customer contact, the SO linked to this customer where not shown after clicking sales smart button in company

Steps to reproduce:
1. App "Contacts": Have a company and a contact as child of this company.
2. App "Sale": Create a Sale Order for the contact of the company and confirm it.
3. App "Contacts": Archive the contact of the company and switch to the company.
4. App "Contacts": The Smart Button for sale orders says it has one sale order but if you click on it NO sale orders will be shown.

opw-2735060

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
