### PR TITLE
[FIX] survey: print all pages from the survey results

### DIFF
--- a/addons/survey/static/src/css/survey_print.css
+++ b/addons/survey/static/src/css/survey_print.css
@@ -14,4 +14,7 @@
     .js_question-wrapper {
         page-break-inside: avoid;
     }
+    html {
+        height: unset;
+    }
 }


### PR DESCRIPTION
**Steps to follow**

  - Use an odoo instance without the planning app
  - Go to the survey app > feedback form
  - Click on "See results"
  - Print the document with your browser
  -> The output only contains the first page

**Cause of the issue**

  A height of 100% is set to the html element
  It works with the planning module because this css is present
  https://github.com/odoo/enterprise/blob/ead53fcca721aaa06619b4113707cae3fe086731/planning/static/src/scss/planning_calendar_report.scss#L57-L60

**Solution**

  Unset the html height property in the survey layout

opw-2724319