### PR TITLE
[IMP] project: improve tags management

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -923,7 +923,7 @@
                             <field name="partner_id" widget="res_partner_many2one" class="o_task_customer_field"/>
                             <field name="partner_phone" widget="phone" attrs="{'invisible': True}"/>
                             <field name="date_deadline" attrs="{'invisible': [('is_closed', '=', True)]}"/>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" context="{'project_id': project_id}"/>
                             <field name="recurring_task" attrs="{'invisible': [('allow_recurring_tasks', '=', False)]}" />
                             <field name="legend_blocked" invisible="1"/>
                             <field name="legend_normal" invisible="1"/>
@@ -1210,7 +1210,7 @@
                     <field name="company_id" groups="base.group_multi_company" optional="show"/>
                     <field name="activity_ids" widget="list_activity" optional="show"/>
                     <field name="date_deadline" optional="hide" widget="remaining_days" attrs="{'invisible': [('is_closed', '=', True)]}"/>
-                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show" context="{'project_id': project_id}"/>
                     <field name="rating_last_text" string="Rating" decoration-danger="rating_last_text == 'ko'"
                         decoration-warning="rating_last_text == 'ok'" decoration-success="rating_last_text == 'top'"
                         attrs="{'invisible': [('rating_last_text', '=', 'none')]}"


### PR DESCRIPTION
In big databases, the number of tags becomes rapidly huge. This makes
it very hard to find revelant tags. In practice, the same few tags are
usually used in a given project.

This commit:
- Limits the search of tags to the project's tags of the task as well
  as to the tasks' tags of the task's project.
- Prevents creating case sensitive variants of existing tags.
- Reuse existing tags from other projects and other projects' tasks
  when the user `creates` (or at least thinks creating as the
  _name_search would not return the searched tag) a new tag in his project.

task-2735833

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
