### PR TITLE
[fix] pos_gift_card: Allow barcode

### DIFF
--- a/addons/gift_card/models/gift_card.py
+++ b/addons/gift_card/models/gift_card.py
@@ -13,7 +13,8 @@ class GiftCard(models.Model):
 
     @api.model
     def _generate_code(self):
-        return '044' + str(uuid4())[4:-8][3:]
+        # 044 is used for the barcode scanner.
+        return '044' + str(uuid4())[7:-8]
 
     name = fields.Char(compute='_compute_name')
     code = fields.Char(default=lambda x: x._generate_code(), required=True, readonly=True, copy=False)

--- a/addons/pos_gift_card/data/gift_card_data.xml
+++ b/addons/pos_gift_card/data/gift_card_data.xml
@@ -15,6 +15,15 @@
             <field name="binding_model_id" ref="model_gift_card"/>
         </record>
 
+        <record id="barcode_rule_giftcard" model="barcode.rule">
+            <field name="name">Gift Card Barcodes</field>
+            <field name="barcode_nomenclature_id" ref="barcodes.default_barcode_nomenclature"/>
+            <field name="sequence">51</field>
+            <field name="type">gift_card</field>
+            <field name="encoding">any</field>
+            <field name="pattern">044</field>
+        </record>
+
         <template id="gift_card_template">
             <t t-call="web.html_container">
                 <t t-foreach="docs" t-as="o">

--- a/addons/pos_gift_card/static/src/js/GiftCardPopup.js
+++ b/addons/pos_gift_card/static/src/js/GiftCardPopup.js
@@ -1,8 +1,9 @@
 odoo.define("pos_gift_card.GiftCardPopup", function (require) {
   "use strict";
 
-  const { useState, useRef } = owl.hooks;
+  const { useState } = owl.hooks;
   const AbstractAwaitablePopup = require("point_of_sale.AbstractAwaitablePopup");
+  const { useBarcodeReader } = require("point_of_sale.custom_hooks");
   const Registries = require("point_of_sale.Registries");
 
   class GiftCardPopup extends AbstractAwaitablePopup {
@@ -17,6 +18,16 @@ odoo.define("pos_gift_card.GiftCardPopup", function (require) {
         amountToSet: 0,
         giftCardBarcode: "",
       });
+      useBarcodeReader(
+        {
+          gift_card: this._onGiftScan,
+        },
+        true
+      );
+    }
+
+    _onGiftScan(code) {
+      this.state.giftCardBarcode = code.base_code;
     }
 
     switchBarcodeView() {


### PR DESCRIPTION
It was not possible to use the barcode in the gift card module.
This commit add the barcode rules to read the gift card.
When the popup is open, it's possible to read it now.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
