### PR TITLE
[IMP] event: order event tags by category sequence / own sequence

### DIFF
--- a/addons/event/models/event_tag.py
+++ b/addons/event/models/event_tag.py
@@ -11,14 +11,23 @@ class EventTagCategory(models.Model):
     _description = "Event Tag Category"
     _order = "sequence"
 
+    def _default_sequence(self):
+        """
+        Here we use a _default method instead of ordering on 'sequence, id' to
+        prevent adding a new related stored field in the 'event.tag' model that
+        would hold the category id.
+        """
+        return (self.search([], order="sequence desc", limit=1).sequence or 0) + 1
+
     name = fields.Char("Name", required=True, translate=True)
-    sequence = fields.Integer('Sequence', default=0)
+    sequence = fields.Integer('Sequence', default=_default_sequence)
     tag_ids = fields.One2many('event.tag', 'category_id', string="Tags")
+
 
 class EventTag(models.Model):
     _name = "event.tag"
     _description = "Event Tag"
-    _order = "sequence"
+    _order = "category_sequence, sequence, id"
 
     def _default_color(self):
         return randint(1, 11)
@@ -26,6 +35,7 @@ class EventTag(models.Model):
     name = fields.Char("Name", required=True, translate=True)
     sequence = fields.Integer('Sequence', default=0)
     category_id = fields.Many2one("event.tag.category", string="Category", required=True, ondelete='cascade')
+    category_sequence = fields.Integer(related='category_id.sequence', string='Category Sequence', store=True)
     color = fields.Integer(
         string='Color Index', default=lambda self: self._default_color(),
         help='Tag color. No color means no display in kanban or front-end, to distinguish internal tags from public categorization tags.')

--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -308,6 +308,7 @@
                     <field name="date_begin" readonly="1" widget="date"/>
                     <field name="date_end" readonly="1" widget="date"/>
                     <field name="stage_id" readonly="1"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
                     <field name="seats_expected" string="Expected Attendees" sum="Total" readonly="1"/>
                     <field name="seats_used" sum="Total" readonly="1"/>
                     <field name="seats_max" string="Maximum Seats" sum="Total" readonly="1" optional="hide"/>

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -203,10 +203,10 @@
                             </time>
                             <!-- Location -->
                             <div itemprop="location" t-field="event.address_id" t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': 'true'}"/>
-                            <div class="mt8 d-flex align-items-center">
+                            <div class="mt8">
                                 <t t-foreach="event.tag_ids.filtered(lambda tag: tag.category_id.is_published)" t-as="tag">
                                     <span t-if="tag.color"
-                                        t-attf-class="badge mr8 #{'badge-primary' if tag in search_tags else 'badge-light'} #{'o_tag_color_%s' % tag.color if tag.color else ''}">
+                                        t-attf-class="badge mr4 #{'badge-primary' if tag in search_tags else 'badge-light'} #{'o_tag_color_%s' % tag.color if tag.color else ''}">
                                         <span t-esc="tag.name"/>
                                     </span>
                                 </t>


### PR DESCRIPTION
PURPOSE

Before this commit the tags were ordered only by its own sequence
making the display quite random when several tags had the same
sequence but belonged to different categories.
After this commit the tags are ordered by its category sequence
followed by its own sequence.

LINKS

Task-2737156



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
