### PR TITLE
[FIX] web_editor: fix lingering only in tests

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1469,7 +1469,6 @@ export class OdooEditor extends EventTarget {
         const result = this._protect(() => this._applyRawCommand(...args));
         this.sanitize();
         this.historyStep();
-        this._handleCommandHint();
         return result;
     }
     /**

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -2248,7 +2248,7 @@ X[]
                         contentAfter: '<p><b>abc</b></p><p>[]<br></p>',
                     });
                 });
-                it.only('should insert line breaks outside the edges of an anchor', async () => {
+                it('should insert line breaks outside the edges of an anchor', async () => {
                     const pressEnter = editor => {
                         editor.document.execCommand('insertParagraph');
                     }


### PR DESCRIPTION
This PR removes a `only` in web_editor tests that prevented the actual test suite to be ran. It also reverts one commit that actually broke the test suite but wasn't properly tested because of the aforementioned mistake. A proper fix for the issue that it was supposed to fix will be merged later.