### PR TITLE
[IMP] survey: Task 2747823, language selection

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -329,6 +329,8 @@ class IrHttp(models.AbstractModel):
 
     @classmethod
     def _get_frontend_langs(cls):
+        if request and request.is_frontend:
+            return [lang[0] for lang in filter(lambda l: l[3], request.env['res.lang'].get_available())]
         return [code for code, _ in request.env['res.lang'].get_installed()]
 
     @classmethod

--- a/addons/http_routing/models/ir_ui_view.py
+++ b/addons/http_routing/models/ir_ui_view.py
@@ -2,7 +2,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models
-from odoo.addons.http_routing.models.ir_http import slug, unslug_url
+from odoo.http import request
+from odoo.addons.http_routing.models.ir_http import slug, unslug_url, url_for
+from odoo.tools import is_html_empty
 
 
 class IrUiView(models.Model):
@@ -13,4 +15,13 @@ class IrUiView(models.Model):
         qcontext = super(IrUiView, self)._prepare_qcontext()
         qcontext['slug'] = slug
         qcontext['unslug_url'] = unslug_url
+        if request and getattr(request, 'is_frontend', False):
+            Lang = request.env['res.lang']
+            portal_lang_code = request.env['ir.http']._get_frontend_langs()
+            qcontext.update(dict(
+                self._context.copy(),
+                languages=[lang for lang in Lang.get_available() if lang[0] in portal_lang_code],
+                url_for=url_for,
+                is_html_empty=is_html_empty,
+            ))
         return qcontext

--- a/addons/http_routing/views/http_routing_template.xml
+++ b/addons/http_routing/views/http_routing_template.xml
@@ -183,4 +183,25 @@
             </body>
         </html>
     </template>
+
+    <template id="language_selector" name="Language Selector">
+        <t t-set="active_lang" t-value="list(filter(lambda lg : lg[0] == lang, languages))[0]"/>
+        <t t-set="language_selector_visible" t-value="len(languages) &gt; 1"/>
+        <div t-attf-class="js_language_selector #{_div_classes}" t-if="language_selector_visible">
+            <button t-attf-class="btn btn-sm btn-outline-secondary border-0 dropdown-toggle #{_btn_class}" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <span t-if="not no_text"
+                        class="align-middle"
+                        t-esc="active_lang[2].split('/').pop()"/>
+            </button>
+            <div t-attf-class="dropdown-menu #{_dropdown_menu_class}" role="menu">
+                <t t-foreach="languages" t-as="lg">
+                    <a t-att-href="url_for(request.httprequest.path + '?' + keep_query(), lang_code=lg[0])"
+                       t-attf-class="dropdown-item js_change_lang #{active_lang == lg and 'active'}"
+                       t-att-data-url_code="lg[1]">
+                        <span t-if="not no_text" t-esc="lg[2].split('/').pop()"/>
+                    </a>
+                </t>
+            </div>
+        </div>
+    </template>
 </odoo>

--- a/addons/portal/models/ir_ui_view.py
+++ b/addons/portal/models/ir_ui_view.py
@@ -11,20 +11,3 @@ class View(models.Model):
     _inherit = "ir.ui.view"
 
     customize_show = fields.Boolean("Show As Optional Inherit", default=False)
-
-    @api.model
-    def _prepare_qcontext(self):
-        """ Returns the qcontext : rendering context with portal specific value (required
-            to render portal layout template)
-        """
-        qcontext = super(View, self)._prepare_qcontext()
-        if request and getattr(request, 'is_frontend', False):
-            Lang = request.env['res.lang']
-            portal_lang_code = request.env['ir.http']._get_frontend_langs()
-            qcontext.update(dict(
-                self._context.copy(),
-                languages=[lang for lang in Lang.get_available() if lang[0] in portal_lang_code],
-                url_for=url_for,
-                is_html_empty=is_html_empty,
-            ))
-        return qcontext

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -38,31 +38,10 @@
     <!-- Added by another template so that it can be disabled if needed -->
     <template id="footer_language_selector" inherit_id="portal.frontend_layout" name="Footer Language Selector">
         <xpath expr="//*[hasclass('o_footer_copyright_name')]" position="after">
-            <t id="language_selector_call" t-call="portal.language_selector">
+            <t id="language_selector_call" t-call="http_routing.language_selector">
                 <t t-set="_div_classes" t-value="(_div_classes or '') + ' dropup'"/>
             </t>
         </xpath>
-    </template>
-
-    <template id="language_selector" name="Language Selector">
-        <t t-set="active_lang" t-value="list(filter(lambda lg : lg[0] == lang, languages))[0]"/>
-        <t t-set="language_selector_visible" t-value="len(languages) &gt; 1"/>
-        <div t-attf-class="js_language_selector #{_div_classes}" t-if="language_selector_visible">
-            <button t-attf-class="btn btn-sm btn-outline-secondary border-0 dropdown-toggle #{_btn_class}" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span t-if="not no_text"
-                        class="align-middle"
-                        t-esc="active_lang[2].split('/').pop()"/>
-            </button>
-            <div t-attf-class="dropdown-menu #{_dropdown_menu_class}" role="menu">
-                <t t-foreach="languages" t-as="lg">
-                    <a t-att-href="url_for(request.httprequest.path + '?' + keep_query(), lang_code=lg[0])"
-                       t-attf-class="dropdown-item js_change_lang #{active_lang == lg and 'active'}"
-                       t-att-data-url_code="lg[1]">
-                        <span t-if="not no_text" t-esc="lg[2].split('/').pop()"/>
-                    </a>
-                </t>
-            </div>
-        </div>
     </template>
 
     <template id="user_dropdown" name="Portal User Dropdown">

--- a/addons/survey/__manifest__.py
+++ b/addons/survey/__manifest__.py
@@ -22,7 +22,6 @@ sent mails with personal token for the invitation of the survey.
         'mail',
         'web_tour',
         'gamification',
-        'portal',
     ],
     'data': [
         'views/survey_report_templates.xml',

--- a/addons/survey/__manifest__.py
+++ b/addons/survey/__manifest__.py
@@ -21,7 +21,9 @@ sent mails with personal token for the invitation of the survey.
         'http_routing',
         'mail',
         'web_tour',
-        'gamification'],
+        'gamification',
+        'portal',
+    ],
     'data': [
         'views/survey_report_templates.xml',
         'views/survey_reports.xml',

--- a/addons/survey/data/mail_template_data.xml
+++ b/addons/survey/data/mail_template_data.xml
@@ -17,7 +17,7 @@
             We are conducting a survey and your response would be appreciated.
         </t>
         <div style="margin: 16px 0px 16px 0px;">
-            <a t-att-href="(object.get_start_url())"
+            <a t-att-href="(object.get_start_url(object.partner_id.lang))"
                 style="background-color: #875A7B; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px; font-size:13px;">
                 <t t-if="object.survey_id.certification">
                     Start Certification

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -991,8 +991,15 @@ class Survey(models.Model):
         self.user_input_ids.sudo().write({'state': 'done'})
         self.env['bus.bus']._sendone(self.access_token, 'end_session', {})
 
-    def get_start_url(self):
-        return '/survey/start/%s' % self.access_token
+    def get_start_url(self, lang_code=None):
+        if lang_code is not None:
+            active_lang_codes = {code for code, _, _, active, *_ in
+                                 self.env['res.lang'].get_available(force_context='front') if active}
+            # restrict lang_code to language available
+            lang_code = lang_code if lang_code in active_lang_codes else None
+        # url_for cannot be used here because it relies on request which is not always available
+        return '/%s/survey/start/%s' % (lang_code, self.access_token) if lang_code is not None \
+            else '/survey/start/%s' % lang_code
 
     def get_start_short_url(self):
         """ See controller method docstring for more details. """

--- a/addons/survey/models/survey_user_input.py
+++ b/addons/survey/models/survey_user_input.py
@@ -228,9 +228,9 @@ class SurveyUserInput(models.Model):
             if challenges:
                 Challenge._cron_update(ids=challenges.ids, commit=False)
 
-    def get_start_url(self):
+    def get_start_url(self, lang_code=None):
         self.ensure_one()
-        return '%s?answer_token=%s' % (self.survey_id.get_start_url(), self.access_token)
+        return '%s?answer_token=%s' % (self.survey_id.get_start_url(lang_code), self.access_token)
 
     def get_print_url(self):
         self.ensure_one()

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -43,6 +43,11 @@
                         </t>
                     </t>
                 </div>
+                <div t-if="len(languages) > 1" class="d-inline-block pr-2 align-top">
+                    <t id="language_selector_call" t-call="portal.language_selector">
+                        <t t-set="_div_classes" t-value="(_div_classes or '') + ' dropup'"/>
+                    </t>
+                </div>
                 <div class="o_survey_brand_message float-right rounded mr-3 border">
                     <div class="px-2 py-2 d-inline-block" t-call="web.brand_promotion_message">
                         <t t-set="_message"></t>

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -43,8 +43,8 @@
                         </t>
                     </t>
                 </div>
-                <div t-if="len(languages) > 1" class="d-inline-block pr-2 align-top">
-                    <t id="language_selector_call" t-call="portal.language_selector">
+                <div t-if="languages and len(languages) > 1" class="d-inline-block pr-2 align-top">
+                    <t id="language_selector_call" t-call="http_routing.language_selector">
                         <t t-set="_div_classes" t-value="(_div_classes or '') + ' dropup'"/>
                     </t>
                 </div>

--- a/addons/website/models/res_lang.py
+++ b/addons/website/models/res_lang.py
@@ -18,7 +18,9 @@ class Lang(models.Model):
 
     @api.model
     @tools.ormcache_context(keys=("website_id",))
-    def get_available(self):
+    def get_available(self, force_context=None):
+        if force_context == 'front':
+            return self.env['website'].get_current_website().language_ids.get_sorted()
         website = ir_http.get_request_website()
         if not website:
             return super().get_available()

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1950,7 +1950,7 @@
     </a>
 </template>
 
-<template id="language_selector" inherit_id="portal.language_selector">
+<template id="language_selector" inherit_id="http_routing.language_selector">
     <xpath expr="//t[@t-set='active_lang']" position="before">
         <t t-if="lang not in (lg[0] for lg in languages)">
             <t t-set="lang" t-value="website.default_lang_id.code"/>
@@ -2013,7 +2013,7 @@
 
 <template id="header_language_selector" inherit_id="website.placeholder_header_language_selector" name="Header Language Selector" active="False">
     <xpath expr="." position="inside">
-        <t id="header_language_selector_call" t-call="portal.language_selector">
+        <t id="header_language_selector_call" t-call="http_routing.language_selector">
             <t t-set="_div_classes" t-value="(_div_classes or '') + ' dropdown'"/>
         </t>
     </xpath>

--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -218,8 +218,9 @@ class Lang(models.Model):
 
     @api.model
     @tools.ormcache()
-    def get_available(self):
-        """ Return the available languages as a list of (code, url_code, name,
+    def get_available(self, force_context=None):
+        """ :param force_context: force the context (ex.: front)
+            Return the available languages as a list of (code, url_code, name,
             active) sorted by name.
         """
         langs = self.with_context(active_test=False).search([])


### PR DESCRIPTION
Display the language selector in the survey if there are more than one language installed
When sending a survey manually, the link to start the survey is configured with the language of the partner

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
