### PR TITLE
[IMP] account: credit limit by partners

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -98,6 +98,8 @@ class ResCompany(models.Model):
 
     invoice_is_email = fields.Boolean('Email by default', default=True)
     invoice_is_print = fields.Boolean('Print by default', default=True)
+    account_use_credit_limit = fields.Boolean(
+        string='Sales Credit Limit', help='Enable the use of credit limit on partners.')
 
     #Fields of the setup step for opening move
     account_opening_move_id = fields.Many2one(string='Opening Journal Entry', comodel_name='account.move', help="The journal entry containing the initial balance of all this company's accounts.")

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -680,6 +680,10 @@
                          attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('auto_post', '=', False)]}">
                         This move is configured to be posted automatically at the accounting date: <field name="date" readonly="1"/>.
                     </div>
+                    <div class="alert alert-warning mb-0" role="alert"
+                         attrs="{'invisible': [('partner_credit_warning', '=', '')]}">
+                        <field name="partner_credit_warning"/>
+                    </div>
                     <!-- Currency consistency -->
                     <div class="alert alert-warning mb-0" role="alert"
                          attrs="{'invisible': ['|', ('display_inactive_currency_warning', '=', False), ('move_type', 'not in', ('in_invoice', 'in_refund', 'in_receipt'))]}">

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -203,6 +203,7 @@
                 <page name="sales_purchases" position="after">
                     <page string="Invoicing" name="accounting" attrs="{'invisible': [('is_company','=',False),('parent_id','!=',False)]}" groups="account.group_account_invoice,account.group_account_readonly">
                         <field name="duplicated_bank_account_partners_count" invisible="1"/>
+                        <field name="show_credit_limit" invisible="1"/>
                         <group>
                             <group string="Bank Accounts" name="banks" groups="account.group_account_invoice,account.group_account_readonly">
                                 <field name="bank_ids" nolabel="1" colspan="2">
@@ -224,6 +225,17 @@
                                 <field name="currency_id" invisible="1"/>
                                 <field name="property_account_receivable_id"/>
                                 <field name="property_account_payable_id"/>
+                            </group>
+                            <group string="Credit Limits"
+                                   name="credit_limits"
+                                   groups="account.group_account_invoice,account.group_account_readonly"
+                                   attrs="{'invisible': [('show_credit_limit', '=', False)]}">
+                                <field name="credit"/>
+                                <div name="partner_credit_limit" colspan="2" class="o_checkbox_optional_field">
+                                    <label for="use_partner_credit_limit"/>
+                                    <field name="use_partner_credit_limit"/>
+                                    <field name="credit_limit" class="oe_inline" attrs="{'invisible': [('use_partner_credit_limit', '=', False)]}"/>
+                                </div>
                             </group>
                         </group>
                     </page>

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -325,6 +325,24 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="col-xs-12 col-md-6 o_setting_box">
+                                <div class="o_setting_left_pane">
+                                    <field name="account_use_credit_limit"/>
+                                </div>
+                                <div class="o_setting_right_pane">
+                                    <label for="account_use_credit_limit"/>
+                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." role="img"/>
+                                    <div class="text-muted">
+                                        Trigger alerts when creating Invoices and Sales Orders for Partners with a Total Receivable amount exceeding a limit.
+                                    </div>
+                                    <div class="content-group mt-2" attrs="{'invisible': [('account_use_credit_limit', '=', False)]}">
+                                        <div class="row">
+                                            <label for="account_default_credit_limit" class="col-lg-4 o_light_label"/>
+                                            <field name="account_default_credit_limit"/>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         <h2>Customer Payments</h2>
                         <div class="row mt16 o_settings_container" id="pay_invoice_online_setting_container">

--- a/addons/base_import/tests/test_base_import.py
+++ b/addons/base_import/tests/test_base_import.py
@@ -488,7 +488,7 @@ class test_convert_import_data(TransactionCase):
         """
         import_wizard = self.env['base_import.import'].create({
             'res_model': 'res.partner',
-            'file': u'name,parent_id/id,parent_id/date,parent_id/credit_limit\n'
+            'file': u'name,parent_id/id,parent_id/date,parent_id/partner_latitude\n'
                     u'"foo","__export__.res_partner_1","2017年10月12日","5,69"\n'.encode('utf-8'),
             'file_type': 'text/csv'
 
@@ -502,7 +502,7 @@ class test_convert_import_data(TransactionCase):
             'has_headers': True
         }
         data, import_fields = import_wizard._convert_import_data(
-            ['name', 'parent_id/.id', 'parent_id/date', 'parent_id/credit_limit'],
+            ['name', 'parent_id/.id', 'parent_id/date', 'parent_id/partner_latitude'],
             options
         )
         result = import_wizard._parse_import_data(data, import_fields, options)

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -146,6 +146,10 @@ class SaleOrder(models.Model):
         store=True, readonly=False, required=True, precompute=True,
         states=LOCKED_FIELD_STATES,
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",)
+    # Credit Limit related field
+    partner_credit_warning = fields.Text(
+        compute='_compute_partner_credit_warning',
+        groups="account.group_account_invoice,account.group_account_readonly")
 
     fiscal_position_id = fields.Many2one(
         comodel_name='account.fiscal.position',
@@ -587,6 +591,17 @@ class SaleOrder(models.Model):
                                  "You may be unable to honor the delivery date.")
                 }
             }
+
+    @api.depends('company_id', 'partner_id', 'amount_total')
+    def _compute_partner_credit_warning(self):
+        for order in self:
+            order.with_company(order.company_id)
+            order.partner_credit_warning = ''
+            show_warning = order.state in ('draft', 'sent') and \
+                           order.company_id.account_use_credit_limit
+            if show_warning:
+                updated_credit = order.partner_id.credit + (order.amount_total * order.currency_rate)
+                order.partner_credit_warning = self.env['account.move']._build_credit_warning_message(order, updated_credit)
 
     @api.onchange('partner_id')
     def _onchange_partner_id_warning(self):

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -217,6 +217,10 @@
                 <button name="action_draft" states="cancel" type="object" string="Set to Quotation" data-hotkey="w"/>
                 <field name="state" widget="statusbar" statusbar_visible="draft,sent,sale"/>
             </header>
+            <field name="partner_credit_warning"
+                   class="alert alert-warning mb-0"
+                   role="alert"
+                   attrs="{'invisible': [('partner_credit_warning', '=', '')]}" />
             <sheet>
                 <div class="oe_button_box" name="button_box">
                     <button name="action_view_invoice"

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -177,7 +177,6 @@ class Partner(models.Model):
 
     category_id = fields.Many2many('res.partner.category', column1='partner_id',
                                     column2='category_id', string='Tags', default=_default_category)
-    credit_limit = fields.Float(string='Credit Limit')
     active = fields.Boolean(default=True)
     employee = fields.Boolean(help="Check this box if this contact is an Employee.")
     function = fields.Char(string='Job Position')
@@ -480,7 +479,7 @@ class Partner(models.Model):
         partners that aren't `commercial entities` themselves, and will be
         delegated to the parent `commercial entity`. The list is meant to be
         extended by inheriting classes. """
-        return ['vat', 'credit_limit']
+        return ['vat']
 
     def _commercial_sync_from_company(self):
         """ Handle sync of commercial fields when a new parent commercial entity is set,

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -507,7 +507,7 @@ class Partner(models.Model):
         if values.get('parent_id') or values.get('type') == 'contact':
             # 1a. Commercial fields: sync if parent changed
             if values.get('parent_id'):
-                self._commercial_sync_from_company()
+                self.sudo()._commercial_sync_from_company()
             # 1b. Address fields: sync if parent or use_parent changed *and* both are now set
             if self.parent_id and self.type == 'contact':
                 onchange_vals = self.onchange_parent_id().get('value', {})

--- a/odoo/addons/base/populate/res_partner.py
+++ b/odoo/addons/base/populate/res_partner.py
@@ -108,9 +108,6 @@ class Partner(models.Model):
                 [50, 10, 2, 20, 5, 10, 1])),
             ('tz', populate.randomize([tz for tz in self.env['res.partner']._fields['tz'].get_values(self.env)])),
             ('website', populate.randomize([False, '', 'http://www.example.com'])),
-            ('credit_limit', populate.randomize(
-                [False, 0, 500, 2500, 5000, 10000],
-                [50, 30, 5, 5, 5, 5])),
             ('name', populate.compute(get_name)),  # keep after is_company
             ('ref', populate.randomize([False, '', '{counter}', 'p-{counter}'], [10, 10, 30, 50])),
             ('industry_id', populate.randomize(

--- a/odoo/addons/base/tests/test_ir_default.py
+++ b/odoo/addons/base/tests/test_ir_default.py
@@ -91,7 +91,7 @@ class TestIrDefault(TransactionCase):
         with self.assertRaises(ValidationError):
             IrDefault.set('res.partner', 'lang', 'some_LANG')
         with self.assertRaises(ValidationError):
-            IrDefault.set('res.partner', 'credit_limit', 'foo')
+            IrDefault.set('res.partner', 'partner_latitude', 'foo')
 
     def test_removal(self):
         """ check defaults for many2one with their value being removed """


### PR DESCRIPTION
The basic idea of this functionality is for users to be able to put limits on Partners that would trigger non-blocking warnings  when trying to confirm new:
* Sales Orders
* Invoices

when that partner has too many open invoices.

task-2722165

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
