### PR TITLE
[IMP] base: allow a full email address in "mail.default.from"

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -436,15 +436,19 @@ class IrMailServer(models.Model):
         Used for the "header from" address when no other has been received.
 
         :return str/None:
-            Combines config parameters ``mail.default.from`` and
+            If the config parameter ``mail.default.from`` contains
+            a full email address, return it.
+            Otherwise, combines config parameters ``mail.default.from`` and
             ``mail.catchall.domain`` to generate a default sender address.
 
             If some of those parameters is not defined, it will default to the
             ``--email-from`` CLI/config parameter.
         """
         get_param = self.env['ir.config_parameter'].sudo().get_param
-        domain = get_param('mail.catchall.domain')
         email_from = get_param("mail.default.from")
+        if email_from and "@" in email_from:
+            return email_from
+        domain = get_param("mail.catchall.domain")
         if email_from and domain:
             return "%s@%s" % (email_from, domain)
         return tools.config.get("email_from")

--- a/odoo/addons/base/tests/test_ir_mail_server.py
+++ b/odoo/addons/base/tests/test_ir_mail_server.py
@@ -237,6 +237,22 @@ class TestIrMailServer(TransactionCase, MockSmtplibCase):
             from_filter=False,
         )
 
+        # Test the case when the "mail.default.from" contains a full email address and not just the local part
+        # the domain of this default email address can be different than the catchall domain
+        self.env['ir.config_parameter'].sudo().set_param('mail.default.from', 'test@custom_domain.com')
+        self.server_default.from_filter = 'custom_domain.com'
+
+        with self.mock_smtplib_connection():
+            message = self._build_email(mail_from='"Name" <test@unknown_domain.com>')
+            IrMailServer.send_email(message)
+
+        self.assert_email_sent_smtp(
+            smtp_from='test@custom_domain.com',
+            smtp_to_list=['dest@xn--example--i1a.com'],
+            message_from='"Name" <test@custom_domain.com>',
+            from_filter='custom_domain.com',
+        )
+
     @mute_logger('odoo.models.unlink')
     def test_mail_server_send_email_smtp_session(self):
         """Test all the cases when we provide the SMTP session.


### PR DESCRIPTION
Purpose
=======
Allow a full email address in the system parameter "mail.default.from".

This is useful if we want to send the emails with a domain different
from the domain used to receive them. E.G. a user on our SaaS can
configure an outgoing mail server for Outlook, use his email address as
the default one (so all emails will be encapsulated into his email
address) but keep our default configuration to receive the emails
(so the catchall domain still remains "mycompany.odoo.com").

Task-2738816