### PR TITLE
[FIX] http: logout when a database is deleted

### DIFF
--- a/addons/survey/tests/common.py
+++ b/addons/survey/tests/common.py
@@ -164,10 +164,6 @@ class SurveyCase(common.TransactionCase):
         url = survey.get_base_url() + '/survey/submit/%s/%s' % (survey.access_token, token)
         return self.opener.post(url=url, json={'params': post_data})
 
-    def _find_csrf_token(self, text):
-        csrf_token_re = re.compile("(input.+csrf_token.+value=\")([a-f0-9]{40}o[0-9]*)", re.MULTILINE)
-        return csrf_token_re.search(text).groups()[1]
-
     def _prepare_post_data(self, question, answers, post_data):
         values = answers if isinstance(answers, list) else [answers]
         if question.question_type == 'multiple_choice':

--- a/addons/web/tests/test_db_manager.py
+++ b/addons/web/tests/test_db_manager.py
@@ -11,7 +11,7 @@ import requests
 
 import odoo
 from odoo import http
-from odoo.tests.common import BaseCase, HttpCase, tagged, _wait_remaining_requests
+from odoo.tests.common import BaseCase, HttpCase, tagged, wait_remaining_requests
 from odoo.tools import config, mute_logger
 
 
@@ -91,6 +91,7 @@ class TestDatabaseOperations(BaseCase):
         self.assertDbs([test_db_name])
 
         # delete the created database
+        wait_remaining_requests(_logger)  # wait for all remaining requests before droping to avoid error on _drop_conn
         res = self.session.post(self.url('/web/database/drop'), data={
             'master_pwd': self.password,
             'name': test_db_name,
@@ -101,6 +102,7 @@ class TestDatabaseOperations(BaseCase):
 
     def test_database_duplicate(self):
         # duplicate this database
+        wait_remaining_requests(_logger)  # wait for all remaining requests before duplicate to avoid error on _drop_conn
         test_db_name = self.db_name + '-test-database-duplicate'
         self.assertNotIn(test_db_name, self.list_dbs_filtered())
         res = self.session.post(self.url('/web/database/duplicate'), data={
@@ -129,6 +131,7 @@ class TestDatabaseOperations(BaseCase):
         self.assertTrue(session['uid'])
 
         # delete the created database
+        wait_remaining_requests(_logger)  # wait for all remaining requests before droping to avoid error on _drop_conn
         res = self.session.post(self.url('/web/database/drop'), data={
             'master_pwd': self.password,
             'name': test_db_name,
@@ -149,7 +152,7 @@ class TestDatabaseOperations(BaseCase):
             #self._logger = logging.getLogger(__name__)  # pylint: disable=attribute-defined-outside-init
             # the raised OperationalError will reach werkzeug and may be logged after the end of the request,
             # outside the mute logger. We need to wait for remaining request to avoid that
-            _wait_remaining_requests(_logger)
+            wait_remaining_requests(_logger)
 
 
         # in any case, session should have been invalidated to avoid being stuck, logged in a dropped database

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1048,6 +1048,7 @@ class OpenERPSession(sessions.Session):
                 del self[k]
         self._default_values()
         self.rotate = True
+        root.session_store.save(self)
 
     def _default_values(self):
         self.setdefault("db", None)

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -182,7 +182,7 @@ class RecordCapturer:
         return self._after
 
 
-def _wait_remaining_requests(logger=None, timeout=10):
+def wait_remaining_requests(logger=None, timeout=10):
     logger = logger or _logger
 
     def get_http_request_threads():
@@ -1666,7 +1666,7 @@ class HttpCase(TransactionCase):
             # the method several times in a test method
             self.browser.delete_cookie('session_id', domain=HOST)
             self.browser.clear()
-            _wait_remaining_requests(self._logger)
+            wait_remaining_requests(self._logger)
 
     @classmethod
     def base_url(cls):


### PR DESCRIPTION
When an OperationalError error occurs trying to initialize a registry,
a possible reason is that the database does not exist, this is the main
reason why 28581cc73442747463386b1a84d1c54d15128078 introduced a logout.

Since #49111, if the error occurs on a /web page, the error is raised,
get_response is never reached, meaning that the session is not saved.

This will lead to an error everytime the page is refreshed on /web since
the database won't be removed from the session.

- connect to a database
- drop it from the database manager
- access /web. An ISE occurs

This is partially fixed in #82874, using logout on the session dropping
the database but the problem will remain for other sessions.

This commit proposes to save the session in all case when logout is
called. Looks like it makes sense in this case since performance-wise
logout won't be called much, and we don't want to lose the logout
information if we don't reach get_response().

Another solution would be to save the session only before raising.

This is a partial alternative to #54102

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
