### PR TITLE
[FIX] mail: channel description modification

### DIFF
--- a/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.xml
+++ b/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.xml
@@ -23,15 +23,15 @@
                             Discuss
                         </div>
                     </t>
-                    <t t-if="threadViewTopbar.thread and threadViewTopbar.thread.isChannelDescriptionChangeable">
+                    <t t-if="threadViewTopbar.hasDescriptionArea">
                         <div class="o_ThreadViewTopbar_threadDescriptionSeparator flex-shrink-0 mx-2"/>
                         <t t-if="!threadViewTopbar.isEditingThreadDescription">
                             <t t-if="threadViewTopbar.thread.description">
-                                <div class="o_ThreadViewTopbar_threadDescription o_ThreadViewTopbar_editableItem text-truncate px-1" t-att-title="threadViewTopbar.thread.description" t-on-click="threadViewTopbar.onClickTopbarThreadDescription" t-on-mouseenter="threadViewTopbar.onMouseEnterTopbarThreadDescription" t-on-mouseleave="threadViewTopbar.onMouseLeaveTopbarThreadDescription" t-att-class="{ 'o-threadDescriptionEditable': threadViewTopbar.isMouseOverThreadDescription and !messaging.isCurrentUserGuest }">
+                                <div class="o_ThreadViewTopbar_threadDescription o_ThreadViewTopbar_editableItem text-truncate px-1" t-att-title="threadViewTopbar.thread.description" t-on-click="threadViewTopbar.onClickTopbarThreadDescription" t-on-mouseenter="threadViewTopbar.onMouseEnterTopbarThreadDescription" t-on-mouseleave="threadViewTopbar.onMouseLeaveTopbarThreadDescription" t-att-class="{ 'o-threadDescriptionEditable': threadViewTopbar.isDescriptionHighlighted }">
                                     <t t-esc="threadViewTopbar.thread.description"/>
                                 </div>
                             </t>
-                            <t t-if="!messaging.isCurrentUserGuest and !threadViewTopbar.thread.description and threadViewTopbar.thread.isChannelDescriptionChangeable">
+                            <t t-if="!threadViewTopbar.thread.description">
                                 <div class="o_ThreadViewTopbar_threadAddDescriptionEmptyLabel text-truncate" t-on-click="threadViewTopbar.onClickTopbarThreadDescription">
                                     Add a description
                                 </div>

--- a/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
@@ -302,7 +302,6 @@ function factory(dependencies) {
             }
             if (current_partner) {
                 const partnerData = this.messaging.models['mail.partner'].convertData(current_partner);
-                partnerData.user = insert({ id: currentUserId });
                 this.messaging.update({
                     currentPartner: insert(partnerData),
                     currentUser: insert({ id: currentUserId }),

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1493,6 +1493,18 @@ function factory(dependencies) {
          * @private
          * @returns {boolean}
          */
+        _computeIsDescriptionEditableByCurrentUser() {
+            return Boolean(
+                this.messaging.currentUser &&
+                this.messaging.currentUser.isInternalUser &&
+                this.isChannelDescriptionChangeable
+            );
+        }
+
+        /**
+         * @private
+         * @returns {boolean}
+         */
         _computeIsChannelRenamable() {
             return (
                 this.model === 'mail.channel' &&
@@ -2292,6 +2304,12 @@ function factory(dependencies) {
         isCurrentPartnerFollowing: attr({
             compute: '_computeIsCurrentPartnerFollowing',
             default: false,
+        }),
+        /**
+         * States whether this thread description is editable by the current user.
+         */
+        isDescriptionEditableByCurrentUser: attr({
+            compute: '_computeIsDescriptionEditableByCurrentUser',
         }),
         /**
          * States whether `this` is currently loading attachments.

--- a/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
+++ b/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
@@ -122,11 +122,7 @@ function factory(dependencies) {
          * @param {MouseEvent} ev
          */
         onClickTopbarThreadDescription(ev) {
-            if (!this.thread || !this.thread.isChannelDescriptionChangeable) {
-                return;
-            }
-            // Guests cannot edit description
-            if (this.messaging.isCurrentUserGuest) {
+            if (!this.thread || !this.thread.isDescriptionEditableByCurrentUser) {
                 return;
             }
             const selection = window.getSelection();
@@ -330,7 +326,7 @@ function factory(dependencies) {
          * @param {MouseEvent} ev
          */
         onMouseEnterTopbarThreadDescription(ev) {
-            if (!this.thread || !this.thread.isChannelDescriptionChangeable) {
+            if (!this.exists()) {
                 return;
             }
             this.update({ isMouseOverThreadDescription: true });
@@ -462,6 +458,25 @@ function factory(dependencies) {
             return Boolean(
                 this.messaging.currentGuest &&
                 this.pendingGuestName !== this.messaging.currentGuest.name
+            );
+        }
+
+        /**
+         * @private
+         * @returns {boolean}
+         */
+        _computeHasDescriptionArea() {
+            return Boolean(this.thread && (this.thread.description || this.thread.isDescriptionEditableByCurrentUser));
+        }
+
+        /**
+         * @private
+         * @returns {boolean}
+         */
+        _computeIsDescriptionHighlighted() {
+            return Boolean(
+                this.isMouseOverThreadDescription &&
+                this.thread.isDescriptionEditableByCurrentUser
             );
         }
 
@@ -625,6 +640,12 @@ function factory(dependencies) {
             readonly: true,
         }),
         /**
+         * Determines whether description area should display on top bar.
+         */
+        hasDescriptionArea: attr({
+            compute: '_computeHasDescriptionArea',
+        }),
+        /**
          * Determines whether the guest is currently being renamed.
          */
         isEditingGuestName: attr({
@@ -642,6 +663,12 @@ function factory(dependencies) {
         invitePopoverView: one2one('mail.popover_view', {
             isCausal: true,
             inverse: 'threadViewTopbarOwner',
+        }),
+        /**
+         * States whether this thread description is highlighted.
+         */
+        isDescriptionHighlighted: attr({
+            compute: '_computeIsDescriptionHighlighted'
         }),
         /**
          * Determines whether this thread is currently being renamed.

--- a/addons/mail/static/src/utils/test_utils.js
+++ b/addons/mail/static/src/utils/test_utils.js
@@ -245,12 +245,13 @@ function beforeEach(self) {
     });
 
     data.currentPartnerId = 3;
+    data.currentUserId = 2;
     data['res.partner'].records.push({
         display_name: "Your Company, Mitchell Admin",
         id: data.currentPartnerId,
         name: "Mitchell Admin",
+        user_ids: [data.currentUserId],
     });
-    data.currentUserId = 2;
     data['res.users'].records.push({
         display_name: "Your Company, Mitchell Admin",
         id: data.currentUserId,

--- a/addons/mail/static/tests/helpers/mock_models.js
+++ b/addons/mail/static/tests/helpers/mock_models.js
@@ -221,6 +221,7 @@ export class MockModels {
                     partner_latitude: { string: "Latitude", type: 'float' },
                     partner_longitude: { string: "Longitude", type: 'float' },
                     partner_share: { string: "Share Partner", type: 'boolean', default: false }, // in python a compute, hard-coded value here for simplicity
+                    user_ids: { string: "Users", type: "one2many", relation: 'res.users', default:[] },
                 },
                 records: [],
             },
@@ -231,6 +232,7 @@ export class MockModels {
                     im_status: { string: "IM Status", type: 'char' },
                     name: { string: "Name", type: 'char' },
                     partner_id: { string: "Related partners", type: 'many2one', relation: 'res.partner' },
+                    share: { string: "Shared users", type: 'boolean', default: false },
                 },
                 records: [],
             },

--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -2065,19 +2065,29 @@ MockServer.include({
             [['id', 'in', ids]],
             { active_test: false }
         );
-        // Servers is also returning `user_id` and `is_internal_user` but not
+        // Servers is also returning `is_internal_user` but not
         // done here for simplification.
-        return new Map(partners.map(partner => [
-            partner.id,
-            {
+        return new Map(partners.map(partner => {
+            const users = this._getRecords('res.users', [['id', 'in', partner.user_ids]]);
+            const internalUsers = users.filter(user => !user.share);
+            let mainUser;
+            if (internalUsers.length > 0) {
+                mainUser = internalUsers[0];
+            } else if (users.length > 0) {
+                mainUser = users[0];
+            } else {
+                mainUser = [];
+            }
+            return [partner.id, {
                 "active": partner.active,
                 "display_name": partner.display_name,
                 "email": partner.email,
                 "id": partner.id,
                 "im_status": partner.im_status,
                 "name": partner.name,
-            }
-        ]));
+                "user_id": mainUser.id,
+            }];
+        }));
     },
     /**
      * Simulates `search_for_channel_invite` on `res.partner`.


### PR DESCRIPTION
**Current behavior before PR:**

For guests and portal users, a separator(differentiates channel name and
description) in the thread view topbar is displayed even if there is no description.
And when portal users are trying to write/edit channel description at that time
access error is generated.

**Desired behavior after PR is merged:**

A separator will only be displayed when there is a description and portal users
will not be able to write/edit channel description as they don't have rights.

**Task**-2664843
