### PR TITLE
[FIX] website_sale: the pricelist is reset when the address is edited

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -728,6 +728,10 @@ class WebsiteSale(http.Controller):
                     if not kw.get('use_same'):
                         kw['callback'] = kw.get('callback') or \
                             (not order.only_services and (mode[0] == 'edit' and '/shop/checkout' or '/shop/address'))
+                    # We need to update the pricelist(by the one selected by the customer), because onchange_partner reset it
+                    # We only need to update the pricelist when it is not redirected to /confirm_order
+                    if kw.get('callback', '') != '/shop/confirm_order':
+                        request.website.sale_get_order(update_pricelist=True)
                 elif mode[1] == 'shipping':
                     order.partner_shipping_id = partner_id
 


### PR DESCRIPTION
Expected behavior : The pricelist must be the one chosen by the customer on the website.

Current behavior : The price list is reset when the address is edited

Steps to reproduce the error :
First of all, you need to setup 2 pricelists on the website:
~ The first in dollars
~ The second in euros
~ Removes the group of countries from both

1. Create an order with the second price list (EURO)
2. Set your address
3. Edit your address
4. The pricelist will be changed to dollars

When you set the address for the first time, It redirects to /shop/confirm_order which
executes sale_get_order(update_pricelist=True) to correct the price list.

But when you edit the address sale_get_order(update_pricelist=True) is not  executed

closes odoo/odoo#83061

https://user-images.githubusercontent.com/35231827/150357083-5f884820-0ce4-4093-b98b-3e58c4cd2a35.mp4

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
