### PR TITLE
[FIX] website: use fake phone numbers on contactus

### DIFF
--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -139,8 +139,8 @@
                             <div class="col-lg-4 mt-4 mt-lg-0">
                                 <ul class="list-unstyled mb-0 pl-2">
                                     <li>My Company</li>
-                                    <li><i class="fa fa-map-marker fa-fw mr-2"/><span class="o_force_ltr">Chaussée de Namur 40</span></li>
-                                    <li><i class="fa fa-phone fa-fw mr-2"/><span class="o_force_ltr">+ 32 81 81 37 00</span></li>
+                                    <li><i class="fa fa-map-marker fa-fw mr-2"/><span class="o_force_ltr">3575 Fake Buena Vista Avenue</span></li>
+                                    <li><i class="fa fa-phone fa-fw mr-2"/><span class="o_force_ltr">+1 (650) 555-0111</span></li>
                                     <li><i class="fa fa-1x fa-fw fa-envelope mr-2"/><span>info@yourcompany.example.com</span></li>
                                 </ul>
                             </div>
@@ -180,8 +180,8 @@
                                     <div class="col-lg-4">
                                         <ul class="list-unstyled mb-0 pl-2">
                                             <li>My Company</li>
-                                            <li><i class="fa fa-map-marker fa-fw mr-2"/><span class="o_force_ltr">Chaussée de Namur 40</span></li>
-                                            <li><i class="fa fa-phone fa-fw mr-2"/><span class="o_force_ltr">+ 32 81 81 37 00</span></li>
+                                            <li><i class="fa fa-map-marker fa-fw mr-2"/><span class="o_force_ltr">3575 Fake Buena Vista Avenue</span></li>
+                                            <li><i class="fa fa-phone fa-fw mr-2"/><span class="o_force_ltr">+1 (650) 555-0111</span></li>
                                             <li><i class="fa fa-1x fa-fw fa-envelope mr-2"/><span>info@yourcompany.example.com</span></li>
                                         </ul>
                                     </div>


### PR DESCRIPTION
When the static "Contact us" page was merged at [1], a real phone number
and address were used. (Odoo BE Support). This causes issues when a
client forgets to change the phone number on that specific page.
Visitors will think Odoo support is the client's phone number.

To fix this we use a fictional phone number and address.

[1]: 2c41797266d0c5d4481a1a3f4f9b9f688de3434c

task-2742123