### PR TITLE
[IMP] website_event[|track|exhibitor]: improve UI of event app

### DIFF
--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -34,7 +34,7 @@
                     <field name="kanban_state" widget="state_selection" class="ms-auto float-end"/>
                     <div class="oe_title">
                         <label for="name" string="Event Name"/>
-                        <h1><field class="text-break" name="name" placeholder="e.g. Conference for Architects"/></h1>
+                        <h1><field class="text-break" name="name" placeholder="e.g. &quot;Conference for Architects&quot;"/></h1>
                     </div>
                     <group>
                         <group>
@@ -147,7 +147,7 @@
         <field name="arch" type="xml">
             <form>
                 <group>
-                    <field name="name" placeholder="e.g. Conference for Architects"/>
+                    <field name="name" placeholder="e.g. &quot;Conference for Architects&quot;"/>
                     <label for="date_begin" string="Date"/>
                     <div class="o_row">
                         <field name="date_begin" widget="daterange" options="{'related_end_date': 'date_end'}"/>

--- a/addons/website_event/static/src/scss/event_templates_common.scss
+++ b/addons/website_event/static/src/scss/event_templates_common.scss
@@ -130,10 +130,7 @@
             // Main panel
             .o_wevent_online_page_main {
                 border: 1px solid $border-color;
-
-                @include media-breakpoint-up(md) {
-                    border-top-width: 0;
-                }
+                margin-top: map-get($spacers, 3);
 
                 .o_wevent_online_page_avatar {
                     min-width: 64px;
@@ -150,10 +147,7 @@
                 // Left panel: content display
                 .o_wevent_online_page_aside_content {
                     border: 1px solid $border-color;
-
-                    @include media-breakpoint-up(md) {
-                        border-top-width: 0;
-                    }
+                    margin-top: map-get($spacers, 3);
 
                     li:not(.nav-item) {
                         border-bottom: 1px solid $border-color;

--- a/addons/website_event/views/event_event_add.xml
+++ b/addons/website_event/views/event_event_add.xml
@@ -9,7 +9,7 @@
             <group>
                 <field name="website_url" invisible="1"/>
                 <field name="company_id" invisible="1"/>
-                <field name="name" placeholder="e.g. Conference for Architects" string="Event Name"/>
+                <field name="name" placeholder="e.g. &quot;Conference for Architects&quot;" string="Event Name"/>
                 <field name="address_id" context="{'show_address': 1}" options='{"always_reload": True}'/>
                 <label for="date_begin" string="Start &#8594; End"/>
                 <div class="o_row w-100">

--- a/addons/website_event_exhibitor/models/event_sponsor.py
+++ b/addons/website_event_exhibitor/models/event_sponsor.py
@@ -30,7 +30,7 @@ class Sponsor(models.Model):
 
     event_id = fields.Many2one('event.event', 'Event', required=True)
     sponsor_type_id = fields.Many2one(
-        'event.sponsor.type', 'Sponsoring Level',
+        'event.sponsor.type', 'Sponsorship Level',
         default=lambda self: self._default_sponsor_type_id(), required=True, auto_join=True)
     url = fields.Char('Sponsor Website', compute='_compute_url', readonly=False, store=True)
     sequence = fields.Integer('Sequence')
@@ -38,7 +38,7 @@ class Sponsor(models.Model):
     # description
     subtitle = fields.Char('Slogan')
     exhibitor_type = fields.Selection(
-        [('sponsor', 'Sponsor'), ('exhibitor', 'Exhibitor'), ('online', 'Online Exhibitor')],
+        [('sponsor', 'Footer Logo Only'), ('exhibitor', 'Exhibitor'), ('online', 'Online Exhibitor')],
         string="Sponsor Type", default="sponsor")
     website_description = fields.Html(
         'Description', compute='_compute_website_description',

--- a/addons/website_event_exhibitor/static/src/scss/event_exhibitor_templates.scss
+++ b/addons/website_event_exhibitor/static/src/scss/event_exhibitor_templates.scss
@@ -116,3 +116,12 @@
         }
     }
 }
+
+.editor_enable {
+    .o_wesponsor_index {
+        .o_wesponsor_exhibitor_main_empty_website_descr_warning {
+            /** Hide warning in edition mode */
+            display: none;
+        }
+    }
+}

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
@@ -99,13 +99,13 @@
         </div>
         <hr class="my-0"/>
         <div class="ms-3 clearfix">
-            <div class="float-start pt-3">
+            <div t-if="sponsor.image_128 or sponsor.partner_id.image_128" class="float-start pt-3 pe-3">
                 <span t-if="sponsor.image_128" t-field="sponsor.image_128" class="o_wevent_online_page_avatar"
                     t-options="{'widget': 'image', 'filename-field': 'partner_name'}"/>
                 <span t-elif="sponsor.partner_id.image_128" t-field="sponsor.partner_id.image_128" class="o_wevent_online_page_avatar"
                     t-options="{'widget': 'image', 'filename-field': 'partner_name'}"/>
             </div>
-            <div class="o_wevent_sponsor px-3 pt-3 d-flex flex-row justify-content-between position-relative">
+            <div class="o_wevent_sponsor pt-3 d-flex flex-row justify-content-between position-relative">
                 <div class="d-flex flex-column">
                     <div class="d-flex align-items-center">
                         <span t-field="sponsor.name" class="h4 mb-0"/>
@@ -145,7 +145,20 @@
                 </a>
             </div>
         </div>
-        <div t-field="sponsor.website_description" class="my-2 mx-3 oe_no_empty"/>
+        <!-- Website description -->
+        <div t-if="not is_html_empty(sponsor.website_description)" t-field="sponsor.website_description"
+             class="my-2 mx-3 oe_no_empty"/>
+        <t t-elif="env.user.has_group('event.group_event_user')">
+            <div t-field="sponsor.website_description" class="my-2 mx-3"
+                 placeholder="e.g. &quot;Openwood specializes in home decoration...&quot;"/>
+            <div class="alert alert-info mx-3 mt-3 o_wesponsor_exhibitor_main_empty_website_descr_warning">
+                The sponsor website description is missing.
+                <a t-attf-href="?{{ keep_query('*', enable_editor=1) }}">
+                    <i class="fa fa-fw fa-arrow-right"></i>
+                    Write one.
+                </a>
+            </div>
+        </t>
     </div>
 </template>
 

--- a/addons/website_event_track/static/src/scss/event_track_templates_online.scss
+++ b/addons/website_event_track/static/src/scss/event_track_templates_online.scss
@@ -87,3 +87,12 @@
         }
     }
 }
+
+.editor_enable {
+    .o_wesession_index {
+        .o_wesession_track_main_empty_descr_warning {
+            /** Hide warning in edition mode */
+            display: none;
+        }
+    }
+}

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -4,7 +4,20 @@
 <!-- Revamped agenda : Will need to replace agenda_online from website_event_track in master -->
 <template id="agenda_online" name="Track Online: Agenda">
     <t t-call="website_event.layout">
-        <div class="o_wevent_online o_weagenda_index">
+        <!-- No tracks -->
+        <div t-if="not tracks_by_days" class="container">
+            <div class="h2 mb-3">No track found.</div>
+            <div t-if="search_key" class="alert alert-info text-center">
+                <p class="m-0">We did not find any track matching your <strong t-out="search_key"/> search.</p>
+            </div>
+            <div t-else="" class="alert alert-info text-center" groups="event.group_event_user">
+                <a target="_blank" t-att-href="'/web?#action=website_event_track.action_event_track_from_event&amp;active_id=%s' % event.id">
+                    <p class="m-0">Schedule some tracks to get started</p>
+                </a>
+            </div>
+        </div>
+
+        <div t-else="" class="o_wevent_online o_weagenda_index">
             <!-- Options -->
             <t t-set="option_track_wishlist" t-value="not event.is_done and is_view_active('website_event_track.agenda_topbar_wishlist')"/>
             <!-- Topbar -->
@@ -58,20 +71,7 @@
 
 <!-- Agenda Main Display -->
 <template id="agenda_main" name="Tracks: Main Display">
-    <!-- No tracks -->
-    <div class="col-12" t-if="not tracks_by_days">
-        <div class="h2 mb-3">No track found.</div>
-        <div t-if="search_key" class="alert alert-info text-center">
-            <p class="m-0">We did not find any track matching your <strong t-out="search_key"/> search.</p>
-        </div>
-        <div t-else="" class="alert alert-info text-center" groups="event.group_event_user">
-            <a target="_blank" t-att-href="'/web?#action=website_event_track.action_event_track_from_event&amp;active_id=%s' % event.id">
-                <p class="m-0">Schedule some tracks to get started</p>
-            </a>
-        </div>
-    </div>
-
-    <section t-else="" class="col-12" t-foreach="days" t-as="day">
+    <section t-foreach="days" t-as="day" class="col-12">
         <!-- DAY HEADER -->
         <div class="o_we_track_day_header mt-3 w-100 d-flex justify-content-between align-items-center">
             <div class="d-flex">

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -174,13 +174,13 @@
                     <div class="d-flex flex-grow-1" t-if="tracks_date">
                         <span class="h1 m-0 fw-bold" t-out="tracks_date"
                             t-options="{'widget': 'date', 'format': 'EEEE dd'}"/>
-                        <div class="d-flex flex-column ms-2">
+                        <div class="d-flex ms-3 me-2 flex-column">
                             <span class="fw-bold" t-out="tracks_date"
                                 t-options="{'widget': 'date', 'format': 'MMMM'}"/>
                             <span class="fw-bold" t-out="tracks_date"
                                 t-options="{'widget': 'date', 'format': 'YYYY'}"/>
                         </div>
-                        <div class="flex-column align-self-center ms-2">
+                        <div class="flex-column align-self-center ms-2 d-none d-sm-block">
                             <span class="small fw-light">(<t t-out="event.date_tz"/>)</span>
                         </div>
                     </div>

--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -28,6 +28,24 @@
 <!-- CONTENT: MAIN TEMPLATES -->
 <!-- ============================================================ -->
 
+<template id="event_track_content_partner_info">
+    <div class="mb-1 align-items-baseline text-break" t-if="track.partner_function">
+        <i class="fa fa-briefcase me-2"/><span t-out="track.partner_function"/>
+        <t t-if="track.partner_company_name">
+            <span> at </span><span t-out="track.partner_company_name"/>
+        </t>
+    </div>
+    <div class="mb-1 align-items-baseline text-break" t-if="track.partner_id.website">
+        <i class="fa fa-home me-2"/><a t-att-href="track.partner_id.website"><span t-field="track.partner_id.website"/></a>
+    </div>
+    <div class="mb-1 align-items-baseline text-break" t-if="track.partner_email">
+        <i class="fa fa-envelope me-2"/><a t-att-mailto="track.partner_email"><span t-field="track.partner_email"/></a>
+    </div>
+    <div class="mb-1 align-items-baseline text-break" t-if="track.partner_phone">
+        <i class="fa fa-phone me-2"/><span t-field="track.partner_phone"/>
+    </div>
+</template>
+
 <template id="event_track_content" name="Track: Main Description">
     <div name="o_wesession_track_main"
          t-att-class="'col-12 o_wevent_online_page_main o_wesession_track_main bg-white p-0 %s' % ('col-md-9 col-lg-10' if option_widescreen else 'col-md-8 col-lg-9')">
@@ -99,37 +117,46 @@
                         t-options='{"widget": "duration", "unit": "hour", "round": "minute"}'/>)
                 </t>
             </div>
-            
+
             <hr class="mt-2 mb-0"/>
 
             <!-- ABOUT AUTHOR -->
-            <div class="mx-3">
-                <div class="mt-2 d-flex">
-                    <span t-if="track.image" t-field="track.image" class="o_wevent_online_page_avatar"
-                        t-options="{'widget': 'image', 'class': 'rounded-circle', 'max_width': '96'}"/>
-                    <div class="ps-2 pe-0 pe-md-2 d-flex flex-column">
-                        <span t-field="track.partner_name" class="fw-bold mb-2"/>
-                        <span class="mb-1 d-flex align-items-baseline text-break" t-if="track.partner_function">
-                            <i class="fa fa-briefcase me-2"/><span t-out="track.partner_function"/>
-                            <t t-if="track.partner_company_name">
-                                <span>&amp;nbsp;at&amp;nbsp;</span><span t-out="track.partner_company_name"/>
-                            </t>
-                        </span>
-                        <span class="mb-1 d-flex align-items-baseline text-break" t-if="track.partner_id.website">
-                            <i class="fa fa-home me-2"/><a t-att-href="track.partner_id.website"><span t-field="track.partner_id.website"/></a>
-                        </span>
-                        <span class="mb-1 d-flex align-items-baseline text-break" t-if="track.partner_email">
-                            <i class="fa fa-envelope me-2"/><a t-att-mailto="track.partner_email"><span t-field="track.partner_email"/></a>
-                        </span>
-                        <span class="mb-1 d-flex align-items-baseline text-break" t-if="track.partner_phone">
-                            <i class="fa fa-phone me-2"/><span t-field="track.partner_phone"/>
-                        </span>
+            <t t-set="track_fields" t-value="['image', 'partner_name', 'partner_function', 'partner_email', 'partner_phone']"/>
+            <!-- Avoid rendering a section for track information if we don't have anything to display -->
+            <t t-if="any(track[track_field] for track_field in track_fields) or track.partner_id.website or not is_html_empty(track.partner_biography)">
+                <div class="mx-3">
+                    <div class="mt-2 mb-2 d-flex">
+                        <div t-if="track.image" t-field="track.image"
+                             t-options="{'widget': 'image', 'class': 'rounded-circle me-2', 'max_width': '96'}"/>
+                        <div class="ps-2 pe-0 pe-md-2 d-flex flex-grow-1 flex-column">
+                            <div t-if="track.partner_name" t-field="track.partner_name" class="fw-bold mb-2"/>
+                            <div class="d-none d-lg-block">
+                                <t t-call="website_event_track.event_track_content_partner_info"/>
+                            </div>
+                        </div>
                     </div>
+                    <div class="d-block d-lg-none mt-3 mb-3">
+                        <t t-call="website_event_track.event_track_content_partner_info"/>
+                    </div>
+                    <div t-if="not is_html_empty(track.partner_biography)" t-field="track.partner_biography"
+                         class="oe_no_empty"/>
+                    <hr t-if="not is_html_empty(track.description)" class="mt-2 pb-1 mb-1"/>
                 </div>
-                <div t-field="track.partner_biography" class="oe_no_empty"/>
-                <hr t-if="not is_html_empty(track.description)" class="mt-2 pb-1 mb-1"/>
-            </div>
-            <div t-field="track.description" class="my-2 mx-3 oe_no_empty"/>
+            </t>
+
+            <!-- Description -->
+            <div t-if="not is_html_empty(track.description)" t-field="track.description" class="my-2 mx-3 oe_no_empty"/>
+            <t t-elif="env.user.has_group('event.group_event_user')">
+                <div t-field="track.description" class="my-2 mx-3"
+                     placeholder="e.g. &quot;This talk will be about...&quot;"/>
+                <div class="alert alert-info mx-3 mt-3 o_wesession_track_main_empty_descr_warning">
+                    This track does not have a description.
+                    <a t-attf-href="?{{ keep_query('*', enable_editor=1) }}">
+                        <i class="fa fa-fw fa-arrow-right"></i>
+                        Write one.
+                    </a>
+                </div>
+            </t>
         </div>
     </div>
 </template>


### PR DESCRIPTION
Improve UI of event app.

Detailed changes:

1) change the wording of the selection item "sponsor" of
event_sponsor.exhibitor_type from "sponsor" to "Footer Logo Only"
2) add a placeholder for the name in the form when creating an event page
3) in the track page and exhibitor page, if the description is empty:
- for external user: hide the empty description zone for external user
- for internal user: display an alert (info) inviting the user to complete it
with a link to the backend
3 bis) in the track page and exhibitor page, the page and the menu aside
are glued to the top. Add some space there.
4) display unpublished tag on the side menu for unpublished tracks

Some other changes:
- when creating an event in the front, add a red border on event name input
when submitting an empty field
- When some content are empty, there were some awkward horizontal lines
separating nothing, we have decided to remove them
- Fix track layout and improve mobile layout
- Fix event track starts warning display condition

Technical remarks:

1) the change is done on the model and then affect view globally
(ex.: also "card view")

Task-2692907
