### PR TITLE
[FIX] base: add missing _name for MockIrQWeb

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -409,6 +409,8 @@ def render(template_name, values, load, **options):
         _Registry__cache = {}
 
     class MockIrQWeb(IrQWeb):
+        _name = 'ir.qweb.mock'
+
         pool = MockPool()
 
         def _get_field(self, *args):


### PR DESCRIPTION
Fixup for #82838, which could cause the following crash when creating a
new database from the DB manager UI, but not from the command-line:

```
Traceback (most recent call last):
  File "/home/odoo/15.0/odoo/service/db.py", line 63, in _initialize_db
    registry = odoo.modules.registry.Registry.new(db_name, demo, None, update_module=True)
  File "/home/odoo/15.0/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/15.0/odoo/modules/loading.py", line 415, in load_modules
    loaded_modules, processed_modules = load_module_graph(
  File "/home/odoo/15.0/odoo/modules/loading.py", line 199, in load_module_graph
    registry.init_models(cr, model_names, {'module': package.name}, new_install)
  File "/home/odoo/15.0/odoo/modules/registry.py", line 427, in init_models
    model._auto_init()
  File "/home/odoo/15.0/odoo/models.py", line 2795, in _auto_init
    raise_on_invalid_object_name(self._name)
  File "/home/odoo/15.0/odoo/models.py", line 104, in raise_on_invalid_object_name
    raise ValueError(msg)
ValueError: The _name attribute MockIrQWeb is not valid.
```

Not visible on runbot as it does not use the DB manager for creating
databases.

Fixes #82843