### PR TITLE
[FIX] point_of_sale : Closing error

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -512,7 +512,7 @@ class PosSession(models.Model):
                     sales[sale_key] = self._update_amounts(sales[sale_key], {'amount': line['amount']}, line['date_order'])
                     # Combine tax lines
                     for tax in line['taxes']:
-                        tax_key = (tax['account_id'], tax['tax_repartition_line_id'], tax['id'], tuple(tax['tag_ids']))
+                        tax_key = (tax['account_id'] or line['income_account_id'], tax['tax_repartition_line_id'], tax['id'], tuple(tax['tag_ids']))
                         order_taxes[tax_key] = self._update_amounts(
                             order_taxes[tax_key],
                             {'amount': tax['amount'], 'base_amount': tax['base']},


### PR DESCRIPTION
Current behavior:
When using a Tax that has no account linked to it, you were not able to close the PoS

Steps to reproduce:
- Create: tax computation: FIXED
- Create product with this new tax, set price, set available in POS (invoice policy: ordered quantity)
- Create sales order, add product: tax is added. Create invoice: tax is added
- Open POS, sell product, select payment.
- When closing the POS session an error message is generated

opw-2725106

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
