### PR TITLE
[FIX] payment: Reduce probability of errors after run a s2s method

### DIFF
--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -1063,6 +1063,7 @@ class PaymentTransaction(models.Model):
     # --------------------------------------------------
 
     def s2s_do_transaction(self, **kwargs):
+        self.flush()
         custom_method_name = '%s_s2s_do_transaction' % self.acquirer_id.provider
         for trans in self:
             trans._log_payment_transaction_sent()
@@ -1070,22 +1071,26 @@ class PaymentTransaction(models.Model):
                 return getattr(trans, custom_method_name)(**kwargs)
 
     def s2s_do_refund(self, **kwargs):
+        self.flush()
         custom_method_name = '%s_s2s_do_refund' % self.acquirer_id.provider
         if hasattr(self, custom_method_name):
             return getattr(self, custom_method_name)(**kwargs)
 
     def s2s_capture_transaction(self, **kwargs):
+        self.flush()
         custom_method_name = '%s_s2s_capture_transaction' % self.acquirer_id.provider
         if hasattr(self, custom_method_name):
             return getattr(self, custom_method_name)(**kwargs)
 
     def s2s_void_transaction(self, **kwargs):
+        self.flush()
         custom_method_name = '%s_s2s_void_transaction' % self.acquirer_id.provider
         if hasattr(self, custom_method_name):
             return getattr(self, custom_method_name)(**kwargs)
 
     def s2s_get_tx_status(self):
         """ Get the tx status. """
+        self.flush()
         invalid_param_method_name = '_%s_s2s_get_tx_status' % self.acquirer_id.provider
         if hasattr(self, invalid_param_method_name):
             return getattr(self, invalid_param_method_name)()


### PR DESCRIPTION
After running a s2s method is a good idea to commit the transaction in order to avoid rollbacking it

But the commit method is calling flush method but what about if this method has an error
e.g. concurrency error to update the computed store=True fields

The s2s method is called to external server but rollbacked in odoo

Calling flush before to call server method reduces the probability to raise an error after
since that the errors will be raised before since that the flush will try to lock the records with all computed fields

The real case of use in the following.

We have subscription auto charged

The following code is committing the payment server external charge just after to be called:
 - https://github.com/odoo/enterprise/blob/085870a63e850f4a1cd7f88fdb392e1148cac5e1/sale_subscription/models/sale_subscription.py#L948-L951

It is awesome!

But the problem is that the commit is calling the flush method:
 - https://github.com/odoo/odoo/blob/71ae792d63b57627cc15eadc1e63a7b7a7dfbe70/odoo/sql_db.py#L442-L444

It means that all the computed fields stored=True will be really stored running an query sentence `UPDATE table...` in the database

And the following constraint is calling flush method too:
 - https://github.com/odoo/odoo/blob/71ae792d63b57627cc15eadc1e63a7b7a7dfbe70/addons/account_check_printing/models/account_payment.py#L50


But what about if that record is locked so you will have the following message of error:

```
2022-01-11 17:30:08,421 38597 ERROR db odoo.addons.sale_subscription.models.sale_subscription: Traceback (most recent call last):
File "enterprise/sale_subscription/models/sale_subscription.py", line 951, in _recurring_create_invoice
cr.commit()
File "<decorator-gen-7>", line 2, in commit
File "odoo/odoo/sql_db.py", line 101, in check
  return f(self, *args, **kwargs)
File "odoo/odoo/sql_db.py", line 444, in commit
  flush_env(self)
File "odoo/odoo/sql_db.py", line 78, in flush_env
  env_to_flush['base'].flush()
File "odoo/odoo/models.py", line 5434, in flush
  self.recompute()
File "odoo/odoo/models.py", line 5893, in recompute
  process(field)
File "odoo/odoo/models.py", line 5877, in process
  field.recompute(recs)
File "odoo/odoo/fields.py", line 1153, in recompute
  self.compute_value(recs)
File "odoo/odoo/fields.py", line 1175, in compute_value
  records._compute_field_value(self)
File "odoo/addons/mail/models/mail_thread.py", line 410, in _compute_field_value
  return super()._compute_field_value(field)
File "odoo/odoo/models.py", line 4064, in _compute_field_value
  self.filtered('id')._validate_fields(fnames)
File "odoo/odoo/models.py", line 1260, in _validate_fields
  check(self)
File "odoo/addons/account_check_printing/models/account_payment.py", line 50, in _constrains_check_number
  self.flush()
File "odoo/odoo/models.py", line 5437, in flush
  process(self.env[model_name], id_vals)
File "odoo/odoo/models.py", line 5428, in process
  recs._write(vals)
File "odoo/odoo/models.py", line 3750, in _write
  cr.execute(query, params + [sub_ids])
File "<decorator-gen-3>", line 2, in execute
File "odoo/odoo/sql_db.py", line 101, in check
  return f(self, *args, **kwargs)
File "odoo/odoo/sql_db.py", line 298, in execute
  res = self._obj.execute(query, params) psycopg2.errors.SerializationFailure: could not serialize access due to concurrent update
2022-01-11 17:30:09,380 38597 ERROR db odoo.addons.sale_subscription.models.sale_subscription: Error during renewal of subscription PLG/2019/009518 (No payment recorded.)
```

The new flush called early in this MR don't avoid raising errors of new computed related with the records created in the payment process itself but will reduce the concurrency errors that could exists and they are known before to call the s2s method