### PR TITLE
[FIX] account: accrual orders lines filter

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -157,7 +157,8 @@ class AccruedExpenseRevenue(models.TransientModel):
                     o.order_line.with_context(accrual_entry_date=self.date)._compute_untaxed_amount_invoiced()
                     o.order_line.with_context(accrual_entry_date=self.date)._get_to_invoice_qty()
                 lines = o.order_line.filtered(
-                    lambda l: fields.Float.compare(
+                    lambda l: l.display_type not in ['line_section', 'line_note'] and
+                    fields.Float.compare(
                         l.qty_to_invoice,
                         0,
                         precision_rounding=l.product_uom.rounding,


### PR DESCRIPTION
Steps to repdroduce:
- install Purchase - Accounting
- Create a new Purchase Order
- Add a product
- Add a section or a note
- in Actions select Accrued Expense Entry
-> traceback rounding error

OPW-2728854
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
