### PR TITLE
[FIX] gamification: stop notifying users on intermediate ranks

### DIFF
--- a/addons/gamification/models/res_users.py
+++ b/addons/gamification/models/res_users.py
@@ -214,6 +214,7 @@ WHERE sub.user_id IN %%s""" % {
                             'rank_id': ranks[i]['rank'].id,
                             'next_rank_id': ranks[i - 1]['rank'].id if 0 < i else False
                         })
+                    else:
                         break
             if old_rank != user.rank_id:
                 user._rank_changed()


### PR DESCRIPTION
Purpose
=======
When a user changes more than one rank at the time, avoid sending emails
for every intermediate rank. This is particularly annoying when creating
a new database, since the admin starts with 2500 karma and is sent 4
emails for each intermediate rank.

Task-2746929
