### PR TITLE
[FIX] mail: Access error closing chat

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -99,7 +99,7 @@ class Channel(models.Model):
 
     @api.constrains('channel_last_seen_partner_ids', 'channel_partner_ids')
     def _constraint_partners_chat(self):
-        for ch in self.filtered(lambda ch: ch.channel_type == 'chat'):
+        for ch in self.sudo().filtered(lambda ch: ch.channel_type == 'chat'):
             if len(ch.channel_last_seen_partner_ids) > 2 or len(ch.channel_partner_ids) > 2:
                 raise ValidationError(_("A channel of type 'chat' cannot have more than two users."))
 


### PR DESCRIPTION
Current behavior:
After creating a group chat in the discuss app you were not able to close it.

Steps to reproduce:
-Create a group chat with more than one user in the discuss app
- Try to leave it
- You get an access error

opw-2736464

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
