### PR TITLE
[FIX] product: prevent user to select a pricelist from another company

### DIFF
--- a/addons/product/models/res_partner.py
+++ b/addons/product/models/res_partner.py
@@ -12,6 +12,7 @@ class Partner(models.Model):
     property_product_pricelist = fields.Many2one(
         'product.pricelist', 'Pricelist', compute='_compute_product_pricelist',
         inverse="_inverse_product_pricelist", company_dependent=False,
+        domain=lambda self: [('company_id', 'in', (self.env.company.id, False))],
         help="This pricelist will be used, instead of the default one, for sales to the current partner")
 
     @api.depends('country_id')


### PR DESCRIPTION
Steps to reproduce the bug:
- Have company A and B
- Create a pricelist A with company A and pricelist B with company B
- Select company A as current company and B as allowed company
- Create contact A without linked company

Problem:
You can select pricelist B while the current company is A, this causes an access error if you save and only select company A in the selector.
It also causes an error when you open a new POS session.

This contact is not linked to a company, so it should be accessible from all companies.

Solution:
Add a domain to allow the user to only select the pricelist linked to the current company or a pricelist that are not linked to a company

opw-2745267


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
