### PR TITLE
[IMP] sale_crm: dependency issue

### DIFF
--- a/addons/sale_crm/__manifest__.py
+++ b/addons/sale_crm/__manifest__.py
@@ -16,7 +16,7 @@ The case is then closed and linked to the generated sales order.
 We suggest you to install this module, if you installed both the sale and the crm
 modules.
     """,
-    'depends': ['sale_management', 'crm'],
+    'depends': ['sale', 'crm'],
     'data': [
         'security/ir.model.access.csv',
         'data/crm_lead_merge_template.xml',


### PR DESCRIPTION
PURPOSE

Currently, sale_crm depends on sale_management and not on sale.
sale_crm doesn't need sale_manegement. Just like sale_renting_crm,
only the 'sale' core should be sufficient.

after this commit, change dependency of sale_crm, to sale only (not sale_management)
and introduce one method `get_prepared_domain` that simply return
the domain for `sale order` and `sale quotation`, using that method
we can override that method in `sale_renting_crm` for splitting
`rental orders` and `sale orders`.

Task-id: 2627580

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
