### PR TITLE
[FIX] mrp: admin rights added to admin/settings group

### DIFF
--- a/addons/mrp/security/mrp_security.xml
+++ b/addons/mrp/security/mrp_security.xml
@@ -40,6 +40,10 @@
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 
+    <record id="base.group_system" model="res.groups">
+        <field name="implied_ids" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
+    </record>
+
 </data>
 <data noupdate="1">
     <record id="base.default_user" model="res.users">


### PR DESCRIPTION
How to reproduce the bug:

- Install the mrp app
- Enable debug mode
- Go to Settings -> Groups
- Add Marc Demo to Administration/Settings group
- Log in to Marc Demo
- Click on the Settings App

Bug:

If, as a basic user, you are added to the Administration/Settings group,
you won't be able to open the Settings module. If you look closer at this group,
you will see that the MRP administration group is not inherited when you install the
module.

opw: 2697030

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
