### PR TITLE
[IMP] no longer flicker when updating we-select

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1004,13 +1004,10 @@ const SelectUserValueWidget = BaseSelectionUserValueWidget.extend({
             return;
         }
 
-        if (this.menuTogglerItemEl) {
-            this.menuTogglerItemEl.remove();
-            this.menuTogglerItemEl = null;
-        }
-
         let textContent = '\u200B'; // Ensures proper height.
         const activeWidget = this._userValueWidgets.find(widget => !widget.isPreviewed() && widget.isActive());
+        const oldTogglerEl = this.menuTogglerItemEl;
+        this.menuTogglerItemEl = null;
         if (activeWidget) {
             const svgTag = activeWidget.el.querySelector('svg'); // useful to avoid searching text content in svg element
             const value = (activeWidget.el.dataset.selectLabel || (!svgTag && activeWidget.el.textContent.replace('\u200B', '').trim()));
@@ -1030,9 +1027,13 @@ const SelectUserValueWidget = BaseSelectionUserValueWidget.extend({
             textContent = "/";
         }
 
-        this.menuTogglerEl.textContent = textContent;
-        if (this.menuTogglerItemEl) {
+        if (!this.menuTogglerItemEl) {
+            this.menuTogglerEl.textContent = textContent;
+        } else if (!oldTogglerEl) {
+            this.menuTogglerEl.textContent = textContent;
             this.menuTogglerEl.appendChild(this.menuTogglerItemEl);
+        } else if (!oldTogglerEl.isEqualNode(this.menuTogglerItemEl)) {
+            this.menuTogglerItemEl = oldTogglerEl.replaceWith(this.menuTogglerItemEl);
         }
     },
     /**


### PR DESCRIPTION
When updating a `SelectUserValueWidget`, the contents of the toggler are removed before adding the new contents. This causes a visible flicker in the layout of the editor. The flicker can be avoided by comparing the new and the old contents first (and only replacing when necessary).
