### PR TITLE
[FIX] hr_fleet: bring back Attachments on assignation log

### DIFF
--- a/addons/hr_fleet/models/employee.py
+++ b/addons/hr_fleet/models/employee.py
@@ -23,7 +23,7 @@ class Employee(models.Model):
             "res_model": "fleet.vehicle.assignation.log",
             "views": [[False, "tree"], [False, "form"]],
             "domain": [("driver_employee_id", "in", self.ids)],
-            "context": dict(self._context, create=False),
+            "context": dict(self._context, default_driver_id=self.user_id.partner_id.id, default_driver_employee_id=self.id),
             "name": "History Employee Cars",
         }
 

--- a/addons/hr_fleet/views/fleet_vehicle_views.xml
+++ b/addons/hr_fleet/views/fleet_vehicle_views.xml
@@ -18,6 +18,8 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='driver_id']" position="after">
                 <field name="driver_employee_id" widget="many2one_avatar" optional="hide"/>
+                <field name="attachment_number" string=" "/>
+                <button name="action_get_attachment_view" string="Attachments" type="object" icon="fa-paperclip"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
The "Attachments" column was removed in odoo/odoo#76550, but it seems that it
is still needed after all.

TaskID: 2741777

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
