### PR TITLE
[FIX] web : display contract report when no data

### DIFF
--- a/addons/web/static/src/legacy/js/views/pivot/pivot_renderer.js
+++ b/addons/web/static/src/legacy/js/views/pivot/pivot_renderer.js
@@ -163,6 +163,13 @@
          * @returns {string} Formatted value
          */
         _getFormattedValue(cell) {
+            const field = this.props.fields[cell.measure];
+            if (["date", "datetime"].includes(field.type)) {
+                if (!cell.value) {
+                    return "-";
+                }
+                return cell.value;
+            }
             const type = this.props.widgets[cell.measure] ||
                 (this.props.fields[cell.measure].type === 'many2one' ? 'integer' : this.props.fields[cell.measure].type);
             const formatter = field_utils.format[type];

--- a/addons/web/static/src/views/pivot/pivot_renderer.js
+++ b/addons/web/static/src/views/pivot/pivot_renderer.js
@@ -26,6 +26,12 @@ export class PivotRenderer extends Component {
      */
     getFormattedValue(cell) {
         const field = this.model.metaData.measures[cell.measure];
+        if (["date", "datetime"].includes(field.type)) {
+            if (!cell.value) {
+                return "-";
+            }
+            return cell.value;
+        }
         let formatType = this.model.metaData.widgets[cell.measure];
         if (!formatType) {
             const fieldType = field.type;


### PR DESCRIPTION
Steps :
- config : {
	"--init=hr,hr_contract",
	"--without-demo=all",
	}
- Employees > Reporting > Contracts

Issue :
- Odoo Client Error : value.setZone is not a function

Cause :
- When no data, formatDateTime receives zero as value.

Fix :
- Return "" when value === 0, just like when value === false

opw-2728024

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
