### PR TITLE
[FIX] website_sale: searchbar also search product code

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -362,10 +362,11 @@ class ProductTemplate(models.Model):
                     ids = [value[1]]
             if attrib:
                 domains.append([('attribute_line_ids.value_ids', 'in', ids)])
-        search_fields = ['name']
+        search_fields = ['name', 'product_variant_ids.default_code']
         fetch_fields = ['id', 'name', 'website_url']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
+            'product_variant_ids.default_code': {'name': 'product_variant_ids.default_code', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
         }
         if with_image:


### PR DESCRIPTION
Step to reproduce:
- Search code of product in website_sale search bar

Current Behaviour:
- No result

Behaviour after PR:
- Search also try to match `variant_ids.default_code`, similar behaviour to V14 and before

opw-2737648

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
