### PR TITLE
[FIX] web_tour, website_blog: restore proper user blog tour

### DIFF
--- a/addons/web_tour/static/src/js/tip.js
+++ b/addons/web_tour/static/src/js/tip.js
@@ -178,7 +178,7 @@ var Tip = Widget.extend({
         this.$el.addClass("o_animated");
     },
     _bind_anchor_events: function () {
-        this.consume_event = Tip.getConsumeEventType(this.$anchor, this.info.run);
+        this.consume_event = this.info.consumeEvent || Tip.getConsumeEventType(this.$anchor, this.info.run);
         this.$consumeEventAnchor = this.$anchor;
         // jQuery-ui draggable triggers 'drag' events on the .ui-draggable element,
         // but the tip is attached to the .ui-draggable-handle element which may

--- a/addons/website_blog/static/src/js/tours/website_blog.js
+++ b/addons/website_blog/static/src/js/tours/website_blog.js
@@ -16,17 +16,36 @@ odoo.define("website_blog.tour", function (require) {
         trigger: "button.btn-continue",
         extra_trigger: "form[id=\"editor_new_blog\"]",
         content: _t("Select the blog you want to add the post to."),
+        // Without demo data (and probably in most user cases) there is only
+        // one blog so this step would not be needed and would block the tour.
+        // We keep the step with "auto: true", so that the main python test
+        // still works but never display this to the user anymore. We suppose
+        // the user does not need guidance once that modal is opened. Note: if
+        // you run the tour via your console without demo data, the tour will
+        // thus fail as this will be considered.
+        auto: true,
     }, {
         trigger: "div[data-oe-expression=\"blog_post.name\"]",
         extra_trigger: "#oe_snippets.o_loaded",
         content: _t("Write a title, the subtitle is optional."),
         position: "top",
+        // FIXME instead of using the default 'click' event that is used to mark
+        // DIV elements as consumed, we would like to use the 'input' event for
+        // this specific contenteditable element. However, using 'input' here
+        // makes the auto test not work as the 'text' run method stops working
+        // correctly for contenteditable element whose 'consumeEvent' is set to
+        // 'input'. The auto tests should be entirely independent of what is set
+        // as 'consumeEvent'. While this is investigated and fixed, let's use
+        // the 'mouseup' event. Indeed we cannot let it to 'click' because of
+        // the old editor currently removing all click handlers on top level
+        // editable content (which the blog post title area is).
+        consumeEvent: 'mouseup',
         run: "text",
     }, {
         trigger: "we-button:containsExact(" + _t("Change Cover") + "):visible",
         extra_trigger: "#wrap div[data-oe-expression=\"blog_post.name\"]:not(:containsExact(\"\"))",
         content: _t("Set a blog post <b>cover</b>."),
-        position: "right",
+        position: "bottom",
     }, {
         trigger: ".o_select_media_dialog .o_existing_attachment_cell:nth(1) img",
         extra_trigger: '.modal:has(.o_existing_attachment_cell:nth(1))',

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.tests
@@ -6,4 +7,7 @@ import odoo.tests
 @odoo.tests.tagged('post_install', '-at_install')
 class TestUi(odoo.tests.HttpCase):
     def test_admin(self):
+        # Ensure at least two blogs exist for the step asking to select a blog
+        self.env['blog.blog'].create({'name': 'Travel'})
+
         self.start_tour("/", 'blog', login='admin')


### PR DESCRIPTION
With [1] in 13.0, the blog post layouts were reviewed. At the same time,
new demo data was introduced. By default, with demo data, you have now
two different blogs. The JS tour was adapted so that when you create a
new blog post, a step explains you have to select the blog you want to
create the post in with the dialog that opens. The main problem that
this PR aims to solve is that all users start without demo data and thus
with only one blog... so with the current tour, the users are blocked
very early in the tour as they do not have the dialog to select the blog
in which to create their blog post. The simple solution that was chosen
is to set the step as "auto", meaning it will only be used in runned
tours (like via python tests), allowing to still test the blog selection
dialog in our python test. Users will not be guided via a tip for this
specific modal but this is not a problem as this is very straightforward
to understand in the case the user explicitely created multiple blogs
before creating blog posts.

This commit also partially backports [2] which made that python test
more robust by not relying on the demo data. That backport was improved
with explanations and got rid of the step_delay that does not seem
needed (and potentially ignores real bugs).

However, allowing the tour to go further than the blog post creation for
the user... revealed that the rest of the tour was still blocking the
user:

A) the very next step is to modify the blog post title. That step was
   simply not possible to consume. Indeed the tour system asks for a
   click event on the title... which is never detected because our old
   editor removes all click handlers on that specific top-level editable
   area. The cleanest way of fixing that is actually to not wait for a
   click but wait that the user actually types text. For this purpose
   a feature was introduced in 14.0 with [3]. Unfortunately, that commit
   was not well split. This commit backports only the relevant one-line
   change with the "consumeEvent" config. Unfortunately again... that
   14.0 feature is currently buggy during test tours as choosing the
   "input" consumeEvent alongside the "text" run method... changes the
   behavior of that "text" run method when the affected element is a
   contenteditable element. That should be fixed but this will be done
   in a further update. Meanwhile, this commit chooses to use the
   consumeEvent 'mouseup' which circles around both issues.

B) the next step after that simply induced an invisible tip, hidden by
   the editor panel that was introduced in that 13.0 version. That was
   fixed changing its position.

[1]: https://github.com/odoo/odoo/commit/bb0cdec4594fab8c22265ed8af0c2d431a263b72
[2]: https://github.com/odoo/odoo/commit/f16f2e212a30352ead86c2f876be02b5c5e23b07
[3]: https://github.com/odoo/odoo/commit/a34cd7c662b3753d630d83793ffcb53b4a0a92d2

Bug revealed by testing task-2728994
