### PR TITLE
[IMP] delivery: picking/order ref in DeliveryPackage

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -300,7 +300,7 @@ class DeliveryCarrier(models.Model):
         package_weights = [max_weight] * total_full_packages + [last_package_weight] if last_package_weight else []
         partial_cost = total_cost / len(package_weights)  # separate the cost uniformly
         for weight in package_weights:
-            packages.append(DeliveryPackage(None, weight, default_package_type, total_cost=partial_cost, currency=order.company_id.currency_id))
+            packages.append(DeliveryPackage(None, weight, default_package_type, total_cost=partial_cost, currency=order.company_id.currency_id, order=order))
         return packages
 
     def _get_packages_from_picking(self, picking, default_package_type):
@@ -309,7 +309,7 @@ class DeliveryCarrier(models.Model):
         if picking.is_return_picking:
             commodities = self._get_commodities_from_stock_move_lines(picking.move_line_ids)
             weight = picking._get_estimated_weight()
-            packages.append(DeliveryPackage(commodities, weight, default_package_type, currency=picking.company_id.currency_id))
+            packages.append(DeliveryPackage(commodities, weight, default_package_type, currency=picking.company_id.currency_id, picking=picking))
             return packages
 
         # Create all packages.
@@ -319,7 +319,7 @@ class DeliveryCarrier(models.Model):
             package_total_cost = 0.0
             for quant in package.quant_ids:
                 package_total_cost += self._product_price_to_company_currency(quant.quantity, quant.product_id, picking.company_id)
-            packages.append(DeliveryPackage(commodities, package.shipping_weight or package.weight, package.package_type_id, name=package.name, total_cost=package_total_cost, currency=picking.company_id.currency_id))
+            packages.append(DeliveryPackage(commodities, package.shipping_weight or package.weight, package.package_type_id, name=package.name, total_cost=package_total_cost, currency=picking.company_id.currency_id, picking=picking))
 
         # Create one package: either everything is in pack or nothing is.
         if picking.weight_bulk:
@@ -327,7 +327,7 @@ class DeliveryCarrier(models.Model):
             package_total_cost = 0.0
             for move_line in picking.move_line_ids:
                 package_total_cost += self._product_price_to_company_currency(move_line.qty_done, move_line.product_id, picking.company_id)
-            packages.append(DeliveryPackage(commodities, picking.weight_bulk, default_package_type, name='Bulk Content', total_cost=package_total_cost, currency=picking.company_id.currency_id))
+            packages.append(DeliveryPackage(commodities, picking.weight_bulk, default_package_type, name='Bulk Content', total_cost=package_total_cost, currency=picking.company_id.currency_id, picking=picking))
 
         return packages
 

--- a/addons/delivery/models/delivery_request_objects.py
+++ b/addons/delivery/models/delivery_request_objects.py
@@ -3,9 +3,12 @@
 
 class DeliveryPackage:
     """ Each provider need similar information about its packages. """
-    def __init__(self, commodities, weight, package_type, name=None, total_cost=0, currency=None):
+    def __init__(self, commodities, weight, package_type, name=None, total_cost=0, currency=None, picking=False, order=False):
         """ The UOMs are based on the config parameters, which is very convenient:
         we do not need to keep those stored."""
+        self.picking_id = picking
+        self.order_id = order
+        self.company_id = order and order.company_id or picking and picking.company_id
         self.commodities = commodities or []  # list of DeliveryCommodity objects
         self.weight = weight
         self.dimension = {


### PR DESCRIPTION
Before this commit, to access some values of the DeliveryPackage
objects, we needed to take the value from the related picking. for
example, for the `payment country code` linked to the package, we need
to retrieve the value from the related picking or order.

To avoid passing too much data to the request objects, it is convenient
to be able to access to the order/picking related to the package
directly from the package.

Because these objects are not children of odoo.models.Model, I do not
need to follow the convention for the names, however, calling the
picking > picking_id in the DeliveryPackage suggests that the picking is
actually a odoo.models.Model child, which should be the case if it
exists.

reference-PR= https://github.com/odoo/enterprise/pull/23124