### PR TITLE
[FIX] models: forbid model changes on xmlid

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4461,6 +4461,12 @@ Fields:
                 to_create.append(data)
                 continue
             d_id, d_module, d_name, d_model, d_res_id, d_noupdate, r_id = row
+            if self._name != d_model:
+                raise ValidationError(
+                    f"For external id {xml_id} "
+                    f"when trying to create/update a record of model {self._name} "
+                    f"found record of different model {d_model} ({d_id})"
+                )
             record = self.browse(d_res_id)
             if r_id:
                 data['record'] = record


### PR DESCRIPTION
Before this commit, changing the model on an existing xml-id may lead to
strange results.

create any record in xml, ie: xml_id=my_xml_id, model=new_model
=> Odoo will create a new external_id, pointing to (new_model, id=1)

change only the model in the xml, ie: xml_id=my_xml_id, model=ir.cron
=> Odoo will use the id of the existing external_id with the new model
 and points now to (ir.cron, id=1)
AND REPLACE the ir.cron id=1 (autovacuum_job) with the data of the xml.

This commit simply prevent that by raising when trying to recycle the
same xmlid for another model. An explicit upgrade script to remove the
existing xmlid and corresponding records should be write.