### PR TITLE
[FIX] im_livechat: few changes for livechat 

### DIFF
--- a/addons/im_livechat/models/mail_channel.py
+++ b/addons/im_livechat/models/mail_channel.py
@@ -154,6 +154,15 @@ class MailChannel(models.Model):
             message_body = '<ul>%s</ul>' % (''.join(html_links))
         self._send_transient_message(self.env['res.partner'].browse(pid), message_body)
 
+    def _message_update_content_after_hook(self, message):
+        self.ensure_one()
+        if self.channel_type == 'livechat':
+            self.env['bus.bus']._sendone(self.uuid, 'mail.message/insert', {
+                'id': message.id,
+                'body': message.body,
+            })
+        super()._message_update_content_after_hook(message=message)
+
     def _get_visitor_leave_message(self, operator=False, cancel=False):
         return _('Visitor has left the conversation.')
 

--- a/addons/im_livechat/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/im_livechat/static/src/components/discuss/tests/discuss_tests.js
@@ -378,6 +378,68 @@ QUnit.test('call buttons should not be present on livechat', async function (ass
     );
 });
 
+QUnit.test('reaction button should not be present on livechat', async function (assert) {
+    assert.expect(1);
+
+    this.data['mail.channel'].records.push({
+        channel_type: 'livechat',
+        id: 10,
+        livechat_operator_id: this.data.currentPartnerId,
+        members: [this.data.currentPartnerId, this.data.publicPartnerId],
+    });
+    await this.start({
+        discuss: {
+            params: {
+                default_active_id: 'mail.channel_10',
+            },
+        },
+    });
+    await afterNextRender(() => {
+        document.querySelector(`.o_ComposerTextInput_textarea`).focus();
+        document.execCommand('insertText', false, "Test");
+    });
+    await afterNextRender(() =>
+        document.querySelector('.o_Composer_buttonSend').click()
+    );
+    await afterNextRender(() => document.querySelector('.o_Message').click());
+    assert.containsNone(
+        document.body,
+        '.o_MessageActionList_actionReaction',
+        "should not have action to add a reaction"
+    );
+});
+
+QUnit.test('reply button should not be present on livechat', async function (assert) {
+    assert.expect(1);
+
+    this.data['mail.channel'].records.push({
+        channel_type: 'livechat',
+        id: 10,
+        livechat_operator_id: this.data.currentPartnerId,
+        members: [this.data.currentPartnerId, this.data.publicPartnerId],
+    });
+    await this.start({
+        discuss: {
+            params: {
+                default_active_id: 'mail.channel_10',
+            },
+        },
+    });
+    await afterNextRender(() => {
+        document.querySelector(`.o_ComposerTextInput_textarea`).focus();
+        document.execCommand('insertText', false, "Test");
+    });
+    await afterNextRender(() =>
+        document.querySelector('.o_Composer_buttonSend').click()
+    );
+    await afterNextRender(() => document.querySelector('.o_Message').click());
+    assert.containsNone(
+        document.body,
+        '.o_MessageActionList_actionReply',
+        "should not have reply action"
+    );
+});
+
 });
 });
 });

--- a/addons/im_livechat/static/src/legacy/public_livechat.js
+++ b/addons/im_livechat/static/src/legacy/public_livechat.js
@@ -221,6 +221,15 @@ var LivechatButton = Widget.extend({
                 this._renderMessages();
                 return;
             }
+            case 'mail.message/insert': {
+                const message = this._messages.find(message => message._id === payload.id);
+                if (!message) {
+                    return;
+                }
+                message._body = utils.Markup(payload.body);
+                this._renderMessages()
+                return;
+            }
         }
     },
     /**
@@ -701,7 +710,8 @@ var WebsiteLivechat = AbstractThread.extend(ThreadTypingMixin, {
      * @returns {im_livechat.legacy.im_livechat.model.WebsiteLivechatMessage[]}
      */
     getMessages: function () {
-        return this._messages;
+        // ignore removed messages
+        return this._messages.filter(message => !message.isEmpty());
     },
     /**
      * @returns {Array}
@@ -2997,7 +3007,7 @@ var ThreadWidget = Widget.extend({
         this._currentThreadID = thread.getID();
 
         // copy so that reverse do not alter order in the thread object
-        var messages = _.clone(thread.getMessages({ domain: options.domain || [] }));
+        var messages = _.clone(thread.getMessages());
 
         var modeOptions = options.isCreateMode ? this._disabledOptions :
                                                     this._enabledOptions;

--- a/addons/im_livechat/static/src/models/message/message.js
+++ b/addons/im_livechat/static/src/models/message/message.js
@@ -1,6 +1,9 @@
 /** @odoo-module **/
 
-import { registerClassPatchModel } from '@mail/model/model_core';
+import {
+    registerClassPatchModel,
+    registerInstancePatchModel,
+} from '@mail/model/model_core';
 
 registerClassPatchModel('mail.message', 'im_livechat/static/src/models/message/message.js', {
     /**
@@ -21,5 +24,21 @@ registerClassPatchModel('mail.message', 'im_livechat/static/src/models/message/m
             }
         }
         return data2;
+    },
+});
+registerInstancePatchModel('mail.message', 'im_livechat/static/src/models/message/message.js', {
+
+    //----------------------------------------------------------------------
+    // Private
+    //----------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    _computeHasReactionIcon() {
+        if (this.originThread && this.originThread.channel_type === 'livechat') {
+            return false;
+        }
+        return this._super();
     },
 });

--- a/addons/im_livechat/static/src/models/message_action_list/message_action_list.js
+++ b/addons/im_livechat/static/src/models/message_action_list/message_action_list.js
@@ -1,0 +1,24 @@
+/** @odoo-module **/
+
+import { registerInstancePatchModel } from '@mail/model/model_core';
+
+registerInstancePatchModel('mail.message_action_list', 'im_livechat/static/src/models/message_action_list/message_action_list.js', {
+
+    //----------------------------------------------------------------------
+    // Private
+    //----------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    _computeHasReplyIcon() {
+        if (
+            this.message &&
+            this.message.originThread &&
+            this.message.originThread.channel_type === 'livechat'
+        ) {
+            return false;
+        }
+        return this._super();
+    }
+});


### PR DESCRIPTION
**Current behavior before PR:**

- When the operator edit or delete a message, but the livechat visitor does not
  receive the updated content.
- If the first message of a series of squashed messages is deleted, the avatar
  and the name of the author are lost on the visitor side.

**Desired behavior after PR is merged:**

- Livechat visitors will receive the updated content instantly and disable
  the reactions and replay buttons for the LiveChat channel.

- Displayed message with the avatar and the name of the author on visitor side.

Task-2678397

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
