### PR TITLE
[FIX] coupon: allow overridden method to be called

### DIFF
--- a/addons/coupon/models/coupon.py
+++ b/addons/coupon/models/coupon.py
@@ -24,7 +24,7 @@ class Coupon(models.Model):
          """
         return str(random.getrandbits(64))
 
-    code = fields.Char(default=_generate_code, required=True, readonly=True)
+    code = fields.Char(default=lambda self: self._generate_code(), required=True, readonly=True)
     expiration_date = fields.Date('Expiration Date', compute='_compute_expiration_date')
     state = fields.Selection([
         ('reserved', 'Pending'),


### PR DESCRIPTION
Due to some changes in the ORM, the previous implementation doesn't allow the override of a method to be called.