### PR TITLE
[IMP] core: commit each populating batch

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6671,6 +6671,7 @@ Fields:
             if len(create_values) >= batch_size:
                 _logger.info('Batch: %s/%s', record_count, min_size)
                 records_batches.append(self.create(create_values))
+                self.env.cr.commit()
                 create_values = []
 
         if create_values:


### PR DESCRIPTION
This prevents memory issues on creating massive amount of records.
For example, on populating `account.move` table,
the process takes 10 time less memory, while execution time per batch is almost the same: ~1 minute.