### PR TITLE
[FIX][14.0]account: Fix bug when change journal on  payment

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -764,6 +764,15 @@ class AccountPayment(models.Model):
 
         for pay in self.with_context(skip_account_move_synchronization=True):
             liquidity_lines, counterpart_lines, writeoff_lines = pay._seek_for_lines()
+            if len(liquidity_lines) != 1 or len(counterpart_lines) != 1:
+
+                raise UserError(_(
+                    "The journal entry %s reached an invalid state relative to its payment.\n"
+                    "To be consistent, the journal entry must always contains:\n"
+                    "- one journal item involving the outstanding payment/receipts account.\n"
+                    "- one journal item involving a receivable/payable account.\n"
+                    "- optional journal items, all sharing the same account.\n\n"
+                ) % pay.move_id.display_name)
 
             # Make sure to preserve the write-off amount.
             # This allows to create a new payment with custom 'line_ids'.


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Fix bug when change `Journal` on `Payment`.

Current behavior before PR:

1. Create a Payment:

     > Journal: **Bank**

     > Is Internal Transfer: **True**

2. Save the Payment:
3. Edit the Payment: change Journal from **Bank** to **Cash**
4. Save the payment -> Error:
![bug_payment](https://user-images.githubusercontent.com/65999461/151498450-145e1b8c-2565-48fb-9c19-c69d0ceba836.png)


Desired behavior after PR is merged:

> give the `UserError`:
![raise_user_error](https://user-images.githubusercontent.com/65999461/151499373-cd85f6e6-8f95-4e36-b60a-7ed9064f05c5.png)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
