### PR TITLE
[FIX] mail: limit reply-to name part

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2725,17 +2725,47 @@ class MailThread(models.AbstractModel):
                 if catchall:
                     result_email.update(dict((rid, '%s@%s' % (catchall, alias_domain)) for rid in left_ids))
 
-            # compute name of reply-to - TDE tocheck: quotes and stuff like that
-            company_name = company.name if company else self.env.company.name
-            for res_id in result_email.keys():
-                name = '%s%s%s' % (company_name, ' ' if doc_names.get(res_id) else '', doc_names.get(res_id, ''))
-                result[res_id] = tools.formataddr((name, result_email[res_id]))
+            for res_id in result_email:
+                result[res_id] = self._notify_get_reply_to_formatted_email(
+                    result_email[res_id],
+                    doc_names.get(res_id) or '',
+                    company or self.env.company
+                )
 
         left_ids = set(_res_ids) - set(result_email)
         if left_ids:
             result.update(dict((res_id, default) for res_id in left_ids))
 
         return result
+
+    def _notify_get_reply_to_formatted_email(self, record_email, record_name, company):
+        """ Compute formatted email for reply_to and try to avoid refold issue
+        with python that splits the reply-to over multiple lines. It is due to
+        a bad management of quotes (missing quotes after refold). This appears
+        therefore only when having quotes (aka not simple names, and not when
+        being unicode encoded).
+
+        To avoid that issue when formataddr would return more than 78 chars we
+        return a simplified name/email to try to stay under 78 chars. If not
+        possible we return only the email and skip the formataddr which causes
+        the issue in python. We do not use hacks like crop the name part as
+        encoding and quoting would be error prone.
+        """
+        # address itself is too long for 78 chars limit: return only email
+        if len(record_email) >= 78:
+            return record_email
+
+        company_name = company.name if company else self.env.company.name
+
+        # try company_name + record_name, or record_name alone (or company_name alone)
+        name = f"{company_name} {record_name}" if record_name else company_name
+
+        formatted_email = tools.formataddr((name, record_email))
+        if len(formatted_email) > 78:
+            formatted_email = tools.formataddr((record_name or company_name, record_email))
+        if len(formatted_email) > 78:
+            formatted_email = record_email
+        return formatted_email
 
     @api.model
     def _notify_get_reply_to_on_records(self, default=None, records=None, company=None, doc_names=None):

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -8,9 +8,10 @@ from odoo.addons.test_mail.tests.common import mail_new_test_user
 from odoo.addons.test_mail.models.test_mail_models import MailTestSimple
 from odoo.exceptions import AccessError, except_orm
 from odoo.tools import mute_logger, formataddr
-from odoo.tests import tagged
+from odoo.tests import tagged, users
 
 
+@tagged('mail_message')
 class TestMessageValues(common.BaseFunctionalTest, common.MockEmails):
 
     @classmethod
@@ -25,8 +26,79 @@ class TestMessageValues(common.BaseFunctionalTest, common.MockEmails):
         })
         cls.Message = cls.env['mail.message'].with_user(cls.user_employee)
 
+    def test_mail_message_values_body_base64_image(self):
+        msg = self.env['mail.message'].with_user(self.user_employee).create({
+            'body': 'taratata <img src="data:image/png;base64,iV/+OkI=" width="2"> <img src="data:image/png;base64,iV/+OkI=" width="2">',
+        })
+        self.assertEqual(len(msg.attachment_ids), 1)
+        self.assertEqual(
+            msg.body,
+            '<p>taratata <img src="/web/image/{attachment.id}?access_token={attachment.access_token}" alt="image0" width="2"> '
+            '<img src="/web/image/{attachment.id}?access_token={attachment.access_token}" alt="image0" width="2"></p>'.format(attachment=msg.attachment_ids[0])
+        )
+
     @mute_logger('odoo.models.unlink')
-    def test_mail_message_values_no_document_values(self):
+    @users('employee')
+    def test_mail_message_values_fromto_long_name(self):
+        """ Long headers may break in python if above 78 chars as folding is not
+        done correctly (see ``_notify_get_reply_to_formatted_email`` docstring
+        + commit linked to this test). """
+        # name would make it blow up: keep only email
+        test_record = self.env['mail.test'].browse(self.alias_record.ids)
+        test_record.write({
+            'name': 'Super Long Name That People May Enter "Even with an internal quoting of stuff"'
+        })
+        msg = self.env['mail.message'].create({
+            'model': test_record._name,
+            'res_id': test_record.id
+        })
+        reply_to_email = f"{test_record.alias_name}@{self.alias_domain}"
+        self.assertEqual(msg.reply_to, reply_to_email,
+                         'Reply-To: use only email when formataddr > 78 chars')
+
+        # name + company_name would make it blow up: keep record_name in formatting
+        test_record.write({'name': 'Name that would be more than 78 with company name'})
+        msg = self.env['mail.message'].create({
+            'model': test_record._name,
+            'res_id': test_record.id
+        })
+        self.assertEqual(msg.reply_to, formataddr((test_record.name, reply_to_email)),
+                         'Reply-To: use recordname as name in format if recordname + company > 78 chars')
+
+        # no record_name: keep company_name in formatting if ok
+        test_record.write({'name': ''})
+        msg = self.env['mail.message'].create({
+            'model': test_record._name,
+            'res_id': test_record.id
+        })
+        self.assertEqual(msg.reply_to, formataddr((self.env.user.company_id.name, reply_to_email)),
+                         'Reply-To: use company as name in format when no record name and still < 78 chars')
+
+        # no record_name and company_name make it blow up: keep only email
+        self.env.user.company_id.write({'name': 'Super Long Name That People May Enter "Even with an internal quoting of stuff"'})
+        msg = self.env['mail.message'].create({
+            'model': test_record._name,
+            'res_id': test_record.id
+        })
+        self.assertEqual(msg.reply_to, reply_to_email,
+                         'Reply-To: use only email when formataddr > 78 chars')
+
+        # whatever the record and company names, email is too long: keep only email
+        test_record.write({
+            'alias_name': 'Waaaay too long alias name that should make any reply-to blow the 78 characters limit',
+            'name': 'Short',
+        })
+        self.env.user.company_id.write({'name': 'Comp'})
+        sanitized_alias_name = 'waaaay-too-long-alias-name-that-should-make-any-reply-to-blow-the-78-characters-limit'
+        msg = self.env['mail.message'].create({
+            'model': test_record._name,
+            'res_id': test_record.id
+        })
+        self.assertEqual(msg.reply_to, f"{sanitized_alias_name}@{self.alias_domain}",
+                         'Reply-To: even a long email is ok as only formataddr is problematic')
+
+    @mute_logger('odoo.models.unlink')
+    def test_mail_message_values_fromto_no_document_values(self):
         msg = self.Message.create({
             'reply_to': 'test.reply@example.com',
             'email_from': 'test.from@example.com',
@@ -36,7 +108,7 @@ class TestMessageValues(common.BaseFunctionalTest, common.MockEmails):
         self.assertEqual(msg.email_from, 'test.from@example.com')
 
     @mute_logger('odoo.models.unlink')
-    def test_mail_message_values_no_document(self):
+    def test_mail_message_values_fromto_no_document(self):
         msg = self.Message.create({})
         self.assertIn('-private', msg.message_id.split('@')[0], 'mail_message: message_id for a void message should be a "private" one')
         reply_to_name = self.env.user.company_id.name
@@ -62,7 +134,7 @@ class TestMessageValues(common.BaseFunctionalTest, common.MockEmails):
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
     @mute_logger('odoo.models.unlink')
-    def test_mail_message_values_document_alias(self):
+    def test_mail_message_values_fromto_document_alias(self):
         msg = self.Message.create({
             'model': 'mail.test',
             'res_id': self.alias_record.id
@@ -99,7 +171,7 @@ class TestMessageValues(common.BaseFunctionalTest, common.MockEmails):
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
     @mute_logger('odoo.models.unlink')
-    def test_mail_message_values_document_no_alias(self):
+    def test_mail_message_values_fromto_document_no_alias(self):
         test_record = self.env['mail.test.simple'].create({'name': 'Test', 'email_from': 'ignasse@example.com'})
 
         msg = self.Message.create({
@@ -113,7 +185,7 @@ class TestMessageValues(common.BaseFunctionalTest, common.MockEmails):
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
     @mute_logger('odoo.models.unlink')
-    def test_mail_message_values_document_manual_alias(self):
+    def test_mail_message_values_fromto_document_manual_alias(self):
         test_record = self.env['mail.test.simple'].create({'name': 'Test', 'email_from': 'ignasse@example.com'})
         alias = self.env['mail.alias'].create({
             'alias_name': 'MegaLias',
@@ -134,7 +206,7 @@ class TestMessageValues(common.BaseFunctionalTest, common.MockEmails):
         self.assertEqual(msg.reply_to, formataddr((reply_to_name, reply_to_email)))
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
-    def test_mail_message_values_no_auto_thread(self):
+    def test_mail_message_values_fromto_no_auto_thread(self):
         msg = self.Message.create({
             'model': 'mail.test',
             'res_id': self.alias_record.id,
@@ -143,15 +215,6 @@ class TestMessageValues(common.BaseFunctionalTest, common.MockEmails):
         self.assertIn('reply_to', msg.message_id.split('@')[0])
         self.assertNotIn('mail.test', msg.message_id.split('@')[0])
         self.assertNotIn('-%d-' % self.alias_record.id, msg.message_id.split('@')[0])
-
-    def test_mail_message_base64_image(self):
-        msg = self.env['mail.message'].with_user(self.user_employee).create({
-            'body': 'taratata <img src="data:image/png;base64,iV/+OkI=" width="2"> <img src="data:image/png;base64,iV/+OkI=" width="2">',
-        })
-        self.assertEqual(len(msg.attachment_ids), 1)
-        body = '<p>taratata <img src="/web/image/%s?access_token=%s" alt="image0" width="2"> <img src="/web/image/%s?access_token=%s" alt="image0" width="2"></p>'
-        body = body % (msg.attachment_ids[0].id, msg.attachment_ids[0].access_token, msg.attachment_ids[0].id, msg.attachment_ids[0].access_token)
-        self.assertEqual(msg.body, body)
 
 
 class TestMessageAccess(common.BaseFunctionalTest, common.MockEmails):
@@ -263,7 +326,8 @@ class TestMessageAccess(common.BaseFunctionalTest, common.MockEmails):
             'datas': base64.b64encode(b'My attachment'),
             'name': 'doc.txt',
             'res_model': self.message._name,
-            'res_id': self.message.id})
+            'res_id': self.message.id,
+        })
         # attach the attachment to the message
         self.message.write({'attachment_ids': [(4, attachment.id)]})
         self.message.write({'partner_ids': [(4, self.user_employee.partner_id.id)]})


### PR DESCRIPTION
Due to a python limitation we may have issues if reply-to of a sent email
contains more than 78 characters. Even if this is technically ok with the
RFC python seems to incorrectly handle it (please refer to [1] for more
details and discussions).

Until this is finally sorted out we decided to avoid issues by shortening
reply-to. Heuristic is now
  * either ``"CompanyName RecordName" <email@domain.com>`` is under 78 and we
    keep it;
  * otherwise we try by stripping out CompanyName as this information is not
    crucial, keeping ``"RecordName" <email@domain.com>``;
  * if this value is > 78 we strip record name extra characters, ending with
    something like ``"TooLong [...]"" <email@domain.com>``;
  * if email address itself is too long it is kept as it is without formating;

Task-2602862
OPW-2733513

[1] See https://bugs.python.org/issue44637
