### PR TITLE
[FIX] Create picking for PoS orders outside session

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -143,7 +143,7 @@ class PosOrder(models.Model):
             pos_order._create_order_picking()
 
         if pos_order.to_invoice and pos_order.state == 'paid':
-            pos_order.action_pos_order_invoice()
+            pos_order._generate_pos_order_invoice()
 
         return pos_order.id
 
@@ -494,8 +494,14 @@ class PosOrder(models.Model):
             else False
         }
         return vals
-
     def action_pos_order_invoice(self):
+        self.write({'to_invoice': True})
+        res = self._generate_pos_order_invoice()
+        if self.company_id.anglo_saxon_accounting and self.session_id.update_stock_at_closing:
+            self._create_order_picking()
+        return res
+
+    def _generate_pos_order_invoice(self):
         moves = self.env['account.move']
 
         for order in self:


### PR DESCRIPTION
In version 14, if you create a PoS order without invoicing it, then leave the session without closing and validating, and open said order and invoice it outside the session, picking order will not be created. After this commit Odoo will check if order that is being invoiced already has picking order, and if not, will create one for it.

OPW-2725930


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
