### PR TITLE
[FIX] sale_purchase: raise if currency are not the same

### DIFF
--- a/addons/sale_purchase/models/sale_order.py
+++ b/addons/sale_purchase/models/sale_order.py
@@ -244,7 +244,7 @@ class SaleOrderLine(models.Model):
         if supplierinfo:
             price_unit = self.env['account.tax'].sudo()._fix_tax_included_price_company(supplierinfo.price, self.product_id.supplier_taxes_id, taxes, self.company_id)
             if purchase_order.currency_id and supplierinfo.currency_id != purchase_order.currency_id:
-                price_unit = supplierinfo.currency_id._convert(price_unit, purchase_order.currency_id, purchase_order.company_id, fields.datetime.today())
+                price_unit = supplierinfo.currency_id._convert(price_unit, purchase_order.currency_id, purchase_order.company_id, fields.Date.context_today(self))
             product_ctx.update({'seller_id': supplierinfo.id})
         else:
             product_ctx.update({'partner_id': purchase_order.partner_id.id})


### PR DESCRIPTION
- Create un SO in EUR with a product with service_to_purchase, with supplier A
- Supplier A work in USD
--> Confirm order
Issue fields.datetime.now() doesn't exist.






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
