### PR TITLE
[REF] web_editor, mass_mailing: rename wysiwyg "intance" typo functions

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -108,7 +108,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
     /**
      * @override
      */
-     _createWysiwygIntance: async function () {
+     _createWysiwygInstance: async function () {
         await this._super(...arguments);
         // Data is removed on save but we need the mailing and its body to be
         // named so they are handled properly by the snippets menu.
@@ -331,11 +331,11 @@ var MassMailingFieldHtml = FieldHtml.extend({
      * @private
      * @param {boolean} activateSnippets
      */
-    _restartWysiwygIntance: async function (activateSnippets = true) {
+    _restartWysiwygInstance: async function (activateSnippets = true) {
         this.wysiwyg.destroy();
         this.$el.empty();
         this._wysiwygSnippetsActive = activateSnippets;
-        await this._createWysiwygIntance();
+        await this._createWysiwygInstance();
     },
     /**
      * @private
@@ -496,7 +496,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
             const themeParams = themesParams[$(e.currentTarget).index()];
 
             if (themeParams.name === "basic") {
-                await this._restartWysiwygIntance(false);
+                await this._restartWysiwygInstance(false);
             }
             this._switchThemes(themeParams);
             this.$content.closest('body').removeClass("o_force_mail_theme_choice");

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -168,7 +168,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
      * @private
      * @returns {$.Promise}
      */
-    _createWysiwygIntance: async function () {
+    _createWysiwygInstance: async function () {
         this.wysiwyg = await wysiwygLoader.createWysiwyg(this, this._getWysiwygOptions());
         this.wysiwyg.__extraAssetsForIframe = this.__extraAssetsForIframe || [];
         return this.wysiwyg.appendTo(this.$el).then(() => {
@@ -290,9 +290,9 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
 
         if (this.nodeOptions.cssEdit) {
             // must be async because the target must be append in the DOM
-            this._createWysiwygIntance();
+            this._createWysiwygInstance();
         } else {
-            return this._createWysiwygIntance();
+            return this._createWysiwygInstance();
         }
     },
     /**


### PR DESCRIPTION
This properly renames the functions `_createWysiwygIntance` and `_restartWysiwygIntance` to, respectively, `_createWysiwygInstance` and `_restartWysiwygInstance` since they both had a typo in them and it's triggering all of our OCDs.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
