### PR TITLE
[FIX] mail: ensures that rtc cards have the right aspect ratio

### DIFF
--- a/addons/mail/static/src/components/rtc_call_viewer/rtc_call_viewer.xml
+++ b/addons/mail/static/src/components/rtc_call_viewer/rtc_call_viewer.xml
@@ -31,7 +31,7 @@
                             <t t-if="!rtcCallViewer.filterVideoGrid or (participantCard.rtcSession and participantCard.rtcSession.videoStream)">
                                 <!-- maybe filter focused partner out? -->
                                 <RtcCallParticipantCard
-                                    class="o_RtcCallViewer_participantCard o_RtcCallViewer_gridTile"
+                                    class="o_RtcCallViewer_participantCard o_RtcCallViewer_gridTile mw-100"
                                     callParticipantCardLocalId="participantCard.localId"
                                 />
                             </t>


### PR DESCRIPTION
Before this commit, the call participant cards in the sidebar of the
call viewer didn't respect the 16:9 aspect ratio on some browsers like
chrome. This commit fixes the issue.

task-2738622

