### PR TITLE
[ADD] web: inline-margin utility classes

### DIFF
--- a/addons/web/static/src/webclient/webclient.scss
+++ b/addons/web/static/src/webclient/webclient.scss
@@ -115,6 +115,22 @@ div.o_boolean_toggle.custom-control.custom-checkbox {
   }
 }
 
+// == Inline margins
+//------------------------------------------------------------------------------
+// "Bootstrap v5 ready" utility-classes to handle inline margins.
+// These classes definitions can be safely removed after migrating to BTS v5.
+
+$o-inline-spacers: map-merge($spacers, ('auto': auto));
+
+@each $size, $length in $o-inline-spacers {
+  .ms-#{$size} {
+    margin-inline-start: $length !important;
+  }
+  .me-#{$size} {
+    margin-inline-end: $length !important;
+  }
+}
+
 //== Badges
 .badge {
   margin: 1px 2px 1px 0;


### PR DESCRIPTION
Define "Bootstrap v5 ready" utility-classes to handle inline margins.
These classes definitions can be safely removed after migrating to v5.

task-2731819



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
