### PR TITLE
[FIX] base_import: allow importing a new file after one has been impo…

### DIFF
--- a/addons/base_import/static/src/js/import_action.js
+++ b/addons/base_import/static/src/js/import_action.js
@@ -854,7 +854,7 @@ StateMachine.create({
     target: DataImport.prototype,
     events: [
         { name: 'loaded_file',
-          from: ['none', 'file_loaded', 'preview_error', 'preview_success', 'results'],
+          from: ['none', 'file_loaded', 'preview_error', 'preview_success', 'results', 'imported'],
           to: 'file_loaded' },
         { name: 'settings_changed',
           from: ['file_loaded', 'preview_error', 'preview_success', 'results'],


### PR DESCRIPTION
…rted

**Steps to follow:**

  - Go to the Accounting Dashboard
  - Click on Bank > Import statements
  - Follow the flow to import a file
  - Once redirected to the reconciliation, go back to the import from
    the breadcrumbs
  - Load a new file

**Cause of the issue**

  The state machine used to handle events didn't allow going from
  imported to filed_loaded

opw-2706505