### PR TITLE
[14.0] [FIX] core/tests: mis-leading KeyError with float field

### DIFF
--- a/doc/cla/corporate/trobz.md
+++ b/doc/cla/corporate/trobz.md
@@ -16,3 +16,4 @@ Denis Barbot dbarbot@trobz.com https://github.com/dbarbot
 Jean-Charles Drubay jcdrubay@trobz.com https://github.com/jcdrubay
 Bui Ngoc Tu tu@trobz.com https://github.com/tungocbui
 Diep Huu Hoang hoang@trobz.com https://github.com/anothingguy
+Hai Lang hailn@trobz.com https://gitlab.com/hailangvn


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

* Current behavior before PR, the unexpected error is `KeyError: 'product_uom_qty'`.
```
Traceback (most recent call last):
  File "/trobz/OCA/delivery-carrier/tree/14.0/delivery_package_fee/tests/test_package_fee.py", line 329, in test_package_no_package
    self.assertRecordValues(
  File "/opt/odoo/14.0/odoo/tests/common.py", line 539, in assertRecordValues
    diff = _compare_candidate(record, candidate, field_names)
  File "/opt/odoo/14.0/odoo/tests/common.py", line 509, in _compare_candidate
    if float_compare(candidate[field_name], record_value, precision_digits=prec) != 0:
KeyError: 'product_uom_qty'
```

* Desired behavior after PR is merged, the expected error is `AssertionError: The records and expected_values do not match.`.
```
Traceback (most recent call last):
  File "/trobz/OCA/delivery-carrier/tree/14.0/delivery_package_fee/tests/test_package_fee.py", line 329, in test_package_no_package
    self.assertRecordValues(
  File "/opt/odoo/14.0/odoo/tests/common.py", line 582, in assertRecordValues
    self.fail('\n'.join(errors))
AssertionError: The records and expected_values do not match.
Wrong number of records to compare: 5 records versus 3 expected values.
```
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr