### PR TITLE
[FIX] tests: report failure when module can't be loaded during tests

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -446,6 +446,8 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
         module_list = [name for (name,) in cr.fetchall()]
         if module_list:
             _logger.error("Some modules have inconsistent states, some dependencies may be missing: %s", sorted(module_list))
+            if tools.config.options['test_enable']:
+                report.record_failure()
 
         # STEP 3.6: apply remaining constraints in case of an upgrade
         registry.finalize_constraints()


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:** When running a test with `odoo --test-enable --stop-after-init --workers=0 -i $MODULE`, it might happen that the module (`$MODULE`) can't be loaded due to inconsistent dependencies. In that case, tests are completely skipped.

**Current behavior before PR:** Tests are skipped and return code is 0 (success)

**Desired behavior after PR is merged:** The return code should reflect the inconsistency in the environment.

If this is not included, the requested module is not loaded but the test passes with a correct return code (0).
By reporting a failure in that case, we can control this outcome.

I am not sure if this could have other implications, so the fix might be somewhere else... 

@Tecnativa
TT33929

ping @pedrobaeza @CarlosRoca13 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
