### PR TITLE
[IMP] payment,web: add copy button widget

### DIFF
--- a/addons/payment/wizards/payment_link_wizard_views.xml
+++ b/addons/payment/wizards/payment_link_wizard_views.xml
@@ -24,7 +24,7 @@
                     </group>
                 </group>
                 <group>
-                    <field name="link" readonly="1" widget="CopyClipboardChar"/>
+                    <field name="link" readonly="1" widget="CopyClipboardButton"/>
                 </group>
                 <group attrs="{'invisible':[('partner_email', '!=', False)]}">
                     <p class="alert alert-warning font-weight-bold" role="alert">This partner has no email, which may cause issues with some payment acquirers. Setting an email for this partner is advised.</p>

--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -1622,7 +1622,7 @@ var FieldText = InputField.extend(TranslatableFieldMixin, {
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
-    
+
     /**
      * @private
      * @override
@@ -1930,6 +1930,11 @@ var CharCopyClipboard = FieldChar.extend(CopyClipboard, {
     description: _lt("Copy to Clipboard"),
     clipboardTemplate: 'CopyClipboardChar',
     className: 'o_field_copy o_text_overflow',
+});
+
+var ButtonCopyClipboard = AbstractField.extend(CopyClipboard, {
+    description: _lt("Copy to Clipboard"),
+    clipboardTemplate: 'CopyClipboardButton',
 });
 
 var URLCopyClipboard = FieldChar.extend(CopyClipboard, {
@@ -4193,6 +4198,7 @@ return {
     TextCopyClipboard: TextCopyClipboard,
     CharCopyClipboard: CharCopyClipboard,
     URLCopyClipboard: URLCopyClipboard,
+    ButtonCopyClipboard: ButtonCopyClipboard,
     JournalDashboardGraph: JournalDashboardGraph,
     AceEditor: AceEditor,
     FieldColor: FieldColor,

--- a/addons/web/static/src/legacy/js/fields/field_registry.js
+++ b/addons/web/static/src/legacy/js/fields/field_registry.js
@@ -44,6 +44,7 @@ registry
     .add('CopyClipboardText', basic_fields.TextCopyClipboard)
     .add('CopyClipboardChar', basic_fields.CharCopyClipboard)
     .add('CopyClipboardURL', basic_fields.URLCopyClipboard)
+    .add('CopyClipboardButton', basic_fields.ButtonCopyClipboard)
     .add('image', basic_fields.FieldBinaryImage)
     .add('image_url', basic_fields.CharImageUrl)
     .add('kanban.image', basic_fields.KanbanFieldBinaryImage)

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -1243,6 +1243,11 @@
         <span class="fa fa-clipboard"></span><span> Copy</span>
     </button>
 </t>
+<t t-name="CopyClipboardButton">
+    <button class="btn btn-primary o_clipboard_button">
+        <span class="fa fa-clipboard"></span><span> Copy</span>
+    </button>
+</t>
 <t t-name="FieldBinaryFile">
     <a t-if="widget.mode === 'readonly'" href="javascript:void(0)" class="o_form_uri"/>
 


### PR DESCRIPTION
Currently, all the copy widgets show what will be copied to the
clipboard.

In most cases, like auto-generated payment links, users don't need to
see what they will copy.

task-2683480



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
