### PR TITLE
[14.0] [UPD] Update chart of accounts and taxes.

### DIFF
--- a/addons/l10n_ro/data/account.account.template.csv
+++ b/addons/l10n_ro/data/account.account.template.csv
@@ -1,477 +1,478 @@
-"id","name","code","user_type_id/id","chart_template_id/id","reconcile"
-"pcg_1011","Capital subscris nevărsat","1011","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1012","Capital subscris vărsat","1012","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1015","Patrimoniul regiei","1015","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1016","Patrimoniul public","1016","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1017","Patrimoniul privat","1017","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1018","Patrimoniul institutelor naționale de cercetare-dezvoltare","1018","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1031","Beneficii acordate angajaților sub forma instrumentelor de capitaluri proprii","1031","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1033","Diferențe de curs valutar în relație cu investiția netă într-o entitate străină","1033","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1038","Diferențe din modificarea valorii juste a activelor financiare disponibile în vederea vânzării și alte elemente de capitaluri proprii","1038","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1041","Prime de emisiune","1041","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1042","Prime de fuziune/divizare","1042","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1043","Prime de aport","1043","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1044","Prime de conversie a obligațiunilor în acțiuni","1044","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_105","Rezerve din reevaluare","105","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1061","Rezerve legale","1061","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1063","Rezerve statutare sau contractuale","1063","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1068","Alte rezerve","1068","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_107","Diferențe de curs valutar din conversie","107","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1081","Interese care nu controlează - rezultatul exercițiului financiar","1081","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1082","Interese care nu controlează - alte capitaluri proprii","1082","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1091","Acțiuni proprii deținute pe termen scurt","1091","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1092","Acțiuni proprii deținute pe termen lung","1092","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1095","Acțiuni proprii reprezentând titluri deținute de societatea absorbită la societatea absorbantă","1095","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1171","Rezultatul reportat reprezentând profitul nerepartizat sau pierderea neacoperită","1171","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1172","Rezultatul reportat provenit din adoptarea pentru prima dată a IAS, mai puțin IAS 29","1172","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1173","Rezultatul reportat provenit din modificările politicilor contabile","1173","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1174","Rezultatul reportat provenit din corectarea erorilor contabile","1174","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1175","Rezultatul reportat reprezentând surplusul realizat din rezerve din reevaluare","1175","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1176","Rezultatul reportat provenit din trecerea la aplicarea reglementărilor contabile conforme cu directivele europene","1176","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_121","Profit sau pierdere","121","account.data_unaffected_earnings","l10n_ro.ro_chart_template","False"
-"pcg_129","Repartizarea profitului","129","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1411","Câștiguri legate de vânzarea instrumentelor de capitaluri proprii","1411","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1412","Câștiguri legate de anularea instrumentelor de capitaluri proprii","1412","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1491","Pierderi rezultate din vânzarea instrumentelor de capitaluri proprii","1491","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1495","Pierderi rezultate din reorganizări, care sunt determinate de anularea titlurilor deținute","1495","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1498","Alte pierderi legate de instrumentele de capitaluri proprii","1498","account.data_account_type_equity","l10n_ro.ro_chart_template","False"
-"pcg_1511","Provizioane pentru litigii","1511","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1512","Provizioane pentru garanții acordate clienților","1512","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1513","Provizioane pentru dezafectare imobilizări corporale și alte acțiuni similare legate de acestea","1513","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1514","Provizioane pentru restructurare","1514","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1515","Provizioane pentru pensii și obligații similare","1515","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1516","Provizioane pentru impozite","1516","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1517","Provizioane pentru terminarea contractului de muncă","1517","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1518","Alte provizioane","1518","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1614","Împrumuturi externe din emisiuni de obligațiuni garantate de stat","1614","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1615","Împrumuturi externe din emisiuni de obligațiuni garantate de bănci","1615","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1617","Împrumuturi interne din emisiuni de obligațiuni garantate de stat","1617","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1618","Alte împrumuturi din emisiuni de obligațiuni","1618","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1621","Credite bancare pe termen lung","1621","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1622","Credite bancare pe termen lung nerambursate la scadență","1622","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1623","Credite externe guvernamentale","1623","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1624","Credite bancare externe garantate de stat","1624","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1625","Credite bancare externe garantate de bănci","1625","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1626","Credite de la trezoreria statului","1626","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1627","Credite bancare interne garantate de stat","1627","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1661","Datorii față de entitățile afiliate","1661","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1663","Datorii față de entitățile asociate și entitățile controlate în comun","1663","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_167","Alte împrumuturi și datorii asimilate","167","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1681","Dobânzi aferente împrumuturilor din emisiuni de obligațiuni","1681","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1682","Dobânzi aferente creditelor bancare pe termen lung","1682","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1685","Dobânzi aferente datoriilor față de entitățile afiliate","1685","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1686","Dobânzi aferente datoriilor fată de entitătile asociate și entitățile controlate în comun","1686","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1687","Dobânzi aferente altor împrumuturi și datorii asimilate","1687","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1691","Prime privind rambursarea obligațiunilor","1691","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_1692","Prime privind rambursarea altor datorii","1692","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_201","Cheltuieli de constituire","201","account.data_account_type_non_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_203","Cheltuieli de dezvoltare","203","account.data_account_type_non_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_205","Concesiuni, brevete, licențe, mărci comerciale, drepturi și active similare","205","account.data_account_type_non_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_206","Active necorporale de explorare și evaluare a resurselor minerale","206","account.data_account_type_non_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_2071","Fond comercial pozitiv","2071","account.data_account_type_non_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_2075","Fond comercial negativ","2075","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_208","Alte imobilizări necorporale","208","account.data_account_type_non_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_2111","Terenuri","2111","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_2112","Amenajări de terenuri","2112","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_212","Construcții","212","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_2131","Echipamente tehnologice (mașini, utilaje și instalații de lucru)","2131","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_2132","Aparate și instalații de măsurare, control și reglare","2132","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_2133","Mijloace de transport","2133","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_214","Mobilier, aparatură birotică, echipamente de protecție a valorilor umane și materiale și alte active corporale","214","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_215","Investiții imobiliare","215","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_216","Active corporale de explorare și evaluare a resurselor minerale","216","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_217","Active biologice productive","217","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_223","Instalații tehnice și mijloace de transport în curs de aprovizionare","223","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_224","Mobilier, aparatură birotică, echipamente de protecție a valorilor umane și materiale și alte active corporale în curs de aprovizionare","224","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_227","Active biologice productive în curs de aprovizionare","227","account.data_account_type_non_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_231","Imobilizări corporale în curs de execuție","231","account.data_account_type_non_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_235","Investiții imobiliare în curs de execuție","235","account.data_account_type_non_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_261","Acțiuni deținute la entitățile afiliate","261","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_262","Acțiuni deținute la entități asociate","262","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_263","Acțiuni deținute la entități controlate în comun","263","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_264","Titluri puse în echivalență","264","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_265","Alte titluri imobilizate","265","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_266","Certificate verzi amânate","266","account.data_account_type_fixed_assets","l10n_ro.ro_chart_template","False"
-"pcg_2671","Sume de încasat de la entitățile afiliate","2671","account.data_account_type_non_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_2672","Dobânda aferentă sumelor de încasat de la entitățile afiliate","2672","account.data_account_type_non_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_2673","Creanțe față de entitățile asociate și entitățile controlate în comun","2673","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_2674","Dobânda aferentă creanțelor față de entitățile asociate și entitățile controlate în comun","2674","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_2675","Împrumuturi acordate pe termen lung","2675","account.data_account_type_non_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_2676","Dobânda aferentă împrumuturilor acordate pe termen lung","2676","account.data_account_type_non_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_2677","Obligațiuni achiziționate cu ocazia emisiunilor efectuate de terți","2677","account.data_account_type_non_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_2678","Alte creanțe imobilizate","2678","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_2679","Dobânzi aferente altor creanțe imobilizate","2679","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_2691","Vărsăminte de efectuat privind acțiunile deținute la entitățile afiliate","2691","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_2692","Vărsăminte de efectuat privind acțiunile deținute la entități asociate","2692","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_2693","Vărsăminte de efectuat privind acțiunile deținute la entități controlate în comun","2693","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_2695","Vărsăminte de efectuat pentru alte imobilizări financiare","2695","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_2801","Amortizarea cheltuielilor de constituire","2801","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2803","Amortizarea cheltuielilor de dezvoltare","2803","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2805","Amortizarea concesiunilor, brevetelor, licențelor, mărcilor comerciale, drepturilor și activelor similare","2805","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2806","Amortizarea activelor necorporale de explorare și evaluare a resurselor minerale","2806","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2807","Amortizarea fondului comercial","2807","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2808","Amortizarea altor imobilizări necorporale","2808","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2811","Amortizarea amenajărilor de terenuri","2811","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2812","Amortizarea construcțiilor","2812","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2813","Amortizarea instalațiilor și mijloacelor de transport","2813","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2814","Amortizarea altor imobilizări corporale","2814","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2815","Amortizarea investițiilor imobiliare","2815","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2816","Amortizarea activelor corporale de explorare și evaluare a resurselor minerale","2816","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2817","Amortizarea activelor biologice productive","2817","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2903","Ajustări pentru deprecierea cheltuielilor de dezvoltare","2903","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2905","Ajustări pentru deprecierea concesiunilor, brevetelor, licențelor, mărcilor comerciale, drepturilor și activelor similare","2905","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2906","Ajustări pentru deprecierea activelor necorporale de explorare și evaluare a resurselor minerale","2906","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2908","Ajustări pentru deprecierea altor imobilizări necorporale","2908","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2911","Ajustări pentru deprecierea terenurilor și amenajărilor de terenuri","2911","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2912","Ajustări pentru deprecierea construcțiilor","2912","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2913","Ajustări pentru deprecierea instalațiilor și mijloacelor de transport","2913","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2914","Ajustări pentru deprecierea altor imobilizări corporale","2914","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2915","Ajustări pentru deprecierea investițiilor imobiliare","2915","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2916","Ajustări pentru deprecierea activelor corporale de explorare și evaluare a resurselor minerale","2916","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2917","Ajustări pentru deprecierea activelor biologice productive","2917","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2931","Ajustări pentru deprecierea imobilizărilor corporale în curs de execuție","2931","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2935","Ajustări pentru deprecierea investiții lor imobiliare în curs de execuție","2935","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2961","Ajustări pentru pierderea de valoare a acțiunilor deținute la entitățile afiliate","2961","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2962","Ajustări pentru pierderea de valoare a acțiunilor deținute la entități asociate și entități controlate în comun","2962","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2963","Ajustări pentru pierderea de valoare a altor titluri imobilizate","2963","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2964","Ajustări pentru pierderea de valoare a sumelor de încasat de la entitățile afiliate","2964","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2965","Ajustări pentru pierderea de valoare a creanțelor față de entitățile asociate și entitățile controlate în comun","2965","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2966","Ajustări pentru pierderea de valoare a împrumuturilor acordate pe termen lung","2966","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_2968","Ajustări pentru pierderea de valoare a altor creanțe","2968","account.data_account_type_depreciation","l10n_ro.ro_chart_template","False"
-"pcg_301","Materii prime","301","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3021","Materiale auxiliare","3021","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3022","Combustibili","3022","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3023","Materiale pentru ambalat","3023","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3024","Piese de schimb","3024","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3025","Semințe și materiale de plantat","3025","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3026","Furaje","3026","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3028","Alte materiale consumabile","3028","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_303","Materiale de natura obiectelor de inventar","303","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_308","Diferențe de preț la materii prime și materiale","308","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_321","Materii prime în curs de aprovizionare","321","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_322","Materiale consumabile în curs de aprovizionare","322","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_323","Materiale de natura obiectelor de inventar în curs de aprovizionare","323","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_326","Active biologice de natura stocurilor în curs de aprovizionare","326","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_327","Mărfuri în curs de aprovizionare","327","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_328","Ambalaje în curs de aprovizionare","328","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_331","Produse în curs de execuție","331","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_332","Servicii în curs de execuție","332","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_341","Semifabricate","341","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_345","Produse finite","345","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_346","Produse reziduale","346","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_347","Produse agricole","347","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_348","Diferențe de preț la produse","348","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_351","Materii și materiale aflate la terți","351","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_354","Produse aflate la terți","354","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_356","Active biologice de natura stocurilor aflate la terți","356","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_357","Mărfuri aflate la terți","357","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_358","Ambalaje aflate la terți","358","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_361","Active biologice de natura stocurilor","361","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_368","Diferențe de preț la active biologice de natura stocurilor","368","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_371","Mărfuri","371","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_378","Diferențe de preț la mărfuri","378","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_381","Ambalaje","381","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_388","Diferențe de preț la ambalaje","388","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_391","Ajustări pentru deprecierea materiilor prime","391","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3921","Ajustări pentru deprecierea materialelor consumabile","3921","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3922","Ajustări pentru deprecierea materialelor de natura obiectelor de inventar","3922","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_393","Ajustări pentru deprecierea producției în curs de execuție","393","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3941","Ajustări pentru deprecierea semifabricatelor","3941","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3945","Ajustări pentru deprecierea produselor finite","3945","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3946","Ajustări pentru deprecierea produselor reziduale","3946","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3947","Ajustări pentru deprecierea produselor agricole","3947","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3951","Ajustări pentru deprecierea materiilor și materialelor aflate la terți","3951","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3952","Ajustări pentru deprecierea semifabricatelor aflate la terți","3952","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3953","Ajustări pentru deprecierea produselor finite aflate la terți","3953","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3954","Ajustări pentru deprecierea produselor reziduale aflate la terți","3954","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3955","Ajustări pentru deprecierea produselor agricole aflate la terți","3955","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3956","Ajustări pentru deprecierea activelor biologice de natura stocurilor aflate la terți","3956","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3957","Ajustări pentru deprecierea mărfurilor aflate la terți","3957","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_3958","Ajustări pentru deprecierea ambalajelor aflate la terți","3958","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_396","Ajustări pentru deprecierea activelor biologice de natura stocurilor","396","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_397","Ajustări pentru deprecierea mărfurilor","397","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_398","Ajustări pentru deprecierea ambalajelor","398","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"ro_pcg_pay","Furnizori","401","account.data_account_type_payable","l10n_ro.ro_chart_template","True"
-"pcg_403","Efecte de plătit","403","account.data_account_type_payable","l10n_ro.ro_chart_template","True"
-"pcg_404","Furnizori de imobilizări","404","account.data_account_type_payable","l10n_ro.ro_chart_template","True"
-"pcg_405","Efecte de plătit pentru imobilizări","405","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","True"
-"pcg_408","Furnizori - facturi nesosite","408","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","True"
-"pcg_4091","Furnizori - debitori pentru cumpărări de bunuri de natura stocurilor","4091","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","True"
-"pcg_4092","Furnizori - debitori pentru prestări de servicii","4092","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","True"
-"pcg_4093","Avansuri acordate pentru imobilizări corporale","4093","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","True"
-"pcg_4094","Avansuri acordate pentru imobilizări necorporale","4094","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","True"
-"ro_pcg_recv","Clienți","4111","account.data_account_type_receivable","l10n_ro.ro_chart_template","True"
-"pcg_4118","Clienți incerți sau în litigiu","4118","account.data_account_type_current_assets","l10n_ro.ro_chart_template","True"
-"pcg_413","Efecte de primit de la clienți","413","account.data_account_type_current_assets","l10n_ro.ro_chart_template","True"
-"pcg_418","Clienți - facturi de întocmit","418","account.data_account_type_current_assets","l10n_ro.ro_chart_template","True"
-"pcg_419","Clienți - creditori","419","account.data_account_type_current_assets","l10n_ro.ro_chart_template","True"
-"pcg_421","Personal - salarii datorate","421","account.data_account_type_payable","l10n_ro.ro_chart_template","True"
-"pcg_423","Personal - ajutoare materiale datorate","423","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_424","Prime reprezentând participarea personalului la profit","424","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_425","Avansuri acordate personalului","425","account.data_account_type_receivable","l10n_ro.ro_chart_template","True"
-"pcg_426","Drepturi de personal neridicate","426","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_427","Rețineri din salarii datorate terților","427","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","True"
-"pcg_4281","Alte datorii în legătură cu personalul","4281","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4282","Alte creanțe în legătură cu personalul","4282","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_4311","Contribuția unității la asigurările sociale","4311","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4312","Contribuția personalului la asigurările sociale","4312","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4313","Contribuția angajatorului pentru asigurările sociale de sănătate","4313","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4314","Contribuția angajaților pentru asigurările sociale de sănătate","4314","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4315","Contribuția de asigurări sociale","4315","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4316","Contribuția de asigurări sociale de sănătate","4316","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4318","Alte contribuții pentru asigurările sociale de sănătate","4318","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_436","Contributia asiguratorie pentru munca","436","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4371","Contribuția unității la fondul de șomaj","4371","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4372","Contribuția personalului la fondul de șomaj","4372","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4381","Alte datorii sociale","4381","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4382","Alte creanțe sociale","4382","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_4411","Impozitul pe profit","4411","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4415","Impozitul specific unor activități","4415","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4418","Impozitul pe venit","4418","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4423","TVA de plată","4423","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4424","TVA de recuperat","4424","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_4426","TVA deductibilă","4426","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4427","TVA colectată","4427","account.data_account_type_non_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_44281","TVA neexigibilă - Colectată","44281","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_44282","TVA neexigibilă - Deductibilă","44282","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_444","Impozitul pe venituri de natura salariilor","444","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","True"
-"pcg_4451","Subvenții guvernamentale","4451","account.data_account_type_non_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_4452","Împrumuturi nerambursabile cu caracter de subvenții","4452","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_4458","Alte sume primite cu caracter de subvenții","4458","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_446","Alte impozite, taxe și vărsăminte asimilate","446","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","True"
-"pcg_447","Fonduri speciale - taxe și vărsăminte asimilate","447","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4481","Alte datorii față de bugetul statului","4481","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4482","Alte creanțe privind bugetul statului","4482","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_4511","Decontări între entitățile afiliate","4511","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4518","Dobânzi aferente decontărilor între entitățile afiliate","4518","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4531","Decontări cu entitățile asociate și entitățile controlate în comun","4531","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4538","Dobânzi aferente decontărilor cu entitățile asociate și entitățile controlate în comun","4538","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4551","Acționari/asociați - conturi curente","4551","account.data_account_type_payable","l10n_ro.ro_chart_template","True"
-"pcg_4558","Acționari/asociați - dobânzi la conturi curente","4558","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","True"
-"pcg_456","Decontări cu acționarii/asociații privind capitalul","456","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_457","Dividende de plată","457","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4581","Decontări din operațiuni în participație - activ","4581","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_4582","Decontări din operațiuni în participație - pasiv","4582","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_461","Debitori diverși","461","account.data_account_type_receivable","l10n_ro.ro_chart_template","True"
-"pcg_462","Creditori diverși","462","account.data_account_type_payable","l10n_ro.ro_chart_template","True"
-"pcg_463","Creante reprezentand dividende repartizate in cursul exercitiului financiar","463","account.data_account_type_payable","l10n_ro.ro_chart_template","True"
-"pcg_4661","Datorii din operațiuni de fiducie","4661","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4662","Creanțe din operațiuni de fiducie","4662","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_471","Cheltuieli înregistrate în avans","471","account.data_account_type_prepayments","l10n_ro.ro_chart_template","False"
-"pcg_472","Venituri înregistrate în avans","472","account.data_account_type_non_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_473","Decontări din operațiuni în curs de clarificare","473","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_4751","Subvenții guvernamentale pentru investiții","4751","account.data_account_type_other_income","l10n_ro.ro_chart_template","False"
-"pcg_4752","Împrumuturi nerambursabile cu caracter de subvenții pentru investiții","4752","account.data_account_type_other_income","l10n_ro.ro_chart_template","False"
-"pcg_4753","Donații pentru investiții","4753","account.data_account_type_other_income","l10n_ro.ro_chart_template","False"
-"pcg_4754","Plusuri de inventar de natura imobilizărilor","4754","account.data_account_type_other_income","l10n_ro.ro_chart_template","False"
-"pcg_4758","Alte sume primite cu caracter de subvenții pentru investiții","4758","account.data_account_type_other_income","l10n_ro.ro_chart_template","False"
-"pcg_478","Venituri în avans aferente activelor primite prin transfer de la clienți","478","account.data_account_type_other_income","l10n_ro.ro_chart_template","False"
-"pcg_481","Decontări între unitate și subunități","481","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_482","Decontări între subunități","482","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_491","Ajustări pentru deprecierea creanțelor - clienți","491","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_495","Ajustări pentru deprecierea creanțelor - decontări în cadrul grupului și cu acționarii/asociații","495","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_496","Ajustări pentru deprecierea creanțelor - debitori diverși","496","account.data_account_type_current_liabilities","l10n_ro.ro_chart_template","False"
-"pcg_501","Acțiuni deținute la entitățile afiliate","501","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_505","Obligațiuni emise și răscumpărate","505","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_506","Obligațiuni","506","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_507","Certificate verzi primite","507","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5081","Alte titluri de plasament","5081","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5088","Dobânzi la obligațiuni și titluri de plasament","5088","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5091","Vărsăminte de efectuat pentru acțiunile deținute la entitățile afiliate","5091","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5092","Vărsăminte de efectuat pentru alte investiții pe termen scurt","5092","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5112","Cecuri de încasat","5112","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5113","Efecte de încasat","5113","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5114","Efecte remise spre scontare","5114","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5121","Conturi la bănci în lei","5121","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5124","Conturi la bănci în valută","5124","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5125","Sume în curs de decontare","5125","account.data_account_type_current_assets","l10n_ro.ro_chart_template","False"
-"pcg_5186","Dobânzi de plătit","5186","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5187","Dobânzi de încasat","5187","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5191","Credite bancare pe termen scurt","5191","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5192","Credite bancare pe termen scurt nerambursate la scadență","5192","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5193","Credite externe guvernamentale","5193","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5194","Credite externe garantate de stat","5194","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5195","Credite externe garantate de bănci","5195","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5196","Credite de la trezoreria statului","5196","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5197","Credite interne garantate de stat","5197","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5198","Dobânzi aferente creditelor bancare pe termen scurt","5198","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5311","Casa în lei","5311","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5314","Casa în valută","5314","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5321","Timbre fiscale și poștale","5321","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5322","Bilete de tratament și odihnă","5322","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5323","Tichete și bilete de călătorie","5323","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5328","Alte valori","5328","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5411","Acreditive în lei","5411","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_5414","Acreditive în valută","5414","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_542","Avansuri de trezorerie","542","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_581","Viramente interne","581","account.data_account_type_liquidity","l10n_ro.ro_chart_template","True"
-"pcg_591","Ajustări pentru pierderea de valoare a acțiunilor deținute la entitățile afiliate","591","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_595","Ajustări pentru pierderea de valoare a obligațiunilor emise și răscumpărate","595","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_596","Ajustări pentru pierderea de valoare a obligațiunilor","596","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_598","Ajustări pentru pierderea de valoare a altor investiții pe termen scurt și creanțe asimilate","598","account.data_account_type_liquidity","l10n_ro.ro_chart_template","False"
-"pcg_601","Cheltuieli cu materiile prime","601","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6021","Cheltuieli cu materiale auxiliare","6021","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6022","Cheltuieli privind combustibilul","6022","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6023","Cheltuieli privind materialele pentru ambalat","6023","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6024","Cheltuieli privind piesele de schimb","6024","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6025","Cheltuieli privind semințele și materialele de plantat","6025","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6026","Cheltuieli privind furajele","6026","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6028","Cheltuieli privind alte materiale consumabile","6028","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_603","Cheltuieli privind materialele de natura obiectelor de inventar","603","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_604","Cheltuieli privind materialele nestocate","604","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_605","Cheltuieli privind energia și apa","605","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_606","Cheltuieli privind activele biologice de natura stocurilor","606","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"ro_pcg_expense","Cheltuieli privind mărfurile","607","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_608","Cheltuieli privind ambalajele","608","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_609","Reduceri comerciale primite","609","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_611","Cheltuieli cu întreținerea și reparațiile","611","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_612","Cheltuieli cu redevențele, locațiile de gestiune și chiriile","612","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_613","Cheltuieli cu primele de asigurare","613","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_614","Cheltuieli cu studiile și cercetările","614","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_615","Cheltuieli cu pregătirea personalului","615","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_621","Cheltuieli cu colaboratorii","621","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_622","Cheltuieli privind comisioanele și onorariile","622","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6231","Cheltuieli de protocol","6231","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6232","Cheltuieli de reclamă și publicitate","6232","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_624","Cheltuieli cu transportul de bunuri și personal","624","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_625","Cheltuieli cu deplasări, detașări și transferări","625","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_626","Cheltuieli poștale și taxe de telecomunicații","626","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_627","Cheltuieli cu serviciile bancare și asimilate","627","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_628","Alte cheltuieli cu serviciile executate de terți","628","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6351","Cheltuieli cu alte impozite, taxe și vărsăminte asimilate","6351","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6352","Cheltuieli cu alte impozite, taxe și vărsăminte asimilate nedeductibile","6352","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_641","Cheltuieli cu salariile personalului","641","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6421","Cheltuieli cu avantajele în natură acordate salariaților","6421","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6422","Cheltuieli cu tichetele acordate salariaților","6422","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_643","Cheltuieli cu remunerarea în instrumente de capitaluri proprii","643","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_644","Cheltuieli cu primele reprezentând participarea personalului la profit","644","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6451","Cheltuieli privind contribuția unității la asigurările sociale","6451","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6452","Cheltuieli privind contribuția unității pentru ajutorul de șomaj","6452","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6453","Cheltuieli privind contribuția angajatorului pentru asigurările sociale de sănătate","6453","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6455","Cheltuieli privind contribuția unității la asigurările de viață","6455","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6456","Cheltuieli privind contribuția unității la fondurile de pensii facultative","6456","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6457","Cheltuieli privind contribuția unității la primele de asigurare voluntară de sănătate","6457","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6458","Alte cheltuieli privind asigurările și protecția socială","6458","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_646","Cheltuieli privind contribuția asiguratorie pentru muncă","646","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6511","Cheltuieli ocazionate de constituirea fiduciei","6511","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6512","Cheltuieli din derularea operațiunilor de fiducie","6512","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6513","Cheltuieli din lichidarea operațiunilor de fiducie","6513","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_652","Cheltuieli cu protecția mediului înconjurător","652","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_654","Pierderi din creanțe și debitori diverși","654","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_655","Cheltuieli din reevaluarea imobilizărilor corporale","655","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6581","Despăgubiri, amenzi și penalități","6581","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6582","Donații acordate","6582","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6583","Cheltuieli privind activele cedate și alte operațiuni de capital","6583","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6584","Cheltuieli cu sumele sau bunurile acordate ca sponsorizări","6584","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6586","Cheltuieli reprezentând transferuri și contribuții datorate în baza unor acte normative speciale","6586","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6587","Cheltuieli privind calamitățile și alte evenimente similare","6587","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_65881","Alte cheltuieli de exploatare","65881","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_65882","Alte cheltuieli de exploatare nedeductibile","65882","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_663","Pierderi din creanțe legate de participații","663","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6641","Cheltuieli privind imobilizările financiare cedate","6641","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6642","Pierderi din investițiile pe termen scurt cedate","6642","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6651","Diferențe nefavorabile de curs valutar legate de elementele monetare exprimate în valută","6651","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6652","Diferențe nefavorabile de curs valutar din evaluarea elementelor monetare care fac parte din investiția netă într-o entitate străină","6652","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_666","Cheltuieli privind dobânzile","666","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_667","Cheltuieli privind sconturile acordate","667","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_668","Alte cheltuieli financiare","668","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6811","Cheltuieli de exploatare privind amortizarea imobilizărilor","6811","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6812","Cheltuieli de exploatare privind provizioanele","6812","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6813","Cheltuieli de exploatare privind ajustările pentru deprecierea imobilizărilor","6813","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6814","Cheltuieli de exploatare privind ajustările pentru deprecierea activelor circulante","6814","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6817","Cheltuieli de exploatare privind ajustările pentru deprecierea fondului comercial","6817","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6861","Cheltuieli privind actualizarea provizioanelor","6861","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6863","Cheltuieli financiare privind ajustările pentru pierderea de valoare a imobilizărilor financiare","6863","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6864","Cheltuieli financiare privind ajustările pentru pierderea de valoare a activelor circulante","6864","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6865","Cheltuieli financiare privind amortizarea diferențelor aferente titlurilor de stat","6865","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_6868","Cheltuieli financiare privind amortizarea primelor de rambursare a obligațiunilor și a altor datorii","6868","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_691","Cheltuieli cu impozitul pe profit","691","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_695","Cheltuieli cu impozitul specific unor activitati","695","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_698","Cheltuieli cu impozitul pe venit și cu alte impozite care nu apar in elementele de mai sus","698","account.data_account_type_expenses","l10n_ro.ro_chart_template","False"
-"pcg_7015","Venituri din vânzarea produselor finite","7015","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7017","Venituri din vânzarea produselor agricole","7017","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7018","Venituri din vânzarea activelor biologice de natura stocurilor","7018","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_702","Venituri din vânzarea semifabricatelor","702","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_703","Venituri din vânzarea produselor reziduale","703","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_704","Venituri din servicii prestate","704","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_705","Venituri din studii și cercetări","705","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_706","Venituri din redevențe, locații de gestiune și chirii","706","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"ro_pcg_sale","Venituri din vânzarea mărfurilor","707","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_708","Venituri din activități diverse","708","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_709","Reduceri comerciale acordate","709","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_711","Venituri aferente costurilor stocurilor de produse","711","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_712","Venituri aferente costurilor serviciilor în curs de execuție","712","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_721","Venituri din producția de imobilizări necorporale","721","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_722","Venituri din producția de imobilizări corporale","722","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_725","Venituri din producția de investiții imobiliare","725","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7411","Venituri din subvenții de exploatare aferente cifrei de afaceri","7411","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7412","Venituri din subvenții de exploatare pentru materii prime și materiale","7412","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7413","Venituri din subvenții de exploatare pentru alte cheltuieli externe","7413","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7414","Venituri din subvenții de exploatare pentru plata personalului","7414","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7415","Venituri din subvenții de exploatare pentru asigurări și protecție socială","7415","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7416","Venituri din subvenții de exploatare pentru alte cheltuieli de exploatare","7416","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7417","Venituri din subvenții de exploatare în caz de calamități și alte evenimente similare","7417","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7418","Venituri din subvenții de exploatare pentru dobânda datorată","7418","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7419","Venituri din subvenții de exploatare aferente altor venituri","7419","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7511","Venituri ocazionate de constituirea fiduciei","7511","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7512","Venituri din derularea operațiunilor de fiducie","7512","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7513","Venituri din lichidarea operațiunilor de fiducie","7513","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_754","Venituri din creanțe reactivate și debitori diverși","754","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_755","Venituri din reevaluarea imobilizărilor corporale","755","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7581","Venituri din despăgubiri, amenzi și penalități","7581","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7582","Venituri din donații primite","7582","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7583","Venituri din vânzarea activelor și alte operațiuni de capital","7583","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7584","Venituri din subvenții pentru investiții","7584","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7586","Venituri reprezentând transferuri cuvenite în baza unor acte normative speciale","7586","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7588","Alte venituri din exploatare","7588","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7611","Venituri din acțiuni deținute la entitățile afiliate","7611","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7612","Venituri din acțiuni deținute la entități asociate","7612","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7613","Venituri din acțiuni deținute la entități controlate în comun","7613","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7615","Venituri din alte imobilizări financiare","7615","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_762","Venituri din investiții financiare pe termen scurt","762","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7641","Venituri din imobilizări financiare cedate","7641","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7642","Câștiguri din investiții pe termen scurt cedate","7642","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7651","Diferențe favorabile de curs valutar legate de elementele monetare exprimate în valută","7651","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7652","Diferențe favorabile de curs valutar din evaluarea elementelor monetare care fac parte din investiția netă într-o entitate străină","7652","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_766","Venituri din dobânzi","766","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_767","Venituri din sconturi obținute","767","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_768","Alte venituri financiare","768","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7812","Venituri din provizioane","7812","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7813","Venituri din ajustări pentru deprecierea imobilizărilor","7813","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7814","Venituri din ajustări pentru deprecierea activelor circulante","7814","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7815","Venituri din fondul comercial negativ","7815","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7863","Venituri financiare din ajustări pentru pierderea de valoare a imobilizărilor financiare","7863","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7864","Venituri financiare din ajustări pentru pierderea de valoare a activelor circulante","7864","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_7865","Venituri financiare din amortizarea diferențelor aferente titlurilor de stat","7865","account.data_account_type_revenue","l10n_ro.ro_chart_template","False"
-"pcg_8011","Giruri și garanții acordate","8011","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_8018","Alte angajamente acordate","8018","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_8021","Giruri și garanții primite","8021","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_8028","Alte angajamente primite","8028","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_8031","Imobilizări corporale luate cu chirie","8031","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_8032","Valori materiale primite spre prelucrare sau reparare","8032","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_8033","Valori materiale primite în păstrare sau custodie","8033","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_8034","Debitori scoși din activ, urmăriți în continuare","8034","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_8035","Stocuri de natura obiectelor de inventar date în folosință","8035","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_8036","Redevențe, locații de gestiune, chirii și alte datorii asimilate","8036","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_8037","Efecte scontate neajunse la scadență","8037","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_8038","Bunuri primite în administrare, concesiune și cu chirie","8038","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_8039","Alte valori în afara bilanțului","8039","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_804","Certificate verzi","804","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_8051","Dobânzi de plătit","8051","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_8052","Dobânzi de încasat","8052","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_806","Certificate de emisii de gaze cu efect de seră","806","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_807","Active contingente","807","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_808","Datorii contingente","808","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_809","Creanțe preluate prin cesionare","809","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_891","Bilanț de deschidere","891","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_892","Bilanț de închidere","892","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_901","Decontări interne privind cheltuielile","901","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_902","Decontări interne privind producția obținută","902","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_903","Decontări interne privind diferențele de preț","903","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_921","Cheltuielile activității de bază","921","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_922","Cheltuielile activităților auxiliare","922","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_923","Cheltuieli indirecte de producție","923","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_924","Cheltuieli generale de administrație","924","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_925","Cheltuieli de desfacere","925","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_931","Costul producției obținute","931","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
-"pcg_933","Costul producției în curs de execuție","933","account.data_account_off_sheet","l10n_ro.ro_chart_template","False"
+id,name,code,user_type_id/id,chart_template_id/id,reconcile
+pcg_1011,Capital subscris nevărsat,1011,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1012,Capital subscris vărsat,1012,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1015,Patrimoniul regiei,1015,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1016,Patrimoniul public,1016,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1017,Patrimoniul privat,1017,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1018,Patrimoniul institutelor naționale de cercetare-dezvoltare,1018,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1031,Beneficii acordate angajaților sub forma instrumentelor de capitaluri proprii,1031,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1033,Diferențe de curs valutar în relație cu investiția netă într-o entitate străină,1033,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1038,Diferențe din modificarea valorii juste a activelor financiare disponibile în vederea vânzării și alte elemente de capitaluri proprii,1038,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1041,Prime de emisiune,1041,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1042,Prime de fuziune/divizare,1042,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1043,Prime de aport,1043,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1044,Prime de conversie a obligațiunilor în acțiuni,1044,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_105,Rezerve din reevaluare,105,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1061,Rezerve legale,1061,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1063,Rezerve statutare sau contractuale,1063,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1068,Alte rezerve,1068,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_107,Diferențe de curs valutar din conversie,107,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1081,Interese care nu controlează - rezultatul exercițiului financiar,1081,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1082,Interese care nu controlează - alte capitaluri proprii,1082,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1091,Acțiuni proprii deținute pe termen scurt,1091,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1092,Acțiuni proprii deținute pe termen lung,1092,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1095,Acțiuni proprii reprezentând titluri deținute de societatea absorbită la societatea absorbantă,1095,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1171,Rezultatul reportat reprezentând profitul nerepartizat sau pierderea neacoperită,1171,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1172,"Rezultatul reportat provenit din adoptarea pentru prima dată a IAS, mai puțin IAS 29",1172,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1173,Rezultatul reportat provenit din modificările politicilor contabile,1173,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1174,Rezultatul reportat provenit din corectarea erorilor contabile,1174,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1175,Rezultatul reportat reprezentând surplusul realizat din rezerve din reevaluare,1175,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1176,Rezultatul reportat provenit din trecerea la aplicarea reglementărilor contabile conforme cu directivele europene,1176,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_121,Profit sau pierdere,121,account.data_unaffected_earnings,l10n_ro.ro_chart_template,False
+pcg_129,Repartizarea profitului,129,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1411,Câștiguri legate de vânzarea instrumentelor de capitaluri proprii,1411,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1412,Câștiguri legate de anularea instrumentelor de capitaluri proprii,1412,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1491,Pierderi rezultate din vânzarea instrumentelor de capitaluri proprii,1491,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1495,"Pierderi rezultate din reorganizări, care sunt determinate de anularea titlurilor deținute",1495,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1498,Alte pierderi legate de instrumentele de capitaluri proprii,1498,account.data_account_type_equity,l10n_ro.ro_chart_template,False
+pcg_1511,Provizioane pentru litigii,1511,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1512,Provizioane pentru garanții acordate clienților,1512,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1513,Provizioane pentru dezafectare imobilizări corporale și alte acțiuni similare legate de acestea,1513,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1514,Provizioane pentru restructurare,1514,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1515,Provizioane pentru pensii și obligații similare,1515,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1516,Provizioane pentru impozite,1516,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1517,Provizioane pentru terminarea contractului de muncă,1517,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1518,Alte provizioane,1518,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1614,Împrumuturi externe din emisiuni de obligațiuni garantate de stat,1614,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1615,Împrumuturi externe din emisiuni de obligațiuni garantate de bănci,1615,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1617,Împrumuturi interne din emisiuni de obligațiuni garantate de stat,1617,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1618,Alte împrumuturi din emisiuni de obligațiuni,1618,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1621,Credite bancare pe termen lung,1621,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1622,Credite bancare pe termen lung nerambursate la scadență,1622,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1623,Credite externe guvernamentale,1623,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1624,Credite bancare externe garantate de stat,1624,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1625,Credite bancare externe garantate de bănci,1625,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1626,Credite de la trezoreria statului,1626,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1627,Credite bancare interne garantate de stat,1627,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1661,Datorii față de entitățile afiliate,1661,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1663,Datorii față de entitățile asociate și entitățile controlate în comun,1663,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_167,Alte împrumuturi și datorii asimilate,167,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1681,Dobânzi aferente împrumuturilor din emisiuni de obligațiuni,1681,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1682,Dobânzi aferente creditelor bancare pe termen lung,1682,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1685,Dobânzi aferente datoriilor față de entitățile afiliate,1685,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1686,Dobânzi aferente datoriilor fată de entitătile asociate și entitățile controlate în comun,1686,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1687,Dobânzi aferente altor împrumuturi și datorii asimilate,1687,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1691,Prime privind rambursarea obligațiunilor,1691,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_1692,Prime privind rambursarea altor datorii,1692,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_201,Cheltuieli de constituire,201,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_203,Cheltuieli de dezvoltare,203,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_205,"Concesiuni, brevete, licențe, mărci comerciale, drepturi și active similare",205,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_206,Active necorporale de explorare și evaluare a resurselor minerale,206,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2071,Fond comercial pozitiv,2071,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2075,Fond comercial negativ,2075,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_208,Alte imobilizări necorporale,208,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2111,Terenuri,2111,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2112,Amenajări de terenuri,2112,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_212,Construcții,212,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2131,"Echipamente tehnologice (mașini, utilaje și instalații de lucru)",2131,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2132,"Aparate și instalații de măsurare, control și reglare",2132,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2133,Mijloace de transport,2133,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_214,"Mobilier, aparatură birotică, echipamente de protecție a valorilor umane și materiale și alte active corporale",214,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_215,Investiții imobiliare,215,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_216,Active corporale de explorare și evaluare a resurselor minerale,216,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_217,Active biologice productive,217,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_223,Instalații tehnice și mijloace de transport în curs de aprovizionare,223,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_224,"Mobilier, aparatură birotică, echipamente de protecție a valorilor umane și materiale și alte active corporale în curs de aprovizionare",224,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_227,Active biologice productive în curs de aprovizionare,227,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_231,Imobilizări corporale în curs de execuție,231,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_235,Investiții imobiliare în curs de execuție,235,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_261,Acțiuni deținute la entitățile afiliate,261,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_262,Acțiuni deținute la entități asociate,262,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_263,Acțiuni deținute la entități controlate în comun,263,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_264,Titluri puse în echivalență,264,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_265,Alte titluri imobilizate,265,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_266,Certificate verzi amânate,266,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2671,Sume de încasat de la entitățile afiliate,2671,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2672,Dobânda aferentă sumelor de încasat de la entitățile afiliate,2672,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2673,Creanțe față de entitățile asociate și entitățile controlate în comun,2673,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2674,Dobânda aferentă creanțelor față de entitățile asociate și entitățile controlate în comun,2674,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2675,Împrumuturi acordate pe termen lung,2675,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2676,Dobânda aferentă împrumuturilor acordate pe termen lung,2676,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2677,Obligațiuni achiziționate cu ocazia emisiunilor efectuate de terți,2677,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2678,Alte creanțe imobilizate,2678,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2679,Dobânzi aferente altor creanțe imobilizate,2679,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2691,Vărsăminte de efectuat privind acțiunile deținute la entitățile afiliate,2691,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2692,Vărsăminte de efectuat privind acțiunile deținute la entități asociate,2692,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2693,Vărsăminte de efectuat privind acțiunile deținute la entități controlate în comun,2693,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2695,Vărsăminte de efectuat pentru alte imobilizări financiare,2695,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2801,Amortizarea cheltuielilor de constituire,2801,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2803,Amortizarea cheltuielilor de dezvoltare,2803,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2805,"Amortizarea concesiunilor, brevetelor, licențelor, mărcilor comerciale, drepturilor și activelor similare",2805,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2806,Amortizarea activelor necorporale de explorare și evaluare a resurselor minerale,2806,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2807,Amortizarea fondului comercial,2807,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2808,Amortizarea altor imobilizări necorporale,2808,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2811,Amortizarea amenajărilor de terenuri,2811,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2812,Amortizarea construcțiilor,2812,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2813,Amortizarea instalațiilor și mijloacelor de transport,2813,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2814,Amortizarea altor imobilizări corporale,2814,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2815,Amortizarea investițiilor imobiliare,2815,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2816,Amortizarea activelor corporale de explorare și evaluare a resurselor minerale,2816,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2817,Amortizarea activelor biologice productive,2817,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2903,Ajustări pentru deprecierea cheltuielilor de dezvoltare,2903,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2905,"Ajustări pentru deprecierea concesiunilor, brevetelor, licențelor, mărcilor comerciale, drepturilor și activelor similare",2905,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2906,Ajustări pentru deprecierea activelor necorporale de explorare și evaluare a resurselor minerale,2906,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2908,Ajustări pentru deprecierea altor imobilizări necorporale,2908,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2911,Ajustări pentru deprecierea terenurilor și amenajărilor de terenuri,2911,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2912,Ajustări pentru deprecierea construcțiilor,2912,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2913,Ajustări pentru deprecierea instalațiilor și mijloacelor de transport,2913,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2914,Ajustări pentru deprecierea altor imobilizări corporale,2914,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2915,Ajustări pentru deprecierea investițiilor imobiliare,2915,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2916,Ajustări pentru deprecierea activelor corporale de explorare și evaluare a resurselor minerale,2916,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2917,Ajustări pentru deprecierea activelor biologice productive,2917,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2931,Ajustări pentru deprecierea imobilizărilor corporale în curs de execuție,2931,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2935,Ajustări pentru deprecierea investiții lor imobiliare în curs de execuție,2935,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2961,Ajustări pentru pierderea de valoare a acțiunilor deținute la entitățile afiliate,2961,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2962,Ajustări pentru pierderea de valoare a acțiunilor deținute la entități asociate și entități controlate în comun,2962,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2963,Ajustări pentru pierderea de valoare a altor titluri imobilizate,2963,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2964,Ajustări pentru pierderea de valoare a sumelor de încasat de la entitățile afiliate,2964,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2965,Ajustări pentru pierderea de valoare a creanțelor față de entitățile asociate și entitățile controlate în comun,2965,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2966,Ajustări pentru pierderea de valoare a împrumuturilor acordate pe termen lung,2966,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_2968,Ajustări pentru pierderea de valoare a altor creanțe,2968,account.data_account_type_fixed_assets,l10n_ro.ro_chart_template,False
+pcg_301,Materii prime,301,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3021,Materiale auxiliare,3021,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3022,Combustibili,3022,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3023,Materiale pentru ambalat,3023,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3024,Piese de schimb,3024,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3025,Semințe și materiale de plantat,3025,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3026,Furaje,3026,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3028,Alte materiale consumabile,3028,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_303,Materiale de natura obiectelor de inventar,303,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_308,Diferențe de preț la materii prime și materiale,308,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_321,Materii prime în curs de aprovizionare,321,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_322,Materiale consumabile în curs de aprovizionare,322,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_323,Materiale de natura obiectelor de inventar în curs de aprovizionare,323,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_326,Active biologice de natura stocurilor în curs de aprovizionare,326,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_327,Mărfuri în curs de aprovizionare,327,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_328,Ambalaje în curs de aprovizionare,328,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_331,Produse în curs de execuție,331,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_332,Servicii în curs de execuție,332,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_341,Semifabricate,341,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_345,Produse finite,345,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_346,Produse reziduale,346,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_347,Produse agricole,347,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_348,Diferențe de preț la produse,348,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_351,Materii și materiale aflate la terți,351,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_354,Produse aflate la terți,354,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_356,Active biologice de natura stocurilor aflate la terți,356,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_357,Mărfuri aflate la terți,357,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_358,Ambalaje aflate la terți,358,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_361,Active biologice de natura stocurilor,361,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_368,Diferențe de preț la active biologice de natura stocurilor,368,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_371,Mărfuri,371,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_378,Diferențe de preț la mărfuri,378,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_381,Ambalaje,381,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_388,Diferențe de preț la ambalaje,388,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_391,Ajustări pentru deprecierea materiilor prime,391,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3921,Ajustări pentru deprecierea materialelor consumabile,3921,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3922,Ajustări pentru deprecierea materialelor de natura obiectelor de inventar,3922,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_393,Ajustări pentru deprecierea producției în curs de execuție,393,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3941,Ajustări pentru deprecierea semifabricatelor,3941,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3945,Ajustări pentru deprecierea produselor finite,3945,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3946,Ajustări pentru deprecierea produselor reziduale,3946,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3947,Ajustări pentru deprecierea produselor agricole,3947,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3951,Ajustări pentru deprecierea materiilor și materialelor aflate la terți,3951,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3952,Ajustări pentru deprecierea semifabricatelor aflate la terți,3952,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3953,Ajustări pentru deprecierea produselor finite aflate la terți,3953,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3954,Ajustări pentru deprecierea produselor reziduale aflate la terți,3954,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3955,Ajustări pentru deprecierea produselor agricole aflate la terți,3955,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3956,Ajustări pentru deprecierea activelor biologice de natura stocurilor aflate la terți,3956,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3957,Ajustări pentru deprecierea mărfurilor aflate la terți,3957,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_3958,Ajustări pentru deprecierea ambalajelor aflate la terți,3958,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_396,Ajustări pentru deprecierea activelor biologice de natura stocurilor,396,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_397,Ajustări pentru deprecierea mărfurilor,397,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_398,Ajustări pentru deprecierea ambalajelor,398,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+ro_pcg_pay,Furnizori,401,account.data_account_type_payable,l10n_ro.ro_chart_template,True
+pcg_403,Efecte de plătit,403,account.data_account_type_payable,l10n_ro.ro_chart_template,True
+pcg_404,Furnizori de imobilizări,404,account.data_account_type_payable,l10n_ro.ro_chart_template,True
+pcg_405,Efecte de plătit pentru imobilizări,405,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,True
+pcg_408,Furnizori - facturi nesosite,408,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,True
+pcg_4091,Furnizori - debitori pentru cumpărări de bunuri de natura stocurilor,4091,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,True
+pcg_4092,Furnizori - debitori pentru prestări de servicii,4092,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,True
+pcg_4093,Avansuri acordate pentru imobilizări corporale,4093,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,True
+pcg_4094,Avansuri acordate pentru imobilizări necorporale,4094,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,True
+ro_pcg_recv,Clienți,4111,account.data_account_type_receivable,l10n_ro.ro_chart_template,True
+pcg_4118,Clienți incerți sau în litigiu,4118,account.data_account_type_receivable,l10n_ro.ro_chart_template,True
+pcg_413,Efecte de primit de la clienți,413,account.data_account_type_current_assets,l10n_ro.ro_chart_template,True
+pcg_418,Clienți - facturi de întocmit,418,account.data_account_type_current_assets,l10n_ro.ro_chart_template,True
+pcg_419,Clienți - creditori,419,account.data_account_type_current_assets,l10n_ro.ro_chart_template,True
+pcg_421,Personal - salarii datorate,421,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,True
+pcg_423,Personal - ajutoare materiale datorate,423,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_424,Prime reprezentând participarea personalului la profit,424,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_425,Avansuri acordate personalului,425,account.data_account_type_current_assets,l10n_ro.ro_chart_template,True
+pcg_426,Drepturi de personal neridicate,426,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_427,Rețineri din salarii datorate terților,427,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,True
+pcg_4281,Alte datorii în legătură cu personalul,4281,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4282,Alte creanțe în legătură cu personalul,4282,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_4311,Contribuția unității la asigurările sociale,4311,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4312,Contribuția personalului la asigurările sociale,4312,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4313,Contribuția angajatorului pentru asigurările sociale de sănătate,4313,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4314,Contribuția angajaților pentru asigurările sociale de sănătate,4314,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4315,Contribuția de asigurări sociale,4315,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4316,Contribuția de asigurări sociale de sănătate,4316,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4318,Alte contribuții pentru asigurările sociale de sănătate,4318,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_436,Contributia asiguratorie pentru munca,436,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4371,Contribuția unității la fondul de șomaj,4371,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4372,Contribuția personalului la fondul de șomaj,4372,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4381,Alte datorii sociale,4381,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4382,Alte creanțe sociale,4382,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_4411,Impozitul pe profit,4411,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4415,Impozitul specific unor activități,4415,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4418,Impozitul pe venit,4418,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4423,TVA de plată,4423,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4424,TVA de recuperat,4424,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_4426,TVA deductibilă,4426,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_4427,TVA colectată,4427,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_44281,TVA neexigibilă - Colectată,44281,account.data_account_type_non_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_44282,TVA neexigibilă - Deductibilă,44282,account.data_account_type_non_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_44283,Baza TVA neexigibilă – Deductibilă / Colectata,44283,account.data_account_type_non_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_444,Impozitul pe venituri de natura salariilor,444,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,True
+pcg_4451,Subvenții guvernamentale,4451,account.data_account_type_non_current_assets,l10n_ro.ro_chart_template,False
+pcg_4452,Împrumuturi nerambursabile cu caracter de subvenții,4452,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_4458,Alte sume primite cu caracter de subvenții,4458,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_446,"Alte impozite, taxe și vărsăminte asimilate",446,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,True
+pcg_447,Fonduri speciale - taxe și vărsăminte asimilate,447,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4481,Alte datorii față de bugetul statului,4481,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4482,Alte creanțe privind bugetul statului,4482,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_4511,Decontări între entitățile afiliate,4511,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4518,Dobânzi aferente decontărilor între entitățile afiliate,4518,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4531,Decontări cu entitățile asociate și entitățile controlate în comun,4531,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4538,Dobânzi aferente decontărilor cu entitățile asociate și entitățile controlate în comun,4538,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4551,Acționari/asociați - conturi curente,4551,account.data_account_type_current_assets,l10n_ro.ro_chart_template,True
+pcg_4558,Acționari/asociați - dobânzi la conturi curente,4558,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,True
+pcg_456,Decontări cu acționarii/asociații privind capitalul,456,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_457,Dividende de plată,457,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4581,Decontări din operațiuni în participație - activ,4581,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_4582,Decontări din operațiuni în participație - pasiv,4582,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_461,Debitori diverși,461,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,True
+pcg_462,Creditori diverși,462,account.data_account_type_current_assets,l10n_ro.ro_chart_template,True
+pcg_463,Creante reprezentand dividende repartizate in cursul exercitiului financiar,463,account.data_account_type_current_assets,l10n_ro.ro_chart_template,True
+pcg_4661,Datorii din operațiuni de fiducie,4661,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4662,Creanțe din operațiuni de fiducie,4662,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_471,Cheltuieli înregistrate în avans,471,account.data_account_type_prepayments,l10n_ro.ro_chart_template,False
+pcg_472,Venituri înregistrate în avans,472,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_473,Decontări din operațiuni în curs de clarificare,473,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_4751,Subvenții guvernamentale pentru investiții,4751,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_4752,Împrumuturi nerambursabile cu caracter de subvenții pentru investiții,4752,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_4753,Donații pentru investiții,4753,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_4754,Plusuri de inventar de natura imobilizărilor,4754,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_4758,Alte sume primite cu caracter de subvenții pentru investiții,4758,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_478,Venituri în avans aferente activelor primite prin transfer de la clienți,478,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_481,Decontări între unitate și subunități,481,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_482,Decontări între subunități,482,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_491,Ajustări pentru deprecierea creanțelor - clienți,491,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_495,Ajustări pentru deprecierea creanțelor - decontări în cadrul grupului și cu acționarii/asociații,495,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_496,Ajustări pentru deprecierea creanțelor - debitori diverși,496,account.data_account_type_current_liabilities,l10n_ro.ro_chart_template,False
+pcg_501,Acțiuni deținute la entitățile afiliate,501,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_505,Obligațiuni emise și răscumpărate,505,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_506,Obligațiuni,506,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_507,Certificate verzi primite,507,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5081,Alte titluri de plasament,5081,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5088,Dobânzi la obligațiuni și titluri de plasament,5088,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5091,Vărsăminte de efectuat pentru acțiunile deținute la entitățile afiliate,5091,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5092,Vărsăminte de efectuat pentru alte investiții pe termen scurt,5092,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5112,Cecuri de încasat,5112,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_5113,Efecte de încasat,5113,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5114,Efecte remise spre scontare,5114,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5121,Conturi la bănci în lei,5121,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5124,Conturi la bănci în valută,5124,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5125,Sume în curs de decontare,5125,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_5186,Dobânzi de plătit,5186,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5187,Dobânzi de încasat,5187,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5191,Credite bancare pe termen scurt,5191,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5192,Credite bancare pe termen scurt nerambursate la scadență,5192,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5193,Credite externe guvernamentale,5193,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5194,Credite externe garantate de stat,5194,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5195,Credite externe garantate de bănci,5195,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5196,Credite de la trezoreria statului,5196,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5197,Credite interne garantate de stat,5197,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5198,Dobânzi aferente creditelor bancare pe termen scurt,5198,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5311,Casa în lei,5311,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5314,Casa în valută,5314,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5321,Timbre fiscale și poștale,5321,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5322,Bilete de tratament și odihnă,5322,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5323,Tichete și bilete de călătorie,5323,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5328,Alte valori,5328,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5411,Acreditive în lei,5411,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_5414,Acreditive în valută,5414,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_542,Avansuri de trezorerie,542,account.data_account_type_liquidity,l10n_ro.ro_chart_template,False
+pcg_581,Viramente interne,581,account.data_account_type_liquidity,l10n_ro.ro_chart_template,True
+pcg_591,Ajustări pentru pierderea de valoare a acțiunilor deținute la entitățile afiliate,591,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_595,Ajustări pentru pierderea de valoare a obligațiunilor emise și răscumpărate,595,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_596,Ajustări pentru pierderea de valoare a obligațiunilor,596,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_598,Ajustări pentru pierderea de valoare a altor investiții pe termen scurt și creanțe asimilate,598,account.data_account_type_current_assets,l10n_ro.ro_chart_template,False
+pcg_601,Cheltuieli cu materiile prime,601,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6021,Cheltuieli cu materiale auxiliare,6021,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6022,Cheltuieli privind combustibilul,6022,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6023,Cheltuieli privind materialele pentru ambalat,6023,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6024,Cheltuieli privind piesele de schimb,6024,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6025,Cheltuieli privind semințele și materialele de plantat,6025,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6026,Cheltuieli privind furajele,6026,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6028,Cheltuieli privind alte materiale consumabile,6028,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_603,Cheltuieli privind materialele de natura obiectelor de inventar,603,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_604,Cheltuieli privind materialele nestocate,604,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_605,Cheltuieli privind energia și apa,605,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_606,Cheltuieli privind activele biologice de natura stocurilor,606,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+ro_pcg_expense,Cheltuieli privind mărfurile,607,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_608,Cheltuieli privind ambalajele,608,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_609,Reduceri comerciale primite,609,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_611,Cheltuieli cu întreținerea și reparațiile,611,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_612,"Cheltuieli cu redevențele, locațiile de gestiune și chiriile",612,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_613,Cheltuieli cu primele de asigurare,613,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_614,Cheltuieli cu studiile și cercetările,614,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_615,Cheltuieli cu pregătirea personalului,615,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_621,Cheltuieli cu colaboratorii,621,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_622,Cheltuieli privind comisioanele și onorariile,622,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6231,Cheltuieli de protocol,6231,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6232,Cheltuieli de reclamă și publicitate,6232,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_624,Cheltuieli cu transportul de bunuri și personal,624,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_625,"Cheltuieli cu deplasări, detașări și transferări",625,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_626,Cheltuieli poștale și taxe de telecomunicații,626,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_627,Cheltuieli cu serviciile bancare și asimilate,627,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_628,Alte cheltuieli cu serviciile executate de terți,628,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6351,"Cheltuieli cu alte impozite, taxe și vărsăminte asimilate",6351,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6352,"Cheltuieli cu alte impozite, taxe și vărsăminte asimilate nedeductibile",6352,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_641,Cheltuieli cu salariile personalului,641,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6421,Cheltuieli cu avantajele în natură acordate salariaților,6421,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6422,Cheltuieli cu tichetele acordate salariaților,6422,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_643,Cheltuieli cu remunerarea în instrumente de capitaluri proprii,643,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_644,Cheltuieli cu primele reprezentând participarea personalului la profit,644,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6451,Cheltuieli privind contribuția unității la asigurările sociale,6451,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6452,Cheltuieli privind contribuția unității pentru ajutorul de șomaj,6452,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6453,Cheltuieli privind contribuția angajatorului pentru asigurările sociale de sănătate,6453,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6455,Cheltuieli privind contribuția unității la asigurările de viață,6455,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6456,Cheltuieli privind contribuția unității la fondurile de pensii facultative,6456,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6457,Cheltuieli privind contribuția unității la primele de asigurare voluntară de sănătate,6457,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6458,Alte cheltuieli privind asigurările și protecția socială,6458,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_646,Cheltuieli privind contribuția asiguratorie pentru muncă,646,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6511,Cheltuieli ocazionate de constituirea fiduciei,6511,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6512,Cheltuieli din derularea operațiunilor de fiducie,6512,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6513,Cheltuieli din lichidarea operațiunilor de fiducie,6513,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_652,Cheltuieli cu protecția mediului înconjurător,652,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_654,Pierderi din creanțe și debitori diverși,654,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_655,Cheltuieli din reevaluarea imobilizărilor corporale,655,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6581,"Despăgubiri, amenzi și penalități",6581,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6582,Donații acordate,6582,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6583,Cheltuieli privind activele cedate și alte operațiuni de capital,6583,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6584,Cheltuieli cu sumele sau bunurile acordate ca sponsorizări,6584,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6586,Cheltuieli reprezentând transferuri și contribuții datorate în baza unor acte normative speciale,6586,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6587,Cheltuieli privind calamitățile și alte evenimente similare,6587,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_65881,Alte cheltuieli de exploatare,65881,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_65882,Alte cheltuieli de exploatare nedeductibile,65882,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_663,Pierderi din creanțe legate de participații,663,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6641,Cheltuieli privind imobilizările financiare cedate,6641,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6642,Pierderi din investițiile pe termen scurt cedate,6642,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6651,Diferențe nefavorabile de curs valutar legate de elementele monetare exprimate în valută,6651,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6652,Diferențe nefavorabile de curs valutar din evaluarea elementelor monetare care fac parte din investiția netă într-o entitate străină,6652,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_666,Cheltuieli privind dobânzile,666,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_667,Cheltuieli privind sconturile acordate,667,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_668,Alte cheltuieli financiare,668,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6811,Cheltuieli de exploatare privind amortizarea imobilizărilor,6811,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6812,Cheltuieli de exploatare privind provizioanele,6812,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6813,Cheltuieli de exploatare privind ajustările pentru deprecierea imobilizărilor,6813,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6814,Cheltuieli de exploatare privind ajustările pentru deprecierea activelor circulante,6814,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6817,Cheltuieli de exploatare privind ajustările pentru deprecierea fondului comercial,6817,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6861,Cheltuieli privind actualizarea provizioanelor,6861,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6863,Cheltuieli financiare privind ajustările pentru pierderea de valoare a imobilizărilor financiare,6863,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6864,Cheltuieli financiare privind ajustările pentru pierderea de valoare a activelor circulante,6864,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6865,Cheltuieli financiare privind amortizarea diferențelor aferente titlurilor de stat,6865,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_6868,Cheltuieli financiare privind amortizarea primelor de rambursare a obligațiunilor și a altor datorii,6868,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_691,Cheltuieli cu impozitul pe profit,691,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_695,Cheltuieli cu impozitul specific unor activitati,695,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_698,Cheltuieli cu impozitul pe venit și cu alte impozite care nu apar in elementele de mai sus,698,account.data_account_type_expenses,l10n_ro.ro_chart_template,False
+pcg_7015,Venituri din vânzarea produselor finite,7015,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7017,Venituri din vânzarea produselor agricole,7017,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7018,Venituri din vânzarea activelor biologice de natura stocurilor,7018,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_702,Venituri din vânzarea semifabricatelor,702,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_703,Venituri din vânzarea produselor reziduale,703,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_704,Venituri din servicii prestate,704,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_705,Venituri din studii și cercetări,705,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_706,"Venituri din redevențe, locații de gestiune și chirii",706,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+ro_pcg_sale,Venituri din vânzarea mărfurilor,707,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_708,Venituri din activități diverse,708,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_709,Reduceri comerciale acordate,709,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_711,Venituri aferente costurilor stocurilor de produse,711,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_712,Venituri aferente costurilor serviciilor în curs de execuție,712,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_721,Venituri din producția de imobilizări necorporale,721,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_722,Venituri din producția de imobilizări corporale,722,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_725,Venituri din producția de investiții imobiliare,725,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7411,Venituri din subvenții de exploatare aferente cifrei de afaceri,7411,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7412,Venituri din subvenții de exploatare pentru materii prime și materiale,7412,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7413,Venituri din subvenții de exploatare pentru alte cheltuieli externe,7413,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7414,Venituri din subvenții de exploatare pentru plata personalului,7414,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7415,Venituri din subvenții de exploatare pentru asigurări și protecție socială,7415,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7416,Venituri din subvenții de exploatare pentru alte cheltuieli de exploatare,7416,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7417,Venituri din subvenții de exploatare în caz de calamități și alte evenimente similare,7417,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7418,Venituri din subvenții de exploatare pentru dobânda datorată,7418,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7419,Venituri din subvenții de exploatare aferente altor venituri,7419,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7511,Venituri ocazionate de constituirea fiduciei,7511,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7512,Venituri din derularea operațiunilor de fiducie,7512,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7513,Venituri din lichidarea operațiunilor de fiducie,7513,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_754,Venituri din creanțe reactivate și debitori diverși,754,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_755,Venituri din reevaluarea imobilizărilor corporale,755,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7581,"Venituri din despăgubiri, amenzi și penalități",7581,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7582,Venituri din donații primite,7582,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7583,Venituri din vânzarea activelor și alte operațiuni de capital,7583,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7584,Venituri din subvenții pentru investiții,7584,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7586,Venituri reprezentând transferuri cuvenite în baza unor acte normative speciale,7586,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7588,Alte venituri din exploatare,7588,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7611,Venituri din acțiuni deținute la entitățile afiliate,7611,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7612,Venituri din acțiuni deținute la entități asociate,7612,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7613,Venituri din acțiuni deținute la entități controlate în comun,7613,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7615,Venituri din alte imobilizări financiare,7615,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_762,Venituri din investiții financiare pe termen scurt,762,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7641,Venituri din imobilizări financiare cedate,7641,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7642,Câștiguri din investiții pe termen scurt cedate,7642,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7651,Diferențe favorabile de curs valutar legate de elementele monetare exprimate în valută,7651,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7652,Diferențe favorabile de curs valutar din evaluarea elementelor monetare care fac parte din investiția netă într-o entitate străină,7652,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_766,Venituri din dobânzi,766,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_767,Venituri din sconturi obținute,767,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_768,Alte venituri financiare,768,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7812,Venituri din provizioane,7812,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7813,Venituri din ajustări pentru deprecierea imobilizărilor,7813,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7814,Venituri din ajustări pentru deprecierea activelor circulante,7814,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7815,Venituri din fondul comercial negativ,7815,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7863,Venituri financiare din ajustări pentru pierderea de valoare a imobilizărilor financiare,7863,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7864,Venituri financiare din ajustări pentru pierderea de valoare a activelor circulante,7864,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_7865,Venituri financiare din amortizarea diferențelor aferente titlurilor de stat,7865,account.data_account_type_revenue,l10n_ro.ro_chart_template,False
+pcg_8011,Giruri și garanții acordate,8011,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_8018,Alte angajamente acordate,8018,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_8021,Giruri și garanții primite,8021,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_8028,Alte angajamente primite,8028,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_8031,Imobilizări corporale luate cu chirie,8031,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_8032,Valori materiale primite spre prelucrare sau reparare,8032,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_8033,Valori materiale primite în păstrare sau custodie,8033,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_8034,"Debitori scoși din activ, urmăriți în continuare",8034,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_8035,Stocuri de natura obiectelor de inventar date în folosință,8035,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_8036,"Redevențe, locații de gestiune, chirii și alte datorii asimilate",8036,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_8037,Efecte scontate neajunse la scadență,8037,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_8038,"Bunuri primite în administrare, concesiune și cu chirie",8038,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_8039,Alte valori în afara bilanțului,8039,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_804,Certificate verzi,804,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_8051,Dobânzi de plătit,8051,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_8052,Dobânzi de încasat,8052,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_806,Certificate de emisii de gaze cu efect de seră,806,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_807,Active contingente,807,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_808,Datorii contingente,808,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_809,Creanțe preluate prin cesionare,809,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_891,Bilanț de deschidere,891,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_892,Bilanț de închidere,892,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_901,Decontări interne privind cheltuielile,901,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_902,Decontări interne privind producția obținută,902,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_903,Decontări interne privind diferențele de preț,903,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_921,Cheltuielile activității de bază,921,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_922,Cheltuielile activităților auxiliare,922,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_923,Cheltuieli indirecte de producție,923,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_924,Cheltuieli generale de administrație,924,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_925,Cheltuieli de desfacere,925,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_931,Costul producției obținute,931,account.data_account_off_sheet,l10n_ro.ro_chart_template,False
+pcg_933,Costul producției în curs de execuție,933,account.data_account_off_sheet,l10n_ro.ro_chart_template,False

--- a/addons/l10n_ro/data/account_tax_data.xml
+++ b/addons/l10n_ro/data/account_tax_data.xml
@@ -1913,48 +1913,72 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'plus_report_line_ids': [ref('account_tax_report_ro_baza_rd262')],
-            }),
-            (0,0, {
-                'factor_percent': -50,
-                'repartition_type': 'tax',
-                'account_id': ref('pcg_4426'),
-                'minus_report_line_ids': [ref('account_tax_report_ro_tva_rd262')],
-            }),
-            (0,0, {
-                'factor_percent': 50,
-                'repartition_type': 'tax',
-                'account_id': ref('pcg_6352'),
+                'plus_report_line_ids': [ref('account_tax_report_ro_baza_rd261')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('pcg_4426'),
+                'plus_report_line_ids': [ref('account_tax_report_ro_tva_rd261')],
+            }),
+            (0,0, {
+                'factor_percent': -50,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_4426'),
+                'plus_report_line_ids': [ref('account_tax_report_ro_tva_rd261')],
+            }),
+            (0,0, {
+                'factor_percent': 50,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_6352'),
                 'plus_report_line_ids': [ref('account_tax_report_ro_tva_rd262')],
+            }),
+            (0,0, {
+                'factor_percent': -1000.00,
+                'repartition_type': 'tax',
+                'plus_report_line_ids': [ref('account_tax_report_ro_baza_rd261')],
+            }),
+            (0,0, {
+                'factor_percent': 1000.00,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_6352'),
+                'plus_report_line_ids': [ref('account_tax_report_ro_baza_rd262')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5,0,0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'minus_report_line_ids': [ref('account_tax_report_ro_baza_rd262')],
-            }),
-            (0,0, {
-                'factor_percent': -50,
-                'repartition_type': 'tax',
-                'account_id': ref('pcg_4426'),
-                'plus_report_line_ids': [ref('account_tax_report_ro_tva_rd262')],
-            }),
-            (0,0, {
-                'factor_percent': 50,
-                'repartition_type': 'tax',
-                'account_id': ref('pcg_6352'),
+                'minus_report_line_ids': [ref('account_tax_report_ro_baza_rd261')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('pcg_4426'),
+                'minus_report_line_ids': [ref('account_tax_report_ro_tva_rd261')],
+            }),
+            (0,0, {
+                'factor_percent': -50,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_4426'),
+                'plus_report_line_ids': [ref('account_tax_report_ro_tva_rd261')],
+            }),
+            (0,0, {
+                'factor_percent': 50,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_6352'),
                 'minus_report_line_ids': [ref('account_tax_report_ro_tva_rd262')],
+            }),
+            (0,0, {
+                'factor_percent': -1000.00,
+                'repartition_type': 'tax',
+                'minus_report_line_ids': [ref('account_tax_report_ro_baza_rd261')],
+            }),
+            (0,0, {
+                'factor_percent': 1000.00,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_6352'),
+                'minus_report_line_ids': [ref('account_tax_report_ro_baza_rd262')],
             }),
         ]"/>
     </record>
@@ -1972,48 +1996,72 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'plus_report_line_ids': [ref('account_tax_report_ro_baza_rd252')],
-            }),
-            (0,0, {
-                'factor_percent': -50,
-                'repartition_type': 'tax',
-                'account_id': ref('pcg_4426'),
-                'minus_report_line_ids': [ref('account_tax_report_ro_tva_rd252')],
-            }),
-            (0,0, {
-                'factor_percent': 50,
-                'repartition_type': 'tax',
-                'account_id': ref('pcg_6352'),
+                'plus_report_line_ids': [ref('account_tax_report_ro_baza_rd251')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('pcg_4426'),
+                'plus_report_line_ids': [ref('account_tax_report_ro_tva_rd251')],
+            }),
+            (0,0, {
+                'factor_percent': -50,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_4426'),
+                'plus_report_line_ids': [ref('account_tax_report_ro_tva_rd251')],
+            }),
+            (0,0, {
+                'factor_percent': 50,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_6352'),
                 'plus_report_line_ids': [ref('account_tax_report_ro_tva_rd252')],
+            }),
+            (0,0, {
+                'factor_percent': -555.56,
+                'repartition_type': 'tax',
+                'plus_report_line_ids': [ref('account_tax_report_ro_baza_rd251')],
+            }),
+            (0,0, {
+                'factor_percent': 555.56,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_6352'),
+                'plus_report_line_ids': [ref('account_tax_report_ro_baza_rd252')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5,0,0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'minus_report_line_ids': [ref('account_tax_report_ro_baza_rd252')],
-            }),
-            (0,0, {
-                'factor_percent': -50,
-                'repartition_type': 'tax',
-                'account_id': ref('pcg_4426'),
-                'plus_report_line_ids': [ref('account_tax_report_ro_tva_rd252')],
-            }),
-            (0,0, {
-                'factor_percent': 50,
-                'repartition_type': 'tax',
-                'account_id': ref('pcg_6352'),
+                'minus_report_line_ids': [ref('account_tax_report_ro_baza_rd251')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('pcg_4426'),
+                'minus_report_line_ids': [ref('account_tax_report_ro_tva_rd251')],
+            }),
+            (0,0, {
+                'factor_percent': -50,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_4426'),
+                'minus_report_line_ids': [ref('account_tax_report_ro_tva_rd251')],
+            }),
+            (0,0, {
+                'factor_percent': 50,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_6352'),
                 'minus_report_line_ids': [ref('account_tax_report_ro_tva_rd252')],
+            }),
+            (0,0, {
+                'factor_percent': -555.56,
+                'repartition_type': 'tax',
+                'minus_report_line_ids': [ref('account_tax_report_ro_baza_rd251')],
+            }),
+            (0,0, {
+                'factor_percent': 555.56,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_6352'),
+                'minus_report_line_ids': [ref('account_tax_report_ro_baza_rd252')],
             }),
         ]"/>
     </record>
@@ -2031,48 +2079,72 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'plus_report_line_ids': [ref('account_tax_report_ro_baza_rd242')],
-            }),
-            (0,0, {
-                'factor_percent': -50,
-                'repartition_type': 'tax',
-                'account_id': ref('pcg_4426'),
-                'minus_report_line_ids': [ref('account_tax_report_ro_tva_rd242')],
-            }),
-            (0,0, {
-                'factor_percent': 50,
-                'repartition_type': 'tax',
-                'account_id': ref('pcg_6352'),
+                'plus_report_line_ids': [ref('account_tax_report_ro_baza_rd241')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('pcg_4426'),
+                'plus_report_line_ids': [ref('account_tax_report_ro_tva_rd241')],
+            }),
+            (0,0, {
+                'factor_percent': -50,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_4426'),
+                'plus_report_line_ids': [ref('account_tax_report_ro_tva_rd241')],
+            }),
+            (0,0, {
+                'factor_percent': 50,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_6352'),
                 'plus_report_line_ids': [ref('account_tax_report_ro_tva_rd242')],
+            }),
+            (0,0, {
+                'factor_percent': -263.16,
+                'repartition_type': 'tax',
+                'plus_report_line_ids': [ref('account_tax_report_ro_baza_rd241')],
+            }),
+            (0,0, {
+                'factor_percent': 263.16,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_6352'),
+                'plus_report_line_ids': [ref('account_tax_report_ro_baza_rd242')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5,0,0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'minus_report_line_ids': [ref('account_tax_report_ro_baza_rd242')],
-            }),
-            (0,0, {
-                'factor_percent': -50,
-                'repartition_type': 'tax',
-                'account_id': ref('pcg_4426'),
-                'plus_report_line_ids': [ref('account_tax_report_ro_tva_rd242')],
-            }),
-            (0,0, {
-                'factor_percent': 50,
-                'repartition_type': 'tax',
-                'account_id': ref('pcg_6352'),
+                'minus_report_line_ids': [ref('account_tax_report_ro_baza_rd241')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('pcg_4426'),
+                'minus_report_line_ids': [ref('account_tax_report_ro_tva_rd241')],
+            }),
+            (0,0, {
+                'factor_percent': -50,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_4426'),
+                'minus_report_line_ids': [ref('account_tax_report_ro_tva_rd241')],
+            }),
+            (0,0, {
+                'factor_percent': 50,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_6352'),
                 'minus_report_line_ids': [ref('account_tax_report_ro_tva_rd242')],
+            }),
+            (0,0, {
+                'factor_percent': -263.16,
+                'repartition_type': 'tax',
+                'minus_report_line_ids': [ref('account_tax_report_ro_baza_rd241')],
+            }),
+            (0,0, {
+                'factor_percent': 263.16,
+                'repartition_type': 'tax',
+                'account_id': ref('pcg_6352'),
+                'minus_report_line_ids': [ref('account_tax_report_ro_baza_rd242')],
             }),
         ]"/>
     </record>

--- a/addons/l10n_ro/data/account_tax_report_data.xml
+++ b/addons/l10n_ro/data/account_tax_report_data.xml
@@ -224,16 +224,16 @@
     </record>
 
     <record id="account_tax_report_ro_baza_rd92" model="account.tax.report.line">
-        <field name="name">9.2 - BAZA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 19%</field>
+        <field name="name">9.2 - BAZA - Achizitii de bunuri şi prestări de servicii nedeductibile taxabile cu cota 19%</field>
+        <field name="tag_name">09_2 - BAZA</field>
         <field name="code">tax_ro_baza_rd92</field>
         <field name="sequence" eval="25"/>
         <field name="parent_id" ref="account_tax_report_ro_baza_rd9"/>
-        <field name="formula">0.5 * tax_ro_baza_rd242</field>
         <field name="report_id" ref="tax_report"/>
     </record>
 
     <record id="account_tax_report_ro_tva_rd92" model="account.tax.report.line">
-        <field name="name">9.2 - TVA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 19%</field>
+        <field name="name">9.2 - TVA - Achizitii de bunuri şi prestări de servicii nedeductibile taxabile cu cota 19%</field>
         <field name="tag_name">09_2 - TVA</field>
         <field name="code">tax_ro_tva_rd92</field>
         <field name="sequence" eval="26"/>
@@ -278,16 +278,16 @@
     </record>
 
     <record id="account_tax_report_ro_baza_rd102" model="account.tax.report.line">
-        <field name="name">10_2 - BAZA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 9%</field>
+        <field name="name">10_2 - BAZA - Achizitii de bunuri şi prestări de servicii nedeductibile taxabile cu cota 9%</field>
+        <field name="tag_name">10_2 - BAZA</field>
         <field name="code">tax_ro_baza_rd102</field>
         <field name="sequence" eval="31"/>
-        <field name="formula">0.5 * tax_ro_baza_rd252</field>
         <field name="parent_id" ref="account_tax_report_ro_baza_rd10"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
     <record id="account_tax_report_ro_tva_rd102" model="account.tax.report.line">
-        <field name="name">10.2 - TVA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 9%</field>
+        <field name="name">10.2 - TVA - Achizitii de bunuri şi prestări de servicii nedeductibile taxabile cu cota 9%</field>
         <field name="tag_name">10_2 - TVA</field>
         <field name="code">tax_ro_tva_rd102</field>
         <field name="sequence" eval="32"/>
@@ -331,16 +331,16 @@
     </record>
 
     <record id="account_tax_report_ro_baza_rd112" model="account.tax.report.line">
-        <field name="name">11.2 - BAZA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 5%</field>
+        <field name="name">11.2 - BAZA - Achizitii de bunuri şi prestări de servicii nedeductibile taxabile cu cota 5%</field>
+        <field name="tag_name">11_2 - BAZA</field>
         <field name="code">tax_ro_baza_rd112</field>
         <field name="sequence" eval="37"/>
-        <field name="formula">0.5 * tax_ro_baza_rd262</field>
         <field name="parent_id" ref="account_tax_report_ro_baza_rd11"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
     <record id="account_tax_report_ro_tva_rd112" model="account.tax.report.line">
-        <field name="name">11.2 - TVA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 5%</field>
+        <field name="name">11.2 - TVA - Achizitii de bunuri şi prestări de servicii nedeductibile taxabile cu cota 5%</field>
         <field name="tag_name">11_2 - TVA</field>
         <field name="code">tax_ro_tva_rd112</field>
         <field name="sequence" eval="38"/>
@@ -653,6 +653,32 @@
         <field name="report_id" ref="tax_report"/>
     </record>
 
+    <record id="account_tax_report_ro_achiz_baza_ned" model="account.tax.report.line">
+        <field name="name">BAZA ACHIZIŢII DE BUNURI/ SERVICII NEDEDUCTIBILE</field>
+        <field name="sequence" eval="198"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="account_tax_report_ro_achiz_tva_ned" model="account.tax.report.line">
+        <field name="name">TVA ACHIZIŢII DE BUNURI/ SERVICII NEDEDUCTIBILE</field>
+        <field name="sequence" eval="199"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="account_tax_report_ro_baza_achiz_ned" model="account.tax.report.line">
+        <field name="name">BAZA ACHIZIŢII DE BUNURI/ SERVICII NEDEDUCTIBILE</field>
+        <field name="sequence" eval="200"/>
+        <field name="parent_id" ref="account_tax_report_ro_achiz_baza_ned"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="account_tax_report_ro_tva_achiz_ned" model="account.tax.report.line">
+        <field name="name">TVA ACHIZIŢII DE BUNURI/ SERVICII NEDEDUCTIBILE</field>
+        <field name="sequence" eval="205"/>
+        <field name="parent_id" ref="account_tax_report_ro_achiz_tva_ned"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
     <record id="account_tax_report_ro_baza_rd24" model="account.tax.report.line">
         <field name="name">24 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, altele decat cele de la rd.27</field>
         <field name="code">tax_ro_baza_rd24</field>
@@ -665,6 +691,7 @@
     <record id="account_tax_report_ro_tva_rd24" model="account.tax.report.line">
         <field name="name">24 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, altele decat cele de la rd.27</field>
         <field name="code">tax_ro_tva_rd24</field>
+        <field name="tag_name" eval="None"/>
         <field name="sequence" eval="71"/>
         <field name="parent_id" ref="account_tax_report_ro_tva_achiz"/>
         <field name="report_id" ref="tax_report"/>
@@ -689,25 +716,29 @@
     </record>
 
     <record id="account_tax_report_ro_baza_rd242" model="account.tax.report.line">
-        <field name="name">24.2 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, nedeductibile 50%</field>
+        <field name="name">24.2 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, nedeductibile</field>
         <field name="tag_name">24_2 - BAZA</field>
         <field name="code">tax_ro_baza_rd242</field>
-        <field name="sequence" eval="74"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd24"/>
+        <field name="parent_id" ref="account_tax_report_ro_baza_achiz_ned"/>
+        <field name="sequence" eval="201"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
     <record id="account_tax_report_ro_tva_rd242" model="account.tax.report.line">
-        <field name="name">24.2 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, nedeductibile 50%</field>
+        <field name="name">24.2 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, nedeductibile</field>
         <field name="tag_name">24_2 - TVA</field>
         <field name="code">tax_ro_tva_rd242</field>
-        <field name="sequence" eval="75"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd24"/>
+        <field name="parent_id" ref="account_tax_report_ro_tva_achiz_ned"/>
+        <field name="sequence" eval="206"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
     <record id="account_tax_report_ro_baza_rd24" model="account.tax.report.line">
-        <field name="formula">tax_ro_baza_rd241 + 0.5 * tax_ro_baza_rd242</field>
+        <field name="formula">tax_ro_baza_rd241</field>
+    </record>
+
+    <record id="account_tax_report_ro_tva_rd24" model="account.tax.report.line">
+        <field name="formula">tax_ro_tva_rd241</field>
     </record>
 
     <record id="account_tax_report_ro_baza_rd25" model="account.tax.report.line">
@@ -721,7 +752,7 @@
 
     <record id="account_tax_report_ro_tva_rd25" model="account.tax.report.line">
         <field name="name">25 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%</field>
-        <field name="tag_name">25 - TVA</field>
+        <field name="tag_name" eval="None"/>
         <field name="code">tax_ro_tva_rd25</field>
         <field name="sequence" eval="77"/>
         <field name="parent_id" ref="account_tax_report_ro_tva_achiz"/>
@@ -747,25 +778,29 @@
     </record>
 
     <record id="account_tax_report_ro_baza_rd252" model="account.tax.report.line">
-        <field name="name">25.2 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%, nedeductibile 50%</field>
+        <field name="name">25.2 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%, nedeductibile</field>
         <field name="tag_name">25_2 - BAZA</field>
         <field name="code">tax_ro_baza_rd252</field>
-        <field name="sequence" eval="80"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd25"/>
+        <field name="sequence" eval="202"/>
+        <field name="parent_id" ref="account_tax_report_ro_baza_achiz_ned"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
     <record id="account_tax_report_ro_tva_rd252" model="account.tax.report.line">
-        <field name="name">25.2 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%, nedeductibile 50%</field>
+        <field name="name">25.2 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%, nedeductibile</field>
         <field name="tag_name">25_2 - TVA</field>
         <field name="code">tax_ro_tva_rd252</field>
-        <field name="sequence" eval="81"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd25"/>
+        <field name="sequence" eval="207"/>
+        <field name="parent_id" ref="account_tax_report_ro_tva_achiz_ned"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
     <record id="account_tax_report_ro_baza_rd25" model="account.tax.report.line">
-        <field name="formula">tax_ro_baza_rd251 + 0.5 * tax_ro_baza_rd252</field>
+        <field name="formula">tax_ro_baza_rd251</field>
+    </record>
+
+    <record id="account_tax_report_ro_tva_rd25" model="account.tax.report.line">
+        <field name="formula">tax_ro_tva_rd251</field>
     </record>
 
     <record id="account_tax_report_ro_baza_rd26" model="account.tax.report.line">
@@ -779,6 +814,7 @@
 
     <record id="account_tax_report_ro_tva_rd26" model="account.tax.report.line">
         <field name="name">26 - TVA - Achiziţii de bunuri taxabile cu cota de 5%</field>
+        <field name="tag_name" eval="None"/>
         <field name="code">tax_ro_tva_rd26</field>
         <field name="sequence" eval="83"/>
         <field name="parent_id" ref="account_tax_report_ro_tva_achiz"/>
@@ -804,25 +840,29 @@
     </record>
 
     <record id="account_tax_report_ro_baza_rd262" model="account.tax.report.line">
-        <field name="name">26.2 - BAZA - Achiziţii de bunuri taxabile cu cota de 5%, nedeductibile 50%</field>
+        <field name="name">26.2 - BAZA - Achiziţii de bunuri taxabile cu cota de 5%, nedeductibile</field>
         <field name="tag_name">26_2 - BAZA</field>
         <field name="code">tax_ro_baza_rd262</field>
-        <field name="sequence" eval="86"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd26"/>
+        <field name="sequence" eval="203"/>
+        <field name="parent_id" ref="account_tax_report_ro_baza_achiz_ned"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
     <record id="account_tax_report_ro_tva_rd262" model="account.tax.report.line">
-        <field name="name">26.2 - TVA - Achiziţii de bunuri taxabile cu cota de 5%, nedeductibile 50%</field>
+        <field name="name">26.2 - TVA - Achiziţii de bunuri taxabile cu cota de 5%, nedeductibile</field>
         <field name="tag_name">26_2 - TVA</field>
         <field name="code">tax_ro_tva_rd262</field>
-        <field name="sequence" eval="87"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd26"/>
+        <field name="sequence" eval="208"/>
+        <field name="parent_id" ref="account_tax_report_ro_tva_achiz_ned"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
     <record id="account_tax_report_ro_baza_rd26" model="account.tax.report.line">
-        <field name="formula">tax_ro_baza_rd261 + 0.5 * tax_ro_baza_rd262</field>
+        <field name="formula">tax_ro_baza_rd261</field>
+    </record>
+
+    <record id="account_tax_report_ro_tva_rd26" model="account.tax.report.line">
+        <field name="formula">tax_ro_tva_rd261</field>
     </record>
 
     <record id="account_tax_report_ro_baza_rd27" model="account.tax.report.line">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Some accounts were not set correctly, all depreciation accounts were change to non current liabilities (it shows a lot of difference since the format changed)
Non deductible taxes were wrong distributed

Current behavior before PR:

Accounts show wrong balances in trial balance
Non deductible taxes moves generates the wrong accounting entries and show wrong info in tax report.

Desired behavior after PR is merged:

Accounts show correct balances in trial balance
Non deductible moves generates the right accounting entries and show correct info in tax report.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
