### PR TITLE
[FIX] delivery: send the expected carrier name to amazon

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -131,6 +131,15 @@ class DeliveryCarrier(models.Model):
     def onchange_countries(self):
         self.state_ids = [(6, 0, self.state_ids.filtered(lambda state: state.id in self.country_ids.mapped('state_ids').ids).ids)]
 
+    def _get_delivery_type(self):
+        """Return the delivery type.
+
+        This method needs to be overridden by a delivery carrier module if the delivery type is not
+        stored on the field `delivery_type`.
+        """
+        self.ensure_one()
+        return self.delivery_type
+        
     # -------------------------- #
     # API for external providers #
     # -------------------------- #


### PR DESCRIPTION
A modification made by Amazon on October 1st restricts the allowed
values for the carrier name. Since it now expects it in a formatted
state, this commit will allow Odoo to send the delivery type of the
carrier rather than its name, which can be customized by the user.

opw-2665099

See also:
- https://github.com/odoo/enterprise/pull/23504