### PR TITLE
[FIX] pos_gift_card: Setting customer reset price

### DIFF
--- a/addons/pos_gift_card/static/src/js/GiftCardPopup.js
+++ b/addons/pos_gift_card/static/src/js/GiftCardPopup.js
@@ -54,6 +54,7 @@ odoo.define("pos_gift_card.GiftCardPopup", function (require) {
           quantity: 1,
           merge: false,
           generated_gift_card_ids: giftCard ? giftCard.id : false,
+          extras: { price_manually_set: true },
         });
       } else {
         await this.showPopup('ErrorPopup', {


### PR DESCRIPTION
Current behavior:
When creating a gift card in a PoS the price was reset to 0 when modifying the customer

Steps to reproduce:
- Set PoS gift card mode in Generate a new barcode and set a price
- Modify the current customer
- The price of the gift card is reset to 0

opw-2666917
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
