### PR TITLE
[FIX] mail: no infinite loop with `useXToModel` hooks

### DIFF
--- a/addons/mail/static/src/component_hooks/use_component_to_model/use_component_to_model.js
+++ b/addons/mail/static/src/component_hooks/use_component_to_model/use_component_to_model.js
@@ -22,10 +22,10 @@ export function useComponentToModel({ fieldName, modelName }) {
     }
     onWillUpdateProps(nextProps => {
         const currentRecord = modelManager.models[modelName].get(component.props.localId);
-        if (currentRecord) {
+        const nextRecord = modelManager.models[modelName].get(nextProps.localId);
+        if (currentRecord && currentRecord !== nextRecord) {
             currentRecord.update({ [fieldName]: clear() });
         }
-        const nextRecord = modelManager.models[modelName].get(nextProps.localId);
         if (nextRecord) {
             nextRecord.update({ [fieldName]: component });
         }

--- a/addons/mail/static/src/component_hooks/use_ref_to_model/use_ref_to_model.js
+++ b/addons/mail/static/src/component_hooks/use_ref_to_model/use_ref_to_model.js
@@ -24,10 +24,10 @@ export function useRefToModel({ fieldName, modelName, refName }) {
     }
     onWillUpdateProps(nextProps => {
         const currentRecord = modelManager.models[modelName].get(component.props.localId);
-        if (currentRecord) {
+        const nextRecord = modelManager.models[modelName].get(nextProps.localId);
+        if (currentRecord && currentRecord !== nextRecord) {
             currentRecord.update({ [fieldName]: clear() });
         }
-        const nextRecord = modelManager.models[modelName].get(nextProps.localId);
         if (nextRecord) {
             nextRecord.update({ [fieldName]: ref });
         }


### PR DESCRIPTION
Before this commit, implementation of `useXToModel` performed
essentially 2 updates in succession, even when ref or component
hasn't changed.

This is a problem, especially when 2 components in hierarchy make
use of `useXToComponents`, as this could lead to infinite loops.

15.0 version: https://github.com/odoo/odoo/pull/83263