### PR TITLE
[FIX] l10n_at: add missing tax (§ 19 Abs. 1e) + better inline references

### DIFF
--- a/addons/l10n_at/data/account_tax_template.xml
+++ b/addons/l10n_at/data/account_tax_template.xml
@@ -20,7 +20,8 @@
         <!-- Vorlagen: Verkauf (Umsatzsteuer) -->
         <!-- Lieferungen, sonstige Leistungen und Eigenverbrauch +000,+001,-021 -->
         <!-- Umsätze, für die die Steuerschuld gemäß § 19 Abs. 1 zweiter
-            Satz sowie gemäß § 19 Abs. 1a, 1b, 1c, 1d und 1e (Umsätze ab 01.07.2010)
+            Satz sowie gemäß § 19 Abs. 1a, 1b,
+            1c, 1d und 1e (Umsätze ab 01.07.2010)
             auf den Leistungsempfänger übergegangen ist. -->
         <record id="account_tax_template_sales_rev_charge_0_code021" model="account.tax.template">
             <field name="name">UST_021 Steuerschuld betrifft Leistungsempfänger</field>
@@ -1193,7 +1194,13 @@
                 }),
             ]"/>
         </record>
-                <!-- Reverse Charge (§ 19 Abs. 1a - Bauleistungen) -->
+
+        <!--    § 19 Abs. 1a
+                https://www.ris.bka.gv.at/eli/bgbl/1994/663/P19/NOR40189968
+                https://www.jusline.at/gesetz/ustg/paragraf/19
+
+                Reverse Charge (§ 19 Abs. 1a - Bauleistungen)
+        -->
         <record id="account_tax_template_purchase_rev_charge_1a" model="account.tax.template">
             <field name="name">Reverse Charge 20% (§ 19 Abs. 1a - Bauleistungen)</field>
             <field name="description">RC 20% § 19 Abs. 1a</field>
@@ -1242,9 +1249,20 @@
             <field name="price_include" eval="0" />
         </record>
 
-        <!-- Reverse Charge gemäß § 19 Abs. 1b (Sicherungseigentum, Vorbehaltseigentum  und Grundstücke im Zwangsversteigerungsverfahren) -->
+        <!--    § 19 Abs. 1b
+                https://www.ris.bka.gv.at/eli/bgbl/1994/663/P19/NOR40189968
+                https://www.jusline.at/gesetz/ustg/paragraf/19
+
+                Reverse Charge gemäß § 19 Abs. 1b (Sicherungseigentum, Vorbehaltseigentum  und
+                Grundstücke im Zwangsversteigerungsverfahren)
+
+                a) sicherungsübereigneter Gegenstände durch den Sicherungsgeber an den Sicherungsnehmer,
+                b) des Vorbehaltskäufers an den Vorbehaltseigentümer im Falle der vorangegangenen Übertragung des vorbehaltenen Eigentums und
+                c) von Grundstücken im Zwangsversteigerungsverfahren durch den Verpflichteten an den Ersteher
+        -->
         <record id="account_tax_template_purchase_rev_charge_1b" model="account.tax.template">
-            <field name="name">Reverse Charge 20% (§ 19 Abs. 1b - Sicherungseigentum)</field>
+            <field name="name">Reverse Charge 20% (§ 19 Abs. 1b - Sicherungseigentum, Vorbehaltseigentum  und
+                Grundstücke im Zwangsversteigerungsverfahren))</field>
             <field name="description">RC 20% § 19 Abs. 1b</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">550</field>
@@ -1291,9 +1309,77 @@
             <field name="tax_group_id" ref="tax_group_0" />
         </record>
 
-        <!-- Reverse Charge gemäß § 19 Abs. 1 zweiter Satz, § 19 Abs. 1c sowie  gemäß Art. 25 Abs. 5 -->
+        <!--    § 19 Abs. 1 zweiter Satz
+                https://www.ris.bka.gv.at/eli/bgbl/1994/663/P19/NOR40189968
+                https://www.jusline.at/gesetz/ustg/paragraf/19
+
+                Art. 25 Abs. 5 (Dreiecksgeschäft)
+                https://www.ris.bka.gv.at/GeltendeFassung.wxe?Abfrage=Bundesnormen&Gesetzesnummer=10004929
+                https://www.jusline.at/gesetz/ustg-anhang/paragraf/artikel25
+
+                Reverse Charge gemäß § 19 Abs. 1 zweiter Satz, sowie  gemäß Art. 25 Abs. 5 (Dreiecksgeschäft)
+        -->
+        <record id="account_tax_template_purchase_rev_charge_19_2_25_5" model="account.tax.template">
+            <field name="name">Reverse Charge 20% (§ 19 Abs. 1 zweiter Satz - Sonstige Leistungen, Art. 25 Abs. 5 - Dreiecksgeschäft</field>
+            <field name="description">RC 20% §19 Sonstige Leistungen, Dreiecksgeschäft</field>
+            <field name="chart_template_id" ref="l10n_at_chart_template" />
+            <field name="sequence">550</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="price_include" eval="0" />
+            <field name="amount">20</field>
+            <field name="amount_type">percent</field>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0,{
+                  'factor_percent': 100,
+                  'repartition_type': 'base',
+                }),
+                (0,0,{
+                  'factor_percent': -100,
+                  'repartition_type': 'tax',
+                  'account_id': ref('chart_at_template_3510'),
+                  'plus_report_line_ids': [ref('tax_report_line_l10n_at_tva_line_4_21')],
+                }),
+                (0,0,{
+                  'factor_percent': 100,
+                  'repartition_type': 'tax',
+                  'account_id': ref('chart_at_template_2510'),
+                  'plus_report_line_ids': [ref('tax_report_line_l10n_at_tva_line_5_5')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0,{
+                  'factor_percent': 100,
+                  'repartition_type': 'base',
+                }),
+                (0,0,{
+                  'factor_percent': -100,
+                  'repartition_type': 'tax',
+                  'account_id': ref('chart_at_template_3510'),
+                  'minus_report_line_ids':  [ref('tax_report_line_l10n_at_tva_line_4_21')],
+                }),
+                (0,0,{
+                  'factor_percent': 100,
+                  'repartition_type': 'tax',
+                  'account_id': ref('chart_at_template_2510'),
+                  'minus_report_line_ids':  [ref('tax_report_line_l10n_at_tva_line_5_5')],
+                }),
+            ]"/>
+            <field name="tax_group_id" ref="tax_group_0" />
+        </record>
+
+        <!--    § 19 Abs. 1c
+                https://www.ris.bka.gv.at/eli/bgbl/1994/663/P19/NOR40189968
+                https://www.jusline.at/gesetz/ustg/paragraf/19
+
+                Reverse Charge gemäß § 19 Abs. 1c
+                Bei der Lieferung von Gas über ein Erdgasnetz im Gebiet der Gemeinschaft oder
+                jedes an ein solches Netz angeschlossene Netz, von Elektrizität oder
+                von Wärme oder Kälte über Wärme- oder Kältenetze, wenn sich der Ort dieser Lieferung nach § 3 Abs. 13 oder 14 bestimmt und
+                der liefernde Unternehmer im Inland weder sein Unternehmen betreibt noch eine an der Lieferung beteiligte Betriebsstätte hat,
+                wird die Steuer vom Empfänger der Lieferung geschuldet, wenn er im Inland für Zwecke der Umsatzsteuer erfasst ist.
+        -->
         <record id="account_tax_template_purchase_rev_charge_1c" model="account.tax.template">
-            <field name="name">Reverse Charge 20% (§ 19 Abs. 1c - Sonstige Leistungen)</field>
+            <field name="name">Reverse Charge 20% (§ 19 Abs. 1c - Gas, Strom, Wärme, Kälte)</field>
             <field name="description">RC 20% § 19 Abs. 1c</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">550</field>
@@ -1340,13 +1426,79 @@
             <field name="tax_group_id" ref="tax_group_0" />
         </record>
 
-        <!-- Reverse Charge gemäß § 19 Abs. 1d (Schrott und Abfallstoffe, Verordnung
-            BGBl. II Nr. 129/2007; Videospielkonsolen, Laptops, Tablet-Computer, Gas
-            und Elektrizität, Gas- und Elektrizitätszertifikate, Metalle, Anlagegold,
-            Verordnung BGBl. II Nr. 369/2013) -->
+        <!--    § 19 Abs. 1d
+                https://www.ris.bka.gv.at/eli/bgbl/1994/663/P19/NOR40189968
+                https://www.jusline.at/gesetz/ustg/paragraf/19
+
+                Reverse Charge gemäß § 19 Abs. 1d (Schrott und Abfallstoffe, Verordnung
+                BGBl. II Nr. 129/2007; Videospielkonsolen, Laptops, Tablet-Computer, Gas
+                und Elektrizität, Gas- und Elektrizitätszertifikate, Metalle, Anlagegold,
+                Verordnung BGBl. II Nr. 369/2013)
+        -->
         <record id="account_tax_template_purchase_rev_charge_1d" model="account.tax.template">
-            <field name="name">Reverse Charge 20% (§ 19 Abs. 1d - Schrott und Abfallstoffe)</field>
+            <field name="name">Reverse Charge 20% (§ 19 Abs. 1d - Schrott und Abfallstoffe, Spielekonsolen, Laptops, Tablet-Computer >= EUR 5.000,-, Gas und Elektrizität, Gas- und Elektrizitätszertifikate, Metalle, Anlagegold)</field>
             <field name="description">RC 20% § 19 Abs. 1d</field>
+            <field name="chart_template_id" ref="l10n_at_chart_template" />
+            <field name="sequence">550</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="price_include" eval="0" />
+            <field name="amount">20</field>
+            <field name="amount_type">percent</field>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0,{
+                  'factor_percent': 100,
+                  'repartition_type': 'base',
+                }),
+                (0,0,{
+                  'factor_percent': -100,
+                  'repartition_type': 'tax',
+                  'account_id': ref('chart_at_template_3510'),
+                  'plus_report_line_ids': [ref('tax_report_line_l10n_at_tva_line_4_24')],
+                }),
+                (0,0,{
+                  'factor_percent': 100,
+                  'repartition_type': 'tax',
+                  'account_id': ref('chart_at_template_2510'),
+                  'plus_report_line_ids': [ref('tax_report_line_l10n_at_tva_line_5_8')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0,{
+                  'factor_percent': 100,
+                  'repartition_type': 'base',
+                }),
+                (0,0,{
+                  'factor_percent': -100,
+                  'repartition_type': 'tax',
+                  'account_id': ref('chart_at_template_3510'),
+                  'minus_report_line_ids':  [ref('tax_report_line_l10n_at_tva_line_4_24')],
+                }),
+                (0,0,{
+                  'factor_percent': 100,
+                  'repartition_type': 'tax',
+                  'account_id': ref('chart_at_template_2510'),
+                  'minus_report_line_ids':  [ref('tax_report_line_l10n_at_tva_line_5_8')],
+                }),
+            ]"/>
+            <field name="tax_group_id" ref="tax_group_0" />
+        </record>
+
+        <!--    § 19 Abs. 1e
+                https://www.ris.bka.gv.at/eli/bgbl/1994/663/P19/NOR40189968
+                https://www.jusline.at/gesetz/ustg/paragraf/19
+
+                Reverse Charge gemäß § 19 Abs. 1e
+                a)  der Übertragung von Treibhausgasemissionszertifikaten im Sinne des Art. 3 der Richtlinie 2003/87/EG
+                    über ein System für den Handel mit Treibhausgasemissionszertifikaten in der Gemeinschaft und
+                    zur Änderung der Richtlinie 96/61/EG des Rates, ABl. Nr. L 275 vom 25.10.2003 S. 32, und bei
+                    der Übertragung von anderen Einheiten, die genutzt werden können, um den Auflagen dieser Richtlinie nachzukommen,
+                b)  der Lieferung von Mobilfunkgeräten (Unterpositionen 8517 12 00 und 8517 18 00 der Kombinierten Nomenklatur)
+                    und integrierten Schaltkreisen (Unterpositionen 8542 31 90, 8473 30 20, 8473 30 80 und 8471 50 00 der Kombinierten Nomenklatur),
+                    wenn das in der Rechnung ausgewiesene Entgelt mindestens 5 000 Euro beträgt.
+        -->
+        <record id="account_tax_template_purchase_rev_charge_1e" model="account.tax.template">
+            <field name="name">Reverse Charge 20% (§ 19 Abs. 1e - Treibhausgasemissionszertifikaten, Mobilfunkgeräte >= EUR 5.000,-)</field>
+            <field name="description">RC 20% § 19 Abs. 1e</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">550</field>
             <field name="type_tax_use">purchase</field>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
See inline documentation and references. In general, adding two new taxes (use cases) to have a more precise set of taxes to apply based on tax laws.

Info: @wt-io-it


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
