### PR TITLE
[FIX] hr: Hide 'change password' action on own profile

### DIFF
--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -76,6 +76,32 @@ class TestSelfAccessProfile(TestHrCommon):
         # Compare both
         self.assertEqual(full_fields.keys(), fields.keys(), "View fields should not depend on user's groups")
 
+    def test_access_my_profile_toolbar(self):
+        """ A simple user shouldn't have the possibilities to see the 'Change Password' action"""
+        james = new_test_user(self.env, login='jam', groups='base.group_user', name='Simple employee', email='jam@example.com')
+        james = james.with_user(james)
+        self.env['hr.employee'].create({
+            'name': 'James',
+            'user_id': james.id,
+        })
+        view = self.env.ref('hr.res_users_view_form_profile')
+        available_actions = james.fields_view_get(view_id=view.id, toolbar=True)['toolbar']['action']
+        change_password_action = self.env.ref("base.change_password_wizard_action")
+
+        self.assertFalse(any(x['id'] == change_password_action.id for x in available_actions))
+
+        """ An ERP manager should have the possibilities to see the 'Change Password' """
+        john = new_test_user(self.env, login='joh', groups='base.group_erp_manager', name='ERP Manager', email='joh@example.com')
+        john = john.with_user(john)
+        self.env['hr.employee'].create({
+            'name': 'John',
+            'user_id': john.id,
+        })
+        view = self.env.ref('hr.res_users_view_form_profile')
+        available_actions = john.fields_view_get(view_id=view.id, toolbar=True)['toolbar']['action']
+        self.assertTrue(any(x['id'] == change_password_action.id for x in available_actions))
+
+
 class TestSelfAccessRights(TestHrCommon):
 
     def setUp(self):

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -41,6 +41,7 @@
             <field name="arch" type="xml">
                 <form position="attributes">
                     <attribute name="create">false</attribute>
+                    <attribute name="delete">false</attribute>
                     <attribute name="js_class">hr_employee_profile_form</attribute>
                 </form>
                 <notebook position="replace">


### PR DESCRIPTION
### Expected Behaviour

When a user goes to his own profile, he has two ways to change his password :
1. through the 'Account security' tab
2. through the 'Actions' > 'Change password' menu in list/form view
Both option should let the user change its password, or one of the two should not be present

### Observed behaviour

While the first one works as expected, the second option gives an error as the user doesn't have the admin rights

### Reproducibility

This bug can be reproduced following these steps:
0. Make sure to have the "Employees" app installed
1. Connect as an employee (e.g. demo/demo on runbot)
2. Click on your name at the top right, go to 'My Profile'
3. Click 'Action' then 'Change password'

### Related Issues/PR
- opw-2735671

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
