### PR TITLE
[FIX] pos_gift_card : Can sell the same gift card multiple times

### DIFF
--- a/addons/pos_gift_card/i18n/pos_gift_card.pot
+++ b/addons/pos_gift_card/i18n/pos_gift_card.pot
@@ -246,6 +246,13 @@ msgid "Scan gift card"
 msgstr ""
 
 #. module: pos_gift_card
+#. openerp-web
+#: code:addons/pos_gift_card/static/src/js/GiftCardPopup.js:0
+#, python-format
+msgid "This gift card has already been sold"
+msgstr ""
+
+#. module: pos_gift_card
 #: model:ir.model.fields,help:pos_gift_card.field_pos_config__gift_card_product_id
 msgid "This product is used as reference on customer receipts."
 msgstr ""
@@ -260,4 +267,11 @@ msgstr ""
 #: code:addons/pos_gift_card/static/src/xml/GiftCardPopup.xml:0
 #, python-format
 msgid "Use a gift card"
+msgstr ""
+
+#. module: pos_gift_card
+#. openerp-web
+#: code:addons/pos_gift_card/static/src/js/GiftCardPopup.js:0
+#, python-format
+msgid "You cannot sell a gift card that has already been sold"
 msgstr ""

--- a/addons/pos_gift_card/static/src/js/GiftCardPopup.js
+++ b/addons/pos_gift_card/static/src/js/GiftCardPopup.js
@@ -37,40 +37,45 @@ odoo.define("pos_gift_card.GiftCardPopup", function (require) {
       this.state.showGiftCardDetails = true;
     }
 
-    addGiftCardProduct(giftCard) {
+    async addGiftCardProduct(giftCard) {
       let gift =
         this.env.pos.db.product_by_id[
           this.env.pos.config.gift_card_product_id[0]
         ];
-      this.env.pos.get_order().add_product(gift, {
-        price: this.state.amountToSet,
-        quantity: 1,
-        merge: false,
-        generated_gift_card_ids: giftCard ? giftCard.id : false,
-      });
+
+      let can_be_sold = true;
+      if (giftCard) {
+        can_be_sold = !(giftCard.buy_pos_order_line_id || giftCard.buy_line_id);
+      }
+
+      if (can_be_sold) {
+        this.env.pos.get_order().add_product(gift, {
+          price: this.state.amountToSet,
+          quantity: 1,
+          merge: false,
+          generated_gift_card_ids: giftCard ? giftCard.id : false,
+        });
+      } else {
+        await this.showPopup('ErrorPopup', {
+          'title': this.env._t('This gift card has already been sold'),
+          'body': this.env._t('You cannot sell a gift card that has already been sold'),
+        });
+      }
     }
 
     async getGiftCard() {
       if (this.state.giftCardBarcode == "") return;
 
-      let giftCard = this.env.pos.giftCard.find(
-        (gift) => gift.code === this.state.giftCardBarcode
-      );
-
-      if (!giftCard) {
-        giftCard = await this.rpc({
-            model: "gift.card",
-            method: "search_read",
-            args: [[["code", "=", this.state.giftCardBarcode]]],
-            fields: ["code", "initial_amount", "balance"],
-          });
-          if (giftCard.length) {
-            this.env.pos.giftCard.push(giftCard[0])
-            giftCard = giftCard[0];
-          } else {
-            return false;
-          }
-      }
+      let giftCard = await this.rpc({
+          model: "gift.card",
+          method: "search_read",
+          args: [[["code", "=", this.state.giftCardBarcode]]],
+        });
+        if (giftCard.length) {
+          giftCard = giftCard[0];
+        } else {
+          return false;
+        }
 
       return giftCard;
     }
@@ -82,12 +87,12 @@ odoo.define("pos_gift_card.GiftCardPopup", function (require) {
       if (this.state.giftCardConfig === "scan_use")
         this.state.amountToSet = giftCard.initial_amount;
 
-      this.addGiftCardProduct(giftCard);
+      await this.addGiftCardProduct(giftCard);
       this.cancel();
     }
 
     async generateBarcode() {
-      this.addGiftCardProduct(false);
+      await this.addGiftCardProduct(false);
       this.confirm();
     }
 

--- a/addons/pos_gift_card/static/src/js/PaymentScreen.js
+++ b/addons/pos_gift_card/static/src/js/PaymentScreen.js
@@ -45,7 +45,6 @@ odoo.define('pos_gift_card.PaymentScreen', function(require) {
                                     });
                                     return;
                                 }
-                                this.env.pos.giftCard.find(gift => gift.id === gift_card[0].id).balance += line.price;
                             }
                         }
                     } catch (e) {

--- a/addons/pos_gift_card/static/src/js/models.js
+++ b/addons/pos_gift_card/static/src/js/models.js
@@ -15,12 +15,6 @@ odoo.define("pos_gift_card.gift_card", function (require) {
 
   models.load_models([
     {
-      model: "gift.card",
-      fields: ["code", "initial_amount", "balance"],
-      loaded: function (self, giftCard) {
-        self.giftCard = giftCard;
-      },
-    }, {
         model: product_model.model,
         fields: product_model.fields,
         order: product_model.order,


### PR DESCRIPTION
Current behavior:
When creating a gift card in the backend you were able to sell it multiple times in a PoS

Steps to reproduce:
- Create a gift card in the backend
- Open PoS with gift card mode in "Scan a barcode and set the price" or "Scan an existing barcode with an existing price"
- You can sell this same card multiple times

opw-2666917
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
