### PR TITLE
[FIX] auth_totp: "Disable TOTP" only available in list view

### DIFF
--- a/addons/auth_totp/views/user_preferences.xml
+++ b/addons/auth_totp/views/user_preferences.xml
@@ -40,7 +40,6 @@
         <field name="name">Disable TOTP on users</field>
         <field name="model_id" ref="base.model_res_users"/>
         <field name="binding_model_id" ref="base.model_res_users"/>
-        <field name="binding_view_types">list</field>
         <field name="state">code</field>
         <field name="code">
             action = records.totp_disable()


### PR DESCRIPTION
The action server is only available on view list. It is hard to find this.
@odony 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
