### PR TITLE
[FIX] stock: disallow unnamed packages

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -963,7 +963,7 @@ class QuantPackage(models.Model):
     _order = 'name'
 
     name = fields.Char(
-        'Package Reference', copy=False, index=True,
+        'Package Reference', copy=False, index=True, required=True,
         default=lambda self: self.env['ir.sequence'].next_by_code('stock.quant.package') or _('Unknown Pack'))
     quant_ids = fields.One2many('stock.quant', 'package_id', 'Bulk Content', readonly=True,
         domain=['|', ('quantity', '!=', 0), ('reserved_quantity', '!=', 0)])


### PR DESCRIPTION
Field `QuantPackage.name` was allowed to be left empty,
which lead to confusing situations for customers
(cfr. ref for more details).

task: 2654703-5
ref: https://www.odoo.com/web#action=333&active_id=809&cids=1&id=2671818&menu_id=4720&model=project.task&view_type=form
