### PR TITLE
[FIX] l10n_it_edi: do not mention the country code

### DIFF
--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -120,9 +120,13 @@ class AccountMove(models.Model):
             return False
 
         def get_vat_number(vat):
+            if vat[:2].isdecimal():
+                return vat.replace(' ', '')
             return vat[2:].replace(' ', '')
 
         def get_vat_country(vat):
+            if vat[:2].isdecimal():
+                return 'IT'
             return vat[:2].upper()
 
         def in_eu(partner):


### PR DESCRIPTION
Italians do not always mention the country code in the VAT
number of the partner, but we can suppose in that case that
it is within Italy.  Instead of IT0477472701, they would put
just 0477472701.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
