### PR TITLE
[FIX] point_of_sale: fix pos_action access error

### DIFF
--- a/addons/point_of_sale/models/res_partner.py
+++ b/addons/point_of_sale/models/res_partner.py
@@ -36,7 +36,7 @@ class ResPartner(models.Model):
         '''
         This function returns an action that displays the pos orders from partner.
         '''
-        action = self.env.ref('point_of_sale.action_pos_pos_form').read()[0]
+        action = self.env['ir.actions.act_window']._for_xml_id('point_of_sale.action_pos_pos_form')
         if self.is_company:
             action['domain'] = [('partner_id.commercial_partner_id.id', '=', self.id)]
         else:


### PR DESCRIPTION
Steps to reproduce the bug:
- Log in as Admin
- Go to POS and open a session
- Select a customer for the order and complete the order
- Close the POS session
- Go to the associated customer to view their contact record
- Click the smart button for "Orders" > Admin can see POS orders for customer
- Log out, then log in as Demo
- Go to the contact and click the smart button for "Orders”

Problem:
An access error was raised:
`You are not allowed to access 'Action Window' (ir.actions.act_window) records.`

Only people in group Administration/Settings could read `action_pos_pos_form`

Solution:
To avoid this error, we should use `_for_xml_id`.

opw-2734462



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
