### PR TITLE
[FIX] purchase_stock: fix system parameter access right

### DIFF
--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -314,7 +314,7 @@ class StockRule(models.Model):
         )
         if values.get('orderpoint_id'):
             procurement_date = fields.Date.to_date(values['date_planned']) - relativedelta(days=int(values['supplier'].delay))
-            delta_days = int(self.env['ir.config_parameter'].get_param('purchase_stock.delta_days_merge') or 0)
+            delta_days = int(self.env['ir.config_parameter'].sudo().get_param('purchase_stock.delta_days_merge') or 0)
             domain += (
                 ('date_order', '<=', datetime.combine(procurement_date + relativedelta(days=delta_days), datetime.max.time())),
                 ('date_order', '>=', datetime.combine(procurement_date - relativedelta(days=delta_days), datetime.min.time()))


### PR DESCRIPTION
You are blocked with an access error when you try to replenish a product with `”Buy”` route if you don't have the settings rights,
because the code tries to read a system parameter.

Solution:
To avoid this error, we need to read it as superuser.

opw-2725702




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
