### PR TITLE
[REM] base: remove deprecated field attribute

### DIFF
--- a/addons/website/models/ir_attachment.py
+++ b/addons/website/models/ir_attachment.py
@@ -12,8 +12,6 @@ class Attachment(models.Model):
 
     _inherit = "ir.attachment"
 
-    # related for backward compatibility with saas-6
-    website_url = fields.Char(string="Website URL", related='local_url', deprecated=True, readonly=False)
     key = fields.Char(help='Technical field used to resolve multiple attachments in a multi-website environment.')
     website_id = fields.Many2one('website')
 

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -278,7 +278,6 @@ class Field(MetaField('DummyField', (object,), {})):
     states = None                       # set readonly and required depending on state
     groups = None                       # csv list of group xml ids
     change_default = False              # whether the field may trigger a "user-onchange"
-    deprecated = None                   # whether the field is deprecated
 
     related_field = None                # corresponding related field
     group_operator = None               # operator for aggregating values
@@ -455,8 +454,8 @@ class Field(MetaField('DummyField', (object,), {})):
 
         self.__dict__.update(attrs)
 
-        # prefetch only stored, column, non-manual and non-deprecated fields
-        if not (self.store and self.column_type) or self.manual or self.deprecated:
+        # prefetch only stored, column, non-manual fields
+        if not self.store or not self.column_type or self.manual:
             self.prefetch = False
 
         if not self.string and not self.related:
@@ -806,7 +805,6 @@ class Field(MetaField('DummyField', (object,), {})):
     _description_states = property(attrgetter('states'))
     _description_groups = property(attrgetter('groups'))
     _description_change_default = property(attrgetter('change_default'))
-    _description_deprecated = property(attrgetter('deprecated'))
     _description_group_operator = property(attrgetter('group_operator'))
 
     def _description_depends(self, env):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3383,8 +3383,6 @@ Fields:
                 field = self._fields[name]
                 if not field.column_type:
                     field.read(fetched)
-                if field.deprecated:
-                    _logger.warning('Field %s is deprecated: %s', field, field.deprecated)
 
         # possibly raise exception for the records that could not be read
         missing = self - fetched
@@ -3947,10 +3945,6 @@ Fields:
                 continue
             field = self._fields[name]
             assert field.store
-
-            if field.deprecated:
-                _logger.warning('Field %s is deprecated: %s', field, field.deprecated)
-
             assert field.column_type
             columns.append((name, field.column_format, val))
 
@@ -4820,10 +4814,6 @@ Fields:
                     blacklist.update(set(self.env[parent_model]._fields) - whitelist)
                 else:
                     blacklist_given_fields(self.env[parent_model])
-            # blacklist deprecated fields
-            for name, field in model._fields.items():
-                if field.deprecated:
-                    blacklist.add(name)
 
         blacklist_given_fields(self)
 


### PR DESCRIPTION
It was only used one time.
We don't want to keep useless fields anymore,
the migration is done for that.
