### PR TITLE
[IMP] survey: remove column_nb from the survey_question model 

### DIFF
--- a/addons/survey/__manifest__.py
+++ b/addons/survey/__manifest__.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Surveys',
-    'version': '3.4',
+    'version': '3.5',
     'category': 'Marketing/Surveys',
     'description': """
 Create beautiful surveys and visualize answers

--- a/addons/survey/data/survey_demo_certification.xml
+++ b/addons/survey/data/survey_demo_certification.xml
@@ -57,7 +57,6 @@
             <field name="sequence">3</field>
             <field name="title">Select all the existing products</field>
             <field name="question_type">multiple_choice</field>
-            <field name="column_nb">4</field>
         </record>
         <record model="survey.question.answer" id="vendor_certification_page_1_question_2_choice_1">
             <field name="question_id" ref="vendor_certification_page_1_question_2"/>
@@ -98,7 +97,6 @@
             <field name="sequence">4</field>
             <field name="title">Select all the available customizations for our Customizable Desk</field>
             <field name="question_type">multiple_choice</field>
-            <field name="column_nb">4</field>
         </record>
         <record model="survey.question.answer" id="vendor_certification_page_1_question_3_choice_1">
             <field name="question_id" ref="vendor_certification_page_1_question_3"/>
@@ -226,7 +224,6 @@
             <field name="sequence">9</field>
             <field name="title">Select all the products that sell for $100 or more</field>
             <field name="question_type">multiple_choice</field>
-            <field name="column_nb">2</field>
         </record>
         <record model="survey.question.answer" id="vendor_certification_page_2_question_2_choice_1">
             <field name="question_id" ref="vendor_certification_page_2_question_2"/>

--- a/addons/survey/data/survey_demo_quiz.xml
+++ b/addons/survey/data/survey_demo_quiz.xml
@@ -330,7 +330,6 @@
         <field name="survey_id" ref="survey_demo_quiz"/>
         <field name="sequence">31</field>
         <field name="question_type">simple_choice</field>
-        <field name="column_nb">6</field>
         <field name="constr_mandatory" eval="True"/>
     </record>
     <record id="survey_demo_quiz_p4_q1_sug1" model="survey.question.answer">
@@ -365,7 +364,6 @@
         <field name="survey_id" ref="survey_demo_quiz"/>
         <field name="sequence">32</field>
         <field name="question_type">simple_choice</field>
-        <field name="column_nb">6</field>
         <field name="constr_mandatory" eval="True"/>
     </record>
     <record id="survey_demo_quiz_p4_q2_sug1" model="survey.question.answer">
@@ -400,7 +398,6 @@
         <field name="survey_id" ref="survey_demo_quiz"/>
         <field name="sequence">33</field>
         <field name="question_type">simple_choice</field>
-        <field name="column_nb">6</field>
         <field name="constr_mandatory" eval="True"/>
         <field name="description" type="html">
             <p>
@@ -467,7 +464,6 @@
         <field name="survey_id" ref="survey_demo_quiz"/>
         <field name="sequence">35</field>
         <field name="question_type">multiple_choice</field>
-        <field name="column_nb">6</field>
         <field name="constr_mandatory" eval="True"/>
     </record>
     <record id="survey_demo_quiz_p4_q5_sug1" model="survey.question.answer">
@@ -508,7 +504,6 @@
         <field name="survey_id" ref="survey_demo_quiz"/>
         <field name="sequence">36</field>
         <field name="question_type">simple_choice</field>
-        <field name="column_nb">6</field>
         <field name="description" type="html">
             <div class="text-center">
                 <div class="media_iframe_video" data-oe-expression="//www.youtube.com/embed/7y4T6yv5L1k?autoplay=0&amp;rel=0" style="width: 50%;">

--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -112,10 +112,6 @@ class SurveyQuestion(models.Model):
         'survey.question.answer', 'matrix_question_id', string='Matrix Rows', copy=True,
         help='Labels used for proposed choices: rows of matrix')
     # -- display & timing options
-    column_nb = fields.Selection([
-        ('12', '1'), ('6', '2'), ('4', '3'), ('3', '4'), ('2', '6')],
-        string='Number of columns', default='12',
-        help='These options refer to col-xx-[12|6|4|3|2] classes in Bootstrap for dropdown-based simple and multiple choice questions.')
     is_time_limited = fields.Boolean("The question is limited in time",
         help="Currently only supported for live sessions.")
     time_limit = fields.Integer("Time limit (seconds)")

--- a/addons/survey/tests/test_survey_ui_certification.py
+++ b/addons/survey/tests/test_survey_ui_certification.py
@@ -52,7 +52,6 @@ class TestUiCertification(HttpCaseWithUserDemo):
                     'title': 'Select all the existing products',
                     'sequence': 3,
                     'question_type': 'multiple_choice',
-                    'column_nb': '4',
                     'suggested_answer_ids': [
                         (0, 0, {
                             'value': 'Chair floor protection',
@@ -83,7 +82,6 @@ class TestUiCertification(HttpCaseWithUserDemo):
                     'title': 'Select all the available customizations for our Customizable Desk',
                     'sequence': 4,
                     'question_type': 'multiple_choice',
-                    'column_nb': '4',
                     'suggested_answer_ids': [
                         (0, 0, {
                             'value': 'Color',
@@ -174,7 +172,6 @@ class TestUiCertification(HttpCaseWithUserDemo):
                     'title': 'Select all the products that sell for $100 or more',
                     'sequence': 9,
                     'question_type': 'multiple_choice',
-                    'column_nb': '2',
                     'suggested_answer_ids': [
                         (0, 0, {
                             'value': 'Corner Desk Right Sit',

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -187,11 +187,13 @@
                                         'required': [('validation_required', '=', True)],
                                         'invisible': [('validation_required', '=', False)]}"/>
 
-                                    <field name="column_nb" string="Number of columns" attrs="{'invisible':[('question_type','not in',['simple_choice', 'multiple_choice'])]}"/>
                                     <field name="matrix_subtype" attrs="{'invisible':[('question_type','not in',['matrix'])],'required':[('question_type','=','matrix')]}"/>
                                     <field name="question_placeholder"
                                         attrs="{'invisible': [('question_type', 'not in', ['text_box', 'char_box', 'date', 'datetime', 'numerical_box'])]}"
                                         placeholder="Help Participants know what to write"/>
+                                    <field name='comments_allowed' attrs="{'invisible':[('question_type','not in',['simple_choice','multiple_choice', 'matrix'])]}"/>
+                                    <field name='comments_message'
+                                        attrs="{'invisible': ['|', ('question_type', 'not in', ['simple_choice','multiple_choice', 'matrix']), ('comments_allowed', '=', False)]}"/>
                                 </group>
                                 <group string="Layout">
                                     <field name="is_conditional" attrs="{'invisible': [('questions_selection', '=', 'random')]}"/>
@@ -200,9 +202,6 @@
                                     <field name="triggering_answer_id" options="{'no_open': True, 'no_create': True}"
                                         attrs="{'invisible': ['|', ('is_conditional','=', False), ('triggering_question_id','=', False)],
                                                 'required': [('is_conditional','=', True)]}"/>
-                                    <field name='comments_allowed' attrs="{'invisible':[('question_type','not in',['simple_choice','multiple_choice', 'matrix'])]}"/>
-                                    <field name='comments_message'
-                                        attrs="{'invisible': ['|', ('question_type', 'not in', ['simple_choice','multiple_choice', 'matrix']), ('comments_allowed', '=', False)]}"/>
                                 </group>
                             </group>
                             <group>

--- a/addons/test_website_slides_full/tests/test_ui_wslides.py
+++ b/addons/test_website_slides_full/tests/test_ui_wslides.py
@@ -98,7 +98,6 @@ class TestUi(TestUICommon):
                     'title': 'Select all the furniture shown in the video',
                     'sequence': 3,
                     'question_type': 'multiple_choice',
-                    'column_nb': '4',
                     'suggested_answer_ids': [
                         (0, 0, {
                             'value': 'Chair',

--- a/addons/website_slides_survey/data/survey_demo.xml
+++ b/addons/website_slides_survey/data/survey_demo.xml
@@ -60,7 +60,6 @@
             <field name="sequence">3</field>
             <field name="title">Select all the furniture shown in the video</field>
             <field name="question_type">multiple_choice</field>
-            <field name="column_nb">4</field>
         </record>
         <record model="survey.question.answer" id="furniture_certification_page_1_question_2_choice_1">
             <field name="question_id" ref="furniture_certification_page_1_question_2"/>


### PR DESCRIPTION
Purpose:

The "column choice" is a remainder of a previous implementation in which users
could decide how the survey would look like.

Since the re-design however, this option is no longer working as we prefer
handling this ourselves:
- To make the code simpler
- Because this is not really a "game-changer" feature
- Because we prefer to decide ourselves how the answers will look like to make
sure it always looks nice

As the field is not used anymore and some customers are wondering why it does
not work, we have decided to remove it.

Specifications:

Remove the field column_nb from the survey_question model
In the form, to make sure the "Answers" group is never empty,
we'll move the "Comments" options there instead

Task 2730409