### PR TITLE
[FIX] {sale,purchase}_{stock,mrp}: compute received/delivered qty

### DIFF
--- a/addons/purchase_mrp/models/purchase_mrp.py
+++ b/addons/purchase_mrp/models/purchase_mrp.py
@@ -22,10 +22,7 @@ class PurchaseOrderLine(models.Model):
                 if kit_bom:
                     moves = line.move_ids.filtered(lambda m: m.state == 'done' and not m.scrapped)
                     order_qty = line.product_uom._compute_quantity(line.product_uom_qty, kit_bom.product_uom_id)
-                    filters = {
-                        'incoming_moves': lambda m: m.location_id.usage == 'supplier' and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
-                        'outgoing_moves': lambda m: m.location_id.usage != 'supplier' and m.to_refund
-                    }
+                    filters = self.env['stock.move']._in_and_out_filters_for_purchase()
                     line.qty_received = moves._compute_kit_quantities(line.product_id, order_qty, kit_bom, filters)
                     kit_lines += line
         super(PurchaseOrderLine, self - kit_lines)._compute_qty_received()

--- a/addons/purchase_mrp/models/stock_move.py
+++ b/addons/purchase_mrp/models/stock_move.py
@@ -12,10 +12,7 @@ class StockMove(models.Model):
         kit_bom = self.env['mrp.bom']._bom_find(product=related_aml.product_id, company_id=related_aml.company_id.id, bom_type='phantom')
         if kit_bom:
             order_qty = related_aml.product_id.uom_id._compute_quantity(related_aml.quantity, kit_bom.product_uom_id)
-            filters = {
-                'incoming_moves': lambda m: m.location_id.usage == 'supplier' and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
-                'outgoing_moves': lambda m: m.location_id.usage != 'supplier' and m.to_refund
-            }
+            filters = self.env['stock.move']._in_and_out_filters_for_purchase()
             valuation_total_qty = self._compute_kit_quantities(related_aml.product_id, order_qty, kit_bom, filters)
             valuation_total_qty = kit_bom.product_uom_id._compute_quantity(valuation_total_qty, related_aml.product_id.uom_id)
         return valuation_price_unit_total, valuation_total_qty

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -34,6 +34,18 @@ class StockMove(models.Model):
         keys_sorted += [move.purchase_line_id.id, move.created_purchase_line_id.id]
         return keys_sorted
 
+    @api.model
+    def _in_and_out_filters_for_purchase(self, reverse=False):
+        in_key = 'incoming_moves'
+        out_key = 'outgoing_moves'
+        if reverse:
+            in_key, out_key = out_key, in_key
+        return {
+            in_key: lambda m: m.location_id.usage in ('supplier', 'transit')
+                              and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
+            out_key: lambda m: m.location_id.usage not in ('supplier', 'transit') and m.to_refund
+        }
+
     def _get_price_unit(self):
         """ Returns the unit price for the move"""
         self.ensure_one()

--- a/addons/sale_mrp/models/sale_mrp.py
+++ b/addons/sale_mrp/models/sale_mrp.py
@@ -48,10 +48,7 @@ class SaleOrderLine(models.Model):
                             order_line.qty_delivered = 0.0
                         continue
                     moves = order_line.move_ids.filtered(lambda m: m.state == 'done' and not m.scrapped)
-                    filters = {
-                        'incoming_moves': lambda m: m.location_dest_id.usage == 'customer' and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
-                        'outgoing_moves': lambda m: m.location_dest_id.usage != 'customer' and m.to_refund
-                    }
+                    filters = self.env['stock.move']._in_and_out_filters_for_sale(reverse=True)
                     order_qty = order_line.product_uom._compute_quantity(order_line.product_uom_qty, relevant_bom.product_uom_id)
                     qty_delivered = moves._compute_kit_quantities(order_line.product_id, order_qty, relevant_bom, filters)
                     order_line.qty_delivered = relevant_bom.product_uom_id._compute_quantity(qty_delivered, order_line.product_uom)

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -453,13 +453,11 @@ class SaleOrderLine(models.Model):
     def _get_outgoing_incoming_moves(self):
         outgoing_moves = self.env['stock.move']
         incoming_moves = self.env['stock.move']
+        filters = self.env['stock.move']._in_and_out_filters_for_sale()
 
-        for move in self.move_ids.filtered(lambda r: r.state != 'cancel' and not r.scrapped and self.product_id == r.product_id):
-            if move.location_dest_id.usage == "customer":
-                if not move.origin_returned_move_id or (move.origin_returned_move_id and move.to_refund):
-                    outgoing_moves |= move
-            elif move.location_dest_id.usage != "customer" and move.to_refund:
-                incoming_moves |= move
+        moves = self.move_ids.filtered(lambda r: r.state != 'cancel' and not r.scrapped and self.product_id == r.product_id)
+        outgoing_moves = moves.filtered(filters['outgoing_moves'])
+        incoming_moves = moves.filtered(filters['incoming_moves'])
 
         return outgoing_moves, incoming_moves
 

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -27,6 +27,18 @@ class StockMove(models.Model):
         keys_sorted.append(move.sale_line_id.id)
         return keys_sorted
 
+    @api.model
+    def _in_and_out_filters_for_sale(self, reverse=False):
+        in_key = 'incoming_moves'
+        out_key = 'outgoing_moves'
+        if reverse:
+            in_key, out_key = out_key, in_key
+        return {
+            in_key: lambda m: m.location_dest_id.usage not in ("customer", "transit") and m.to_refund,
+            out_key: lambda m: m.location_dest_id.usage in ("customer", "transit")
+                               and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
+        }
+
     def _get_related_invoices(self):
         """ Overridden from stock_account to return the customer invoices
         related to this stock move.


### PR DESCRIPTION
In a multi-company environment, when selling a product to another
company and using a transit location as destination, the computation of
the delivered quantity is incorrect

To reproduce the issue:
(Need sale_management. Use demo data. Enable debug mode)
1. Use "My Company (San Fransisco)"
2. In Settings, enable "Multi-Step Routes"
3. Inventory > Configuration > Routes, edit "YourCompany: Deliver in 1
step (ship)":
    - Add a rule: "Pull From WH/Stock to Virtual Locations/Inter Company
Transit"
4. Customers > Edit "My Company (Chicago)":
    - Customer Location: Virtual Locations/Inter Company Transit
    - Vendor Location: Virtual Locations/Inter Company Transit
5. Create a SO:
    - Customer: "My Company (Chicago)"
    - Add one product
6. Confirm the SO and process the delivery
7. Go back to the SO

Error: The delivered quantity is still 0

The SM filters used in `_compute_qty_delivered` do not consider the case
of a transit location

A similar issue can be reproduced when selling/buying a kit

OPW-2729885