### PR TITLE
[FIX] account: use same date for paired internal transfer

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -889,7 +889,8 @@ class AccountPayment(models.Model):
                 'payment_type': payment.payment_type == 'outbound' and 'inbound' or 'outbound',
                 'move_id': None,
                 'ref': payment.ref,
-                'paired_internal_transfer_payment_id': payment.id
+                'paired_internal_transfer_payment_id': payment.id,
+                'date': payment.date,
             })
             paired_payment.move_id._post(soft=False)
             payment.paired_internal_transfer_payment_id = paired_payment


### PR DESCRIPTION
The paired payment generated when doing an internal transfer didn't have the correct date

Steps to reproduce:
1. Install Accounting
2. Go to Accounting -> Configuration -> Accounting -> Journals and duplicate the 'Bank' journal
3. Go to the Accounting Dashboard
4. Create a new internal transfer in Bank (go to the three dots on the top left corner of Bank and select New -> Internal Transfer)
5. Select 'Bank (copy)' as destination journal and select a date in the past
6. Save and confirm the internal transfer
7. Go to the paired internal transfer (link in the log notes)
8. The date of the transfer is the date of creation, it should be the same as the other transfer

Solution:
Use the date of the posted internal transfer to create the paired one

OPW-2710356
OPW-2730529