### PR TITLE
[FIX] hr_timesheet: fix timesheet creation in project

### DIFF
--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -134,7 +134,7 @@
                                     <field name="date"/>
                                     <field name="user_id" invisible="1"/>
                                     <field name="employee_id" required="1"/>
-                                    <field name="name"/>
+                                    <field name="name" required="0"/>
                                     <field name="unit_amount" string="Duration" widget="float_time"/>
                                     <field name="project_id" invisible="1"/>
                                     <field name="company_id" invisible="1"/>


### PR DESCRIPTION
before this PR,
when user tries to create a timesheet from task form view' page
in mobile without any description then it shows required field
is missing but in actual is description is not provided then it
should add '/' in description but in mobile timesheet is not
created on save of the form view of timesheet it will be
on save of the task that why it showing required field is
missing.

after this PR,
make description non required in timesheet form view of mobile
so it does not show required field missing warning.

task-2740041

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
