### PR TITLE
[FIX] mass_mailing: fix missing columns option of text_block snippet

### DIFF
--- a/addons/mass_mailing/views/snippets/s_text_block.xml
+++ b/addons/mass_mailing/views/snippets/s_text_block.xml
@@ -2,13 +2,15 @@
 <odoo>
     <template id="s_text_block" name="Text">
         <div class="s_text_block pt40 pb40 px-3 o_mail_snippet_general" data-snippet="s_text_block">
-            <p class="o_default_snippet_text"> The open source model of Odoo has allowed us to leverage thousands of developers and
-                business experts to build hundreds of apps in just a few years.</p>
-            <p class="o_default_snippet_text"> With strong technical foundations, Odoo's framework is unique.
-                It provides top notch usability that scales across all apps.</p>
-            <p class="o_default_snippet_text"> Usability improvements made on Odoo will automatically apply to all
-                of our fully integrated apps.</p>
-            <p class="o_default_snippet_text"> That way, Odoo evolves much faster than any other solution.</p>
+            <div class="container s_allow_columns">
+                <p class="o_default_snippet_text"> The open source model of Odoo has allowed us to leverage thousands of developers and
+                    business experts to build hundreds of apps in just a few years.</p>
+                <p class="o_default_snippet_text"> With strong technical foundations, Odoo's framework is unique.
+                    It provides top notch usability that scales across all apps.</p>
+                <p class="o_default_snippet_text"> Usability improvements made on Odoo will automatically apply to all
+                    of our fully integrated apps.</p>
+                <p class="o_default_snippet_text"> That way, Odoo evolves much faster than any other solution.</p>
+            </div>
         </div>
     </template>
 </odoo>


### PR DESCRIPTION
The text_block snippet has the option to add columns in website but not in mass_mailing. This is a clear oversight that is hereby addressed.

task-2737896

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
