### PR TITLE
[FIX] Remove the context to disable prediction when importing invoices

### DIFF
--- a/addons/account_edi_facturx/models/account_edi_format.py
+++ b/addons/account_edi_facturx/models/account_edi_format.py
@@ -210,8 +210,7 @@ class AccountEdiFormat(models.Model):
         invoice.move_type = default_move_type
 
         # self could be a single record (editing) or be empty (new).
-        with Form(invoice.with_context(default_move_type=default_move_type,
-                                       account_predictive_bills_disable_prediction=True)) as invoice_form:
+        with Form(invoice.with_context(default_move_type=default_move_type)) as invoice_form:
             self_ctx = self.with_company(invoice.company_id)
 
             # Partner (first step to avoid warning 'Warning! You must first select a partner.').

--- a/addons/account_edi_ubl/models/account_edi_format.py
+++ b/addons/account_edi_ubl/models/account_edi_format.py
@@ -57,7 +57,7 @@ class AccountEdiFormat(models.Model):
         def _find_value(xpath, element=tree):
             return self._find_value(xpath, element, namespaces)
 
-        with Form(invoice.with_context(account_predictive_bills_disable_prediction=True)) as invoice_form:
+        with Form(invoice) as invoice_form:
             self_ctx = self.with_company(invoice.company_id.id)
 
             # Reference

--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -276,8 +276,7 @@ class AccountEdiFormat(models.Model):
 
             # Setup the context for the Invoice Form
             invoice_ctx = invoice.with_company(company) \
-                                 .with_context(default_move_type=move_type,
-                                               account_predictive_bills_disable_prediction=True)
+                                 .with_context(default_move_type=move_type)
 
             # move could be a single record (editing) or be empty (new).
             with Form(invoice_ctx) as invoice_form:


### PR DESCRIPTION
Allow the bill prediction when data like facturx is imported.
This revert #68311 stating prediction might cause traceback when no account_id is found.
Now, this error seems to not occur anymore.
When importing data like facturx and no account_id is predicted, the default account set on the
vendor journal will be set.

opw-2662158

