### PR TITLE
[FIX] account: fix failing on hiding an undefined button.

### DIFF
--- a/addons/account/static/src/js/bank_statement.js
+++ b/addons/account/static/src/js/bank_statement.js
@@ -7,7 +7,7 @@ odoo.define('account.bank_statement', function(require) {
     var includeDict = {
         renderButtons: function () {
             this._super.apply(this, arguments);
-            if (this.modelName === "account.bank.statement") {
+            if (this.hasButtons && this.modelName === "account.bank.statement") {
                 var data = this.model.get(this.handle);
                 if (data.context.journal_type !== 'cash') {
                     this.$buttons.find('button.o_button_import').hide();


### PR DESCRIPTION
Steps to reproduce:

1 - Go to accounting then browse to operations of some bank (bank.statement.line)
2 - Edit / Create a statement line
3 - try to choose a different statement by cliking search more on the selection input (make sure there are multiple bank statments to show the 'search more' option.

The tarceback is self expalanatory -> trying to call find on an undefined var.

in version 14 this was fixed as there is always a value in the ```this.$buttons```

opw-2729453


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
