### PR TITLE
[FIX] mass_mailing: fix emoji widget position

### DIFF
--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -1,7 +1,7 @@
 .o_form_view.o_mass_mailing_mailing_form {
 
     input.o_field_char.o_field_widget {
-        padding-right: 30px; // Avoid overlapping subject text on emoji widget
+        padding-right: 40px; // Avoid overlapping subject text on emoji widget
     }
 
     .o_notebook .tab-content .tab-pane .o_mail_body {
@@ -62,6 +62,7 @@
             margin-right: -50px;
         }
         .o_mail_emojis_dropdown {
+            margin-left: -40px;
             bottom: 0;
         }
         span.o_field_char {


### PR DESCRIPTION
Current behavior before PR:
When editing a mailing in "wide" mode, the emoji widget is outside of the subject field

Desired behavior after PR is merged:
The emoji widget will be inside the subject field

Task: https://www.odoo.com/web#id=2826521&menu_id=4720&cids=2&action=4043&model=project.task&view_type=form

--
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)