### PR TITLE
[ADD] web, mail: define `o_avatar_inline` css class

### DIFF
--- a/addons/mail/static/src/components/activity/activity.scss
+++ b/addons/mail/static/src/components/activity/activity.scss
@@ -8,13 +8,6 @@
     padding: map-get($spacers, 2);
 }
 
-.o_Activity_detailsUserAvatar {
-    margin-inline-end: map-get($spacers, 2);
-    object-fit: cover;
-    height: 18px;
-    width: 18px;
-}
-
 .o_Activity_dueDateText, .o_Activity_summary {
     margin-inline-end: map-get($spacers, 2);
 }

--- a/addons/mail/static/src/components/activity/activity.xml
+++ b/addons/mail/static/src/components/activity/activity.xml
@@ -65,7 +65,7 @@
                                     <div class="d-md-table-cell font-weight-bold text-md-right m-0 py-md-1 px-md-4">Created</div>
                                     <div class="o_Activity_detailsCreation d-md-table-cell py-md-1 pr-4">
                                         <t t-esc="activityView.formattedCreateDatetime"/>, by
-                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsCreatorAvatar" t-attf-src="/web/image/res.users/{{ activityView.activity.creator.id }}/avatar_128" t-att-title="activityView.activity.creator.nameOrDisplayName" t-att-alt="activityView.activity.creator.nameOrDisplayName"/>
+                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsCreatorAvatar o_avatar_inline" t-attf-src="/web/image/res.users/{{ activityView.activity.creator.id }}/avatar_128" t-att-title="activityView.activity.creator.nameOrDisplayName" t-att-alt="activityView.activity.creator.nameOrDisplayName"/>
                                         <b class="o_Activity_detailsCreator">
                                             <t t-esc="activityView.activity.creator.nameOrDisplayName"/>
                                         </b>
@@ -74,7 +74,7 @@
                                 <div t-if="activityView.activity.assignee" class="d-md-table-row mb-3">
                                     <div class="d-md-table-cell font-weight-bold text-md-right m-0 py-md-1 px-md-4">Assigned to</div>
                                     <div class="o_Activity_detailsAssignation d-md-table-cell py-md-1 pr-4">
-                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsAssignationUserAvatar" t-attf-src="/web/image/res.users/{{ activityView.activity.assignee.id }}/avatar_128" t-att-title="activityView.activity.assignee.nameOrDisplayName" t-att-alt="activityView.activity.assignee.nameOrDisplayName"/>
+                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsAssignationUserAvatar o_avatar_inline" t-attf-src="/web/image/res.users/{{ activityView.activity.assignee.id }}/avatar_128" t-att-title="activityView.activity.assignee.nameOrDisplayName" t-att-alt="activityView.activity.assignee.nameOrDisplayName"/>
                                         <b t-esc="activityView.activity.assignee.nameOrDisplayName"/>
                                     </div>
                                 </div>

--- a/addons/web/static/src/legacy/scss/primary_variables.scss
+++ b/addons/web/static/src/legacy/scss/primary_variables.scss
@@ -114,6 +114,7 @@ $o-modal-md: 650px !default;
 $o-sheet-cancel-tpadding: 0px !default;
 
 $o-avatar-size: 90px !default;
+$o-avatar-inline-size: 1.4em !default;
 
 $o-statusbar-height: 33px !default;
 

--- a/addons/web/static/src/legacy/scss/ui.scss
+++ b/addons/web/static/src/legacy/scss/ui.scss
@@ -95,6 +95,18 @@ span.o_force_ltr {
     direction: ltr;
 }
 
+// == Inline avatar image
+//------------------------------------------------------------------------------
+// Commonly used for avatar images rendered within text.
+// Its size is relative to the current font-size.
+
+.o_avatar_inline {
+    width: $o-avatar-inline-size;
+    height: $o-avatar-inline-size;
+    object-fit: cover;
+    vertical-align: text-bottom;
+}
+
 // To fill the available space while keeping aspect ratio (crop).
 // Assuming the important part of the image is its center.
 .o_object_fit_cover {


### PR DESCRIPTION
New css class to handle avatars images when rendered within text.
Part of the overall v16 SCSS optimisation/restyle (task-2704984).

task-2731819

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
