### PR TITLE
[FIX] base: class name is used as variable

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -962,7 +962,6 @@ class Module(models.Model):
                     [('id', 'not in', excluded_category_ids)],
                 ])
 
-            Module = self.env['ir.module.module']
             records = self.env['ir.module.category'].search_read(domain, ['display_name'], order="sequence")
 
             values_range = OrderedDict()
@@ -975,7 +974,7 @@ class Module(models.Model):
                         kwargs.get('filter_domain', []),
                         [('category_id', 'child_of', record_id), ('category_id', 'not in', excluded_category_ids)]
                     ])
-                    record['__count'] = Module.search_count(model_domain)
+                    record['__count'] = self.env['ir.module.module'].search_count(model_domain)
                 values_range[record_id] = record
 
             return {


### PR DESCRIPTION
Class name is Module and a variable also is named Module.

![Selection_151](https://user-images.githubusercontent.com/25005517/149555745-088d0e60-8f39-495e-a978-4fd08cd9d9c7.png)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr