### PR TITLE
[IMP] account: add auto_join to speed up reports

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3489,6 +3489,7 @@ class AccountMoveLine(models.Model):
         help='Utility field to express amount currency')
     account_id = fields.Many2one('account.account', string='Account',
         index=True, ondelete="cascade",
+        auto_join=True,
         domain="[('deprecated', '=', False), ('company_id', '=', 'company_id'),('is_off_balance', '=', False)]",
         check_company=True,
         tracking=True)


### PR DESCRIPTION
Without `auto_join=True` a query the Trial Balance report has extra tables
scanning because of the following where condition:

```
      "account_move_line"."account_id" in (
        SELECT
          "account_account".id
        FROM
          "account_account"
        WHERE
          (
            "account_account"."user_type_id" in (
              SELECT
                "account_account_type".id
              FROM
                "account_account_type"
              WHERE
                (
                  "account_account_type"."include_initial_balance" IS NULL
                  or "account_account_type"."include_initial_balance" = false
                )
            )
          )
          AND (
            "account_account"."company_id" IS NULL
            OR (
              "account_account"."company_id" in (1)
            )
          )
      )
```

---

task-2743905

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
