### PR TITLE
[FIX] base: don't lose sudo when searching partners

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -759,7 +759,7 @@ class Partner(models.Model):
 
     @api.model
     def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
-        self = self.with_user(name_get_uid or self.env.uid)
+        self = self.with_user(name_get_uid) if name_get_uid else self
         # as the implementation is in SQL, we force the recompute of fields if necessary
         self.recompute(['display_name'])
         self.flush()


### PR DESCRIPTION
Currently, when searching a partner through a related record using
`sudo()`, the superuser privileges are used when searching the record,
but not when searching the related partner. That's because partner
lookup is implemented low-level (via SQL), taking care of record rules
considering the current user, but without considering whether sudo was
used.

For instance, a code like the following wouldn't work if the current
user has no enough rights (e.g. the public user):

    self.sudo().search([('partner_id', 'ilike', 'John Doe')])

To solve the above, sudo is preserved while searching partners.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
