### PR TITLE
Allow XML template attachments

### DIFF
--- a/addons/web/tests/test_serving_base.py
+++ b/addons/web/tests/test_serving_base.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from lxml import etree
 import logging
 
-from odoo.tests.common import BaseCase, tagged
+from odoo.tests.common import BaseCase, HttpCase, tagged
 from odoo.tools import topological_sort
 from odoo.addons.web.controllers.main import HomeStaticTemplateHelpers
 
@@ -900,6 +900,35 @@ class TestStaticInheritance(TestStaticInheritanceCommon):
 
         self.assertXMLEqual(contents, expected)
 
+@tagged('static_templates')
+class TestHttpStaticInheritance(HttpCase):
+    def test_static_attachments(self):
+        url = '/test_module/test_file.xml'
+        self.env['ir.attachment'].create({
+            'name': 'test_attachment',
+            'url': url,
+            'res_model': 'ir.ui.view',
+            'type': 'binary',
+            'raw': b"""
+                <templates>
+                    <t t-name="test_template">
+                        <div class="test_div" />
+                    </t>
+                </templates>
+            """
+        })
+        self.env['ir.asset'].create({
+            'name': 'test_asset',
+            'path': url,
+            'bundle': 'test.bundle',
+        })
+
+
+        res = self.url_open('/web/webclient/qweb/HASH_BIDON?bundle=test.bundle')
+        [template] = etree.fromstring(res.text)
+
+        self.assertEqual(template.get('t-name'), 'test_template')
+        self.assertEqual(template[0].get('class'), 'test_div')
 
 @tagged('-standard', 'static_templates_performance')
 class TestStaticInheritancePerformance(TestStaticInheritanceCommon):


### PR DESCRIPTION
Before this commit: static XML templates could only be defined on the
file system, and called by manifest assets or ir.asset records.
Attachments were not taken into account when evaluating static
templates.

Now, if a given path does not match a file on the system, an
additional check is run on ir.attachment records instead of failing
directly.

Task [2715333](https://www.odoo.com/web#id=2715333&cids=1&model=project.task&view_type=form)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
