### PR TITLE
[IMP] l10n_dk: tax implementation, fix and last fine tuning

### DIFF
--- a/addons/l10n_dk/data/account_tax_template_data.xml
+++ b/addons/l10n_dk/data/account_tax_template_data.xml
@@ -328,7 +328,7 @@
         <field name="sequence">450</field>
         <field name="name">Restaurationsmoms 6,25%, købsmoms</field>
         <field name="description">6,25%</field>
-        <field name="amount">6.25</field>
+        <field name="amount">25</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -337,10 +337,14 @@
                 'repartition_type': 'base',
             }),
             (0,0, {
-                'factor_percent': 100,
+                'factor_percent': 25,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
                 'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
+            }),
+            (0,0, {
+                'factor_percent': 75,
+                'repartition_type': 'tax',
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -349,10 +353,56 @@
                 'repartition_type': 'base',
             }),
             (0,0, {
-                'factor_percent': 100,
+                'factor_percent': 25,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
-                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
+            }),
+            (0,0, {
+                'factor_percent': 75,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+    </record>
+    <record id="tax460" model="account.tax.template">
+        <field name="chart_template_id" ref="dk_chart_template"/>
+        <field name="sequence">450</field>
+        <field name="name">Restaurationsmoms indeholdt 6,25%, købsmoms</field>
+        <field name="description">6,25%</field>
+        <field name="amount">25</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="price_include" eval="True"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 25,
+                'repartition_type': 'tax',
+                'account_id': ref('a8740'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
+            }),
+            (0,0, {
+                'factor_percent': 75,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 25,
+                'repartition_type': 'tax',
+                'account_id': ref('a8740'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
+            }),
+            (0,0, {
+                'factor_percent': 75,
+                'repartition_type': 'tax',
             }),
         ]"/>
     </record>
@@ -553,7 +603,8 @@
         <field name="sequence">710</field>
         <field name="name">Olie- og flaskegasafgift</field>
         <field name="amount">100</field>
-        <field name="amount_type">percent</field>
+        <field name="amount_type">division</field>
+        <field name="price_include" eval="True"/>
         <field name="type_tax_use">purchase</field>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
@@ -567,7 +618,7 @@
                 'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_oil_bottle_tax')],
             }),
             (0,0, {
-                'factor_percent': -92.83,
+                'factor_percent': 7.17,
                 'repartition_type': 'tax',
             }),
         ]"/>
@@ -583,7 +634,7 @@
                 'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_oil_bottle_tax')],
             }),
             (0,0, {
-                'factor_percent': -92.83,
+                'factor_percent': 7.17,
                 'repartition_type': 'tax',
             }),
         ]"/>
@@ -631,7 +682,8 @@
         <field name="sequence">730</field>
         <field name="name">Naturgas- og bygasafgift</field>
         <field name="amount">100</field>
-        <field name="amount_type">percent</field>
+        <field name="amount_type">division</field>
+        <field name="price_include" eval="True"/>
         <field name="type_tax_use">purchase</field>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
@@ -645,7 +697,7 @@
                 'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_gas_tax')],
             }),
             (0,0, {
-                'factor_percent': -92.83,
+                'factor_percent': 7.17,
                 'repartition_type': 'tax',
             }),
         ]"/>
@@ -661,7 +713,7 @@
                 'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_gas_tax')],
             }),
             (0,0, {
-                'factor_percent': -92.83,
+                'factor_percent': 7.17,
                 'repartition_type': 'tax',
             }),
         ]"/>


### PR DESCRIPTION
## The aim of this commit is to:
- correct the implementation of the restaurationMoms
- add a price_include version of restauraionMoms
- make a better implementation of the energy tax

## before this commit:
The implementation of the restaurationMoms is completly false.
The implementation of tax energy is quite complicated and makes
the UI display a "0 tax value".

## after this commit:
2 restaurationMoms version and both are correct.
Tax energy implementation is more user-friendly and more correct
regarding information displayed by the UI.

task: #2748309
PR: #83666