### PR TITLE
[FIX] account: multi-company error bill created by email with alias

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2266,7 +2266,12 @@ class AccountMove(models.Model):
             if is_internal_partner(partners[0]):
                 # Search for partners in the mail's body.
                 body_mail_addresses = set(email_re.findall(msg_dict.get('body')))
-                partners = [partner for partner in self._mail_find_partner_from_emails(body_mail_addresses, extra_domain) if not is_internal_partner(partner)]
+                company_id = custom_values.get('company_id', self.env.company.id)
+                partners = [
+                    partner
+                    for partner in self._mail_find_partner_from_emails(body_mail_addresses, extra_domain)
+                    if not is_internal_partner(partner) and partner.company_id.id in (False, company_id)
+                ]
 
         # Little hack: Inject the mail's subject in the body.
         if msg_dict.get('subject') and msg_dict.get('body'):


### PR DESCRIPTION
Steps to reproduce:
- Set up an alias to receive vendor bills to company 2
- Forward a mail to this alias from an internal user
- The mail should have the email address of a partner belonging to company 1 in it

Current behavior:
- The partner from company 1 can be set as vendor even tho the vendor bill will be from company 2 (inconsistent)
- This leads to a multi-company error, and you can't open the bill as an user who can see it but not the partner.

Intended behavior:
- Partner from company 1 shouldn't be set as vendor if the vendor bill has been created from email alias of company 2.

As the intended behavior says, avoid to set the vendor if the bill is created through an alias.

opw-2587047

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
