### PR TITLE
[FIX] mail: handle contact with several emails in a batch sending

### DIFF
--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -19,7 +19,7 @@ from odoo.addons.mail.models.mail_mail import MailMail
 from odoo.addons.mail.models.mail_message import Message
 from odoo.addons.mail.models.mail_notification import MailNotification
 from odoo.tests import common, new_test_user
-from odoo.tools import formataddr, pycompat
+from odoo.tools import formataddr, pycompat, email_re
 
 mail_new_test_user = partial(new_test_user, context={'mail_create_nolog': True, 'mail_create_nosubscribe': True, 'mail_notrack': True, 'no_reset_password': True})
 
@@ -450,7 +450,10 @@ class MockEmail(common.BaseCase):
             if isinstance(email_to, self.env['res.partner'].__class__):
                 email_to_list.append(formataddr((email_to.name, email_to.email)))
             else:
-                email_to_list.append(email_to)
+                email_to_list.extend([
+                    email
+                    for email in email_re.findall(email_to)
+                ])
         expected['email_to'] = email_to_list
 
         sent_mail = next(

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -452,8 +452,9 @@ class MailComposer(models.TransientModel):
                     mail_to.append(mail_values['email_to'])
             # add email from recipients (res.partner)
             mail_to += [
-                recipient_emails[recipient_command[1]]
+                email
                 for recipient_command in mail_values.get('recipient_ids') or []
+                for email in email_re.findall(recipient_emails[recipient_command[1]])
                 if recipient_command[1]
             ]
             mail_to = list(set(mail_to))

--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -21,7 +21,7 @@ class MailMail(models.Model):
         mails = super(MailMail, self).create(values_list)
         for mail, values in zip(mails, values_list):
             if values.get('mailing_trace_ids'):
-                mail.mailing_trace_ids.write({'message_id': mail.message_id})
+                mail.mailing_trace_ids.write({'message_id': mail.message_id, 'email': mail.email_to if mail.email_to else mail.mailing_trace_ids.email})
         return mails
 
     def _get_tracking_url(self):


### PR DESCRIPTION
### Current behavior
In a batch sending, if the concerned partner has several emails (separated with a comma) the mail won't be sent

### Steps
- Install Invoicing
- Create two contact, one of them with at least two email addresses (separated with a comma, e.g. : `test@test.com,test2@test.com`)
- Create invoices among which one has the contact with two email addresses as customer
- In the invoicing app, select several invoices and go to Action > Send and Print

### Reason
Since this commit and especially this diff [1], the state is always `cancel` in this case because `mail_to_normalized` is empty when the partner has several emails and therefore the email isn't sent because we fall into this case [2].

[1] : https://github.com/odoo/odoo/commit/213d5d396c811d8e07ce928c0d31a7f47756a644#diff-898a3d5c08a567c1a7b82c026a213d796e850e376cbdb1c9e7936409f440d37aR485-R487
[2] : https://github.com/odoo/odoo/blob/0b43f52116fd9a58fb0a123db576d822fd541043/addons/mail/models/mail_mail.py#L326-L329
OPW-2740106
