### PR TITLE
[FIX] stock_account: use stock input account in vendor bill lin…

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -224,6 +224,7 @@ class AccountMoveLine(models.Model):
         self.ensure_one()
         self = self.with_company(self.move_id.journal_id.company_id)
         if self.product_id.type == 'product' \
+            and self.product_id.valuation == 'real_time' \
             and self.move_id.company_id.anglo_saxon_accounting \
             and self.move_id.is_purchase_document():
             fiscal_position = self.move_id.fiscal_position_id


### PR DESCRIPTION
…es only if valuation method is real_time

When the company is using anglo-saxon accounting, stock input account is being used as default account
im vendor bill lines. This should not be the case if the valuation method is not real time since
the stock input account selection will be hidden in product category view and user will get confused
in such cases.

fixes #83049

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
