### PR TITLE
send partner_bank_id at the end of PoS session for swiss QR_Bill

### DIFF
--- a/addons/l10n_ch/models/account_invoice.py
+++ b/addons/l10n_ch/models/account_invoice.py
@@ -298,6 +298,9 @@ class AccountMove(models.Model):
         """
         self.ensure_one()
 
+        if not self.partner_bank_id:
+            raise UserError(_("QR-Bill can not be generated on paid invoices. If the invoice is not fully paid, please make sure Recipient Bank field is not empty and try again."))
+
         if not self.partner_bank_id._eligible_for_qr_code('ch_qr', self.partner_id, self.currency_id):
             raise UserError(_("Cannot generate the QR-bill. Please check you have configured the address of your company and debtor. If you are using a QR-IBAN, also check the invoice's payment reference is a QR reference."))
 

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -479,6 +479,16 @@ class PosOrder(models.Model):
         currency = self.currency_id
         return currency.round(amount) if currency else amount
 
+    def _get_partner_bank_id(self):
+        bank_partner_id = False
+        has_pay_later = any(not pm.journal_id for pm in self.payment_ids.mapped('payment_method_id'))
+        if has_pay_later:
+            if self.amount_total <= 0 and self.partner_id.bank_ids:
+                bank_partner_id = self.partner_id.bank_ids[0].id
+            elif self.amount_total >= 0 and self.company_id.partner_id.bank_ids:
+                bank_partner_id = self.company_id.partner_id.bank_ids[0].id
+        return bank_partner_id
+
     def _create_invoice(self, move_vals):
         self.ensure_one()
         new_move = self.env['account.move'].sudo().with_company(self.company_id).with_context(default_move_type=move_vals['move_type']).create(move_vals)
@@ -585,6 +595,7 @@ class PosOrder(models.Model):
             'move_type': 'out_invoice' if self.amount_total >= 0 else 'out_refund',
             'ref': self.name,
             'partner_id': self.partner_id.id,
+            'partner_bank_id': self._get_partner_bank_id(),
             # considering partner's sale pricelist's currency
             'currency_id': self.pricelist_id.currency_id.id,
             'invoice_user_id': self.user_id.id,


### PR DESCRIPTION
Description of the issue/feature this PR addresses: in v15.0 people with Swiss localization have a possibility to create QR_Bills from their invoices. However, while they can create QR_bill when creating invoices manually in accounting app, whenever they try to do the same with invoice generated by PoS session, they stumble upon this error:
Cannot generate the QR-bill. Please check you have configured the address of your company and debtor. If you are using a QR-IBAN, also check the invoice's payment reference is a QR reference.

Current behavior before PR:  The difference between creating invoice manually from accounting -> invoicing or after a PoS session is "Recipient Bank" field. If one manually fills said field in PoS invoice, then they will be able to print QR_bill again.

Desired behavior after PR: Users will be able to print QR_Bill without having to manually add Recipient Bank value to each invoice.

OPW-2695969
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
