### PR TITLE
[IMP] base, project: some improvements for project, base

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1159,8 +1159,8 @@
                             <field name="partner_id" widget="res_partner_many2one" class="o_task_customer_field"/>
                             <field name="partner_phone" widget="phone" attrs="{'invisible': True}"/>
                             <field name="date_deadline" attrs="{'invisible': [('is_closed', '=', True)]}"/>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" context="{'project_id': project_id}"/>
                             <field name="recurring_task" attrs="{'invisible': ['|', ('allow_recurring_tasks', '=', False), ('active', '=', False)]}"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" context="{'project_id': project_id}"/>
                             <field name="legend_blocked" invisible="1"/>
                             <field name="legend_normal" invisible="1"/>
                             <field name="legend_done" invisible="1"/>
@@ -1625,11 +1625,23 @@
             </field>
         </record>
 
+        <record id="view_task_kanban_inherit_my_task" model="ir.ui.view">
+            <field name="name">project.task.kanban.inherit.my.task</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="view_task_kanban"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <xpath expr="//kanban" position="attributes">
+                    <attribute name="default_group_by">personal_stage_type_ids</attribute>
+                </xpath>
+            </field>
+        </record>
+
         <record id="action_view_all_task" model="ir.actions.act_window">
             <field name="name">My Tasks</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">kanban,tree,form,calendar,pivot,graph,activity</field>
-            <field name="context">{'search_default_my_tasks': 1, 'search_default_personal_stage': 1, 'all_task': 0, 'default_user_ids': [(4, uid)]}</field>
+            <field name="context">{'search_default_my_tasks': 1, 'all_task': 0, 'default_user_ids': [(4, uid)]}</field>
             <field name="search_view_id" ref="view_task_search_form_extended"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
@@ -1656,6 +1668,7 @@
         <record id="open_view_all_task_list_kanban" model="ir.actions.act_window.view">
             <field name="sequence" eval="10"/>
             <field name="view_mode">kanban</field>
+            <field name="view_id" ref="view_task_kanban_inherit_my_task"/>
             <field name="act_window_id" ref="action_view_all_task"/>
         </record>
         <record id="open_view_all_task_list_tree" model="ir.actions.act_window.view">

--- a/odoo/addons/base/views/ir_module_views.xml
+++ b/odoo/addons/base/views/ir_module_views.xml
@@ -196,12 +196,12 @@
                             <field groups="!base.group_no_one" name="summary"/>
                             <code groups="base.group_no_one"><field name="name"/></code>
                           </p>
-                          <div class="oe_module_action">
+                          <div class="oe_module_action d-flex flex-wrap justify-content-between">
+                            <button type="object" class="btn btn-primary btn-sm" name="button_immediate_install" states="uninstalled" t-if="! record.to_buy.raw_value">Install</button>
+                            <div t-if="installed" class="d-flex align-items-center text-muted float-start">Installed</div>
                             <a t-att-href="record.website.raw_value" target="_blank" attrs="{'invisible':[('website', '=', '')]}" class="btn btn-sm btn-secondary float-end o-hidden-ios" role="button">Learn More</a>
                             <a type="edit" class="btn btn-secondary btn-sm float-end" role="button" attrs="{'invisible': [('website', '&lt;&gt;', '')]}">Module Info</a>
-                            <button type="object" class="btn btn-primary btn-sm" name="button_immediate_install" states="uninstalled" t-if="! record.to_buy.raw_value">Install</button>
                             <a href="https://odoo.com/pricing?utm_source=db&amp;utm_medium=module#hosting=on_premise" target="_blank" class="btn btn-info btn-sm" states="uninstalled,uninstallable" t-if="record.to_buy.raw_value" role="button">Upgrade</a>
-                            <div t-if="installed" class="text-muted float-start">Installed</div>
                             <button states="to remove" type="object" class="btn btn-sm btn-primary" name="button_uninstall_cancel">Cancel Uninstall</button>
                             <button states="to install" type="object" class="btn btn-sm btn-primary" name="button_install_cancel">Cancel Install</button>
                           </div>

--- a/odoo/addons/base/wizard/base_module_uninstall.py
+++ b/odoo/addons/base/wizard/base_module_uninstall.py
@@ -26,7 +26,7 @@ class BaseModuleUninstall(models.TransientModel):
     @api.depends('module_id', 'show_all')
     def _compute_module_ids(self):
         for wizard in self:
-            modules = wizard._get_modules()
+            modules = wizard._get_modules().sorted(lambda m: (not m.application, m.sequence))
             wizard.module_ids = modules if wizard.show_all else modules.filtered('application')
 
     def _get_models(self):

--- a/odoo/addons/base/wizard/base_module_uninstall_views.xml
+++ b/odoo/addons/base/wizard/base_module_uninstall_views.xml
@@ -43,7 +43,7 @@
                         </tree>
                     </field>
                     <div class="alert alert-warning" role="alert">
-                        <p>
+                        <p class="mt-3">
                             Module uninstallation is not always consistent and can sometimes lead to issues,
                             some data may be deleted, the database could be left in an unstable state,
                             the server could crash, etc. While this is rare, we recommend testing


### PR DESCRIPTION
Some improvements for project and base.

For project > my tasks menu
 - removed the grouped by personal stage from the search view
    and set 'personal stage' as the default group by for kanban view.

For project.task form view
- moved the 'recurrent' field above the 'tags' field

For ir.module.module:
- displayed the 'module info' button below the 'install' button for mobile view

For ir.module.module > uninstall module wizard:
- vertically centered the alert warning message
- sorted the application name alphabatically

TaskID-2731708