### PR TITLE
[FIX] media link tool

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4717,17 +4717,17 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
     /**
      * @override
      */
-    async start() {
+    onFocus() {
         core.bus.on('activate_image_link_tool', this, this._activateLinkTool);
-        return this._super(...arguments);
+        // When we start editing an image, rerender the UI to ensure the
+        // we-select that suggests the anchors is in a consistent state.
+        this.rerender = true;
     },
     /**
      * @override
      */
-    onFocus() {
-        // When we start editing an image, rerender the UI to ensure the
-        // we-select that suggests the anchors is in a consistent state.
-        this.rerender = true;
+    onBlur() {
+        core.bus.off('activate_image_link_tool', this, this._activateLinkTool);
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1312,7 +1312,7 @@ const Wysiwyg = Widget.extend({
         // Open the link tool when CTRL+K is pressed.
         if (e && e.key === 'k' && (e.ctrlKey || e.metaKey)) {
             e.preventDefault();
-            const targetEl = this.odooEditor.document.getSelection().baseNode; // FIXME this is undefined on Firefox after clicking on an image and hitting CTRL-K
+            const targetEl = this.odooEditor.document.getSelection().getRangeAt(0).startContainer;
             // Link tool is different if the selection is an image or a text.
             if (targetEl instanceof HTMLElement
                     && (targetEl.tagName === 'IMG' || targetEl.querySelectorAll('img').length === 1)) {


### PR DESCRIPTION
This fix the media link tool shortcut
- The CTRL + K shortcut never worked on firefox.
- The shortcut activated the link tool on all started images

--
task-2666467

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
