### PR TITLE
[FIX] sale_stock: download delivery order as portal user

### DIFF
--- a/addons/sale_stock/controllers/portal.py
+++ b/addons/sale_stock/controllers/portal.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import exceptions
+from odoo import exceptions, SUPERUSER_ID
 from odoo.addons.sale.controllers.portal import CustomerPortal
 from odoo.http import request, route
 from odoo.tools import consteq
@@ -29,8 +29,8 @@ class SaleStockPortal(CustomerPortal):
         except exceptions.AccessError:
             return request.redirect('/my')
 
-        # print report as sudo, since it require access to product, taxes, payment term etc.. and portal does not have those access rights.
-        pdf = request.env.ref('stock.action_report_delivery').sudo()._render_qweb_pdf([picking_sudo.id])[0]
+        # print report as SUPERUSER, since it require access to product, taxes, payment term etc.. and portal does not have those access rights.
+        pdf = request.env.ref('stock.action_report_delivery').with_user(SUPERUSER_ID)._render_qweb_pdf([picking_sudo.id])[0]
         pdfhttpheaders = [
             ('Content-Type', 'application/pdf'),
             ('Content-Length', len(pdf)),


### PR DESCRIPTION
### Current behavior
A portal user couldn't download a delivery order

### Steps to reproduce
1. Install Sales and Stock
2. Create a new portal user
3. Create a new quotation with a deliverable item for the new portal user
4. As the portal user, go to your SO through the portal and try to get the Delivery Order

### Reason
`sudo` is forced to False when rendering a template. But as we're checking access rights, we can use `SUPERUSER_ID` even if it's a public controller (see 61b4b6777d64218f94c51ec839c187fdc7b2034f for more info)

OPW-2734203