### PR TITLE
[REV] website: revert commit ability to restrict groups on website menu

### DIFF
--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -43,8 +43,6 @@ class Menu(models.Model):
     child_id = fields.One2many('website.menu', 'parent_id', string='Child Menus')
     parent_path = fields.Char(index=True, unaccent=False)
     is_visible = fields.Boolean(compute='_compute_visible', string='Is Visible')
-    group_ids = fields.Many2many('res.groups', string='Visible Groups',
-                                 help="User need to be at least in one of these groups to see the menu")
     is_mega_menu = fields.Boolean(compute=_compute_field_is_mega_menu, inverse=_set_field_is_mega_menu)
     mega_menu_content = fields.Html(translate=html_translate, sanitize=False, prefetch=True)
     mega_menu_classes = fields.Char()
@@ -101,7 +99,7 @@ class Menu(models.Model):
 
     def write(self, values):
         res = super().write(values)
-        if 'website_id' in values or 'group_ids' in values or 'sequence' in values:
+        if 'website_id' in values or 'sequence' in values:
             self.clear_caches()
         return res
 

--- a/addons/website/security/website_security.xml
+++ b/addons/website/security/website_security.xml
@@ -29,12 +29,6 @@
 
     <data noupdate="1">
 
-    <record id="website_menu" model="ir.rule">
-        <field name="name">Website menu: group_ids</field>
-        <field name="model_id" ref="model_website_menu"/>
-        <field name="domain_force">['|', ('group_ids', '=', False), ('group_ids', 'in', user.groups_id.ids)]</field>
-    </record>
-
     <record id="website_designer_edit_qweb" model="ir.rule">
         <field name="name">website_designer: Manage Website and qWeb view</field>
         <field name="model_id" ref="base.model_ir_ui_view"/>

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -193,7 +193,6 @@
                             </group>
                             <group>
                                 <field name="parent_id" context="{'display_website': True}"/>
-                                <field name="group_ids"/>
                             </group>
                         </group>
                         <label for="child_id" string="Child Menus"/>
@@ -222,7 +221,6 @@
                     <field name="is_mega_menu"/>
                     <field name="new_window"/>
                     <field name="parent_id" context="{'display_website': True}"/>
-                    <field name="group_ids" widget="many2many_tags"/>
                 </tree>
             </field>
         </record>

--- a/addons/website_forum/controllers/main.py
+++ b/addons/website_forum/controllers/main.py
@@ -77,13 +77,11 @@ class WebsiteForum(WebsiteProfile):
             forum['authorized_group_id'] = forum_privacy_group
         forum_id = request.env['forum.forum'].create(forum)
         if add_menu:
-            group = [int(forum_privacy_group)] if forum_privacy == 'private' else [request.env.ref('base.group_portal').id, request.env.ref('base.group_user').id]
             menu_id = request.env['website.menu'].create({
                 'name': forum_name,
                 'url': "/forum/%s" % slug(forum_id),
                 'parent_id': request.website.menu_id.id,
                 'website_id': request.website.id,
-                'group_ids': [(6, 0, group)]
             })
             forum_id.menu_id = menu_id
         return "/forum/%s" % slug(forum_id)

--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -206,12 +206,8 @@ class Forum(models.Model):
             elif vals['privacy'] == 'public':
                 # The forum is public, the menu must be also public
                 vals['authorized_group_id'] = False
-                self.menu_id.write({'group_ids': [(5, 0, 0)]})
             elif vals['privacy'] == 'connected':
                 vals['authorized_group_id'] = False
-                self.menu_id.write({'group_ids': [(6, 0, [self.env.ref('base.group_portal').id, self.env.ref('base.group_user').id])]})
-        if 'authorized_group_id' in vals and vals['authorized_group_id']:
-            self.menu_id.write({'group_ids': [(6, 0, [vals['authorized_group_id']])]})
 
         res = super(Forum, self).write(vals)
         if 'active' in vals:


### PR DESCRIPTION
[REV] website: revert commit ability to restrict groups on website menu 

revert odoo@b5091c7

fp asks to remove the groups on the menus to simplify the
model and allow the menu to be cached in the future. The user can change
the templates, use the big menu, add custom t-if, groups...

task-2737973