### PR TITLE
[IMP] web, base: export field res_partner.name by default in import-compatible

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1710,7 +1710,8 @@ class Export(http.Controller):
                       'value': val, 'children': False,
                       'field_type': field.get('type'),
                       'required': field.get('required'),
-                      'relation_field': field.get('relation_field')}
+                      'relation_field': field.get('relation_field'),
+                      'default_export': import_compat and field.get('default_export_compatible')}
             records.append(record)
 
             if len(id.split('/')) < 3 and 'relation' in field:

--- a/addons/web/static/src/legacy/js/widgets/data_export.js
+++ b/addons/web/static/src/legacy/js/widgets/data_export.js
@@ -397,10 +397,14 @@ var DataExport = Dialog.extend({
             self._onShowData(records);
             self.$('.o_fields_list').empty();
 
+            const forceDefaultExportFields = records.filter(r => r.default_export).map(r => r.id);
+
             _.chain(self.$fieldsList.find('.o_export_field'))
             .map(function (field) { return $(field).data('field_id'); })
+            .union(forceDefaultExportFields)
             .union(self.defaultExportFields)
             .intersection(compatibleFields)
+            .uniq()
             .each(function (field) {
                 var record = _.find(records, function (rec) {
                     return rec.id === field;

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -150,7 +150,7 @@ class Partner(models.Model):
             values['lang'] = values.get('lang') or parent.lang or self.env.lang
         return values
 
-    name = fields.Char(index=True)
+    name = fields.Char(index=True, default_export_compatible=True)
     display_name = fields.Char(compute='_compute_display_name', recursive=True, store=True, index=True)
     date = fields.Date(index=True)
     title = fields.Many2one('res.partner.title')

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -231,6 +231,8 @@ class Field(MetaField('DummyField', (object,), {})):
 
     :param str related: sequence of field names
 
+    :param bool default_export_compatible: whether the field must be exported by default in an import-compatible export
+
         .. seealso:: :ref:`Advanced fields/Related fields <reference/fields/related>`
     """
 
@@ -289,6 +291,8 @@ class Field(MetaField('DummyField', (object,), {})):
     group_operator = None               # operator for aggregating values
     group_expand = None                 # name of method to expand groups in read_group()
     prefetch = True                     # whether the field is prefetched
+
+    default_export_compatible = False   # whether the field must be exported by default in an import-compatible export
 
     def __init__(self, string=Default, **kwargs):
         kwargs['string'] = string
@@ -812,6 +816,7 @@ class Field(MetaField('DummyField', (object,), {})):
     _description_groups = property(attrgetter('groups'))
     _description_change_default = property(attrgetter('change_default'))
     _description_group_operator = property(attrgetter('group_operator'))
+    _description_default_export_compatible = property(attrgetter('default_export_compatible'))
 
     def _description_depends(self, env):
         return env.registry.field_depends[self]


### PR DESCRIPTION
…atible mode by default

In contacts, action export, when import-compatible is selected, the name is included by default in the field list to export.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
