### PR TITLE
[13.0][FIX] mail: no message preview in notification chat

### DIFF
--- a/addons/mail/static/src/js/models/messages/message.js
+++ b/addons/mail/static/src/js/models/messages/message.js
@@ -251,6 +251,8 @@ var Message =  AbstractMessage.extend(Mixins.EventDispatcherMixin, ServicesMixin
             title = this.hasSubject() ? this.getSubject() : this.getDisplayedAuthor();
         }
         return {
+            tracking_description: this._subtypeDescription || this.getSubtypeDescription(),
+            tracking_data: this.getTrackingValues(),
             author: this.getDisplayedAuthor(),
             body: mailUtils.htmlToTextContentInline(this.getBody()),
             date: this.getDate(),

--- a/addons/mail/static/src/xml/discuss.xml
+++ b/addons/mail/static/src/xml/discuss.xml
@@ -343,6 +343,25 @@
                         </t>
                         <t t-esc="preview.body"/>
                     </t>
+                    <t t-elif="preview.tracking_description">
+                        <t t-if="preview.isMyselfAuthor">
+                            <span class="fa fa-mail-reply" role="img" aria-label="Reply"/> You:
+                        </t>
+                        <t t-elif="preview.author">
+                            <t t-esc="preview.author"/>:
+                        </t>
+                        <t t-esc="preview.tracking_description"/>
+                        <t t-foreach='preview.tracking_data' t-as='value'>
+                                <t t-esc="value.changed_field"/>:
+                                <t t-if="value.old_value">
+                                    <span> <t t-esc="value.old_value || ((value.field_type !== 'boolean') and '')"/> </span>
+                                    <span t-if="value.old_value !== value.new_value" class="fa fa-long-arrow-right" role="img" aria-label="Changed" title="Changed"/>
+                                </t>
+                                <span t-if="value.old_value !== value.new_value">
+                                    <t t-esc="value.new_value || ((value.field_type !== 'boolean') and '')"/>
+                                </span>
+                        </t>
+                    </t>
                 </div>
                 <span title="Mark as Read" class="o_discuss_icon o_mail_preview_mark_as_read fa fa-check" t-if="preview.unreadCounter"/>
             </div>

--- a/doc/cla/individual/ralfiannor.md
+++ b/doc/cla/individual/ralfiannor.md
@@ -8,4 +8,4 @@ declaration.
 
 Signed,
 
-Rizal Alfiannor ralfiannor@gmail.com https://github.com/ralfiannor
+Rizal Alfiannor rizal.alfiannor@mbiz.co.id https://github.com/ralfiannor

--- a/doc/cla/individual/ralfiannor.md
+++ b/doc/cla/individual/ralfiannor.md
@@ -1,0 +1,11 @@
+Indonesia, 2022-01-24
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Rizal Alfiannor ralfiannor@gmail.com https://github.com/ralfiannor


### PR DESCRIPTION
When your account setting preference to Notification -> Handle in Odoo. Your notification message will show a body but in tracking feature your message not have body. This fix will generate body message by tracking description in odoo

Description of the issue/feature this PR addresses:

Current behavior before PR: 
- No message preview in notification (mail tracking)

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
