### PR TITLE
[FIX] factur-x: fix line chargeAmount export

### DIFF
--- a/addons/account_facturx/data/facturx_templates.xml
+++ b/addons/account_facturx/data/facturx_templates.xml
@@ -26,10 +26,11 @@
 
                     <!-- Amounts. -->
                     <ram:SpecifiedLineTradeAgreement>
+                        <!-- Line information, with discount and unit price separate -->
                         <ram:GrossPriceProductTradePrice>
                             <ram:ChargeAmount
                                 t-att-currencyID="currency.name"
-                                t-esc="format_monetary(line.price_subtotal, currency)"/>
+                                t-esc="format_monetary(line.price_unit, currency)"/>
 
                             <!-- Discount. -->
                             <ram:AppliedTradeAllowanceCharge t-if="line.discount">
@@ -39,6 +40,12 @@
                                 <ram:CalculationPercent t-esc="line.discount"/>
                             </ram:AppliedTradeAllowanceCharge>
                         </ram:GrossPriceProductTradePrice>
+                        <!-- Line unit price, with discount applied -->
+                        <ram:NetPriceProductTradePrice>
+                            <ram:ChargeAmount
+                                t-att-currencyID="currency.name"
+                                t-esc="format_monetary(line.price_subtotal/line.quantity, currency)"/>
+                        </ram:NetPriceProductTradePrice>
                     </ram:SpecifiedLineTradeAgreement>
 
                     <!-- Quantity. -->

--- a/addons/account_facturx/tests/test_facturx.py
+++ b/addons/account_facturx/tests/test_facturx.py
@@ -84,7 +84,7 @@ class TestAccountEdiFacturx(AccountTestEdiCommon):
                         </SpecifiedTradeProduct>
                         <SpecifiedLineTradeAgreement>
                             <GrossPriceProductTradePrice>
-                                <ChargeAmount currencyID="Gol">1100.000</ChargeAmount>
+                                <ChargeAmount currencyID="Gol">275.000</ChargeAmount>
                                 <AppliedTradeAllowanceCharge>
                                     <ChargeIndicator>
                                         <Indicator>true</Indicator>
@@ -92,6 +92,9 @@ class TestAccountEdiFacturx(AccountTestEdiCommon):
                                     <CalculationPercent>20.0</CalculationPercent>
                                 </AppliedTradeAllowanceCharge>
                             </GrossPriceProductTradePrice>
+                            <NetPriceProductTradePrice>
+                                <ChargeAmount currencyID="Gol">220.000</ChargeAmount>
+                            </NetPriceProductTradePrice>
                         </SpecifiedLineTradeAgreement>
                         <SpecifiedLineTradeDelivery>
                             <BilledQuantity>5.0</BilledQuantity>
@@ -172,8 +175,8 @@ class TestAccountEdiFacturx(AccountTestEdiCommon):
             expected_etree = self.with_applied_xpath(
                 self.get_xml_tree_from_string(self.expected_invoice_facturx_values),
                 '''
-                    <xpath expr="//GrossPriceProductTradePrice/ChargeAmount" position="replace">
-                        <ChargeAmount currencyID="Gol">1000.000</ChargeAmount>
+                    <xpath expr="//NetPriceProductTradePrice/ChargeAmount" position="replace">
+                        <ChargeAmount currencyID="Gol">200.000</ChargeAmount>
                     </xpath>
                     <xpath expr="//SpecifiedLineTradeSettlement" position="replace">
                         <SpecifiedLineTradeSettlement>


### PR DESCRIPTION
The current behavior is that we are exporting the line subtotal as
chargeAmount of the line.
This is an issue as this field is expecting the unit price instead.
A bugfix was done for importing extern invoices properly that broke
importing factur-x files from Odoo as it doesn't support that custom
behavior anymore.
Thus, this will correct the export to properly store the unit price
in the GrossPriceProductTradePrice ChargeAmount.

At the same time, add the NetPriceProductTradePrice ChargeAmount,
which is required and should contain the unit price with discount
applied.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
