### PR TITLE
[FIX] sale: fix archived tax on sales orders

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1265,7 +1265,7 @@ class SaleOrderLine(models.Model):
     price_total = fields.Monetary(compute='_compute_amount', string='Total', readonly=True, store=True)
 
     price_reduce = fields.Float(compute='_get_price_reduce', string='Price Reduce', digits='Product Price', readonly=True, store=True)
-    tax_id = fields.Many2many('account.tax', string='Taxes', domain=['|', ('active', '=', False), ('active', '=', True)])
+    tax_id = fields.Many2many('account.tax', string='Taxes', context={'active_test': False})
     price_reduce_taxinc = fields.Monetary(compute='_get_price_reduce_tax', string='Price Reduce Tax inc', readonly=True, store=True)
     price_reduce_taxexcl = fields.Monetary(compute='_get_price_reduce_notax', string='Price Reduce Tax excl', readonly=True, store=True)
 


### PR DESCRIPTION
When archiving a Tax, you do not want that action to
invalidate Sales Orders and Invoices confirmed in the past
and that were using it.

The purpose of Archiving it is that it would not appear
or be proposed to new items created.

Until now, we had an inconsistency between Sales Orders and Invoices
when a Tax was archived.
The tax "disappeared" from old SOs,
but the amounts remained unchanged, which created an inconsistency.

The domain in the field definition no longer works
because a custom domain in the view is shadowing the current domain.

task-2745094

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
