### PR TITLE
[FIX] l10n_latam_invoice_document: refund doc type

### DIFF
--- a/addons/l10n_latam_invoice_document/wizards/account_move_reversal.py
+++ b/addons/l10n_latam_invoice_document/wizards/account_move_reversal.py
@@ -8,10 +8,14 @@ class AccountMoveReversal(models.TransientModel):
     _inherit = "account.move.reversal"
 
     l10n_latam_use_documents = fields.Boolean(compute='_compute_document_type')
-    l10n_latam_document_type_id = fields.Many2one('l10n_latam.document.type', 'Document Type', ondelete='cascade', domain="[('id', 'in', l10n_latam_available_document_type_ids)]", compute='_compute_document_type', readonly=False)
+    l10n_latam_document_type_id = fields.Many2one('l10n_latam.document.type', 'Document Type', ondelete='cascade', domain="[('id', 'in', l10n_latam_available_document_type_ids)]", compute='_compute_document_type', readonly=False, inverse='_inverse_document_type')
     l10n_latam_available_document_type_ids = fields.Many2many('l10n_latam.document.type', compute='_compute_document_type')
     l10n_latam_document_number = fields.Char(string='Document Number')
     l10n_latam_manual_document_number = fields.Boolean(compute='_compute_l10n_latam_manual_document_number', string='Manual Number')
+
+    def _inverse_document_type(self):
+        self._clean_pipe()
+        self.l10n_latam_document_number = '%s|%s' % (self.l10n_latam_document_type_id.id or '', self.l10n_latam_document_number or '')
 
     @api.depends('l10n_latam_document_type_id')
     def _compute_l10n_latam_manual_document_number(self):
@@ -59,15 +63,32 @@ class AccountMoveReversal(models.TransientModel):
         """ Set the default document type and number in the new revsersal move taking into account the ones selected in
         the wizard """
         res = super()._prepare_default_reversal(move)
-        res.update({
-            'l10n_latam_document_type_id': self.l10n_latam_document_type_id.id,
-            'l10n_latam_document_number': self.l10n_latam_document_number,
-        })
+        # self.l10n_latam_document_number will have a ',' only if l10n_latam_document_type_id is changed and inverse methods is called
+        if self.l10n_latam_document_number and '|' in self.l10n_latam_document_number:
+            l10n_latam_document_type_id, l10n_latam_document_number = self.l10n_latam_document_number.split('|')
+            res.update({
+                'l10n_latam_document_type_id': int(l10n_latam_document_type_id) if l10n_latam_document_type_id else False,
+                'l10n_latam_document_number': l10n_latam_document_number or False,
+            })
+        else:
+            res.update({
+                'l10n_latam_document_type_id': self.l10n_latam_document_type_id.id,
+                'l10n_latam_document_number': self.l10n_latam_document_number,
+            })
         return res
+
+    def _clean_pipe(self):
+        """ Clean pipe in case the user confirm but he gets a raise, the l10n_latam_document_number is stored now
+        with the doc type id, we should remove to append new one or to format properly"""
+        latam_document = self.l10n_latam_document_number or ''
+        if '|' in latam_document:
+            latam_document = latam_document[latam_document.index('|')+1:]
+        self.l10n_latam_document_number = latam_document
 
     @api.onchange('l10n_latam_document_number', 'l10n_latam_document_type_id')
     def _onchange_l10n_latam_document_number(self):
         if self.l10n_latam_document_type_id:
+            self._clean_pipe()
             l10n_latam_document_number = self.l10n_latam_document_type_id._format_document_number(
                 self.l10n_latam_document_number)
             if self.l10n_latam_document_number != l10n_latam_document_number:


### PR DESCRIPTION
Prior to this change, if the user use a full refund option and choose a document type different than default one, the default document type was use regardless of the choosen one.

This was broken on this commit dfd01b8#diff-1369ca152be95632086495cfcfbd54a0d18d893c2389670ff1d516f1596f3e0d

As l10n_latam_document_type_id is not stored, it's change is not saved and sended to to backend. We make this hack so that we don't break stable policy

This should be FP only till v15, on master this should be applied https://github.com/odoo/odoo/pull/82670




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
