### PR TITLE
[IMP] account: Add index on reversed_entry_id

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -257,7 +257,7 @@ class AccountMove(models.Model):
 
     # ==== Reverse feature fields ====
     reversed_entry_id = fields.Many2one('account.move', string="Reversal of", readonly=True, copy=False,
-        check_company=True)
+        check_company=True, index=True)
     reversal_move_id = fields.One2many('account.move', 'reversed_entry_id')
 
     # =========================================================


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Performances improvement

Current behavior before PR:

An unlink on account_move can lose 600 ms

Desired behavior after PR is merged:

Restore 600 ms on unlink


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
