### PR TITLE
[FIX] sale, purchase: set customer/supplier_rank when creating SO/PO

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -200,6 +200,10 @@ class PurchaseOrder(models.Model):
             self.order_line.filtered(lambda line: not line.display_type).date_planned = self.date_planned
 
     def write(self, vals):
+        if 'partner_id' in vals:
+            partner = self.env['res.partner'].browse(vals.get('partner_id'))
+            if not partner.supplier_rank:
+                partner.supplier_rank = 1
         vals, partner_vals = self._write_partner_values(vals)
         res = super().write(vals)
         if partner_vals:
@@ -217,6 +221,10 @@ class PurchaseOrder(models.Model):
                 seq_date = fields.Datetime.context_timestamp(self, fields.Datetime.to_datetime(vals['date_order']))
             vals['name'] = self_comp.env['ir.sequence'].next_by_code('purchase.order', sequence_date=seq_date) or '/'
         vals, partner_vals = self._write_partner_values(vals)
+
+        partner = self.env['res.partner'].browse(vals.get('partner_id'))
+        if not partner.supplier_rank:
+            partner.supplier_rank = 1
         res = super(PurchaseOrder, self_comp).create(vals)
         if partner_vals:
             res.sudo().write(partner_vals)  # Because the purchase user doesn't have write on `res.partner`

--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -508,7 +508,19 @@ class SaleOrder(models.Model):
             vals['partner_invoice_id'] = vals.setdefault('partner_invoice_id', addr['invoice'])
             vals['partner_shipping_id'] = vals.setdefault('partner_shipping_id', addr['delivery'])
             vals['pricelist_id'] = vals.setdefault('pricelist_id', partner.property_product_pricelist.id)
+        partner = self.env['res.partner'].browse(vals.get('partner_id'))
+        if not partner.customer_rank:
+            partner.customer_rank = 1
         result = super(SaleOrder, self).create(vals)
+        return result
+
+    def write(self, vals):
+        if 'partner_id' in vals:
+            partner = self.env['res.partner'].browse(vals.get('partner_id'))
+            if not partner.customer_rank:
+                partner.customer_rank = 1
+
+        result = super(SaleOrder, self).write(vals)
         return result
 
     def _compute_field_value(self, field):


### PR DESCRIPTION
Reproduce(SO):
1) create a contact
2) go to sales, generate a quote & confirm
3) customer_rank is not set on contact
4) create invoice from the SO
5) customer_rank is set on contact

a) Create a contact directly from a quote
b) customer_rank is set on contact, no invoice needed

Similar issue for PO

Reason: Currently the customer_rank is increased when a new customer is created in a sales order or an invoice is posted to an existing customer. However, customer_rank should be set to 1 as soon as a SO is created for an existing contact with customer_rank == 0. For PO, the supplier_rank should be set to 1 as soon as a PO is created for an existing contact with supplier_rank == 0.

opw-2733844



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
