### PR TITLE
[FIX] website_sale: remove unpublished product from cart

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -638,10 +638,9 @@ class Website(Home):
         Model = request.env[object]
         record = Model.browse(int(id))
 
-        values = {}
         if 'website_published' in Model._fields:
-            values['website_published'] = not record.website_published
-            record.write(values)
+            # browse single int so no ensure_one needed
+            record.website_publish_button()
             return bool(record.website_published)
         return False
 

--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -3018,6 +3018,14 @@ msgid ""
 msgstr ""
 
 #. module: website_sale
+#: code:addons/website_sale/models/product_template.py:0
+#, python-format
+msgid ""
+"This product is currently used in the following carts : %s.\n"
+"If you wish to remove the item from those cart, you will need to do it manually."
+msgstr ""
+
+#. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.cart
 msgid "This is your current cart."
 msgstr ""


### PR DESCRIPTION
Step to reproduce:
- Add a product to your cart on the website app.
- Unpublish the product.
- Go back to your cart and process checkout with the now unpublished product.

Current Behaviour:
- Customers on the site are able to purchase unpublished products that were published at the time they added the product to their cart.

Behaviour After PR:
- Item is removed from cart when updating cart
This behaviour is preferable to removing on unpublished because it doesn't remove if the item is unadvertendly unpublished/published.

opw-2742258

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
