### PR TITLE
15.0 fix misc tours bso

### DIFF
--- a/addons/website/static/src/js/tours/configurator_tour.js
+++ b/addons/website/static/src/js/tours/configurator_tour.js
@@ -31,7 +31,7 @@ if ($(shapeSelector).first().length) {
         shapeStep.push(wTourUtils.clickOnSnippet(shapeSelector));
     }
     shapeStep.push(wTourUtils.changeOption('BackgroundShape', 'we-toggler', _t('Background Shape')));
-    shapeStep.push(wTourUtils.selectNested('we-select-page', 'BackgroundShape', ':not(.o_we_pager_controls', _t('Background Shape')));
+    shapeStep.push(wTourUtils.selectNested('we-select-page', 'BackgroundShape', ':not(.o_we_pager_controls)', _t('Background Shape')));
 }
 
 const steps = [

--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -11,7 +11,8 @@ odoo.define("website_event.tour", function (require) {
         url: "/",
     }, [{
         content: _t("Click here to add new content to your website."),
-        trigger: '#new-content-menu > a',
+        trigger: "body:has(#o_new_content_menu_choices.o_hidden) #new-content-menu > a",
+        consumeVisibleOnly: true,
         position: 'bottom',
     }, {
         trigger: "a[data-action=new_event]",


### PR DESCRIPTION
This PR fixes several tour issues:
- a typo in the configurator tour
- require palette to be closed before showing further options steps
- have the events tour participate in the `consumeVisibleOnly` mechanism that was introduced in https://github.com/odoo/odoo/commit/0fa40e37e596798665a098ee999f49749b6012a2

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
