### PR TITLE
[FIX] web_editor: revert text color previews

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -737,6 +737,19 @@ export class OdooEditor extends EventTarget {
         this._toRollback = false;
     }
     /**
+     * Undo the current non-recorded draft step.
+     */
+    historyRevertCurrentStep() {
+        this.observerFlush();
+        this.historyRevert(this._currentStep, {sideEffect: false});
+        this.observerFlush();
+        // Clear current step from all previous changes.
+        this._currentStep.mutations = [];
+
+        this._activateContenteditable();
+        this.historySetSelection(this._currentStep);
+    }
+    /**
      * Undo a step of the history.
      *
      * this._historyStepsState is a map from it's location (index) in this.history to a state.

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -3123,6 +3123,26 @@ X[]
                 });
             });
         });
+        describe('revertCurrentStep', () => {
+            it('should not lose initially nested style', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a[b<span style="color: tomato;">c</span>d]e</p>',
+                    stepFunction: async editor => {
+                        // simulate preview
+                        editor.historyPauseSteps();
+                        try {
+                            applyInlineStyle(editor, (el) => el.style.color = 'lime');
+                            // a[bcd]e with bcd in lime
+                        } finally {
+                            editor.historyUnpauseSteps();
+                        }
+                        // simulate preview's reset
+                        editor.historyRevertCurrentStep(); // back to initial state
+                    },
+                    contentAfter: '<p>a[b<span style="color: tomato;">c</span>d]e</p>',
+                });
+            });
+        });
     });
 
     describe('applyColor', () => {

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1265,7 +1265,7 @@ const Wysiwyg = Widget.extend({
                         this._processAndApplyColor(eventName, ev.data.color);
                         this._updateEditorUI();
                     });
-                    colorpicker.on('color_hover color_leave', null, ev => {
+                    colorpicker.on('color_hover', null, ev => {
                         if (hadNonCollapsedSelection) {
                             this.odooEditor.historyResetLatestComputedSelection(true);
                         }
@@ -1275,6 +1275,9 @@ const Wysiwyg = Widget.extend({
                         } finally {
                             this.odooEditor.historyUnpauseSteps();
                         }
+                    });
+                    colorpicker.on('color_leave', null, ev => {
+                        this.odooEditor.historyRevertCurrentStep();
                     });
                     colorpicker.on('enter_key_color_colorpicker', null, () => {
                         $dropdown.children('.dropdown-toggle').dropdown('hide');


### PR DESCRIPTION
Before this commit when a text color was applied on a text within
which an already colored text already existed, the inner coloring was
lost during preview. All text was therefore set to the initial coloring
of the external selected text.

After this commit the "reset" of the text color preview is done by
undoing the draft "in progress" history step that contains the preview
changes, but that is not stored within the history itself.

Steps to reproduce:
- drop the Text snippet
- select a word in the middle of a sentence (e.g. "personality")
- set text color to red
- select several words containing the colored one (e.g. "story with
personality for potential")
- open text color palette
- hover over colors but do not click
- leave color palette
=> colored word is not colored anymore

Steps to reproduce a secondary problem also fixed by this commit:
- drop the Text snippet
- select text surrounding some bold (e.g. "have a personality. Consider")
- open text color palette
- quickly hover through several colors (i.e. move pointer downwards)
=> text selection range changed between some of the color previews

task-2742112 (was task-2666200)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
