### PR TITLE
[FIX] delivery: Do not show HS code when state != done

### DIFF
--- a/addons/delivery/views/report_deliveryslip.xml
+++ b/addons/delivery/views/report_deliveryslip.xml
@@ -18,10 +18,6 @@
             <t t-set="has_hs_code" t-value="o.move_lines.filtered(lambda l: l.product_id.hs_code)"/>
         </xpath>
 
-        <xpath expr="//table[@name='stock_move_table']/thead/tr" position="inside">
-            <th t-if="has_hs_code"><strong>HS Code</strong></th>
-        </xpath>
-
         <xpath expr="//table[@name='stock_move_line_table']/thead/tr" position="inside">
             <th t-if="has_hs_code"><strong>HS Code</strong></th>
         </xpath>


### PR DESCRIPTION
Steps to reproduce:

- Let's consider a storable product P with HS code
- Create a SO with P and confirm it
- Print the delivery slip

Bug:

The header HS CODE was displayed even if the column doesn't exist in the table

opw:2744000