### PR TITLE
[FIX] l10n_dk: restaurationmoms tax implementation

### DIFF
--- a/addons/l10n_dk/data/account_tax_template_data.xml
+++ b/addons/l10n_dk/data/account_tax_template_data.xml
@@ -323,13 +323,19 @@
             }),
         ]"/>
     </record>
+    <!-- 25% deduction on VAT (which is 25% of the base amount) -->
+    <!-- Use case: 100 price include -->
+    <!-- base = 95 = 80 (base) + 15 (Vat not deduced) -->
+    <!-- tax = 5 = 80 * 25% * 25% -->
+    <!-- https://skat.dk/data.aspx?oid=2244623 -->
     <record id="tax450" model="account.tax.template">
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">450</field>
         <field name="name">Restaurationsmoms 6,25%, købsmoms</field>
-        <field name="description">6,25%</field>
-        <field name="amount">6.25</field>
-        <field name="amount_type">percent</field>
+        <field name="description">25% deduction of 25% VAT</field>
+        <field name="amount">5.00</field>
+        <field name="price_include" eval="True"/>
+        <field name="amount_type">division</field>
         <field name="type_tax_use">purchase</field>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {


### PR DESCRIPTION
## goal
The aim of this commit is to fix the
implementation of the restaurationmoms tax.

## context:
VAT rate in Denmark is 25%
According to the SKAT website, only 25% of the VAT
on restauration fees can be deduced.
25% * 25% is indeed 6.25% but it's the amount that
can be deduced, not the VAT itself.

### Usecase:
100 amount tax included
base = 80
tax = 20
tax to deduced = 20 * 25% = 5

### results in:
tax to deduced = 5
expense = 95 = base + remaining VAT

## Previous to this commit:
The tax implementation was completly wrong.
Setting a price = 80 results in an invoice of 85.00
But the VAT is 20 which means, the invoice total
should have been 100.

## After this commit:
- The tax implementation become price include
- It only calculates what can be deduced

ticket: 2746310
