### PR TITLE
[IMP] sale_timesheet: Add index on timesheet_invoice_id

### DIFF
--- a/addons/sale_timesheet/models/account.py
+++ b/addons/sale_timesheet/models/account.py
@@ -20,7 +20,7 @@ class AccountAnalyticLine(models.Model):
         ('non_billable', 'Non Billable Tasks'),
         ('non_billable_timesheet', 'Non Billable Timesheet'),
         ('non_billable_project', 'No task found')], string="Billable Type", compute='_compute_timesheet_invoice_type', compute_sudo=True, store=True, readonly=True)
-    timesheet_invoice_id = fields.Many2one('account.move', string="Invoice", readonly=True, copy=False, help="Invoice created from the timesheet")
+    timesheet_invoice_id = fields.Many2one('account.move', string="Invoice", readonly=True, copy=False, help="Invoice created from the timesheet", index=True)
     non_allow_billable = fields.Boolean("Non-Billable", help="Your timesheet will not be billed.")
     so_line = fields.Many2one(compute="_compute_so_line", store=True, readonly=False)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Performances improvement

Current behavior before PR:

An unlink on account_move can lose 250 ms

Desired behavior after PR is merged:

Restore 250 ms on unlink


Tested on one `DELETE FROM account_move WHERE id = <id>;`

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
