### PR TITLE
[FIX] product: make cache invalidation more specific

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -331,11 +331,7 @@ class ProductProduct(models.Model):
         if 'product_template_attribute_value_ids' in values:
             # `_get_variant_id_for_combination` depends on `product_template_attribute_value_ids`
             self.clear_caches()
-        if 'active' in values:
-            # prefetched o2m have to be reloaded (because of active_test)
-            # (eg. product.template: product_variant_ids)
-            self.flush()
-            self.invalidate_cache()
+        elif 'active' in values:
             # `_get_first_possible_variant_id` depends on variants active state
             self.clear_caches()
         return res

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -574,8 +574,8 @@ class PricelistItem(models.Model):
         res = super(PricelistItem, self).write(values)
         # When the pricelist changes we need the product.template price
         # to be invalided and recomputed.
-        self.flush()
-        self.invalidate_cache()
+        self.env['product.template'].invalidate_cache(['price'])
+        self.env['product.product'].invalidate_cache(['price'])
         return res
 
     def _compute_price(self, price, price_uom, product, quantity=1.0, partner=False):


### PR DESCRIPTION
Some aggressive cache invalidation in the middle of method write() where
the model has children models (in the _inherits sense) causes very nasty
errors that are hard to fix.

Consider two models A and B, where B inherits from A.  Also consider two
fields a1 and a2 on A, which are thus both inherited by B.  Now take a
record from model B, and update both fields as:

    record.write({'a1': ..., 'a2': ...})

As both fields appear as related fields on model B, the method write()
puts all values in cache, then it proceeds to call the inverse method of
both fields.  The inverse method of a1 is called, and this writes on the
parent record.  Now imagine that some override on A invalidates the
whole cache.  When the inverse method of a2 is called, the field's value
on B has been invalidated, and this therefore writes the value False on
the record's parent.

This patch removes and adapt such cache invalidations:
 - Since 4b1cb41cf7a3f936a1e6d00a2bb6a6a29e82d711, the cache invalidation
   in method write() of product.product is no longer necessary.
 - The cache invalidation in method write() of product.pricelist.item
   has been made more specific: it only invalidates the field that needs
   to be recomputed.

Fixes #76946, #77042

OPW: 2657461