### PR TITLE
Master test db manager

### DIFF
--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_db_manager
 from . import test_health
 from . import test_image
 from . import test_js

--- a/addons/web/tests/test_db_manager.py
+++ b/addons/web/tests/test_db_manager.py
@@ -1,0 +1,121 @@
+# -*- encoding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import operator
+import re
+import secrets
+from unittest.mock import patch
+
+import requests
+
+import odoo
+from odoo.tests.common import BaseCase, HttpCase, tagged
+from odoo.tools import config
+
+
+class TestDatabaseManager(HttpCase):
+    def test_database_manager(self):
+        res = self.url_open('/web/database/manager')
+        self.assertEqual(res.status_code, 200)
+
+        # check that basic existing db actions are present
+        self.assertIn('.o_database_backup', res.text)
+        self.assertIn('.o_database_duplicate', res.text)
+        self.assertIn('.o_database_delete', res.text)
+
+        # check that basic db actions are present
+        self.assertIn('.o_database_create', res.text)
+        self.assertIn('.o_database_restore', res.text)
+
+
+@tagged('-at_install', 'post_install', '-standard', 'database_operations')
+class TestDatabaseOperations(BaseCase):
+    def setUp(self):
+        self.password = secrets.token_hex()
+
+        # monkey-patch password verification
+        self.verify_admin_password_patcher = patch(
+            'odoo.tools.config.verify_admin_password', self.password.__eq__,
+        )
+        self.verify_admin_password_patcher.start()
+        self.addCleanup(self.verify_admin_password_patcher.stop)
+
+        self.db_name = config['db_name']
+        self.assertTrue(self.db_name)
+
+        # monkey-patch db-filter
+        self.addCleanup(operator.setitem, config, 'dbfilter', config['dbfilter'])
+        config['dbfilter'] = self.db_name + '-.*'
+
+        self.base_databases = self.list_dbs()
+        self.session = requests.Session()
+        self.session.get(self.url('/web/database/manager'))
+
+    def tearDown(self):
+        self.assertEqual(
+            self.list_dbs(),
+            self.base_databases,
+            'No database should have been created or removed at the end of this test',
+        )
+
+    def list_dbs(self):
+        return set(odoo.service.db.list_dbs(True))
+
+    def list_dbs_filtered(self):
+        return set(db for db in self.list_dbs() if re.match(db, config['dbfilter']))
+
+    def url(self, path):
+        return HttpCase.base_url() + path
+
+    def assertDbs(self, dbs):
+        self.assertEqual(self.list_dbs() - self.base_databases, set(dbs))
+
+    def test_database_creation(self):
+        # check verify_admin_password patch
+        self.assertTrue(odoo.tools.config.verify_admin_password(self.password))
+
+        # create a database
+        test_db_name = self.db_name + '-test-database-creation'
+        self.assertNotIn(test_db_name, self.list_dbs_filtered())
+        res = self.session.post(self.url('/web/database/create'), data={
+            'master_pwd': self.password,
+            'name': test_db_name,
+            'login': 'admin',
+            'password': 'admin',
+            'lang': 'en_US',
+            'phone': '',
+        }, allow_redirects=False)
+        self.assertEqual(res.status_code, 303)
+        self.assertIn('/web', res.headers['Location'])
+        self.assertDbs([test_db_name])
+
+        # delete the created database
+        res = self.session.post(self.url('/web/database/drop'), data={
+            'master_pwd': self.password,
+            'name': test_db_name,
+        }, allow_redirects=False)
+        self.assertEqual(res.status_code, 303)
+        self.assertIn('/web/database/manager', res.headers['Location'])
+        self.assertDbs([])
+
+    def test_database_duplicate(self):
+        # duplicate this database
+        test_db_name = self.db_name + '-test-database-duplicate'
+        self.assertNotIn(test_db_name, self.list_dbs_filtered())
+        res = self.session.post(self.url('/web/database/duplicate'), data={
+            'master_pwd': self.password,
+            'name': self.db_name,
+            'new_name': test_db_name,
+        }, allow_redirects=False)
+        self.assertEqual(res.status_code, 303)
+        self.assertIn('/web/database/manager', res.headers['Location'])
+        self.assertDbs([test_db_name])
+
+        # delete the created database
+        res = self.session.post(self.url('/web/database/drop'), data={
+            'master_pwd': self.password,
+            'name': test_db_name,
+        }, allow_redirects=False)
+        self.assertEqual(res.status_code, 303)
+        self.assertIn('/web/database/manager', res.headers['Location'])
+        self.assertDbs([])

--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -347,7 +347,7 @@ def exp_rename(old_name, new_name):
 @check_db_management_enabled
 def exp_change_admin_password(new_password):
     odoo.tools.config.set_admin_password(new_password)
-    odoo.tools.config.save()
+    odoo.tools.config.save(['admin_passwd'])
     return True
 
 @check_db_management_enabled

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -633,11 +633,17 @@ class configmanager(object):
         except ConfigParser.NoSectionError:
             pass
 
-    def save(self):
+    def save(self, keys=None):
         p = ConfigParser.RawConfigParser()
         loglevelnames = dict(zip(self._LOGLEVELS.values(), self._LOGLEVELS))
-        p.add_section('options')
+        rc_exists = os.path.exists(self.rcfile)
+        if rc_exists and keys:
+            p.read([self.rcfile])
+        if not p.has_section('options'):
+            p.add_section('options')
         for opt in sorted(self.options):
+            if keys is not None and opt not in keys:
+                continue
             if opt in ('version', 'language', 'translate_out', 'translate_in', 'overwrite_existing_translations', 'init', 'update'):
                 continue
             if opt in self.blacklist_for_save:
@@ -656,7 +662,6 @@ class configmanager(object):
 
         # try to create the directories and write the file
         try:
-            rc_exists = os.path.exists(self.rcfile)
             if not rc_exists and not os.path.exists(os.path.dirname(self.rcfile)):
                 os.makedirs(os.path.dirname(self.rcfile))
             try:


### PR DESCRIPTION
Implements test coverage for the database manager screens, which are "meta" tools that were not previously covered by the standard test suite. They require control of the super-admin password, and perform database management operations that are normally under control of the CI system.

Also modifies the way the config is saved after setting the master password in order to avoid to add config parameters unexpectedly.