### PR TITLE
[IMP] l10n_es: change the type of the account 5585

### DIFF
--- a/addons/l10n_es/data/account.account.template-common.csv
+++ b/addons/l10n_es/data/account.account.template-common.csv
@@ -328,7 +328,7 @@
 "account_common_5566","Desembolsos exigidos sobre participaciones de otras empresas","5566","account.data_account_type_current_liabilities","l10n_es.account_chart_template_common","False"
 "account_common_557","Dividendo activo a cuenta","557","account.data_account_type_current_assets","l10n_es.account_chart_template_common","False"
 "account_common_5580","Socios por desembolsos exigidos sobre acciones o participaciones ordinarias","5580","account.data_account_type_current_assets","l10n_es.account_chart_template_common","False"
-"account_common_5585","Socios por desembolsos exigidos sobre acciones o participaciones consideradas como pasivos financieros","5585","account.data_account_type_non_current_liabilities","l10n_es.account_chart_template_common","False"
+"account_common_5585","Socios por desembolsos exigidos sobre acciones o participaciones consideradas como pasivos financieros","5585","account.data_account_type_current_liabilities","l10n_es.account_chart_template_common","False"
 "account_common_5590","Activos por derivados financieros a corto plazo, cartera de negociación","5590","account.data_account_type_current_assets","l10n_es.account_chart_template_common","False"
 "account_common_5595","Pasivos por derivados financieros a corto plazo, cartera de negociación","5595","account.data_account_type_current_liabilities","l10n_es.account_chart_template_common","False"
 "account_common_560","Fianzas recibidas a corto plazo","560","account.data_account_type_current_liabilities","l10n_es.account_chart_template_common","False"


### PR DESCRIPTION
Change the type of the account 5585 to be current
liabilities instead of non-current as it makes more sense.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
