### PR TITLE
[FIX] account: allows changing journals on internal transfer

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -793,13 +793,18 @@ class AccountPayment(models.Model):
             line_vals_list = pay._prepare_move_line_default_vals(write_off_line_vals=write_off_line_vals)
 
             line_ids_commands = []
-            if liquidity_lines:
+            if len(liquidity_lines) == 1:
                 line_ids_commands.append((1, liquidity_lines.id, line_vals_list[0]))
             else:
+                for line in liquidity_lines:
+                    line_ids_commands.append((2, line.id, 0))
                 line_ids_commands.append((0, 0, line_vals_list[0]))
-            if counterpart_lines:
+
+            if len(counterpart_lines) == 1:
                 line_ids_commands.append((1, counterpart_lines.id, line_vals_list[1]))
             else:
+                for line in counterpart_lines:
+                    line_ids_commands.append((2, line.id, 0))
                 line_ids_commands.append((0, 0, line_vals_list[1]))
 
             for line in writeoff_lines:

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -820,3 +820,19 @@ class TestAccountPayment(AccountTestInvoicingCommon):
         self.assertRecordValues(payment, [{
             'partner_bank_id': self.comp_bank_account2.id,
         }])
+
+    def test_internal_transfer_change_journal(self):
+        self.bank_journal_1.bank_account_id = self.comp_bank_account1
+
+        payment = self.env['account.payment'].create({
+            'journal_id': self.bank_journal_1.id,
+            'amount': 50.0,
+            'is_internal_transfer': True,
+            'payment_type': 'outbound',
+            'partner_bank_id': self.comp_bank_account2.id,
+        })
+
+        # This should not raise an error.
+        payment.write({
+            'journal_id': self.company_data['default_journal_cash'].id
+        })


### PR DESCRIPTION
At the moment, going from let's say bank to cash journal
while editing an internal transfer will result in a traceback
due to the fact that seek_for_line cannot properly map the
move lines after changing the journal.
This fix will make it so that we drop completely the old
lines and then recreate them when such an issue arises.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
