### PR TITLE
[REF] mrp: replace production's onchanges by computes

### DIFF
--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -78,13 +78,6 @@
             <field name="product_qty">3</field>
             <field name="bom_id" ref="mrp_bom_manufacture"/>
         </record>
-
-        <function model="stock.move" name="create">
-            <value model="stock.move" eval="
-                obj().env.ref('mrp.mrp_production_1')._get_moves_raw_values() +
-                obj().env.ref('mrp.mrp_production_1')._get_moves_finished_values()"/>
-        </function>
-
         <!-- Table -->
 
         <record id="product_product_computer_desk" model="product.product">
@@ -295,12 +288,6 @@
             <field name="bom_id" ref="mrp_bom_desk"/>
         </record>
 
-        <function model="stock.move" name="create">
-            <value model="stock.move" eval="
-                obj().env.ref('mrp.mrp_production_3')._get_moves_raw_values() +
-                obj().env.ref('mrp.mrp_production_3')._get_moves_finished_values()"/>
-        </function>
-
         <record id="mrp_bom_table_top" model="mrp.bom">
             <field name="product_tmpl_id" ref="product_product_computer_desk_head_product_template"/>
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
@@ -402,14 +389,6 @@
             <field name="location_dest_id" ref="stock.stock_location_stock"/>
             <field name="bom_id" ref="mrp_bom_table_top"/>
         </record>
-
-        <!-- Generate Table & Table Top MO's moves -->
-        <function model="stock.move" name="create">
-            <value model="stock.move" eval="
-                obj().env.ref('mrp.mrp_production_4')._get_moves_raw_values() +
-                obj().env.ref('mrp.mrp_production_4')._get_moves_finished_values()"/>
-        </function>
-
         <!-- Table Kit -->
 
         <record id="product_product_table_kit" model="product.product">
@@ -651,12 +630,6 @@
             <field name="bom_id" ref="mrp_bom_drawer"/>
         </record>
 
-        <function model="stock.move" name="create">
-            <value model="stock.move" eval="
-                obj().env.ref('mrp.mrp_production_drawer')._get_moves_raw_values() +
-                obj().env.ref('mrp.mrp_production_drawer')._get_moves_finished_values()"/>
-        </function>
-
         <!-- Run Scheduler -->
         <function model="procurement.group" name="run_scheduler"/>
 
@@ -704,10 +677,6 @@
             <field name="date_start" eval="(datetime.now() - timedelta(hours=1)).strftime('%Y-%m-%d %H:%M:%S')"/>
         </record>
 
-        <function model="mrp.production" name="_create_workorder">
-            <value eval="[ref('mrp.mrp_production_3')]"/>
-        </function>
-
         <function model="mrp.production" name="action_confirm" eval="[[
             ref('mrp.mrp_production_3'),
             ref('mrp.mrp_production_4'),
@@ -730,10 +699,6 @@
         <function model="stock.move" name="write">
             <value model="stock.move" eval="obj().env['stock.move'].search([('raw_material_production_id', '=', obj().env.ref('mrp.mrp_production_drawer').id)]).ids"/>
             <value eval="{'quantity_done': 5}"/>
-        </function>
-
-        <function model="mrp.production" name="_post_inventory">
-            <value eval="[ref('mrp.mrp_production_drawer')]"/>
         </function>
 
         <function model="mrp.production" name="button_mark_done">

--- a/addons/mrp/populate/mrp.py
+++ b/addons/mrp/populate/mrp.py
@@ -271,17 +271,6 @@ class MrpProduction(models.Model):
     def _populate(self, size):
         productions = super()._populate(size)
 
-        def fill_mo_with_bom_info():
-            productions_with_bom = productions.filtered('bom_id')
-            _logger.info("Create Raw moves of MO(s) with bom (%d)" % len(productions_with_bom))
-            self.env['stock.move'].create(productions_with_bom._get_moves_raw_values())
-            _logger.info("Create Finished moves of MO(s) with bom (%d)" % len(productions_with_bom))
-            self.env['stock.move'].create(productions_with_bom._get_moves_finished_values())
-            _logger.info("Create Workorder moves of MO(s) with bom (%d)" % len(productions_with_bom))
-            productions_with_bom._create_workorder()
-
-        fill_mo_with_bom_info()
-
         def confirm_bom_mo(sample_ratio):
             # Confirm X % of prototype MO
             random = populate.Random('confirm_bom_mo')

--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -316,13 +316,11 @@ class TestMrpProductionBackorder(TestMrpCommon):
             backorder.save().action_backorder()
             return mo.procurement_group_id.mrp_production_ids[-1]
 
-        default_picking_type_id = self.env['mrp.production']._get_default_picking_type()
+        default_picking_type_id = self.env['mrp.production']._get_default_picking_type_id(self.env.company.id)
         default_picking_type = self.env['stock.picking.type'].browse(default_picking_type_id)
         mo_sequence = default_picking_type.sequence_id
-
         mo_sequence.prefix = "WH-MO-"
         initial_mo_name = mo_sequence.prefix + str(mo_sequence.number_next_actual).zfill(mo_sequence.padding)
-
         production = self.generate_mo(qty_final=5)[0]
         self.assertEqual(production.name, initial_mo_name)
 
@@ -331,7 +329,6 @@ class TestMrpProductionBackorder(TestMrpCommon):
         self.assertEqual(backorder.name, initial_mo_name + "-002")
 
         backorder.backorder_sequence = 998
-
         for seq in [998, 999, 1000]:
             new_backorder = produce_one(backorder)
             self.assertEqual(backorder.name, initial_mo_name + "-" + str(seq))
@@ -425,7 +422,7 @@ class TestMrpProductionBackorder(TestMrpCommon):
                 'location_id': self.stock_location.id,
             })._apply_inventory()
 
-        default_picking_type_id = self.env['mrp.production']._get_default_picking_type()
+        default_picking_type_id = self.env['mrp.production']._get_default_picking_type_id(self.env.company.id)
         default_picking_type = self.env['stock.picking.type'].browse(default_picking_type_id)
 
         # make sure generated MO will auto-assign

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -337,6 +337,7 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(production.workorder_ids.duration_expected, 165)
 
     def test_update_quantity_4(self):
+        """ Workcenter 1 has 10' start time and 5' stop time """
         bom = self.env['mrp.bom'].create({
             'product_id': self.product_6.id,
             'product_tmpl_id': self.product_6.product_tmpl_id.id,
@@ -364,6 +365,14 @@ class TestMrpOrder(TestMrpCommon):
         mo_form = Form(production)
         mo_form.product_qty = 3
         production = mo_form.save()
+        self.assertEqual(production.workorder_ids.duration_expected, 40)
+
+        production.action_confirm()
+        update_quantity_wizard = self.env['change.production.qty'].create({
+            'mo_id': production.id,
+            'product_qty': 9,
+        })
+        update_quantity_wizard.change_prod_qty()
         self.assertEqual(production.workorder_ids.duration_expected, 90)
 
     def test_update_quantity_5(self):
@@ -549,8 +558,7 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(mo.move_finished_ids[0].date, datetime(2023, 5, 15, 10, 0))
         mo.action_confirm()
         mo.button_plan()
-        with Form(mo) as frm:
-            frm.date_planned_start = datetime(2024, 5, 15, 9, 0)
+        mo.date_planned_start = datetime(2024, 5, 15, 9, 0)
         self.assertEqual(mo.move_finished_ids[0].date, datetime(2024, 5, 15, 10, 0))
 
     def test_rounding(self):

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from odoo import fields
 from odoo.tests import Form
@@ -250,9 +250,7 @@ class TestProcurement(TestMrpCommon):
         self.assertEqual(move_orig.product_qty, 10, 'the quantity to produce is not good relative to the move')
 
         new_sheduled_date = fields.Datetime.to_datetime(mo.date_planned_start) + timedelta(days=5)
-        mo_form = Form(mo)
-        mo_form.date_planned_start = new_sheduled_date
-        mo = mo_form.save()
+        mo.date_planned_start = new_sheduled_date
 
         self.assertAlmostEqual(mo.move_raw_ids.date, mo.date_planned_start, delta=timedelta(seconds=1))
         self.assertAlmostEqual(mo.move_finished_ids.date, mo.date_planned_finished, delta=timedelta(seconds=1))

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -211,7 +211,7 @@
                                 </button>
                                 <label for="product_uom_id" string="" class="oe_inline"/>
                                 <field name="product_uom_category_id" invisible="1"/>
-                                <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" force_save="1" groups="uom.group_uom" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                                <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                                 <span class='font-weight-bold'>To Produce</span>
                                 <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" attrs="{'invisible': [('forecasted_issue', '=', True)]}"/>
                                 <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" attrs="{'invisible': [('forecasted_issue', '=', False)]}" class="text-danger"/>

--- a/addons/mrp_account/data/mrp_account_demo.xml
+++ b/addons/mrp_account/data/mrp_account_demo.xml
@@ -23,14 +23,6 @@
         <field name="date_planned_start" eval="(datetime.now() - relativedelta(weeks=1)).strftime('%Y-%m-%d %H:%M:%S')"/>
     </record>
 
-    <function model="stock.move" name="create">
-        <value model="stock.move" eval="
-            obj().env.ref('mrp_account.mrp_production_drawer_2')._get_moves_raw_values() +
-            obj().env.ref('mrp_account.mrp_production_drawer_2')._get_moves_finished_values() +
-            obj().env.ref('mrp_account.mrp_production_drawer_3')._get_moves_raw_values() +
-            obj().env.ref('mrp_account.mrp_production_drawer_3')._get_moves_finished_values()"/>
-    </function>
-
     <function model="mrp.production" name="action_confirm" eval="[[
         ref('mrp_account.mrp_production_drawer_2'),
         ref('mrp_account.mrp_production_drawer_3'),

--- a/addons/mrp_account/tests/test_analytic_account.py
+++ b/addons/mrp_account/tests/test_analytic_account.py
@@ -121,6 +121,7 @@ class TestAnalyticAccount(TransactionCase):
         self.assertEqual(len(mo.workorder_ids.wc_analytic_account_line_id), 0)
 
         # change duration to 60
+        mo_form = Form(mo)
         with mo_form.workorder_ids.edit(0) as line_edit:
             line_edit.duration = 60.0
         mo_form.save()
@@ -161,6 +162,7 @@ class TestAnalyticAccount(TransactionCase):
         self.assertEqual(len(mo.workorder_ids.wc_analytic_account_line_id), 0)
 
         # change duration to 60
+        mo_form = Form(mo)
         with mo_form.workorder_ids.edit(0) as line_edit:
             line_edit.duration = 60.0
         mo_form.save()

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -506,7 +506,6 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
             move.product_uom_qty = 1
         picking_receipt = picking_form.save()
         picking_receipt.action_confirm()
-
         self.assertEqual(picking_receipt.display_action_record_components, 'facultative')
         action = picking_receipt.action_record_components()
         mo = self.env['mrp.production'].browse(action['res_id'])


### PR DESCRIPTION
Replaces the `mrp.production` onchanges by computes when it's possible.
The purpose is to have the same behavior back-end and front-end, and so, avoid to call manually some methods (to create the moves for example).

Enterprise PR: odoo/enterprise#24405