### PR TITLE
[FIX] point_of_sale : Opening cash not working with comma

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/CashBoxOpening.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/CashBoxOpening.js
@@ -4,19 +4,27 @@ odoo.define('point_of_sale.CashBoxOpening', function(require) {
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
     const { Gui } = require('point_of_sale.Gui');
+    const field_utils = require('web.field_utils');
 
     class CashBoxOpening extends PosComponent {
         constructor() {
             super(...arguments);
             this.changes = {};
-            this.defaultValue = this.env.pos.bank_statement.balance_start || 0;
+            this.defaultValue = this.env.pos.format_currency_no_symbol(
+                this.env.pos.bank_statement.balance_start || 0
+            );
             this.symbol = this.env.pos.currency.symbol;
         }
         captureChange(event) {
             this.changes[event.target.name] = event.target.value;
         }
         startSession() {
-            let cashOpening = this.changes.cashBoxValue? this.changes.cashBoxValue: this.defaultValue;
+            let cashOpening = this.changes.cashBoxValue ? this.changes.cashBoxValue : this.defaultValue;
+            try {
+               cashOpening = field_utils.parse.float(cashOpening);
+            } catch (err) {
+                cashOpening = NaN;
+            }
             if(isNaN(cashOpening)) {
                 Gui.showPopup('ErrorPopup',{
                     'title': 'Wrong value',


### PR DESCRIPTION
Current behavior:
When using deutch language, in the PoS opening cash control using a comma returns an error.

Steps to reproduce:
- Activate deutch language
- Turn on Advanced cash control on PoS
- Enter a value with a comma (28,6 for example)
- An error message appears

opw-2727647
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
