### PR TITLE
[IMP] mail: AttachmentBoxView should own the attachmentList

### DIFF
--- a/addons/mail/static/src/components/attachment_box/attachment_box.xml
+++ b/addons/mail/static/src/components/attachment_box/attachment_box.xml
@@ -18,10 +18,10 @@
                             onDropzoneFilesDropped="_onDropZoneFilesDropped"
                         />
                     </t>
-                    <t t-if="attachmentBoxView.chatter.attachmentList">
+                    <t t-if="attachmentBoxView.attachmentList">
                         <AttachmentList
                             className="'o_attachmentBox_attachmentList'"
-                            localId="attachmentBoxView.chatter.attachmentList.localId"
+                            localId="attachmentBoxView.attachmentList.localId"
                             onAttachmentRemoved="attachmentBoxView.onAttachmentRemoved"
                         />
                     </t>

--- a/addons/mail/static/src/models/attachment_box_view/attachment_box_view.js
+++ b/addons/mail/static/src/models/attachment_box_view/attachment_box_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { insertAndReplace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'AttachmentBoxView',
@@ -21,8 +21,26 @@ registerModel({
         onClickAddAttachment() {
             this.fileUploader.openBrowserFileUploader();
         },
+        /**
+         * @private
+         * @returns {FieldCommand}
+         */
+        _computeAttachmentList() {
+            return (this.chatter.thread && this.chatter.thread.allAttachments.length > 0)
+                ? insertAndReplace()
+                : clear();
+        },
     },
     fields: {
+        /**
+         * Determines the attachment list that will be used to display the attachments.
+         */
+        attachmentList: one('AttachmentList', {
+            compute: '_computeAttachmentList',
+            inverse: 'attachmentBoxViewOwner',
+            isCausal: true,
+            readonly: true,
+        }),
         chatter: one('Chatter', {
             inverse: 'attachmentBoxView',
             readonly: true,

--- a/addons/mail/static/src/models/attachment_image/attachment_image.js
+++ b/addons/mail/static/src/models/attachment_image/attachment_image.js
@@ -61,7 +61,7 @@ registerModel({
             if (this.attachmentList.composerView) {
                 return 50;
             }
-            if (this.attachmentList.chatter) {
+            if (this.attachmentList.attachmentBoxViewOwner) {
                 return 160;
             }
             if (this.attachmentList.message) {

--- a/addons/mail/static/src/models/attachment_list/attachment_list.js
+++ b/addons/mail/static/src/models/attachment_list/attachment_list.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace, replace } from '@mail/model/model_field_comman
 
 registerModel({
     name: 'AttachmentList',
-    identifyingFields: [['composerView', 'messageView', 'chatter']],
+    identifyingFields: [['composerView', 'messageView', 'attachmentBoxViewOwner']],
     recordMethods: {
         _computeAttachmentImages() {
             return insertAndReplace(this.imageAttachments.map(attachment => {
@@ -29,8 +29,8 @@ registerModel({
             if (this.message) {
                 return replace(this.message.attachments);
             }
-            if (this.chatter && this.chatter.thread) {
-                return replace(this.chatter.thread.allAttachments);
+            if (this.attachmentBoxViewOwner) {
+                return replace(this.attachmentBoxViewOwner.chatter.thread.allAttachments);
             }
             if (this.composerView && this.composerView.composer) {
                 return replace(this.composerView.composer.attachments);
@@ -58,11 +58,11 @@ registerModel({
     },
     fields: {
         /**
-         * States the attachments to be displayed by this attachment list.
+         * Link with a AttachmentBoxView to handle attachments.
          */
-        attachments: many('Attachment', {
-            compute: '_computeAttachments',
-            inverse: 'attachmentLists',
+        attachmentBoxViewOwner: one('AttachmentBoxView', {
+            inverse: 'attachmentList',
+            readonly: true,
         }),
         /**
          * States the attachment cards that are displaying this nonImageAttachments.
@@ -81,11 +81,11 @@ registerModel({
             isCausal: true,
         }),
         /**
-         * Link with a chatter to handle attachments.
+         * States the attachments to be displayed by this attachment list.
          */
-        chatter: one('Chatter', {
-            inverse: 'attachmentList',
-            readonly: true,
+        attachments: many('Attachment', {
+            compute: '_computeAttachments',
+            inverse: 'attachmentLists',
         }),
         /**
          * Link with a composer view to handle attachments.

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -152,15 +152,6 @@ registerModel({
          * @private
          * @returns {boolean}
          */
-        _computeAttachmentList() {
-            return (this.thread && this.thread.allAttachments.length > 0)
-                ? insertAndReplace()
-                : clear();
-        },
-        /**
-         * @private
-         * @returns {boolean}
-         */
         _computeHasThreadView() {
             return Boolean(this.thread && this.hasMessageList);
         },
@@ -263,15 +254,6 @@ registerModel({
         attachmentBoxView: one('AttachmentBoxView', {
             inverse: 'chatter',
             isCausal: true,
-        }),
-        /**
-         * Determines the attachment list that will be used to display the attachments.
-         */
-        attachmentList: one('AttachmentList', {
-            compute: '_computeAttachmentList',
-            inverse: 'chatter',
-            isCausal: true,
-            readonly: true,
         }),
         /**
          * States the OWL Chatter component of this chatter.


### PR DESCRIPTION
Before this PR, AttachmentBoxView required a Chatter to have an
AttachmentList. This model is wrong since the attachmentBoxView can direcly own
the AttachmentList.

task-2740183