### PR TITLE
[REV] web: revert ensure scrollbar in mail designer

### DIFF
--- a/addons/web/static/src/legacy/scss/base_frontend.scss
+++ b/addons/web/static/src/legacy/scss/base_frontend.scss
@@ -1,5 +1,5 @@
 // Frontend general
-html:not(:has(.o_in_iframe)), body:not(.o_in_iframe), #wrapwrap {
+html, body, #wrapwrap {
     width: 100%;
     height: 100%;
     overflow: hidden;


### PR DESCRIPTION
This reverts commit 247adbb3aa79223c18083caf31e6580905ce32e8 as it broke
the website design. We do not know yet what the reason is and we'll need
to investigate further. Probably a css specifity issue, but since this
is 15.0 stable, we chose to first revert the commit asap and re-do the
fix in another way later.
