### PR TITLE
[FIX] resource: use admin timezone for the default working calendar

### DIFF
--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -208,7 +208,7 @@ class ResourceCalendar(models.Model):
                                  help="Average hours per day a resource is supposed to work with this calendar.")
     tz = fields.Selection(
         _tz_get, string='Timezone', required=True,
-        default=lambda self: self._context.get('tz') or self.env.user.tz or 'UTC',
+        default=lambda self: self._context.get('tz') or self.env.user.tz or self.env.ref('base.user_admin').tz or 'UTC',
         help="This field is used in order to define in which timezone the resources will work.")
     tz_offset = fields.Char(compute='_compute_tz_offset', string='Timezone offset', invisible=True)
     two_weeks_calendar = fields.Boolean(string="Calendar in 2 weeks mode")


### PR DESCRIPTION
When creating a new working calendar, its timezone is set to the one of the user creating the record.

However, when first installing the resource app, the timezone of the default working calendar is always UTC regardless of the timezone of the users.

To fix this, this PR sets the timezone of the default working calendar to the timezone of the admin instead.

Task 2744201