### PR TITLE
[FIX] sale: search order lines by order number not working

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1654,6 +1654,7 @@ class SaleOrderLine(models.Model):
                 args or [],
                 ['|', ('order_id.name', operator, name), ('name', operator, name)]
             ])
+            return self._search(args, limit=limit, access_rights_uid=name_get_uid)
         return super(SaleOrderLine, self)._name_search(name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid)
 
     def _check_line_unlink(self):


### PR DESCRIPTION
When searching sale order lines from another model (e.g. task), the
order number was not being considered.

The technical reason for the above is the resulting domaing was like this:

    [
        '|',
        ('order_id.name', 'ilike', 'SO name'),
        ('name', 'ilike', 'SO name'),
        # The below line is added by _name_search of base model
        ('name', 'ilike', 'SO name'),
    ])

So, even though the order number is added to the domain, an extra
condition was forcing the line description to be the only field to be
considered.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
