### PR TITLE
[FIX] web, website: allow scrolling when only cookies bar remains

### DIFF
--- a/addons/web/static/src/legacy/js/core/dialog.js
+++ b/addons/web/static/src/legacy/js/core/dialog.js
@@ -276,7 +276,7 @@ var Dialog = Widget.extend({
             this.$modal.remove();
         }
 
-        var modals = $('.modal[role="dialog"]').filter(':visible');
+        const modals = $('.modal[role="dialog"]').filter(':visible').filter(this._isBlocking);
         if (modals.length) {
             if (!isFocusSet) {
                 modals.last().focus();
@@ -340,6 +340,19 @@ var Dialog = Widget.extend({
             }
         });
     },
+    /**
+     * Returns false for non-"blocking" dialogs.
+     * This is intended to be overridden by subclasses.
+     *
+     * @private
+     * @param {int} index
+     * @param {element} el The element of a dialog.
+     * @returns {boolean}
+     */
+    _isBlocking(index, el) {
+        return true;
+    },
+
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -123,6 +123,7 @@
             'website/static/src/scss/website.ui.scss',
             'website/static/src/js/utils.js',
             'website/static/src/js/content/website_root.js',
+            'website/static/src/js/widgets/dialog.js',
             'website/static/src/js/widgets/fullscreen_indication.js',
             'website/static/src/js/content/compatibility.js',
             'website/static/src/js/content/menu.js',

--- a/addons/website/static/src/js/widgets/dialog.js
+++ b/addons/website/static/src/js/widgets/dialog.js
@@ -1,0 +1,21 @@
+/** @odoo-module **/
+
+import Dialog from 'web.Dialog';
+
+Dialog.include({
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    _isBlocking(index, el) {
+        if (el.parentElement && el.parentElement.id === 'website_cookies_bar'
+                && !el.classList.contains('o_cookies_popup')) {
+            return false;
+        }
+        return this._super(...arguments);
+    },
+});


### PR DESCRIPTION
Since [1] when web was migrated to OWL, the cookies bar was considered
as a parent modal of any openend modal that got closed - thus preventing
scrolling the full page.

After this commit the cookies bar in the front end is not considered as
a remaining modal anymore, and therefore does not prevent scrolling on
the currently displayed website page.

[1]: https://github.com/odoo/odoo/commit/29731b404fe624b733d784cd4321113d6b0d27b7

task-2741894

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
