### PR TITLE
[FIX] sale_timesheet: Wrong remaining hour in project update

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -334,7 +334,7 @@ class Project(models.Model):
                 #We only want to consider hours and days for this calculation, and eventually units if the service policy is not based on milestones
                 if sol.product_uom.category_id == self.env.company.timesheet_encode_uom_id.category_id or (sol.product_uom == product_uom_unit and sol.product_id.service_policy != 'delivered_manual'):
                     sold_items['total_sold'] += product_uom_qty
-                    sold_items['effective_sold'] += sol.product_uom._compute_quantity(qty_delivered, self.env.company.timesheet_encode_uom_id, raise_if_failure=False)
+                    sold_items['effective_sold'] += qty_delivered
         remaining = sold_items['total_sold'] - sold_items['effective_sold']
         sold_items['remaining'] = {
             'value': remaining,


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a SO with 1 day of the "Senior Architect" and confirm it
- A project P and a task T are automatically created
- Record multiple timesheets for T

Bug:

The remaining hours was wrong

PS: qty_delivered was already computed in timesheet_encode_uom_id

opw:2731384