### PR TITLE
[FIX] pos_coupon: Coupons code disappear when switching table

### DIFF
--- a/addons/pos_coupon/models/pos_order.py
+++ b/addons/pos_coupon/models/pos_order.py
@@ -64,7 +64,11 @@ class PosOrder(models.Model):
 
     def _get_fields_for_order_line(self):
         fields = super(PosOrder, self)._get_fields_for_order_line()
-        fields.append('is_program_reward')
+        fields.extend({
+            'is_program_reward',
+            'coupon_id',
+            'program_id',
+        })
         return fields
 
 class PosOrderLine(models.Model):

--- a/addons/pos_coupon/static/src/js/coupon.js
+++ b/addons/pos_coupon/static/src/js/coupon.js
@@ -273,9 +273,9 @@ odoo.define('pos_coupon.pos', function (require) {
             return res;
         },
         init_from_JSON: function (json) {
+            this.bookedCouponCodes = this.bookedCouponCodes ? this.order.bookedCouponCodes : {};
+            this.activePromoProgramIds = this.activePromoProgramIds ? this.order.activePromoProgramIds : [];
             _order_super.init_from_JSON.apply(this, arguments);
-            this.bookedCouponCodes = json.bookedCouponCodes;
-            this.activePromoProgramIds = json.activePromoProgramIds;
         },
         export_as_JSON: function () {
             let json = _order_super.export_as_JSON.apply(this, arguments);
@@ -1048,6 +1048,11 @@ odoo.define('pos_coupon.pos', function (require) {
                 this.is_program_reward = json.is_program_reward;
                 this.program_id = json.program_id;
                 this.coupon_id = json.coupon_id;
+                if (this.coupon_id && this.coupon_id[1]) {
+                    this.order.bookedCouponCodes[this.coupon_id[1]] = new CouponCode(this.coupon_id[1], this.coupon_id[0], this.program_id[0]);
+                } else if (json.program_id && json.program_id[0]) {
+                    this.order.activePromoProgramIds.push(json.program_id[0]);
+                }
             }
             _orderline_super.init_from_JSON.apply(this, [json]);
         },


### PR DESCRIPTION
Current behavior:
When adding a coupon with a code in a PoS (restaurant/bar) if you switch table and come back to the first table the coupon code is disappearing

Steps to reproduce:
- Activate promo code for a PoS (restaurant/bar)
- Go on table A, add some product and enter a code for the order
- Leave table, and come back to table A
- The promo code has disappeared

note: A better fix could be done on master adding bookedCouponCode on order field to save it between the table switching.

opw-2733081

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
