### PR TITLE
[FIX] mrp: mass produce should fill qty_done

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1525,7 +1525,7 @@ class MrpProduction(models.Model):
                 wo.qty_producing = wo.qty_remaining
         return backorders
 
-    def _split_productions(self, amounts=False, cancel_remaning_qty=False):
+    def _split_productions(self, amounts=False, cancel_remaning_qty=False, set_consumed_qty=False):
         """ Splits productions into productions smaller quantities to produce, i.e. creates
         its backorders.
         :param dict amounts: a dict with a production as key and a list value containing
@@ -1650,12 +1650,17 @@ class MrpProduction(models.Model):
                     taken_qty_uom = product_uom._compute_quantity(taken_qty, move_line.product_uom_id)
                     if move == initial_move:
                         move_line.with_context(bypass_reservation_update=True).product_uom_qty = taken_qty_uom
+                        if set_consumed_qty:
+                            move_line.qty_done = taken_qty_uom
                     elif not float_is_zero(taken_qty_uom, precision_rounding=move_line.product_uom_id.rounding):
-                        move_lines_vals.append(dict(
+                        new_ml_vals = dict(
                             ml_vals,
                             product_uom_qty=taken_qty_uom,
                             move_id=move.id
-                        ))
+                        )
+                        if set_consumed_qty:
+                            new_ml_vals['qty_done'] = taken_qty_uom
+                        move_lines_vals.append(new_ml_vals)
                     quantity -= taken_qty
                     move_qty_to_reserve -= taken_qty
 


### PR DESCRIPTION
[FIX] mrp: mass produce should fill qty_done
Usecase:
- Create a BoM with a product tracked by SN
- Create a MO with qty 5
- Mass produce
- Generate

-> All the `stock.move.line` in the move_raw_ids don't have
the qty done prefilled. The purpose of the feature is to create
and validate a lot of MO at once. Which is impossible if you have
to fill all the quantity manualy.

The choice of a new kwargs that directly set the qty_done is justified
by the performance.

-> For On a BoM with 10 components for a final product. For 1000 finished
product with SN
- If we do a loop on each `stock.move.line` to set
qty_done as the reserved quantity. It goes from 40s to 135s
- With the kwargs. It remaines 40s
