### PR TITLE
[FIX] mail: update chatter attachments when a log is deleted

### DIFF
--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -39,9 +39,12 @@ class IrAttachment(models.Model):
     def _delete_and_notify(self):
         for attachment in self:
             if attachment.res_model == 'mail.channel' and attachment.res_id:
-                self.env['bus.bus']._sendone(self.env['mail.channel'].browse(attachment.res_id), 'ir.attachment/delete', {
-                    'id': attachment.id,
-                })
+                target = self.env['mail.channel'].browse(attachment.res_id)
+            else:
+                target = self.env.user.partner_id
+            self.env['bus.bus']._sendone(target, 'ir.attachment/delete', {
+                'id': attachment.id,
+            })
         self.unlink()
 
     def _attachment_format(self, commands=False):

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -680,7 +680,7 @@ class Message(models.Model):
         thread._check_can_update_message_content(self)
         self.body = body
         if not attachment_ids:
-            self.attachment_ids.unlink()
+            self.attachment_ids._delete_and_notify()
         else:
             message_values = {
                 'model': self.model,


### PR DESCRIPTION
Attachments of the chatter didn't update when a log with an attachment was deleted

Steps to reproduce:
1. Install Sales app
2. Open any sale
3. Create a log note with an image attached
4. Delete the log note
5. The image is still in the sale's chatter attachments

Solution:
Check if attachments were deleted when updating the log and remove them from the chatter attachments

OPW-2732793