### PR TITLE
[IMP] mass_mailing_{sms}: group visibility for email marketing

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -283,9 +283,8 @@
                             </page>
                             <page string="Settings" name="settings">
                                 <group>
-                                    <group string="Email Content">
+                                    <group string="Email Content" attrs="{'invisible': [('mailing_type', '!=', 'mail')]}">
                                         <field class="o_text_overflow" name="preview" string="Preview Text" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}" widget="char_emojis" placeholder="e.g. Check it out before it's too late!"/>
-                                        <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
                                         <field name="email_from" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                         <label for="reply_to"/>
                                         <div name="reply_to_details">
@@ -314,7 +313,7 @@
                                                 attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                         </div>
                                     </group>
-                                    <group string="Tracking" groups="base.group_no_one,mass_mailing.group_mass_mailing_campaign">
+                                    <group string="Tracking">
                                         <field name="campaign_id"
                                             string="Campaign"
                                             groups="mass_mailing.group_mass_mailing_campaign"
@@ -331,6 +330,7 @@
                                             class="o_text_overflow"
                                             groups="base.group_no_one"
                                             attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
+                                        <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
                                     </group>
                                     <group string="Advanced" groups="base.group_no_one">
                                         <field name="mail_server_available" invisible="1"/>

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -117,8 +117,10 @@
                         options='{"enable_emojis": True}'/>
                 </page>
             </xpath>
-            <xpath expr="//field[@name='user_id']" position="after">
-                <field name="sms_allow_unsubscribe" attrs="{'invisible': [('mailing_type', '!=', 'sms')], 'readonly': [('state', 'in', ('sending', 'done'))]}"/>
+            <xpath expr="//page[@name='settings']/group/group[1]" position="after">
+                <group string="Options" attrs="{'invisible': [('mailing_type', '!=', 'sms')]}">
+                    <field name="sms_allow_unsubscribe" attrs="{'invisible': [('mailing_type', '!=', 'sms')], 'readonly': [('state', 'in', ('sending', 'done'))]}"/>
+                </group>
             </xpath>
 
             <xpath expr="//field[@name='contact_list_ids']" position="attributes">


### PR DESCRIPTION
PURPOSE

While creating a new SMS mailing, The settings tab should
have 'Responsible' field inside Tracking group and 'Include opt-out link' field
inside 'Options' group.

SPECIFICATIONS

While creating a new SMS mailing, There is an empty settings tab.

With this Commit,
- We have added a new 'Option' group and set the 'Include opt-out link'
field in this group.
- We have moved the 'Responsible' from Email Content to Tracking group.
- Responsible(user_id) will be always visible.
- Email Content group will visible only while creating Email Marketing.

PR #83183
Task-2710557

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr