### PR TITLE
[FIX] website: website_form_project get wrong arguments

### DIFF
--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -141,7 +141,7 @@ class WebsiteForm(http.Controller):
             'meta': '',         # Add metadata if enabled
         }
 
-        authorized_fields = model.sudo()._get_form_writable_fields()
+        authorized_fields = model.with_user(SUPERUSER_ID)._get_form_writable_fields()
         error_fields = []
         custom_fields = []
 
@@ -239,7 +239,7 @@ class WebsiteForm(http.Controller):
         orphan_attachment_ids = []
         model_name = model.sudo().model
         record = model.env[model_name].browse(id_record)
-        authorized_fields = model.sudo()._get_form_writable_fields()
+        authorized_fields = model.with_user(SUPERUSER_ID)._get_form_writable_fields()
         for file in files:
             custom_field = file.field_name not in authorized_fields
             attachment_value = {


### PR DESCRIPTION
Step to reproduce:
- Create a website form with its action set to 'create a task'
- Set a project for the task to be created in
- Submit the form while logged in as a portal user

Current Behaviour:
- Task is created but the data from fields is not take into account
This lead to the task not being linked to the project and ending as 'Private'
- Due to the changes of sudo in V15, authorized fields are not fetched
and thus cannot be set properly.

Behaviour after PR:
- The data is fetch via the SUPERUSER instead of sudo to ensure correct data
- The fields are correctly set and the task is created
in the corresponding project.

opw-2743065

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
