### PR TITLE
[FIX][13.0] account: correct journal entry's number when changing journal on payment

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -170,6 +170,8 @@ class account_payment(models.Model):
     @api.onchange('journal_id')
     def _onchange_journal(self):
         if self.journal_id:
+            if self._origin and self._origin.journal_id and self.journal_id.type != self._origin.journal_id.type:
+                self.move_name = False
             if self.journal_id.currency_id:
                 self.currency_id = self.journal_id.currency_id
 

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -153,6 +153,7 @@
                             <h1><field name="name"/></h1>
                         </div>
                         <group>
+                            <field name="move_name" force_save="1"/>
                             <field name="invoice_ids" invisible="1"/>
                             <group name="partner_group" invisible="context.get('active_model') == 'account.move'">
                                 <field name="payment_type" widget="radio"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Steps:
1. Create a payment with journal as BANK
2. Validate a payment, then a journal entry is created which having number as BNK...
3. Reset to draft this payment and changing journal as CASH
4. Validate a payment, then a journal entry is created which having number as BNK...

Expected:
- a journal entry is created which having number as CASH...

**Current behavior before PR:**
Wrong journal entry's number when changing journal on payment

**Desired behavior after PR is merged:**
Correct journal entry's number when changing journal on payment



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
