### PR TITLE
[FIX] base: do not put mockup class in future registries

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -409,7 +409,7 @@ def render(template_name, values, load, **options):
         _Registry__cache = {}
 
     class MockIrQWeb(IrQWeb):
-        _name = 'ir.qweb.mock'
+        _register = False               # not visible in real registry
 
         pool = MockPool()
 


### PR DESCRIPTION
Followup of #82838 and #82844

By default, every subclass of BaseModel is registered in a mapping for
the automatic discovery of model classes by registries.  Prevent
registration of the mockup class used for rendering the database manager
templates.