### PR TITLE
[FIX] calendar: remove the 'With Username' in meeting invitation email

### DIFF
--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -22,7 +22,7 @@
         Hello <t t-out="object.common_name or ''">Wood Corner</t>,<br/><br/>
 
         <t t-if="is_online and target_customer">
-            Your appointment <strong t-out="object.event_id.appointment_type_id.name or ''">Schedule a Demo</strong> with <t t-out="object.event_id.user_id.name or ''">Ready Mat</t> has been booked.
+            Your appointment <strong t-out="object.event_id.appointment_type_id.name or ''">Schedule a Demo</strong> <t t-if="object.event_id.appointment_type_id.category != 'custom'"> with <t t-out="object.event_id.user_id.name or ''">Ready Mat</t></t> has been booked.
         </t>
         <t t-elif="is_online and target_responsible">
             <t t-if="customer">


### PR DESCRIPTION
Current behavior before PR:

Email of booking and canceling the meeting has "Your appointment Meeting with Username with Username has been booked".

Desired behavior after PR is merged:

We have removed the repeating word "with Username" in the email template and set the "Your appointment Meeting with username has been booked".

This is the goal of this commit.


PR #82894
Task-2713963

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
