### PR TITLE
[FIX] web: do not send unmodified data to the server on record save

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -1787,7 +1787,9 @@ var BasicModel = AbstractModel.extend({
                         id = rec.id;
                         record._changes[name] = id;
                     }
-                } else {
+                } else if (oldValue !== false) {
+                    // if no value is provided for a m2o,
+                    // we should only consider the field updated if it had a value before
                     record._changes[name] = false;
                 }
             } else if (field.type === 'reference') {


### PR DESCRIPTION
Following recent conversion of onchanges to computes in the sale scope,
it was observed that updating one line triggered price recomputation in other
lines (which isn't expected).

After investigation, it seems that the `product_packaging_id` field is considered
modified and sent on SO save for all the lines, which triggers the `product_uom_qty`
record computation, then the whole price computation is triggered, since it depends
on that quantity field.

This commit aims to fix this case by only considering a m2o field as modified
if its value was effectively changed.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
