### PR TITLE
[REV] mrp: don't suggest qty to produce when start workorder

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -550,8 +550,6 @@ class MrpWorkorder(models.Model):
 
         if self.product_tracking == 'serial':
             self.qty_producing = 1.0
-        else:
-            self.qty_producing = self.qty_remaining
 
         self.env['mrp.workcenter.productivity'].create(
             self._prepare_timeline_vals(self.duration, datetime.now())

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -366,35 +366,6 @@ class TestMrpOrder(TestMrpCommon):
         production = mo_form.save()
         self.assertEqual(production.workorder_ids.duration_expected, 90)
 
-    def test_qty_producing(self):
-        """Qty producing should be the qty remain to produce, instead of 0"""
-        bom = self.env['mrp.bom'].create({
-            'product_id': self.product_6.id,
-            'product_tmpl_id': self.product_6.product_tmpl_id.id,
-            'product_qty': 1,
-            'product_uom_id': self.product_6.uom_id.id,
-            'type': 'normal',
-            'bom_line_ids': [
-                (0, 0, {'product_id': self.product_2.id, 'product_qty': 2.00}),
-            ],
-        })
-        production_form = Form(self.env['mrp.production'])
-        production_form.product_id = self.product_6
-        production_form.bom_id = bom
-        production_form.product_qty = 5
-        production_form.product_uom_id = self.product_6.uom_id
-        production = production_form.save()
-        production_form = Form(production)
-        with production_form.workorder_ids.new() as wo:
-            wo.name = 'OP1'
-            wo.workcenter_id = self.workcenter_1
-            wo.duration_expected = 40
-        production = production_form.save()
-        production.action_confirm()
-        production.button_plan()
-        production.workorder_ids[0].button_start()
-        self.assertEqual(production.workorder_ids.qty_producing, 5, "Wrong quantity is suggested to produce.")
-
     def test_update_quantity_5(self):
         bom = self.env['mrp.bom'].create({
             'product_id': self.product_6.id,


### PR DESCRIPTION
In 9f7e6d2bb6ae0a6b0257edf26a5aa069cd00d78e , when start a workorder, we
always suggest the qty to produce to be the full qty to produce on MO.
If the previous WO produced less than the full qty to produce on MO,
user won't aware of that when start the WO. We revert it in this committ

Task-2678388



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
