### PR TITLE
[FIX] mail: no infinite loop with `useXToModel` hooks

### DIFF
--- a/addons/mail/static/src/component_hooks/use_component_to_model/use_component_to_model.js
+++ b/addons/mail/static/src/component_hooks/use_component_to_model/use_component_to_model.js
@@ -24,10 +24,10 @@ export function useComponentToModel({ fieldName, modelName, propNameAsRecordLoca
     }
     onWillUpdateProps(nextProps => {
         const currentRecord = modelManager.models[modelName].get(component.props[propNameAsRecordLocalId]);
-        if (currentRecord) {
+        const nextRecord = modelManager.models[modelName].get(nextProps[propNameAsRecordLocalId]);
+        if (currentRecord && currentRecord !== nextRecord) {
             currentRecord.update({ [fieldName]: clear() });
         }
-        const nextRecord = modelManager.models[modelName].get(nextProps[propNameAsRecordLocalId]);
         if (nextRecord) {
             nextRecord.update({ [fieldName]: component });
         }

--- a/addons/mail/static/src/component_hooks/use_ref_to_model/use_ref_to_model.js
+++ b/addons/mail/static/src/component_hooks/use_ref_to_model/use_ref_to_model.js
@@ -26,10 +26,10 @@ export function useRefToModel({ fieldName, modelName, propNameAsRecordLocalId, r
     }
     onWillUpdateProps(nextProps => {
         const currentRecord = modelManager.models[modelName].get(component.props[propNameAsRecordLocalId]);
-        if (currentRecord) {
+        const nextRecord = modelManager.models[modelName].get(nextProps[propNameAsRecordLocalId]);
+        if (currentRecord && currentRecord !== nextRecord) {
             currentRecord.update({ [fieldName]: clear() });
         }
-        const nextRecord = modelManager.models[modelName].get(nextProps[propNameAsRecordLocalId]);
         if (nextRecord) {
             nextRecord.update({ [fieldName]: ref });
         }


### PR DESCRIPTION
Before this commit, implementation of `useXToModel` performed
essentially 2 updates in succession, even when ref or component
hasn't changed.

This is a problem, especially when 2 components in hierarchy make
use of `useXToComponents`, as this could lead to infinite loops.

master version: https://github.com/odoo/odoo/pull/83261