### PR TITLE
[REF] delivery: Packages and Commodities in base

### DIFF
--- a/addons/delivery/models/delivery_request_objects.py
+++ b/addons/delivery/models/delivery_request_objects.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+class DeliveryPackage:
+    """ Each provider need similar information about its packages. """
+    def __init__(self, commodities, weight, package_type, name=None, total_cost=0, currency=None):
+        """ The UOMs are based on the config parameters, which is very convenient:
+        we do not need to keep those stored."""
+        self.commodities = commodities or []  # list of DeliveryCommodity objects
+        self.weight = weight
+        self.dimension = {
+            'length': package_type.packaging_length,
+            'width': package_type.width,
+            'height': package_type.height
+        }
+        self.packaging_type = package_type.shipper_package_code or False
+        self.name = name
+        self.total_cost = total_cost
+        self.currency_id = currency
+
+
+class DeliveryCommodity:
+    """ Commodities information are needed for Commercial invoices with each provider. """
+    def __init__(self, product, amount, monetary_value, country_of_origin):
+        self.product_id = product
+        self.qty = amount
+        self.monetary_value = monetary_value  # based on company currency
+        self.country_of_origin = country_of_origin


### PR DESCRIPTION
Each delivery provider, requires some information about the packages
that need to be sent as well as about the commodities (for commecial
invoices). Since this is needed by each provider, and the required
values are very similar, these packages and commodities can be done one
step ahead: in the base delivery module.

These new `_get` functions return a list of custom objects containing
the most important values concerning packages and commodities, and can
be called directly from the child classes.