### PR TITLE
[IMP] delivery: ease to inherit delivery currency computation

### DIFF
--- a/addons/delivery/models/delivery_grid.py
+++ b/addons/delivery/models/delivery_grid.py
@@ -56,14 +56,27 @@ class ProviderGrid(models.Model):
                     'price': 0.0,
                     'error_message': e.name,
                     'warning_message': False}
-        if order.company_id.currency_id.id != order.pricelist_id.currency_id.id:
-            price_unit = order.company_id.currency_id._convert(
-                price_unit, order.pricelist_id.currency_id, order.company_id, order.date_order or fields.Date.today())
+
+        price_unit = self._compute_currency(order, price_unit, 'company_to_pricelist')
 
         return {'success': True,
                 'price': price_unit,
                 'error_message': False,
                 'warning_message': False}
+
+    def _get_conversion_currencies(self, order, conversion):
+        if conversion == 'company_to_pricelist':
+            from_currency, to_currency = order.company_id.currency_id, order.pricelist_id.currency_id
+        elif conversion == 'pricelist_to_company':
+            from_currency, to_currency = order.currency_id, order.company_id.currency_id
+
+        return from_currency, to_currency
+
+    def _compute_currency(self, order, price, conversion):
+        from_currency, to_currency = self._get_conversion_currencies(order, conversion)
+        if from_currency.id == to_currency.id:
+            return price
+        return from_currency._convert(price, to_currency, order.company_id, order.date_order or fields.Date.today())
 
     def _get_price_available(self, order):
         self.ensure_one()
@@ -84,8 +97,7 @@ class ProviderGrid(models.Model):
             quantity += qty
         total = (order.amount_total or 0.0) - total_delivery
 
-        total = order.currency_id._convert(
-            total, order.company_id.currency_id, order.company_id, order.date_order or fields.Date.today())
+        total = self._compute_currency(order, total, 'pricelist_to_company')
 
         return self._get_price_from_picking(total, weight, volume, quantity)
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Hook up the currency computation which is embedded in essential methods which makes it hard to inherit without rewriting the methods completely which is never a great idea.

**Background**: having a module to define the `delivery.carrier` currency, so calculate based on the carrier currency instead of the company currency in relation to the sale order currency, needed this extraction and as it is uniting the currency conversion, I think it is a good addition to core to create more flexibility here. Actually, this hack is already in use since 11.0, but is still valid in 15.0, so it should be also easy and painless to forward-port which we did in our fork.

Info: @wt-io-it



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
