### PR TITLE
[FIX] pos_sale: Force sale order invoice

### DIFF
--- a/addons/pos_sale/__manifest__.py
+++ b/addons/pos_sale/__manifest__.py
@@ -38,6 +38,7 @@ This module adds a custom Sales Team for the Point of Sale. This enables you to 
             'pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js',
             'pos_sale/static/src/js/OrderManagementScreen/SaleOrderRow.js',
             'pos_sale/static/src/js/ProductScreen.js',
+            'pos_sale/static/src/js/PaymentScreen.js',
         ],
         'web.assets_qweb': [
             'pos_sale/static/src/xml/**/*',

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
@@ -233,6 +233,7 @@ odoo.define('pos_sale.SaleOrderManagementScreen', function (require) {
                 }
               }
 
+              currentPOSOrder.set_to_invoice(true);
               currentPOSOrder.trigger('change');
               this.close();
             }

--- a/addons/pos_sale/static/src/js/PaymentScreen.js
+++ b/addons/pos_sale/static/src/js/PaymentScreen.js
@@ -1,0 +1,33 @@
+odoo.define('pos_sale.PosSalePaymentScreen', function (require) {
+    'use strict';
+
+    const PaymentScreen = require('point_of_sale.PaymentScreen');
+    const Registries = require('point_of_sale.Registries');
+
+    const PosSalePaymentScreen = (PaymentScreen) =>
+        class extends PaymentScreen {
+            toggleIsToInvoice() {
+                if(this.isSaleOrder()) {
+                    this.showPopup('ErrorPopup',{
+                        'title': this.env._t('Invoice Required'),
+                        'body':  this.env._t('An invoice is required to complete a sale order.'),
+                    });
+                } else {
+                    super.toggleIsToInvoice();
+                }
+            }
+            isSaleOrder() {
+                let lines = this.currentOrder.get_orderlines();
+                for(let line of lines) {
+                    if(line.sale_order_line_id) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        };
+
+    Registries.Component.extend(PaymentScreen, PosSalePaymentScreen);
+
+    return PosSalePaymentScreen;
+});

--- a/addons/pos_sale/static/src/js/models.js
+++ b/addons/pos_sale/static/src/js/models.js
@@ -39,6 +39,8 @@ models.Orderline = models.Orderline.extend({
       super_order_line_model.init_from_JSON.apply(this, arguments);
       this.sale_order_origin_id = json.sale_order_origin_id;
       this.sale_order_line_id = json.sale_order_line_id;
+      if(this.sale_order_origin_id)
+        this.order.set_to_invoice(true);
       this.down_payment_details = json.down_payment_details && JSON.parse(json.down_payment_details);
   },
   export_as_JSON: function () {


### PR DESCRIPTION
In case a sale order was used in the pos front end and wasn't invoiced, it was not so easy to get the invoice on the sale order.
Now we force the invoice from the front end so it'll be available on the sale order.

task-id: 2741749

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
