### PR TITLE
[FIX] stock: add margin to inventory_at_date button

### DIFF
--- a/addons/stock/static/src/xml/inventory_report.xml
+++ b/addons/stock/static/src/xml/inventory_report.xml
@@ -3,7 +3,7 @@
 
 <t t-extend="ListView.buttons" t-name="StockInventoryReport.Buttons">
     <t t-jquery="button.o_list_button_discard" t-operation="after">
-        <button class="btn btn-primary o_button_at_date" type="button">
+        <button class="btn btn-primary o_button_at_date mr-2" type="button">
             Inventory at Date
         </button>
     </t>


### PR DESCRIPTION
Steps to reproduce:
- go to inventory report
- remove the `"Product > Location"` Group by filter.

Problem:
The buttons `“Inventory at Date”` and `“Create”` are like merged together because there is no margin right

Before the commit:
![2022-01-26_15-18](https://user-images.githubusercontent.com/78867936/151179664-5f087b6a-2ee2-4a6f-8ca9-e49ab3915866.png)


After:
![2022-01-26_15-18_1](https://user-images.githubusercontent.com/78867936/151179652-f6a2aecc-5f82-42c0-a68a-10afd4aa1337.png)


opw-2721995




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
