### PR TITLE
[FIX] product_expiry: Fix JS traceback of undefined view

### DIFF
--- a/addons/product_expiry/models/stock_picking.py
+++ b/addons/product_expiry/models/stock_picking.py
@@ -23,7 +23,9 @@ class StockPicking(models.Model):
 
     def _action_generate_expired_wizard(self):
         expired_lot_ids = self.move_line_ids.filtered(lambda ml: ml.lot_id.product_expiry_alert).lot_id.ids
+        view_id = self.env.ref('product_expiry.confirm_expiry_view').id
         context = dict(self.env.context)
+
         context.update({
             'default_picking_ids': [(6, 0, self.ids)],
             'default_lot_ids': [(6, 0, expired_lot_ids)],
@@ -33,6 +35,8 @@ class StockPicking(models.Model):
             'type': 'ir.actions.act_window',
             'res_model': 'expiry.picking.confirmation',
             'view_mode': 'form',
+            'views': [(view_id, 'form')],
+            'view_id': view_id,
             'target': 'new',
             'context': context,
         }


### PR DESCRIPTION
Steps to reproduce:

- Install stock, stock_barcode, product_expiry
- Create a product tracked by lots or unique SN
- Activate expiration date on the product
- Create a lot for the product
- Set an old expiration date for the lot so it expires
- Go Barcode/Operations
- Choose whatever operation, for ex: Delivery
- Add the product you created
- Set the qty and choose the expired lot you created

Current behavior before PR:

- JS traceback as the view confirm_expiry_view is undefined

```
Traceback:
TypeError: Cannot read properties of undefined (reading 'slice')
at Class._loadViews (https://runbot.odoo.com/web/content/30387-19ad92a/web.assets_backend.js:460:228)
at Class._executeWindowAction [as _super] (https://runbot.odoo.com/web/content/30387-19ad92a/web.assets_backend.js:453:435)
at Class._executeWindowAction (https://runbot.odoo.com/web/content/140-9ec14c8/web_studio.assets.js:6:20)
at Class._executeWindowAction (https://runbot.odoo.com/web/content/30181-63e2b20/web.assets_common.js:4648:371)
at Class._handleAction (https://runbot.odoo.com/web/content/30387-19ad92a/web.assets_backend.js:459:109)
at Class.<anonymous> (https://runbot.odoo.com/web/content/30181-63e2b20/web.assets_common.js:4648:371)
at Class._handleAction (https://runbot.odoo.com/web/content/30387-19ad92a/web.assets_backend.js:479:20)
at Class.<anonymous> (https://runbot.odoo.com/web/content/30181-63e2b20/web.assets_common.js:4648:371)
at Class._handleAction (https://runbot.odoo.com/web/content/30387-19ad92a/web.assets_backend.js:7157:20)
at Class._handleAction (https://runbot.odoo.com/web/content/30181-63e2b20/web.assets_common.js:4648:371
```

Desired behavior after PR is merged:

- Open the confirmation view confirm_expiry_view which warns the customer that one of the lots is expired.

opw-2659939
opw-2729865
opw-2712550

backport of: odoo/odoo#83053

