### PR TITLE
[FIX] l10n_fr_pos_cert: Fix bad xpath making everything editable

### DIFF
--- a/addons/l10n_fr_pos_cert/views/account_views.xml
+++ b/addons/l10n_fr_pos_cert/views/account_views.xml
@@ -12,13 +12,13 @@
                 <attribute name="attrs">{'readonly': [('pos_session_id', '!=', False)]}</attribute>
             </xpath>
             <xpath expr="//field[@name='journal_id']" position="attributes">
-                <attribute name="attrs">{'readonly': [('pos_session_id', '!=', False)]}</attribute>
+                <attribute name="attrs">{'readonly': ['|', ('move_line_count','!=', 0), ('pos_session_id', '!=', False)]}</attribute>
             </xpath>
             <xpath expr="//field[@name='date']" position="attributes">
-                <attribute name="attrs">{'readonly': [('pos_session_id', '!=', False)]}</attribute>
+                <attribute name="attrs">{'readonly': ['|', ('state', '!=', 'open'), ('pos_session_id', '!=', False)]}</attribute>
             </xpath>
             <xpath expr="//field[@name='line_ids']" position="attributes">
-                <attribute name="attrs">{'readonly': [('pos_session_id', '!=', False)]}</attribute>
+                <attribute name="attrs">{'readonly': ['|', ('state', '!=', 'open'), ('pos_session_id', '!=', False)]}</attribute>
             </xpath>
 
         </field>


### PR DESCRIPTION
When installing 'l10n_fr_pos_cert', some fields become always editables on the bank statement form even the state is not 'open'.
This allows the user to introduce a lot of unconsistencies regarding the bank statement balances.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
