### PR TITLE
[FIX] project: fix the importing tasks with recurrence

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1612,6 +1612,18 @@ class Task(models.Model):
             if field not in self.SELF_WRITABLE_FIELDS:
                 raise AccessError(_('You have not write access of %s field.') % field)
 
+    def _load_records_create(self, vals_list):
+        projects_with_recurrence = self.env['project.project'].search([('allow_recurring_tasks', '=', True)])
+        for vals in vals_list:
+            if vals.get('recurring_task'):
+                if vals.get('project_id') in projects_with_recurrence.ids and not vals.get('recurrence_id'):
+                    default_val = self.default_get(self._get_recurrence_fields())
+                    vals.update(**default_val)
+                else:
+                    for field_name in self._get_recurrence_fields() + ['recurring_task']:
+                        vals.pop(field_name, None)
+        return super()._load_records_create(vals_list)
+
     @api.model_create_multi
     def create(self, vals_list):
         is_portal_user = self.env.user.has_group('base.group_portal')


### PR DESCRIPTION
Currently, when making an import on the project. task and trying to enable the
'recurring_task' to True, the field is updated but a recurrence record is not
created.

Steps:
    1. Create an import file of a new task record
    2. Add 'recurring_task' field set to true

Technical Description:
The default value is not set when the file is imported. Such as repeat_interval,
repeat_unit, etc. So we have called the default_get method.

task-2733539