### PR TITLE
[IMP]: account: Allow inheritance of chart template fields and clean redundancy

### DIFF
--- a/addons/l10n_se/data/account_chart_template_before_accounts.xml
+++ b/addons/l10n_se/data/account_chart_template_before_accounts.xml
@@ -14,23 +14,11 @@
         <record id="l10nse_chart_template_K2" model="account.chart.template">
             <field name="name">Swedish BAS Chart of Account complete K2</field>
             <field name="parent_id" ref="l10nse_chart_template"/>
-            <field name="currency_id" ref="base.SEK"/>
-            <field name="bank_account_code_prefix">193</field>
-            <field name="cash_account_code_prefix">191</field>
-            <field name="transfer_account_code_prefix">194</field>
-            <field name="code_digits">4</field>
-            <field name="country_id" ref="base.se"/>
         </record>
 
         <record id="l10nse_chart_template_K3" model="account.chart.template">
             <field name="name">Swedish BAS Chart of Account complete K3</field>
             <field name="parent_id" ref="l10nse_chart_template_K2"/>
-            <field name="currency_id" ref="base.SEK"/>
-            <field name="bank_account_code_prefix">193</field>
-            <field name="cash_account_code_prefix">191</field>
-            <field name="transfer_account_code_prefix">194</field>
-            <field name="code_digits">4</field>
-            <field name="country_id" ref="base.se"/>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
### [IMP]: account: Allow inheritance of chart template fields values
### [IMP]: l10n_se: Remove redundant fields definition

#### Description of the issue/feature this PR addresses: 

Some fields that could be inherited through the chart_templates parent_id are actually required to be re-defined in every new child template. That unnecessarily increase the chart template definition and thus decrease readability. It could also lead to issues when those values are changed in a parent and not in the children.

#### Current behavior before PR:

As some fields are set as required, when a child template is set a few fields has to be explicitly set even if the value is the same as the parent.

#### Desired behavior after PR is merged:

This allows to use the parent chart template values by default instead, and only reports an error when value is never set in the hierarchy.

As the fields are inherited, they should not be overriding the parent values with the same value as it would break change propagation.

less complexity

The concerned fields are: 
- currency_id
- bank_account_code_prefix
- cash_account_code_prefix
- transfer_account_code_prefix
- code_digits
-  country_id.

**Task:** task-2674123
**Linked to PR:** odoo/odoo/80223

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
