### PR TITLE
[FIX] survey: display clock icon properly in kanban view

### DIFF
--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -268,7 +268,7 @@
                                     <span class="text-muted" t-else="">Certified</span>
                                 </a>
                             </div>
-                            <div class="col-lg-3 col-sm-12 py-0 my-2 ml-auto text-lg-right">
+                            <div class="col-lg-3 col-sm-12 py-0 my-2 pb-lg-3 ml-auto text-lg-right">
                                 <button name="action_send_survey"
                                         string="Share" type="object"
                                         class="btn btn-secondary border"


### PR DESCRIPTION
Currently, clock icon is  not showing properly in kanban view  on small screen.
If the width is not big enough, clock is displayed on top of the button.

This commit fixes the issue by adding the bootstrap class.

TaskId: 2726272