### PR TITLE
[FIX] l10n_ar: forgot to change move_type in fw-port

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -247,7 +247,7 @@ class AccountMove(models.Model):
         sign = -1 if (company_currency and self.is_inbound()) else 1
 
         # if we are on a document that works invoice and refund and it's a refund, we need to export it as negative
-        sign = -sign if self.type in ('out_refund', 'in_refund') and\
+        sign = -sign if self.move_type in ('out_refund', 'in_refund') and\
             self.l10n_latam_document_type_id.code in self._get_l10n_ar_codes_used_for_inv_and_ref() else sign
 
         tax_lines = self.line_ids.filtered('tax_line_id')
@@ -283,7 +283,7 @@ class AccountMove(models.Model):
         sign = -1 if (company_currency and self.is_inbound()) else 1
 
         # if we are on a document that works invoice and refund and it's a refund, we need to export it as negative
-        sign = -sign if self.type in ('out_refund', 'in_refund') and\
+        sign = -sign if self.move_type in ('out_refund', 'in_refund') and\
             self.l10n_latam_document_type_id.code in self._get_l10n_ar_codes_used_for_inv_and_ref() else sign
 
         res = []


### PR DESCRIPTION
bad fw-port:
https://github.com/odoo/odoo/commit/3060e57773aa3081b8e10a2e9fb1e882e17b0932

In v14, type changed to move_type

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
