### PR TITLE
[FIX] website_sale: copied line is linked with the original order

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -365,7 +365,7 @@ class SaleOrderLine(models.Model):
 
     name_short = fields.Char(compute="_compute_name_short")
 
-    linked_line_id = fields.Many2one('sale.order.line', string='Linked Order Line', domain="[('order_id', '!=', order_id)]", ondelete='cascade')
+    linked_line_id = fields.Many2one('sale.order.line', string='Linked Order Line', domain="[('order_id', '=', order_id)]", ondelete='cascade', copy=False)
     option_line_ids = fields.One2many('sale.order.line', 'linked_line_id', string='Options Linked')
 
     def get_sale_order_line_multiline_description_sale(self, product):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Create a sale.order with a product with an optional product
- Confirm order A
- Copy this order A, a new order B is created
--> Issue: the new line of order B are linked with an line of order A

@tivisse @tde-banana-odoo 

Note the best solution is (maybe for master):

```python
class SaleOrder():
    order_line = One2many(copy=False)
   
    def copy(self, default=None):
        new_order = super().copy(default)
        map_line = {}
        map_line_linked = {}
        for line in self.order_line:
            new_line = line.copy({'order_id':  new_order.id}
            map_line[line] = new_line
            map_line_linked[new_line] = line.linked_line_id
        for line in new_order.order_line:
            linked = map_line_linked.get(line)
            if linked:
                line.linked_line_id = map_line[linked]
        return new_order
```
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
