### PR TITLE
[FIX] product: fix contained quantity decimal precision

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -722,7 +722,7 @@ class ProductPackaging(models.Model):
     name = fields.Char('Package Type', required=True)
     sequence = fields.Integer('Sequence', default=1, help="The first in the sequence is the default one.")
     product_id = fields.Many2one('product.product', string='Product', check_company=True)
-    qty = fields.Float('Contained Quantity', help="Quantity of products contained in the packaging.")
+    qty = fields.Float('Contained Quantity', digits='Product Unit of Measure', help="Quantity of products contained in the packaging.")
     barcode = fields.Char('Barcode', copy=False, help="Barcode used for packaging identification. Scan this packaging barcode from a transfer in the Barcode app to move all the contained units")
     product_uom_id = fields.Many2one('uom.uom', related='product_id.uom_id', readonly=True)
     company_id = fields.Many2one('res.company', 'Company', index=True)


### PR DESCRIPTION
Steps to reproduce the bug:
- Activate packaging in inventory configurations
- set the product UOM digits to more than 2 decimals
- Create a storable product:
    - Go to inventory tab > Packaging > Add a line
    - Change the contained quantity to a value with more than 2 decimal places

Problem:
It will round it to 2 decimal places regardless of the set digits.
Because the formatFloat function does not receive the digits in parameter, so it uses 2 as default value

Problem:

opw-2723068




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
