### PR TITLE
[FIX] web: Reconcilication widget fail on astrophe as a thousands seperator

### DIFF
--- a/addons/web/static/src/fields/parsers.js
+++ b/addons/web/static/src/fields/parsers.js
@@ -125,24 +125,27 @@ export function parsePercentage(value) {
  */
 export function parseMonetary(value, options = {}) {
     const values = value.split("&nbsp;");
-    if (values.length === 1) {
-        return parseFloat(value);
-    }
     let currency;
+    let numericValue;
+    // get the currency
     if (options.currencyId) {
         currency = session.currencies[options.currencyId];
     } else {
         currency = Object.values(session.currencies)[0];
     }
-    const symbolIndex = values.findIndex((v) => v === currency.symbol);
-    if (symbolIndex === -1) {
+    // get the numeric value (without the currency symbol)
+    if (values.length === 1) {
+        numericValue = values[0];
+    } else if (values.length === 2) {
+        numericValue = values[0] === currency.symbol ? values[1] : values[0]
+    } else {
         throw new InvalidNumberError(`"${value}" is not a correct number`);
     }
-    values.splice(symbolIndex, 1);
-    if (values.length !== 1) {
-        throw new InvalidNumberError(`"${value}" is not a correct number`);
-    }
-    return parseFloat(values[0]);
+    //check if the separator is a non html special character as parse float doesn't expect that.
+    let isMarkup = /&#[0-9a-zA-Z]{2,3};/.exec(numericValue);
+    isMarkup ? numericValue = numericValue.replace(isMarkup[0], '') : numericValue = numericValue;
+
+    return parseFloat(numericValue);
 }
 
 registry

--- a/addons/web/static/src/legacy/js/fields/field_utils.js
+++ b/addons/web/static/src/legacy/js/fields/field_utils.js
@@ -417,7 +417,7 @@ function formatSelection(value, field, options) {
 /**
  * Smart date inputs are shortcuts to write dates quicker.
  * These shortcuts should respect the format ^[+-]\d+[dmwy]?$
- * 
+ *
  * e.g.
  *   "+1d" or "+1" will return now + 1 day
  *   "-2w" will return now - 2 weeks
@@ -611,14 +611,10 @@ function parseFloat(value) {
  */
 function parseMonetary(value, field, options) {
     var values = value.split('&nbsp;');
-    if (values.length === 1) {
-        return parseFloat(value);
-    }
-    else if (values.length !== 2) {
-        throw new Error(_.str.sprintf(core._t("'%s' is not a correct monetary field"), value));
-    }
     options = options || {};
     var currency = options.currency;
+    var numericValue;
+    // get the currency
     if (!currency) {
         var currency_id = options.currency_id;
         if (!currency_id && options.data) {
@@ -627,7 +623,19 @@ function parseMonetary(value, field, options) {
         }
         currency = session.get_currency(currency_id);
     }
-    return parseFloat(values[0] === currency.symbol ? values[1] : values[0]);
+    // get the numeric value (without currency symbol)
+    if (values.length === 1) {
+        numericValue = values[0];
+    } else if (values.length === 2) {
+        numericValue = values[0] === currency.symbol ? values[1] : values[0]
+    } else {
+        throw new Error(_.str.sprintf(core._t("'%s' is not a correct monetary"), value));
+    }
+    //check if the separator is a non html special character as parse float doesn't expect that.
+    var isMarkup = /&#[0-9a-zA-Z]{2,3};/.exec(numericValue);
+    isMarkup ? numericValue = numericValue.replace(isMarkup[0], '') : numericValue = numericValue;
+
+    return parseFloat(numericValue);
 }
 
 /**

--- a/addons/web/static/tests/fields/parsers_tests.js
+++ b/addons/web/static/tests/fields/parsers_tests.js
@@ -117,6 +117,12 @@ QUnit.module("Fields", (hooks) => {
         assert.strictEqual(parseMonetary("$&nbsp;125.00", { currencyId: 3 }), 125);
         assert.strictEqual(parseMonetary("1,000.00&nbsp;€", { currencyId: 1 }), 1000);
 
+        // same tests with a different thousand separator
+        assert.strictEqual(parseMonetary("1'000.00"), 1000);
+        assert.strictEqual(parseMonetary("1'000'000.00"), 1000000);
+        assert.strictEqual(parseMonetary("$&nbsp;125'000.00", { currencyId: 3 }), 125);
+        assert.strictEqual(parseMonetary("1'000.00&nbsp;€", { currencyId: 1 }), 1000);
+
         assert.throws(() => parseMonetary("&nbsp;", { currencyId: 3 }));
         assert.throws(() => parseMonetary("1&nbsp;", { currencyId: 3 }));
         assert.throws(() => parseMonetary("&nbsp;1", { currencyId: 3 }));

--- a/addons/web/static/tests/fields/parsers_tests.js
+++ b/addons/web/static/tests/fields/parsers_tests.js
@@ -120,7 +120,7 @@ QUnit.module("Fields", (hooks) => {
         // same tests with a different thousand separator
         assert.strictEqual(parseMonetary("1'000.00"), 1000);
         assert.strictEqual(parseMonetary("1'000'000.00"), 1000000);
-        assert.strictEqual(parseMonetary("$&nbsp;125'000.00", { currencyId: 3 }), 125);
+        assert.strictEqual(parseMonetary("$&nbsp;125'000.00", { currencyId: 3 }), 125000);
         assert.strictEqual(parseMonetary("1'000.00&nbsp;€", { currencyId: 1 }), 1000);
 
         assert.throws(() => parseMonetary("&nbsp;", { currencyId: 3 }));


### PR DESCRIPTION

__Reproduction__:

- Setup new DB and change the Separator to anastrophe ```'```
- Browse to accounting -> Reconciliation (journal doesn't matter)
- Find an entry with a minimum of 4 figures to include a thousand separator
- Choose the entry and click on Manual Entry

__Result__: TB -> ```X``` is not a correct float

 This was a result of an unmatched behavior between the two functions ParseNumber and ParseMonetary which results in HTML special char (separator) not being removed.

opw-2725822

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
