### PR TITLE
[FIX] stock: remove products not present in the package

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -777,6 +777,8 @@ class StockMoveLine(models.Model):
 
         # Does the same for empty move line to retrieve the ordered qty. for partially done moves
         # (as they are splitted when the transfer is done and empty moves don't have move lines).
+        if kwargs.get('strict'):
+            return aggregated_move_lines
         pickings = (self.picking_id | backorders)
         for empty_move in pickings.move_lines.filtered(
             lambda m: m.state == "cancel" and m.product_uom_qty

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -119,7 +119,7 @@
                                     </t>
                                     <!-- If not printing lots/serial numbers => merge lines with same product+description+uom -->
                                     <t t-else="">
-                                        <t t-set="aggregated_lines" t-value="package_move_lines._get_aggregated_product_quantities()"/>
+                                        <t t-set="aggregated_lines" t-value="package_move_lines._get_aggregated_product_quantities(strict=True)"/>
                                         <t t-call="stock.stock_report_delivery_aggregated_move_lines"/>
                                     </t>
                                 </t>


### PR DESCRIPTION
Delivery slip packages contains products not present in the package

Steps to reproduce:
1. Install Sales and Inventory
2. Go to Settings > Inventory > Operations and enable Packages
3. Create and confirm a sale order with product A, B and C
4. Click on the delivery smart button and create and assign different packages for products A and B
5. Set done quantities for products A and B
6. Validate the delivery with no backorder
7. Click on Print > Delivery Slip
8. Product C is in both packages

Solution:
Don't print empty moves when packages are used

Problem:
`_get_aggregated_product_quantities` returns all move lines related to a certain `stock.picking`, even the empty ones
It is called for each package so the same empty lines will be displayed for all packages

OPW-2727659