### PR TITLE
[IMP] website_event[_questions]: allow setting event questions as mandatory

### DIFF
--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -288,12 +288,12 @@
                                 <h5 class="mt-1 pb-2 border-bottom">Ticket #<span t-esc="counter"/> <small class="text-muted">- <span t-esc="ticket['name']"/></small></h5>
                                 <div class="row">
                                     <div class="col-lg my-2">
-                                        <label>Name</label>
+                                        <label>Name *</label>
                                         <input class="form-control" type="text" t-attf-name="#{counter}-name" required="This field is required"
                                             t-att-value="default_first_attendee.get('name', '') if counter == 1 else ''"/>
                                     </div>
                                     <div class="col-lg my-2">
-                                        <label>Email</label>
+                                        <label>Email *</label>
                                         <input class="form-control" type="email" t-attf-name="#{counter}-email" required="This field is required"
                                             t-att-value="default_first_attendee.get('email', '') if counter == 1 else ''"/>
                                     </div>

--- a/addons/website_event_questions/models/event_event.py
+++ b/addons/website_event_questions/models/event_event.py
@@ -59,6 +59,7 @@ class EventEvent(models.Model):
                         'question_type': question.question_type,
                         'sequence': question.sequence,
                         'once_per_order': question.once_per_order,
+                        'is_mandatory_answer': question.is_mandatory_answer,
                         'answer_ids': [(0, 0, {
                             'name': answer.name,
                             'sequence': answer.sequence

--- a/addons/website_event_questions/models/event_question.py
+++ b/addons/website_event_questions/models/event_question.py
@@ -19,9 +19,10 @@ class EventQuestion(models.Model):
     event_id = fields.Many2one('event.event', 'Event', ondelete='cascade')
     answer_ids = fields.One2many('event.question.answer', 'question_id', "Answers", copy=True)
     sequence = fields.Integer(default=10)
-    once_per_order = fields.Boolean('Ask only once per order',
+    once_per_order = fields.Boolean('Ask once per order',
                                     help="If True, this question will be asked only once and its value will be propagated to every attendees."
                                          "If not it will be asked for every attendee of a reservation.")
+    is_mandatory_answer = fields.Boolean('Mandatory Answer')
 
     @api.constrains('event_type_id', 'event_id')
     def _constrains_event(self):

--- a/addons/website_event_questions/views/event_question_views.xml
+++ b/addons/website_event_questions/views/event_question_views.xml
@@ -9,11 +9,11 @@
                     <h1><field name="title" placeholder='e.g. "Do you have any diet restrictions?"' /></h1>
                     <group>
                         <group>
-                            <div colspan="2">
-                                <field name="once_per_order"/>
-                                <label for="once_per_order"/>
-                            </div>
-                            <field name="question_type" widget="radio" options="{'horizontal': true}" />
+                            <field name="is_mandatory_answer"/>
+                            <field name="question_type" widget="radio" options="{'horizontal': true}"/>
+                        </group>
+                        <group>
+                            <field name="once_per_order"/>
                         </group>
                     </group>
                     <notebook attrs="{'invisible': [('question_type', '!=', 'simple_choice')]}">

--- a/addons/website_event_questions/views/event_templates.xml
+++ b/addons/website_event_questions/views/event_templates.xml
@@ -32,15 +32,19 @@
 
 <template id="registration_event_question" name="Registration Event Question">
     <label t-esc="question.title"/>
+    <span t-if="question.is_mandatory_answer">*</span>
     <t t-if="question.question_type == 'simple_choice'">
-        <select t-attf-name="question_answer-#{registration_index}-#{question.id}" class="custom-select" required="true">
+        <select t-attf-name="question_answer-#{registration_index}-#{question.id}" class="custom-select"
+                t-att-required="question.is_mandatory_answer">
+            <option value=""/>
             <t t-foreach="question.answer_ids" t-as="answer">
                 <option t-esc="answer.name" t-att-value="answer.id"/>
             </t>
         </select>
     </t>
     <t t-elif="question.question_type == 'text_box'">
-        <textarea t-attf-name="question_answer-#{registration_index}-#{question.id}" class="col-lg-12 form-control"/>
+        <textarea t-attf-name="question_answer-#{registration_index}-#{question.id}" class="col-lg-12 form-control"
+                  t-att-required="question.is_mandatory_answer"/>
     </t>
 </template>
 

--- a/addons/website_event_questions/views/event_views.xml
+++ b/addons/website_event_questions/views/event_views.xml
@@ -10,6 +10,8 @@
                      <field name="question_ids" class="w-100">
                          <tree sample="1">
                              <field name="title"/>
+                             <field name="is_mandatory_answer"/>
+                             <field name="once_per_order"/>
                              <field name="question_type" />
                              <field name="answer_ids" widget = "many2many_tags"/>
                          </tree>
@@ -31,6 +33,7 @@
                             <tree>
                                 <field name="sequence" widget="handle" />
                                 <field name="title"/>
+                                <field name="is_mandatory_answer"/>
                                 <field name="once_per_order"/>
                                 <field name="question_type" string="Type" />
                                 <field name="answer_ids" widget="many2many_tags"
@@ -43,13 +46,13 @@
                             <form string="Question">
                                 <sheet>
                                     <h1><field name="title" placeholder='e.g. "Do you have any diet restrictions?"' /></h1>
-                                    <group class="mb-0">
-                                        <group class="mb-0">
-                                            <div colspan="2">
-                                                <field name="once_per_order"/>
-                                                <label for="once_per_order"/>
-                                            </div>
-                                            <field name="question_type" widget="radio" options="{'horizontal': true}" />
+                                    <group>
+                                        <group>
+                                            <field name="is_mandatory_answer"/>
+                                            <field name="question_type" widget="radio" options="{'horizontal': true}"/>
+                                        </group>
+                                        <group>
+                                            <field name="once_per_order"/>
                                         </group>
                                     </group>
                                     <notebook attrs="{'invisible': [('question_type', '!=', 'simple_choice')]}">


### PR DESCRIPTION
… Answers

Add mandatory_answer to event.question model and form view to enable the user to specify which question requires an answer

In the registration form:
- Add * next to each mandatory question + also next to name and email
- Make the answer actually mandatory for the mandatory question (this includes adding an empty choice selection to force the user to choose one option)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
