### PR TITLE
[IMP] account: Add index for accounting dashboard

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -46,6 +46,8 @@ class AccountMove(models.Model):
             CREATE INDEX IF NOT EXISTS account_move_payment_idx
             ON account_move(journal_id, state, payment_state, move_type, date);
         """)
+        # Create an index for journal dashboard sql query in get_line_graph_datas()
+        self.env.cr.execute("CREATE INDEX IF NOT EXISTS account_move_journal_date_desc_idx ON account_move (journal_id, date DESC)")
 
     @property
     def _sequence_monthly_regex(self):


### PR DESCRIPTION
Due to query present in dashboard get_line_graph_datas(),
this index is mandatory for performance reasons

https://github.com/odoo/odoo/blob/14.0/addons/account/models/account_journal_dashboard.py#L84


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
