### PR TITLE
[FIX] website_slides: broken course description

### DIFF
--- a/addons/website_slides/static/src/xml/website_slides_channel.xml
+++ b/addons/website_slides/static/src/xml/website_slides_channel.xml
@@ -31,8 +31,7 @@
                 <div class="form-group">
                     <label for="title">Description</label>
                     <textarea rows="2" class="form-control" name="description" id="description"
-                              placeholder='e.g. "Common tasks for a computer scientist is asking the right questions.
-                              In this course, you will study those topics with activities about mathematics, science and logic."' />
+                        placeholder="e.g. Common tasks for a computer scientist is asking the right questions. In this course, you will study those topics with activities about mathematics, science and logic."/>
                 </div>
                 <label id="communication-label">Review</label>
                 <div class="form-group">


### PR DESCRIPTION
before this commit, there was a gap in the placeholder description
when we create a new course.

so this commit fixes the issue by removing the gap from the description

Task Id: 2734524