### PR TITLE
[FIX] web_editor: fix width/height of img set to 0 when not visible

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -341,7 +341,7 @@ function toInline($editable, cssRules) {
     // Fix outlook image rendering bug (this change will be kept in both
     // fields).
     _.each(['width', 'height'], function (attribute) {
-        $editable.find('img').attr(attribute, function () {
+        $editable.find('img:visible').attr(attribute, function () {
             return $(this)[attribute]();
         }).css(attribute, function () {
             return $(this).get(0).style[attribute] || attribute === 'width' ? $(this)[attribute]() + 'px' : '';


### PR DESCRIPTION
- Go to Email Marketing and create a new mailing
- Select a template containing an image
- Swith to any tab other than "Mail Body"
- Save
Every images will have a width and height of 0 applied to them.

Upon save, width and height attributes of all img are set with
their actual size in JS.
As they are not visible, these values are 0.

This fix ignores it if the img is not visible.

opw-2686316
opw-2735636




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
