### PR TITLE
[FIX] mail, mass_mailing: fix picture of masanry snippet in mailing test

### DIFF
--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -166,7 +166,7 @@ class MailRenderMixin(models.AbstractModel):
             r"""( # Group 1: element up to url in style
                 <[^>]+\bstyle=" # Element with a style attribute
                 [^"]+\burl\( # Style attribute contains "url(" style
-                (?:&\#34;|')?) # url style may start with (escaped) quote: capture it
+                (?:&\#34;|'|&quot;)?) # url style may start with (escaped) quote: capture it
             ( # Group 2: url itself
                 /(?:[^'")]|(?!&\#34;))+ # stop at the first closing quote
         )""", re.VERBOSE), _sub_relative2absolute, html)

--- a/addons/mass_mailing/wizard/mailing_mailing_test.py
+++ b/addons/mass_mailing/wizard/mailing_mailing_test.py
@@ -49,7 +49,6 @@ class TestMassMailing(models.TransientModel):
 
         # Convert links in absolute URLs before the application of the shortener
         full_body = self.env['mail.render.mixin']._replace_local_links(full_body)
-        full_body = tools.html_sanitize(full_body, sanitize_attributes=True, sanitize_style=True)
 
         for valid_email in valid_emails:
             mail_values = {


### PR DESCRIPTION
- Go to Email Marketing and create a new mailing
- Add Masonry snippet in mail body
- Send a test mail
The picture of the Masonry snippet is missing.

The masonry image is displayed with CSS via background-image attribute.

There are 2 causes for this issue:

1) The relative url cannot be converted to an absolute one.
This is due to the &quot; entity used to surround the url that is not detected.

```style="background-image: url(&quot;/web/image/mass_mailing.s_masonry_block_default_image_1&quot;);"```

2) html_sanitize is applied to mail body, but html_sanitize doesn't allow
background-image style attribute.

opw-2735636

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
