### PR TITLE
[FIX] product : save price when create and edit a product

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -366,6 +366,9 @@
                 <field name="list_price" position="attributes">
                    <attribute name="attrs">{'readonly': [('product_variant_count', '&gt;', 1)]}</attribute>
                 </field>
+                <field name="list_price" position="after">
+                   <field name="lst_price" invisible="1"/>
+                </field>
                 <group name="packaging" position="attributes">
                     <attribute name="attrs">{'invisible': 0}</attribute>
                 </group>


### PR DESCRIPTION
- Steps :
Sales > New Quotation > Order Lines > in a new product line :
 Write a price
 Write a name, Create and Edit
In the form, change the price of it and Save.

- Issues :
When first getting in the form, the price is not correctly computed from
the sol.
When saving the form, the price is not saved.

- Cause :
`lst_price` is the product's price.
`list_price` is the template's price.
The sale/quotation view puts `default_lst_price` in the context with the
unit price of the sol.
Yet lst_price is not in the form, so its value remains zero as this context key is not taken into account.
However, list_price is in the form. After this has been changed
manually, when the form is saved, it takes the value of lst_price = zero.

- Fix :
Add an invisible field lst_price in the product form.
This way, the context key is taken into account, so lst_price is
changed, and list_price accordingly.

opw-2731620

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
