### PR TITLE
[FIX] website_sale: only show item from current category

### DIFF
--- a/addons/website_sale/static/src/snippets/s_products_searchbar/000.js
+++ b/addons/website_sale/static/src/snippets/s_products_searchbar/000.js
@@ -67,6 +67,7 @@ publicWidget.registry.productsSearchBar = publicWidget.Widget.extend({
                     'display_description': this.displayDescription,
                     'display_price': this.displayPrice,
                     'max_nb_chars': Math.round(Math.max(this.autocompleteMinWidth, parseInt(this.$el.width())) * 0.22),
+                    'category': new URL(this.target.action).searchParams.get('category')
                 },
             },
         });


### PR DESCRIPTION
What are the steps to reproduce your issue?
- Select a category.
- Search for a term in the product title.

What is the current behavior that you observe?
- All products with term appear not just the ones in the category

What would be your expected behavior in this case?
- Only products in the category should appear.

opw-2739602

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
