### PR TITLE
[FIX] pos_sale: decrase sale.report ID conflict


### DIFF
--- a/addons/pos_sale/report/sale_report.py
+++ b/addons/pos_sale/report/sale_report.py
@@ -23,7 +23,7 @@ class SaleReport(models.Model):
         res = super(SaleReport, self)._query(with_clause, fields, groupby, from_clause)
 
         select_ = '''
-            MIN(l.id) AS id,
+            -MIN(l.id) AS id,
             l.product_id AS product_id,
             t.uom_id AS product_uom,
             sum(l.qty) AS product_uom_qty,


### PR DESCRIPTION

issues:

- search sale.report with `('order_id', '!=', False)` in list view =>
  you might get lines without sale order, with the wrong product, ...

- group sale.report by product on list view => you might get lines with
  a different product than the group

cause:

the sale.report IDs are an union of sale_order_line.id and
pos_order_line.id => so there can be 2 lines of sale.report with same
IDs but pointing two completely different record.

rejected solution:

using row_number() over() for ID after the UNION ALL => rejected since
there was a `row_number` on sale.report at one point that was removed
because of performance issue (03bd6f5243e189cd05b3fc7ad774cc07ea733e14).

solution:

using negative IDs for pos_order_line lines

drawback:

in 14.0, we already use negative IDs for sale_order without lines =>
the probability of conflict is lower for this case and sale.order.line
not being in conflict is better.

opw-2586062
opw-2694529
