### PR TITLE
[FIX] web_editor: resolve ajax request of cleanForSave

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1934,14 +1934,15 @@ var SnippetsMenu = Widget.extend({
      *        If no element is given, all the editors are destroyed.
      */
     _destroyEditors: async function ($el) {
-        const proms = _.map(this.snippetEditors, async function (snippetEditor) {
-            if ($el && !$el.has(snippetEditor.$target).length) {
-                return;
-            }
-            await snippetEditor.cleanForSave();
-            snippetEditor.destroy();
+        const aliveEditors = this.snippetEditors.filter((snippetEditor) => {
+            return !$el || $el.has(snippetEditor.$target).length;
         });
-        await Promise.all(proms);
+        const cleanForSavePromises = aliveEditors.map((snippetEditor) => snippetEditor.cleanForSave());
+        await Promise.all(cleanForSavePromises);
+
+        for (const snippetEditor of aliveEditors) {
+            snippetEditor.destroy();
+        }
         this.snippetEditors.splice(0);
     },
     /**

--- a/addons/website/static/src/snippets/s_social_media/options.js
+++ b/addons/website/static/src/snippets/s_social_media/options.js
@@ -38,7 +38,7 @@ options.registry.SocialMedia = options.Class.extend({
                 websiteId = ctx['website_id'];
             },
         });
-        this._rpc({
+        await this._rpc({
             model: 'website',
             method: 'write',
             args: [[websiteId], this.dbSocialValues],


### PR DESCRIPTION
[FIX] web_editor: resolve ajax request of cleanForSave

Upon save in website or in mass_mailing, if a `cleanForSave` of a
`SnippetEditor` or a `SnippetOption` wait for the end of an
`this._rpc()` request AND the `SnippetEditor` or the `SnippetEditor`
of the `SnippetOption` has a `SnippetEditor` ancestor, the
`cleanForSave` will never resolve.

Here is the scenario:

- **SnippetEditor B** has **SnippetEditor A** as its odoo widget parent

In `SnippetMenu` `_destroyEditors`:
- **SnippetEditor A** and **all its SnippetOption** call `cleanForSave`. 
- **SnippetEditor B** and **all its SnippetOption** call `cleanForSave`.
  One of the promise of **SnippetEditor B** includes the result of
  `rpc()` in `ajax_service.js`.

- **SnippetEditor A** and **all its SnippetOption**
  `cleanForSave promises` resolve (but not **SnippetEditor B**).
- **SnippetEditor A** get's destroyed (`snippetEditor.destroy()`). As
**SnippetEditor B** is a `Widget` child of **SnippetEditor A**:
- **SnippetEditor B** get's destroyed (here is where the problem start).

... in the mean time ...

The ajax request of a promise of **SnippetEditor B** ends. The promise
of the `rpc()` will never finish because **SnippetEditor B** is
destroyed and the condition in `rpc()` is:
```js
if (!target.isDestroyed()) {
    resolve(result);
}
```

Because the promise will never finish for `_destroyEditors`, the save
action will never fully complete.

Task-2742008