### PR TITLE
[FIX] account: apply the right currency rate on vendor bill

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3037,7 +3037,7 @@ class AccountMoveLine(models.Model):
             move_type=move_type or self.move_id.type,
             currency=currency or self.currency_id,
             company=company or self.move_id.company_id,
-            date=date or self.move_id.date,
+            date=date or self.move_id.invoice_date,
         )
 
     @api.model


### PR DESCRIPTION
Steps to reproduce:

- With multi-currency activated (USD as principal currency, and EUR for example)
- Create a Vendor Bill in EUR

Issue:

The currency rate is applied according to the accounting date instead
of the bill date.

opw-2692918

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
