### PR TITLE
width of reciept is calculated for smaller devices

### DIFF
--- a/addons/point_of_sale/static/src/js/printers.js
+++ b/addons/point_of_sale/static/src/js/printers.js
@@ -98,6 +98,7 @@ var PrinterMixin = {
             html2canvas(self.receipt[0], {
                 onparsed: function(queue) {
                     queue.stack.ctx.height = Math.ceil(self.receipt.outerHeight() + self.receipt.offset().top);
+                    queue.stack.ctx.width = Math.ceil(self.receipt.outerWidth() + self.receipt.offset().left);
                 },
                 onrendered: function (canvas) {
                     $('.pos-receipt-print').empty();


### PR DESCRIPTION
Description of the issue/feature this PR addresses: When user tries to print a receipt from a small device, sometimes receipt is cropped on the right side. This happens because unlike height, receipt width is not calculated, instead it is equal to the width of the receipt div. 


Desired behavior after PR is merged: the width of the receipt is equal to the outer width of the receipt instead of div, and the receipts are not cropped anymore.


OPW-2721030 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
