### PR TITLE
[FIX] mail: fix the MailThread unlink search

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -333,7 +333,7 @@ class MailThread(models.AbstractModel):
             return True
         # discard pending tracking
         self._discard_tracking()
-        self.env['mail.message'].search([('model', '=', self._name), ('res_id', 'in', self.ids)]).sudo().unlink()
+        self.env['mail.message'].sudo().search([('model', '=', self._name), ('res_id', 'in', self.ids)]).unlink()
         res = super(MailThread, self).unlink()
         self.env['mail.followers'].sudo().search(
             [('res_model', '=', self._name), ('res_id', 'in', self.ids)]


### PR DESCRIPTION

When deleting a ticket from the Helpdesk app, if you don't have the rights to delete the "You have been assigned to [ticket]" message of another person who was automatically assigned, this message won't be deleted when you delete the tic>

Steps to reproduce:
- Three users, one is admin, the other twos are users who can use helpdesk. For users, go to User -> Preferences -> Notification and click on Handle in Odoo.
- Set up a helpdesk team as shown in attachment: assigned at random (balanced might also work), and everyone but the admin as team members.
- Set up a support alias for this support team. The owner must be no one or Odoobot.
- Send a ticket to the support alias. Check with the assigned user if he received the message "You have been assigned to [ticket]". The admin shouldn't have the access right to read this message.
- As admin, delete the helpdesk ticket associated: this exact message won't be deleted, but all the other ones will.
- As the other user, if you didn't read the notification bar, the notification will still be here and add to the counter. If you try to open it, you'll get an error.

This is happening because when using unlink to delete a ticket, there is no sudo() in the search used to look for messages linked to the deleted record. The intended behavior should be that all the messages associated to a record should be deleted, regardless of the current user's rights to see them. If you have the right to delete a record, you should have the rights to delete the messages associated with it.

Current behavior before the PR:
When a record is deleted, only the messages that the current user can see will be deleted.

Behavior desired after the PR is merged:
All messages linked to the records are deleted regardless of current user's rights to see them.

Ticket: #2615470