### PR TITLE
[FIX] web: Allow user to groupby nonstored field

### DIFF
--- a/addons/project/static/tests/burndown_chart_tests.js
+++ b/addons/project/static/tests/burndown_chart_tests.js
@@ -18,9 +18,9 @@ QUnit.module("Project", {}, () => {
                     burndown_chart: {
                         fields: {
                             date: { string: "Date", type: "date", store: true, sortable: true },
-                            project_id: { string: "Project", type: "many2one", relation: "project", store: true },
-                            stage_id: { string: "Stage", type: "many2one", relation: "stage", store: true },
-                            nb_tasks: { string: "Number of Tasks", type: "integer", store: true, group_operator: "sum" }
+                            project_id: { string: "Project", type: "many2one", relation: "project", store: true, sortable: true },
+                            stage_id: { string: "Stage", type: "many2one", relation: "stage", store: true, sortable: true },
+                            nb_tasks: { string: "Number of Tasks", type: "integer", store: true, sortable: true, group_operator: "sum" }
                         },
                         records: [
                             { id: 1, project_id: 1, stage_id: 1, date: "2020-01-01", nb_tasks: 10 },

--- a/addons/web/static/src/views/graph/graph_model.js
+++ b/addons/web/static/src/views/graph/graph_model.js
@@ -501,9 +501,9 @@ export class GraphModel extends Model {
         const processedGroupBy = [];
         for (const gb of groupBy) {
             const { fieldName, interval } = gb;
-            const { store, type } = fields[fieldName];
+            const { sortable, type } = fields[fieldName];
             if (
-                !store ||
+                !sortable ||
                 ["id", "__count"].includes(fieldName) ||
                 !GROUPABLE_TYPES.includes(type)
             ) {

--- a/addons/web/static/tests/views/graph_view_tests.js
+++ b/addons/web/static/tests/views/graph_view_tests.js
@@ -152,19 +152,21 @@ QUnit.module("Views", (hooks) => {
                 foo: {
                     fields: {
                         id: { string: "Id", type: "integer" },
-                        foo: { string: "Foo", type: "integer", store: true, group_operator: "sum" },
-                        bar: { string: "bar", type: "boolean", store: true },
+                        foo: { string: "Foo", type: "integer", store: true, group_operator: "sum", sortable: true },
+                        bar: { string: "bar", type: "boolean", store: true, sortable: true },
                         product_id: {
                             string: "Product",
                             type: "many2one",
                             relation: "product",
                             store: true,
+                            sortable: true
                         },
                         color_id: {
                             string: "Color",
                             type: "many2one",
                             relation: "color",
                             store: true,
+                            sortable: true
                         },
                         date: { string: "Date", type: "date", store: true, sortable: true },
                         revenue: {
@@ -172,6 +174,7 @@ QUnit.module("Views", (hooks) => {
                             type: "float",
                             store: true,
                             group_operator: "sum",
+                            sortable: true
                         },
                     },
                     records: [
@@ -3577,4 +3580,22 @@ QUnit.module("Views", (hooks) => {
             "backgroundColor": undefined,
         });
     });
+
+    QUnit.test("group by a non stored, sortable field", async function (assert) {
+        assert.expect(1);
+        // When a field is non-stored but sortable it's inherited
+        // from a stored field, so it can be sortable
+        serverData.models.foo.fields.date.store = false;
+        const graph = await makeView({
+            serverData,
+            type: "graph",
+            resModel: "foo",
+            groupBy: ["date:month"],
+            arch: `<graph type="line"/>`,
+            config: {
+                views: [[false, "search"]],
+            },
+        });
+        checkLabels(assert, graph, ["January 2016", "March 2016", "May 2016", "April 2016"]);
+    })
 });


### PR DESCRIPTION
For the moment we cannot groupby an inherited field (which is therefore related), so it is counted as being non-stored.
Because in the `_normalize` function we do not process fields that are not stored, whereas like here

https://github.com/odoo/odoo/blob/d679cd0d8ba9a2420e81a42a698763e9be2327e1/addons/web/static/src/legacy/js/control_panel/groupby_menu.js#L45-L49.

Typically when a field is non-stored but sortable it is inherited from a stored field, so it can be sortable

So we have to use `sortable` instead of `sort` to make it consistent.

opw-2733133