### PR TITLE
[FIX] tests: bump allowed assets generation time

### DIFF
--- a/addons/web/tests/test_assets.py
+++ b/addons/web/tests/test_assets.py
@@ -58,6 +58,12 @@ class TestAssetsGenerateTime(TestAssetsGenerateTimeCommon):
     """
 
     def test_assets_generate_time(self):
+        thresholds = {
+            'web.qunit_suite_tests.js': 3.6,
+            'project.webclient.js': 2.5,
+            'point_of_sale.pos_assets_backend.js': 2.5,
+            'web.assets_backend.js': 2.5,
+        }
         for bundle, duration in self.generate_bundles():
-            threshold = 2
+            threshold = thresholds.get(bundle, 2)
             self.assertLess(duration, threshold, "Bundle %r took more than %s sec" % (bundle, threshold))


### PR DESCRIPTION
As this test is always red, notably because of the qunit asset bundle, the
threshold is raised for some bundles based on runbot builds
observations.