### PR TITLE
[FIX] product: improve name_get performance

### DIFF
--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -499,7 +499,9 @@ class ProductTemplateAttributeValue(models.Model):
 
     def _get_combination_name(self):
         """Exclude values from single value lines or from no_variant attributes."""
-        return ", ".join([ptav.name for ptav in self._without_no_variant_attributes()._filter_single_value_lines()])
+        ptavs = self._without_no_variant_attributes().with_prefetch(self._prefetch_ids)
+        ptavs = ptavs._filter_single_value_lines().with_prefetch(self._prefetch_ids)
+        return ", ".join([ptav.name for ptav in ptavs])
 
     def _filter_single_value_lines(self):
         """Return `self` with values from single value lines filtered out


### PR DESCRIPTION
Currently, product.name_get goes through
each product in the record set
before calling _get_combination_name
on its attribute values.

This can lead to some slowdowns when the recordset
starts to grow (> 100 products). The reason for
that is that _get_combination_name
filters the recordset twice.

This commit speed-up _get_combination_name
by resetting prefetch_ids to self._prefetch_ids,
i.e. the prefetch_ids of the whole recordset.


This is a backport of https://github.com/odoo/odoo/pull/75893 which was done against V14 but the same behaviour also applies for V13




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
