### PR TITLE
[FIX] microsoft_calendar: add 'none' state to attendee state convertor

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -16,6 +16,7 @@ ATTENDEE_CONVERTER_O2M = {
     'accepted': 'accepted'
 }
 ATTENDEE_CONVERTER_M2O = {
+    'none': 'needsAction',
     'notResponded': 'needsAction',
     'tentativelyAccepted': 'tentative',
     'declined': 'declined',


### PR DESCRIPTION
Before this commit, the 'none' state was not considered as a possible
attendee state for the microsoft, and it created an empty field in
Odoo.

This commit maps the 'none' state to the 'needsAction', based on the
microsoft documentation.

opw-2694644
