### PR TITLE
[FIX] stock: Change default value for 'counted' quants

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -133,7 +133,7 @@ class StockQuant(models.Model):
 
     @api.depends('inventory_quantity')
     def _compute_inventory_quantity_set(self):
-        self.inventory_quantity_set = True
+        self.inventory_quantity_set = False
 
     @api.depends('inventory_quantity', 'quantity', 'product_id')
     def _compute_is_outdated(self):
@@ -197,6 +197,7 @@ class StockQuant(models.Model):
             quant.inventory_quantity = inventory_quantity
             quant.user_id = vals.get('user_id', self.env.user.id)
             quant.inventory_date = fields.Date.today()
+            quant.inventory_quantity_set = True
 
             return quant
         res = super(StockQuant, self).create(vals)
@@ -238,6 +239,8 @@ class StockQuant(models.Model):
             if any(quant.location_id.usage == 'inventory' for quant in self):
                 # Do nothing when user tries to modify manually a inventory loss
                 return
+            if 'inventory_quantity' in vals and 'inventory_quantity_set' not in vals:
+                vals['inventory_quantity_set'] = True
             if any(field for field in vals.keys() if field not in allowed_fields):
                 raise UserError(_("Quant's editing is restricted, you can't do this operation."))
             self = self.sudo()

--- a/addons/stock/tests/test_inventory.py
+++ b/addons/stock/tests/test_inventory.py
@@ -306,6 +306,7 @@ class TestInventory(TransactionCase):
             'inventory_quantity': 42,
         })
         # Applies the change, the quant must have a quantity of 42 and a inventory quantity to 0.
+        inventory_quant = inventory_quant.with_context(inventory_mode=True)
         inventory_quant.action_apply_inventory()
         self.assertEqual(len(inventory_quant), 1)
         self.assertEqual(inventory_quant.inventory_quantity, 0)
@@ -338,6 +339,7 @@ class TestInventory(TransactionCase):
         # and its `inventory_quantity` must be equal to zero.
         self.assertEqual(inventory_quant.inventory_quantity, 0)
 
+        inventory_quant = inventory_quant.with_context(inventory_mode=True)
         inventory_quant.inventory_quantity = 5
         self.assertEqual(inventory_quant.inventory_diff_quantity, -2)
 


### PR DESCRIPTION
Creating a new quant will always set the value of
`inventory_quantity_set` to `True`. The reason was the only editable
quantity field in the inventory list view is `inventory_quantity`. If
the inventory_quantity_set was initiated to `False`. The input value
would have been lost at the quant creation.

The side effect of this boolean field is that any new quant created by
stock flows (a reception for instance) is created with counted quantity
to 0 and thus diff quantity to `-quantity`. This makes not much sense as
the quant is newly created and not newly counted.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
