### PR TITLE
[FIX] web_editor: discard background positioning when clicking outside

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4528,7 +4528,7 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
      * @private
      */
     _onDocumentClicked: function (ev) {
-        if (!$(ev.target).closest('.o_we_background_position_overlay')) {
+        if (!$(ev.target).closest('.o_we_background_position_overlay').length) {
             this._toggleBgOverlay(false);
         }
     },


### PR DESCRIPTION
Since [1] options could still be used while a background positioning
overlay was opened.

After this commit the overlay is deactivated whenever an element outside
of it is clicked - as initially intended.

[1] https://github.com/odoo/odoo/commit/dfd98f49e7f2ab5c94dcae3af2d14750d301fa0a

task-2735690

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
