### PR TITLE
[FIX] crm, sales_team: compute company within allowed_company_ids

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -291,8 +291,10 @@ class Lead(models.Model):
 
             # propose a new company based on responsible, limited by team
             if not proposal:
-                if lead.user_id:
-                    proposal = lead.team_id.company_id or lead.user_id.company_id
+                if lead.user_id and lead.team_id.company_id:
+                    proposal = lead.team_id.company_id
+                elif lead.user_id:
+                    proposal = lead.user_id.company_id & self.env.companies
                 elif lead.team_id:
                     proposal = lead.team_id.company_id
                 else:

--- a/addons/crm/tests/test_crm_lead_multicompany.py
+++ b/addons/crm/tests/test_crm_lead_multicompany.py
@@ -102,20 +102,20 @@ class TestCRMLeadMultiCompany(TestCrmCommon):
         lead = LeadUnsyncCids.sudo().create({
             'name': 'My Lead MC',
         })
-        self.assertEqual(lead.company_id, self.company_2)
-        self.assertEqual(lead.team_id, self.team_company2)
-        # self.assertEqual(lead.team_id, self.sales_team_1,
-        #                  'Lead: due to MC rule, took first availability in other company')
+        self.assertFalse(lead.company_id,
+                         'Lead: due to MC rule, avoid setting a company when it would cause crashes')
+        self.assertEqual(lead.team_id, self.sales_team_1,
+                         'Lead: due to MC rule, took first availability in other company')
         self.assertEqual(lead.user_id, self.user_sales_manager_mc)
 
-        # multicompany raises if trying to create manually
-        with self.assertRaises(AccessError):
-            lead = LeadUnsyncCids.create({
-                'name': 'My Lead MC',
-            })
-            # self.assertEqual(lead.company_id.id, False)
-            # self.assertEqual(lead.team_id, self.sales_team_1)
-            # self.assertEqual(lead.user_id, self.user_sales_manager_mc)
+        # manual creation
+        lead = LeadUnsyncCids.create({
+            'name': 'My Lead MC',
+        })
+        self.assertFalse(lead.company_id,
+                         'Lead: due to MC rule, avoid setting a company when it would cause crashes')
+        self.assertEqual(lead.team_id, self.sales_team_1)
+        self.assertEqual(lead.user_id, self.user_sales_manager_mc)
 
     @users('user_sales_manager_mc')
     def test_lead_mc_company_form(self):

--- a/addons/crm/tests/test_crm_lead_multicompany.py
+++ b/addons/crm/tests/test_crm_lead_multicompany.py
@@ -63,6 +63,61 @@ class TestCRMLeadMultiCompany(TestCrmCommon):
         self.assertEqual(lead_team_no_company.team_id, self.team_company2)
 
     @users('user_sales_manager_mc')
+    def test_lead_mc_company_computation_env_team_norestrict(self):
+        """ Check that the computed company is the one coming from the team even
+        when it's not in self.env.companies. This may happen when running the
+        Lead Assignment task. """
+        LeadUnsyncCids = self.env['crm.lead'].with_context(allowed_company_ids=[self.company_main.id])
+        self.assertEqual(LeadUnsyncCids.env.company, self.company_main)
+        self.assertEqual(LeadUnsyncCids.env.companies, self.company_main)
+        self.assertEqual(LeadUnsyncCids.env.user.company_id, self.company_2)
+
+        # multicompany raises if trying to create manually
+        with self.assertRaises(AccessError):
+            lead = LeadUnsyncCids.create({
+                'name': 'My Lead MC',
+                'team_id': self.team_company2.id
+            })
+
+        # simulate auto-creation through sudo (assignment-like)
+        lead = LeadUnsyncCids.sudo().create({
+            'name': 'My Lead MC',
+            'team_id': self.team_company2.id,
+        })
+        self.assertEqual(lead.company_id, self.company_2)
+        self.assertEqual(lead.team_id, self.team_company2)
+        self.assertEqual(lead.user_id, self.user_sales_manager_mc)
+
+    @users('user_sales_manager_mc')
+    def test_lead_mc_company_computation_env_user_restrict(self):
+        """ Check that the computed company is allowed (aka in self.env.companies).
+        User is logged in company_main even his default default company is
+        company_2. """
+        LeadUnsyncCids = self.env['crm.lead'].with_context(allowed_company_ids=[self.company_main.id])
+        self.assertEqual(LeadUnsyncCids.env.company, self.company_main)
+        self.assertEqual(LeadUnsyncCids.env.companies, self.company_main)
+        self.assertEqual(LeadUnsyncCids.env.user.company_id, self.company_2)
+
+        # simulate auto-creation through sudo (assignment-like)
+        lead = LeadUnsyncCids.sudo().create({
+            'name': 'My Lead MC',
+        })
+        self.assertEqual(lead.company_id, self.company_2)
+        self.assertEqual(lead.team_id, self.team_company2)
+        # self.assertEqual(lead.team_id, self.sales_team_1,
+        #                  'Lead: due to MC rule, took first availability in other company')
+        self.assertEqual(lead.user_id, self.user_sales_manager_mc)
+
+        # multicompany raises if trying to create manually
+        with self.assertRaises(AccessError):
+            lead = LeadUnsyncCids.create({
+                'name': 'My Lead MC',
+            })
+            # self.assertEqual(lead.company_id.id, False)
+            # self.assertEqual(lead.team_id, self.sales_team_1)
+            # self.assertEqual(lead.user_id, self.user_sales_manager_mc)
+
+    @users('user_sales_manager_mc')
     def test_lead_mc_company_form(self):
         """ Test lead company computation using form view """
         crm_lead_form = Form(self.env['crm.lead'])

--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -45,7 +45,7 @@ class CrmTeam(models.Model):
             user = self.env.user
         else:
             user = self.env['res.users'].sudo().browse(user_id)
-        valid_cids = [False] + user.company_ids.ids
+        valid_cids = [False] + [c for c in user.company_ids.ids if c in self.env.companies.ids]
 
         # 1- find in user memberships - note that if current user in C1 searches
         # for team belonging to a user in C1/C2 -> only results for C1 will be returned


### PR DESCRIPTION
Steps to follow

  - Select only one company in the company selector but not the default one from the current user
  - Go the the CRM app
  - Create a lead
  -> A multi company error appears

Solution

  When computing the company_id and team_id, keep only the ones within
  the allowed_company_ids

opw-2713757