### PR TITLE
[FIX] web_editor: restore rules cache

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -336,8 +336,11 @@ function classToStyle($editable, cssRules) {
  *                                   specificity: number;}>
  */
 function toInline($editable, cssRules) {
+    const doc = $editable[0].ownerDocument;
+    cssRules = cssRules || doc._rulesCache;
     if (!cssRules) {
-        cssRules = getCSSRules($editable[0].ownerDocument);
+        cssRules = getCSSRules(doc);
+        doc._rulesCache = cssRules;
     }
 
     // Fix outlook image rendering bug (this change will be kept in both


### PR DESCRIPTION
This commit restores the cache on the document that was lost with the new parsing system [1]. It allows for faster convertion to inline styles after the first time on the same document.

[1] https://github.com/odoo/odoo/commit/10e749537186dfb80aee1f2537f3b5804f66cfe5#diff-5922d38ff6520249ff5b3a3240eebc350c6f9f4d9f486d512128c23261c45841L19

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
