### PR TITLE
[FIX] sale_coupon: last use of promotion program coupon fails

### DIFF
--- a/addons/sale_coupon/models/sale_coupon_program.py
+++ b/addons/sale_coupon/models/sale_coupon_program.py
@@ -237,7 +237,12 @@ class SaleCouponProgram(models.Model):
         return self.filtered(lambda program: program.promo_code_usage == 'code_needed' and program.promo_code != order.promo_code)
 
     def _filter_unexpired_programs(self, order):
-        return self.filtered(lambda program: program.maximum_use_number == 0 or program.order_count < program.maximum_use_number)
+        return self.filtered(
+            lambda program: program.maximum_use_number == 0
+            or program.order_count < program.maximum_use_number
+            or program
+            in (order.code_promo_program_id + order.no_code_promo_program_ids)
+        )
 
     def _filter_programs_on_partners(self, order):
         return self.filtered(lambda program: program._is_valid_partner(order.partner_id))

--- a/addons/sale_coupon/tests/test_program_numbers.py
+++ b/addons/sale_coupon/tests/test_program_numbers.py
@@ -1179,3 +1179,28 @@ class TestSaleCouponProgramNumbers(TestSaleCouponCommon):
         order2.recompute_coupon_lines()
         self.assertEqual(order2.amount_total, 22.5, "10% discount should be applied")
         self.assertEqual(len(order2.order_line.ids), 2, "discount should be applied")
+
+    def test_program_maximum_use_number_last_order(self):
+        # reuse p1 with a different promo code and a maximum_use_number of 1
+        self.p1.promo_code = 'promo1'
+        self.p1.maximum_use_number = 1
+
+        # check that the discount is applied on the first order
+        order = self.empty_order
+        self.env['sale.order.line'].create({
+            'product_id': self.drawerBlack.id,
+            'product_uom_qty': 1.0,
+            'order_id': order.id,
+        })
+        self.env['sale.coupon.apply.code'].sudo().apply_coupon(order, 'promo1')
+        order.recompute_coupon_lines()
+        self.assertEqual(order.amount_total, 22.5, "10% discount should be applied")
+        self.assertEqual(len(order.order_line.ids), 2, "discount should be applied")
+
+        # duplicating to mimic website behavior (each refresh to /shop/cart
+        # recompute coupon lines if website_sale_coupon is installed)
+        order.recompute_coupon_lines()
+        self.assertEqual(order.amount_total, 22.5, "10% discount should be applied")
+        self.assertEqual(len(order.order_line.ids), 2, "discount should be applied")
+        # applying the code again should return that it has been expired.
+        self.assertDictEqual(self.env['sale.coupon.apply.code'].sudo().apply_coupon(order, 'promo1'), {'error': 'Promo code promo1 has been expired.'})


### PR DESCRIPTION
Steps to reproduce:

1- install ecommerce - sales
2- sales > settings > enable coupons/promotion program
3- create a promotion program that applies on the first n orders
4- make orders with the promo code applied until order no. n-1
5- order no. n will fail when you add the promo code without giving an
 error message

Bug:

the currently applied promotion program will not be applied if this is
 the last order allowed in the program

Fix:

include currently applied promotion program if it was the last order
allowed in it

this PR also fixes #83515

OPW-2737423