### PR TITLE
[IMP] hr_contract: add employee manager role

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -13,6 +13,7 @@ class Contract(models.Model):
     _name = 'hr.contract'
     _description = 'Contract'
     _inherit = ['mail.thread', 'mail.activity.mixin']
+    _mail_post_access = 'read'
 
     name = fields.Char('Contract Reference', required=True)
     active = fields.Boolean(default=True)

--- a/addons/hr_contract/security/ir.model.access.csv
+++ b/addons/hr_contract/security/ir.model.access.csv
@@ -6,3 +6,4 @@ access_hr_contract_manager,hr.contract.manager,model_hr_contract,hr_contract.gro
 access_hr_contract_type_manager,hr.contract.type.manager,model_hr_contract_type,hr_contract.group_hr_contract_manager,1,1,1,1
 access_hr_contract_history_manager,hr.contract.history.manager,model_hr_contract_history,hr_contract.group_hr_contract_manager,1,1,1,1
 access_hr_payroll_structure_type_hr_contract_manager,hr.payroll.structure.type.contract.manager,model_hr_payroll_structure_type,hr_contract.group_hr_contract_manager,1,1,1,1
+access_hr_contract_hr_employee_manager,hr.contract.hr.employee.manager,model_hr_contract,hr_contract.group_hr_contract_employee_manager,1,0,0,0

--- a/addons/hr_contract/security/security.xml
+++ b/addons/hr_contract/security/security.xml
@@ -6,10 +6,16 @@
             <field name="sequence">10</field>
         </record>
 
+        <record id="hr_contract.group_hr_contract_employee_manager" model="res.groups">
+            <field name="name">Employee Manager</field>
+            <field name="category_id" ref="base.module_category_hidden"/>
+            <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
+        </record>
+
         <record id="hr_contract.group_hr_contract_manager" model="res.groups">
             <field name="name">Administrator</field>
             <field name="category_id" ref="base.module_category_human_resources_contracts"/>
-            <field name="implied_ids" eval="[(4, ref('base.group_user')), (4, ref('hr.group_hr_user'))]"/>
+            <field name="implied_ids" eval="[(4, ref('hr_contract.group_hr_contract_employee_manager')), (4, ref('hr.group_hr_user'))]"/>
             <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         </record>
 
@@ -21,6 +27,20 @@
             <field name="name">HR Contract History: Multi Company</field>
             <field name="model_id" ref="model_hr_contract_history"/>
             <field name="domain_force">['|', ('employee_id.company_id', '=', False), ('employee_id.company_id', 'in', company_ids)]</field>
+        </record>
+
+        <record id="ir_rule_hr_contract_employee_manager" model="ir.rule">
+            <field name="name">HR Contract: Employee Manager</field>
+            <field name="model_id" ref="model_hr_contract"/>
+            <field name="groups" eval="[(4, ref('hr_contract.group_hr_contract_employee_manager'))]"/>
+            <field name="domain_force">['|', ('employee_id.parent_id.user_id', '=', user.id), ('employee_id.user_id', '=', user.id)]</field>
+        </record>
+
+        <record id="ir_rule_hr_contract_manager" model="ir.rule">
+            <field name="name">HR Contract: Contract Manager</field>
+            <field name="model_id" ref="model_hr_contract"/>
+            <field name="groups" eval="[(4, ref('hr_contract.group_hr_contract_manager'))]"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
         </record>
 
         <record id="ir_rule_hr_contract_multi_company" model="ir.rule">

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -135,7 +135,7 @@
             <field name="arch" type="xml">
                 <form string="Current Contract">
                     <header>
-                        <field name="state" widget="statusbar" options="{'clickable': '1'}"/>
+                        <field name="state" widget="statusbar"/>
                     </header>
                     <sheet>
                         <div class="oe_button_box" name="button_box"/>
@@ -143,7 +143,7 @@
                         <div class="oe_title pr-0" name="title">
                             <h1 class="d-flex flex-row justify-content-between">
                                 <field name="name" class="text-truncate" placeholder="Contract Reference"/>
-                                <field name="kanban_state" widget="state_selection"/>
+                                <field name="kanban_state" widget="state_selection" readonly="1"/>
                             </h1>
                             <h2>
                                 <field name="company_id" groups="base.group_multi_company" invisible="1"/>
@@ -157,11 +157,11 @@
                                 <field name="date_end" string="Contract End Date"/>
                                 <field name="company_country_id" invisible="1"/>
                                 <field name="country_code" invisible="1"/>
-                                <field name="structure_type_id" domain="['|', ('country_id', '=', False), ('country_id', '=', company_country_id)]"/>
+                                <field name="structure_type_id" domain="['|', ('country_id', '=', False), ('country_id', '=', company_country_id)]" options="{'no_open': True, 'no_create': True}"/>
                                 <field name="calendar_mismatch" invisible="1"/>
                                 <label for="resource_calendar_id"/>
                                 <div>
-                                    <field name="resource_calendar_id" required="1" nolabel="1"/>
+                                    <field name="resource_calendar_id" required="1" nolabel="1" options="{'no_open': True, 'no_create': True}"/>
                                     <span attrs="{'invisible': ['|', ('calendar_mismatch', '=', False), ('state', '!=', 'open')]}"
                                         class="fa fa-exclamation-triangle text-danger o_calendar_warning pl-3">
                                     </span>
@@ -171,14 +171,14 @@
                                 </div>
                             </group>
                             <group name="top_info_right">
-                                <field name="department_id"/>
-                                <field name="job_id"/>
-                                <field name="contract_type_id"/>
+                                <field name="department_id" options="{'no_open': True, 'no_create': True}"/>
+                                <field name="job_id" options="{'no_open': True, 'no_create': True}"/>
+                                <field name="contract_type_id" options="{'no_open': True, 'no_create': True}"/>
                                 <field name="hr_responsible_id" required="1"/>
                             </group>
                         </group>
                         <notebook>
-                            <page string="Contract Details" name="other">
+                            <page string="Contract Details" name="other" groups="hr_contract.group_hr_contract_manager">
                                 <group><group name="contract_details"/></group>
                                 <group name="notes_group" string="Notes">
                                     <field name="notes" nolabel="1"/>
@@ -204,6 +204,36 @@
                         <field name="message_ids"/>
                     </div>
                 </form>
+            </field>
+        </record>
+
+        <record id="hr_contract_manager_view_form" model="ir.ui.view">
+            <field name="name">hr.contract.manager.view.form</field>
+            <field name="model">hr.contract</field>
+            <field name="inherit_id" ref="hr_contract.hr_contract_view_form"/>
+            <field name="groups_id" eval="[(4,ref('hr_contract.group_hr_contract_manager'))]"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='structure_type_id']" position="attributes">
+                    <attribute name="options">{}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='resource_calendar_id']" position="attributes">
+                    <attribute name="options">{}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='department_id']" position="attributes">
+                    <attribute name="options">{}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='job_id']" position="attributes">
+                    <attribute name="options">{}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='contract_type_id']" position="attributes">
+                    <attribute name="options">{}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='state']" position="attributes">
+                    <attribute name="options">{'clickable': '1'}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='kanban_state']" position="attributes">
+                    <attribute name="readonly">0</attribute>
+                </xpath>
             </field>
         </record>
 
@@ -239,7 +269,7 @@
                     <templates>
                     <t t-name="kanban-box">
                         <div class="oe_kanban_card oe_kanban_global_click">
-                            <div class="o_dropdown_kanban dropdown" t-if="!selection_mode" groups="base.group_user">
+                            <div class="o_dropdown_kanban dropdown" t-if="!selection_mode" groups="hr_contract.group_hr_contract_manager">
                                 <a class="dropdown-toggle o-no-caret btn" role="button" data-toggle="dropdown" data-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                     <span class="fa fa-ellipsis-v"/>
                                 </a>


### PR DESCRIPTION
Currently, there are two security roles in Payroll: officer and administrator.
Both roles allow the user to have a full overview on all salaries of the company.

This commit adds an employee manager role allowing an employee manager to view
his reports' contracts.

task-2731933

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
