### PR TITLE
[FW][ADD] l10n_ar: refunds with liquido docs

### DIFF
--- a/addons/l10n_ar/models/account_journal.py
+++ b/addons/l10n_ar/models/account_journal.py
@@ -83,7 +83,6 @@ class AccountJournal(models.Model):
         receipt_m_code = ['54']
         receipt_codes = ['4', '9', '15']
         expo_codes = ['19', '20', '21']
-        liq_product_codes = ['60', '61']
         if self.type != 'sale':
             return []
         elif self.l10n_ar_afip_pos_system == 'II_IM':
@@ -91,7 +90,7 @@ class AccountJournal(models.Model):
             return usual_codes + receipt_codes + expo_codes + invoice_m_code + receipt_m_code
         elif self.l10n_ar_afip_pos_system in ['RAW_MAW', 'RLI_RLM']:
             # electronic/online invoice
-            return usual_codes + receipt_codes + invoice_m_code + receipt_m_code + mipyme_codes + liq_product_codes
+            return usual_codes + receipt_codes + invoice_m_code + receipt_m_code + mipyme_codes
         elif self.l10n_ar_afip_pos_system in ['CPERCEL', 'CPEWS']:
             # invoice with detail
             return usual_codes + invoice_m_code

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -47,13 +47,14 @@ class AccountMove(models.Model):
         """ LATAM module define that we are not able to use debit_note or invoice document types in an invoice refunds,
         However for Argentinian Document Type's 99 (internal type = invoice) we are able to used in a refund invoices.
 
-        In this method we exclude the argentinian document type 99 from the generic constraint """
-        ar_doctype_99 = self.filtered(
+        In this method we exclude the argentinian documents that can be used as invoice and refund from the generic
+        constraint """
+        docs_used_for_inv_and_ref = self.filtered(
             lambda x: x.country_code == 'AR' and
-            x.l10n_latam_document_type_id.code == '99' and
+            x.l10n_latam_document_type_id.code in self._get_l10n_ar_codes_used_for_inv_and_ref() and
             x.move_type in ['out_refund', 'in_refund'])
 
-        super(AccountMove, self - ar_doctype_99)._check_invoice_type_document_type()
+        super(AccountMove, self - docs_used_for_inv_and_ref)._check_invoice_type_document_type()
 
     def _get_afip_invoice_concepts(self):
         """ Return the list of values of the selection field. """
@@ -87,6 +88,13 @@ class AccountMove(models.Model):
             afip_concept = '3'
         return afip_concept
 
+    @api.model
+    def _get_l10n_ar_codes_used_for_inv_and_ref(self):
+        """ List of document types that can be used as an invoice and refund. This list can be increased once needed
+        and demonstrated. As far as we've checked document types of wsfev1 don't allow negative amounts so, for example
+        document 60 and 61 could not be used as refunds. """
+        return ['99', '186', '188', '189']
+
     def _get_l10n_latam_documents_domain(self):
         self.ensure_one()
         domain = super()._get_l10n_latam_documents_domain()
@@ -97,7 +105,7 @@ class AccountMove(models.Model):
             if codes:
                 domain.append(('code', 'in', codes))
             if self.move_type == 'in_refund':
-                domain = ['|', ('code', 'in', ['99'])] + domain
+                domain = ['|', ('code', 'in', self._get_l10n_ar_codes_used_for_inv_and_ref())] + domain
         return domain
 
     def _check_argentinian_invoice_taxes(self):
@@ -237,6 +245,11 @@ class AccountMove(models.Model):
         amount_field = company_currency and 'balance' or 'price_subtotal'
         # if we use balance we need to correct sign (on price_subtotal is positive for refunds and invoices)
         sign = -1 if (company_currency and self.is_inbound()) else 1
+
+        # if we are on a document that works invoice and refund and it's a refund, we need to export it as negative
+        sign = -sign if self.type in ('out_refund', 'in_refund') and\
+            self.l10n_latam_document_type_id.code in self._get_l10n_ar_codes_used_for_inv_and_ref() else sign
+
         tax_lines = self.line_ids.filtered('tax_line_id')
         vat_taxes = tax_lines.filtered(lambda r: r.tax_line_id.tax_group_id.l10n_ar_vat_afip_code)
 
@@ -268,6 +281,11 @@ class AccountMove(models.Model):
         amount_field = company_currency and 'balance' or 'price_subtotal'
         # if we use balance we need to correct sign (on price_subtotal is positive for refunds and invoices)
         sign = -1 if (company_currency and self.is_inbound()) else 1
+
+        # if we are on a document that works invoice and refund and it's a refund, we need to export it as negative
+        sign = -sign if self.type in ('out_refund', 'in_refund') and\
+            self.l10n_latam_document_type_id.code in self._get_l10n_ar_codes_used_for_inv_and_ref() else sign
+
         res = []
         vat_taxable = self.env['account.move.line']
         # get all invoice lines that are vat taxable


### PR DESCRIPTION
Two modifications related to document types of type "liquidación"

Do not allow to use liquido producto on Sales POS, they are mean to be used in purchases
Previously only document 99 was able to be used on invoices and refunds, now we add more documents ('186', '188', '189') and we also fix export to VAT book (if a document for invoices is used for refunds it should be exported with negative amounts)
This PR goes together with odoo/enterprise#21662

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
