### PR TITLE
[14.0][FIX] mrp: date_planned_finished field correctly saved

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -121,6 +121,7 @@ class StockRule(models.Model):
             'bom_id': bom.id,
             'date_deadline': date_deadline,
             'date_planned_start': date_planned,
+            'date_planned_finished': fields.Datetime.from_string(values['date_planned']),
             'procurement_group_id': False,
             'propagate_cancel': self.propagate_cancel,
             'orderpoint_id': values.get('orderpoint_id', False) and values.get('orderpoint_id').id,

--- a/doc/cla/corporate/forgeflow.md
+++ b/doc/cla/corporate/forgeflow.md
@@ -18,3 +18,4 @@ Miquel Raich miquel.raich@forgeflow.com https://github.com/MiquelRForgeFlow
 Jordi Ballester jordi.ballester@forgeflow.com https://github.com/JordiBForgeFlow
 Jordi Masvidal jordi.masvidal@forgeflow.com https://github.com/JordiMForgeFlow
 Hector Villarreal hector.villarreal@forgeflow.com https://github.com/HviorForgeFlow
+Bernat Puig bernat.puig@forgeflow.com https://github.com/BernatPForgeFlow


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When creating a MO from a SO _date_planned_finished_ is not added.
Consequently calculates wrongly the date planned to finish the MO.

Current behavior before PR:
The calculation of date_planned_finished is not correctly saved. Consequently, it shows a non desirable date.

Desired behavior after PR is merged:
The calculation of date_planned_finished is saved. Consequently, it shows the correct date planned to finish manufacture orders.

Steps to reproduce:
1. Add to a product a _Manufacturing Lead Time_ and routes (_MTO + Manufacture_).

![2022-02-03_12-34](https://user-images.githubusercontent.com/90243017/152335461-d1d5bcce-5d93-49a7-9445-450df21c08ea.png)

2. Create a SO of this product with a concrete _Delivery Date_.

![2022-02-03_12-29](https://user-images.githubusercontent.com/90243017/152335595-5edf1069-a5e1-4d6d-8afa-6a0229e8248f.png)

3. Open MO and see _Scheduled End Date_. To see _Scheduled End Date_ you have to edit the form view manually in _Edit View: Form_ option.

![2022-02-03_12-27](https://user-images.githubusercontent.com/90243017/152335937-43169b1d-70d0-4e89-8968-74af009392fa.png)

**Scheduled End Date cannot be 3rd February 2022 if it started on 10th**


Using the PR fix, the result would be like this:

![2022-02-03_12-41](https://user-images.githubusercontent.com/90243017/152336337-4b0f3212-edb8-48d1-8128-162a2150d2e2.png)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
