### PR TITLE
[FIX] sale: Report on converted currency

### DIFF
--- a/addons/sale_margin/report/sale_report.py
+++ b/addons/sale_margin/report/sale_report.py
@@ -11,5 +11,8 @@ class SaleReport(models.Model):
 
     def _select_additional_fields(self):
         res = super()._select_additional_fields()
-        res['margin'] = "SUM(l.margin / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END)"
+        res['margin'] = f"""SUM(l.margin
+            * {self._case_value_or_one('s.currency_rate')}
+            * {self._case_value_or_one('currency_table.rate')})
+        """
         return res


### PR DESCRIPTION
Before when reporting in the sale module in a multi-company
environment currencies where not converted to a unique currency
before mathematical operations (sum, avg, ...).
Now before mathematical operations currencies are converted to
the currency of the company currently selected.

Task - 2696759


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
