### PR TITLE
[FIX] event_booth_sale: add ondelete cascade to sol in registrations

### DIFF
--- a/addons/event_booth_sale/models/event_booth_registration.py
+++ b/addons/event_booth_sale/models/event_booth_registration.py
@@ -11,7 +11,7 @@ class EventBoothRegistration(models.Model):
     _name = 'event.booth.registration'
     _description = 'Event Booth Registration'
 
-    sale_order_line_id = fields.Many2one('sale.order.line', string='Sale Order Line', required=True)
+    sale_order_line_id = fields.Many2one('sale.order.line', string='Sale Order Line', required=True, ondelete='cascade')
     event_booth_id = fields.Many2one('event.booth', string='Booth', required=True)
     partner_id = fields.Many2one(
         'res.partner', related='sale_order_line_id.order_partner_id', store=True)


### PR DESCRIPTION
PURPOSE

Before this commit it's impossible to unlink a sale order line containing
a booth product (the ondelete parameter is unset thus default to restrict)
After this commit this bug is fixed.
Further explanation on the task implying a bug on the database setting
the on delete to cascade despite the default value...

LINKS

Task-2749521



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
