### PR TITLE
[ADD] mail, im_livechat: define `o_avatar_thread` css class

### DIFF
--- a/addons/im_livechat/static/src/legacy/public_livechat.scss
+++ b/addons/im_livechat/static/src/legacy/public_livechat.scss
@@ -304,12 +304,6 @@ $o-mail-thread-window-zindex: $zindex-modal + 1 !default;
                 margin-top: 4px;
                 font-size: x-small;
             }
-
-            .o_thread_message_avatar {
-                width: $o-mail-thread-avatar-size;
-                height: $o-mail-thread-avatar-size;
-                object-fit: cover;
-            }
             .o_thread_message_side_date {
                 display: none;
                 margin-left: -5px;

--- a/addons/im_livechat/static/src/legacy/public_livechat.xml
+++ b/addons/im_livechat/static/src/legacy/public_livechat.xml
@@ -335,7 +335,7 @@
                             t-att-src="message.getAvatarSource()"
                             data-oe-model="res.partner"
                             t-att-data-oe-id="message.shouldRedirectToAuthor() ? message.getAuthorID() : ''"
-                            t-attf-class="o_thread_message_avatar rounded-circle #{message.shouldRedirectToAuthor() ? 'o_mail_redirect' : ''}"/>
+                            t-attf-class="o_thread_message_avatar o_avatar_thread rounded-circle #{message.shouldRedirectToAuthor() ? 'o_mail_redirect' : ''}"/>
                         <t t-call="im_livechat.legacy.mail.UserStatus">
                             <t t-set="status" t-value="message.getAuthorImStatus()"/>
                             <t t-set="partnerID" t-value="message.getAuthorID()"/>
@@ -346,7 +346,7 @@
                     <img t-if="displayAuthorMessages[message.getID()]"
                         alt=""
                         t-att-src="message.getAvatarSource()"
-                        class="o_thread_message_avatar rounded-circle"/>
+                        class="o_thread_message_avatar o_avatar_thread rounded-circle"/>
                 </t>
                 <span t-if="!displayAuthorMessages[message.getID()]" t-att-title="message.getDate().format(dateFormat)" class="o_thread_message_side_date">
                     <t t-esc="message.getDate().format('hh:mm')"/>

--- a/addons/mail/static/src/scss/shared_classes.scss
+++ b/addons/mail/static/src/scss/shared_classes.scss
@@ -1,0 +1,11 @@
+// Regrup CSS classes shared across several components.
+// Thes rules can be used by modules with mail dependecy.
+
+
+// == Thread avatar image
+//------------------------------------------------------------------------------
+.o_avatar_thread {
+    width: $o-mail-thread-avatar-size;
+    height: $o-mail-thread-avatar-size;
+    object-fit: cover;
+}

--- a/addons/mail/static/src/scss/thread.scss
+++ b/addons/mail/static/src/scss/thread.scss
@@ -53,12 +53,6 @@
                 margin-top: 4px;
                 font-size: x-small;
             }
-
-            .o_thread_message_avatar {
-                width: $o-mail-thread-avatar-size;
-                height: $o-mail-thread-avatar-size;
-                object-fit: cover;
-            }
         }
         .o_thread_icon {
             cursor: pointer;


### PR DESCRIPTION
Adds a new CSS class to handle avatars images when used in threads.
Part of the overall v16 SCSS optimization/restyle (task-2704984).

task-2731819





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
