### PR TITLE
[FIX] product : Price not formatted in pricelist

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -5,8 +5,7 @@ from itertools import chain
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import float_repr
-from odoo.tools.misc import get_lang
+from odoo.tools.misc import formatLang, get_lang
 
 
 class Pricelist(models.Model):
@@ -486,23 +485,7 @@ class PricelistItem(models.Model):
                 item.name = _("All Products")
 
             if item.compute_price == 'fixed':
-                decimal_places = self.env['decimal.precision'].precision_get('Product Price')
-                if item.currency_id.position == 'after':
-                    item.price = "%s %s" % (
-                        float_repr(
-                            item.fixed_price,
-                            decimal_places,
-                        ),
-                        item.currency_id.symbol,
-                    )
-                else:
-                    item.price = "%s %s" % (
-                        item.currency_id.symbol,
-                        float_repr(
-                            item.fixed_price,
-                            decimal_places,
-                        ),
-                    )
+                item.price = formatLang(item.env, item.fixed_price, monetary=True, dp="Product Price", currency_obj=item.currency_id)
             elif item.compute_price == 'percentage':
                 item.price = _("%s %% discount", item.percent_price)
             else:


### PR DESCRIPTION
Current behavior :
When modifyin the decimal point and thousands separator in the language you're using the changes where not reflected in the pricelists

Steps to reproduce:
- Use the language en_US
- Set the decimal separator to , instead of . and change the thousand separator from . to ,
- Use the "activate and translate" smart button, "add" the language and "close and switch to the US language"
- Open a pricelist and the pricelist item in the list is with a decimal separator of . instead of ,
- But if you click on the item, the separator is correct.

PS : I had to duplicate a runbot to reproduce the issue

opw-2715993

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
