### PR TITLE
[FIX] project: prevent issue on description field resize in form

### DIFF
--- a/addons/project/static/src/js/project_form.js
+++ b/addons/project/static/src/js/project_form.js
@@ -123,6 +123,7 @@ const FormDescriptionExpanderRenderer = FormRenderer.extend(Object.assign({}, Fo
     // 58px is the sum of the top margin of o_form_sheet 12 px + the bottom padding of o_form_sheet 24px
     // + 5px margin bottom (o_field_widget) + 1px border + the bottom padding of tab-pane 16 px.
     bottomDistance: 58,
+    fieldQuerySelector: '.o_xxl_form_view .oe_form_field.oe_form_field_html[name="description"]',
 }));
 
 export const FormDescriptionExpanderView = FormView.extend({


### PR DESCRIPTION
Prior to this commit:

    - The selector used by the FormHtmlFieldExpanderMixin is the generic one
      '.o_xxl_form_view .oe_form_field.oe_form_field_html'. This selector, altough
      valid, could lead to an undesired behavior if another html field is present
      previously (before the description one) in the view.

After this commit:

    - The '[name="description"] is added to the selector which reduces the possible
      matches only to the one of the description field.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
