### PR TITLE
[FIX] pos_gift_card : Cannot use PoS gift card in eCommerce

### DIFF
--- a/addons/pos_gift_card/models/gift_card.py
+++ b/addons/pos_gift_card/models/gift_card.py
@@ -41,7 +41,4 @@ class GiftCard(models.Model):
 
     def can_be_used_in_pos(self):
         # expired state are computed once a day, so can be not synchro
-        return self.state == 'valid' and self.balance > 0 and self.expired_date >= fields.Date.today() and self.buy_pos_order_line_id
-
-    def can_be_used(self):
-        return super(GiftCard, self).can_be_used() and not self.buy_pos_order_line_id
+        return self.state == 'valid' and self.balance > 0 and self.expired_date >= fields.Date.today()


### PR DESCRIPTION
Current behavior:
When creating a gift card in PoS you are not able to use it in the eCommerce website

Steps to reproduce:
- Activate gift card in PoS, in Generate barcode mode
- Create a gift card in the PoS
- Try to use this gift card in the eCommerce website
- You get an error "expired or not valid"

opw-2727404

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
