### PR TITLE
[FIX] website_livechat: access error when retrieving chatter info

### DIFF
--- a/addons/website_livechat/models/mail_channel.py
+++ b/addons/website_livechat/models/mail_channel.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
+from odoo.exceptions import AccessError
 
 
 class MailChannel(models.Model):
@@ -29,9 +30,9 @@ class MailChannel(models.Model):
         """
         channel_infos = super(MailChannel, self).channel_info(extra_info)
         channel_infos_dict = dict((c['id'], c) for c in channel_infos)
-        for channel in self:
+        for channel in self.filtered('livechat_visitor_id'):
             visitor = channel.livechat_visitor_id
-            if visitor:
+            try:
                 channel_infos_dict[channel.id]['visitor'] = {
                     'name': visitor.display_name,
                     'country_code': visitor.country_id.code.lower() if visitor.country_id else False,
@@ -42,6 +43,8 @@ class MailChannel(models.Model):
                     'lang': visitor.lang_id.name,
                     'partner_id': visitor.partner_id.id,
                 }
+            except AccessError:
+                pass
         return list(channel_infos_dict.values())
 
     def _get_visitor_history(self, visitor):

--- a/addons/website_livechat/tests/common.py
+++ b/addons/website_livechat/tests/common.py
@@ -9,12 +9,18 @@ class TestLivechatCommon(tests.TransactionCase):
         super(TestLivechatCommon, self).setUp()
         self.base_datetime = fields.Datetime.from_string("2019-11-11 21:30:00")
 
+        self.group_user = self.env.ref('base.group_user')
+        self.group_livechat_user = self.env.ref('im_livechat.im_livechat_group_user')
         self.operator = self.env['res.users'].create({
             'name': 'Operator Michel',
             'login': 'operator',
             'email': 'operator@example.com',
             'password': "ideboulonate",
             'livechat_username': 'El Deboulonnator',
+            'groups_id': [(6, 0, [
+                self.group_user.id,
+                self.group_livechat_user.id,
+            ])],
         })
 
         self.livechat_channel = self.env['im_livechat.channel'].create({
@@ -46,6 +52,7 @@ class TestLivechatCommon(tests.TransactionCase):
 
         self.send_feedback_url = base_url + "/im_livechat/feedback"
         self.leave_session_url = base_url + "/im_livechat/visitor_leave_session"
+        self.message_info_url = base_url + "/mail/init_messaging"
 
         # override the get_available_users to return only Michel as available
         operators = self.operator

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -77,6 +77,25 @@ class TestLivechatBasicFlowHttpCase(tests.HttpCase, TestLivechatCommon):
         self.assertEqual(channel.message_ids[0].body, "<p>%s has left the conversation.</p>" % self.visitor.display_name)
         self.assertEqual(channel.livechat_active, False, "The livechat session must be inactive since visitor has left the conversation.")
 
+    def test_visitor_info_access_rights(self): 
+        channel = self._common_basic_flow()
+        self.authenticate(self.operator.login, 'ideboulonate')
+
+        # Retrieve channels information, visitor info should be there
+        res = self.opener.get(self.message_info_url, json={})
+        self.assertEqual(res.status_code, 200)
+        messages_info = res.json().get('result', {})
+        livechat_info = messages_info['channel_slots']['channel_livechat']
+        self.assertIn('visitor', livechat_info[0])
+
+        # Remove access to visitors and try again, visitors info shouldn't be included
+        self.operator.groups_id -= self.group_livechat_user
+        res = self.opener.get(self.message_info_url, json={})
+        self.assertEqual(res.status_code, 200)
+        messages_info = res.json().get('result', {})
+        livechat_info = messages_info['channel_slots']['channel_livechat']
+        self.assertNotIn('visitor', livechat_info[0])
+
     def _common_basic_flow(self):
         # Open a new live chat
         res = self.opener.post(url=self.open_chat_url, json=self.open_chat_params)


### PR DESCRIPTION
When chatter information is retrieved but current user has no access to website visitors, an access error is raised and chatter messages are not displayed.

To replicate:
- Enable livechat for current website
- Set user A as member of the livechat
- Log-in with user B, who doesn't have access to website visitors
- Visit any page that automatically opens the livechat with user B (no
  need to input anything, as a livechat is created when the chat window
  pops up)
- Go to backend with user B

To solve the above, visitor information is included only if current user
has enough right to access it.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr


OPW #2743176.