### PR TITLE
[FIX] hr_attendance: hide create on overtime

### DIFF
--- a/addons/hr_attendance/views/hr_attendance_overtime_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_overtime_view.xml
@@ -4,7 +4,7 @@
         <field name="name">hr.attendance.overtime.tree</field>
         <field name="model">hr.attendance.overtime</field>
         <field name="arch" type="xml">
-            <tree edit="0">
+            <tree edit="0" create="0">
                 <field name="date"/>
                 <field name="employee_id"/>
                 <field name="duration" widget="float_time"/>


### PR DESCRIPTION
Current Behaviour:
- 'Create' button on hr.attendance.overtime is present but serve no purpose

Behaviour after PR:
- 'Create' button is hidden

'Create' in hr.attendance.overtime is present but has no effect because all the overtime are computed based on attendance.

opw-2730433

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
