### PR TITLE
[FIX] *: Don't override HttpCase.base_url() in tests

### DIFF
--- a/addons/account/tests/test_portal_attachment.py
+++ b/addons/account/tests/test_portal_attachment.py
@@ -26,7 +26,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
             ],
         })
 
-        cls.base_url = cls.out_invoice.get_base_url()
+        cls.invoice_base_url = cls.out_invoice.get_base_url()
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_01_portal_attachment(self):
@@ -36,7 +36,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
 
         # Test public user can't create attachment without token of document
         res = self.url_open(
-            url='%s/portal/attachment/add' % self.base_url,
+            url=f'{self.invoice_base_url}/portal/attachment/add',
             data={
                 'name': "new attachment",
                 'res_model': self.out_invoice._name,
@@ -50,7 +50,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
 
         # Test public user can create attachment with token
         res = self.url_open(
-            url='%s/portal/attachment/add' % self.base_url,
+            url=f'{self.invoice_base_url}/portal/attachment/add',
             data={
                 'name': "new attachment",
                 'res_model': self.out_invoice._name,
@@ -74,7 +74,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
 
         # Test mimetype is neutered as non-admin
         res = self.url_open(
-            url='%s/portal/attachment/add' % self.base_url,
+            url=f'{self.invoice_base_url}/portal/attachment/add',
             data={
                 'name': "new attachment",
                 'res_model': self.out_invoice._name,
@@ -98,7 +98,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
 
         # Test attachment can't be removed without valid token
         res = self.opener.post(
-            url='%s/portal/attachment/remove' % self.base_url,
+            url=f'{self.invoice_base_url}/portal/attachment/remove',
             json={
                 'params': {
                     'attachment_id': create_res['id'],
@@ -112,7 +112,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
 
         # Test attachment can be removed with token if "pending" state
         res = self.opener.post(
-            url='%s/portal/attachment/remove' % self.base_url,
+            url=f'{self.invoice_base_url}/portal/attachment/remove',
             json={
                 'params': {
                     'attachment_id': create_res['id'],
@@ -131,7 +131,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
             'access_token': self.env['ir.attachment']._generate_access_token(),
         })
         res = self.opener.post(
-            url='%s/portal/attachment/remove' % self.base_url,
+            url=f'{self.invoice_base_url}/portal/attachment/remove',
             json={
                 'params': {
                     'attachment_id': attachment.id,
@@ -153,7 +153,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
             'attachment_ids': [(6, 0, attachment.ids)],
         })
         res = self.opener.post(
-            url='%s/portal/attachment/remove' % self.base_url,
+            url=f'{self.invoice_base_url}/portal/attachment/remove',
             json={
                 'params': {
                     'attachment_id': attachment.id,
@@ -168,7 +168,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
 
         # Test attachment can't be associated if no attachment token.
         res = self.opener.post(
-            url='%s/mail/chatter_post' % self.base_url,
+            url=f'{self.invoice_base_url}/mail/chatter_post',
             json={
                 'params': {
                     'res_model': self.out_invoice._name,
@@ -185,7 +185,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
 
         # Test attachment can't be associated if no main document token
         res = self.opener.post(
-            url='%s/mail/chatter_post' % self.base_url,
+            url=f'{self.invoice_base_url}/mail/chatter_post',
             json={
                 'params': {
                     'res_model': self.out_invoice._name,
@@ -204,7 +204,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
         self.assertFalse(self.out_invoice.message_ids)
         attachment.write({'res_model': 'model'})
         res = self.opener.post(
-            url='%s/mail/chatter_post' % self.base_url,
+            url=f'{self.invoice_base_url}/mail/chatter_post',
             json={
                 'params': {
                     'res_model': self.out_invoice._name,
@@ -226,7 +226,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
         # Test attachment can't be associated if not correct user
         attachment.write({'res_model': 'mail.compose.message'})
         res = self.opener.post(
-            url='%s/mail/chatter_post' % self.base_url,
+            url=f'{self.invoice_base_url}/mail/chatter_post',
             json={
                 'params': {
                     'res_model': self.out_invoice._name,
@@ -247,7 +247,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
 
         # Test attachment can be associated if all good (complete flow)
         res = self.url_open(
-            url='%s/portal/attachment/add' % self.base_url,
+            url=f'{self.invoice_base_url}/portal/attachment/add',
             data={
                 'name': "final attachment",
                 'res_model': self.out_invoice._name,
@@ -262,7 +262,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
         self.assertEqual(create_res['name'], "final attachment")
 
         res = self.opener.post(
-            url='%s/mail/chatter_post' % self.base_url,
+            url=f'{self.invoice_base_url}/mail/chatter_post',
             json={
                 'params': {
                     'res_model': self.out_invoice._name,

--- a/addons/test_website/tests/test_image_upload_progress.py
+++ b/addons/test_website/tests/test_image_upload_progress.py
@@ -7,9 +7,6 @@ from odoo.addons.web_unsplash.controllers.main import Web_Unsplash
 import odoo.tests
 
 from odoo import http
-from odoo.tools import config
-
-BASE_URL = "http://127.0.0.1:%s" % (config["http_port"],)
 
 
 @odoo.tests.common.tagged('post_install', '-at_install')
@@ -19,6 +16,8 @@ class TestImageUploadProgress(odoo.tests.HttpCase):
         self.start_tour("/test_image_progress", 'test_image_upload_progress', login="admin")
 
     def test_02_image_upload_progress_unsplash(self):
+        BASE_URL = self.base_url()
+
         def media_library_search(self, **params):
             return {"results": 0, "media": []}
 

--- a/addons/test_website/tests/test_redirect.py
+++ b/addons/test_website/tests/test_redirect.py
@@ -23,8 +23,6 @@ class TestRedirect(HttpCase):
             'groups_id': [(6, 0, [self.env.ref('base.group_portal').id])]
         })
 
-        self.base_url = "http://%s:%s" % (HOST, odoo.tools.config['http_port'])
-
     def test_01_redirect_308_model_converter(self):
 
         self.env['website.rewrite'].create({
@@ -74,36 +72,36 @@ class TestRedirect(HttpCase):
         WebsiteHttp = odoo.addons.website.models.ir_http.Http
 
         def _get_error_html(env, code, value):
-            return str(code).split('_')[-1], "CUSTOM %s" % code
+            return str(code).split('_')[-1], f"CUSTOM {code}"
 
         with patch.object(WebsiteHttp, '_get_error_html', _get_error_html):
             # Patch will avoid to display real 404 page and regenerate assets each time and unlink old one.
             # And it allow to be sur that exception id handled by handle_exception and return a "managed error" page.
 
             # published
-            resp = self.url_open("/test_website/200/name-%s" % rec_published.id, allow_redirects=False)
+            resp = self.url_open(f"/test_website/200/name-{rec_published.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/name-%s" % rec_published.id)
+            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/name-{rec_published.id}")
 
-            resp = self.url_open("/test_website/308/name-%s" % rec_published.id, allow_redirects=False)
+            resp = self.url_open(f"/test_website/308/name-{rec_published.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 200)
 
-            resp = self.url_open("/test_website/200/xx-%s" % rec_published.id, allow_redirects=False)
+            resp = self.url_open(f"/test_website/200/xx-{rec_published.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/xx-%s" % rec_published.id)
+            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/xx-{rec_published.id}")
 
-            resp = self.url_open("/test_website/308/xx-%s" % rec_published.id, allow_redirects=False)
+            resp = self.url_open(f"/test_website/308/xx-{rec_published.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 301)
-            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/name-%s" % rec_published.id)
+            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/name-{rec_published.id}")
 
-            resp = self.url_open("/test_website/200/xx-%s" % rec_published.id, allow_redirects=True)
+            resp = self.url_open(f"/test_website/200/xx-{rec_published.id}", allow_redirects=True)
             self.assertEqual(resp.status_code, 200)
-            self.assertEqual(resp.url, self.base_url + "/test_website/308/name-%s" % rec_published.id)
+            self.assertEqual(resp.url, f"{self.base_url()}/test_website/308/name-{rec_published.id}")
 
             # unexisting
             resp = self.url_open("/test_website/200/name-100", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/name-100")
+            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/name-100")
 
             resp = self.url_open("/test_website/308/name-100", allow_redirects=False)
             self.assertEqual(resp.status_code, 404)
@@ -111,26 +109,26 @@ class TestRedirect(HttpCase):
 
             resp = self.url_open("/test_website/200/xx-100", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/xx-100")
+            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/xx-100")
 
             resp = self.url_open("/test_website/308/xx-100", allow_redirects=False)
             self.assertEqual(resp.status_code, 404)
             self.assertEqual(resp.text, "CUSTOM 404")
 
             # unpublish
-            resp = self.url_open("/test_website/200/name-%s" % rec_unpublished.id, allow_redirects=False)
+            resp = self.url_open(f"/test_website/200/name-{rec_unpublished.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/name-%s" % rec_unpublished.id)
+            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/name-{rec_unpublished.id}")
 
-            resp = self.url_open("/test_website/308/name-%s" % rec_unpublished.id, allow_redirects=False)
+            resp = self.url_open(f"/test_website/308/name-{rec_unpublished.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 403)
             self.assertEqual(resp.text, "CUSTOM 403")
 
-            resp = self.url_open("/test_website/200/xx-%s" % rec_unpublished.id, allow_redirects=False)
+            resp = self.url_open(f"/test_website/200/xx-{rec_unpublished.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/xx-%s" % rec_unpublished.id)
+            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/xx-{rec_unpublished.id}")
 
-            resp = self.url_open("/test_website/308/xx-%s" % rec_unpublished.id, allow_redirects=False)
+            resp = self.url_open(f"/test_website/308/xx-{rec_unpublished.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 403)
             self.assertEqual(resp.text, "CUSTOM 403")
 
@@ -138,24 +136,24 @@ class TestRedirect(HttpCase):
             rec_published.seo_name = "seo_name"
             rec_unpublished.seo_name = "seo_name"
 
-            resp = self.url_open("/test_website/200/seo-name-%s" % rec_published.id, allow_redirects=False)
+            resp = self.url_open(f"/test_website/200/seo-name-{rec_published.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/seo-name-%s" % rec_published.id)
+            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/seo-name-{rec_published.id}")
 
-            resp = self.url_open("/test_website/308/seo-name-%s" % rec_published.id, allow_redirects=False)
+            resp = self.url_open(f"/test_website/308/seo-name-{rec_published.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 200)
 
-            resp = self.url_open("/test_website/200/xx-%s" % rec_unpublished.id, allow_redirects=False)
+            resp = self.url_open(f"/test_website/200/xx-{rec_unpublished.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/xx-%s" % rec_unpublished.id)
+            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/xx-{rec_unpublished.id}")
 
-            resp = self.url_open("/test_website/308/xx-%s" % rec_unpublished.id, allow_redirects=False)
+            resp = self.url_open(f"/test_website/308/xx-{rec_unpublished.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 403)
             self.assertEqual(resp.text, "CUSTOM 403")
 
             resp = self.url_open("/test_website/200/xx-100", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/xx-100")
+            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/xx-100")
 
             resp = self.url_open("/test_website/308/xx-100", allow_redirects=False)
             self.assertEqual(resp.status_code, 404)

--- a/odoo/addons/test_auth_custom/tests/test_endpoints.py
+++ b/odoo/addons/test_auth_custom/tests/test_endpoints.py
@@ -15,7 +15,7 @@ class TestCustomAuth(HttpCase):
 
         # but preflight should work
         self.env['base'].flush()
-        url = "http://%s:%s/test_auth_custom/json" % (HOST, odoo.tools.config['http_port'])
+        url = f"{self.base_url()}/test_auth_custom/json"
         r = self.opener.options(url, headers={
             'Origin': 'localhost',
             'Access-Control-Request-Method': 'QUX',
@@ -26,6 +26,7 @@ class TestCustomAuth(HttpCase):
         self.assertEqual(r.headers['Access-Control-Allow-Methods'], 'POST', "json is always POST")
         self.assertNotIn('XYZ', r.headers['Access-Control-Allow-Headers'], "headers are ignored")
 
+    @odoo.tools.mute_logger('odoo.http')
     def test_http(self):
         # straight request should fail
         r = self.url_open('/test_auth_custom/http')
@@ -33,7 +34,7 @@ class TestCustomAuth(HttpCase):
 
         # but preflight should work
         self.env['base'].flush()
-        url = "http://%s:%s/test_auth_custom/http" % (HOST, odoo.tools.config['http_port'])
+        url = f"{self.base_url()}/test_auth_custom/http"
         r = self.opener.options(url, headers={
             'Origin': 'localhost',
             'Access-Control-Request-Method': 'QUX',

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -71,6 +71,7 @@ _logger = logging.getLogger(__name__)
 # The odoo library is supposed already configured.
 ADDONS_PATH = odoo.tools.config['addons_path']
 HOST = '127.0.0.1'
+PORT = odoo.tools.config['http_port']
 # Useless constant, tests are aware of the content of demo data
 ADMIN_USER_ID = odoo.SUPERUSER_ID
 
@@ -1523,7 +1524,7 @@ class HttpCase(TransactionCase):
 
     def url_open(self, url, data=None, files=None, timeout=10, headers=None, allow_redirects=True, head=False):
         if url.startswith('/'):
-            url = "http://%s:%s%s" % (HOST, odoo.tools.config['http_port'], url)
+            url = self.base_url() + url
         if head:
             return self.opener.head(url, data=data, files=files, timeout=timeout, headers=headers, allow_redirects=False)
         if data or files:
@@ -1660,7 +1661,7 @@ class HttpCase(TransactionCase):
 
     @classmethod
     def base_url(cls):
-        return "http://%s:%s" % (HOST, odoo.tools.config['http_port'])
+        return f"http://{HOST}:{PORT}"
 
     def start_tour(self, url_path, tour_name, step_delay=None, **kwargs):
         """Wrapper for `browser_js` to start the given `tour_name` with the


### PR DESCRIPTION
Multiple tests were wrongly overriding `base_url` instead of using the
`base_url` method of HttpCase.
