### PR TITLE
web_editor: Improve HTML field design

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -113,7 +113,7 @@
                         </group>
                         </page>
                     </notebook>
-                    <field name="note" placeholder="Legal Notes..."/>
+                    <field name="note" class="oe-bordered-editor" placeholder="Legal Notes..."/>
                     </sheet>
                 </form>
             </field>

--- a/addons/account/wizard/account_invoice_send_views.xml
+++ b/addons/account/wizard/account_invoice_send_views.xml
@@ -48,7 +48,7 @@
                                 </div>
                                 <field name="subject" placeholder="Subject..." attrs="{'required': [('is_email', '=', True), ('composition_mode', '=', 'comment')]}"/>
                             </group>
-                            <field name="body" style="border:none;" options="{'style-inline': true}"/>
+                            <field name="body" class="oe-bordered-editor" options="{'style-inline': true}"/>
                         </div>
                         <group>
                             <group attrs="{'invisible': [('composition_mode', '=', 'mass_mail')]}">

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -162,8 +162,9 @@
                                     <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                                 </group>
                             </group>
-                            <label for="description"/>
-                            <field name="description"/>
+                            <group>
+                                <field name="description"/>
+                            </group>
                         </page>
                         <page name="page_options" string="Options">
                             <group>

--- a/addons/hr/views/hr_job_views.xml
+++ b/addons/hr/views/hr_job_views.xml
@@ -20,10 +20,7 @@
                         </div>
                         <notebook> 
                             <page string="Job Description">
-                                <div attrs="{'invisible': [('state', '!=', 'recruit')]}" name="job_description">
-                                    <label for="description"/>
-                                    <field name="description" options="{'collaborative': true}"/>
-                                </div>
+                                <field name="description" options="{'collaborative': true}" attrs="{'invisible': [('state', '!=', 'recruit')]}"/>
                             </page>
                             <page string="Recruitment">
                                 <group>

--- a/addons/mail/views/ir_actions_server_views.xml
+++ b/addons/mail/views/ir_actions_server_views.xml
@@ -35,7 +35,7 @@
                                 }"/>
                             </group>
                         </group>
-                        <field name="activity_note" placeholder="Log a note..."/>
+                        <field name="activity_note" class="oe-bordered-editor" placeholder="Log a note..."/>
                     </page>
                 </xpath>
                 <xpath expr="//field[@name='link_field_id']" position="after">

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -44,8 +44,9 @@
                             </div>
                         </group>
                     </group>
-                    <label for="default_note"/>
-                    <field name="default_note"/>
+                    <group>
+                        <field name="default_note"/>
+                    </group>
                     <p class="alert alert-info" role="alert" attrs="{'invisible': [('res_model_change', '=', False)]}">Modifying the model can have an impact on existing activities using this activity type, be careful.</p>
                 </sheet>
             </form>
@@ -126,7 +127,7 @@
                             <field name="user_id"/>
                         </group>
                     </group>
-                    <field name="note" placeholder="Log a note..."/>
+                    <field name="note" class="oe-bordered-editor" placeholder="Log a note..."/>
                     <footer>
                         <field name="id" invisible="1"/>
                         <button id="mail_activity_schedule" string="Schedule" name="action_close_dialog" type="object" class="btn-primary"

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -46,7 +46,7 @@
                                 <div class="oe_title">
                                     <h2 style="display: inline-block;"><field name="subject" placeholder="Subject (placeholders may be used here)"/></h2>
                                 </div>
-                                <field name="body_html" widget="html" options="{'style-inline': true, 'codeview': true }"/>
+                                <field name="body_html" widget="html" class="oe-bordered-editor" options="{'style-inline': true, 'codeview': true }"/>
                                 <field name="attachment_ids" widget="many2many_binary"/>
                             </page>
                             <page string="Email Configuration" name="email_configuration">

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -69,7 +69,7 @@
                                     'required':[('reply_to_mode', '!=', 'update'), ('composition_mode', '=', 'mass_mail')]}"/>
                     </group>
                     <field name="can_edit_body" invisible="1"/>
-                    <field name="body" options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
+                    <field name="body" class="oe-bordered-editor" options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
                     <group col="4">
                         <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1" colspan="2"/>
                         <field name="template_id" options="{'no_create': True}"

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -99,7 +99,9 @@
                             <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                         </group>
                     </group>
-                    <field name='description' placeholder="Internal Notes"/>
+                    <group>
+                        <field name='description' placeholder="Internal Notes"/>
+                    </group>
                 </sheet>
                 <div class="oe_chatter">
                     <field name="message_follower_ids"/>
@@ -612,7 +614,9 @@
                         </div>
                     </div>
                 </group>
-                <field name="note" nolabel="1"/>
+                <group>
+                    <field name="note"/>
+                </group>
                 </sheet>
                 <div class="oe_chatter">
                     <field name="message_follower_ids"/>

--- a/addons/note/static/src/scss/note.scss
+++ b/addons/note/static/src/scss/note.scss
@@ -33,7 +33,8 @@
         }
         .note-editable {
             border: none;
-            padding: $o-sheet-vpadding $o-horizontal-padding;
+            padding: $o-sheet-vpadding $o-horizontal-padding 10px !important;
+            min-height: 300px;
         }
     }
     .oe_form_field.oe_memo {

--- a/addons/project/static/src/js/project_form.js
+++ b/addons/project/static/src/js/project_form.js
@@ -17,9 +17,8 @@ const ProjectFormController = FormController.extend({
     _onDomUpdated() {
         const $editable = this.$el.find('.note-editable');
         if ($editable.length) {
-            const resizerHeight = this.$el.find('.o_wysiwyg_resizer').outerHeight();
-            const newHeight = window.innerHeight - $editable.offset().top - resizerHeight - 1;
-            $editable.outerHeight(newHeight);
+            const minHeight = window.innerHeight - $editable.offset().top - 42;
+            $editable.css('min-height', minHeight + 'px');
         }
     },
     on_detach_callback() {

--- a/addons/project/static/src/js/widgets/html_with_action_widget.js
+++ b/addons/project/static/src/js/widgets/html_with_action_widget.js
@@ -15,9 +15,8 @@ export const FieldHtmlWithAction = FieldHtml.extend({
             bus.on("DOM_updated", this, () => {
                 const $editable = this.$el.find('.note-editable');
                 if ($editable.length) {
-                    const resizerHeight = this.$el.find('.o_wysiwyg_resizer').outerHeight();
-                    const newHeight = window.innerHeight - $editable.offset().top - resizerHeight - 1;
-                    $editable.outerHeight(newHeight);
+                    const minHeight = window.innerHeight - $editable.offset().top - 30;
+                    $editable.css('min-height', minHeight + 'px');
                 }
             });
         }

--- a/addons/project/static/src/scss/project_form.scss
+++ b/addons/project/static/src/scss/project_form.scss
@@ -5,7 +5,7 @@
 .o_form_project_project, .o_form_project_tasks {
     .note-editable {
         border: 0;
-        padding: $o-horizontal-padding $o-horizontal-padding;
+        padding: 0;
     }
 }
 

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -353,10 +353,14 @@
                                      </templates>
                                  </kanban>
                             </field>
-                            <group class="oe_subtotal_footer oe_right">
-                                <field name="tax_totals_json" widget="account-tax-totals-field" nolabel="1" colspan="2"/>
+                            <group>
+                                <group>
+                                    <field name="notes" nolabel="1" placeholder="Define your terms and conditions ..."/>
+                                </group>
+                                <group class="oe_subtotal_footer oe_right">
+                                    <field name="tax_totals_json" widget="account-tax-totals-field" nolabel="1" colspan="2"/>
+                                </group>
                             </group>
-                            <field name="notes" class="oe_inline" placeholder="Define your terms and conditions ..."/>
                             <div class="oe_clear"/>
                         </page>
                         <page string="Other Information" name="purchase_delivery_invoice">

--- a/addons/purchase_requisition/views/purchase_requisition_views.xml
+++ b/addons/purchase_requisition/views/purchase_requisition_views.xml
@@ -190,7 +190,7 @@
                             </form>
                         </field>
                         <separator string="Terms and Conditions"/>
-                        <field name="description" attrs="{'readonly': [('state','not in',('draft','in_progress','open'))]}"/>
+                        <field name="description" class="oe-bordered-editor" attrs="{'readonly': [('state','not in',('draft','in_progress','open'))]}"/>
                     </page>
                 </notebook>
             </sheet>

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -640,7 +640,7 @@
                             </field>
                             <group name="note_group" col="6" class="mt-2 mt-md-0">
                                 <group colspan="4">
-                                    <field name="note" nolabel="1" placeholder="Terms and conditions..."/>
+                                    <field name="note" class="oe-bordered-editor" nolabel="1" placeholder="Terms and conditions..."/>
                                 </group>
                                 <group class="oe_subtotal_footer oe_right" colspan="2" name="sale_total">
                                     <field name="tax_totals_json" widget="account-tax-totals-field" nolabel="1" colspan="2"/>

--- a/addons/survey/wizard/survey_invite_views.xml
+++ b/addons/survey/wizard/survey_invite_views.xml
@@ -45,7 +45,7 @@
                             <field name="subject" placeholder="Subject..."/>
                         </group>
                         <field name="can_edit_body" invisible="1"/>
-                        <field name="body" options="{'style-inline': true, 'height': 380}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
+                        <field name="body" class="oe-bordered-editor" options="{'style-inline': true, 'height': 380}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
                         <group>
                             <group>
                                 <field name="attachment_ids" widget="many2many_binary"/>

--- a/addons/web/static/src/legacy/scss/form_view.scss
+++ b/addons/web/static/src/legacy/scss/form_view.scss
@@ -686,14 +686,18 @@ $o-form-label-margin-right: 0px;
 
     // Translate icon
     span.o_field_translate {
-            padding: 0 $o-form-spacing-unit 0 0 !important;
-            vertical-align: top;
-            position: relative;
-            margin-left: -35px;
-            width: 35px !important; // important is usefull for textarea
-            display: inline-block;
-            text-align: right;
-            border: none;  // usefull for textarea
+        padding: 0 $o-form-spacing-unit 0 0 !important;
+        vertical-align: top;
+        position: relative;
+        margin-left: -35px;
+        width: 35px !important; // important is useful for textarea
+        display: inline-block;
+        text-align: right;
+        border: none;  // usefull for textarea
+        background-color: rgba($o-view-background-color, 0.8); // useful in code view
+        &:hover {
+            background-color: $o-view-background-color
+        }
     }
     input, textarea {
         &.o_field_translate {

--- a/addons/web/static/src/legacy/scss/form_view.scss
+++ b/addons/web/static/src/legacy/scss/form_view.scss
@@ -654,6 +654,17 @@ $o-form-label-margin-right: 0px;
 
         .tab-content > .tab-pane {
             padding: $o-horizontal-padding 0;
+            >.oe_form_field {
+                >.note-editable {
+                    border-width: 0;
+                    padding: 0;
+                    min-height: 180px;
+                }
+                &.oe-bordered-editor>.note-editable {
+                    border-width: 1px;
+                    padding: 4px;
+                }
+            }
         }
     }
 
@@ -672,7 +683,7 @@ $o-form-label-margin-right: 0px;
     }
     .o_field_widget, .btn {
         .o_field_widget {
-            margin-bottom: 0px;
+            margin-bottom: 0;
         }
     }
     .o_td_label .o_form_label:not(.o_status), .o_checkbox_optional_field > .o_form_label {

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2287,7 +2287,7 @@ export class OdooEditor extends EventTarget {
 
     clean() {
         this.observerUnactive();
-        for (const hint of this.document.querySelectorAll('.oe-hint')) {
+        for (const hint of this.editable.querySelectorAll('.oe-hint')) {
             hint.classList.remove('oe-hint', 'oe-command-temporary-hint');
             hint.removeAttribute('placeholder');
         }

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -204,10 +204,11 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
                 noVideos: 'noVideos' in this.nodeOptions ? this.nodeOptions.noVideos : true,
             },
             linkForceNewWindow: true,
-
             tabsize: 0,
-            height: this.nodeOptions.height || 110,
-            resizable: 'resizable' in this.nodeOptions ? this.nodeOptions.resizable : true,
+            height: this.nodeOptions.height,
+            minHeight: this.nodeOptions.minHeight,
+            maxHeight: this.nodeOptions.maxHeight,
+            resizable: 'resizable' in this.nodeOptions ? this.nodeOptions.resizable : false,
             editorPlugins: [QWebPlugin],
         });
     },

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -550,7 +550,15 @@ const Wysiwyg = Widget.extend({
     renderElement: function () {
         this.$editable = this.options.editable || $('<div class="note-editable">');
         this.$root = this.$editable;
-
+        if (this.options.height) {
+            this.$editable.height(this.options.height);
+        }
+        if (this.options.minHeight) {
+            this.$editable.css('min-height', this.options.minHeight);
+        }
+        if (this.options.maxHeight && this.options.maxHeight > 10) {
+            this.$editable.css('max-height', this.options.maxHeight);
+        }
         if (this.options.resizable && !device.isMobile) {
             const $wrapper = $('<div class="o_wysiwyg_wrapper odoo-editor">');
             this.$root = $wrapper;

--- a/addons/web_editor/static/src/scss/web_editor.backend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.backend.scss
@@ -3,7 +3,7 @@
     word-wrap: break-word;
     overflow: hidden;
 
-    .odoo-editor #codeview-btn-group {
+    #codeview-btn-group {
         position: absolute;
         top: 0;
         right: 0;

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -708,7 +708,15 @@ img::selection {
     background: white;
     color: black;
     height: 100%;
-    padding: 5px 10px;
+    padding: 4px;
+    min-height: 10px;
+    border-radius: 3px;
+}
+
+.oe-bordered-editor>.note-editable {
+    border-width: 1px;
+    padding: 4px;
+    min-height: 180px;
 }
 
 .o_we_no_pointer_events {

--- a/addons/website_sale_stock/views/product_template_views.xml
+++ b/addons/website_sale_stock/views/product_template_views.xml
@@ -20,7 +20,7 @@
                         Units
                     </span>
                 </div>
-                <field name="out_of_stock_message" attrs="{'invisible': [('type', 'in', ['service', 'consu'])]}" options="{'height': 150}"/>
+                <field name="out_of_stock_message" attrs="{'invisible': [('type', 'in', ['service', 'consu'])]}"/>
             </xpath>
         </field>
     </record>

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -82,9 +82,7 @@
                                 </field>
                             </page>
                             <page name="description" string="Description">
-                                <group>
-                                    <field name="description" colspan="4" placeholder="Common tasks for a computer scientist is asking the right questions and answering questions. In this course, you'll study those topics with activities about mathematics, science and logic."/>
-                                </group>
+                                <field name="description" colspan="4" placeholder="Common tasks for a computer scientist is asking the right questions and answering questions. In this course, you'll study those topics with activities about mathematics, science and logic."/>
                             </page>
                             <page name="options" string="Options">
                                 <group>

--- a/addons/website_slides/wizard/slide_channel_invite_views.xml
+++ b/addons/website_slides/wizard/slide_channel_invite_views.xml
@@ -20,7 +20,7 @@
                             <field name="subject" placeholder="Subject..."/>
                         </group>
                         <field name="can_edit_body" invisible="1"/>
-                        <field name="body" options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
+                        <field name="body" class="oe-bordered-editor" options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
                         <group>
                             <group>
                                 <field name="attachment_ids" widget="many2many_binary"/>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -344,7 +344,7 @@
                             </group>
                         </page>
                         <page name='internal_notes' string="Internal Notes">
-                            <field name="comment" options="{'height': 70}" placeholder="Internal note..."/>
+                            <field name="comment" placeholder="Internal note..."/>
                         </page>
                     </notebook>
                 </sheet>


### PR DESCRIPTION
Some html field are not in their ideal style, we fix it by : 

1. Changing the default behavior of the html fields to fit most cases.

> 
> As the style for html fields is now dependent of
> where you are in the xml view ( in group or not),
> we have to adapt some views and flags some fields
> to ensure they have the correct look.
> 
> This change is only be a visual enhancement
> and should not prevent the function of said html fields
> event if the views are not updated.



2. Minor fix in html fields placeholder, support placeholder when multiple editors are present.
3. Minor fix on Code view and Translate button, make sure they don't interfere with each other visually.

-----

task-2637488

----
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
