### PR TITLE
[FIX] website: restore carousel slide addition (broken indicators)

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1598,7 +1598,7 @@ options.registry.Carousel = options.Class.extend({
         this.$controls.removeClass('d-none');
         const $active = $items.filter('.active');
         this.$indicators.append($('<li>', {
-            'data-target': '#' + $active.attr('id'),
+            'data-target': '#' + this.$target.attr('id'),
             'data-slide-to': $items.length,
         }));
         this.$indicators.append(' ');


### PR DESCRIPTION
Commit [1] changed the data-target used by new indicators for no
apparent reason. That broke their behavior.

[1]: https://github.com/odoo/odoo/commit/33b74a0fba8915766753474acb629616a1d0f6b2
