### PR TITLE
[FIX]TIP Type on Popup change Tip

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -103,17 +103,16 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
         }
         async addTip() {
             // click_tip
-            const tip = this.currentOrder.get_tip();
+            let tip = this.currentOrder.get_tip();
             const change = this.currentOrder.get_change();
-            let value = tip.toFixed(this.env.pos.decimals);
 
             if (tip === 0 && change > 0) {
-                value = change;
+                tip = change;
             }
 
             const { confirmed, payload } = await this.showPopup('NumberPopup', {
                 title: tip ? this.env._t('Change Tip') : this.env._t('Add Tip'),
-                startingValue: value,
+                startingValue: tip,
             });
 
             if (confirmed) {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When user want to change tip value, this is not in preview, because
NumberPopup allows only number typeof , toFixed make value into string
typeof

Current behavior before PR:
toString converts number to string, so , NumberPopup expects number
typeof for startingValue

Desired behavior after PR is merged:
Don't convert toString before call popup, left to popup doit

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
