### PR TITLE
[FIX] models: warn model changes on xmlid

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4141,6 +4141,14 @@ Fields:
                 to_create.append(data)
                 continue
             d_id, d_module, d_name, d_model, d_res_id, d_noupdate, r_id = row
+            if self._name != d_model:
+                _logger.warning((
+                    "For external id %s "
+                    "when trying to create/update a record of model %s "
+                    "found record of different model %s (%s)"
+                    "\nUpdating record %s of target model %s"),
+                    xml_id, self._name, d_model, d_id, d_id, self._name
+                )
             record = self.browse(d_res_id)
             if update and d_noupdate:
                 data['record'] = record


### PR DESCRIPTION
Before this commit, changing the model on an existing xml-id may lead to
strange results.

create any record in xml, ie: xml_id=my_xml_id, model=new_model
=> Odoo will create a new external_id, pointing to (new_model, id=1)

change only the model in the xml, ie: xml_id=my_xml_id, model=ir.cron
=> Odoo will use the id of the existing external_id with the new model
 and points now to (ir.cron, id=1)
AND REPLACE the ir.cron id=1 (autovacuum_job) with the data of the xml.

This commit simply add a warning when trying to recycle the
same xmlid for another model. An explicit upgrade script to remove the
existing xmlid and corresponding records should be writen.

This behaviour will change in master with #83422 replacing the warning
with an Exception.
