### PR TITLE
Master base group inheritance warning nla

### DIFF
--- a/addons/web/static/src/legacy/js/fields/field_registry.js
+++ b/addons/web/static/src/legacy/js/fields/field_registry.js
@@ -77,6 +77,7 @@ registry
 // Relational fields
 registry
     .add('selection', relational_fields.FieldSelection)
+    .add('res_groups_selection', relational_fields.FieldResGroupsSelection)
     .add('radio', relational_fields.FieldRadio)
     .add('selection_badge', relational_fields.FieldSelectionBadge)
     .add('many2one', relational_fields.FieldMany2One)

--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -3424,27 +3424,27 @@ const FieldResGroupsSelection = FieldSelection.extend({
     // Private
     //--------------------------------------------------------------------------
 
-    /**
-     * Check the Group Inheritance on change of selection
-     * @override
-     * @private
-     */
-    _onChange: async function () {
-        await this._super(...arguments);
-        const groups_id = [];
-        for (const [key, value] of Object.entries(this.recordData)) {
-            if (key.includes('sel_groups_') && value) {
-                groups_id.push(value);
-            }
-        }
-        this._rpc({
-            model: 'res.groups',
-            method: 'check_group_inheritance',
-            args: [groups_id],
-        }).then((result) => {
-            core.bus.trigger('show_res_groups_inheritance_warning', {warnings: result});
-        });
-    },
+    // /**
+    //  * Check the Group Inheritance on change of selection
+    //  * @override
+    //  * @private
+    //  */
+    // _onChange: async function () {
+    //     await this._super(...arguments);
+    //     const groups_id = [];
+    //     for (const [key, value] of Object.entries(this.recordData)) {
+    //         if (key.includes('sel_groups_') && value) {
+    //             groups_id.push(value);
+    //         }
+    //     }
+    //     this._rpc({
+    //         model: 'res.groups',
+    //         method: 'check_group_inheritance',
+    //         args: [groups_id],
+    //     }).then((result) => {
+    //         core.bus.trigger('show_res_groups_inheritance_warning', {warnings: result});
+    //     });
+    // },
 
     /**
      * Show the Warning if the Current Widget's Previous group is

--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -3402,9 +3402,9 @@ var FieldSelection = AbstractField.extend({
             var value = _.find(this.values, function (val) {
                 return val[0] === res_id;
             });
-            this._setValue({id: res_id, display_name: value[1]});
+            return this._setValue({id: res_id, display_name: value[1]});
         } else {
-            this._setValue(res_id);
+            return this._setValue(res_id);
         }
     },
 });

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -205,12 +205,10 @@ class Groups(models.Model):
                     rgir.gid
                 FROM
                     res_groups_implied_rel rgir
-                LEFT JOIN
-                    res_groups_implied_rel rgirr ON rgirr.hid=rgir.gid
                 JOIN
                     res_groups rg ON rg.id=rgir.gid
                 WHERE
-                    rgir.hid IN %s and rg.category_id IN %s
+                    rgir.hid IN %s and rg.category_id = %s
 
                 UNION ALL
 
@@ -221,16 +219,16 @@ class Groups(models.Model):
                 JOIN
                     group_implied_tree git ON git.gid = rgirr.hid
                 JOIN
-                    res_groups rg ON rg.id=git.gid
+                    res_groups rg ON rg.id=rgirr.gid
                 WHERE
-                    rg.category_id IN %s
+                    rg.category_id = %s
             )
             SELECT
                 gid
             FROM
                 group_implied_tree;
         """
-        self.env.cr.execute(query, [tuple(self.ids), tuple(self.category_id.ids), tuple(self.category_id.ids)])
+        self.env.cr.execute(query, [tuple(self.ids), self.category_id.id, self.category_id.id])
         return [x[0] for x in self.env.cr.fetchall()]
 
     def check_group_inheritance(self):

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -238,6 +238,7 @@ class Groups(models.Model):
             return {}
         inherited_groups = {}
         for group in self:
+            # Filter out the groups which are applying current groups due to group inheritance
             inherited_groups[group] = self.filtered(
                 lambda grp:
                 group.category_id in grp.implied_ids.category_id and
@@ -246,12 +247,14 @@ class Groups(models.Model):
         warnings = {}
         for key, value in inherited_groups.items():
             if value:
+                # Filter out the group which will be applied upon saving record
                 parent_group = value.implied_ids.filtered(
                     lambda grp:
                     grp.category_id == key.category_id and
                     grp not in (key | key.implied_ids | self)
                 )
                 if parent_group:
+                    # Get all the Parent groups which may add current group in hierarchy
                     parent_ids = parent_group._get_parent_group_ids()
                     if not any([gid in parent_ids for gid in self.ids]):
                         warnings[key.id] = _("Since you are a/an %s %s, you cannot have %s right lower than %s") % (value[0].category_id.name, value[0].name, parent_group[0].category_id.name, parent_group[0].name)

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1316,6 +1316,7 @@ class GroupsView(models.Model):
                     # application name with a selection field
                     field_name = name_selection_groups(gs.ids)
                     attrs['attrs'] = user_type_readonly
+                    attrs['on_change'] = '1'
                     attrs['widget'] = 'res_groups_selection'
                     if category_name not in xml_by_category:
                         xml_by_category[category_name] = []
@@ -1521,16 +1522,25 @@ class UsersView(models.Model):
                 + [field for field in names if not is_reified_group(field)]
             )
             values.pop('groups_id', None)
+            self._on_change_field_group()
             values.update(self._remove_reified_groups(values))
 
         field_onchange['groups_id'] = ''
         result = super().onchange(values, field_name, field_onchange)
+        print(">>>>>>>>>>>>", field_name)
         if not field_name: # merged default_get
             self._add_reified_groups(
                 filter(is_reified_group, field_onchange),
                 result.setdefault('value', {})
             )
         return result
+
+
+    @api.onchange('groups_id')
+    def _on_change_field_group(self):
+        import pdb
+        pdb.set_trace()
+        print
 
     def read(self, fields=None, load='_classic_read'):
         # determine whether reified groups fields are required, and which ones

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -198,6 +198,26 @@ class TestUsers2(TransactionCase):
         self.assertTrue(user_form.share, 'The groups_id onchange should have been triggered')
 
     def test_user_group_inheritance_no_warning(self):
+        """
+            Category:
+                Sales
+                ├── Manager
+                └── User
+                Field Service
+                ├── Manager
+                └── User
+
+            Groups:
+                Sales Manager
+                └── Sales User
+
+                Field Service Manager
+                ├── Sales Manager
+                └── Field Service User
+
+            When User tries to change the Sales and Field Service Groups as Manager, warning
+            should not be raise.
+        """
         cat_foo = self.env['ir.module.category'].create({'name': 'Foo'})
         cat_bar = self.env['ir.module.category'].create({'name': 'Bar'})
 
@@ -218,6 +238,30 @@ class TestUsers2(TransactionCase):
         self.assertFalse(warning)
 
     def test_user_group_parent_inheritance_no_warning(self):
+        """
+            Category:
+                Timesheets
+                ├── Administrator
+                ├── User: all timesheets
+                └── User: own timesheets only
+                Field Service
+                ├── Manager
+                └── User
+
+            Groups:
+                Timesheets Administrator
+                └── Timesheets User: all timesheets
+                    └── Timesheets User: own timesheets only
+
+                Field Service Manager
+                └── Field Service User
+                    └── Timesheets User: own timesheets only
+
+            Here, Field Service User will automatically apply the Timesheets User: own timesheets only
+            User has Timesheets Administrator group and make changes For Field Service User.
+            now, User already have Timesheet Administrator group so it will automatially Apply User Own timesheet,
+            so in that case warning shouldn't be raised.
+        """
         cat_foo = self.env['ir.module.category'].create({'name': 'Foo'})
         cat_bar = self.env['ir.module.category'].create({'name': 'Bar'})
 
@@ -242,6 +286,27 @@ class TestUsers2(TransactionCase):
         self.assertFalse(warning)
 
     def test_user_group_inheritance_warning(self):
+        """
+            Category:
+                Sales
+                ├── Manager
+                └── User
+                Field Service
+                ├── Manager
+                └── User
+
+            Groups:
+                Sales Manager
+                └── Sales User
+
+                Field Service Manager
+                ├── Sales Manager
+                └── Field Service User
+
+            Here Sales Manager is required when We have Field service as a Manager.
+            so, When user tries to change the Sales as a user, it will show the warning
+            about Sales Manager required since we have Field service as a manager
+        """
         cat_foo = self.env['ir.module.category'].create({'name': 'Foo'})
         cat_bar = self.env['ir.module.category'].create({'name': 'Bar'})
 
@@ -264,6 +329,36 @@ class TestUsers2(TransactionCase):
         self.assertEqual(warning[group_user_foo.id], 'Since you are a/an Bar Manager, you cannot have Foo right lower than Manager')
 
     def test_user_multi_group_inheritance_warning(self):
+        """
+            Category:
+                Sales
+                ├── Manager
+                └── User
+                Project
+                ├── Manager
+                └── User
+                Field Service
+                ├── Manager
+                └── User
+
+            Groups:
+                Sales Manager
+                └── Sales User
+
+                Project Manager
+                └── Project User
+
+                Field Service Manager
+                ├── Sales Manager
+                ├── Project Manager
+                └── Field Service User
+
+            Here, If user has Field service manager then it will automatically apply
+            the Sales Manager and Project manager.
+            Now, User has Sales, Project and Field Service as user and make changes in
+            Field Service as a Manager, it will show the Warning in Both Project and
+            Sales for group inconsistency.
+        """
         cat_foo = self.env['ir.module.category'].create({'name': 'Foo'})
         cat_bar = self.env['ir.module.category'].create({'name': 'Bar'})
         cat_baz = self.env['ir.module.category'].create({'name': 'Baz'})

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -217,6 +217,30 @@ class TestUsers2(TransactionCase):
         warning = (group_manager_foo | group_manager_bar).check_group_inheritance()
         self.assertFalse(warning)
 
+    def test_user_group_parent_inheritance_no_warning(self):
+        cat_foo = self.env['ir.module.category'].create({'name': 'Foo'})
+        cat_bar = self.env['ir.module.category'].create({'name': 'Bar'})
+
+        group_visitor_foo, group_user_foo, group_manager_foo = self.env['res.groups'].create([
+            {'name': name, 'category_id': cat_foo.id}
+            for name in ('Visitor', 'User', 'Manager')
+        ])
+
+        group_user_bar, group_manager_bar = self.env['res.groups'].create([
+            {'name': name, 'category_id': cat_bar.id}
+            for name in ('User', 'Manager')
+        ])
+
+        group_manager_foo.implied_ids = group_user_foo
+        group_user_foo.implied_ids = group_visitor_foo
+
+        group_manager_bar.implied_ids = group_user_bar
+        group_user_bar.implied_ids = group_visitor_foo
+
+        warning = (group_manager_foo | group_user_bar).check_group_inheritance()
+
+        self.assertFalse(warning)
+
     def test_user_group_inheritance_warning(self):
         cat_foo = self.env['ir.module.category'].create({'name': 'Foo'})
         cat_bar = self.env['ir.module.category'].create({'name': 'Bar'})


### PR DESCRIPTION
Current behavior before PR:

Communicate to users that specific access rights configuration is not possible due to group inheritance.
Because sometimes it is necessary to have a particular group due to some inheritance from the parent application and it will update the access rights without informing the user.

Desired behavior after PR is merged:

we will show the warning beside the group if the user tries to change the access right that will be gonna impacted by
the parent group.
so, users can understand the access right and have prior information about the access hierarchy, and can make changes according to it.

Task: https://www.odoo.com/web#id=2646704&menu_id=4720&cids=2&action=4043&model=project.task&view_type=form

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
