### PR TITLE
[FIX] web_editor: prevent reloading page when searching icon

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -64,6 +64,7 @@ var MediaWidget = Widget.extend({
 
 var SearchableMediaWidget = MediaWidget.extend({
     events: _.extend({}, MediaWidget.prototype.events || {}, {
+        'keydown .o_we_search': '_onSearchKeydown',
         'input .o_we_search': '_onSearchInput',
     }),
 
@@ -104,6 +105,16 @@ var SearchableMediaWidget = MediaWidget.extend({
     // Handlers
     //--------------------------------------------------------------------------
 
+    /**
+     * @private
+     */
+    _onSearchKeydown: function (ev) {
+        // If the template contains a form that has only one input, the enter
+        // will reload the page as the html 2.0 specify this behavior.
+        if (ev.originalEvent && (ev.originalEvent.code === "Enter" || ev.originalEvent.key === "Enter")) {
+            ev.preventDefault();
+        }
+    },
     /**
      * @private
      */


### PR DESCRIPTION
Before this commit, when the user hit the key enter, in the media
dialog, in the icon tab, in the input, the page was reloaded instead
of searching for the icon.

Task-2733154




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
