### PR TITLE
[IMP] web: allow caching get_fonts calls in NameAndSignature

### DIFF
--- a/addons/web/static/src/legacy/js/widgets/name_and_signature.js
+++ b/addons/web/static/src/legacy/js/widgets/name_and_signature.js
@@ -84,11 +84,17 @@ var NameAndSignature = Widget.extend({
      * @override
      */
     willStart: function () {
-        var self = this;
+        /** LPR: in sign module, the web/sign/get_fonts call is cached since
+         * many NameAndSignature widgets are created. This way, we prevent
+         * doing the rpc call if it was already done inside sign
+         */
+        if (this.fonts && this.fonts.length > 0) {
+            return this._super.apply(this, arguments);
+        }
         return Promise.all([
             this._super.apply(this, arguments),
-            this._rpc({route: '/web/sign/get_fonts/' + self.defaultFont}).then(function (data) {
-                self.fonts = data;
+            this._rpc({route: '/web/sign/get_fonts/' + this.defaultFont}).then(data => {
+                this.fonts = data;
             })
         ]);
     },


### PR DESCRIPTION
In sign many NameAndSignature widgets are opened and closed since it is
expected that documents have multiple initial/signature fields. Everytime
the widget is opened, an rpc call to get_fonts is done, even if the request
has already been done before. This commit prevents this rpc call if the fonts
are already loaded.

task-2735814

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
