### PR TITLE
[FIX] web: ensure scrollbar in mail designer

### DIFF
--- a/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
@@ -6,6 +6,10 @@
     margin-bottom: -$o-sheet-cancel-bpadding;
 }
 
+html, body {
+    overflow: visible !important;
+}
+
 .o_mail_theme_selector {
     > a {
         height: $o-we-toolbar-height;


### PR DESCRIPTION
Commit [1] moved the scrollbar from the document body to the top element (#wrapwrap). This works for website builder but fails for iframes which don't have that element. This is apparent in Marketing Automation mail templates where it's become impossible to scroll down.
This fixes that issue by unsetting the overflow in the iframe.

task-2734825

[1] https://github.com/odoo/odoo/commit/9f048625e11dacda9fd49694e89ae65bc112374f

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
