### PR TITLE
[FIX] website: always load editor after redirect

### DIFF
--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -247,7 +247,7 @@
                 freeze and could be missing on first installed db.
             -->
             <field name="name">Website Edit Mode</field>
-            <field name="url">/?enable_editor=1</field>
+            <field name="url">/website/lang/default?r=%2F%3Fenable_editor%3D1</field>
             <field name="target">self</field>
         </record>
         <record id="base.open_menu" model="ir.actions.todo">

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -936,6 +936,9 @@ class Website(models.Model):
     def button_go_website(self, path='/', mode_edit=False):
         self._force()
         if mode_edit:
+            # If the user gets on a translated page (e.g /fr) the editor will
+            # never start. Forcing the default language fixes this issue.
+            path = url_for(path, self.default_lang_id.url_code)
             path += '?enable_editor=1'
         return {
             'type': 'ir.actions.act_url',

--- a/addons/website/static/tests/tours/automatic_editor.js
+++ b/addons/website/static/tests/tours/automatic_editor.js
@@ -1,0 +1,89 @@
+odoo.define('website.tour.automatic_editor', function (require) {
+'use strict';
+
+const tour = require('web_tour.tour');
+
+tour.register('automatic_editor_on_new_website', {
+    test: true,
+    url: '/',
+},
+[
+    {
+        content: "Select the language dropdown",
+        trigger: '.js_language_selector .dropdown-toggle'
+    },
+    {
+        content: "click on Add a language",
+        trigger: 'a.o_add_language',
+    },
+    {
+        content: "Select dropdown",
+        trigger: 'select[name=lang]',
+        run: () => {
+            $('select[name="lang"]').val('"pa_GB"').change();
+        }
+    },
+    {
+        content: "load parseltongue",
+        extra_trigger: '.modal select[name="lang"]:propValueContains(pa_GB)',
+        trigger: '.modal-footer button:first',
+    },
+    {
+        content: "Select the language dropdown",
+        trigger: '.js_language_selector .dropdown-toggle',
+    },
+    {
+        content: "Select parseltongue",
+        trigger: 'a.js_change_lang[data-url_code=pa_GB]',
+    },
+    {
+        content: "Check that we're on parseltongue and then go to settings",
+        trigger: 'html[lang=pa-GB]',
+        run: () => {
+            // Now go through the settings for a new website. A frontend_lang
+            // cookie was set during previous steps. It should not be used when
+            // redirecting to the frontend in the following steps.
+            window.location.href = '/web#action=website.action_website_configuration';
+        }
+    },
+    {
+        content: "create a new website",
+        trigger: 'button[name="action_website_create_new"]',
+    },
+    {
+        content: "insert website name",
+        trigger: 'input[name="name"]',
+        run: 'text Website EN'
+    },
+    {
+        content: "validate the website creation modal",
+        trigger: 'button.btn-primary'
+    },
+    {
+        content: "make hover button appear",
+        trigger: '.o_theme_preview',
+        run: () => {
+            $('.o_theme_preview .o_button_area').attr('style', 'visibility: visible; opacity: 1;');
+        },
+    },
+    {
+        content: "Install a theme",
+        trigger: 'button[data-name="button_choose_theme"]'
+    },
+    {
+        content: "Check that the editor is loaded",
+        trigger: 'body.editor_enable',
+        timeout: 30000,
+        run: () => null, // it's a check
+    },
+    {
+        content: "exit edit mode",
+        trigger: '.o_we_website_top_actions button.btn-primary:contains("Save")',
+    },
+    {
+        content: "wait for editor to close",
+        trigger: 'body:not(.editor_enable)',
+        run: () => null, // It's a check
+    }
+]);
+});

--- a/addons/website/tests/__init__.py
+++ b/addons/website/tests/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import test_attachment
 from . import test_auth_signup_uninvited
+from . import test_automatic_editor
 from . import test_base_url
 from . import test_converter
 from . import test_crawl

--- a/addons/website/tests/test_automatic_editor.py
+++ b/addons/website/tests/test_automatic_editor.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+
+from odoo.tests import HttpCase, tagged
+
+@tagged('post_install', '-at_install')
+class TestAutomaticEditor(HttpCase):
+
+    def _theme_upgrade_upstream(self):
+        # Because we cannot do _theme_upgrade_upstream, the theme install action
+        # isn't consumed, so it puts the user back on the install theme screen.
+        # So actions prior are disabled and an action that will trigger what
+        # needs to be tested is created.
+        actions = self.env['ir.actions.todo'].search([('state', '=', 'open')])
+        actions.write({'state': 'done'})
+        self.env['ir.actions.todo'].create({'action_id': self.env.ref('website.action_website_edit').id, 'state': 'open'})
+
+    def setUp(self):
+        super().setUp()
+        patcher = patch('odoo.addons.website.models.ir_module_module.IrModuleModule._theme_upgrade_upstream', wraps=self._theme_upgrade_upstream)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_01_automatic_editor_on_new_website(self):
+        # We create a lang because if the new website is displayed in this lang
+        # instead of the website's default one, the editor won't automatically
+        # start.
+        self.env['res.lang'].create({
+            'name': 'Parseltongue',
+            'code': 'pa_GB',
+            'iso_code': 'pa_GB',
+            'url_code': 'pa_GB',
+        })
+        self.start_tour('/', 'automatic_editor_on_new_website', login='admin')

--- a/addons/website/views/assets.xml
+++ b/addons/website/views/assets.xml
@@ -20,6 +20,7 @@
 <template id="assets_tests" name="Website Assets Tests" inherit_id="web.assets_tests">
     <xpath expr="." position="inside">
         <script type="text/javascript" src="/website/static/tests/tours/carousel_content_removal.js"/>
+        <script type="text/javascript" src="/website/static/tests/tours/automatic_editor.js"/>
         <script type="text/javascript" src="/website/static/tests/tours/reset_password.js"></script>
         <script type="text/javascript" src="/website/static/tests/tours/rte.js"/>
         <script type="text/javascript" src="/website/static/tests/tours/focus_blur_snippets.js"/>


### PR DESCRIPTION
[FIX] website: fix infinite loading after creating a website
Commit [1] introduced an automatic start of edit mode when
selecting a theme but didn't take into account wether the frontend lang
of the user was matching that of the website that is supposed to enter
in edit mode.

Commit [2] introduce a `website_edit` action but also didn't take into
account that the frontend lang might not be the source's lang.

Steps to reproduce:
- Create an empty database and install website
- Add an extra lang on website (e.g FR) and visit the website in that
lang
- Go in settings an create a new website, select a theme
- Redirect is with enable_editor but nothing happens

The editor isn't started if not in the source's lang.

This commit redirect the user to the default_lang of the website
so that editor can always be started. It also introduces a tour
to test out the flow.

[1]: f474eac
[2]: e0cc28d
