### PR TITLE
[IMP] sms: sms composer promenade

### DIFF
--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -35,6 +35,7 @@ class SendSMS(models.TransientModel):
         ('mass', 'Send SMS in batch')], string='Composition Mode',
         compute='_compute_composition_mode', precompute=True, readonly=False, required=True, store=True)
     res_model = fields.Char('Document Model Name')
+    res_model_description = fields.Char('Document Model Description', compute='_compute_res_model_description')
     res_id = fields.Integer('Document ID')
     res_ids = fields.Char('Document IDs')
     res_ids_count = fields.Integer(
@@ -75,6 +76,12 @@ class SendSMS(models.TransientModel):
                     composer.composition_mode = 'mass'
                 else:
                     composer.composition_mode = 'comment'
+
+    @api.depends('res_model')
+    def _compute_res_model_description(self):
+        self.res_model_description = False
+        for composer in self.filtered('res_model'):
+            composer.res_model_description = self.env['ir.model']._get(composer.res_model).display_name
 
     @api.depends('res_model', 'res_id', 'res_ids')
     def _compute_res_ids_count(self):

--- a/addons/sms/wizard/sms_composer_views.xml
+++ b/addons/sms/wizard/sms_composer_views.xml
@@ -5,6 +5,25 @@
         <field name="model">sms.composer</field>
         <field name="arch" type="xml">
             <form string="Send an SMS">
+                <!-- Single mode information (invalid number) -->
+                <div colspan="2" class="alert alert-danger text-center mb-0" role="alert"
+                    attrs="{'invisible': ['|', '|', ('res_model_description', '=', False), ('comment_single_recipient', '=', False), ('recipient_single_valid', '=', True)]}">
+                    <p class="my-0">
+                        <strong>Invalid number:</strong>
+                        <span> make sure to set a country on the </span>
+                        <span><field name="res_model_description"/></span>
+                        <span> or to specify the country code.</span>
+                    </p>
+                </div>
+
+                <!-- Mass mode information (res_ids versus active domain) -->
+                <div colspan="2" class="alert alert-info text-center mb-0" role="alert"
+                        attrs="{'invisible': ['|', ('comment_single_recipient', '=', True), ('recipient_invalid_count', '=', 0)]}">
+                    <p class="my-0">
+                        <field class="oe_inline font-weight-bold" name="recipient_invalid_count"/> out of
+                        <field class="oe_inline font-weight-bold" name="res_ids_count"/> recipients have an invalid phone number and will not receive this text message.
+                    </p>
+                </div>
                 <sheet>
                     <group>
                         <field name="composition_mode" invisible="1"/>
@@ -18,21 +37,6 @@
                         <field name="number_field_name" invisible="1"/>
                         <field name="numbers" invisible="1"/>
                         <field name="sanitized_numbers" invisible="1"/>
-
-                        <!-- Single mode information (invalid number) -->
-                        <div colspan="2" class="alert alert-danger text-center mb-3" role="alert"
-                            attrs="{'invisible': ['|', ('comment_single_recipient', '=', False), ('recipient_single_valid', '=', True)]}">
-                            <p class="my-0">Invalid phone number</p>
-                        </div>
-
-                        <!-- Mass mode information (res_ids versus active domain) -->
-                        <div colspan="2" class="alert alert-info text-center mb-3" role="alert"
-                                attrs="{'invisible': ['|', ('comment_single_recipient', '=', True), ('recipient_invalid_count', '=', 0)]}">
-                            <p class="my-0">
-                                <field class="oe_inline font-weight-bold" name="recipient_invalid_count"/> out of
-                                <field class="oe_inline font-weight-bold" name="res_ids_count"/> recipients have an invalid phone number and will not receive this text message.
-                            </p>
-                        </div>
 
                         <label for="recipient_single_description" string="Recipient"
                             class="font-weight-bold"


### PR DESCRIPTION
Current behavior before PR:

There is an extra space at the top of the SMS composer and
an extra space below the validation message.
The validation message has no model description.

Desired behavior after PR is merged:

Below points:

1/ Remove additional space on top of the SMS composer.
2/ Remove the additional space below the validation message.
3/ Improve the validation message of the invalid phone number.

This is the goal of this commit.

PR #83062
Task-2710478



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
