### PR TITLE
[FIX] web_studio: add background image in the cache hashes

### DIFF
--- a/addons/web/models/ir_ui_menu.py
+++ b/addons/web/models/ir_ui_menu.py
@@ -32,6 +32,7 @@ class IrUiMenu(models.Model):
                     "actionModel": False,
                     "webIcon": None,
                     "webIconData": None,
+                    "backgroundImage": menu.get('backgroundImage'),
                 }
             else:
                 action = menu['action']

--- a/addons/web/tests/test_load_menus.py
+++ b/addons/web/tests/test_load_menus.py
@@ -41,7 +41,8 @@ class LoadMenusTests(HttpCase):
                 "name": "root",
                 "webIcon": None,
                 "webIconData": None,
-                "xmlid": ""
+                "xmlid": "",
+                "backgroundImage": None,
             }
         }
 


### PR DESCRIPTION
When changing the background image with studio the image does not update.
It works in debug=assets mode.
This is due to the fact that the caching system is not aware of the presence of a possible background image


enterprise: https://github.com/odoo/enterprise/pull/22915
opw-2696786
