### PR TITLE
[FIX] l10n_it_edi_sdicoop: Success on send for b2b invoices

### DIFF
--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -152,7 +152,7 @@ class AccountEdiFormat(models.Model):
         if invoice.l10n_it_einvoice_id:
             invoice.l10n_it_einvoice_id.unlink()
         res = invoice.invoice_generate_xml()
-        if len(invoice.commercial_partner_id.l10n_it_pa_index or '') == 6:
+        if invoice._is_commercial_partner_pa():
             invoice.message_post(
                 body=(_("Invoices for PA are not managed by Odoo, you can download the document and send it on your own."))
             )

--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -81,6 +81,12 @@ class AccountMove(models.Model):
         )
         return {'attachment': attachment}
 
+    def _is_commercial_partner_pa(self):
+        """
+            Returns True if the destination of the FatturaPA belongs to the Public Administration.
+        """
+        return len(self.commercial_partner_id.l10n_it_pa_index or '')  == 6
+
     def _prepare_fatturapa_export_values(self):
         self.ensure_one()
 
@@ -132,9 +138,7 @@ class AccountMove(models.Model):
                 return True
             return False
 
-        formato_trasmissione = "FPR12"
-        if len(self.commercial_partner_id.l10n_it_pa_index or '1') == 6:
-            formato_trasmissione = "FPA12"
+        formato_trasmissione = "FPA12" if self._is_commercial_partner_pa() else "FPR12"
 
         if self.move_type == 'out_invoice':
             document_type = 'TD01'


### PR DESCRIPTION
B2b invoices have no success notification event (notificaEsito), so invoices can be considered successfully sent right after posting.

Task: https://www.odoo.com/web#id=2729771&model=project.task
Spec: https://www.fatturapa.gov.it/export/documenti/ws/trasmissione/v3.x/Istruzioni-per-il-servizio-SDICoop-Trasmissione-versione3.2.pdf
Ref:  https://www.fatturapa.gov.it/it/norme-e-regole/DocumentazioneSDI/