### PR TITLE
[IMP] 13.0 chrome tests windows

### DIFF
--- a/doc/cla/individual/SplashS.md
+++ b/doc/cla/individual/SplashS.md
@@ -1,0 +1,11 @@
+Russian Federation, 2021-06-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Sergey Shebanin sergey@shebanin.ru https://github.com/SplashS

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -702,15 +702,24 @@ class ChromeBrowser():
                     return bin_
 
         elif system == 'Windows':
-            # TODO: handle windows platform: https://stackoverflow.com/a/40674915
-            pass
+            bins = [
+                '%ProgramFiles%\\Google\\Chrome\\Application\\chrome.exe',
+                '%ProgramFiles(x86)%\\Google\\Chrome\\Application\\chrome.exe',
+                '%LocalAppData%\\Google\\Chrome\\Application\\chrome.exe',
+            ]
+            for bin_ in bins:
+                bin_ = os.path.expandvars(bin_)
+                if os.path.exists(bin_):
+                    return bin_
 
         raise unittest.SkipTest("Chrome executable not found")
 
     def _spawn_chrome(self, cmd):
-        if os.name != 'posix':
-            return
-        pid = os.fork()
+        if os.name == 'nt':
+            proc = subprocess.Popen(cmd, stderr=subprocess.DEVNULL)
+            pid = proc.pid
+        else:
+            pid = os.fork()
         if pid != 0:
             return pid
         else:
@@ -791,7 +800,7 @@ class ChromeBrowser():
             version : get chrome and dev tools version
             protocol : get the full protocol
         """
-        command = os.path.join('json', command).strip('/')
+        command = '/'.join(['json', command]).strip('/')
         url = werkzeug.urls.url_join('http://%s:%s/' % (HOST, self.devtools_port), command)
         self._logger.info("Issuing json command %s", url)
         delay = 0.1


### PR DESCRIPTION
Before this commit there is no support to run chrome js tests on Windows.

After this commit there is this support.

This fix can be applied to versions from 13.0 to master




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
