### PR TITLE
[FIX] website_slides: restore 'latest created' default promote strategy

### DIFF
--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -178,7 +178,7 @@ class Channel(models.Model):
         ('most_viewed', 'Most Viewed'),
         ('specific', 'Select Manually'),
         ('none', 'None')],
-        string="Featured Content", default='specific', required=False,
+        string="Featured Content", default='latest', required=False,
         help='Defines the content that will be promoted on the course home page',
     )
     promoted_slide_id = fields.Many2one('slide.slide', string='Promoted Slide')


### PR DESCRIPTION
To reproduce :
- Create a new documentation course from front-end
- Add a content there
- Edit the course in backend
=> any attempt to save the record or exiting it will trigger an error
as the specific option is set and no content has been manually set.

This has been introduced in 2597345
=> We restore the default 'latest created' that makes it work all the time.

Task-2731468