### PR TITLE
15.0 conflict commandbar linkialog nby

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -332,6 +332,9 @@ var MassMailingFieldHtml = FieldHtml.extend({
      * @override
      */
     _onLoadWysiwyg: function () {
+        // Let the global hotkey manager know about our iframe.
+        this.call('hotkey', 'registerIframe', this.wysiwyg.$iframe[0]);
+
         if (this.snippetsLoaded) {
             this._onSnippetsLoaded(this.snippetsLoaded);
         }

--- a/addons/web/static/src/core/commands/command_palette.js
+++ b/addons/web/static/src/core/commands/command_palette.js
@@ -67,6 +67,7 @@ export class CommandPalette extends Component {
     setup() {
         this.keyId = 1;
         this.keepLast = new KeepLast();
+        this._sessionId = CommandPalette.lastSessionId++;
         this.DefaultCommandItem = DefaultCommandItem;
         this.activeElement = useService("ui").activeElement;
         const onDebouncedSearchInput = debounce.apply(this, [this.onSearchInput, 200]);
@@ -145,6 +146,7 @@ export class CommandPalette extends Component {
         this.setCommands(namespace, {
             activeElement: this.activeElement,
             searchValue: "",
+            sessionId: this._sessionId,
         });
         this.state.searchValue = namespace === "default" ? "" : namespace;
     }
@@ -267,7 +269,9 @@ export class CommandPalette extends Component {
         await this.setCommands(namespace, {
             searchValue,
             activeElement: this.activeElement,
+            sessionId: this._sessionId,
         });
     }
 }
+CommandPalette.lastSessionId = 0;
 CommandPalette.template = "web.CommandPalette";

--- a/addons/web/static/src/core/hotkeys/hotkey_service.js
+++ b/addons/web/static/src/core/hotkeys/hotkey_service.js
@@ -33,10 +33,14 @@ export const hotkeyService = {
         let nextToken = 0;
         let overlaysVisible = false;
 
-        browser.addEventListener("keydown", onKeydown);
-        browser.addEventListener("keyup", removeHotkeyOverlays);
-        browser.addEventListener("blur", removeHotkeyOverlays);
-        browser.addEventListener("click", removeHotkeyOverlays);
+        addListeners(browser);
+
+        function addListeners(target) {
+            target.addEventListener("keydown", onKeydown);
+            target.addEventListener("keyup", removeHotkeyOverlays);
+            target.addEventListener("blur", removeHotkeyOverlays);
+            target.addEventListener("click", removeHotkeyOverlays);
+        }
 
         /**
          * Handler for keydown events.
@@ -358,6 +362,12 @@ export const hotkeyService = {
                 return () => {
                     unregisterHotkey(token);
                 };
+            },
+            /**
+             * @param {HTMLIFrameElement} iframe
+             */
+            registerIframe(iframe) {
+                addListeners(iframe.contentWindow);
             },
         };
     },

--- a/addons/web/static/tests/core/commands/command_palette_tests.js
+++ b/addons/web/static/tests/core/commands/command_palette_tests.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { browser } from "@web/core/browser/browser";
+import { CommandPalette } from "@web/core/commands/command_palette";
 import { CommandPaletteDialog } from "@web/core/commands/command_palette_dialog";
 import { commandService } from "@web/core/commands/command_service";
 import { dialogService } from "@web/core/dialog/dialog_service";
@@ -1069,4 +1070,42 @@ QUnit.test("navigate in the command palette with an empty list", async (assert) 
     await nextTick();
     assert.containsNone(target, ".o_command");
     assert.containsOnce(target, ".o_command_palette_listbox_empty");
+});
+
+QUnit.test("generate new session id when opened", async (assert) => {
+    assert.expect(4);
+
+    let lastSessionId;
+    CommandPalette.lastSessionId = 0;
+    testComponent = await mount(TestComponent, { env, target });
+    const providers = [
+        {
+            provide: (env, {sessionId}) => {
+                lastSessionId = sessionId;
+                return [];
+            },
+        },
+    ];
+    const config = {
+        providers,
+    };
+    env.services.dialog.add(CommandPaletteDialog, {
+        config,
+    });
+
+    await nextTick();
+    assert.equal(lastSessionId, 0);
+
+    await editSearchBar("a");
+    assert.equal(lastSessionId, 0);
+
+    window.dispatchEvent(new MouseEvent("mousedown"));
+    await nextTick();
+    assert.equal(lastSessionId, 0);
+
+    env.services.dialog.add(CommandPaletteDialog, {
+        config,
+    });
+    await nextTick();
+    assert.equal(lastSessionId, 1);
 });

--- a/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
+++ b/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
@@ -6,7 +6,13 @@ import { registry } from "@web/core/registry";
 import { uiService, useActiveElement } from "@web/core/ui/ui_service";
 import { hotkeyService } from "@web/core/hotkeys/hotkey_service";
 import { makeTestEnv } from "../../helpers/mock_env";
-import { getFixture, nextTick, patchWithCleanup, triggerHotkey } from "../../helpers/utils";
+import {
+    getFixture,
+    makeDeferred,
+    nextTick,
+    patchWithCleanup,
+    triggerHotkey,
+} from "../../helpers/utils";
 
 const { Component, mount, tags } = owl;
 const { xml } = tags;
@@ -690,4 +696,35 @@ QUnit.test("ignore numpad keys", async (assert) => {
     window.dispatchEvent(keydown);
     await nextTick();
     assert.verifySteps(['1']);
+});
+
+QUnit.test("within iframes", async (assert) => {
+    assert.expect(5);
+    env.services.hotkey.add("enter", () => assert.step("called"));
+    await nextTick();
+
+    // Dispatch directly to target to show that the hotkey service works as expected
+    target.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await nextTick();
+    assert.verifySteps(["called"]);
+
+    // Append an iframe to target and wait until it is fully loaded.
+    const iframe = document.createElement("iframe");
+    iframe.srcdoc = "<h1>Hello world!</h1>";
+    const def = makeDeferred();
+    iframe.onload = def.resolve;
+    target.appendChild(iframe);
+    await def;
+
+    // Dispatch an hotkey from within the iframe
+    const h1 = iframe.contentDocument.querySelector("h1");
+    h1.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await nextTick();
+    assert.verifySteps([]);
+
+    // Register the iframe to the hotkey service
+    env.services.hotkey.registerIframe(iframe);
+    h1.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await nextTick();
+    assert.verifySteps(["called"]);
 });

--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -26,6 +26,8 @@ Odoo Web Editor widget.
             'web_editor/static/src/xml/*.xml',
         ],
         'web_editor.assets_wysiwyg': [
+            # dependency
+            'web/core/commands/default_providers',
 
             # lib
             'web_editor/static/lib/cropperjs/cropper.css',
@@ -56,6 +58,7 @@ Odoo Web Editor widget.
             'web_editor/static/lib/odoo-editor/src/commands/toggleList.js',
 
             # utils
+            'web_editor/static/src/js/wysiwyg/linkDialogCommand.js',
             'web_editor/static/src/js/wysiwyg/PeerToPeer.js',
 
             # odoo utils

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1641,7 +1641,7 @@ export class OdooEditor extends EventTarget {
             focusNode: sel.focusNode,
             focusOffset: sel.focusOffset,
         };
-        if (this._isSelectionInEditable(sel)) {
+        if (!sel.isCollapsed && this.isSelectionInEditable(sel)) {
             this._latestComputedSelectionInEditable = this._latestComputedSelection;
         }
         return this._latestComputedSelection;
@@ -2435,7 +2435,7 @@ export class OdooEditor extends EventTarget {
         this._computeHistorySelection();
 
         const selection = this.document.getSelection();
-        this._updateToolbar(this._isSelectionInEditable(selection));
+        this._updateToolbar(!selection.isCollapsed && this.isSelectionInEditable(selection));
 
         if (this._currentMouseState === 'mouseup') {
             this._fixFontAwesomeSelection();
@@ -2452,13 +2452,12 @@ export class OdooEditor extends EventTarget {
     /**
      * Returns true if the current selection is inside the editable.
      *
-     * @private
-     * @param {Object} selection
+     * @param {Object} [selection]
      * @returns {boolean}
      */
-    _isSelectionInEditable(selection) {
-        return !selection.isCollapsed &&
-            this.editable.contains(selection.anchorNode) &&
+    isSelectionInEditable(selection) {
+        selection = selection || this.document.getSelection()
+        return selection && selection.anchorNode && this.editable.contains(selection.anchorNode) &&
             this.editable.contains(selection.focusNode);
     }
 

--- a/addons/web_editor/static/src/js/backend/command_category.js
+++ b/addons/web_editor/static/src/js/backend/command_category.js
@@ -1,0 +1,6 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+
+const commandCategoryRegistry = registry.category("command_categories");
+commandCategoryRegistry.add("shortcut_conflict", {}, { sequence: 5 });

--- a/addons/web_editor/static/src/js/wysiwyg/linkDialogCommand.js
+++ b/addons/web_editor/static/src/js/wysiwyg/linkDialogCommand.js
@@ -1,0 +1,54 @@
+/** @odoo-module **/
+
+import { registry } from '@web/core/registry'
+import { HotkeyCommandItem } from '@web/core/commands/default_providers'
+import Wysiwyg from 'web_editor.wysiwyg'
+
+// The only way to know if an editor is under focus when the command palette
+// open is to look if there in a selection within a wysiwyg editor in the page.
+// As the selection changes after the command palette is open, we need to save
+// the action (that have the range and editor in the closure) as well as the
+// label to use.
+let sessionActionLabel = [];
+
+const commandProviderRegistry = registry.category("command_provider");
+commandProviderRegistry.add("link dialog", {
+    async provide(env, { sessionId }) {
+        let [lastSessionId, action, label] = sessionActionLabel;
+        if (lastSessionId !== sessionId) {
+            const wysiwyg = [...Wysiwyg.activeWysiwygs].find((wysiwyg) => {
+                return wysiwyg.isSelectionInEditable();
+            });
+            const selection = wysiwyg && wysiwyg.odooEditor && wysiwyg.odooEditor.document.getSelection();
+            const range = selection && selection.rangeCount && selection.getRangeAt(0);
+            if (range) {
+                label = !wysiwyg.getInSelection('a') ? 'Create link' : 'Edit link';
+                action = () => {
+                    const selection = wysiwyg.odooEditor.document.getSelection();
+                    selection.removeAllRanges();
+                    selection.addRange(range);
+
+                    wysiwyg.openLinkToolsFromSelection();
+                }
+                sessionActionLabel = [sessionId, action, label]
+            } else {
+                sessionActionLabel = [sessionId];
+            }
+        }
+        [lastSessionId, action, label] = sessionActionLabel;
+
+        if (action) {
+            return [
+                {
+                    Component: HotkeyCommandItem,
+                    action: action,
+                    category: 'shortcut_conflict',
+                    name: label,
+                    props: { hotkey: 'control+k' },
+                }
+            ]
+        } else {
+            return [];
+        }
+    },
+});

--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -416,6 +416,7 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
             controlHistoryFromDocument: true,
             getContentEditableAreas: this._getContentEditableAreas.bind(this),
             powerboxCommands: this._getSnippetsCommands(),
+            bindLinkTool: true,
         }, collaborationConfig);
         return wysiwygLoader.createWysiwyg(this,
             Object.assign(params, this.wysiwygOptions),


### PR DESCRIPTION
Whenever the user hit ctrl+k when being on an html field, both the
link dialog and the command palette opened.

In order to resolve the conflict, now ctrl+k open the command palette
with the first entry being the command to open the linktool and
a subsequent hit to ctrl+k when the command palette is open to open
the link dialog.

Task-2738457

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
