### PR TITLE
[14.0][FIX] - Fix monetary title in list view

### DIFF
--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -556,7 +556,7 @@ var ListRenderer = BasicRenderer.extend({
         var formattedValue = formatter(value, field, formatOptions);
         var title = '';
         if (field.type !== 'boolean') {
-            title = formatter(value, field, _.extend(formatOptions, {escape: false}));
+            title = formatter(value, field, _.extend(formatOptions, {escape: false, forceString: true}));
         }
         return $td.html(formattedValue).attr('title', title);
     },


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR fix the title for monetary fields in list view

Current behavior before PR:

![2022-01-17_18-57](https://user-images.githubusercontent.com/12665409/149818319-c179b246-6640-49fc-b389-2b7ec0dedd6e.png)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
