### PR TITLE
[FIX] http: logout when a database is deleted

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1038,6 +1038,7 @@ class OpenERPSession(werkzeug.contrib.sessions.Session):
                 del self[k]
         self._default_values()
         self.rotate = True
+        root.session_store.save(self)
 
     def _default_values(self):
         self.setdefault("db", None)


### PR DESCRIPTION
When an OperationalError error occurs trying to initialize a registry,
a possible reason is that the database does not exist, this is the main
reason why 28581cc73442747463386b1a84d1c54d15128078 introduced a logout.

Since #49111, if the error occurs on a /web page, the error is raised,
get_response is never reached, meaning that the session is not saved.

This will lead to an error everytime the page is refreshed on /web since
the database won't be removed from the session.

- connect to a database
- drop it from the database manager
- access /web. An ISE occurs

This is partially fixed in #82874, using logout on the session dropping
the database but the problem will remain for other sessions.

This commit proposes to save the session in all case when logout is
called. Looks like it makes sense in this case since performance-wise
logout won't be called much, and we don't want to lose the logout
information if we don't reach get_response().

Another solution would be to save the session only before raising.

This is a partial alternative to #54102
This is a partial backport of #83035 (without tests)