### PR TITLE
resource.py float_to_time() function fails with hours having many decimals such as 9.999

### DIFF
--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -51,8 +51,9 @@ def float_to_time(hours):
     """ Convert a number of hours into a time object. """
     if hours == 24.0:
         return time.max
-    fractional, integral = math.modf(hours)
-    return time(int(integral), int(float_round(60 * fractional, precision_digits=0)), 0)
+    fractional, seconds = math.modf(hours * 3600)
+    microseconds = round(fractional * 1e6)
+    return (datetime(1, 1, 1) + timedelta(seconds=seconds, microseconds=microseconds)).time()
 
 
 def _boundaries(intervals, opening, closing):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

float_to_time() function (resource.py) fails with hours having many decimals such as 9.999 .
Also, since the current function can return time.max, which have seconds and microseconds on it, when you pass 24 hours as a parameter, I have decided to also handle the conversion to properly calculate seconds and microseconds. Also, if you pass an hour beyond 24, it will overflow: e.g. 25 will return time(1,0). 


Current behavior before PR:
Exception: "ValueError: minute must be in 0..59"


Desired behavior after PR is merged:
returns time(9, 59, 56, 400000)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
