### PR TITLE
[IMP] payment_buckaroo: accept webhook notifications

### DIFF
--- a/addons/payment_buckaroo/tests/common.py
+++ b/addons/payment_buckaroo/tests/common.py
@@ -18,6 +18,19 @@ class BuckarooCommon(PaymentCommon):
         'brq_signature': '5d389aa4f563cd99666a2e6bef79da3d4a32eb50',
     }
 
+    ASYNC_NOTIFICATION_DATA = {
+        'brq_transactions': '0123456789ABCDEF0123456789ABCDEF',
+        'brq_transaction_method': 'paypal',
+        'brq_statuscode': '190',  # confirmed
+        'brq_statusmessage': 'Transaction successfully processed',
+        'brq_invoicenumber': 'Test Transaction',  # Shamefully copy-pasted from payment
+        'brq_amount': '1111.11',
+        'brq_currency': 'USD',
+        'brq_timestamp': '2022-01-01 12:00:00',
+        'brq_transaction_type': 'V010',
+        'brq_signature': '9ba976c3a6a3d2d1b5b58d3aa8c2c6fe269a9c27',
+    }
+
     @classmethod
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)


### PR DESCRIPTION
Before this commit, it was not possible for a Buckaroo acquirer to
accept asynchronous notifications for payment updates. This is
important because, without them, an acquirer can only rely on
synchronous notifications (i.e. redirect requests from the provider's
checkout page) which can be unreliable and do not allow receiving
status updates, should payments take a bit longer to be confirmed by the
provider.

This commit adds a webhook controller whose route can be configured in
Buckaroo Plaza (backend) to send asynchronous notifications.

See also:
- https://github.com/odoo/documentation/pull/1481

task-2687586