### PR TITLE
[FIX] sale_management: lines reset on template change

### DIFF
--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -87,12 +87,15 @@ class SaleOrder(models.Model):
     def _onchange_sale_order_template_id(self):
         sale_order_template = self.sale_order_template_id.with_context(lang=self.partner_id.lang)
 
-        self.order_line = [
+        order_lines_data = [fields.Command.clear()]
+        order_lines_data += [
             fields.Command.create(
                 self._compute_line_data_for_template_change(line)
             )
             for line in sale_order_template.sale_order_template_line_ids
         ]
+
+        self.order_line = order_lines_data
 
         option_lines_data = [fields.Command.clear()]
         option_lines_data += [


### PR DESCRIPTION
The removal of existing order lines on template update was unexpectedly
lost in recent code changes.

This commit brings back the old expected behavior.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
