### PR TITLE
[FIX] hr_holidays : allow user to take time off allocated in the future

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -232,7 +232,7 @@ class HolidaysType(models.Model):
         ])
 
         if not date:
-            date = fields.Date.context_today(self)
+            date = self.env.context.get('default_date_from', fields.Date.context_today(self))
         allocations = self.env['hr.leave.allocation'].search([
             ('employee_id', 'in', employee_ids),
             ('state', 'in', ['confirm', 'validate1', 'validate']),


### PR DESCRIPTION
Steps:
- Install Time Off
- Create Time Off Type T
- Create Time Off Allocation :
	- Time Off Type : T
	- Validity Period : in the future
	- Employee : Demo
- As Demo, create Time Off Request

Issue :
- As a Time Off Type, T is not displayed

Cause :
- This dropdown list calls _compute_leaves, which calls
get_employees_days with no date.
- As a result, this method search Time Off Allocations available today.
- Yet, T doesn't satisfy this condition.

Fix :
- Append date conditions to domain search only when a date is given s
param.

opw-2730416

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
