### PR TITLE
[FIX] web_editor, mass_mailing: speed up opening of field html inline

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -115,10 +115,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
         this.$content.find('.o_layout').addBack().data('name', 'Mailing');
         // We don't want to drop snippets directly within the wysiwyg.
         this.$content.removeClass('o_editable');
-        // Force compute CSS rules even without the style-inline node option.
-        if (this.mode === 'edit' && !this.cssRules) {
-            this.cssRules = convertInline.getCSSRules(this.wysiwyg.getEditable()[0].ownerDocument);
-        }
     },
     /**
      * Returns true if the editable area is empty.

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -955,14 +955,6 @@ FieldHtml.include({
     // Public
     //--------------------------------------------------------------------------
 
-    _createWysiwygIntance: function () {
-        return this._super(...arguments).then(() => {
-            if (this.nodeOptions['style-inline'] && this.mode === "edit") {
-                this.cssRules = getCSSRules(this.wysiwyg.getEditable()[0].ownerDocument);
-            }
-        });
-    },
-
     /**
      * @override
      */


### PR DESCRIPTION
On opening field html with the inline styles option we were parsing all the css in the page. This should only be needed when we save. This commit moves the call to `getCSSRules`back to `commitChanges`.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
