### PR TITLE
[FIX] purchase: get the right fiscal position on vendor bill

### DIFF
--- a/addons/sale/models/account_invoice.py
+++ b/addons/sale/models/account_invoice.py
@@ -28,6 +28,8 @@ class AccountMove(models.Model):
         """
         Trigger the change of fiscal position when the shipping address is modified.
         """
+        if self.type not in self.get_sale_types():
+            return
         delivery_partner_id = self._get_invoice_delivery_partner_id()
         fiscal_position = self.env['account.fiscal.position'].with_context(force_company=self.company_id.id).get_fiscal_position(
             self.partner_id.id, delivery_id=delivery_partner_id)


### PR DESCRIPTION
Steps to reproduce:

- Set a vendor with fiscal position A
- Create a Purchase Order with fiscal position B,
  confirm and receive
- Click on Create Bill button

Issue:

Fiscal position on vendor bill is the one from the vendor instead
of the one from the PO.

opw-2719766

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
