### PR TITLE
[IMP] account: Add index on tax_cash_basis_move_id

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -248,6 +248,7 @@ class AccountMove(models.Model):
              "This is needed when cancelling the source: it will post the inverse journal entry to cancel that part too.")
     tax_cash_basis_move_id = fields.Many2one(
         comodel_name='account.move',
+        index=True,
         string="Origin Tax Cash Basis Entry",
         help="The journal entry from which this tax cash basis journal entry has been created.")
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Performances improvement

Current behavior before PR:

An unlink on account_move can lose 1000 ms

Desired behavior after PR is merged:

Restore 1000 ms on unlink


Tested with one DELETE FROM account_move WHERE id = <id>;

Before : 

![image](https://user-images.githubusercontent.com/19529533/151344756-6e462305-518f-40be-8f70-dfe8c4e98caa.png)


After:

![image](https://user-images.githubusercontent.com/19529533/151344779-195d304d-3627-4b27-a8d1-76ba4d738f04.png)





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
