### PR TITLE
[FIX] web: display_name in analytical tag not displayed

### DIFF
--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -130,6 +130,23 @@ var ListController = BasicController.extend({
         });
     },
     /**
+     * Returns the list of currently selected records (with the check boxes on
+     * the left) or the whole domain records if it is selected
+     *
+     * @returns {Promise<{id, display_name}[]>}
+     */
+    getSelectedRecordsWithDomain: async function () {
+        if (this.isDomainSelected) {
+            const state = this.model.get(this.handle, {raw: true});
+            return await this._domainToRecords(state.getDomain(), session.active_ids_limit);
+        } else {
+            return Promise.resolve(this.selectedRecords.map(localId => {
+                const data = this.model.localData[localId].data;
+                return { id: data.id, display_name: data.display_name };
+            }));
+        }
+    },
+    /**
      * Display and bind all buttons in the control panel
      *
      * Note: clicking on the "Save" button does nothing special. Indeed, all
@@ -382,6 +399,25 @@ var ListController = BasicController.extend({
         var self = this;
         return this._super(recordID).then(function () {
             self.updateButtons('readonly');
+        });
+    },
+    /**
+     * Returns the records matching the given domain.
+     *
+     * @private
+     * @param {Array[]} domain
+     * @param {integer} [limit]
+     * @returns {Promise<{id, display_name}[]>}
+     */
+    _domainToRecords: function (domain, limit) {
+        return this._rpc({
+            model: this.modelName,
+            method: 'search_read',
+            args: [domain],
+            kwargs: {
+                fields: ['display_name'],
+                limit: limit,
+            },
         });
     },
     /**

--- a/addons/web/static/src/js/views/view_dialogs.js
+++ b/addons/web/static/src/js/views/view_dialogs.js
@@ -462,8 +462,7 @@ var SelectCreateDialog = ViewDialog.extend({
                 disabled: true,
                 close: true,
                 click: async () => {
-                    const resIds = await this.viewController.getSelectedIdsWithDomain();
-                    const values = resIds.map(e => ({id: e}));
+                    const values = await this.viewController.getSelectedRecordsWithDomain();
                     this.on_selected(values);
                 },
             });

--- a/addons/web/static/tests/views/view_dialogs_tests.js
+++ b/addons/web/static/tests/views/view_dialogs_tests.js
@@ -583,7 +583,7 @@ QUnit.module('Views', {
     });
 
     QUnit.test('SelectCreateDialog calls on_selected with every record matching the domain', async function (assert) {
-        assert.expect(1);
+        assert.expect(3);
 
         const parent = await createParent({
             data: this.data,
@@ -604,13 +604,51 @@ QUnit.module('Views', {
         new dialogs.SelectCreateDialog(parent, {
             res_model: 'partner',
             on_selected: function(records) {
-                assert.equal(records.length, 3)
+                assert.equal(records.length, 3);
+                assert.strictEqual(records.map((r) => r.display_name).toString(), "blipblip,macgyver,Jack O'Neill");
+                assert.strictEqual(records.map((r) => r.id).toString(), "1,2,3");
             }
         }).open();
         await testUtils.nextTick();
 
         await testUtils.dom.click($('thead .o_list_record_selector input'));
         await testUtils.dom.click($('.o_list_selection_box .o_list_select_domain'));
+        await testUtils.dom.click($('.modal .o_select_button'));
+
+        parent.destroy();
+    });
+
+    QUnit.test('SelectCreateDialog calls on_selected with every record matching without selecting a domain', async function (assert) {
+        assert.expect(3);
+
+        const parent = await createParent({
+            data: this.data,
+            archs: {
+                'partner,false,list':
+                    '<tree limit="2" string="Partner">' +
+                        '<field name="display_name"/>' +
+                        '<field name="foo"/>' +
+                    '</tree>',
+                'partner,false,search':
+                    '<search>' +
+                        '<field name="foo"/>' +
+                    '</search>',
+            },
+            session: {},
+        });
+
+        new dialogs.SelectCreateDialog(parent, {
+            res_model: 'partner',
+            on_selected: function(records) {
+                assert.equal(records.length, 2);
+                assert.strictEqual(records.map((r) => r.display_name).toString(), "blipblip,macgyver");
+                assert.strictEqual(records.map((r) => r.id).toString(), "1,2");
+            }
+        }).open();
+        await testUtils.nextTick();
+
+        await testUtils.dom.click($('thead .o_list_record_selector input'));
+        await testUtils.dom.click($('.o_list_selection_box '));
         await testUtils.dom.click($('.modal .o_select_button'));
 
         parent.destroy();


### PR DESCRIPTION
Steps to reproduce:
- Install accounting
- Create more than 6 analytical tags
- Create an invoice
- Create a payment
- Go in Accounting>Actions>Reconciliation, tab Manal Operations
- In the field Analytical Tag, click on 'Search More' and selected 1 or multiple tags

Issue:
Void tags are displayed

Solution:
Fetch the field `display_name`

ref commit: 84f0644802865c6454014059842eb6a9d4fd40e4
Tests in reconciliation model: https://github.com/odoo/enterprise/pull/25247
opw-2734029
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
