### PR TITLE
[FIX] tests: fix test retry mechanism for subtests

### DIFF
--- a/odoo/addons/base/tests/test_test_retry.py
+++ b/odoo/addons/base/tests/test_test_retry.py
@@ -28,3 +28,23 @@ class TestRetryFailures(BaseCase):
 
     def test_retry_failure_log(self):
         _logger.error('Failure')
+
+
+@tagged('-standard', 'test_retry', 'test_retry_success', 'subtest_retry_success')
+class TestRetrySubtest(BaseCase):
+    def test_retry_subtest_success_subtest(self):
+        with self.subTest():
+            tests_run_count = int(os.environ.get('ODOO_TEST_FAILURE_RETRIES', 0)) + 1
+            self.count = getattr(self, 'count', 0) + 1
+            self.assertEqual(tests_run_count, self.count)
+
+
+@tagged('-standard', 'test_retry', 'test_retry_failures', 'subtest_retry_failures')
+class TestRetrySubtestFailures(BaseCase):
+    def test_retry_subtest_failure_assert(self):
+        with self.subTest():
+            self.assertFalse(1 == 1)
+
+    def test_retry_subtest_failure_log(self):
+        with self.subTest():
+            _logger.error('Failure')

--- a/odoo/tests/runner.py
+++ b/odoo/tests/runner.py
@@ -108,6 +108,8 @@ class OdooTestResult(unittest.result.TestResult):
             else:
                 flavour = "ERROR"
             self.logError(flavour, subtest, err)
+        if self._soft_fail:
+            return
         super().addSubTest(test, subtest, err)
 
     def addSkip(self, test, reason):


### PR DESCRIPTION
When a subtest fails, the failure or error is taken into account and even if
the subtest was silenced the test itself logs an ERROR with the count of
failures.

With this commit, at the first try, the subtest result is not taken into
account.

Example of such an issue:
https://runbot.odoo.com/runbot/build/12208163