### PR TITLE
[FIX] l10n_fr_fec: remove duplicated translation

### DIFF
--- a/addons/l10n_fr_fec/i18n/fr.po
+++ b/addons/l10n_fr_fec/i18n/fr.po
@@ -244,11 +244,6 @@ msgid "Invalid VAT number for company %s"
 msgstr "Numéro de TVA invalide sur la société %s"
 
 #. module: l10n_fr_fec
-#: view:account.fr.fec:0
-msgid "Cancel"
-msgstr "Annuler"
-
-#. module: l10n_fr_fec
 #: model:ir.model.fields.selection,name:l10n_fr_fec.selection__account_fr_fec__export_type__official
 msgid "Official FEC report (posted entries only)"
 msgstr "Rapport FEC officiel (uniquement les entrées comptabilisées)"


### PR DESCRIPTION
Remove the duplicated translation for "Cancel" in the .po file introduced in https://github.com/odoo/odoo/commit/51e969c6e04d7a8d699e355dda951b44c53da9dd
It caused an error when installing the FR language for the l10n_fr_fec module. 
