### PR TITLE
[FIX] website: don't translate exemple of rule

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -456,9 +456,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website.view_edit_robots
 msgid ""
 "<br/><br/>\n"
-"                    Example of rule:<br/>\n"
-"                    <code class=\"ml-4\">Disallow: /web/login</code><br/>\n"
-"                    <code class=\"ml-4\">Allow: *</code>"
+"                    Example of rule:<br/>"
 msgstr ""
 
 #. module: website

--- a/addons/website/wizard/website_robots.xml
+++ b/addons/website/wizard/website_robots.xml
@@ -13,8 +13,8 @@
                     </a>
                     <br/><br/>
                     Example of rule:<br/>
-                    <code class='ml-4'>Disallow: /web/login</code><br/>
-                    <code class='ml-4'>Allow: *</code>
+                    <code t-translation="off" class='ml-4'>Disallow: /web/login</code><br/>
+                    <code t-translation="off" class='ml-4'>Allow: *</code>
                 </small>
                 <footer>
                     <button string="Save" name="action_save" type="object" class="oe_highlight"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Install website and set in French
- in the robot wizard you see:
Exemple de règle :
Refuser : /web/login
Autoriser : *

@nim-odoo



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
