### PR TITLE
[FIX] hr: only show companies' Unusual days

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -444,7 +444,8 @@ class HrEmployeePrivate(models.Model):
         dfrom = datetime.combine(fields.Date.from_string(date_from), time.min).replace(tzinfo=pytz.UTC)
         dto = datetime.combine(fields.Date.from_string(date_to), time.max).replace(tzinfo=pytz.UTC)
 
-        works = {d[0].date() for d in calendar._work_intervals_batch(dfrom, dto)[False]}
+        domain = [('company_id', 'in', self.env.companies.ids)]
+        works = {d[0].date() for d in calendar._work_intervals_batch(dfrom, dto, domain=domain)[False]}
         return {fields.Date.to_string(day.date()): (day.date() not in works) for day in rrule(DAILY, dfrom, until=dto)}
 
     # ---------------------------------------------------------


### PR DESCRIPTION
The "Public Holidays" of all the companies were showing on the calendar,
even if the user was not part of them.

Now only the Public Holidays of the companies the user is logged into are shown.

TaskID: 2733480

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
