### PR TITLE
[FIX] phone_validation: new convention number for Ivory Coast

### DIFF
--- a/addons/phone_validation/lib/__init__.py
+++ b/addons/phone_validation/lib/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import lib
-from . import tools
-from . import models
+from . import phonenumbers_patch

--- a/addons/phone_validation/lib/phonemetadata.py
+++ b/addons/phone_validation/lib/phonemetadata.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+try:
+    # import for usage in phonenumbers_patch/region_*.py files
+    from phonenumbers.phonemetadata import NumberFormat, PhoneNumberDesc, PhoneMetadata # pylint: disable=unused-import
+except ImportError:
+    pass

--- a/addons/phone_validation/lib/phonenumbers_patch/__init__.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/__init__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2009 The Libphonenumber Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# https://github.com/google/libphonenumber
+
+from odoo.tools.parse_version import parse_version
+
+try:
+    import phonenumbers
+    # MONKEY PATCHING phonemetadata of Ivory Coast if phonenumbers is too old
+    if parse_version('7.6.1') <= parse_version(phonenumbers.__version__) < parse_version('8.12.32'):
+        def _local_load_region(code):
+            __import__("region_%s" % code, globals(), locals(),
+                fromlist=["PHONE_METADATA_%s" % code], level=1)
+        # loading updated region_CI.py from current directory
+        # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.12.32/python/phonenumbers/data/region_CI.py
+        phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('CI', _local_load_region)
+except ImportError:
+    pass

--- a/addons/phone_validation/lib/phonenumbers_patch/region_CI.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/region_CI.py
@@ -1,0 +1,9 @@
+"""Auto-generated file, do not edit by hand. CI metadata"""
+from ..phonemetadata import NumberFormat, PhoneNumberDesc, PhoneMetadata
+
+PHONE_METADATA_CI = PhoneMetadata(id='CI', country_code=225, international_prefix='00',
+    general_desc=PhoneNumberDesc(national_number_pattern='[02]\\d{9}', possible_length=(10,)),
+    fixed_line=PhoneNumberDesc(national_number_pattern='2(?:[15]\\d{3}|7(?:2(?:0[23]|1[2357]|[23][45]|4[3-5])|3(?:06|1[69]|[2-6]7)))\\d{5}', example_number='2123456789', possible_length=(10,)),
+    mobile=PhoneNumberDesc(national_number_pattern='0704[0-7]\\d{5}|0(?:[15]\\d\\d|7(?:0[0-37-9]|[4-9][7-9]))\\d{6}', example_number='0123456789', possible_length=(10,)),
+    number_format=[NumberFormat(pattern='(\\d{2})(\\d{2})(\\d)(\\d{5})', format='\\1 \\2 \\3 \\4', leading_digits_pattern=['2']),
+        NumberFormat(pattern='(\\d{2})(\\d{2})(\\d{2})(\\d{4})', format='\\1 \\2 \\3 \\4', leading_digits_pattern=['0'])])

--- a/addons/phone_validation/tests/__init__.py
+++ b/addons/phone_validation/tests/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import lib
-from . import tools
-from . import models
+from . import test_phonenumbers_patch

--- a/addons/phone_validation/tests/test_phonenumbers_patch.py
+++ b/addons/phone_validation/tests/test_phonenumbers_patch.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+try:
+    import phonenumbers
+except ImportError:
+    phonenumbers = None
+
+from odoo.tests.common import BaseCase
+from odoo.tools.parse_version import parse_version
+from odoo.addons.phone_validation.lib import phonenumbers_patch
+
+class TestPhonenumbersPatch(BaseCase):
+    def test_region_CI_monkey_patch(self):
+        """Test if the  patch is apply on the good version of the lib
+        And test some phonenumbers"""
+        if not phonenumbers:
+            self.skipTest('Cannot test without phonenumbers module installed.')
+        # MONKEY PATCHING phonemetadata of Ivory Coast if phonenumbers is too old
+        if parse_version('7.6.1') <= parse_version(phonenumbers.__version__) < parse_version('8.12.32'):
+            # check that _local_load_region is set to `odoo.addons.phone_validation.lib.phonenumbers_patch._local_load_region`
+            # check that you can load a new ivory coast phone number without error
+            parsed_phonenumber_1 = phonenumbers.parse("20 25/35-51 ", region="CI", keep_raw_input=True)
+            self.assertEqual(parsed_phonenumber_1.national_number, 20253551, "The national part of the phonenumber should be 22522586")
+            self.assertEqual(parsed_phonenumber_1.country_code, 225, "The country code of Ivory Coast is 225")
+
+            parsed_phonenumber_2 = phonenumbers.parse("+225 22 52 25 86 ", region="CI", keep_raw_input=True)
+            self.assertEqual(parsed_phonenumber_2.national_number, 22522586, "The national part of the phonenumber should be 22522586")
+            self.assertEqual(parsed_phonenumber_2.country_code, 225, "The country code of Ivory Coast is 225")
+        else:
+            self.assertFalse(hasattr(phonenumbers_patch, '_local_load_region'),
+                "The code should not be monkey patched with phonenumbers > 8.12.32.")


### PR DESCRIPTION
Step to reproduce:

- Install contacts
- create a new contact and add "Côte d'Ivoire" to the Company Address field
- add a phone number like this one: (+225) 05 06 00 79 95 
- try to send a sms to the number, it's says "(Invalid number)" instate of the number, so it's not possible to send the SMS


The Ivory Coast has a new standard for the phone number since the 31 January 2021, the phone number can have a length of ten digits. And we use the library `phonenumbers` with the version `8.9.10` and `8.8.1` for the runbot and the SaaS server, but it's quite old (the `8.9.10` is released on Jul 12 2018). The library in version `8.12.29` resolve the issue, but we probably won't update them.

If we update the library, we should revert this commit.

opw-2726582

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
