### PR TITLE
[REV] base: enforce the usage of ir.qweb instead of qweb"

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -2,11 +2,9 @@
 from __future__ import print_function
 from textwrap import dedent
 import copy
-import io
 import logging
 import re
 import markupsafe
-import tokenize
 from lxml import html, etree
 
 from odoo import api, models, tools
@@ -378,13 +376,6 @@ class IrQWeb(models.AbstractModel, QWeb):
 
         :param expr: string
         """
-        readable = io.BytesIO(expr.strip().encode('utf-8'))
-        try:
-            tokens = list(tokenize.tokenize(readable.readline))
-        except tokenize.TokenError:
-            raise ValueError(f"Cannot compile expression: {expr}")
-
-        namespace_expr = self._compile_expr_tokens(tokens, self._allowed_keyword + list(self._available_objects.keys()), raise_on_missing=raise_on_missing)
-
+        namespace_expr = super()._compile_expr(expr, raise_on_missing=raise_on_missing)
         assert_valid_codeobj(_SAFE_QWEB_OPCODES, compile(namespace_expr, '<>', 'eval'), expr)
         return namespace_expr

--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -574,8 +574,20 @@ class QWeb(object):
         return ''.join(code)
 
     def _compile_expr(self, expr, raise_on_missing=False):
-        """This method must be overridden by <ir.qweb> in order to compile the template."""
-        raise NotImplementedError("Templates should use the ir.qweb compile method")
+        """Transform string coming into a python instruction in textual form by
+        adding the namepaces for the dynamic values.
+        This method tokenize the string and call ``_compile_expr_tokens``
+        method.
+        """
+        readable = io.BytesIO(expr.strip().encode('utf-8'))
+        try:
+            tokens = list(tokenize.tokenize(readable.readline))
+        except tokenize.TokenError:
+            raise ValueError(f"Can not compile expression: {expr}")
+
+        expression = self._compile_expr_tokens(tokens, self._allowed_keyword + list(self._available_objects.keys()), raise_on_missing=raise_on_missing)
+
+        return f"({expression})"
 
     def _compile_bool(self, attr, default=False):
         """Convert the statements as a boolean."""

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -1110,7 +1110,7 @@ class TestQWebBasic(TransactionCase):
         try:
             self.env['ir.qweb']._render(t.id)
         except QWebException as e:
-            self.assertIn('Cannot compile expression', e.message)
+            self.assertIn('Can not compile expression', e.message)
             self.assertIn('<div t-esc="abc + def + ("/>', e.message)
 
 from copy import deepcopy


### PR DESCRIPTION
This reverts commit 8ec7739dd72fa0976697f7738b225dbb9efa7c97.
The database manager actually needs to use qweb and not ir.qweb

Fixes odoo/odoo#82835
