### PR TITLE
[FIX] web_editor: remove gradient background image when removing format

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -334,7 +334,7 @@ export const editorCommands = {
             ) {
                 setSelection(block, 0, block, nodeSize(block));
                 editor.historyPauseSteps();
-                editor.document.execCommand('removeFormat');
+                editor.execCommand('removeFormat');
                 editor.historyUnpauseSteps();
                 setTagName(block, tagName);
             } else {
@@ -371,7 +371,13 @@ export const editorCommands = {
     italic: editor => editor.document.execCommand('italic'),
     underline: editor => editor.document.execCommand('underline'),
     strikeThrough: editor => editor.document.execCommand('strikeThrough'),
-    removeFormat: editor => editor.document.execCommand('removeFormat'),
+    removeFormat: editor => {
+        editor.document.execCommand('removeFormat');
+        for (const node of getTraversedNodes(editor.editable)) {
+            // The only possible background image on text is the gradient.
+            closestElement(node).style.backgroundImage = '';
+        }
+    },
 
     // Align
     justifyLeft: editor => align(editor, 'left'),

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -2805,6 +2805,13 @@ X[]
                     contentAfter: '<div><h1>[ab]</h1></div>',
                 });
             });
+            it('should remove the background image while turning a p>font into a heading 1>span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div><p><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(255, 204, 51) 0%, rgb(226, 51, 255) 100%);">[ab]</font></p></div>',
+                    stepFunction: editor => editor.execCommand('setTag', 'h1'),
+                    contentAfter: '<div><h1><span style="">[ab]</span></h1></div>',
+                });
+            });
         });
         describe('to heading 2', () => {
             it('should turn a heading 1 into a heading 2', async () => {


### PR DESCRIPTION
Before this commit the removeFormat command was only doing its default
native implementation, which did not clean the background-image CSS
property. Because of this, text-gradients became highlight gradients.

After this commit in addition to the default native implementation, the
removeFormat also clears the background-image CSS property.

Steps to reproduce:
- edit the website homepage
- drop a text snippet
- enter a new line of text
- set a text gradient on the new line
- switch the new line to Heading 1
=> new line has the gradient used as background

task-2741684 (was part of task-2666200)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
