### PR TITLE
[FIX] pos_restaurant: remove useless cleaning

### DIFF
--- a/addons/pos_restaurant/static/src/js/multiprint.js
+++ b/addons/pos_restaurant/static/src/js/multiprint.js
@@ -300,13 +300,6 @@ models.Order = models.Order.extend({
     init_from_JSON: function(json){
         _super_order.init_from_JSON.apply(this,arguments);
         this.saved_resume = json.multiprint_resume && JSON.parse(json.multiprint_resume);
-        // Since the order summary structure has changed, we need to remove the old lines
-        // Otherwise, this fix deployment will lead to some errors
-        for (var key in this.saved_resume) {
-            if (this.saved_resume[key].pid == undefined) {
-                delete this.saved_resume[key];
-            }
-        }
     },
 });
 


### PR DESCRIPTION
[1] has changed the summary structure of an order. To avoid any issues
during the deployment, we added some instructions to remove the old
summaries. Now, these instructions can be removed.

[1] 911a178c99fe56c5f644083a0bb5e992a11f34ed