### PR TITLE
[IMP] {event_}sms, test_mail_full: remove record count in SMS composer

### DIFF
--- a/addons/event_sms/models/event_mail.py
+++ b/addons/event_sms/models/event_mail.py
@@ -49,9 +49,8 @@ class EventMailScheduler(models.Model):
                     continue
                 # Do not send SMS if the communication was scheduled before the event but the event is over
                 if scheduler.scheduled_date <= now and (scheduler.interval_type != 'before_event' or scheduler.event_id.date_end > now):
-                    self.env['event.registration']._message_sms_schedule_mass(
+                    scheduler.event_id.registration_ids.filtered(lambda registration: registration.state != 'cancel')._message_sms_schedule_mass(
                         template=scheduler.template_ref,
-                        active_domain=[('event_id', '=', scheduler.event_id.id), ('state', '!=', 'cancel')],
                         mass_keep_log=True
                     )
                     scheduler.update({

--- a/addons/sms/models/mail_thread.py
+++ b/addons/sms/models/mail_thread.py
@@ -153,25 +153,19 @@ class MailThread(models.AbstractModel):
                 }
         return result
 
-    def _message_sms_schedule_mass(self, body='', template=False, active_domain=None, **composer_values):
+    def _message_sms_schedule_mass(self, body='', template=False, **composer_values):
         """ Shortcut method to schedule a mass sms sending on a recordset.
 
         :param template: an optional sms.template record;
-        :param active_domain: bypass self.ids and apply composer on active_domain
-          instead;
         """
         composer_context = {
             'default_res_model': self._name,
             'default_composition_mode': 'mass',
             'default_template_id': template.id if template else False,
+            'default_res_ids': self.ids,
         }
         if body and not template:
             composer_context['default_body'] = body
-        if active_domain is not None:
-            composer_context['default_use_active_domain'] = True
-            composer_context['default_active_domain'] = repr(active_domain)
-        else:
-            composer_context['default_res_ids'] = self.ids
 
         create_vals = {
             'mass_force_send': False,

--- a/addons/sms/wizard/sms_composer_views.xml
+++ b/addons/sms/wizard/sms_composer_views.xml
@@ -11,7 +11,6 @@
                         <field name="comment_single_recipient" invisible="1"/>
                         <field name="res_id" invisible="1"/>
                         <field name="res_ids" invisible="1"/>
-                        <field name="active_domain" invisible="1"/>
                         <field name="res_model" invisible="1"/>
                         <field name="mass_force_send" invisible="1"/>
                         <field name="recipient_single_valid" invisible="1"/>
@@ -28,15 +27,10 @@
 
                         <!-- Mass mode information (res_ids versus active domain) -->
                         <div colspan="2" class="alert alert-info text-center mb-3" role="alert"
-                                attrs="{'invisible': [('comment_single_recipient', '=', True)]}">
+                                attrs="{'invisible': ['|', ('comment_single_recipient', '=', True), ('recipient_invalid_count', '=', 0)]}">
                             <p class="my-0">
-                                <span attrs="{'invisible': [('use_active_domain', '=', 'True')]}">
-                                    <field class="oe_inline font-weight-bold" name="res_ids_count"/> records selected.
-                                </span>
-                                Check <field class="oe_inline ml-2" name="use_active_domain"/> to send to all
-                                <field class="oe_inline font-weight-bold ml-2" name="active_domain_count"/> records instead. <br/>
-                                <field class="oe_inline font-weight-bold" name="recipient_valid_count"/> recipients are valid
-                                and <field class="oe_inline font-weight-bold" name="recipient_invalid_count"/> are invalid.
+                                <field class="oe_inline font-weight-bold" name="recipient_invalid_count"/> out of
+                                <field class="oe_inline font-weight-bold" name="res_ids_count"/> recipients have an invalid phone number and will not receive this text message.
                             </p>
                         </div>
 

--- a/addons/test_mail_full/tests/test_sms_composer.py
+++ b/addons/test_mail_full/tests/test_sms_composer.py
@@ -215,46 +215,12 @@ class TestSMSComposerBatch(TestMailFullCommon):
         cls._create_records_for_batch('mail.test.sms', 3)
         cls.sms_template = cls._create_sms_template('mail.test.sms')
 
-    def test_composer_batch_active_domain(self):
-        with self.with_user('employee'):
-            composer = self.env['sms.composer'].with_context(
-                default_composition_mode='comment',
-                default_res_model='mail.test.sms',
-                default_use_active_domain=True,
-                active_domain=[('id', 'in', self.records.ids)],
-            ).create({
-                'body': self._test_body,
-            })
-
-            with self.mockSMSGateway():
-                messages = composer._action_send_sms()
-
-        for record in self.records:
-            self.assertSMSNotification([{'partner': r.customer_id} for r in self.records], 'Zizisse an SMS.', messages)
-
     def test_composer_batch_active_ids(self):
         with self.with_user('employee'):
             composer = self.env['sms.composer'].with_context(
                 default_composition_mode='comment',
                 default_res_model='mail.test.sms',
                 active_ids=self.records.ids
-            ).create({
-                'body': self._test_body,
-            })
-
-            with self.mockSMSGateway():
-                messages = composer._action_send_sms()
-
-        for record in self.records:
-            self.assertSMSNotification([{'partner': r.customer_id} for r in self.records], 'Zizisse an SMS.', messages)
-
-    def test_composer_batch_domain(self):
-        with self.with_user('employee'):
-            composer = self.env['sms.composer'].with_context(
-                default_composition_mode='comment',
-                default_res_model='mail.test.sms',
-                default_use_active_domain=True,
-                default_active_domain=repr([('id', 'in', self.records.ids)]),
             ).create({
                 'body': self._test_body,
             })
@@ -291,42 +257,6 @@ class TestSMSComposerMass(TestMailFullCommon):
 
         cls._create_records_for_batch('mail.test.sms', 3)
         cls.sms_template = cls._create_sms_template('mail.test.sms')
-
-    def test_composer_mass_active_domain(self):
-        with self.with_user('employee'):
-            composer = self.env['sms.composer'].with_context(
-                default_composition_mode='mass',
-                default_res_model='mail.test.sms',
-                default_use_active_domain=True,
-                active_domain=[('id', 'in', self.records.ids)],
-            ).create({
-                'body': self._test_body,
-                'mass_keep_log': False,
-            })
-
-            with self.mockSMSGateway():
-                composer.action_send_sms()
-
-        for record in self.records:
-            self.assertSMSOutgoing(record.customer_id, None, content=self._test_body)
-
-    def test_composer_mass_active_domain_w_template(self):
-        with self.with_user('employee'):
-            composer = self.env['sms.composer'].with_context(
-                default_composition_mode='mass',
-                default_res_model='mail.test.sms',
-                default_use_active_domain=True,
-                active_domain=[('id', 'in', self.records.ids)],
-                default_template_id=self.sms_template.id,
-            ).create({
-                'mass_keep_log': False,
-            })
-
-            with self.mockSMSGateway():
-                composer.action_send_sms()
-
-        for record in self.records:
-            self.assertSMSOutgoing(record.customer_id, None, content='Dear %s this is an SMS.' % record.display_name)
 
     def test_composer_mass_active_ids(self):
         with self.with_user('employee'):

--- a/addons/test_mail_full/tests/test_sms_performance.py
+++ b/addons/test_mail_full/tests/test_sms_performance.py
@@ -107,33 +107,31 @@ class TestSMSMassPerformance(BaseMailPerformance, sms_common.MockSMS):
     @mute_logger('odoo.addons.sms.models.sms_sms')
     @users('employee')
     @warmup
-    def test_composer_mass_active_domain(self):
+    def test_sms_composer_mass(self):
         composer = self.env['sms.composer'].with_context(
             default_composition_mode='mass',
             default_res_model='mail.test.sms',
-            default_use_active_domain=True,
-            active_domain=[('id', 'in', self.records.ids)],
+            active_ids=self.records.ids,
         ).create({
             'body': self._test_body,
             'mass_keep_log': False,
         })
 
-        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=57):
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=56):
             composer.action_send_sms()
 
     @mute_logger('odoo.addons.sms.models.sms_sms')
     @users('employee')
     @warmup
-    def test_composer_mass_active_domain_w_log(self):
+    def test_sms_composer_mass_w_log(self):
         composer = self.env['sms.composer'].with_context(
             default_composition_mode='mass',
             default_res_model='mail.test.sms',
-            default_use_active_domain=True,
-            active_domain=[('id', 'in', self.records.ids)],
+            active_ids=self.records.ids,
         ).create({
             'body': self._test_body,
             'mass_keep_log': True,
         })
 
-        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=59):
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=58):
             composer.action_send_sms()


### PR DESCRIPTION
Currently we have the record counter in sms composer wizard, that allows
us to select all the records with given active domain (so that instead of
just the records selected by user, SMS can be sent on all the records
matching the active domain).

However, now in standard, we already have a feature that allows user to
not only select records in the current page, but from all the records
matching the current domain in list view. So, in the SMS composer, the
feature to select all records is not much useful, and repeats the
information user already has.

With this commit, we remove this feature and it's related code, to make
the composer simpler and align it with what has been done for the
mail composer. We also improve the wordings for invalid phone number
related warning.

ID-2728556