### PR TITLE
fix po file

### DIFF
--- a/addons/l10n_fr_fec/i18n/fr.po
+++ b/addons/l10n_fr_fec/i18n/fr.po
@@ -7,13 +7,15 @@ msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-10-27 14:45+0000\n"
-"PO-Revision-Date: 2021-10-27 14:45+0000\n"
+"PO-Revision-Date: 2022-01-27 00:25+0100\n"
 "Last-Translator: Rémi CAZENAVE <remi@le-filament.com>, 2021\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"Language: fr\n"
+"X-Generator: Poedit 2.2.1\n"
 
 #. module: l10n_fr_fec
 #: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
@@ -57,6 +59,7 @@ msgstr ""
 
 #. module: l10n_fr_fec
 #: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
+#: view:account.fr.fec:0
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -236,17 +239,14 @@ msgstr ""
 #. module: l10n_fr_fec
 #: model:ir.model.fields.selection,name:l10n_fr_fec.selection__account_fr_fec__export_type__nonofficial
 msgid "Non-official FEC report (posted and unposted entries)"
-msgstr "Rapport FEC non-officiel (avec à la fois les entrées comptabilisées et non comptabilisées)"
+msgstr ""
+"Rapport FEC non-officiel (avec à la fois les entrées comptabilisées et non "
+"comptabilisées)"
 
 #: code:addons/l10n_fr_fec/wizard/fec.py:98
 #, python-format
 msgid "Invalid VAT number for company %s"
 msgstr "Numéro de TVA invalide sur la société %s"
-
-#. module: l10n_fr_fec
-#: view:account.fr.fec:0
-msgid "Cancel"
-msgstr "Annuler"
 
 #. module: l10n_fr_fec
 #: model:ir.model.fields.selection,name:l10n_fr_fec.selection__account_fr_fec__export_type__official
@@ -317,17 +317,17 @@ msgstr "Nous utilisons partner.id"
 #: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
 msgid ""
 "When you download a FEC file, the lock date is set to the end date.\n"
-"                If you want to test the FEC file generation, please tick the test file checkbox."
+"                If you want to test the FEC file generation, please tick the "
+"test file checkbox."
 msgstr ""
-"Quand vous téléchargez un fichier FEC, la date de verrouillage est configurée avec la date de fin.\n
-"                Si vous voulez tester la génération du fichier FEC, cliquez sur la coche Fichier de Test."
 
 #. module: l10n_fr_fec
 #: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
 msgid ""
 "You are in test mode. The FEC file generation will not set the lock date."
 msgstr ""
-"Vous êtes en mode test. La génération du fichier FEC ne configurera la date de verrouillage."
+"Vous êtes en mode test. La génération du fichier FEC ne configurera la date "
+"de verrouillage."
 
 #. module: l10n_fr_fec
 #: code:addons/l10n_fr_fec/wizard/account_fr_fec.py:0

--- a/addons/l10n_fr_fec/i18n/fr.po
+++ b/addons/l10n_fr_fec/i18n/fr.po
@@ -243,6 +243,7 @@ msgstr ""
 "Rapport FEC non-officiel (avec à la fois les entrées comptabilisées et non "
 "comptabilisées)"
 
+#. module: l10n_fr_fec
 #: code:addons/l10n_fr_fec/wizard/fec.py:98
 #, python-format
 msgid "Invalid VAT number for company %s"

--- a/doc/cla/individual/petrus-v.md
+++ b/doc/cla/individual/petrus-v.md
@@ -1,0 +1,11 @@
+France, 2021-03-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Pierre Verkest pierreverkest84@gmail.com https://github.com/petrus-v


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Wrong po file format make update ``--i18n-overwrite`` not working

Current behavior before PR:

odoo is raising while updating **l10n_fr_fec** module

```
2022-01-26 23:20:17,055 25305 ERROR cgi-20220110 odoo.sql_db: bad query:  INSERT INTO ir_translation(name, lang, res_id, src, type, value, module, state, comments)
                           SELECT name, lang, res_id, src, type, value, module, state, comments
                           FROM tmp_ir_translation_import
                           WHERE type = 'model_terms'
                           AND noupdate IS NOT TRUE
                           ON CONFLICT (type, name, lang, res_id, md5(src))
                            DO UPDATE SET (name, lang, res_id, src, type, value, module, state, comments) = (EXCLUDED.name, EXCLUDED.lang, EXCLUDED.res_id, EXCLUDED.src, EXCLUDED.type, EXCLUDED.value, EXCLUDED.module, EXCLUDED.state, EXCLUDED.comments)
                            WHERE EXCLUDED.value IS NOT NULL AND EXCLUDED.value != '';
                       
ERROR: ERREUR:  la commande ON CONFLICT DO UPDATE ne peut pas affecter une ligne la deuxième fois
ASTUCE : S'assure qu'aucune ligne proposée à l'insertion dans la même commande n'a de valeurs contraintes dupliquées.
```


Desired behavior after PR is merged:

To be able to update the module.

I guess this PR won't be merged directly as translate files are managed differently, I'm not sure how terms are committed in po files but would be great to prevent that kind of duplicate terms adding some .po/pot linter in changes those files.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
