### PR TITLE
[IMP] mass_mailing: add extra data for styles on email layout wrapper

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -269,6 +269,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
         }
         var $newLayout = $('<div/>', {
             class: 'o_layout oe_unremovable oe_unmovable bg-200 ' + themeParams.className,
+            style: themeParams.layoutStyles,
             'data-name': 'Mailing',
         }).append($new_wrapper);
 
@@ -418,7 +419,8 @@ var MassMailingFieldHtml = FieldHtml.extend({
                         return imagesInfo[filename];
                     }
                     return imagesInfo.all;
-                }
+                },
+                layoutStyles: $theme.data('layout-styles'),
             };
         });
         $themes.parent().remove();


### PR DESCRIPTION
When creating email templates, it's currently impossible to customize the background color of a template's layout.

By adding a `data-layout-styles` attribute to the template, and appending that attribute's value to `themeParams` we can add custom styles to the layout's wrapper.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
