### PR TITLE
[FIX] payment_buckaroo: prevent creating new session for returning users

### DIFF
--- a/addons/payment_buckaroo/controllers/main.py
+++ b/addons/payment_buckaroo/controllers/main.py
@@ -12,9 +12,19 @@ _logger = logging.getLogger(__name__)
 class BuckarooController(http.Controller):
     _return_url = '/payment/buckaroo/return'
 
-    @http.route(_return_url, type='http', auth='public', methods=['POST'], csrf=False)
+    @http.route(
+        _return_url, type='http', auth='public', methods=['POST'], csrf=False, save_session=False
+    )
     def buckaroo_return_from_redirect(self, **data):
         """ Process the data returned by Buckaroo after redirection.
+
+        The route is flagged with `save_session=False` to prevent Odoo from assigning a new session
+        to the user if they are redirected to this route with a POST request. Indeed, as the session
+        cookie is created without a `SameSite` attribute, some browsers that don't implement the
+        recommended default `SameSite=Lax` behavior will not include the cookie in the redirection
+        request from the payment provider to Odoo. As the redirection to the '/payment/status' page
+        will satisfy any specification of the `SameSite` attribute, the session of the user will be
+        retrieved and with it the transaction which will be immediately post-processed.
 
         :param dict data: The feedback data
         """


### PR DESCRIPTION
Before this commit, users returning from Buckaroo to Odoo after payment
could see their session renewed, depending on their browser's
implementation of the `SameSite` cookie attribute. This prevented Odoo
from retrieving the transaction from the users' session.

This commit flags the return route of Buckaroo with
`save_session=False`, hence allowing all users to immediately
post-process their transactions when they return to Odoo.
