### PR TITLE
[FIX] payment_paypal: use the correct method to validate PDT data

### DIFF
--- a/addons/payment_paypal/controllers/main.py
+++ b/addons/payment_paypal/controllers/main.py
@@ -4,6 +4,8 @@ import logging
 import pprint
 
 import requests
+from requests.exceptions import ConnectionError, HTTPError
+from werkzeug import urls
 
 from odoo import _, http
 from odoo.exceptions import ValidationError
@@ -24,56 +26,112 @@ class PaypalController(http.Controller):
         The route also allows the GET method in case the user clicks on "go back to merchant site".
         """
         _logger.info("beginning DPN with post data:\n%s", pprint.pformat(data))
-        try:
-            self._validate_data_authenticity(**data)
-        except ValidationError:
-            pass  # The transaction has been moved to state 'error'. Redirect to /payment/status.
+        if not data:  # The customer has cancelled the payment
+            pass  # Redirect them to the status page to browse the draft transaction
         else:
-            if data:
-                request.env['payment.transaction'].sudo()._handle_feedback_data('paypal', data)
+            try:
+                notification_data = self._validate_pdt_data_authenticity(**data)
+            except ValidationError:
+                _logger.exception("could not verify the origin of the PDT; discarding it")
             else:
-                pass  # The customer has cancelled the payment, don't do anything
+                request.env['payment.transaction'].sudo()._handle_feedback_data(
+                    'paypal', notification_data
+                )
+
         return request.redirect('/payment/status')
+
+    def _validate_pdt_data_authenticity(self, **data):
+        """ Validate the authenticity of PDT data and return the retrieved notification data.
+
+        The validation is done in four steps:
+
+        1. Make a POST request to Paypal with the `tx`, the GET param received with the PDT data,
+           and the two other required params `cmd` and `at`.
+        2. PayPal sends back a response text starting with either 'SUCCESS' or 'FAIL'. If the
+           validation was a success, the notification data are appended to the response text as a
+           string formatted as follows: 'SUCCESS\nparam1=value1\nparam2=value2\n...'
+        3. Extract the notification data and process these instead of the PDT data.
+        4. Return an empty HTTP 200 response (done at the end of the route controller).
+
+        See https://developer.paypal.com/docs/api-basics/notifications/payment-data-transfer/.
+
+        :param dict data: The data whose authenticity must be checked.
+        :return: The retrieved notification data
+        :raise ValidationError: if the authenticity could not be verified
+        """
+        if 'tx' not in data:  # We did not receive PDT data but directly notification data
+            # When PDT is not enabled, PayPal sends directly the notification data instead. We can't
+            # verify them but we can process them as is.
+            notification_data = data
+        else:
+            acquirer_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
+                'paypal', data
+            ).acquirer_id
+            if not acquirer_sudo.paypal_pdt_token:  # We received PDT data but can't verify them
+                raise ValidationError("PayPal: The PDT token is not set; cannot verify data origin")
+            else:  # The PayPal account is configured to receive PDT data, and the PDT token is set
+                # Request a PDT data authenticity check and the notification data to PayPal
+                url = acquirer_sudo._paypal_get_api_url()
+                payload = {
+                    'cmd': '_notify-synch',
+                    'tx': data['tx'],
+                    'at': acquirer_sudo.paypal_pdt_token,
+                }
+                try:
+                    response = requests.post(url, data=payload, timeout=10)
+                    response.raise_for_status()
+                except (ConnectionError, HTTPError):
+                    raise ValidationError("PayPal: Encountered an error when verifying PDT origin")
+                else:
+                    notification_data = self._parse_pdt_validation_response(response.text)
+                    if notification_data is None:
+                        raise ValidationError("PayPal: The PDT origin was not verified by PayPal")
+
+        return notification_data
+
+    @staticmethod
+    def _parse_pdt_validation_response(response_content):
+        """ Parse the validation response and return the parsed notification data.
+
+        :param str response_content: The PDT validation request response
+        :return: The parsed notification data
+        :rtype: dict
+        """
+        response_items = response_content.splitlines()
+        if response_items[0] == 'SUCCESS':
+            notification_data = {}
+            for notification_data_param in response_items[1:]:
+                key, raw_value = notification_data_param.split('=', 1)
+                notification_data[key] = urls.url_unquote_plus(raw_value)
+            return notification_data
+        return None
 
     @http.route(_notify_url, type='http', auth='public', methods=['GET', 'POST'], csrf=False)
     def paypal_ipn(self, **data):
         """ Route used by the IPN. """
         _logger.info("beginning IPN with post data:\n%s", pprint.pformat(data))
         try:
-            self._validate_data_authenticity(**data)
+            self._validate_ipn_data_authenticity(**data)
             request.env['payment.transaction'].sudo()._handle_feedback_data('paypal', data)
         except ValidationError:  # Acknowledge the notification to avoid getting spammed
             _logger.exception("unable to handle the IPN data; skipping to acknowledge the notif")
         return ''
 
-    def _validate_data_authenticity(self, **data):
-        """ Validate the authenticity of data received through DPN or IPN
+    def _validate_ipn_data_authenticity(self, **data):
+        """ Validate the authenticity of IPN data.
 
         The verification is done in three steps:
-          - 1: POST the complete, unaltered, message back to Paypal (preceded by
-               `cmd=_notify-validate`), in the same encoding.
-          - 2: PayPal sends back either 'VERIFIED' or 'INVALID'.
-          - 3: Return an empty HTTP 200 response (done at the end of the route method).
-        See https://developer.paypal.com/docs/api-basics/notifications/ipn/IPNIntro
 
-        As per https://developer.paypal.com/docs/api-basics/notifications/payment-data-transfer/,
-        PDT notifications should be verified in a similar but different manner:
-          - The transaction ID should be retrieved from the GET param `tx`.
-          - The POST should use `_notify-synch` (as per previous versions of this method) as `cmd`,
-            and only have as params the transaction ID and the PDT Identity Token (under the key
-            `at`, as per previous versions of this method).
-          - The payment data should be parsed from the response of the check request.
-        In practice, however, the transaction ID is never given by PayPal and the documentation
-        has no mention of `_notify_synch` nor `at`. Because of this, PDT cannot be verified as
-        prescribed by the documentation.
-        Nevertheless, previous versions of this method used a bad heuristic (assessing the presence
-        of the optional, PDT-specific, param `amt`) to determine whether the notification was a PDT.
-        Since PDT notifications have in practice always been successfully authenticated by using the
-        IPN protocol, this method does explicitly that for both PDT and IPN.
+        1. POST the complete, unaltered, message back to Paypal (preceded by
+           `cmd=_notify-validate`), in the same encoding.
+        2. PayPal sends back either 'VERIFIED' or 'INVALID'.
+        3. Return an empty HTTP 200 response (done at the end of the route method).
 
-        :param dict data: The data whose authenticity to check
+        See https://developer.paypal.com/docs/api-basics/notifications/ipn/IPNIntro/.
+
+        :param dict data: The data whose authenticity must be checked.
         :return: None
-        :raise: ValidationError if the authenticity could not be verified
+        :raise ValidationError: if the authenticity could not be verified
         """
         tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
             'paypal', data

--- a/addons/payment_paypal/tests/test_paypal.py
+++ b/addons/payment_paypal/tests/test_paypal.py
@@ -153,3 +153,15 @@ class PaypalForm(PaypalCommon):
         })
         total_fee = self.paypal._compute_fees(100, False, False)
         self.assertEqual(round(total_fee, 2), 3.3, 'Wrong computation of the Paypal fees')
+
+    def test_parsing_pdt_validation_response_returns_notification_data(self):
+        """ Test that the notification data are parsed from the content of a validation response."""
+        response_content = 'SUCCESS\nkey1=val1\nkey2=val+2\n'
+        notification_data = PaypalController._parse_pdt_validation_response(response_content)
+        self.assertDictEqual(notification_data, {'key1': 'val1', 'key2': 'val 2'})
+
+    def test_fail_to_parse_pdt_validation_response_if_not_successful(self):
+        """ Test that no notification data are returned from parsing unsuccessful PDT validation."""
+        response_content = 'FAIL\ndoes-not-matter'
+        notification_data = PaypalController._parse_pdt_validation_response(response_content)
+        self.assertIsNone(notification_data)


### PR DESCRIPTION
With commit 7b165cd5, it was incorrectly assumed that PDT notifications
sent by PayPal could not be verified with the suggested method
(dedicated to PDT notifications) because they were missing some required
parameters. The code was thus adapted to have their verification done
with the method already in place for IPN notifications, as it seemed to
do the job. It turns out that the PayPal sandbox account that was used
at that time was not properly configured, and that PayPal was then
sending IPN-like notifications instead of actual PDT notifications,
which is the reason why the swap of methods worked.

Actually, once the account is properly configured, PayPal sends
correctly populated PDT notifications that must be verified with the
method dedicated to PDT notifications, as the one dedicated to IPN
notifications stops working in that case.

With this commit, the method used to verify the origin and integrity of
PDT notifications is replaced by the one that was previously removed.
The method is however implemented in a more defensive manner to:
1. accept and process the notification without verification if the
   account is not properly configured on PayPal.
2. silently discard the notification if the acquirer is not properly
   configured on Odoo. We then rely on the IPN (webhook) to confirm the
   transaction.

task-2744043

See also:
- https://github.com/odoo/documentation/pull/1480