### PR TITLE
[FIX] web: ensure scrollbar in mail designer

### DIFF
--- a/addons/web/static/src/legacy/scss/base_frontend.scss
+++ b/addons/web/static/src/legacy/scss/base_frontend.scss
@@ -1,5 +1,5 @@
 // Frontend general
-html, body, #wrapwrap {
+html:not(:has(.o_in_iframe)), body:not(.o_in_iframe), #wrapwrap {
     width: 100%;
     height: 100%;
     overflow: hidden;


### PR DESCRIPTION
Commit [1] moved the scrollbar from the document body to the top element (#wrapwrap). This works for website builder but fails for iframes which don't have that element. This is apparent in Marketing Automation mail templates where it's become impossible to scroll down. This fixes that issue by excluding iframes in that rule.

task-2734825

[1] https://github.com/odoo/odoo/commit/9f048625e11dacda9fd49694e89ae65bc112374f

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
