### PR TITLE
[FIX] pos_sale: fix error when no down payment product

### DIFF
--- a/addons/pos_sale/i18n/pos_sale.pot
+++ b/addons/pos_sale/i18n/pos_sale.pot
@@ -135,6 +135,15 @@ msgid "Invoiced"
 msgstr ""
 
 #. module: pos_sale
+#. openerp-web
+#: code:addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js:0
+#, python-format
+msgid ""
+"It seems that you didn't configure a down payment product in your point of sale.\n"
+"                        You can go to your point of sale configuration to choose one."
+msgstr ""
+
+#. module: pos_sale
 #: code:addons/pos_sale/models/sale_order.py:0
 #, python-format
 msgid "Linked POS Orders"
@@ -185,6 +194,13 @@ msgstr ""
 #: code:addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js:0
 #, python-format
 msgid "No"
+msgstr ""
+
+#. module: pos_sale
+#. openerp-web
+#: code:addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js:0
+#, python-format
+msgid "No down payment product"
 msgstr ""
 
 #. module: pos_sale

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
@@ -187,39 +187,50 @@ odoo.define('pos_sale.SaleOrderManagementScreen', function (require) {
               }
               else {
                 // apply a downpayment
-                let lines = sale_order.order_line;
-                let tab = [];
+                if (this.env.pos.config.down_payment_product_id){
 
-                for (let i=0; i<lines.length; i++) {
-                    tab[i] = {
-                        'product_name': lines[i].product_id[1],
-                        'product_uom_qty': lines[i].product_uom_qty,
-                        'price_unit': lines[i].price_unit,
-                        'total': lines[i].price_total,
-                    };
+                    let lines = sale_order.order_line;
+                    let tab = [];
+
+                    for (let i=0; i<lines.length; i++) {
+                        tab[i] = {
+                            'product_name': lines[i].product_id[1],
+                            'product_uom_qty': lines[i].product_uom_qty,
+                            'price_unit': lines[i].price_unit,
+                            'total': lines[i].price_total,
+                        };
+                    }
+
+                    let down_payment = sale_order.amount_total;
+                    const { confirmed, payload } = await this.showPopup('NumberPopup', {
+                        title: sprintf(this.env._t("Percentage of %s"), this.env.pos.format_currency(sale_order.amount_total)),
+                        startingValue: 0,
+                    });
+                    if (confirmed){
+                        down_payment = sale_order.amount_total * parse.float(payload) / 100;
+                    }
+
+
+                    let new_line = new models.Orderline({}, {
+                        pos: this.env.pos,
+                        order: this.env.pos.get_order(),
+                        product: this.env.pos.db.get_product_by_id(this.env.pos.config.down_payment_product_id[0]),
+                        price: down_payment,
+                        price_manually_set: true,
+                        sale_order_origin_id: clickedOrder,
+                        down_payment_details: tab,
+                    });
+                    new_line.set_unit_price(down_payment);
+                    this.env.pos.get_order().add_orderline(new_line);
                 }
-
-                let down_payment = sale_order.amount_total;
-                const { confirmed, payload } = await this.showPopup('NumberPopup', {
-                    title: sprintf(this.env._t("Percentage of %s"), this.env.pos.format_currency(sale_order.amount_total)),
-                    startingValue: 0,
-                });
-                if (confirmed){
-                    down_payment = sale_order.amount_total * parse.float(payload) / 100;
+                else {
+                    const title = this.env._t('No down payment product');
+                    const body = this.env._t(
+                        "It seems that you didn't configure a down payment product in your point of sale.\
+                        You can go to your point of sale configuration to choose one."
+                    );
+                    await this.showPopup('ErrorPopup', { title, body });
                 }
-
-
-                let new_line = new models.Orderline({}, {
-                    pos: this.env.pos,
-                    order: this.env.pos.get_order(),
-                    product: this.env.pos.db.get_product_by_id(this.env.pos.config.down_payment_product_id[0]),
-                    price: down_payment,
-                    price_manually_set: true,
-                    sale_order_origin_id: clickedOrder,
-                    down_payment_details: tab,
-                });
-                new_line.set_unit_price(down_payment);
-                this.env.pos.get_order().add_orderline(new_line);
               }
 
               currentPOSOrder.trigger('change');


### PR DESCRIPTION
When you are choosing to apply a down payment on a sale order in pos,
it'll add a line to the pos order with the down payment product and the
value you choosed.

In this case we are considering that the down payment product is set and
a traceback is triggered when you try to apply down payment.

So we are now handling this error when no down payment is configured.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
