### PR TITLE
[FIX] payment_paypal: prevent creating new session for returning users

### DIFF
--- a/addons/payment_paypal/controllers/main.py
+++ b/addons/payment_paypal/controllers/main.py
@@ -16,12 +16,23 @@ class PaypalController(http.Controller):
     _return_url = '/payment/paypal/dpn/'
     _notify_url = '/payment/paypal/ipn/'
 
-    @http.route(_return_url, type='http', auth='public', methods=['GET', 'POST'], csrf=False)
+    @http.route(
+        _return_url, type='http', auth='public', methods=['GET', 'POST'], csrf=False,
+        save_session=False
+    )
     def paypal_dpn(self, **data):
         """ Route used by the PDT notification.
 
         The "PDT notification" is actually POST data sent along the user redirection.
         The route also allows the GET method in case the user clicks on "go back to merchant site".
+
+        The route is flagged with `save_session=False` to prevent Odoo from assigning a new session
+        to the user if they are redirected to this route with a POST request. Indeed, as the session
+        cookie is created without a `SameSite` attribute, some browsers that don't implement the
+        recommended default `SameSite=Lax` behavior will not include the cookie in the redirection
+        request from the payment provider to Odoo. As the redirection to the '/payment/status' page
+        will satisfy any specification of the `SameSite` attribute, the session of the user will be
+        retrieved and with it the transaction which will be immediately post-processed.
         """
         _logger.info("beginning DPN with post data:\n%s", pprint.pformat(data))
         try:


### PR DESCRIPTION
Before this commit, users returning from PayPal to Odoo after payment
could see their session renewed, depending on their browser's
implementation of the `SameSite` cookie attribute. This prevented Odoo
from retrieving the transaction from the users' session.

This commit flags the return route of PayPal with `save_session=False`,
hence allowing all users to immediately post-process their transactions
when they return to Odoo.
