### PR TITLE
[FIX] point_of_sale : No cash journal

### DIFF
--- a/addons/point_of_sale/models/account_journal.py
+++ b/addons/point_of_sale/models/account_journal.py
@@ -11,6 +11,6 @@ class AccountJournal(models.Model):
 
     @api.constrains('type')
     def _check_type(self):
-        methods = self.env['pos.payment.method'].sudo().search([("journal_id", "=", self.id)])
+        methods = self.env['pos.payment.method'].sudo().search([("journal_id", "in", self.ids)])
         if methods:
             raise ValidationError(_("This journal is associated with a payment method. You cannot modify its type"))


### PR DESCRIPTION
Patch of the previous fix that cause traceback in some cases

Current behavior:
In some cases self could contain more than one journal record and throw a traceback

previous patch: #82710

opw-2732933

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
