### PR TITLE
[FIX] hr_attendance : display proportionned logo in kiosk mode

### DIFF
--- a/addons/hr_attendance/static/src/scss/hr_attendance.scss
+++ b/addons/hr_attendance/static/src/scss/hr_attendance.scss
@@ -208,6 +208,7 @@
         overflow:hidden; // prevent margins colapsing with h1
         margin: 1rem 0 2rem;
         width: 200px;
+        height: auto;
     }
 
     p {


### PR DESCRIPTION
Steps :
- Upload logo of company
- Attendance > Kiosk mode

Issue :
- Logo is distorded

Cause :
- width is set, but not height

Fix :
- height : auto to adjust height to width.

opw-2739471

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
