### PR TITLE
[FIX] account: fix reverse caba entries tax account

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2131,7 +2131,8 @@ class AccountMove(models.Model):
                 refund_repartition_line = tax_repartition_lines_mapping[invoice_repartition_line]
 
                 # Find the right account.
-                if cancel:
+                if invoice_repartition_line.tax_id.tax_exigibility == 'on_payment':
+                    # keep same account on CABA entries
                     account_id = line_vals['account_id']
                 else:
                     account_id = self.env['account.move.line']._get_default_tax_account(refund_repartition_line).id

--- a/addons/account/tests/test_account_move_in_refund.py
+++ b/addons/account/tests/test_account_move_in_refund.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collections import defaultdict
 from odoo.addons.account.tests.account_test_savepoint import AccountTestInvoicingCommon
 from odoo.tests.common import Form
 from odoo.tests import tagged
@@ -1020,3 +1021,98 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             **self.move_vals,
             'currency_id': self.currency_data['currency'].id,
         })
+
+    def test_in_refund_reverse_move_tags_and_accoounts(self):
+        def get_tags(name):
+            tags = defaultdict(dict)
+            for line_type, repartition_type in [(l, r) for l in ('invoice', 'refund') for r in ('base', 'tax')]:
+                tags[line_type][repartition_type] = self.env['account.account.tag'].create({
+                    'name': '%s %s %s' % (name, line_type, repartition_type),
+                    'applicability': 'taxes',
+                    'country_id': self.env.ref('base.us').id,
+                })
+            return tags
+
+        def get_tax(name, tags, invoice_tax_account, refund_tax_account):
+            return self.env['account.tax'].create({
+                'type_tax_use': 'purchase',
+                'name': name,
+                'amount': 10.0,
+                'invoice_repartition_line_ids': [
+                    (0, 0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'base',
+                        'tag_ids': [(6, 0, tags['invoice']['base'].ids)],
+                    }),
+                    (0, 0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'tax',
+                        'tag_ids': [(6, 0, tags['invoice']['tax'].ids)],
+                        'account_id': invoice_tax_account.id,
+                    }),
+                ],
+                'refund_repartition_line_ids': [
+                    (0, 0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'base',
+                        'tag_ids': [(6, 0, tags['refund']['base'].ids)],
+                    }),
+                    (0, 0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'tax',
+                        'tag_ids': [(6, 0, tags['refund']['tax'].ids)],
+                        'account_id': refund_tax_account.id,
+                    }),
+                ],
+            })
+
+        invoice_tax_account = self.company_data['default_account_tax_purchase']
+        refund_tax_account = invoice_tax_account.copy()
+        tax_1_tags = get_tags('tax 1 tags')
+        tax_2_tags = get_tags('tax 2 tags')
+        tax_1 = get_tax('tax 1', tax_1_tags, invoice_tax_account, refund_tax_account)
+        tax_2 = get_tax('tax 2', tax_2_tags, invoice_tax_account, refund_tax_account)
+
+        refund = self.env['account.move'].create({
+            'type': 'in_refund',
+            'partner_id': self.partner_a.id,
+            'invoice_date': fields.Date.from_string('2019-01-01'),
+            'invoice_payment_term_id': self.pay_terms_a.id,
+            'invoice_line_ids': [
+                (0, 0, {
+                    'product_id': self.product_a.id,
+                    'price_unit': 1000.0,
+                    'tax_ids': [(6, 0, (tax_1 + tax_2).ids)],
+                }),
+            ]
+        })
+
+        self.assertRecordValues(refund.line_ids.sorted('tax_line_id'), [
+            # Product line
+            {'tax_line_id': False,      'tax_ids': (tax_1 + tax_2).ids,   'tag_ids': (tax_1_tags['refund']['base'] + tax_2_tags['refund']['base']).ids,   'account_id':self.company_data['default_account_expense'].id},
+            # Receivable line
+            {'tax_line_id': False,      'tax_ids': [],                    'tag_ids': [],                                                                  'account_id': self.company_data['default_account_payable'].id},
+            # Tax lines
+            {'tax_line_id': tax_1.id,   'tax_ids': [],                    'tag_ids': tax_1_tags['refund']['tax'].ids,                                     'account_id': refund_tax_account.id},
+            {'tax_line_id': tax_2.id,   'tax_ids': [],                    'tag_ids': tax_2_tags['refund']['tax'].ids,                                     'account_id': refund_tax_account.id},
+        ])
+        reversed = refund._reverse_moves(cancel=True)
+        self.assertRecordValues(reversed.line_ids.sorted('tax_line_id'), [
+            # Product line
+            {'tax_line_id': False,      'tax_ids': (tax_1 + tax_2).ids,   'tag_ids': (tax_1_tags['refund']['base'] + tax_2_tags['refund']['base']).ids,   'account_id':self.company_data['default_account_expense'].id},
+            # Receivable line
+            {'tax_line_id': False,      'tax_ids': [],                     'tag_ids': [],                                                                 'account_id': self.company_data['default_account_payable'].id},
+            # Tax lines
+            {'tax_line_id': tax_1.id,   'tax_ids': [],                     'tag_ids': tax_1_tags['refund']['tax'].ids,                                    'account_id': refund_tax_account.id},
+            {'tax_line_id': tax_2.id,   'tax_ids': [],                     'tag_ids': tax_2_tags['refund']['tax'].ids,                                    'account_id': refund_tax_account.id},
+        ])
+        reversed = refund._reverse_moves(cancel=False)
+        self.assertRecordValues(reversed.line_ids.sorted('tax_line_id'), [
+            # Product line
+            {'tax_line_id': False,      'tax_ids': (tax_1 + tax_2).ids,   'tag_ids': (tax_1_tags['refund']['base'] + tax_2_tags['refund']['base']).ids,   'account_id':self.company_data['default_account_expense'].id},
+            # Receivable line
+            {'tax_line_id': False,      'tax_ids': [],                     'tag_ids': [],                                                                 'account_id': self.company_data['default_account_payable'].id},
+            # Tax lines
+            {'tax_line_id': tax_1.id,   'tax_ids': [],                     'tag_ids': tax_1_tags['refund']['tax'].ids,                                    'account_id': refund_tax_account.id},
+            {'tax_line_id': tax_2.id,   'tax_ids': [],                     'tag_ids': tax_2_tags['refund']['tax'].ids,                                    'account_id': refund_tax_account.id},
+        ])

--- a/addons/account/tests/test_account_move_out_refund.py
+++ b/addons/account/tests/test_account_move_out_refund.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collections import defaultdict
 from odoo.addons.account.tests.account_test_savepoint import AccountTestInvoicingCommon
 from odoo.tests.common import Form
 from odoo.tests import tagged
@@ -1003,3 +1004,97 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             **self.move_vals,
             'currency_id': self.currency_data['currency'].id,
         })
+
+    def test_out_refund_reverse_move_tags_and_accoounts(self):
+        def get_tags(name):
+            tags = defaultdict(dict)
+            for line_type, repartition_type in [(l, r) for l in ('invoice', 'refund') for r in ('base', 'tax')]:
+                tags[line_type][repartition_type] = self.env['account.account.tag'].create({
+                    'name': '%s %s %s' % (name, line_type, repartition_type),
+                    'applicability': 'taxes',
+                    'country_id': self.env.ref('base.us').id,
+                })
+            return tags
+
+        def get_tax(name, tags, invoice_tax_account, refund_tax_account):
+            return self.env['account.tax'].create({
+                'name': name,
+                'amount': 10.0,
+                'invoice_repartition_line_ids': [
+                    (0, 0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'base',
+                        'tag_ids': [(6, 0, tags['invoice']['base'].ids)],
+                    }),
+                    (0, 0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'tax',
+                        'tag_ids': [(6, 0, tags['invoice']['tax'].ids)],
+                        'account_id': invoice_tax_account.id,
+                    }),
+                ],
+                'refund_repartition_line_ids': [
+                    (0, 0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'base',
+                        'tag_ids': [(6, 0, tags['refund']['base'].ids)],
+                    }),
+                    (0, 0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'tax',
+                        'tag_ids': [(6, 0, tags['refund']['tax'].ids)],
+                        'account_id': refund_tax_account.id,
+                    }),
+                ],
+            })
+
+        invoice_tax_account = self.company_data['default_account_tax_purchase']
+        refund_tax_account = invoice_tax_account.copy()
+        tax_1_tags = get_tags('tax 1 tags')
+        tax_2_tags = get_tags('tax 2 tags')
+        tax_1 = get_tax('tax 1', tax_1_tags, invoice_tax_account, refund_tax_account)
+        tax_2 = get_tax('tax 2', tax_2_tags, invoice_tax_account, refund_tax_account)
+
+        credit_note = self.env['account.move'].create({
+            'type': 'out_refund',
+            'partner_id': self.partner_a.id,
+            'invoice_date': fields.Date.from_string('2019-01-01'),
+            'invoice_payment_term_id': self.pay_terms_a.id,
+            'invoice_line_ids': [
+                (0, 0, {
+                    'product_id': self.product_a.id,
+                    'price_unit': 1000.0,
+                    'tax_ids': [(6, 0, (tax_1 + tax_2).ids)],
+                }),
+            ]
+        })
+
+        self.assertRecordValues(credit_note.line_ids.sorted('tax_line_id'), [
+            # Product line
+            {'tax_line_id': False,      'tax_ids': (tax_1 + tax_2).ids,   'tag_ids': (tax_1_tags['refund']['base'] + tax_2_tags['refund']['base']).ids,   'account_id':self.company_data['default_account_revenue'].id},
+            # Receivable line
+            {'tax_line_id': False,      'tax_ids': [],                    'tag_ids': [],                                                                  'account_id': self.company_data['default_account_receivable'].id},
+            # Tax lines
+            {'tax_line_id': tax_1.id,   'tax_ids': [],                    'tag_ids': tax_1_tags['refund']['tax'].ids,                                     'account_id': refund_tax_account.id},
+            {'tax_line_id': tax_2.id,   'tax_ids': [],                    'tag_ids': tax_2_tags['refund']['tax'].ids,                                     'account_id': refund_tax_account.id},
+        ])
+        reversed = credit_note._reverse_moves(cancel=True)
+        self.assertRecordValues(reversed.line_ids.sorted('tax_line_id'), [
+            # Product line
+            {'tax_line_id': False,      'tax_ids': (tax_1 + tax_2).ids,   'tag_ids': (tax_1_tags['refund']['base'] + tax_2_tags['refund']['base']).ids,   'account_id':self.company_data['default_account_revenue'].id},
+            # Receivable line
+            {'tax_line_id': False,      'tax_ids': [],                     'tag_ids': [],                                                                 'account_id': self.company_data['default_account_receivable'].id},
+            # Tax lines
+            {'tax_line_id': tax_1.id,   'tax_ids': [],                     'tag_ids': tax_1_tags['refund']['tax'].ids,                                    'account_id': refund_tax_account.id},
+            {'tax_line_id': tax_2.id,   'tax_ids': [],                     'tag_ids': tax_2_tags['refund']['tax'].ids,                                    'account_id': refund_tax_account.id},
+        ])
+        reversed = credit_note._reverse_moves(cancel=False)
+        self.assertRecordValues(reversed.line_ids.sorted('tax_line_id'), [
+            # Product line
+            {'tax_line_id': False,      'tax_ids': (tax_1 + tax_2).ids,   'tag_ids': (tax_1_tags['refund']['base'] + tax_2_tags['refund']['base']).ids,   'account_id':self.company_data['default_account_revenue'].id},
+            # Receivable line
+            {'tax_line_id': False,      'tax_ids': [],                     'tag_ids': [],                                                                 'account_id': self.company_data['default_account_receivable'].id},
+            # Tax lines
+            {'tax_line_id': tax_1.id,   'tax_ids': [],                     'tag_ids': tax_1_tags['refund']['tax'].ids,                                    'account_id': refund_tax_account.id},
+            {'tax_line_id': tax_2.id,   'tax_ids': [],                     'tag_ids': tax_2_tags['refund']['tax'].ids,                                    'account_id': refund_tax_account.id},
+        ])


### PR DESCRIPTION
Reversed CABA entries must have same tax account as reversed entries.
Bug introduced in https://github.com/odoo/odoo/commit/d22cd5473326b3b5af4ae44b0d121349a1a90850 (commit created to fix https://github.com/odoo/odoo/commit/fbe031740841eef855777e98ee806c19dd89bc04)
This commit prevent changing account and add tests for tax tag ids and account on revere entries.

Task: 2744922