### PR TITLE
[FIX] core: possibility of allocation error in native magic libraries

### DIFF
--- a/odoo/tools/mimetypes.py
+++ b/odoo/tools/mimetypes.py
@@ -160,9 +160,9 @@ else:
 
     # magic from pypi https://pypi.python.org/pypi/python-magic/
     if hasattr(magic,'from_buffer'):
-        guess_mimetype = lambda bin_data, default=None: magic.from_buffer(bin_data, mime=True)
+        guess_mimetype = lambda bin_data, default=None: magic.from_buffer(bin_data[:1024], mime=True)
     # magic from file(1) https://packages.debian.org/squeeze/python-magic
     elif hasattr(magic,'open'):
         ms = magic.open(magic.MAGIC_MIME_TYPE)
         ms.load()
-        guess_mimetype = lambda bin_data, default=None: ms.buffer(bin_data)
+        guess_mimetype = lambda bin_data, default=None: ms.buffer(bin_data[:1024])


### PR DESCRIPTION
Both of the native `magic` libraries can trigger an allocation error
if the buffer being sniffed is large. This results in nothing useful
for the user and just triggers and exception when trying to create
large attachments (in the hundreds of MBs).

Fix by implementing the workaround suggested in
ahupp/python-magic#82, under the assumption that it should also work
fine for Debian's python-magic.

The pure-python trivial version of odoo should not have this issue, as
it does not normally copy the source buffer in full, it just seeks and
slices the buffer, and occasionally parses it as a zip (but does not
normally load everything in memory).

Task-2722110
