### PR TITLE
[FIX] web: Infinite loop with datepicker input

### DIFF
--- a/addons/web/static/src/legacy/js/components/datepicker.js
+++ b/addons/web/static/src/legacy/js/components/datepicker.js
@@ -81,7 +81,9 @@ odoo.define('web.DatePickerOwl', function (require) {
          * @param {...any} args anything that will be passed to the datetimepicker function.
          */
         _datetimepicker(...args) {
+            this.ignoreBootstrapEvents = true;
             $(this.el).datetimepicker(...args);
+            this.ignoreBootstrapEvents = false;
         }
 
         /**
@@ -120,6 +122,9 @@ odoo.define('web.DatePickerOwl', function (require) {
          * @private
          */
         _onDateTimePickerHide() {
+            if (this.ignoreBootstrapEvents) {
+                return;
+            }
             const date = this._parseInput(this.inputRef.el.value);
             this.state.warning = date.format('YYYY-MM-DD') > moment().format('YYYY-MM-DD');
             this.trigger('datetime-changed', { date });
@@ -132,6 +137,9 @@ odoo.define('web.DatePickerOwl', function (require) {
          * @private
          */
         _onDateTimePickerShow() {
+            if (this.ignoreBootstrapEvents) {
+                return;
+            }
             this.inputRef.el.select();
         }
 


### PR DESCRIPTION
Steps:
 - Go into a view and filter on date/datetime
 - Select between
 - change the input max date manually
 - click outside the calendar while remaining in the filter dropdown to "validate" the input
 - infinite loop/crash

Same problem/fix as https://github.com/odoo/odoo/pull/78394 in 14.0

opw-2722797