### PR TITLE
use os.replace

### DIFF
--- a/doc/cla/individual/milahu.md
+++ b/doc/cla/individual/milahu.md
@@ -1,0 +1,11 @@
+Germany, 2022-01-25
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Milan Hauth <milahu@gmail.com> https://github.com/milahu

--- a/odoo/tools/_vendor/sessions.py
+++ b/odoo/tools/_vendor/sessions.py
@@ -26,7 +26,7 @@ from pickle import load
 from time import time
 
 from werkzeug.datastructures import CallbackDict
-from werkzeug.posixemulation import rename
+from os import replace
 
 _sha1_re = re.compile(r"^[a-f0-9]{40}$")
 
@@ -198,7 +198,7 @@ class FilesystemSessionStore(SessionStore):
         finally:
             f.close()
         try:
-            rename(tmp, fn)
+            replace(tmp, fn)
             os.chmod(fn, self.mode)
         except (IOError, OSError):
             pass


### PR DESCRIPTION
**what**

replace `werkzeug.posixemulation.rename` with `os.replace`

**before**

require old version of `werkzeug`

**after**

work with current version of `werkzeug`

**why**

werkzeug.posixemulation was removed in werkzeug 2.0
since python 3.3, "unix rename" is provided by os.replace

https://stackoverflow.com/a/70846357/10440128

**todo**

* ~~update requirements.txt to werkzeug 2.0~~
  * ~~generally, update all dependencies to latest versions~~
  * wontfix: versions are limited by debian stable
* require python 3.3

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
