### PR TITLE
[FIX] account: fix the tax template test

### DIFF
--- a/addons/account/tests/test_templates_consistency.py
+++ b/addons/account/tests/test_templates_consistency.py
@@ -46,7 +46,7 @@ class AccountingTestTemplConsistency(TransactionCase):
         '''Test fields consistency for ('account.tax', 'account.tax.template')
         '''
         self.check_fields_consistency('account.tax.template', 'account.tax', exceptions=['chart_template_id'])
-        self.check_fields_consistency('account.tax', 'account.tax.template', exceptions=['company_id', 'country_id'])
+        self.check_fields_consistency('account.tax', 'account.tax.template', exceptions=['company_id', 'country_id', 'real_amount'])
         self.check_fields_consistency('account.tax.repartition.line.template', 'account.tax.repartition.line', exceptions=['plus_report_line_ids', 'minus_report_line_ids'])
         self.check_fields_consistency('account.tax.repartition.line', 'account.tax.repartition.line.template', exceptions=['tag_ids', 'country_id', 'company_id', 'sequence'])
 


### PR DESCRIPTION
In master, the tax template consistency test
is broken since 8fb53c53c3128e8cea7ef20b9ab4946ac2f9b7d9
Fix this to make sure we add an exception for
that new computed field as it should not be in
the template.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
