### PR TITLE
[FIX] mail, mass_mailing: fix attachment ownership (cont)

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -194,15 +194,20 @@ class MailTemplate(models.Model):
             self.sub_model_object_field = False
             self.null_value = False
 
-    @api.model
-    def create(self, values):
-        result = super().create(values)
+    def _fix_attachment_ownership(self):
+        for record in self:
+            record.attachment_ids.write({'res_model': record._name, 'res_id': record.id})
+        return self
 
-        # fix attachment ownership
-        if result.attachment_ids:
-            result.attachment_ids.write({'res_model': self._name, 'res_id': result.id})
+    @api.model_create_multi
+    def create(self, values_list):
+        return super().create(values_list)\
+            ._fix_attachment_ownership()
 
-        return result
+    def write(self, vals):
+        super().write(vals)
+        self._fix_attachment_ownership()
+        return True
 
     def unlink(self):
         self.unlink_action()

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -233,18 +233,20 @@ class MassMailing(models.Model):
             values['body_html'] = self._convert_inline_images_to_urls(values['body_html'])
         if 'medium_id' not in values and values.get('mailing_type', 'mail') == 'mail':
             values['medium_id'] = self.env.ref('utm.utm_medium_email').id
-        result = super().create(values)
-
-        # fix attachment ownership
-        if result.attachment_ids:
-            result.attachment_ids.write({'res_model': self._name, 'res_id': result.id})
-
-        return result
+        return super().create(values)\
+            ._fix_attachment_ownership()
 
     def write(self, values):
         if values.get('body_html'):
             values['body_html'] = self._convert_inline_images_to_urls(values['body_html'])
-        return super(MassMailing, self).write(values)
+        super().write(values)
+        self._fix_attachment_ownership()
+        return True
+
+    def _fix_attachment_ownership(self):
+        for record in self:
+            record.attachment_ids.write({'res_model': record._name, 'res_id': record.id})
+        return self
 
     @api.returns('self', lambda value: value.id)
     def copy(self, default=None):

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -60,8 +60,7 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
             'mailing_domain': [('id', 'in', self.mm_recs.ids)],
         })
 
-        # TDE test_mail: 1864 / 2063
-        with self.assertQueryCount(__system__=1864, marketing=2063):
+        with self.assertQueryCount(__system__=1865, marketing=2065):
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)
@@ -100,8 +99,7 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
             'mailing_domain': [('id', 'in', self.mm_recs.ids)],
         })
 
-        # TDE test_mail: 2178 / 2389
-        with self.assertQueryCount(__system__=2178, marketing=2389):
+        with self.assertQueryCount(__system__=2179, marketing=2391):
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)


### PR DESCRIPTION
Followup to #82105: turns out we kind-of forgot that records could be updated with new attachment and the exact same issue could occur.

So with the same reasoning as the previous PR, re-attach attachments to the current object when updating it.
