### PR TITLE
[FIX] hr_attendance : stop polling when kiosk_mode

### DIFF
--- a/addons/hr_attendance/static/src/js/kiosk_mode.js
+++ b/addons/hr_attendance/static/src/js/kiosk_mode.js
@@ -75,7 +75,6 @@ var KioskMode = AbstractAction.extend({
         core.bus.off('barcode_scanned', this, this._onBarcodeScanned);
         clearInterval(this.clock_start);
         clearInterval(this._interval);
-        this.call('bus_service', 'startPolling');
         this._super.apply(this, arguments);
     },
 


### PR DESCRIPTION
Steps :
- Attendances > Kiosk Mode
- Log in or out several times

Issue :
- Interface slows down

Cause :
- When a kiosk is destroyed, poll is started
- Yet each time a kiosk is started, the old kiosk is destroyed, which starts a new poll.

Fix :
- Given that the kiosk mode can't be escaped from the interface,
	it is not necessary to restart polling when destroying.

opw-2735324

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
