### PR TITLE
[FIX] sale_project: widget call from missing dependency

### DIFF
--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -7,8 +7,8 @@
         <field name="inherit_id" ref="project.view_project"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='analytic_account_id']" position="after">
-                <field name="sale_order_id" optional="hide" widget="sale_order_many2one"/>
-                <field name="sale_line_id" optional="hide" widget="sale_order_many2one" readonly="1"/>
+                <field name="sale_order_id" optional="hide"/>
+                <field name="sale_line_id" optional="hide" readonly="1"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Steps to reproduce:

- install only sale_project
- go to Project > Configuration > Projects
-> Warning in the JS console

OPW-2717655
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
