### PR TITLE
[FIX] account: merge account moves with the correct total amount

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2341,6 +2341,16 @@ class AccountMove(models.Model):
             'in_receipt': _('Purchase Receipt Created'),
         }[self.move_type]
 
+    def _merge_method(self, destination, source):
+        self.env['data_merge.record']._update_foreign_keys(destination=destination, source=source)
+        destination._compute_amount()
+
+        return {
+            'records_merged': len(source) + 1,
+            'log_chatter': True,
+            'post_merge': True,
+        }
+
     # -------------------------------------------------------------------------
     # RECONCILIATION METHODS
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Merging account moves didn't recompute the amounts

Steps to reproduce:
1. Install Data Cleaning and Invoicing apps
2. Go to Settings -> Technical -> Database Structure -> Models and enable merge for model 'account.move'
3. Create and save two invoices
4. Go to the list view of the invoices and select the two just created
5. Select the action 'Merge', finalize and confirm
6. The amounts of the merged invoice are not correct

Solution:
Add a merge method for account moves that will recompute the amounts

OPW-2727730