### PR TITLE
[IMP] l10n_pt: add financial reports menu for Portugal

### DIFF
--- a/addons/l10n_pt/data/l10n_pt_chart_data.xml
+++ b/addons/l10n_pt/data/l10n_pt_chart_data.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <menuitem id="account_reports_pt_statements_menu" name="Portugal" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly" />
+
     <data>
 
     <record id="pt_chart_template" model="account.chart.template">


### PR DESCRIPTION
This PR adds the menuitem for Portugal's financial reports.

Related Enterprise PR : https://github.com/odoo/enterprise/pull/22559