### PR TITLE
[FIX] sale : Show SO with archived customer (reimplementation)

### DIFF
--- a/addons/sale/views/res_partner_views.xml
+++ b/addons/sale/views/res_partner_views.xml
@@ -4,7 +4,7 @@
             <field name="name">Quotations and Sales</field>
             <field name="res_model">sale.order</field>
             <field name="view_mode">tree,form,graph</field>
-            <field name="context">{'search_default_partner_id': active_id, 'default_partner_id': active_id, 'active_test': False}</field>
+            <field name="context">{'search_default_partner_id': active_id, 'default_partner_id': active_id}</field>
             <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -735,7 +735,7 @@
             <field name="arch" type="xml">
                 <search string="Search Sales Order">
                     <field name="name" string="Order" filter_domain="['|', '|', ('name', 'ilike', self), ('client_order_ref', 'ilike', self), ('partner_id', 'child_of', self)]"/>
-                    <field name="partner_id" operator="child_of"/>
+                    <field name="partner_id" operator="child_of" context="{'active_test': False}"/>
                     <field name="user_id"/>
                     <field name="team_id" string="Sales Team"/>
                     <field name="order_line" string="Product" filter_domain="[('order_line.product_id', 'ilike', self)]"/>


### PR DESCRIPTION
This reverts commit f22364c32ac1438ededd611578b64a69186d7c9c.

- go to a partner
- click on the button "Sale"
- Create a new order
--> Issue you see all product archived (and all the python logique run
    with active_test = False)

note: since the original issue would be reintroduced, this commit apply
the active_test only to the search filter so it will only be applied in
the search unless the filter is removed.

closes #83600