### PR TITLE
[FIX] web, website_livechat: fix embedable chat on external websites

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -986,7 +986,7 @@ class WebClient(http.Controller):
         return {"modules": translations_per_module,
                 "lang_parameters": None}
 
-    @http.route('/web/webclient/translations/<string:unique>', type='http', auth="public")
+    @http.route('/web/webclient/translations/<string:unique>', type='http', auth="public", cors="*")
     def translations(self, unique, mods=None, lang=None):
         """
         Load the translations for the specified language and modules

--- a/addons/web/static/src/core/assets.js
+++ b/addons/web/static/src/core/assets.js
@@ -102,9 +102,8 @@ const loadCSS = memoize(function loadCSS(url) {
 export const loadBundleTemplates = memoize(async function loadBundleTemplates(name) {
     // TODO: quid of the "unique" in the URL? We can"t have one cache_hash
     // for each and every bundle I"m guessing.
-    const bundleURL = new URL(`/web/webclient/qweb/${Date.now()}`, window.location.origin);
-    bundleURL.searchParams.set("bundle", name);
-    const templates = await (await browser.fetch(bundleURL.href)).text();
+    const bundleURL = `/web/webclient/qweb/${Date.now()}?bundle=${name}`;
+    const templates = await (await browser.fetch(bundleURL)).text();
     return processTemplates(templates);
 });
 

--- a/addons/web/static/src/core/network/rpc_service.js
+++ b/addons/web/static/src/core/network/rpc_service.js
@@ -38,7 +38,7 @@ export function makeErrorFromResponse(reponse) {
     return error;
 }
 
-function jsonrpc(env, rpcId, url, params, settings = {}) {
+export function jsonrpc(env, rpcId, url, params, settings = {}) {
     const bus = env.bus;
     const XHR = browser.XMLHttpRequest;
     const data = {


### PR DESCRIPTION
Recently, a lot of the network infrastructure code was rewritten. A lot
of this new code doesn't account for the possibility of being on an
external website, and so network requests made with relative URLs would
not make their request to the odoo server but to the server serving the
external page which would fail.

This commit fixes that by replacing the regular rpc service with one
that will add the correct prefix, as well as patching the
"browser.fetch" method to do the same. Additionally, the localization
service is now less fault-tolerant, and won't silently fall back to a
default configuration if it cannot get the translations from the server,
as such, the tranlsations route is made available cross-origin, which
has the added bonus of making translations available to the embeded
code.

opw-2677184