### PR TITLE
[FIX] mail {project}: Only hide rating emoticon in chatter-box

### DIFF
--- a/addons/mail/static/src/components/message/message.scss
+++ b/addons/mail/static/src/components/message/message.scss
@@ -239,6 +239,6 @@
 // Used to hide buttons on rating emails in chatter
 // FIXME: should use a better approach for not having such buttons
 // in chatter of such messages, but keep having them in emails.
-.o_Message_content [summary~="o_mail_notification"] {
+.o_Chatter .o_Message_content [summary~="o_mail_notification"] {
     display: none;
 }


### PR DESCRIPTION
Step to reproduce:
- configure notifications managed in odoo from users profile
- create a task where the customer is an internal user
- configure a ranking template in the final stage
- close the task

Current behaviour:
- The message send to the user-customer has no rating emoji shown

Behaviour after PR:
- Revert part of 1515719938fda3468fd3da80a3316b9bb3419b8f to only hide ratings emoticon in the chatter box.

opw-2720840

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
