### PR TITLE
[FIX] web_editor, mass_mailing: improve convert_inline performance

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -35,11 +35,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
         if (!this.nodeOptions.snippets) {
             this.nodeOptions.snippets = 'mass_mailing.email_designer_snippets';
         }
-
-        // All the code related to this __extraAssetsForIframe variable is an
-        // ugly hack to restore mass mailing options in stable versions. The
-        // whole logic has to be refactored as soon as possible...
-        this.__extraAssetsForIframe = [{jsLibs: []}];
     },
 
     //--------------------------------------------------------------------------

--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -67,7 +67,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
             self._isDirty = self.wysiwyg.isDirty();
             self._doAction();
 
-            convertInline.toInline($editable, self.wysiwyg.$iframe);
+            convertInline.toInline($editable.get(0), self.wysiwyg.$iframe.get(0));
 
             self.trigger_up('field_changed', {
                 dataPointID: self.dataPointID,

--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -67,7 +67,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
             self._isDirty = self.wysiwyg.isDirty();
             self._doAction();
 
-            convertInline.toInline($editable, self.cssRules, self.wysiwyg.$iframe);
+            convertInline.toInline($editable, self.wysiwyg.$iframe);
 
             self.trigger_up('field_changed', {
                 dataPointID: self.dataPointID,

--- a/addons/mass_mailing/tests/test_mailing_ui.py
+++ b/addons/mass_mailing/tests/test_mailing_ui.py
@@ -20,4 +20,4 @@ class TestUi(HttpCaseWithUserDemo):
         # for email client compatibility should be saved in body_html. This
         # ensures both fields have different values.
         self.assertEqual(mail.body_arch, '<p><br></p>')
-        self.assertEqual(mail.body_html, '<p style="margin:0px 0 14px 0;box-sizing:border-box;"><br style="box-sizing:border-box;"></p>')
+        self.assertEqual(mail.body_html, '<p style="margin:0px 0 14px 0;"><br></p>')

--- a/addons/mass_mailing/views/assets.xml
+++ b/addons/mass_mailing/views/assets.xml
@@ -22,7 +22,7 @@
             * {
                 box-sizing: border-box !important;
             }
-            * h1, h2, h3, h4, h5, h6, p, td, th, div {
+            * {
                 font-family: Arial, sans-serif !important;
             }
             /* Remove space around the email design. */

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -26,7 +26,6 @@ const TABLE_ATTRIBUTES = {
 const TABLE_STYLES = {
     'border-collapse': 'collapse',
     'text-align': 'inherit',
-    'font-size': 'unset',
     'line-height': 'unset',
 };
 
@@ -935,13 +934,6 @@ function _getMatchedCSSRules(node, cssRules) {
             style[key] = value.replace(/\s*!important\s*$/, '');
         }
     };
-
-    if (style.display === 'block' && !(node.classList && node.classList.contains('btn-block'))) {
-        delete style.display;
-    }
-    if (!style['box-sizing']) {
-        style['box-sizing'] = 'border-box'; // This is by default with Bootstrap.
-    }
 
     // The css generates all the attributes separately and not in simplified
     // form. In order to have a better compatibility (outlook for example) we

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -493,6 +493,7 @@ function fontToImg($editable) {
  * @param {JQuery} $editable
  */
 function formatTables($editable) {
+    const writes = [];
     for (const table of $editable.find('table.o_mail_snippet_general, .o_mail_snippet_general table')) {
         const $table = $(table);
         const tablePaddingTop = parseFloat($table.css('padding-top').match(RE_PADDING)[1]);
@@ -509,26 +510,27 @@ function formatTables($editable) {
             if (!rowIndex) {
                 const match = $column.css('padding-top').match(RE_PADDING);
                 const columnPaddingTop = match ? parseFloat(match[1]) : 0;
-                $column.css('padding-top', columnPaddingTop + tablePaddingTop);
+                writes.push(() => { $column.css('padding-top', columnPaddingTop + tablePaddingTop); });
             }
             if (columnIndex === $columnsInRow.length - 1) {
                 const match = $column.css('padding-right').match(RE_PADDING);
                 const columnPaddingRight = match ? parseFloat(match[1]) : 0;
-                $column.css('padding-right', columnPaddingRight + tablePaddingRight);
+                writes.push(() => { $column.css('padding-right', columnPaddingRight + tablePaddingRight); });
             }
             if (rowIndex === $rows.length - 1) {
                 const match = $column.css('padding-bottom').match(RE_PADDING);
                 const columnPaddingBottom = match ? parseFloat(match[1]) : 0;
-                $column.css('padding-bottom', columnPaddingBottom + tablePaddingBottom);
+                writes.push(() => { $column.css('padding-bottom', columnPaddingBottom + tablePaddingBottom); });
             }
             if (!columnIndex) {
                 const match = $column.css('padding-left').match(RE_PADDING);
                 const columnPaddingLeft = match ? parseFloat(match[1]) : 0;
-                $column.css('padding-left', columnPaddingLeft + tablePaddingLeft);
+                writes.push(() => { $column.css('padding-left', columnPaddingLeft + tablePaddingLeft); });
             }
         }
-        $table.css('padding', '');
+        writes.push(() => { $table.css('padding', ''); });
     }
+    writes.forEach((fn) => fn());
     // Ensure a tbody in every table and cancel its default style.
     for (const table of $editable.find('table:not(:has(tbody))')) {
         const $contents = $(table).contents();

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -289,13 +289,14 @@ function cardToTable($editable) {
  * @param {Object} cssRules
  */
 function classToStyle($editable, cssRules) {
+    const writes = [];
     _applyOverDescendants($editable[0], function (node) {
         const $target = $(node);
         const css = _getMatchedCSSRules(node, cssRules);
         // Flexbox
         for (const styleName of node.style) {
             if (styleName.includes('flex') || `${node.style[styleName]}`.includes('flex')) {
-                node.style[styleName] = '';
+                writes.push(() => { node.style[styleName] = ''; });
             }
         }
         // Ignore font-family (mail-safe font declared in <head>)
@@ -313,30 +314,33 @@ function classToStyle($editable, cssRules) {
             }
         };
         if (_.isEmpty(style)) {
-            $target.removeAttr('style');
+            writes.push(() => { $target.removeAttr('style'); });
         } else {
-            $target.attr('style', style);
-        }
-        if ($target.get(0).style.width) {
-            $target.attr('width', $target.css('width')); // Widths need to be applied as attributes as well.
+            writes.push(() => {
+                $target.attr('style', style);
+                if ($target.get(0).style.width) {
+                    $target.attr('width', $target.css('width'));
+                }
+            });
         }
 
         // Media list images should not have an inline height
         if (node.nodeName === 'IMG' && $target.hasClass('s_media_list_img')) {
-            $target.css('height', '');
+            writes.push(() => { $target.css('height', ''); });
         }
         // Apple Mail
         if (node.nodeName === 'TD' && !node.childNodes.length) {
-            $(node).append('&nbsp;');
+            writes.push(() => { $(node).append('&nbsp;'); });
         }
         // Outlook
         if (node.nodeName === 'A' && $target.hasClass('btn') && !$target.hasClass('btn-link') && !$target.children().length) {
-            $target.prepend(`<!--[if mso]><i style="letter-spacing: 25px; mso-font-width: -100%; mso-text-raise: 30pt;">&nbsp;</i><![endif]-->`);
-            $target.append(`<!--[if mso]><i style="letter-spacing: 25px; mso-font-width: -100%;">&nbsp;</i><![endif]-->`);
+            writes.push(() => { $target.prepend(`<!--[if mso]><i style="letter-spacing: 25px; mso-font-width: -100%; mso-text-raise: 30pt;">&nbsp;</i><![endif]-->`); });
+            writes.push(() => { $target.append(`<!--[if mso]><i style="letter-spacing: 25px; mso-font-width: -100%;">&nbsp;</i><![endif]-->`); });
         } else if (node.nodeName === 'IMG' && $target.is('.mx-auto.d-block')) {
-            $target.wrap('<p class="o_outlook_hack" style="text-align:center;margin:0"/>');
+            writes.push(() => { $target.wrap('<p class="o_outlook_hack" style="text-align:center;margin:0"/>'); });
         }
     });
+    writes.forEach(fn => fn());
 }
 /**
  * Convert the contents of an editable area (as a JQuery element) into content

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -495,6 +495,7 @@ function fontToImg(editable) {
             image.style.setProperty('line-height', lineHeight);
             image.style.setProperty('width', intrinsicWidth + 'px');
             image.style.setProperty('height', intrinsicHeight + 'px');
+            image.style.setProperty('display', 'block');
             if (!padding) {
                 image.style.setProperty('margin', _getStylePropertyValue(font, 'margin'));
             }

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -370,19 +370,10 @@ function classToStyle($editable, cssRules) {
  * will be computed for the editable element's owner document.
  *
  * @param {JQuery} $editable
- * @param {Object[]} [cssRules] Array<{selector: string;
- *                                   style: {[styleName]: string};
- *                                   specificity: number;}>
  * @param {JQuery} [$iframe] the iframe containing the editable, if any
  */
-function toInline($editable, cssRules, $iframe) {
-    const doc = $editable[0].ownerDocument;
-    cssRules = cssRules || doc._rulesCache;
-    if (!cssRules) {
-        cssRules = getCSSRules(doc);
-        doc._rulesCache = cssRules;
-    }
-
+function toInline($editable, $iframe) {
+    const cssRules = getCSSRules($editable[0].ownerDocument);
     // If the editable is not visible, we need to make it visible in order to
     // retrieve image/icon dimensions. This iterates over ancestors to make them
     // visible again. We then restore it at the end of this function.
@@ -599,6 +590,8 @@ function formatTables($editable) {
         }
     }
 }
+
+let cssRulesCache;
 /**
  * Parse through the given document's stylesheets, preprocess(*) them and return
  * the result as an array of objects, each containing a selector string , a
@@ -612,7 +605,11 @@ function formatTables($editable) {
  *                            specificity: number;}>
  */
 function getCSSRules(doc) {
-    const cssRules = [];
+    if (cssRulesCache) {
+        return cssRulesCache;
+    }
+    cssRulesCache = [];
+    const cssRules = cssRulesCache;
     for (const sheet of doc.styleSheets) {
         // try...catch because browser may not able to enumerate rules for cross-domain sheets
         let rules;
@@ -747,6 +744,12 @@ function normalizeRem($editable) {
             node.setAttribute('style', node.getAttribute('style').replace(rem, pxValue + 'px'));
         }
     }
+}
+/**
+ * Reset the CSS Rules cache.
+ */
+function resetCssRulesCache() {
+    cssRulesCache = undefined;
 }
 
 //--------------------------------------------------------------------------
@@ -1026,7 +1029,7 @@ FieldHtml.include({
         $odooEditor.removeClass('odoo-editor');
         $editable.html(html);
 
-        toInline($editable, this.cssRules, this.wysiwyg.$iframe);
+        toInline($editable, this.wysiwyg.$iframe);
         $odooEditor.addClass('odoo-editor');
 
         this.wysiwyg.setValue($editable.html(), {
@@ -1047,5 +1050,6 @@ export default {
     listGroupToTable: listGroupToTable,
     normalizeColors: normalizeColors,
     normalizeRem: normalizeRem,
+    resetCssRulesCache: resetCssRulesCache,
     toInline: toInline,
 };

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -257,6 +257,7 @@ function bootstrapToTable(editable) {
 function cardToTable(editable) {
     for (const card of editable.querySelectorAll('.card')) {
         const table = _createTable(card.attributes);
+        table.style.removeProperty('overflow');
         for (const child of [...card.childNodes]) {
             const row = document.createElement('tr');
             const col = document.createElement('td');

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -311,7 +311,7 @@ function classToStyle($editable, cssRules) {
         rules.sort((a, b) => a.specificity - b.specificity);
     }
 
-    _applyOverDescendants($editable[0], function (node) {
+    for (const node of nodeToRules.keys()) {
         const $target = $(node);
         const nodeRules = nodeToRules.get(node);
         const css = nodeRules ? _getMatchedCSSRules(node, nodeRules) : {};
@@ -361,7 +361,7 @@ function classToStyle($editable, cssRules) {
         } else if (node.nodeName === 'IMG' && $target.is('.mx-auto.d-block')) {
             writes.push(() => { $target.wrap('<p class="o_outlook_hack" style="text-align:center;margin:0"/>'); });
         }
-    });
+    };
     writes.forEach(fn => fn());
 }
 /**
@@ -766,32 +766,6 @@ function _applyColspan($element, colspan) {
     const width = (Math.round(+$element.attr('colspan') * 10000 / 12) / 100) + '%';
     $element.attr('width', width);
     $element.css('width', width);
-}
-/*
- * Utility function to apply function over descendants elements
- *
- * This is needed until the following issue of jQuery is solved:
- *  https://github.com./jquery/sizzle/issues/403
- *
- * @param {Element} node The root Element node
- * @param {Function} func The function applied over descendants
- */
-function _applyOverDescendants(node, func) {
-    node = node.firstChild;
-    while (node) {
-        if (node.nodeType === 1) {
-            func(node);
-            _applyOverDescendants(node, func);
-        }
-        var $node = $(node);
-        if (node.nodeName === 'A' && $node.hasClass('btn') && !$node.children().length && $(node).parents('.o_outlook_hack').length)  {
-            node = $(node).parents('.o_outlook_hack')[0];
-        }
-        else if (node.nodeName === 'IMG' && $node.parent('p').hasClass('o_outlook_hack')) {
-            node = $node.parent()[0];
-        }
-        node = node.nextSibling;
-    }
 }
 /**
  * Take a selector and return its specificity according to the w3 specification.

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -9,6 +9,7 @@ import { isBlock, rgbToHex } from '../../../lib/odoo-editor/src/utils/utils';
 //--------------------------------------------------------------------------
 
 const RE_COL_MATCH = /(^| )col(-[\w\d]+)*( |$)/;
+const RE_COMMAS_OUTSIDE_PARENTHESES = /,(?![^(]*?\))/g;
 const RE_OFFSET_MATCH = /(^| )offset(-[\w\d]+)*( |$)/;
 const RE_PADDING = /([\d.]+)/;
 const RE_WHITESPACE = /[\s\u200b]*/;
@@ -289,9 +290,31 @@ function cardToTable($editable) {
  */
 function classToStyle($editable, cssRules) {
     const writes = [];
+    const nodeToRules = new Map();
+    const rulesToProcess = [];
+    for (const rule of cssRules) {
+        const nodes = $editable[0].querySelectorAll(rule.selector);
+        if (nodes.length) {
+            rulesToProcess.push(rule);
+        }
+        for (const node of nodes) {
+            const nodeRules = nodeToRules.get(node);
+            if (!nodeRules) {
+                nodeToRules.set(node, [rule]);
+            } else {
+                nodeRules.push(rule);
+            }
+        }
+    }
+    _computeStyleAndSpecificityOnRules(rulesToProcess);
+    for (const rules of nodeToRules.values()) {
+        rules.sort((a, b) => a.specificity - b.specificity);
+    }
+
     _applyOverDescendants($editable[0], function (node) {
         const $target = $(node);
-        const css = _getMatchedCSSRules(node, cssRules);
+        const nodeRules = nodeToRules.get(node);
+        const css = nodeRules ? _getMatchedCSSRules(node, nodeRules) : {};
         // Flexbox
         for (const styleName of node.style) {
             if (styleName.includes('flex') || `${node.style[styleName]}`.includes('flex')) {
@@ -617,17 +640,15 @@ function getCSSRules(doc) {
             }
             for (const subRule of subRules) {
                 const selectorText = subRule.selectorText || '';
-                for (const selector of selectorText.split(',')) {
+                // Split selectors, making sure not to split at commas in parentheses.
+                for (const selector of selectorText.split(RE_COMMAS_OUTSIDE_PARENTHESES)) {
                     if (selector && !SELECTORS_IGNORE.test(selector)) {
-                        const style = _normalizeStyle(subRule.style);
-                        if (Object.keys(style).length) {
-                            cssRules.push({ selector, style, specificity: _computeSpecificity(selector) });
-                            if (selector === 'body') {
-                                // The top element of a mailing has the class
-                                // 'o_layout'. Give it the body's styles so they can
-                                // trickle down.
-                                cssRules.push({ selector: '.o_layout', style, specificity: 1 });
-                            }
+                        cssRules.push({ selector: selector.trim(), rawRule: subRule });
+                        if (selector === 'body') {
+                            // The top element of a mailing has the class
+                            // 'o_layout'. Give it the body's styles so they can
+                            // trickle down.
+                            cssRules.push({ selector: '.o_layout', rawRule: subRule, specificity: 1 });
                         }
                     }
                 }
@@ -789,6 +810,24 @@ function _computeSpecificity(selector) {
     return (a * 100) + (b * 10) + c;
 }
 /**
+ * Take all the rules and modify them to contain information on their
+ * specificity and to have normalized style.
+ *
+ * @see _computeSpecificity
+ * @see _normalizeStyle
+ * @param {Object} cssRules
+ */
+function _computeStyleAndSpecificityOnRules(cssRules) {
+    for (const cssRule of cssRules) {
+        if (!cssRule.style && cssRule.rawRule.style) {
+            const style = _normalizeStyle(cssRule.rawRule.style);
+            if (Object.keys(style).length) {
+                Object.assign(cssRule,  { style, specificity: _computeSpecificity(cssRule.selector) });
+            }
+        }
+    }
+}
+/**
  * Return an array of twelve table cells as JQuery elements.
  *
  * @returns {JQuery[]}
@@ -860,13 +899,7 @@ function _getColumnSize(column) {
  */
 function _getMatchedCSSRules(node, cssRules) {
     node.matches = node.matches || node.webkitMatchesSelector || node.mozMatchesSelector || node.msMatchesSelector || node.oMatchesSelector;
-    const css = [];
-    cssRules.sort((a, b) => a.specificity - b.specificity);
-    for (const rule of cssRules) {
-        if (node.matches(rule.selector)) {
-            css.push([rule.selector, rule.style, rule.specificity]);
-        }
-    }
+    const styles = cssRules.map((rule) => rule.style).filter(Boolean);
 
     // Add inline styles at the highest specificity.
     if (node.style.length) {
@@ -874,21 +907,21 @@ function _getMatchedCSSRules(node, cssRules) {
         for (const styleName of node.style) {
             inlineStyles[styleName] = node.style[styleName];
         }
-        css.push([node, inlineStyles]);
+        styles.push(inlineStyles);
     }
 
-    const style = {};
-    for (const cssValue of css) {
-        for (const [key, value] of Object.entries(cssValue[1])) {
-            if (!style[key] || !style[key].includes('important') || value.includes('important')) {
-                style[key] = value;
+    const processedStyle = {};
+    for (const style of styles) {
+        for (const [key, value] of Object.entries(style)) {
+            if (!processedStyle[key] || !processedStyle[key].includes('important') || value.includes('important')) {
+                processedStyle[key] = value;
             }
-        };
-    };
+        }
+    }
 
-    for (const [key, value] of Object.entries(style)) {
+    for (const [key, value] of Object.entries(processedStyle)) {
         if (value.endsWith('important')) {
-            style[key] = value.replace(/\s*!important\s*$/, '');
+            processedStyle[key] = value.replace(/\s*!important\s*$/, '');
         }
     };
 
@@ -903,55 +936,55 @@ function _getMatchedCSSRules(node, cssRules) {
     ]) {
         const positions = ['top', 'right', 'bottom', 'left'];
         const positionalKeys = positions.map(position => `${info.name}-${position}${info.suffix || ''}`);
-        const hasStyles = positionalKeys.some(key => style[key]);
-        const inherits = positionalKeys.some(key => ['inherit', 'initial'].includes((style[key] || '').trim()));
+        const hasStyles = positionalKeys.some(key => processedStyle[key]);
+        const inherits = positionalKeys.some(key => ['inherit', 'initial'].includes((processedStyle[key] || '').trim()));
         if (hasStyles && !inherits) {
             const propertyName = `${info.name}${info.suffix || ''}`;
-            style[propertyName] = positionalKeys.every(key => style[positionalKeys[0]] === style[key])
-                ? style[propertyName] = style[positionalKeys[0]] // top = right = bottom = left => property: [top];
-                : positionalKeys.map(key => style[key] || (info.defaultValue || 0)).join(' '); // property: [top] [right] [bottom] [left];
+            processedStyle[propertyName] = positionalKeys.every(key => processedStyle[positionalKeys[0]] === processedStyle[key])
+                ? processedStyle[propertyName] = processedStyle[positionalKeys[0]] // top = right = bottom = left => property: [top];
+                : positionalKeys.map(key => processedStyle[key] || (info.defaultValue || 0)).join(' '); // property: [top] [right] [bottom] [left];
             for (const prop of positionalKeys) {
-                delete style[prop];
+                delete processedStyle[prop];
             }
         }
     };
 
-    if (style['border-bottom-left-radius']) {
-        style['border-radius'] = style['border-bottom-left-radius'];
-        delete style['border-bottom-left-radius'];
-        delete style['border-bottom-right-radius'];
-        delete style['border-top-left-radius'];
-        delete style['border-top-right-radius'];
+    if (processedStyle['border-bottom-left-radius']) {
+        processedStyle['border-radius'] = processedStyle['border-bottom-left-radius'];
+        delete processedStyle['border-bottom-left-radius'];
+        delete processedStyle['border-bottom-right-radius'];
+        delete processedStyle['border-top-left-radius'];
+        delete processedStyle['border-top-right-radius'];
     }
 
     // If the border styling is initial we remove it to simplify the css tags
     // for compatibility. Also, since we do not send a css style tag, the
     // initial value of the border is useless.
-    for (const styleName in style) {
-        if (styleName.includes('border') && style[styleName] === 'initial') {
-            delete style[styleName];
+    for (const styleName in processedStyle) {
+        if (styleName.includes('border') && processedStyle[styleName] === 'initial') {
+            delete processedStyle[styleName];
         }
     };
 
     // text-decoration rule is decomposed in -line, -color and -style. This is
     // however not supported by many browser/mail clients and the editor does
     // not allow to change -color and -style rule anyway
-    if (style['text-decoration-line']) {
-        style['text-decoration'] = style['text-decoration-line'];
-        delete style['text-decoration-line'];
-        delete style['text-decoration-color'];
-        delete style['text-decoration-style'];
-        delete style['text-decoration-thickness'];
+    if (processedStyle['text-decoration-line']) {
+        processedStyle['text-decoration'] = processedStyle['text-decoration-line'];
+        delete processedStyle['text-decoration-line'];
+        delete processedStyle['text-decoration-color'];
+        delete processedStyle['text-decoration-style'];
+        delete processedStyle['text-decoration-thickness'];
     }
 
     // flexboxes are not supported in Windows Outlook
-    for (const styleName in style) {
-        if (styleName.includes('flex') || `${style[styleName]}`.includes('flex')) {
-            delete style[styleName];
+    for (const styleName in processedStyle) {
+        if (styleName.includes('flex') || `${processedStyle[styleName]}`.includes('flex')) {
+            delete processedStyle[styleName];
         }
     }
 
-    return style;
+    return processedStyle;
 }
 /**
  * Take a css style declaration return a "normalized" version of it (as a

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -37,34 +37,37 @@ const TABLE_STYLES = {
 /**
  * Convert snippets and mailing bodies to tables.
  *
- * @param {JQuery} $editable
+ * @param {Element} editable
  */
-function addTables($editable) {
-    for (const snippet of $editable.find('.o_mail_snippet_general, .o_layout')) {
+function addTables(editable) {
+    for (const snippet of editable.querySelectorAll('.o_mail_snippet_general, .o_layout')) {
         // Convert all snippets and the mailing itself into table > tr > td
-        const $table = _createTable(snippet.attributes);
-        const $row = $('<tr/>');
-        const $col = $('<td/>');
-        $row.append($col);
-        $table.append($row);
+        const table = _createTable(snippet.attributes);
+
+        const row = document.createElement('tr');
+        const col = document.createElement('td');
+        row.appendChild(col);
+        table.appendChild(row);
+
         for (const child of [...snippet.childNodes]) {
-            $col.append(child);
+            col.appendChild(child);
         }
-        $(snippet).before($table);
-        $(snippet).remove();
+        snippet.before(table);
+        snippet.remove();
 
         // If snippet doesn't have a table as child, wrap its contents in one.
-        if (!$col.children().filter('table').length) {
-            const $tableB = _createTable();
-            $tableB[0].style.width
-            const $rowB = $('<tr/>');
-            const $colB = $('<td/>');
-            $rowB.append($colB);
-            $tableB.append($rowB);
-            for (const child of [...$col[0].childNodes]) {
-                $colB.append(child);
+        const childTables = [...col.children].filter(child => child.nodeName === 'TABLE');
+        if (!childTables.length) {
+            const tableB = _createTable();
+            const rowB = document.createElement('tr');
+            const colB = document.createElement('td');
+
+            rowB.appendChild(colB);
+            tableB.appendChild(rowB);
+            for (const child of [...col.childNodes]) {
+                colB.appendChild(child);
             }
-            $col.append($tableB);
+            col.appendChild(tableB);
         }
     }
 }
@@ -73,17 +76,20 @@ function addTables($editable) {
  * Without this post process, the display depends on the CSS and the picture
  * does not appear when we use the html without css (to send by email for e.g.)
  *
- * @param {jQuery} $editable
+ * @param {Element} editable
  */
-function attachmentThumbnailToLinkImg($editable) {
-    $editable.find('a[href*="/web/content/"][data-mimetype]').filter(':empty, :containsExact( )').each(function () {
-        var $link = $(this);
-        var $img = $('<img/>')
-            .attr('src', $link.css('background-image').replace(/(^url\(['"])|(['"]\)$)/g, ''))
-            .css('height', Math.max(1, $link.height()) + 'px')
-            .css('width', Math.max(1, $link.width()) + 'px');
-        $link.prepend($img);
-    });
+function attachmentThumbnailToLinkImg(editable) {
+    const links = [...editable.querySelectorAll(`a[href*="/web/content/"][data-mimetype]:empty`)].filter(link => (
+        RE_WHITESPACE.test(link.textContent)
+    ));
+    for (const link of links) {
+        const image = document.createElement('img');
+        image.setAttribute('src', _getStylePropertyValue(link, 'background-image').replace(/(^url\(['"])|(['"]\)$)/g, ''));
+        // Note: will trigger layout thrashing.
+        image.setAttribute('height', Math.max(1, _getHeight(link)) + 'px');
+        image.setAttribute('width', Math.max(1, _getWidth(link)) + 'px');
+        link.prepend(image);
+    };
 }
 /**
  * Convert Bootstrap rows and columns to actual tables.
@@ -92,71 +98,75 @@ function attachmentThumbnailToLinkImg($editable) {
  * support the mixing and matching of column options (e.g., "col-4 col-sm-6" and
  * "col col-4" aren't supported).
  *
- * @param {jQuery} $editable
+ * @param {Element} editable
  */
-function bootstrapToTable($editable) {
+function bootstrapToTable(editable) {
     // First give all rows in columns a separate container parent.
-    $editable.find('.row').filter((i, row) => RE_COL_MATCH.test(row.parentElement.className)).wrap('<div class="o_fake_table"/>');
+    for (const rowInColumn of [...editable.querySelectorAll('.row')].filter(row => RE_COL_MATCH.test(row.parentElement.className))) {
+        _wrap(rowInColumn, 'div', 'o_fake_table');
+    }
 
     // These containers from the mass mailing masonry snippet require full
     // height contents, which is only possible if the table itself has a set
     // height. We also need to restyle it because of the change in structure.
-    $editable.find('.o_masonry_grid_container').css('padding', 0)
-    .find('> .o_fake_table').css('height', function() { return $(this).height() });
-    for (const masonryRow of $editable.find('.o_masonry_grid_container > .o_fake_table > .row.h-100')) {
+    for (const masonryGrid of editable.querySelectorAll('.o_masonry_grid_container')) {
+        masonryGrid.style.setProperty('padding', 0);
+        for (const fakeTable of [...masonryGrid.children].filter(c => c.classList.contains('o_fake_table'))) {
+            fakeTable.style.setProperty('height', _getHeight(fakeTable));
+        }
+    }
+    for (const masonryRow of editable.querySelectorAll('.o_masonry_grid_container > .o_fake_table > .row.h-100')) {
         masonryRow.style.removeProperty('height');
         masonryRow.parentElement.style.setProperty('height', '100%');
     }
 
     // Now convert all containers with rows to tables.
-    for (const container of $editable.find('.container:has(.row), .container-fluid:has(.row), .o_fake_table:has(.row)')) {
-        const $container = $(container);
-
-
+    for (const container of [...editable.querySelectorAll('.container, .container-fluid, .o_fake_table')].filter(n => [...n.children].some(c => c.classList.contains('row')))) {
         // TABLE
-        const $table = _createTable(container.attributes);
+        const table = _createTable(container.attributes);
         for (const child of [...container.childNodes]) {
-            $table.append(child);
+            table.append(child);
         }
-        $table.removeClass('container container-fluid o_fake_table');
-        if (!$table[0].className) {
-            $table.removeAttr('class');
+        table.classList.remove('container', 'container-fluid', 'o_fake_table');
+        if (!table.className) {
+            table.removeAttribute('class');
         }
-        $container.before($table);
-        $container.remove();
+        container.before(table);
+        container.remove();
 
 
         // ROWS
         // First give all siblings of rows a separate row/col parent combo.
-        $table.children().filter((i, child) => isBlock(child) && !$(child).hasClass('row')).wrap('<div class="row"><div class="col-12"/></div>');
+        for (const row of [...table.children].filter(child => isBlock(child) && !child.classList.contains('row'))) {
+            const newCol = _wrap(row, 'div', 'col-12');
+            _wrap(newCol, 'div', 'row');
+        }
 
-        const $bootstrapRows = $table.children().filter('.row');
-        for (const bootstrapRow of $bootstrapRows) {
-            const $bootstrapRow = $(bootstrapRow);
-            const $row = $('<tr/>');
+        for (const bootstrapRow of [...table.children].filter(c => c.classList.contains('row'))) {
+            const tr = document.createElement('tr');
             for (const attr of bootstrapRow.attributes) {
-                $row.attr(attr.name, attr.value);
+                tr.setAttribute(attr.name, attr.value);
             }
-            $row.removeClass('row');
-            if (!$row[0].className) {
-                $row.removeAttr('class');
+            tr.classList.remove('row');
+            if (!tr.className) {
+                tr.removeAttribute('class');
             }
             for (const child of [...bootstrapRow.childNodes]) {
-                $row.append(child);
+                tr.append(child);
             }
-            $bootstrapRow.before($row);
-            $bootstrapRow.remove();
+            bootstrapRow.before(tr);
+            bootstrapRow.remove();
 
 
             // COLUMNS
-            const $bootstrapColumns = $row.children().filter((i, column) => column.className && column.className.match(RE_COL_MATCH));
+            const bootstrapColumns = [...tr.children].filter(column => column.className && column.className.match(RE_COL_MATCH));
 
             // 1. Replace generic "col" classes with specific "col-n", computed
             //    by sharing the available space between them.
-            const $flexColumns = $bootstrapColumns.filter((i, column) => !/\d/.test(column.className.match(RE_COL_MATCH)[0] || '0'));
-            const colTotalSize = $bootstrapColumns.toArray().map(child => _getColumnSize(child)).reduce((a, b) => a + b);
-            const colSize = Math.max(1, Math.round((12 - colTotalSize) / $flexColumns.length));
-            for (const flexColumn of $flexColumns) {
+            const flexColumns = bootstrapColumns.filter(column => !/\d/.test(column.className.match(RE_COL_MATCH)[0] || '0'));
+            const colTotalSize = bootstrapColumns.map(child => _getColumnSize(child)).reduce((a, b) => a + b);
+            const colSize = Math.max(1, Math.round((12 - colTotalSize) / flexColumns.length));
+            for (const flexColumn of flexColumns) {
                 flexColumn.classList.remove(flexColumn.className.match(RE_COL_MATCH)[0].trim());
                 flexColumn.classList.add(`col-${colSize}`);
             }
@@ -164,33 +174,33 @@ function bootstrapToTable($editable) {
             // 2. Create and fill up the row(s) with grid(s).
             let grid = _createColumnGrid();
             let gridIndex = 0;
-            let $currentRow = $($row[0].cloneNode());
-            $row.after($currentRow);
-            let $currentCol;
+            let currentRow = tr.cloneNode();
+            tr.after(currentRow);
+            let currentCol;
             let columnIndex = 0;
-            for (const bootstrapColumn of $bootstrapColumns) {
+            for (const bootstrapColumn of bootstrapColumns) {
                 const columnSize = _getColumnSize(bootstrapColumn);
                 if (gridIndex + columnSize < 12) {
-                    $currentCol = grid[gridIndex];
-                    _applyColspan($currentCol, columnSize);
-                    if (columnIndex === $bootstrapColumns.length - 1) {
+                    currentCol = grid[gridIndex];
+                    _applyColspan(currentCol, columnSize);
+                    if (columnIndex === bootstrapColumns.length - 1) {
                         // We handled all the columns but there is still space
                         // in the row. Insert the columns and fill the row.
-                        grid[gridIndex].attr('colspan', 12 - gridIndex);
-                        $currentRow.append(...grid.filter(td => td.attr('colspan')));
+                        grid[gridIndex].setAttribute('colspan', 12 - gridIndex);
+                        currentRow.append(...grid.filter(td => td.getAttribute('colspan')));
                     }
                     gridIndex += columnSize;
                 } else if (gridIndex + columnSize === 12) {
                     // Finish the row.
-                    $currentCol = grid[gridIndex];
-                    _applyColspan($currentCol, columnSize);
-                    $currentRow.append(...grid.filter(td => td.attr('colspan')));
-                    if (columnIndex !== $bootstrapColumns.length - 1) {
+                    currentCol = grid[gridIndex];
+                    _applyColspan(currentCol, columnSize);
+                    currentRow.append(...grid.filter(td => td.getAttribute('colspan')));
+                    if (columnIndex !== bootstrapColumns.length - 1) {
                         // The row was filled before we handled all of its
                         // columns. Create a new one and start again from there.
-                        const $previousRow = $currentRow;
-                        $currentRow = $($currentRow[0].cloneNode());
-                        $previousRow.after($currentRow);
+                        const previousRow = currentRow;
+                        currentRow = currentRow.cloneNode();
+                        previousRow.after(currentRow);
                         grid = _createColumnGrid();
                         gridIndex = 0;
                     }
@@ -198,102 +208,101 @@ function bootstrapToTable($editable) {
                     // Fill the row with what was in the grid before it
                     // overflowed.
                     _applyColspan(grid[gridIndex], 12 - gridIndex);
-                    $currentRow.append(...grid.filter(td => td.attr('colspan')));
+                    currentRow.append(...grid.filter(td => td.getAttribute('colspan')));
                     // Start a new row that starts with the current col.
-                    const $previousRow = $currentRow;
-                    $currentRow = $($currentRow[0].cloneNode());
-                    $previousRow.after($currentRow);
+                    const previousRow = currentRow;
+                    currentRow = currentRow.cloneNode();
+                    previousRow.after(currentRow);
                     grid = _createColumnGrid();
-                    $currentCol = grid[0];
-                    _applyColspan($currentCol, columnSize);
+                    currentCol = grid[0];
+                    _applyColspan(currentCol, columnSize);
                     gridIndex = columnSize;
-                    if (columnIndex === $bootstrapColumns.length - 1 && gridIndex < 12) {
+                    if (columnIndex === bootstrapColumns.length - 1 && gridIndex < 12) {
                         // We handled all the columns but there is still space
                         // in the row. Insert the columns and fill the row.
-                        grid[gridIndex].attr('colspan', 12 - gridIndex);
-                        $currentRow.append(...grid.filter(td => td.attr('colspan')));
+                        grid[gridIndex].setAttribute('colspan', 12 - gridIndex);
+                        currentRow.append(...grid.filter(td => td.getAttribute('colspan')));
                         // Adapt width to colspan.
                         _applyColspan(grid[gridIndex], 12 - gridIndex);
                     }
                 }
-                if ($currentCol) {
+                if (currentCol) {
                     for (const attr of bootstrapColumn.attributes) {
                         if (attr.name !== 'colspan') {
-                            $currentCol.attr(attr.name, attr.value);
+                            currentCol.setAttribute(attr.name, attr.value);
                         }
                     }
                     const colMatch = bootstrapColumn.className.match(RE_COL_MATCH);
-                    $currentCol.removeClass(colMatch[0]);
-                    if (!$currentCol[0].className) {
-                        $currentCol.removeAttr('class');
+                    currentCol.classList.remove(colMatch[0].trim());
+                    if (!currentCol.className) {
+                        currentCol.removeAttribute('class');
                     }
                     for (const child of [...bootstrapColumn.childNodes]) {
-                        $currentCol.append(child);
+                        currentCol.append(child);
                     }
                     // Adapt width to colspan.
-                    _applyColspan($currentCol, +$currentCol.attr('colspan'));
+                    _applyColspan(currentCol, +currentCol.getAttribute('colspan'));
                 }
                 columnIndex++;
             }
-            $row.remove(); // $row was cloned and inserted already
+            tr.remove(); // row was cloned and inserted already
         }
     }
 }
 /**
  * Convert Bootstrap cards to table structures.
  *
- * @param {JQuery} $editable
+ * @param {Element} editable
  */
-function cardToTable($editable) {
-    for (const card of $editable.find('.card')) {
-        const $card = $(card);
-        const $table = _createTable(card.attributes);
+function cardToTable(editable) {
+    for (const card of editable.querySelectorAll('.card')) {
+        const table = _createTable(card.attributes);
         for (const child of [...card.childNodes]) {
-            const $row = $('<tr/>');
-            const $col = $('<td/>');
+            const row = document.createElement('tr');
+            const col = document.createElement('td');
             if (child.nodeName === 'IMG') {
-                $col.append(child);
+                col.append(child);
             } else if (child.nodeType === Node.TEXT_NODE) {
                 if (child.textContent.replace(RE_WHITESPACE, '').length) {
-                    $col.append(child);
+                    col.append(child);
                 } else {
                     continue;
                 }
             } else {
                 for (const attr of child.attributes) {
-                    $col.attr(attr.name, attr.value);
+                    col.setAttribute(attr.name, attr.value);
                 }
                 for (const descendant of [...child.childNodes]) {
-                    $col.append(descendant);
+                    col.append(descendant);
                 }
-                $(child).remove();
+                child.remove();
             }
-            const $subTable = _createTable();
-            const $superRow = $('<tr/>');
-            const $superCol = $('<td/>');
-            $row.append($col);
-            $subTable.append($row);
-            $superCol.append($subTable);
-            $superRow.append($superCol);
-            $table.append($superRow);
+            const subTable = _createTable();
+            const superRow = document.createElement('tr');
+            const superCol = document.createElement('td');
+            row.append(col);
+            subTable.append(row);
+            superCol.append(subTable);
+            superRow.append(superCol);
+            table.append(superRow);
         }
-        $card.before($table);
-        $card.remove();
+        card.before(table);
+        card.remove();
     }
 }
 /**
  * Convert CSS style to inline style (leave the classes on elements but forces
  * the style they give as inline style).
  *
- * @param {jQuery} $editable
+ * @param {Element} editable
  * @param {Object} cssRules
  */
-function classToStyle($editable, cssRules) {
+function classToStyle(editable, cssRules) {
     const writes = [];
     const nodeToRules = new Map();
     const rulesToProcess = [];
     for (const rule of cssRules) {
-        const nodes = $editable[0].querySelectorAll(rule.selector);
+        const nodes = editable.querySelectorAll(rule.selector);
         if (nodes.length) {
             rulesToProcess.push(rule);
         }
@@ -312,7 +321,6 @@ function classToStyle($editable, cssRules) {
     }
 
     for (const node of nodeToRules.keys()) {
-        const $target = $(node);
         const nodeRules = nodeToRules.get(node);
         const css = nodeRules ? _getMatchedCSSRules(node, nodeRules) : {};
         // Flexbox
@@ -327,7 +335,7 @@ function classToStyle($editable, cssRules) {
         }
 
         // Do not apply css that would override inline styles (which are prioritary).
-        let style = $target.attr('style') || '';
+        let style = node.getAttribute('style') || '';
         // Outlook doesn't support inline !important
         style = style.replace(/!important/g,'');
         for (const [key, value] of Object.entries(css)) {
@@ -336,30 +344,30 @@ function classToStyle($editable, cssRules) {
             }
         };
         if (_.isEmpty(style)) {
-            writes.push(() => { $target.removeAttr('style'); });
+            writes.push(() => { node.removeAttribute('style'); });
         } else {
             writes.push(() => {
-                $target.attr('style', style);
-                if ($target.get(0).style.width) {
-                    $target.attr('width', $target.css('width'));
+                node.setAttribute('style', style);
+                if (node.style.width) {
+                    node.setAttribute('width', node.style.width);
                 }
             });
         }
 
         // Media list images should not have an inline height
-        if (node.nodeName === 'IMG' && $target.hasClass('s_media_list_img')) {
-            writes.push(() => { $target.css('height', ''); });
+        if (node.nodeName === 'IMG' && node.classList.contains('s_media_list_img')) {
+            writes.push(() => { node.style.removeProperty('height'); });
         }
         // Apple Mail
         if (node.nodeName === 'TD' && !node.childNodes.length) {
-            writes.push(() => { $(node).append('&nbsp;'); });
+            writes.push(() => { node.appendChild(document.createTextNode('&nbsp;')); });
         }
         // Outlook
-        if (node.nodeName === 'A' && $target.hasClass('btn') && !$target.hasClass('btn-link') && !$target.children().length) {
-            writes.push(() => { $target.prepend(`<!--[if mso]><i style="letter-spacing: 25px; mso-font-width: -100%; mso-text-raise: 30pt;">&nbsp;</i><![endif]-->`); });
-            writes.push(() => { $target.append(`<!--[if mso]><i style="letter-spacing: 25px; mso-font-width: -100%;">&nbsp;</i><![endif]-->`); });
-        } else if (node.nodeName === 'IMG' && $target.is('.mx-auto.d-block')) {
-            writes.push(() => { $target.wrap('<p class="o_outlook_hack" style="text-align:center;margin:0"/>'); });
+        if (node.nodeName === 'A' && node.classList.contains('btn') && !node.classList.contains('btn-link') && !node.children.length) {
+            writes.push(() => { node.prepend(document.createComment('[if mso]><i style="letter-spacing: 25px; mso-font-width: -100%; mso-text-raise: 30pt;">&nbsp;</i><![endif]')); });
+            writes.push(() => { node.append(document.createComment('[if mso]><i style="letter-spacing: 25px; mso-font-width: -100%;">&nbsp;</i><![endif]')); });
+        } else if (node.nodeName === 'IMG' && node.classList.contains('mx-auto') && node.classList.contains('d-block')) {
+            writes.push(() => { _wrap(node, 'p', 'o_outlook_hack', 'text-align:center;margin:0'); });
         }
     };
     writes.forEach(fn => fn());
@@ -369,69 +377,74 @@ function classToStyle($editable, cssRules) {
  * that is widely compatible with email clients. If no CSS Rules are given, they
  * will be computed for the editable element's owner document.
  *
- * @param {JQuery} $editable
- * @param {JQuery} [$iframe] the iframe containing the editable, if any
+ * @param {Element} editable
+ * @param {Element} [iframe] the iframe containing the editable, if any
  */
-function toInline($editable, $iframe) {
-    const cssRules = getCSSRules($editable[0].ownerDocument);
+function toInline(editable, iframe) {
+    const cssRules = getCSSRules(editable.ownerDocument);
     // If the editable is not visible, we need to make it visible in order to
     // retrieve image/icon dimensions. This iterates over ancestors to make them
     // visible again. We then restore it at the end of this function.
     const displaysToRestore = [];
-    if (!$editable.is(':visible')) {
-        let $ancestor = $editable;
-        while ($ancestor[0] && !$ancestor.is('html') && !$ancestor.is(':visible')) {
-            if ($ancestor.css('display') === 'none') {
-                displaysToRestore.push([$ancestor, $ancestor[0].style.display]);
-                $ancestor.css('display', 'block');
+    if (_isHidden(editable)) {
+        let ancestor = editable;
+        while (ancestor && ancestor.nodeName !== 'html' && _isHidden(ancestor)) {
+            if (_getStylePropertyValue(ancestor, 'display') === 'none') {
+                displaysToRestore.push([ancestor, ancestor.style.display]);
+                ancestor.style.setProperty('display', 'block');
             }
-            $ancestor = $ancestor.parent();
-            if ((!$ancestor[0] || $ancestor.is('html')) && $iframe && $iframe[0]) {
-                $ancestor = $iframe;
+            ancestor = ancestor.parentElement;
+            if ((!ancestor || ancestor.nodeName === 'HTML') && iframe) {
+                ancestor = iframe;
             }
         }
     }
 
     // Fix outlook image rendering bug (this change will be kept in both
     // fields).
-    _.each(['width', 'height'], function (attribute) {
-        $editable.find('img').attr(attribute, function () {
-            return ($(this).attr(attribute)) || (attribute === 'height' && this.offsetHeight) || $(this)[attribute]();
-        }).css(attribute, function () {
-            return $(this).attr(attribute);
-        });
-    });
+    for (const attributeName of ['width', 'height']) {
+        const images = editable.querySelectorAll('img');
+        for (const image of images) {
+            let value = image.getAttribute(attributeName) || (attributeName === 'height' && image.offsetHeight);
+            if (!value) {
+                value = attributeName === 'width' ? _getWidth(image) : _getHeight(image);;
+            }
+            image.setAttribute(attributeName, value);
+            image.style.setProperty(attributeName, image.getAttribute(attributeName));
+        };
+    };
 
-    attachmentThumbnailToLinkImg($editable);
-    fontToImg($editable);
-    classToStyle($editable, cssRules);
-    bootstrapToTable($editable);
-    cardToTable($editable);
-    listGroupToTable($editable);
-    addTables($editable);
-    formatTables($editable);
-    normalizeColors($editable);
-    normalizeRem($editable);
+    attachmentThumbnailToLinkImg(editable);
+    fontToImg(editable);
+    classToStyle(editable, cssRules);
+    bootstrapToTable(editable);
+    cardToTable(editable);
+    listGroupToTable(editable);
+    addTables(editable);
+    formatTables(editable);
+    normalizeColors(editable);
+    const rootFontSizeProperty = getComputedStyle(editable.ownerDocument.documentElement).fontSize;
+    const rootFontSize = parseFloat(rootFontSizeProperty.replace(/[^\d\.]/g, ''));
+    normalizeRem(editable, rootFontSize);
 
-    for (const displayToRestore of displaysToRestore) {
-        $(displayToRestore[0]).css('display', displayToRestore[1]);
+    for (const [node, displayValue] of displaysToRestore) {
+        node.style.setProperty('display', displayValue);
     }
 }
 /**
  * Convert font icons to images.
  *
- * @param {jQuery} $editable - the element in which the font icons have to be
+ * @param {Element} editable - the element in which the font icons have to be
  *                           converted to images
  */
-function fontToImg($editable) {
+function fontToImg(editable) {
     const fonts = odoo.__DEBUG__.services["wysiwyg.fonts"];
 
-    $editable.find('.fa').each(function () {
-        const $font = $(this);
+    for (const font of editable.querySelectorAll('.fa')) {
         let icon, content;
-        _.find(fonts.fontIcons, function (font) {
-            return _.find(fonts.getCssSelectors(font.parser), function (data) {
-                if ($font.is(data.selector.replace(/::?before/g, ''))) {
+        fonts.fontIcons.find(fontIcon => {
+            return fonts.getCssSelectors(fontIcon.parser).find(data => {
+                if (font.matches(data.selector.replace(/::?before/g, ''))) {
                     icon = data.names[0].split('-').shift();
                     content = data.css.match(/content:\s*['"]?(.)['"]?/)[1];
                     return true;
@@ -439,28 +452,30 @@ function fontToImg($editable) {
             });
         });
         if (content) {
-            const color = $font.css('color').replace(/\s/g, '');
-            let $backgroundColoredElement = $font;
+            const color = _getStylePropertyValue(font, 'color').replace(/\s/g, '');
+            let backgroundColoredElement = font;
             let bg, isTransparent;
             do {
-                bg = $backgroundColoredElement.css('background-color').replace(/\s/g, '');
+                bg = _getStylePropertyValue(backgroundColoredElement, 'background-color').replace(/\s/g, '');
                 isTransparent = bg === 'transparent' || bg === 'rgba(0,0,0,0)';
-                $backgroundColoredElement = $backgroundColoredElement.parent();
-            } while (isTransparent && $backgroundColoredElement[0]);
+                backgroundColoredElement = backgroundColoredElement.parentElement;
+            } while (isTransparent && backgroundColoredElement);
             if (bg === 'rgba(0,0,0,0)' && isTransparent) {
                 // default on white rather than black background since opacity
                 // is not supported.
                 bg = 'rgb(255,255,255)';
             }
-            const style = $font.attr('style');
-            const width = $font.width();
-            const height = $font.height();
-            const lineHeight = $font.css('line-height');
+            const style = font.getAttribute('style');
+            const width = _getWidth(font);
+            const height = _getHeight(font);
+            const lineHeight = _getStylePropertyValue(font, 'line-height');
             // Compute the padding.
             // First get the dimensions of the icon itself (::before)
-            $font.css({height: 'fit-content', width: 'fit-content', 'line-height': 'normal'});
-            const intrinsicWidth = $font.width();
-            const intrinsicHeight = $font.height();
+            font.style.setProperty('height', 'fit-content');
+            font.style.setProperty('width', 'fit-content');
+            font.style.setProperty('line-height', 'normal');
+            const intrinsicWidth = _getWidth(font);
+            const intrinsicHeight = _getHeight(font);
             const hPadding = width && (width - intrinsicWidth) / 2;
             const vPadding = height && (height - intrinsicHeight) / 2;
             let padding = '';
@@ -468,90 +483,94 @@ function fontToImg($editable) {
                 padding = vPadding ? vPadding + 'px ' : '0 ';
                 padding += hPadding ? hPadding + 'px' : '0';
             }
-            const $img = $('<img/>').attr({
-                width, height,
-                src: `/web_editor/font_to_img/${content.charCodeAt(0)}/${window.encodeURI(color)}/${window.encodeURI(bg)}/${Math.max(1, Math.round(intrinsicWidth))}x${Math.max(1, Math.round(intrinsicHeight))}`,
-                'data-class': $font.attr('class'),
-                'data-style': style,
-                style,
-            }).css({
-                'box-sizing': 'border-box', // keep the fontawesome's dimensions
-                'line-height': lineHeight,
-                width: intrinsicWidth, height: intrinsicHeight,
-            });
+            const image = document.createElement('img');
+            image.setAttribute('width', width);
+            image.setAttribute('height', height);
+            image.setAttribute('src', `/web_editor/font_to_img/${content.charCodeAt(0)}/${window.encodeURI(color)}/${window.encodeURI(bg)}/${Math.max(1, Math.round(intrinsicWidth))}x${Math.max(1, Math.round(intrinsicHeight))}`);
+            image.setAttribute('data-class', font.getAttribute('class'));
+            image.setAttribute('data-style', style);
+            image.setAttribute('style', style);
+            image.style.setProperty('box-sizing', 'border-box'); // keep the fontawesome's dimensions
+            image.style.setProperty('line-height', lineHeight);
+            image.style.setProperty('width', intrinsicWidth + 'px');
+            image.style.setProperty('height', intrinsicHeight + 'px');
             if (!padding) {
-                $img.css('margin', $font.css('margin'));
+                image.style.setProperty('margin', _getStylePropertyValue(font, 'margin'));
             }
             // For rounded images, apply the rounded border to a wrapper, make
             // sure it doesn't get applied to the image itself so the image
             // doesn't get cropped in the process.
-            const $wrapper = $('<span style="display: inline-block;"/>');
-            $wrapper.append($img);
-            $font.replaceWith($wrapper);
-            $wrapper.css({
-                padding, width: width + 'px', height: height + 'px',
-                'vertical-align': 'middle',
-                'background-color': $img[0].style.backgroundColor,
-            }).attr('class', $font.attr('class').replace(new RegExp('(^|\\s+)' + icon + '(-[^\\s]+)?', 'gi'), '')) // remove inline font-awsome style);
+            const wrapper = document.createElement('span');
+            wrapper.style.setProperty('display', 'inline-block');
+            wrapper.append(image);
+            font.before(wrapper);
+            font.remove();
+            wrapper.style.setProperty('padding', padding);
+            wrapper.style.setProperty('width', width + 'px');
+            wrapper.style.setProperty('height', height + 'px');
+            wrapper.style.setProperty('vertical-align', 'middle');
+            wrapper.style.setProperty('background-color', image.style.backgroundColor);
+            wrapper.setAttribute('class', font.getAttribute('class').replace(new RegExp('(^|\\s+)' + icon + '(-[^\\s]+)?', 'gi'), '')); // remove inline font-awsome style);
         } else {
-            $font.remove();
+            font.remove();
         }
-    });
+    }
 }
 /**
  * Format table styles so they display well in most mail clients. This implies
  * moving table paddings to its cells, adding tbody (with canceled styles) where
  * needed, and adding pixel heights to parents of elements with percent heights.
  *
- * @param {JQuery} $editable
+ * @param {Element} editable
  */
-function formatTables($editable) {
+function formatTables(editable) {
     const writes = [];
-    for (const table of $editable.find('table.o_mail_snippet_general, .o_mail_snippet_general table')) {
-        const $table = $(table);
-        const tablePaddingTop = parseFloat($table.css('padding-top').match(RE_PADDING)[1]);
-        const tablePaddingRight = parseFloat($table.css('padding-right').match(RE_PADDING)[1]);
-        const tablePaddingBottom = parseFloat($table.css('padding-bottom').match(RE_PADDING)[1]);
-        const tablePaddingLeft = parseFloat($table.css('padding-left').match(RE_PADDING)[1]);
-        const $rows = $table.find('tr').filter((i, tr) => $(tr).closest('table').is($table));
-        const $columns = $table.find('td').filter((i, td) => $(td).closest('table').is($table));
-        for (const column of $columns) {
-            const $column = $(column);
-            const $columnsInRow = $column.closest('tr').find('td').filter((i, td) => $(td).closest('table').is($table));
-            const columnIndex = $columnsInRow.toArray().findIndex(col => $(col).is($column));
-            const rowIndex = $rows.toArray().findIndex(row => $(row).is($column.closest('tr')));
+    for (const table of editable.querySelectorAll('table.o_mail_snippet_general, .o_mail_snippet_general table')) {
+        const tablePaddingTop = parseFloat(_getStylePropertyValue(table, 'padding-top').match(RE_PADDING)[1]);
+        const tablePaddingRight = parseFloat(_getStylePropertyValue(table, 'padding-right').match(RE_PADDING)[1]);
+        const tablePaddingBottom = parseFloat(_getStylePropertyValue(table, 'padding-bottom').match(RE_PADDING)[1]);
+        const tablePaddingLeft = parseFloat(_getStylePropertyValue(table, 'padding-left').match(RE_PADDING)[1]);
+        const rows = [...table.querySelectorAll('tr')].filter(tr => tr.closest('table') === table);
+        const columns = [...table.querySelectorAll('td')].filter(td => td.closest('table') === table);
+        for (const column of columns) {
+            const columnsInRow = [...column.closest('tr').querySelectorAll('td')].filter(td => td.closest('table') === table);
+            const columnIndex = columnsInRow.findIndex(col => col === column);
+            const rowIndex = rows.findIndex(row => row === column.closest('tr'));
+
             if (!rowIndex) {
-                const match = $column.css('padding-top').match(RE_PADDING);
+                const match = _getStylePropertyValue(column, 'padding-top').match(RE_PADDING);
                 const columnPaddingTop = match ? parseFloat(match[1]) : 0;
-                writes.push(() => { $column.css('padding-top', columnPaddingTop + tablePaddingTop); });
+                writes.push(() => {column.style['padding-top'] = `${columnPaddingTop + tablePaddingTop}px`; });
             }
-            if (columnIndex === $columnsInRow.length - 1) {
-                const match = $column.css('padding-right').match(RE_PADDING);
+            if (columnIndex === columnsInRow.length - 1) {
+                const match = _getStylePropertyValue(column, 'padding-right').match(RE_PADDING);
                 const columnPaddingRight = match ? parseFloat(match[1]) : 0;
-                writes.push(() => { $column.css('padding-right', columnPaddingRight + tablePaddingRight); });
+                writes.push(() => {column.style['padding-right'] = `${columnPaddingRight + tablePaddingRight}px`; });
             }
-            if (rowIndex === $rows.length - 1) {
-                const match = $column.css('padding-bottom').match(RE_PADDING);
+            if (rowIndex === rows.length - 1) {
+                const match = _getStylePropertyValue(column, 'padding-bottom').match(RE_PADDING);
                 const columnPaddingBottom = match ? parseFloat(match[1]) : 0;
-                writes.push(() => { $column.css('padding-bottom', columnPaddingBottom + tablePaddingBottom); });
+                writes.push(() => {column.style['padding-bottom'] = `${columnPaddingBottom + tablePaddingBottom}px`; });
             }
             if (!columnIndex) {
-                const match = $column.css('padding-left').match(RE_PADDING);
+                const match = _getStylePropertyValue(column, 'padding-left').match(RE_PADDING);
                 const columnPaddingLeft = match ? parseFloat(match[1]) : 0;
-                writes.push(() => { $column.css('padding-left', columnPaddingLeft + tablePaddingLeft); });
+                writes.push(() => {column.style['padding-left'] = `${columnPaddingLeft + tablePaddingLeft}px`; });
             }
         }
-        writes.push(() => { $table.css('padding', ''); });
+        writes.push(() => { table.style.removeProperty('padding'); });
     }
     writes.forEach((fn) => fn());
     // Ensure a tbody in every table and cancel its default style.
-    for (const table of $editable.find('table:not(:has(tbody))')) {
-        const $contents = $(table).contents();
-        $(table).prepend('<tbody style="vertical-align: top;"/>');
-        $(table.firstChild).append($contents);
+    for (const table of [...editable.querySelectorAll('table')].filter(n => ![...n.children].some(c => c.nodeName === 'TBODY'))) {
+        const contents = [...table.childNodes];
+        const tbody = document.createElement('tbody');
+        tbody.style.setProperty('vertical-align', 'top');
+        table.prepend(tbody);
+        tbody.append(...contents);
     }
     // Children will only take 100% height if the parent has a height property.
-    for (const node of $editable.find('*').filter((i, n) => (
+    for (const node of [...editable.querySelectorAll('*')].filter(n => (
         n.style && n.style.getPropertyValue('height') === '100%' && (
             !n.parentElement.style.getPropertyValue('height') ||
             n.parentElement.style.getPropertyValue('height').includes('%'))
@@ -567,7 +586,7 @@ function formatTables($editable) {
         }
     }
     // Align self and justify content don't work on table cells.
-    for (const cell of $editable.find('td')) {
+    for (const cell of editable.querySelectorAll('td')) {
         const alignSelf = cell.style.alignSelf;
         const justifyContent = cell.style.justifyContent;
         if (alignSelf === 'start' || justifyContent === 'start' || justifyContent === 'flex-start') {
@@ -579,7 +598,7 @@ function formatTables($editable) {
         }
     }
     // Align items doesn't work on table rows.
-    for (const cell of $editable.find('tr')) {
+    for (const cell of editable.querySelectorAll('tr')) {
         const alignItems = cell.style.alignItems;
         if (alignItems === 'flex-start') {
             cell.style.verticalAlign = 'top';
@@ -658,59 +677,55 @@ function getCSSRules(doc) {
 /**
  * Convert Bootstrap list groups and their items to table structures.
  *
- * @param {JQuery} $editable
+ * @param {Element} editable
  */
-function listGroupToTable($editable) {
-    for (const listGroup of $editable.find('.list-group')) {
-        const $listGroup = $(listGroup);
-        let $table;
-        if ($listGroup.find('.list-group-item').length) {
-            $table = _createTable(listGroup.attributes);
+function listGroupToTable(editable) {
+    for (const listGroup of editable.querySelectorAll('.list-group')) {
+        let table;
+        if (listGroup.querySelectorAll('.list-group-item').length) {
+            table = _createTable(listGroup.attributes);
         } else {
-            $table = $(listGroup.cloneNode());
-            for (const attr of $listGroup.attributes) {
-                $table.attr(attr.name, attr.value);
+            table = listGroup.cloneNode();
+            for (const attr of listGroup.attributes) {
+                table.setAttribute(attr.name, attr.value);
             }
         }
         for (const child of [...listGroup.childNodes]) {
-            const $child = $(child);
-            if ($child.hasClass('list-group-item')) {
+            if (child.classList && child.classList.contains('list-group-item')) {
                 // List groups are <ul>s that render like tables. Their
                 // li.list-group-item children should translate to tr > td.
-                const $row = $('<tr/>');
-                const $col = $('<td/>');
+                const row = document.createElement('tr');
+                const col = document.createElement('td');
                 for (const attr of child.attributes) {
-                    $col.attr(attr.name, attr.value);
+                    col.setAttribute(attr.name, attr.value);
                 }
-                for (const descendant of [...child.childNodes]) {
-                    $col.append(descendant);
+                col.append(...child.childNodes);
+                col.classList.remove('list-group-item');
+                if (!col.className) {
+                    col.removeAttribute('class');
                 }
-                $col.removeClass('list-group-item');
-                if (!$col[0].className) {
-                    $col.removeAttr('class');
-                }
-                $row.append($col);
-                $table.append($row);
-                $(child).remove();
+                row.append(col);
+                table.append(row);
+                child.remove();
             } else if (child.nodeName === 'LI') {
-                $table.append(...child.childNodes);
+                table.append(...child.childNodes);
             } else {
-                $table.append(child);
+                table.append(child);
             }
         }
-        $table.removeClass('list-group');
-        if (!$table[0].className) {
-            $table.removeAttr('class');
+        table.classList.remove('list-group');
+        if (!table.className) {
+            table.removeAttribute('class');
         }
-        if ($listGroup.is('td')) {
-            $listGroup.append($table);
-            $listGroup.removeClass('list-group');
-            if (!$listGroup[0].className) {
-                $listGroup.removeAttr('class');
+        if (listGroup.nodeName === 'TD') {
+            listGroup.append(table);
+            listGroup.classList.remove('list-group');
+            if (!listGroup.className) {
+                listGroup.removeAttribute('class');
             }
         } else {
-            $listGroup.before($table);
-            $listGroup.remove();
+            listGroup.before(table);
+            listGroup.remove();
         }
     }
 }
@@ -718,10 +733,10 @@ function listGroupToTable($editable) {
  * Convert all styles containing rgb colors to hexadecimal colors.
  * Note: ignores rgba colors, which are not supported in Microsoft Outlook.
  *
- * @param {JQuery} $editable
+ * @param {Element} editable
  */
-function normalizeColors($editable) {
-    for (const node of $editable.find('[style*="rgb"]')) {
+function normalizeColors(editable) {
+    for (const node of editable.querySelectorAll('[style*="rgb"]')) {
         const rgbMatch = node.getAttribute('style').match(/rgb?\(([\d\.]*,?\s?){3,4}\)/g);
         for (const rgb of rgbMatch || []) {
             node.setAttribute('style', node.getAttribute('style').replace(rgb, rgbToHex(rgb)));
@@ -731,12 +746,11 @@ function normalizeColors($editable) {
 /**
  * Convert all css values that use the rem unit to px.
  *
- * @param {JQuery} $editable
+ * @param {Element} editable
+ * @param {Number} rootFontSize=16 The font size of the root element, in pixels
  */
-function normalizeRem($editable) {
-    const rootFontSizeProperty = $editable.closest('html').css('font-size');
-    const rootFontSize = parseFloat(rootFontSizeProperty.replace(/[^\d\.]/g, ''));
-    for (const node of $editable.find('[style*="rem"]')) {
+function normalizeRem(editable, rootFontSize=16) {
+    for (const node of editable.querySelectorAll('[style*="rem"]')) {
         const remMatch = node.getAttribute('style').match(/[\d\.]+\s*rem/g);
         for (const rem of remMatch || []) {
             const remValue = parseFloat(rem.replace(/[^\d\.]/g, ''));
@@ -757,18 +771,18 @@ function resetCssRulesCache() {
 //--------------------------------------------------------------------------
 
 /**
- * Take a JQuery element and apply a colspan to it. In this context, this
- * implies to also apply a width to it, that corresponds to the colspan.
+ * Take an element and apply a colspan to it. In this context, this implies to
+ * also apply a width to it, that corresponds to the colspan.
  *
- * @param {JQuery} $element
+ * @param {Element} element
  * @param {number} colspan
  */
-function _applyColspan($element, colspan) {
-    $element.attr('colspan', colspan);
+function _applyColspan(element, colspan) {
+    element.setAttribute('colspan', colspan);
     // Round to 2 decimal places.
-    const width = (Math.round(+$element.attr('colspan') * 10000 / 12) / 100) + '%';
-    $element.attr('width', width);
-    $element.css('width', width);
+    const width = (Math.round(+element.getAttribute('colspan') * 10000 / 12) / 100) + '%';
+    element.setAttribute('width', width);
+    element.style.setProperty('width', width);
 }
 /**
  * Take a selector and return its specificity according to the w3 specification.
@@ -807,44 +821,45 @@ function _computeStyleAndSpecificityOnRules(cssRules) {
 /**
  * Return an array of twelve table cells as JQuery elements.
  *
- * @returns {JQuery[]}
+ * @returns {Element[]}
  */
 function _createColumnGrid() {
-    return new Array(12).fill().map(() => $('<td/>'));
+    return new Array(12).fill().map(() => document.createElement('td'));
 }
 /**
- * Return a table as a JQuery element, with its default styles and attributes,
- * as well as the applicable given attributes, if any.
+ * Return a table element, with its default styles and attributes, as well as
+ * the applicable given attributes, if any.
  *
  * @see TABLE_ATTRIBUTES
  * @see TABLE_STYLES
  * @param {NamedNodeMap | Attr[]} [attributes] default: []
- * @returns {JQuery}
+ * @returns {Element}
  */
 function _createTable(attributes = []) {
-    const $table = $('<table/>');
-    $table.attr(TABLE_ATTRIBUTES);
-    $table[0].style.setProperty('width', '100%', 'important');
+    const table = document.createElement('table');
+    Object.entries(TABLE_ATTRIBUTES).forEach(([att, value]) => table.setAttribute(att, value));
+    // $table.attr(TABLE_ATTRIBUTES);
+    table.style.setProperty('width', '100%', 'important');
     for (const attr of attributes) {
         if (!(attr.name === 'width' && attr.value === '100%')) {
-            $table.attr(attr.name, attr.value);
+            table.setAttribute(attr.name, attr.value);
         }
     }
-    if ($table.hasClass('o_layout')) {
+    if (table.classList.contains('o_layout')) {
         // The top mailing element inherits the body's font size and line-height
         // and should keep them.
         const layoutStyles = {...TABLE_STYLES};
         delete layoutStyles['font-size'];
         delete layoutStyles['line-height'];
-        $table.css(layoutStyles);
+        Object.entries(layoutStyles).forEach(([att, value]) => table.style[att] = value)
     } else {
         for (const styleName in TABLE_STYLES) {
             if (!('style' in attributes && attributes.style.value.includes(styleName + ':'))) {
-                $table.css(styleName, TABLE_STYLES[styleName]);
+                table.style[styleName] = TABLE_STYLES[styleName];
             }
         }
     }
-    return $table;
+    return table;
 }
 /**
  * Take a Bootstrap grid column element and return its size, computed by using
@@ -963,6 +978,51 @@ function _getMatchedCSSRules(node, cssRules) {
 
     return processedStyle;
 }
+let lastComputedStyleElement;
+let lastComputedStyle
+/**
+ * Return the value of the given style property on the given element. This
+ * caches the last computed style so if it's called several times in a row for
+ * the same element, we don't recompute it every time.
+ *
+ * @param {Element} element
+ * @param {string} propertyName
+ * @returns
+ */
+function _getStylePropertyValue(element, propertyName) {
+    const computedStyle = lastComputedStyleElement === element ? lastComputedStyle : getComputedStyle(element)
+    lastComputedStyleElement = element;
+    lastComputedStyle = computedStyle;
+    return computedStyle[propertyName] || element.style.getPropertyValue(propertyName);
+}
+/**
+ * Equivalent to JQuery's `width` method. Returns the element's visible width.
+ *
+ * @param {Element} element
+ * @returns {Number}
+ */
+function _getWidth(element) {
+    return parseFloat(getComputedStyle(element).width.replace('px', ''));
+}
+/**
+ * Equivalent to JQuery's `height` method. Returns the element's visible height.
+ *
+ * @param {Element} element
+ * @returns {Number}
+ */
+function _getHeight(element) {
+    return parseFloat(getComputedStyle(element).height.replace('px', ''));
+}
+/**
+ * Return true if the given element is hidden.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
+ * @param {Element} element
+ * @returns {boolean}
+ */
+function _isHidden(element) {
+    return element.offsetParent === null;
+}
 /**
  * Take a css style declaration return a "normalized" version of it (as a
  * standard object) for the purposes of emails. This means removing its styles
@@ -987,6 +1047,23 @@ function _normalizeStyle(style) {
         }
     }
     return normalizedStyle;
+}
+/**
+ * Wrap a given element into a new parent, in place.
+ *
+ * @param {Element} element
+ * @param {string} wrapperTag
+ * @param {string} [wrapperClass] optional class to apply to the wrapper
+ * @param {string} [wrapperStyle] optional style to apply to the wrapper
+ * @returns {Element} the wrapper
+ */
+ function _wrap(element, wrapperTag, wrapperClass, wrapperStyle) {
+    const wrapper = document.createElement(wrapperTag);
+    wrapper.className = wrapperClass;
+    wrapper.style.cssText = wrapperStyle;
+    element.parentElement.insertBefore(wrapper, element);
+    wrapper.append(element);
+    return wrapper;
 }
 
 //--------------------------------------------------------------------------
@@ -1029,7 +1106,7 @@ FieldHtml.include({
         $odooEditor.removeClass('odoo-editor');
         $editable.html(html);
 
-        toInline($editable, this.wysiwyg.$iframe);
+        toInline($editable.get(0), this.wysiwyg.$iframe && this.wysiwyg.$iframe.get(0));
         $odooEditor.addClass('odoo-editor');
 
         this.wysiwyg.setValue($editable.html(), {

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -169,7 +169,6 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
      */
     _createWysiwygIntance: async function () {
         this.wysiwyg = await wysiwygLoader.createWysiwyg(this, this._getWysiwygOptions());
-        this.wysiwyg.__extraAssetsForIframe = this.__extraAssetsForIframe || [];
         return this.wysiwyg.appendTo(this.$el).then(() => {
             this.$content = this.wysiwyg.$editable;
             this._onLoadWysiwyg();

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
@@ -26,7 +26,6 @@ Wysiwyg.include({
         if (this.options.inIframe) {
             this._onUpdateIframeId = 'onLoad_' + this.id;
         }
-        this.__extraAssetsForIframe = [];
     },
     /**
      * Load assets to inject into iframe.
@@ -151,7 +150,7 @@ Wysiwyg.include({
                 }
 
                 var iframeContent = qweb.render('wysiwyg.iframeContent', {
-                    assets: assets.concat(self.__extraAssetsForIframe),
+                    assets: assets,
                     updateIframeId: self._onUpdateIframeId,
                     avoidDoubleLoad: _avoidDoubleLoad
                 });

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -584,12 +584,14 @@ QUnit.module('convert_inline', {}, function () {
                 border-top-left-radius: 40%;
             }
         `, 0);
+        convertInline.resetCssRulesCache();
         let $editable = $(`<div>${`<div class="test-border-radius"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border-radius" style="border-radius:30%;"></div>`,
             "should have converted border-[position]-radius styles (from class) to border-radius");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         // convert all positional styles to a style in the form `property: a b c d`
 
@@ -606,6 +608,7 @@ QUnit.module('convert_inline', {}, function () {
             `<div class="test-border" style="border-style:dotted dashed none solid;"></div>`,
             "should have converted border-[position]-style styles (from class) to border-style");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         styleSheet.insertRule(`
             .test-margin {
@@ -620,6 +623,7 @@ QUnit.module('convert_inline', {}, function () {
             `<div class="test-margin" style="margin:0 20px 30px 40px;"></div>`,
             "should have converted margin-[position] styles (from class) to margin");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         styleSheet.insertRule(`
             .test-padding {
@@ -634,6 +638,7 @@ QUnit.module('convert_inline', {}, function () {
             `<div class="test-padding" style="padding:10px 0 30px 40px;"></div>`,
             "should have converted padding-[position] styles (from class) to padding");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         // convert all positional styles to a style in the form `property: a`
 
@@ -651,6 +656,7 @@ QUnit.module('convert_inline', {}, function () {
             `<div class="test-border-uniform" style="border-style:dotted;"></div>`,
             "should have converted uniform border-[position]-style styles (from class) to border-style");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         styleSheet.insertRule(`
             .test-margin-uniform {
@@ -666,6 +672,7 @@ QUnit.module('convert_inline', {}, function () {
             `<div class="test-margin-uniform" style="margin:10px;"></div>`,
             "should have converted uniform margin-[position] styles (from class) to margin");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         styleSheet.insertRule(`
             .test-padding-uniform {
@@ -681,6 +688,7 @@ QUnit.module('convert_inline', {}, function () {
             `<div class="test-padding-uniform" style="padding:10px;"></div>`,
             "should have converted uniform padding-[position] styles (from class) to padding");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         // do not convert positional styles that include an "inherit" value
 
@@ -698,6 +706,7 @@ QUnit.module('convert_inline', {}, function () {
             `<div class="test-border-inherit" style="border-left-style:solid;border-bottom-style:inherit;border-right-style:dashed;border-top-style:dotted;"></div>`,
             "should not have converted border-[position]-style styles (from class) to border-style as they include an inherit");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         styleSheet.insertRule(`
             .test-margin-inherit {
@@ -713,6 +722,7 @@ QUnit.module('convert_inline', {}, function () {
             `<div class="test-margin-inherit" style="margin-left:40px;margin-bottom:30px;margin-right:inherit;margin-top:10px;"></div>`,
             "should not have converted margin-[position] styles (from class) to margin as they include an inherit");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         styleSheet.insertRule(`
             .test-padding-inherit {
@@ -728,6 +738,7 @@ QUnit.module('convert_inline', {}, function () {
             `<div class="test-padding-inherit" style="padding-left:40px;padding-bottom:inherit;padding-right:20px;padding-top:10px;"></div>`,
             "should have converted padding-[position] styles (from class) to padding as they include an inherit");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         // do not convert positional styles that include an "initial" value
 
@@ -747,6 +758,7 @@ QUnit.module('convert_inline', {}, function () {
             `<div class="test-margin-initial" style="margin-left:40px;margin-bottom:30px;margin-right:20px;margin-top:initial;"></div>`,
             "should not have converted margin-[position] styles (from class) to margin as they include an initial");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         styleSheet.insertRule(`
             .test-padding-initial {
@@ -762,6 +774,7 @@ QUnit.module('convert_inline', {}, function () {
             `<div class="test-padding-initial" style="padding-left:initial;padding-bottom:30px;padding-right:20px;padding-top:10px;"></div>`,
             "should not have converted padding-[position] styles (from class) to padding as they include an initial");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         $styleSheet.remove();
     });
@@ -781,12 +794,14 @@ QUnit.module('convert_inline', {}, function () {
                 text-decoration-thickness: 10px;
             }
         `, 0);
+        convertInline.resetCssRulesCache();
         let $editable = $(`<div>${`<div class="test-decoration"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-decoration" style="text-decoration:underline;"></div>`,
             "should have removed all text-decoration-[prop] styles (from class) and kept a simple text-decoration");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         // border[\w-]*: initial
         styleSheet.insertRule(`
@@ -803,6 +818,7 @@ QUnit.module('convert_inline', {}, function () {
             `<div class="test-border-initial" style="border-bottom-style:double;border-right-style:dashed;border-top-style:dotted;"></div>`,
             "should have removed border initial");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         // !important
         styleSheet.insertRule(`
@@ -820,6 +836,7 @@ QUnit.module('convert_inline', {}, function () {
                 color: red !important;
             }
         `, 0);
+        convertInline.resetCssRulesCache();
         $editable = $(`<div>${`<div class="test-important-color test-unimportant-color"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
@@ -827,6 +844,7 @@ QUnit.module('convert_inline', {}, function () {
             "should have converted an important color and removed the !important");
         styleSheet.deleteRule(0);
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         // animation
         styleSheet.insertRule(`
@@ -850,12 +868,14 @@ QUnit.module('convert_inline', {}, function () {
                 animation-direction: alternate;
             }
         `, 0);
+        convertInline.resetCssRulesCache();
         $editable = $(`<div>${`<div class="test-animation-specific"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-animation-specific"></div>`,
             "should have removed all specific animation styles");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         // flex
         styleSheet.insertRule(`
@@ -864,6 +884,7 @@ QUnit.module('convert_inline', {}, function () {
                 flex-flow: column wrap;
             }
         `, 0);
+        convertInline.resetCssRulesCache();
         $editable = $(`<div>${`<div class="test-flex"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
@@ -880,12 +901,14 @@ QUnit.module('convert_inline', {}, function () {
                 flex-grow: 4;
             }
         `, 0);
+        convertInline.resetCssRulesCache();
         $editable = $(`<div>${`<div class="test-flex-specific"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-flex-specific"></div>`,
             "should have removed all specific flex styles");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         $styleSheet.remove();
     });
@@ -913,6 +936,7 @@ QUnit.module('convert_inline', {}, function () {
             `<div class="o_layout" style="font-size:50px;color:white;background-color:red;padding: 50px;"></div>`,
             "should have given all styles of body to .o_layout");
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         $iframe.remove();
     });
@@ -963,6 +987,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable = $(`<div><div class="test-color"></div></div>`);
+        convertInline.resetCssRulesCache();
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-color" style="color:black;"></div>`,
@@ -972,6 +997,7 @@ QUnit.module('convert_inline', {}, function () {
         styleSheet.deleteRule(0);
         styleSheet.deleteRule(0);
         styleSheet.deleteRule(0);
+        convertInline.resetCssRulesCache();
 
         $styleSheet.remove();
     });

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -2,11 +2,8 @@
 import convertInline from '@web_editor/js/backend/convert_inline';
 import {getGridHtml, getTableHtml, getRegularGridHtml, getRegularTableHtml} from 'web_editor.test_utils';
 
-
 QUnit.module('web_editor', {}, function () {
 QUnit.module('convert_inline', {}, function () {
-    let $editable;
-
     QUnit.module('Convert Bootstrap grids to tables');
     // Test bootstrapToTable, cardToTable and listGroupToTable
 
@@ -14,7 +11,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(4);
 
         // 1x1
-        $editable = $(`<div>${getRegularGridHtml(1, 1)}</div>`);
+        let $editable = $(`<div>${getRegularGridHtml(1, 1)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getRegularTableHtml(1, 1, 12, 100),
             "should have converted a 1x1 grid to an equivalent table");
@@ -41,7 +38,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(4);
 
         // 1x13
-        $editable = $(`<div>${getRegularGridHtml(1, 13)}</div>`);
+        let $editable = $(`<div>${getRegularGridHtml(1, 13)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
@@ -82,7 +79,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(4);
 
         // 2x1
-        $editable = $(`<div>${getRegularGridHtml(2, 1)}</div>`);
+        let $editable = $(`<div>${getRegularGridHtml(2, 1)}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getRegularTableHtml(2, 1, 12, 100),
             "should have converted a 2x1 grid to an equivalent table");
@@ -109,7 +106,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(4);
 
         // 2x[13,1]
-        $editable = $(`<div>${getRegularGridHtml(2, [13, 1])}</div>`);
+        let $editable = $(`<div>${getRegularGridHtml(2, [13, 1])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
@@ -146,7 +143,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(2);
 
         // 1x2
-        $editable = $(`<div>${getGridHtml([[8, 4]])}</div>`);
+        let $editable = $(`<div>${getGridHtml([[8, 4]])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getTableHtml([[[8, 66.67], [4, 33.33]]]),
             "should have converted a 1x2 irregular grid to an equivalent table");
@@ -161,7 +158,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(2);
 
         // 1x2
-        $editable = $(`<div>${getGridHtml([[8, 5]])}</div>`);
+        let $editable = $(`<div>${getGridHtml([[8, 5]])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getTableHtml([
                 [[8, 66.67], [4, 33.33, '']],
@@ -183,7 +180,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(2);
 
         // 2x2
-        $editable = $(`<div>${getGridHtml([[1, 11], [2, 10]])}</div>`);
+        let $editable = $(`<div>${getGridHtml([[1, 11], [2, 10]])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(), getTableHtml([[[1, 8.33], [11, 91.67]], [[2, 16.67], [10, 83.33]]]),
             "should have converted a 2x2 irregular grid to an equivalent table");
@@ -198,7 +195,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(3);
 
         // 2x2 (both rows overflow)
-        $editable = $(`<div>${getGridHtml([[6, 8], [7, 9]])}</div>`);
+        let $editable = $(`<div>${getGridHtml([[6, 8], [7, 9]])}</div>`);
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getTableHtml([
@@ -234,8 +231,8 @@ QUnit.module('convert_inline', {}, function () {
     QUnit.test('convert a card to a table', async function (assert) {
         assert.expect(1);
 
-        $editable.html(
-            `<div class="card">` +
+        const $editable = $(
+            `<div><div class="card">` +
                 `<div class="card-header">` +
                     `<span>HEADER</span>` +
                 `</div>` +
@@ -246,7 +243,7 @@ QUnit.module('convert_inline', {}, function () {
                 `<div class="card-footer">` +
                     `<a href="#" class="btn">FOOTER</a>` +
                 `</div>` +
-            `</div>`);
+            `</div></div>`);
         convertInline.cardToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(3, 1, 12, 100)
@@ -277,8 +274,8 @@ QUnit.module('convert_inline', {}, function () {
     QUnit.test('convert a list group to a table', async function (assert) {
         assert.expect(1);
 
-        $editable.html(
-            `<ul class="list-group list-group-flush">` +
+        const $editable = $(
+            `<div><ul class="list-group list-group-flush">` +
                 `<li class="list-group-item">` +
                     `<strong>(0, 0)</strong>` +
                 `</li>` +
@@ -289,7 +286,7 @@ QUnit.module('convert_inline', {}, function () {
                 `<li class="list-group-item">` +
                     `<strong class="b">(2, 0)</strong>` +
                 `</li>` +
-            `</ul>`);
+            `</ul></div>`);
         convertInline.listGroupToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(3, 1, 12, 100)
@@ -306,12 +303,12 @@ QUnit.module('convert_inline', {}, function () {
     QUnit.test('convert rgb color to hexadecimal', async function (assert) {
         assert.expect(1);
 
-        $editable.html(
-            `<div style="color: rgb(0, 0, 0);">` +
+        const $editable = $(
+            `<div><div style="color: rgb(0, 0, 0);">` +
                 `<div class="a" style="padding: 0; background-color:rgb(255,255,255)" width="100%">` +
                     `<p style="border: 1px rgb(50, 100,200 ) solid; color: rgb(35, 134, 54);">Test</p>` +
                 `</div>` +
-            `</div>`
+            `</div></div>`
         );
         convertInline.normalizeColors($editable);
         assert.strictEqual($editable.html(),
@@ -332,7 +329,7 @@ QUnit.module('convert_inline', {}, function () {
             `</div>` +
         `</div>`;
 
-        $editable = $(`<div>${testDom}</div>`);
+        let $editable = $(`<div>${testDom}</div>`);
         document.body.append($editable[0]);
         convertInline.normalizeRem($editable);
         assert.strictEqual($editable.html(),
@@ -430,7 +427,7 @@ QUnit.module('convert_inline', {}, function () {
         `</table>`;
 
         // table.o_mail_snippet_general
-        $editable = $(`<div>${testTable}</div>`);
+        const $editable = $(`<div>${testTable}</div>`);
         convertInline.formatTables($editable);
         assert.strictEqual($editable.html(), expectedTable,
             "should have moved the padding from table.o_mail_snippet_general and table in it to their respective cells"
@@ -439,7 +436,7 @@ QUnit.module('convert_inline', {}, function () {
     QUnit.test('add a tbody to any table that doesn\'t have one', async function (assert) {
         assert.expect(1);
 
-        $editable = $(`<div>${`<table><tr><td>I don't have a body :'(</td></tr></table>`}</div>`);
+        const $editable = $(`<div>${`<table><tr><td>I don't have a body :'(</td></tr></table>`}</div>`);
         $editable.find('tr').unwrap();
         convertInline.formatTables($editable);
         assert.strictEqual($editable.html(), `<table><tbody style="vertical-align: top;"><tr><td>I don't have a body :'(</td></tr></tbody></table>`,
@@ -449,7 +446,7 @@ QUnit.module('convert_inline', {}, function () {
     QUnit.test('add number heights to parents of elements with percent heights', async function (assert) {
         assert.expect(3);
 
-        $editable = $(`<div>${`<table><tbody><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`}</div>`);
+        let $editable = $(`<div>${`<table><tbody><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`}</div>`);
         convertInline.formatTables($editable);
         assert.strictEqual($editable.html(), `<table><tbody style="height: 0px;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`,
             "should have added a 0 height to the parent of a 100% height element"
@@ -470,7 +467,7 @@ QUnit.module('convert_inline', {}, function () {
     QUnit.test('express align-self with vertical-align on table cells', async function (assert) {
         assert.expect(3);
 
-        $editable = $(`<div><table><tbody><tr><td style="align-self: start;">yup</td></tr></tbody></table></div>`);
+        let $editable = $(`<div><table><tbody><tr><td style="align-self: start;">yup</td></tr></tbody></table></div>`);
         convertInline.formatTables($editable);
         assert.strictEqual($editable.html(), `<table><tbody><tr><td style="align-self: start; vertical-align: top;">yup</td></tr></tbody></table>`,
             "should have added a top vertical alignment"
@@ -495,10 +492,10 @@ QUnit.module('convert_inline', {}, function () {
     QUnit.test('convert snippets to tables', async function (assert) {
         assert.expect(2);
 
-        $editable.html(
-            `<div class="o_mail_snippet_general">` +
+        let $editable = $(
+            `<div><div class="o_mail_snippet_general">` +
                 `<div>Snippet</div>` +
-            `</div>`
+            `</div></div>`
         );
         convertInline.addTables($editable);
         assert.strictEqual($editable.html(),
@@ -508,10 +505,10 @@ QUnit.module('convert_inline', {}, function () {
             "should have converted .o_mail_snippet_general to a special table structure with a table in it"
         );
 
-        $editable.html(
-            `<div class="o_mail_snippet_general">` +
+        $editable = $(
+            `<div><div class="o_mail_snippet_general">` +
                 `<table><tbody><tr><td>Snippet</td></tr></tbody></table>` +
-            `</div>`
+            `</div></div>`
         );
         convertInline.addTables($editable);
         assert.strictEqual($editable.html(),
@@ -524,10 +521,10 @@ QUnit.module('convert_inline', {}, function () {
     QUnit.test('convert mailing bodies to tables', async function (assert) {
         assert.expect(2);
 
-        $editable.html(
-            `<div class="o_layout">` +
+        let $editable = $(
+            `<div><div class="o_layout">` +
                 `<div>Mailing</div>` +
-            `</div>`
+            `</div></div>`
         );
         convertInline.addTables($editable);
         assert.strictEqual($editable.html(),
@@ -538,10 +535,10 @@ QUnit.module('convert_inline', {}, function () {
             "should have converted .o_layout to a special table structure with a table in it"
         );
 
-        $editable.html(
-            `<div class="o_layout">` +
+        $editable = $(
+            `<div><div class="o_layout">` +
                 `<table><tbody><tr><td>Mailing</td></tr></tbody></table>` +
-            `</div>`
+            `</div></div>`
         );
         convertInline.addTables($editable);
         assert.strictEqual($editable.html(),
@@ -559,7 +556,7 @@ QUnit.module('convert_inline', {}, function () {
     QUnit.test('convert Bootstrap classes to inline styles', async function (assert) {
         assert.expect(1);
 
-        $editable = $(`<div>${`<div class="container"><div class="row"><div class="col">Hello</div></div></div>`}</div>`);
+        const $editable = $(`<div><div class="container"><div class="row"><div class="col">Hello</div></div></div></div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         const containerStyle = `padding:0 16px 0 16px;margin:0 auto 0 auto;box-sizing:border-box;max-width:1140px;width:100%;`;
         const rowStyle = `margin:0 -16px 0 -16px;box-sizing:border-box;`;
@@ -587,7 +584,7 @@ QUnit.module('convert_inline', {}, function () {
                 border-top-left-radius: 40%;
             }
         `, 0);
-        $editable = $(`<div>${`<div class="test-border-radius"></div>`}</div>`);
+        let $editable = $(`<div>${`<div class="test-border-radius"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border-radius" style="border-radius:30%;box-sizing:border-box;"></div>`,
@@ -784,7 +781,7 @@ QUnit.module('convert_inline', {}, function () {
                 text-decoration-thickness: 10px;
             }
         `, 0);
-        $editable = $(`<div>${`<div class="test-decoration"></div>`}</div>`);
+        let $editable = $(`<div>${`<div class="test-decoration"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-decoration" style="text-decoration:underline;box-sizing:border-box;"></div>`,
@@ -960,19 +957,19 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 2);
 
-        $editable = $(`<div>${`<span class="test-color"></span>`}</div>`);
+        let $editable = $(`<div><span class="test-color"></span></div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<span class="test-color" style="box-sizing:border-box;color:blue;"></span>`,
             "should have prioritized the last defined style");
 
-        $editable = $(`<div>${`<div class="test-color"></div>`}</div>`);
+        $editable = $(`<div><div class="test-color"></div></div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-color" style="box-sizing:border-box;color:green;"></div>`,
             "should have prioritized the more specific style");
 
-        $editable = $(`<div>${`<div class="test-color" style="color: yellow;"></div>`}</div>`);
+        $editable = $(`<div><div class="test-color" style="color: yellow;"></div></div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-color" style="box-sizing:border-box;color: yellow;"></div>`,
@@ -983,7 +980,7 @@ QUnit.module('convert_inline', {}, function () {
                 color: black !important;
             }
         `, 0);
-        $editable = $(`<div>${`<div class="test-color"></div>`}</div>`);
+        $editable = $(`<div><div class="test-color"></div></div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-color" style="box-sizing:border-box;color:black;"></div>`,

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -252,21 +252,21 @@ QUnit.module('convert_inline', {}, function () {
                     `<td>` +
                         `<table cellspacing=\"0\" cellpadding=\"0\" border=\"0\" width=\"100%\" align=\"center\" ` +
                         `role=\"presentation\" style=\"width: 100% !important; border-collapse: collapse; text-align: inherit; ` +
-                        `font-size: unset; line-height: unset;\"><tr>` +
+                        `line-height: unset;\"><tr>` +
                             `<td class="card-header"><span>HEADER</span></td>` +
                         `</tr></table></td>`)
                 .replace(/<td[^>]*>\(1, 0\)<\/td>/,
                     `<td>` +
                         `<table cellspacing=\"0\" cellpadding=\"0\" border=\"0\" width=\"100%\" align=\"center\" ` +
                         `role=\"presentation\" style=\"width: 100% !important; border-collapse: collapse; text-align: inherit; ` +
-                        `font-size: unset; line-height: unset;\"><tr>` +
+                        `line-height: unset;\"><tr>` +
                             `<td class="card-body"><h2 class="card-title">TITLE</h2><small>BODY <img></small></td>` +
                         `</tr></table></td>`)
                 .replace(/<td[^>]*>\(2, 0\)<\/td>/,
                     `<td>` +
                         `<table cellspacing=\"0\" cellpadding=\"0\" border=\"0\" width=\"100%\" align=\"center\" ` +
                         `role=\"presentation\" style=\"width: 100% !important; border-collapse: collapse; text-align: inherit; ` +
-                        `font-size: unset; line-height: unset;\"><tr>` +
+                        `line-height: unset;\"><tr>` +
                             `<td class="card-footer"><a href="#" class="btn">FOOTER</a></td>` +
                         `</tr></table></td>`),
             "should have converted a card structure into a table");
@@ -530,7 +530,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 1, 12, 100)
                 .split('style=').join('class="o_layout" style=')
-                .replace(' font-size: unset; line-height: unset;', '') // o_layout keeps those default values
+                .replace(' line-height: unset;', '') // o_layout keeps those default values
                 .replace(/<td[^>]*>\(0, 0\)/, '<td>' + getRegularTableHtml(1, 1, 12, 100).replace(/<td[^>]*>\(0, 0\)/, '<td><div>Mailing</div>')),
             "should have converted .o_layout to a special table structure with a table in it"
         );
@@ -544,7 +544,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 1, 12, 100)
                 .split('style=').join('class="o_layout" style=')
-                .replace(' font-size: unset; line-height: unset;', '') // o_layout keeps those default values
+                .replace(' line-height: unset;', '') // o_layout keeps those default values
                 .replace(/<td[^>]*>\(0, 0\)/, '<td><table><tbody><tr><td>Mailing</td></tr></tbody></table>'),
             "should have converted .o_layout to a special table structure, keeping the table in it"
         );
@@ -558,9 +558,9 @@ QUnit.module('convert_inline', {}, function () {
 
         const $editable = $(`<div><div class="container"><div class="row"><div class="col">Hello</div></div></div></div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
-        const containerStyle = `padding:0 16px 0 16px;margin:0 auto 0 auto;box-sizing:border-box;max-width:1140px;width:100%;`;
-        const rowStyle = `margin:0 -16px 0 -16px;box-sizing:border-box;`;
-        const colStyle = `padding:0 16px 0 16px;box-sizing:border-box;max-width:100%;width:100%;position:relative;`;
+        const containerStyle = `padding:0 16px 0 16px;margin:0 auto 0 auto;max-width:1140px;width:100%;`;
+        const rowStyle = `margin:0 -16px 0 -16px;`;
+        const colStyle = `padding:0 16px 0 16px;max-width:100%;width:100%;position:relative;`;
         assert.strictEqual($editable.html(),
             `<div class="container" style="${containerStyle}" width="100%">` +
             `<div class="row" style="${rowStyle}">` +
@@ -587,7 +587,7 @@ QUnit.module('convert_inline', {}, function () {
         let $editable = $(`<div>${`<div class="test-border-radius"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-border-radius" style="border-radius:30%;box-sizing:border-box;"></div>`,
+            `<div class="test-border-radius" style="border-radius:30%;"></div>`,
             "should have converted border-[position]-radius styles (from class) to border-radius");
         styleSheet.deleteRule(0);
 
@@ -603,7 +603,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-border"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-border" style="border-style:dotted dashed none solid;box-sizing:border-box;"></div>`,
+            `<div class="test-border" style="border-style:dotted dashed none solid;"></div>`,
             "should have converted border-[position]-style styles (from class) to border-style");
         styleSheet.deleteRule(0);
 
@@ -617,7 +617,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-margin"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-margin" style="margin:0 20px 30px 40px;box-sizing:border-box;"></div>`,
+            `<div class="test-margin" style="margin:0 20px 30px 40px;"></div>`,
             "should have converted margin-[position] styles (from class) to margin");
         styleSheet.deleteRule(0);
 
@@ -631,7 +631,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-padding"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-padding" style="padding:10px 0 30px 40px;box-sizing:border-box;"></div>`,
+            `<div class="test-padding" style="padding:10px 0 30px 40px;"></div>`,
             "should have converted padding-[position] styles (from class) to padding");
         styleSheet.deleteRule(0);
 
@@ -648,7 +648,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-border-uniform"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-border-uniform" style="border-style:dotted;box-sizing:border-box;"></div>`,
+            `<div class="test-border-uniform" style="border-style:dotted;"></div>`,
             "should have converted uniform border-[position]-style styles (from class) to border-style");
         styleSheet.deleteRule(0);
 
@@ -663,7 +663,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-margin-uniform"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-margin-uniform" style="margin:10px;box-sizing:border-box;"></div>`,
+            `<div class="test-margin-uniform" style="margin:10px;"></div>`,
             "should have converted uniform margin-[position] styles (from class) to margin");
         styleSheet.deleteRule(0);
 
@@ -678,7 +678,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-padding-uniform"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-padding-uniform" style="padding:10px;box-sizing:border-box;"></div>`,
+            `<div class="test-padding-uniform" style="padding:10px;"></div>`,
             "should have converted uniform padding-[position] styles (from class) to padding");
         styleSheet.deleteRule(0);
 
@@ -695,7 +695,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-border-inherit"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-border-inherit" style="box-sizing:border-box;border-left-style:solid;border-bottom-style:inherit;border-right-style:dashed;border-top-style:dotted;"></div>`,
+            `<div class="test-border-inherit" style="border-left-style:solid;border-bottom-style:inherit;border-right-style:dashed;border-top-style:dotted;"></div>`,
             "should not have converted border-[position]-style styles (from class) to border-style as they include an inherit");
         styleSheet.deleteRule(0);
 
@@ -710,7 +710,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-margin-inherit"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-margin-inherit" style="box-sizing:border-box;margin-left:40px;margin-bottom:30px;margin-right:inherit;margin-top:10px;"></div>`,
+            `<div class="test-margin-inherit" style="margin-left:40px;margin-bottom:30px;margin-right:inherit;margin-top:10px;"></div>`,
             "should not have converted margin-[position] styles (from class) to margin as they include an inherit");
         styleSheet.deleteRule(0);
 
@@ -725,7 +725,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-padding-inherit"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-padding-inherit" style="box-sizing:border-box;padding-left:40px;padding-bottom:inherit;padding-right:20px;padding-top:10px;"></div>`,
+            `<div class="test-padding-inherit" style="padding-left:40px;padding-bottom:inherit;padding-right:20px;padding-top:10px;"></div>`,
             "should have converted padding-[position] styles (from class) to padding as they include an inherit");
         styleSheet.deleteRule(0);
 
@@ -744,7 +744,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-margin-initial"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-margin-initial" style="box-sizing:border-box;margin-left:40px;margin-bottom:30px;margin-right:20px;margin-top:initial;"></div>`,
+            `<div class="test-margin-initial" style="margin-left:40px;margin-bottom:30px;margin-right:20px;margin-top:initial;"></div>`,
             "should not have converted margin-[position] styles (from class) to margin as they include an initial");
         styleSheet.deleteRule(0);
 
@@ -759,14 +759,14 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-padding-initial"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-padding-initial" style="box-sizing:border-box;padding-left:initial;padding-bottom:30px;padding-right:20px;padding-top:10px;"></div>`,
+            `<div class="test-padding-initial" style="padding-left:initial;padding-bottom:30px;padding-right:20px;padding-top:10px;"></div>`,
             "should not have converted padding-[position] styles (from class) to padding as they include an initial");
         styleSheet.deleteRule(0);
 
         $styleSheet.remove();
     });
     QUnit.test('remove unsupported styles', async function (assert) {
-        assert.expect(10);
+        assert.expect(8);
 
         const $styleSheet = $('<style type="text/css" title="test-stylesheet"/>');
         document.head.appendChild($styleSheet[0])
@@ -784,7 +784,7 @@ QUnit.module('convert_inline', {}, function () {
         let $editable = $(`<div>${`<div class="test-decoration"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-decoration" style="text-decoration:underline;box-sizing:border-box;"></div>`,
+            `<div class="test-decoration" style="text-decoration:underline;"></div>`,
             "should have removed all text-decoration-[prop] styles (from class) and kept a simple text-decoration");
         styleSheet.deleteRule(0);
 
@@ -800,26 +800,8 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-border-initial"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-border-initial" style="box-sizing:border-box;border-bottom-style:double;border-right-style:dashed;border-top-style:dotted;"></div>`,
+            `<div class="test-border-initial" style="border-bottom-style:double;border-right-style:dashed;border-top-style:dotted;"></div>`,
             "should have removed border initial");
-        styleSheet.deleteRule(0);
-
-        // display: block (except for .btn-block)
-        styleSheet.insertRule(`
-            .test-block {
-                display: block;
-            }
-        `, 0);
-        $editable = $(`<div>${`<div class="test-block"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
-        assert.strictEqual($editable.html(),
-            `<div class="test-block" style="box-sizing:border-box;"></div>`,
-            "should have removed display block");
-        $editable = $(`<div>${`<div class="btn-block"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
-        assert.strictEqual($editable.html(),
-            `<div class="btn-block" style="box-sizing:border-box;width:100%;display:block;" width="100%"></div>`,
-            "should not have removed display block for .btn-block");
         styleSheet.deleteRule(0);
 
         // !important
@@ -831,7 +813,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-unimportant-color"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-unimportant-color" style="box-sizing:border-box;color:blue;"></div>`,
+            `<div class="test-unimportant-color" style="color:blue;"></div>`,
             "should have converted a simple color");
         styleSheet.insertRule(`
             .test-important-color {
@@ -841,7 +823,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-important-color test-unimportant-color"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-important-color test-unimportant-color" style="box-sizing:border-box;color:red;"></div>`,
+            `<div class="test-important-color test-unimportant-color" style="color:red;"></div>`,
             "should have converted an important color and removed the !important");
         styleSheet.deleteRule(0);
         styleSheet.deleteRule(0);
@@ -855,7 +837,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-animation"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-animation" style="box-sizing:border-box;"></div>`,
+            `<div class="test-animation"></div>`,
             "should have removed animation style");
         styleSheet.deleteRule(0);
         styleSheet.insertRule(`
@@ -871,7 +853,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-animation-specific"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-animation-specific" style="box-sizing:border-box;"></div>`,
+            `<div class="test-animation-specific"></div>`,
             "should have removed all specific animation styles");
         styleSheet.deleteRule(0);
 
@@ -885,7 +867,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-flex"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-flex" style="box-sizing:border-box;"></div>`,
+            `<div class="test-flex"></div>`,
             "should have removed all flex styles");
         styleSheet.deleteRule(0);
         styleSheet.insertRule(`
@@ -901,7 +883,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div>${`<div class="test-flex-specific"></div>`}</div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-flex-specific" style="box-sizing:border-box;"></div>`,
+            `<div class="test-flex-specific"></div>`,
             "should have removed all specific flex styles");
         styleSheet.deleteRule(0);
 
@@ -928,7 +910,7 @@ QUnit.module('convert_inline', {}, function () {
         $iframeEditable.append(`<div class="o_layout" style="padding: 50px;"></div>`);
         convertInline.classToStyle($iframeEditable, convertInline.getCSSRules($iframeEditable[0].ownerDocument));
         assert.strictEqual($iframeEditable.html(),
-            `<div class="o_layout" style="box-sizing:border-box;font-size:50px;color:white;background-color:red;padding: 50px;"></div>`,
+            `<div class="o_layout" style="font-size:50px;color:white;background-color:red;padding: 50px;"></div>`,
             "should have given all styles of body to .o_layout");
         styleSheet.deleteRule(0);
 
@@ -960,19 +942,19 @@ QUnit.module('convert_inline', {}, function () {
         let $editable = $(`<div><span class="test-color"></span></div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<span class="test-color" style="box-sizing:border-box;color:blue;"></span>`,
+            `<span class="test-color" style="color:blue;"></span>`,
             "should have prioritized the last defined style");
 
         $editable = $(`<div><div class="test-color"></div></div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-color" style="box-sizing:border-box;color:green;"></div>`,
+            `<div class="test-color" style="color:green;"></div>`,
             "should have prioritized the more specific style");
 
         $editable = $(`<div><div class="test-color" style="color: yellow;"></div></div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-color" style="box-sizing:border-box;color: yellow;"></div>`,
+            `<div class="test-color" style="color: yellow;"></div>`,
             "should have prioritized the inline style");
 
         styleSheet.insertRule(`
@@ -983,7 +965,7 @@ QUnit.module('convert_inline', {}, function () {
         $editable = $(`<div><div class="test-color"></div></div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-color" style="box-sizing:border-box;color:black;"></div>`,
+            `<div class="test-color" style="color:black;"></div>`,
             "should have prioritized the important style");
 
         styleSheet.deleteRule(0);

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -12,25 +12,25 @@ QUnit.module('convert_inline', {}, function () {
 
         // 1x1
         let $editable = $(`<div>${getRegularGridHtml(1, 1)}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(), getRegularTableHtml(1, 1, 12, 100),
             "should have converted a 1x1 grid to an equivalent table");
 
         // 1x2
         $editable = $(`<div>${getRegularGridHtml(1, 2)}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(), getRegularTableHtml(1, 2, 6, 50),
             "should have converted a 1x2 grid to an equivalent table");
 
         // 1x3
         $editable = $(`<div>${getRegularGridHtml(1, 3)}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(), getRegularTableHtml(1, 3, 4, 33.33),
             "should have converted a 1x3 grid to an equivalent table");
 
         // 1x12
         $editable = $(`<div>${getRegularGridHtml(1, 12)}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(), getRegularTableHtml(1, 12, 1, 8.33),
             "should have converted a 1x12 grid to an equivalent table");
     });
@@ -39,7 +39,7 @@ QUnit.module('convert_inline', {}, function () {
 
         // 1x13
         let $editable = $(`<div>${getRegularGridHtml(1, 13)}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
                 `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 12)</td></tr></table>`,
@@ -47,7 +47,7 @@ QUnit.module('convert_inline', {}, function () {
 
         // 1x14
         $editable = $(`<div>${getRegularGridHtml(1, 14)}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
                 `<tr><td colspan="1" width="8.33%" style="width: 8.33%;">(0, 12)</td>` +
@@ -56,7 +56,7 @@ QUnit.module('convert_inline', {}, function () {
 
         // 1x25
         $editable = $(`<div>${getRegularGridHtml(1, 25)}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
             getRegularTableHtml(1, 12, 1, 8.33).replace(/\(0, (\d+)\)/g, (s, c) => `(0, ${+c + 12})`)
@@ -66,7 +66,7 @@ QUnit.module('convert_inline', {}, function () {
 
         // 1x26
         $editable = $(`<div>${getRegularGridHtml(1, 26)}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
             getRegularTableHtml(1, 12, 1, 8.33).replace(/\(0, (\d+)\)/g, (s, c) => `(0, ${+c + 12})`)
@@ -80,25 +80,25 @@ QUnit.module('convert_inline', {}, function () {
 
         // 2x1
         let $editable = $(`<div>${getRegularGridHtml(2, 1)}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(), getRegularTableHtml(2, 1, 12, 100),
             "should have converted a 2x1 grid to an equivalent table");
 
         // 2x[1,2]
         $editable = $(`<div>${getRegularGridHtml(2, [1, 2])}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(), getRegularTableHtml(2, [1, 2], [12, 6], [100, 50]),
             "should have converted a 2x[1,2] grid to an equivalent table");
 
         // 3x3
         $editable = $(`<div>${getRegularGridHtml(3, 3)}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(), getRegularTableHtml(3, 3, 4, 33.33),
             "should have converted a 3x3 grid to an equivalent table");
 
         // 3x[3,2,1]
         $editable = $(`<div>${getRegularGridHtml(3, [3,2,1])}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(), getRegularTableHtml(3, [3, 2, 1], [4, 6, 12], [33.33, 50, 100]),
             "should have converted a 3x[3,2,1] grid to an equivalent table");
     });
@@ -107,7 +107,7 @@ QUnit.module('convert_inline', {}, function () {
 
         // 2x[13,1]
         let $editable = $(`<div>${getRegularGridHtml(2, [13, 1])}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
                 `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 12)</td></tr>` +
@@ -116,7 +116,7 @@ QUnit.module('convert_inline', {}, function () {
 
         // 2x[1,13]
         $editable = $(`<div>${getRegularGridHtml(2, [1, 13])}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(),
             getRegularTableHtml(2, [1, 12], [12, 1], [100, 8.33]).slice(0, -8) +
                 `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 12)</td></tr></table>`,
@@ -124,7 +124,7 @@ QUnit.module('convert_inline', {}, function () {
 
         // 3x[1,13,6]
         $editable = $(`<div>${getRegularGridHtml(3, [1, 13, 6])}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(),
             getRegularTableHtml(2, [1, 12], [12, 1], [100, 8.33]).slice(0, -8) +
                 `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 12)</td></tr>` +
@@ -133,7 +133,7 @@ QUnit.module('convert_inline', {}, function () {
 
         // 3x[1,6,13]
         $editable = $(`<div>${getRegularGridHtml(3, [1, 6, 13])}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(),
             getRegularTableHtml(3, [1, 6, 12], [12, 2, 1], [100, 16.67, 8.33]).slice(0, -8) +
                 `<tr><td colspan="12" width="100%" style="width: 100%;">(2, 12)</td></tr></table>`,
@@ -144,13 +144,13 @@ QUnit.module('convert_inline', {}, function () {
 
         // 1x2
         let $editable = $(`<div>${getGridHtml([[8, 4]])}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(), getTableHtml([[[8, 66.67], [4, 33.33]]]),
             "should have converted a 1x2 irregular grid to an equivalent table");
 
         // 1x3
         $editable = $(`<div>${getGridHtml([[2, 3, 7]])}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(), getTableHtml([[[2, 16.67], [3, 25], [7, 58.33]]]),
             "should have converted a 1x3 grid to an equivalent table");
     });
@@ -159,7 +159,7 @@ QUnit.module('convert_inline', {}, function () {
 
         // 1x2
         let $editable = $(`<div>${getGridHtml([[8, 5]])}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(), getTableHtml([
                 [[8, 66.67], [4, 33.33, '']],
                 [[5, 41.67, '(0, 1)'], [7, 58.33, '']],
@@ -168,7 +168,7 @@ QUnit.module('convert_inline', {}, function () {
 
         // 1x3
         $editable = $(`<div>${getGridHtml([[7, 6, 9]])}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(), getTableHtml([
                 [[7, 58.33], [5, 41.67, '']],
                 [[6, 50, '(0, 1)'], [6, 50, '']],
@@ -181,13 +181,13 @@ QUnit.module('convert_inline', {}, function () {
 
         // 2x2
         let $editable = $(`<div>${getGridHtml([[1, 11], [2, 10]])}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(), getTableHtml([[[1, 8.33], [11, 91.67]], [[2, 16.67], [10, 83.33]]]),
             "should have converted a 2x2 irregular grid to an equivalent table");
 
         // 2x[2,3]
         $editable = $(`<div>${getGridHtml([[3, 9], [4, 6, 2]])}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(), getTableHtml([[[3, 25], [9, 75]], [[4, 33.33], [6, 50], [2, 16.67]]]),
             "should have converted a 2x[2,3] irregular grid to an equivalent table");
     });
@@ -196,7 +196,7 @@ QUnit.module('convert_inline', {}, function () {
 
         // 2x2 (both rows overflow)
         let $editable = $(`<div>${getGridHtml([[6, 8], [7, 9]])}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(),
             getTableHtml([
                 [[6, 50], [6, 50, '']],
@@ -208,7 +208,7 @@ QUnit.module('convert_inline', {}, function () {
 
         // 2x[2,3] (first row overflows)
         $editable = $(`<div>${getGridHtml([[5, 8], [4, 2, 6]])}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(),
             getTableHtml([
                 [[5, 41.67], [7, 58.33, '']],
@@ -219,7 +219,7 @@ QUnit.module('convert_inline', {}, function () {
 
         // 2x[3,2] (second row overflows)
         $editable = $(`<div>${getGridHtml([[4, 2, 6], [5, 8]])}</div>`);
-        convertInline.bootstrapToTable($editable);
+        convertInline.bootstrapToTable($editable.get(0));
         assert.strictEqual($editable.html(),
             getTableHtml([
                 [[4, 33.33], [2, 16.67], [6, 50]],
@@ -244,7 +244,7 @@ QUnit.module('convert_inline', {}, function () {
                     `<a href="#" class="btn">FOOTER</a>` +
                 `</div>` +
             `</div></div>`);
-        convertInline.cardToTable($editable);
+        convertInline.cardToTable($editable.get(0));
         assert.strictEqual($editable.html(),
             getRegularTableHtml(3, 1, 12, 100)
                 .split('style="').join('class="card" style="')
@@ -287,7 +287,7 @@ QUnit.module('convert_inline', {}, function () {
                     `<strong class="b">(2, 0)</strong>` +
                 `</li>` +
             `</ul></div>`);
-        convertInline.listGroupToTable($editable);
+        convertInline.listGroupToTable($editable.get(0));
         assert.strictEqual($editable.html(),
             getRegularTableHtml(3, 1, 12, 100)
                 .split('style="').join('class="list-group-flush" style="')
@@ -310,7 +310,7 @@ QUnit.module('convert_inline', {}, function () {
                 `</div>` +
             `</div></div>`
         );
-        convertInline.normalizeColors($editable);
+        convertInline.normalizeColors($editable.get(0));
         assert.strictEqual($editable.html(),
             `<div style="color: #000000;">` +
                 `<div class="a" style="padding: 0; background-color:#ffffff" width="100%">` +
@@ -331,22 +331,20 @@ QUnit.module('convert_inline', {}, function () {
 
         let $editable = $(`<div>${testDom}</div>`);
         document.body.append($editable[0]);
-        convertInline.normalizeRem($editable);
+        convertInline.normalizeRem($editable.get(0));
         assert.strictEqual($editable.html(),
-            `<div style="font-size: 24px;">` +
-                `<div class="a" style="color: #000000; padding: 30px" width="100%">` +
-                    `<p style="border: 14.4px #aaaaaa solid; margin: 45.48px;">Test</p>` +
+            `<div style="font-size: 32px;">` +
+                `<div class="a" style="color: #000000; padding: 40px" width="100%">` +
+                    `<p style="border: 19.2px #aaaaaa solid; margin: 60.64px;">Test</p>` +
                 `</div>` +
             `</div>`,
             "should have converted several rem sizes to px using the default rem size"
         );
         $editable.remove();
 
-        const html = document.createElement('html');
-        html.style.setProperty('font-size', '20px');
         $editable = $(`<div>${testDom}</div>`);
-        html.append($editable[0]);
-        convertInline.normalizeRem($editable);
+        document.body.append($editable[0]);
+        convertInline.normalizeRem($editable.get(0), 20);
         assert.strictEqual($editable.html(),
             `<div style="font-size: 40px;">` +
                 `<div class="a" style="color: #000000; padding: 50px" width="100%">` +
@@ -428,7 +426,7 @@ QUnit.module('convert_inline', {}, function () {
 
         // table.o_mail_snippet_general
         const $editable = $(`<div>${testTable}</div>`);
-        convertInline.formatTables($editable);
+        convertInline.formatTables($editable.get(0));
         assert.strictEqual($editable.html(), expectedTable,
             "should have moved the padding from table.o_mail_snippet_general and table in it to their respective cells"
         );
@@ -438,7 +436,7 @@ QUnit.module('convert_inline', {}, function () {
 
         const $editable = $(`<div>${`<table><tr><td>I don't have a body :'(</td></tr></table>`}</div>`);
         $editable.find('tr').unwrap();
-        convertInline.formatTables($editable);
+        convertInline.formatTables($editable.get(0));
         assert.strictEqual($editable.html(), `<table><tbody style="vertical-align: top;"><tr><td>I don't have a body :'(</td></tr></tbody></table>`,
             "should have added a tbody to a table that didn't have one"
         );
@@ -447,19 +445,19 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(3);
 
         let $editable = $(`<div>${`<table><tbody><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`}</div>`);
-        convertInline.formatTables($editable);
+        convertInline.formatTables($editable.get(0));
         assert.strictEqual($editable.html(), `<table><tbody style="height: 0px;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`,
             "should have added a 0 height to the parent of a 100% height element"
         );
 
         $editable = $(`<div>${`<table><tbody style="height: 200px;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`}</div>`);
-        convertInline.formatTables($editable);
+        convertInline.formatTables($editable.get(0));
         assert.strictEqual($editable.html(), `<table><tbody style="height: 200px;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`,
             "should not have changed the height of the parent of a 100% height element"
         );
 
         $editable = $(`<div>${`<table><tbody style="height: 50%;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`}</div>`);
-        convertInline.formatTables($editable);
+        convertInline.formatTables($editable.get(0));
         assert.strictEqual($editable.html(), `<table style="height: 0px;"><tbody style="height: 50%;"><tr style="height: 100%;"><td>yup</td></tr></tbody></table>`,
             "should have changed the height of the grandparent of a 100% height element"
         );
@@ -468,19 +466,19 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(3);
 
         let $editable = $(`<div><table><tbody><tr><td style="align-self: start;">yup</td></tr></tbody></table></div>`);
-        convertInline.formatTables($editable);
+        convertInline.formatTables($editable.get(0));
         assert.strictEqual($editable.html(), `<table><tbody><tr><td style="align-self: start; vertical-align: top;">yup</td></tr></tbody></table>`,
             "should have added a top vertical alignment"
         );
 
         $editable = $(`<div><table><tbody><tr><td style="align-self: center;">yup</td></tr></tbody></table></div>`);
-        convertInline.formatTables($editable);
+        convertInline.formatTables($editable.get(0));
         assert.strictEqual($editable.html(), `<table><tbody><tr><td style="align-self: center; vertical-align: middle;">yup</td></tr></tbody></table>`,
             "should have added a middle vertical alignment"
         );
 
         $editable = $(`<div><table><tbody><tr><td style="align-self: end;">yup</td></tr></tbody></table></div>`);
-        convertInline.formatTables($editable);
+        convertInline.formatTables($editable.get(0));
         assert.strictEqual($editable.html(), `<table><tbody><tr><td style="align-self: end; vertical-align: bottom;">yup</td></tr></tbody></table>`,
             "should have added a bottom vertical alignment"
         );
@@ -497,7 +495,7 @@ QUnit.module('convert_inline', {}, function () {
                 `<div>Snippet</div>` +
             `</div></div>`
         );
-        convertInline.addTables($editable);
+        convertInline.addTables($editable.get(0));
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 1, 12, 100)
                 .split('style=').join('class="o_mail_snippet_general" style=')
@@ -510,7 +508,7 @@ QUnit.module('convert_inline', {}, function () {
                 `<table><tbody><tr><td>Snippet</td></tr></tbody></table>` +
             `</div></div>`
         );
-        convertInline.addTables($editable);
+        convertInline.addTables($editable.get(0));
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 1, 12, 100)
                 .split('style=').join('class="o_mail_snippet_general" style=')
@@ -526,7 +524,7 @@ QUnit.module('convert_inline', {}, function () {
                 `<div>Mailing</div>` +
             `</div></div>`
         );
-        convertInline.addTables($editable);
+        convertInline.addTables($editable.get(0));
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 1, 12, 100)
                 .split('style=').join('class="o_layout" style=')
@@ -540,7 +538,7 @@ QUnit.module('convert_inline', {}, function () {
                 `<table><tbody><tr><td>Mailing</td></tr></tbody></table>` +
             `</div></div>`
         );
-        convertInline.addTables($editable);
+        convertInline.addTables($editable.get(0));
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 1, 12, 100)
                 .split('style=').join('class="o_layout" style=')
@@ -557,7 +555,7 @@ QUnit.module('convert_inline', {}, function () {
         assert.expect(1);
 
         const $editable = $(`<div><div class="container"><div class="row"><div class="col">Hello</div></div></div></div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         const containerStyle = `padding:0 16px 0 16px;margin:0 auto 0 auto;max-width:1140px;width:100%;`;
         const rowStyle = `margin:0 -16px 0 -16px;`;
         const colStyle = `padding:0 16px 0 16px;max-width:100%;width:100%;position:relative;`;
@@ -586,7 +584,7 @@ QUnit.module('convert_inline', {}, function () {
         `, 0);
         convertInline.resetCssRulesCache();
         let $editable = $(`<div>${`<div class="test-border-radius"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border-radius" style="border-radius:30%;"></div>`,
             "should have converted border-[position]-radius styles (from class) to border-radius");
@@ -603,7 +601,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable = $(`<div>${`<div class="test-border"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border" style="border-style:dotted dashed none solid;"></div>`,
             "should have converted border-[position]-style styles (from class) to border-style");
@@ -618,7 +616,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable = $(`<div>${`<div class="test-margin"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-margin" style="margin:0 20px 30px 40px;"></div>`,
             "should have converted margin-[position] styles (from class) to margin");
@@ -633,7 +631,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable = $(`<div>${`<div class="test-padding"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-padding" style="padding:10px 0 30px 40px;"></div>`,
             "should have converted padding-[position] styles (from class) to padding");
@@ -651,7 +649,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable = $(`<div>${`<div class="test-border-uniform"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border-uniform" style="border-style:dotted;"></div>`,
             "should have converted uniform border-[position]-style styles (from class) to border-style");
@@ -667,7 +665,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable = $(`<div>${`<div class="test-margin-uniform"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-margin-uniform" style="margin:10px;"></div>`,
             "should have converted uniform margin-[position] styles (from class) to margin");
@@ -683,7 +681,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable = $(`<div>${`<div class="test-padding-uniform"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-padding-uniform" style="padding:10px;"></div>`,
             "should have converted uniform padding-[position] styles (from class) to padding");
@@ -701,7 +699,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable = $(`<div>${`<div class="test-border-inherit"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border-inherit" style="border-left-style:solid;border-bottom-style:inherit;border-right-style:dashed;border-top-style:dotted;"></div>`,
             "should not have converted border-[position]-style styles (from class) to border-style as they include an inherit");
@@ -717,7 +715,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable = $(`<div>${`<div class="test-margin-inherit"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-margin-inherit" style="margin-left:40px;margin-bottom:30px;margin-right:inherit;margin-top:10px;"></div>`,
             "should not have converted margin-[position] styles (from class) to margin as they include an inherit");
@@ -733,7 +731,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable = $(`<div>${`<div class="test-padding-inherit"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-padding-inherit" style="padding-left:40px;padding-bottom:inherit;padding-right:20px;padding-top:10px;"></div>`,
             "should have converted padding-[position] styles (from class) to padding as they include an inherit");
@@ -753,7 +751,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable = $(`<div>${`<div class="test-margin-initial"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-margin-initial" style="margin-left:40px;margin-bottom:30px;margin-right:20px;margin-top:initial;"></div>`,
             "should not have converted margin-[position] styles (from class) to margin as they include an initial");
@@ -769,7 +767,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable = $(`<div>${`<div class="test-padding-initial"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-padding-initial" style="padding-left:initial;padding-bottom:30px;padding-right:20px;padding-top:10px;"></div>`,
             "should not have converted padding-[position] styles (from class) to padding as they include an initial");
@@ -796,7 +794,7 @@ QUnit.module('convert_inline', {}, function () {
         `, 0);
         convertInline.resetCssRulesCache();
         let $editable = $(`<div>${`<div class="test-decoration"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-decoration" style="text-decoration:underline;"></div>`,
             "should have removed all text-decoration-[prop] styles (from class) and kept a simple text-decoration");
@@ -813,7 +811,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable = $(`<div>${`<div class="test-border-initial"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-border-initial" style="border-bottom-style:double;border-right-style:dashed;border-top-style:dotted;"></div>`,
             "should have removed border initial");
@@ -827,7 +825,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable = $(`<div>${`<div class="test-unimportant-color"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-unimportant-color" style="color:blue;"></div>`,
             "should have converted a simple color");
@@ -838,7 +836,7 @@ QUnit.module('convert_inline', {}, function () {
         `, 0);
         convertInline.resetCssRulesCache();
         $editable = $(`<div>${`<div class="test-important-color test-unimportant-color"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-important-color test-unimportant-color" style="color:red;"></div>`,
             "should have converted an important color and removed the !important");
@@ -853,7 +851,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $editable = $(`<div>${`<div class="test-animation"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-animation"></div>`,
             "should have removed animation style");
@@ -870,7 +868,7 @@ QUnit.module('convert_inline', {}, function () {
         `, 0);
         convertInline.resetCssRulesCache();
         $editable = $(`<div>${`<div class="test-animation-specific"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-animation-specific"></div>`,
             "should have removed all specific animation styles");
@@ -886,7 +884,7 @@ QUnit.module('convert_inline', {}, function () {
         `, 0);
         convertInline.resetCssRulesCache();
         $editable = $(`<div>${`<div class="test-flex"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-flex"></div>`,
             "should have removed all flex styles");
@@ -903,7 +901,7 @@ QUnit.module('convert_inline', {}, function () {
         `, 0);
         convertInline.resetCssRulesCache();
         $editable = $(`<div>${`<div class="test-flex-specific"></div>`}</div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-flex-specific"></div>`,
             "should have removed all specific flex styles");
@@ -931,7 +929,7 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 0);
         $iframeEditable.append(`<div class="o_layout" style="padding: 50px;"></div>`);
-        convertInline.classToStyle($iframeEditable, convertInline.getCSSRules($iframeEditable[0].ownerDocument));
+        convertInline.classToStyle($iframeEditable.get(0), convertInline.getCSSRules($iframeEditable[0].ownerDocument));
         assert.strictEqual($iframeEditable.html(),
             `<div class="o_layout" style="font-size:50px;color:white;background-color:red;padding: 50px;"></div>`,
             "should have given all styles of body to .o_layout");
@@ -964,19 +962,19 @@ QUnit.module('convert_inline', {}, function () {
         `, 2);
 
         let $editable = $(`<div><span class="test-color"></span></div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<span class="test-color" style="color:blue;"></span>`,
             "should have prioritized the last defined style");
 
         $editable = $(`<div><div class="test-color"></div></div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-color" style="color:green;"></div>`,
             "should have prioritized the more specific style");
 
         $editable = $(`<div><div class="test-color" style="color: yellow;"></div></div>`);
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-color" style="color: yellow;"></div>`,
             "should have prioritized the inline style");
@@ -988,7 +986,7 @@ QUnit.module('convert_inline', {}, function () {
         `, 0);
         $editable = $(`<div><div class="test-color"></div></div>`);
         convertInline.resetCssRulesCache();
-        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        convertInline.classToStyle($editable.get(0), convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
             `<div class="test-color" style="color:black;"></div>`,
             "should have prioritized the important style");

--- a/addons/web_editor/static/tests/test_utils.js
+++ b/addons/web_editor/static/tests/test_utils.js
@@ -738,7 +738,6 @@ const tableAttributesString = Object.keys(tableAttributes).map(key => `${key}="$
 const tableStyles = {
     'border-collapse': 'collapse',
     'text-align': 'inherit',
-    'font-size': 'unset',
     'line-height': 'unset',
 };
 const tableStylesString = Object.keys(tableStyles).map(key => `${key}: ${tableStyles[key]};`).join(' ');

--- a/addons/web_editor/views/editor.xml
+++ b/addons/web_editor/views/editor.xml
@@ -2,9 +2,8 @@
 <odoo>
 
 <template id="wysiwyg_iframe_editor_assets" name="Editor assets for wysiwyg iframe content" groups="base.group_user">
-    <t t-call-assets="web.assets_common"/>
-    <t t-call-assets="web.assets_frontend" t-js="false"/>
-    <t t-call-assets="web_editor.assets_wysiwyg"/>
+    <t t-call-assets="web.assets_common" t-css="false" />
+    <t t-call-assets="web_editor.assets_wysiwyg" t-css="false" />
 </template>
 
 <template id="compiled_assets_wysiwyg" name="Wysiwyg Editor" groups="base.group_public,base.group_portal,base.group_user">


### PR DESCRIPTION
This generally improves the performance of `convert_inline` so `mass_mailing` can load and save faster.

Tested on the saving of the "newsletter" template on runbot, the conversion is about **13.5x faster** with this PR than before (from 2.99s to 220.91ms).

- Some tests depended on a variable to be defined, which was only defined in other tests.
- `__extraAssetsForIframe` had been kept in `mass_mailing` and `web_editor` for historical reasons but was not used anymore. This removes it.
- `web.assets_frontend` was called in `wysiwyg_iframe_editor_assets` _and_ in `iframe_css_assets_edit`. As a result, they were loaded twice in edit mode.
- This batches all writes in the `classToStyle` method of `convert_inline` so as to minimize layout thrashing and therefore improve performance.
- This batches all writes in the `formatTables` method of `convert_inline` so as to minimize layout thrashing and therefore improve performance.
- `convert_inline` used to do some style adaptations that seem to only have been needed due to improper css assets loading, which was fixed in a previous commit.
- Since some css was loaded twice, when parsing rules, we grouped similar rules in order to minimize the amount of rules on which to iterate during conversion, so as to improve performance. This is not needed anymore now css is loaded only once, so we can remove this extra processing.
- This improves performance of `classToStyle` by first selecting which nodes and which rules will be concerned. When parsing the css rules, we computed their specificity and normalized their styles one by one. This applies these processes only on the concerned rules, all at once.
- Rules used to be applied in the DOM sequencially, in traversal order. This is slow and confusing to debug. Meanwhile, most functions had been adapted to process the rules in a simple loop on the concerned nodes. This commit does that for `classToStyle`, the last remaining function that wasn't doing it yet, and removes the utility function `applyOverDescendants` altogether.
- This refactors the cache of cssRules.
- jQuery was used extensively in `convert_inline`, slowing it down by a factor of more than 2. This replaces all use of jQuery with vanilla javascript so as to improve performance significantly.
- The conversion of the comparison snippet for mail compatibility involves heavy changes in the html. In order to preserve the style, some style changes were needed as well. This change to the style of cards allows us to restore the border around the snippet.
- The final mail to be sent will have to use a mail-safe font everywhere so we can't allow other fonts to be applied in some elements. Because of the way the css was declared, we still had other fonts on some elements, like .btn. As a result, we had a different look between readonly and edit modes.
- Icons converted to images were improperly aligned because as inline elements their vertical-align style property used their first block ancestor as reference.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
