### PR TITLE
[FIX] digest: Multicompany digest

### DIFF
--- a/addons/digest/data/digest_tips_data.xml
+++ b/addons/digest/data/digest_tips_data.xml
@@ -8,6 +8,7 @@
             <field name="next_run_date" eval="DateTime.now().strftime('%Y-%m-%d')"/>
             <field name="kpi_res_users_connected">True</field>
             <field name="kpi_mail_message_total">True</field>
+            <field name="company_id" eval="None"/>
         </record>
 
         <record id="digest_tip_digest_0" model="digest.tip">

--- a/addons/digest/views/digest_views.xml
+++ b/addons/digest/views/digest_views.xml
@@ -40,7 +40,7 @@
                     <group>
                         <group>
                             <field name="periodicity" widget="radio" options="{'horizontal': true}"/>
-                            <field name="company_id" options="{'no_create': True}" invisible="1"/>
+                            <field name="company_id" options="{'no_create': True}"/>
                         </group>
                         <group>
                             <field name="next_run_date" groups="base.group_system"/>


### PR DESCRIPTION
Current behavior :
Digest was always sending digest corresponding to the user company

Steps to reproduce :
- Get in a multi company environement
- Send email digest in both company
- The emails are the same

opw-2713585

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
