### PR TITLE
[FIX] mass_mailing: prevent regrouping unequal style property

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -631,17 +631,26 @@ function getCSSRules(doc) {
             if (i > j && cssRules[i].selector === cssRules[j].selector) {
                 // Styles of "later" selector override styles of "earlier" one.
                 const importantJStyles = {};
-                for (const [key, value] of Object.entries(cssRules[j].style)) {
-                    if (value.endsWith('!important')) {
-                        importantJStyles[key] = value;
+
+                const previousStyle = cssRules[j].style;
+                const previousStyleKey = Object.keys(previousStyle);
+                const sameKeys = Object.keys(cssRules[i].style).filter(x => previousStyleKey.includes(x));
+
+                for (const key of sameKeys) {
+                    if (previousStyle[key].endsWith('!important')) {
+                        importantJStyles[key] = previousStyle[key];
                     }
+                    delete previousStyle[key];
                 }
-                cssRules[i].style = {...cssRules[j].style, ...cssRules[i].style};
+
                 for (const [key, value] of Object.entries(importantJStyles)) {
                     cssRules[i].style[key] = value;
                 }
-                cssRules.splice(j, 1);
-                i--;
+
+                if (!Object.keys(previousStyleKey).length) {
+                    cssRules.splice(j, 1);
+                    i--;
+                }
             }
         }
     }


### PR DESCRIPTION
Before this commit, whenever converting css to inline in mass_mailing,
all the css property defined with a selector were grouped to the
lastest defined selector.

For example, the following css:

```css
.a {
    text: red;
    background: black;
}
.b {
    text: blue;
}
.a {
    background: purple;
}
.a {
    background: orange;
}
```

When converted, it became equivalent to the following (inlined).
```css
.b {
    text: blue;
}
.a {
    text: red;
    background: orange;
}
```

Wich is wrong.

If in the HTML
```html
<span class="a b">word</span>
```

The text color should be blue as the `.b` selector is the last defined
for the property `text` but will be text after the conversion.

The convertion should become equivalent to the following (inlined).
```css
.a {
    text: red;
}
.b {
    text: blue;
}
.a {
    background: orange;
}
```

Thus, keeping the first `.a` selector with the property `text` defined
before the `.b` selector gets define. Ensuring the correct css
interpretation.

Task-2744237






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
