### PR TITLE
[IMP] sale: Prevent paying for a canceled SO

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -126,6 +126,9 @@ class PaymentPortal(portal.CustomerPortal):
         # Generate a new access token in case the partner id or the currency id was updated
         access_token = payment_utils.generate_access_token(partner_sudo.id, amount, currency.id)
 
+        # The invoice status is required to warn the user/customer about cancelled invoices
+        invoice_state = request.env["account.move"].sudo().browse(invoice_id).state
+
         rendering_context = {
             'acquirers': acquirers_sudo,
             'tokens': payment_tokens,
@@ -140,6 +143,7 @@ class PaymentPortal(portal.CustomerPortal):
             'landing_route': '/payment/confirmation',
             'partner_is_different': partner_is_different,
             'invoice_id': invoice_id,
+            'invoice_state': invoice_state,
             **self._get_custom_rendering_context_values(**kwargs),
         }
         return request.render(self._get_payment_page_template_xmlid(**kwargs), rendering_context)

--- a/addons/payment/views/payment_templates.xml
+++ b/addons/payment/views/payment_templates.xml
@@ -43,6 +43,14 @@
             <t t-set="footer_template_id"
                t-value="footer_template_id or 'payment.footer'"/>
 
+            <t t-if="invoice_state=='cancel'">
+                <div class="alert alert-danger" role="alert">
+                    <strong>
+                        Attention: this invoice has been cancelled.
+                    </strong>
+                </div>
+            </t>
+
             <div class="card">
                 <!-- === Acquirers === -->
                 <t t-foreach="acquirers" t-as="acquirer">

--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -358,10 +358,12 @@ class PaymentPortal(payment_portal.PaymentPortal):
                 'partner_id': order_sudo.partner_id.id,
                 'company_id': order_sudo.company_id.id,
                 'sale_order_id': sale_order_id,
+                'sale_order_state': order_sudo.state,
             })
         return super().payment_pay(*args, amount=amount, access_token=access_token, **kwargs)
 
-    def _get_custom_rendering_context_values(self, sale_order_id=None, **kwargs):
+    def _get_custom_rendering_context_values(self, sale_order_id=None, sale_order_state=None,
+                                             **kwargs):
         """ Override of payment to add the sale order id in the custom rendering context values.
 
         :param int sale_order_id: The sale order for which a payment id made, as a `sale.order` id
@@ -371,6 +373,8 @@ class PaymentPortal(payment_portal.PaymentPortal):
         rendering_context_values = super()._get_custom_rendering_context_values(**kwargs)
         if sale_order_id:
             rendering_context_values['sale_order_id'] = sale_order_id
+        if sale_order_state:
+            rendering_context_values['sale_order_state'] = sale_order_state
         return rendering_context_values
 
     def _create_transaction(self, *args, sale_order_id=None, custom_create_values=None, **kwargs):

--- a/addons/sale/views/payment_templates.xml
+++ b/addons/sale/views/payment_templates.xml
@@ -6,6 +6,15 @@
         <xpath expr="//form[@name='o_payment_checkout']" position="attributes">
             <attribute name="t-att-data-sale-order-id">sale_order_id</attribute>
         </xpath>
+        <xpath expr="//form[@name='o_payment_checkout']" position="before">
+            <t t-if="sale_order_state == 'cancel'">
+                <div class="alert alert-danger" role="alert">
+                    <strong>
+                        Attention: this order has been cancelled.
+                    </strong>
+                </div>
+            </t>
+        </xpath>
     </template>
 
     <!-- Include sale-related values in payment manage form to pass them to the client -->


### PR DESCRIPTION
Before an order that has been cancelled could still be paid, from
a payment link for example.
Now we still leave the final choice to the client, but whenever
an order is cancelled a warning to the customer will display.

Task - 2735019


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
