### PR TITLE
[FIX] account: fix default journal in register payment wizard

### DIFF
--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -452,6 +452,13 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
 
         self.in_invoice_1.partner_bank_id = bank1
         self.in_invoice_2.partner_bank_id = bank2
+        # Update the bank journal (now default payment register journal is bank/cash journal with the lowest sequence)
+        self.bank_journal_1 = self.env['account.journal'].search([
+            ('type', 'in', ('bank', 'cash')),
+            ('company_id', '=', self.env.company.id),
+        ], order='sequence asc', limit=1)
+        self.inbound_payment_method_line = self.bank_journal_1.inbound_payment_method_line_ids[0]
+        self.outbound_payment_method_line = self.bank_journal_1.outbound_payment_method_line_ids[0]
 
         active_ids = (self.in_invoice_1 + self.in_invoice_2 + self.in_refund_1).ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
@@ -527,6 +534,14 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         ''' Choose to pay multiple batches, one with two customer invoices (1000 + 2000)
         and one with a vendor bill of 600, by grouping payments.
         '''
+        # Update the bank journal (now default payment register journal is bank/cash journal with the lowest sequence)
+        self.bank_journal_1 = self.env['account.journal'].search([
+                    ('type', 'in', ('bank', 'cash')),
+                    ('company_id', '=', self.env.company.id),
+                ], order='sequence asc', limit=1)
+        self.inbound_payment_method_line = self.bank_journal_1.inbound_payment_method_line_ids[0]
+        self.outbound_payment_method_line = self.bank_journal_1.outbound_payment_method_line_ids[0]
+
         active_ids = (self.in_invoice_1 + self.in_invoice_2 + self.in_invoice_3).ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
             'group_payment': True,
@@ -583,6 +598,13 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         ''' Choose to pay multiple batches, one with two customer invoices (1000 + 2000)
          and one with a vendor bill of 600, by splitting payments.
          '''
+         # Update the bank journal (now default payment register journal is bank/cash journal with the lowest sequence)
+        self.bank_journal_1 = self.env['account.journal'].search([
+            ('type', 'in', ('bank', 'cash')),
+            ('company_id', '=', self.env.company.id),
+        ], order='sequence asc', limit=1)
+        self.inbound_payment_method_line = self.bank_journal_1.inbound_payment_method_line_ids[0]
+        self.outbound_payment_method_line = self.bank_journal_1.outbound_payment_method_line_ids[0]
         self.in_invoice_1.partner_bank_id = self.partner_bank_account1
         self.in_invoice_2.partner_bank_id = self.partner_bank_account2
 

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -423,6 +423,7 @@
                       sample="1">
                     <header>
                         <button name="action_register_payment" type="object" string="Register Payment"
+                            context="{'dont_redirect_to_payments': True}"
                             groups="account.group_account_user"
                             invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt', 'in_invoice', 'in_refund','in_receipt')"/>
                     </header>

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -329,7 +329,7 @@ class AccountPaymentRegister(models.TransientModel):
                 wizard.journal_id = self.env['account.journal'].search([
                     ('type', 'in', ('bank', 'cash')),
                     ('company_id', '=', wizard.company_id.id),
-                ], limit=1)
+                ], order='sequence asc', limit=1)
 
     @api.depends('can_edit_wizard', 'journal_id')
     def _compute_available_partner_bank_ids(self):


### PR DESCRIPTION
Task ID: 2730832

Current behaviour:
- Open register payment wizard. The journal_id field is filled with the sales/purchases journal of the invoices selected, while the domain is bank or cash

Expected:
- Populate journal_id with a bank or cash journal with the smallest sequence


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
