### PR TITLE
[FIX] website_sale: only show item from current category

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -851,6 +851,7 @@ publicWidget.registry.productsSearchBar = publicWidget.Widget.extend({
         this.displayDescription = !!this.$input.data('displayDescription');
         this.displayPrice = !!this.$input.data('displayPrice');
         this.displayImage = !!this.$input.data('displayImage');
+        this.category = new URL(this.target.action).searchParams.get('category')
 
         if (this.limit) {
             this.$input.attr('autocomplete', 'off');
@@ -877,6 +878,7 @@ publicWidget.registry.productsSearchBar = publicWidget.Widget.extend({
                     'display_description': this.displayDescription,
                     'display_price': this.displayPrice,
                     'max_nb_chars': Math.round(Math.max(this.autocompleteMinWidth, parseInt(this.$el.width())) * 0.22),
+                    'category': this.category,
                 },
             },
         });


### PR DESCRIPTION
What are the steps to reproduce your issue?
- Select a category.
- Search for a term in the product title.

What is the current behavior that you observe?
- All products with term appear not just the ones in the category

What would be your expected behavior in this case?
- Only products in the category should appear.

opw-2739602

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
