### PR TITLE
[FIX] account: send the right context in payment register wizard

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -455,6 +455,11 @@ class AccountPaymentRegister(models.TransientModel):
                     "The register payment wizard should only be called on account.move or account.move.line records."
                 ))
 
+            if 'journal_id' in res and not self.env['account.journal'].browse(res['journal_id'])\
+                    .filtered_domain([('company_id', '=', lines.company_id.id), ('type', 'in', ('bank', 'cash'))]):
+                # default can be inherited from the list view, should be computed instead
+                del res['journal_id']
+
             # Keep lines having a residual amount to pay.
             available_lines = self.env['account.move.line']
             for line in lines:


### PR DESCRIPTION
Steps to reproduce:

- Create an invoice and confirm it
- In Accounting Dashboard, on the Customer Invoices card,
  click on 'Unpaid Invoices'
- Select the invoice with the checkbox
- Click on button 'Register Payment'

Issue:

- The journal_id is not set by default

Before this commit, when opening the payment register wizard,
we inherited the customer invoices journal from the context.

opw-2729754

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
