### PR TITLE
[MOV] sale_stock: move query counters in an independent module

### DIFF
--- a/addons/sale_stock/tests/__init__.py
+++ b/addons/sale_stock/tests/__init__.py
@@ -11,4 +11,4 @@ from . import test_sale_order_dates
 from . import test_sale_stock_multicompany
 from . import test_sale_stock_accrued_entries
 from . import test_sale_stock_access_rights
-from . import test_create_perf
+# from . import test_create_perf


### PR DESCRIPTION
in enterprise repository, with dependency on all sale modules to 
hopefully improve tests reliability, and in the future add other tests 
covering other parts of the sale flows/process.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
