### PR TITLE
[IMP] barcodes(_gs1_nomenclature): add packaging case

### DIFF
--- a/addons/barcodes/models/barcode_rule.py
+++ b/addons/barcodes/models/barcode_rule.py
@@ -24,8 +24,8 @@ class BarcodeRule(models.Model):
             ('alias', 'Alias'),
             ('product', 'Unit Product'),
         ], default='product')
-    pattern = fields.Char(string='Barcode Pattern', size=32, help="The barcode matching pattern", required=True, default='.*')
-    alias = fields.Char(string='Alias', size=32, default='0', help='The matched pattern will alias to this barcode', required=True)
+    pattern = fields.Char(string='Barcode Pattern', help="The barcode matching pattern", required=True, default='.*')
+    alias = fields.Char(string='Alias', default='0', help='The matched pattern will alias to this barcode', required=True)
 
     @api.constrains('pattern')
     def _check_pattern(self):

--- a/addons/barcodes_gs1_nomenclature/data/barcodes_gs1_rules.xml
+++ b/addons/barcodes_gs1_nomenclature/data/barcodes_gs1_rules.xml
@@ -90,12 +90,12 @@
 
         <!-- Date Barcodes -->
         <record id="barcode_rule_gs1_13" model="barcode.rule">
-            <field name="name">Packaging date (YYMMDD)</field>
+            <field name="name">Pack date (YYMMDD)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
             <field name="sequence">137</field>
             <field name="encoding">gs1-128</field>
             <field name="pattern">(13)(\d{6})</field>
-            <field name="type">packaging_date</field>
+            <field name="type">pack_date</field>
             <field name="gs1_content_type">date</field>
         </record>
 

--- a/addons/barcodes_gs1_nomenclature/models/barcode_rule.py
+++ b/addons/barcodes_gs1_nomenclature/models/barcode_rule.py
@@ -22,8 +22,8 @@ class BarcodeRule(models.Model):
             ('package', 'Package'),
             ('use_date', 'Best before Date'),
             ('expiration_date', 'Expiration Date'),
-            ('package_type', 'Packaging Type'),
-            ('packaging_date', 'Packaging Date'),
+            ('package_type', 'Package Type'),
+            ('pack_date', 'Pack Date'),
         ], ondelete={
             'quantity': 'set default',
             'location': 'set default',
@@ -33,7 +33,7 @@ class BarcodeRule(models.Model):
             'use_date': 'set default',
             'expiration_date': 'set default',
             'package_type': 'set default',
-            'packaging_date': 'set default',
+            'pack_date': 'set default',
         })
     is_gs1_nomenclature = fields.Boolean(related="barcode_nomenclature_id.is_gs1_nomenclature")
     gs1_content_type = fields.Selection([

--- a/addons/barcodes_gs1_nomenclature/static/src/js/tests/barcode_parser_tests.js
+++ b/addons/barcodes_gs1_nomenclature/static/src/js/tests/barcode_parser_tests.js
@@ -75,12 +75,12 @@ QUnit.module('Barcode GS1 Parser', {
                         gs1_decimal_usage: false
                     }, {
                         id: 6,
-                        name: "Packaging date (YYMMDD)",
+                        name: "Pack date (YYMMDD)",
                         barcode_nomenclature_id: 2,
                         sequence: 103,
                         encoding: "gs1-128",
                         pattern: "(13)(\\d{6})",
-                        type: "packaging_date",
+                        type: "pack_date",
                         gs1_content_type: "date",
                         gs1_decimal_usage: false
                     }, {


### PR DESCRIPTION
The first commit removes the confusion between a package and a packaging. Here is the current situation:
![unknown](https://user-images.githubusercontent.com/26028297/149761938-9b60c4c8-d894-4a05-9990-01bd5411ea24.png)

The second one allows a user to scan a packaging (https://github.com/odoo/enterprise/pull/22952#issuecomment-1005573592)

odoo/upgrade#3180
odoo/enterprise#23550