### PR TITLE
[FIX] web,mail: fix wrong assertions in tests

### DIFF
--- a/addons/mail/static/src/components/chat_window_manager/tests/chat_window_manager_tests.js
+++ b/addons/mail/static/src/components/chat_window_manager/tests/chat_window_manager_tests.js
@@ -161,7 +161,7 @@ QUnit.test('chat window new message: focused on open [REQUIRE FOCUS]', async fun
         document.querySelector(`.o_ChatWindow`).classList.contains('o-focused'),
         "chat window should be focused"
     );
-    assert.ok(
+    assert.strictEqual(
         document.activeElement,
         document.querySelector(`.o_ChatWindow_newMessageFormInput`),
         "chat window focused = selection input focused"

--- a/addons/web/static/tests/legacy/views/form_tests.js
+++ b/addons/web/static/tests/legacy/views/form_tests.js
@@ -1852,7 +1852,7 @@ QUnit.module('Views', {
             res_id: 1,
         });
 
-        assert.containsOnce(form, 'span.o_required_modifier', form);
+        assert.containsOnce(form, 'span.o_required_modifier');
 
         await testUtils.form.clickEdit(form);
         assert.containsOnce(form, 'input.o_required_modifier',


### PR DESCRIPTION
[FIX] web,mail: fix wrong assertions in tests
This is not a big deal, but by passing a widget instance or a DOM
node as message to a QUnit.assert function, QUnit keeps a reference
to that instance or DOM element, and it can never be garbage
collected (nor its bound handlers in the case of a DOM element).

For the mail case, this was a bit more critical as we didn't check
what the author of the test actually wanted to check.