### PR TITLE
[FIX] project: display rating average percentage

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -743,7 +743,7 @@ class Project(models.Model):
             buttons.append({
                 'icon': 'smile-o',
                 'text': _('Satisfaction'),
-                'number': f'{self.rating_avg_percentage} %',
+                'number': f'{round(100 * self.rating_avg_percentage, 2)} %',
                 'action_type': 'object',
                 'action': 'action_view_all_rating',
                 'show': self.rating_active and self.rating_count > 0,


### PR DESCRIPTION
This PR display rating average percentage in project update right
side panel view's rating stat button instead of just displaying
rating_avg_percentange field's value.

task-2732325

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
