### PR TITLE
[FIX] website: make animation works when cookies bar opened

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -1261,8 +1261,12 @@ registry.WebsiteAnimate = publicWidget.Widget.extend({
 
             // We need to offset for the change in position from some animation.
             // So we get the top value by not taking CSS transforms into calculations.
-            const $openModal = this.$target.find('.modal:visible');
-            const scrollTop = $openModal.length ? $openModal.scrollTop() : this.$scrollingElement.scrollTop();
+            // Cookies bar might be opened and considered as a modal but it is
+            // not really one (eg 'discrete' layout), and should not be used as
+            // scrollTop value.
+            const scrollTop = document.body.classList.contains("modal-open") ?
+                this.$target.find('.modal:visible').scrollTop() :
+                this.$scrollingElement.scrollTop();
             const elTop = this._getElementOffsetTop($el[0]) - scrollTop;
 
             const visible = this.windowsHeight > (elTop + elOffset) && 0 < (elTop + elHeight - elOffset);


### PR DESCRIPTION
Before this commit, since [1], when the cookies bar is opened, the pages'
animations would not work at all.
Animated images would not even be shown, remaining invisible.

This is because the s_popup when not using the layout 'popup' is still using
the modal/popup snippet structure but is not really a modal anymore.

As BS provide a built-in way to know if there is an open modal, which works
well with the cookies bar, use it instead.

opw-2712755 (detected during migration)

[1]: https://github.com/odoo/design-themes/commit/e025296ccf5b8d8ea19bd354d9fbd52a12fc4d94
