### PR TITLE
[FIX] project, hr, web: some bug fixes for project, hr, web

### DIFF
--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -92,7 +92,7 @@
                         </h1>
                     </div>
                     <div class="row">
-                        <h2 class="col-6">
+                        <h2 class="col-6 pl-0">
                             <field name="job_title" placeholder="Job Position" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                         </h2>
                     </div>

--- a/addons/project/static/src/js/project_task_kanban_examples.js
+++ b/addons/project/static/src/js/project_task_kanban_examples.js
@@ -4,8 +4,8 @@ import { _lt } from 'web.core';
 import {Markup} from 'web.utils';
 import kanbanExamplesRegistry from 'web.kanban_examples_registry';
 
-const greenBullet = Markup`<span class="o_status o_status_green"></span>`;
-const redBullet = Markup`<span class="o_status o_status_red"></span>`;
+const greenBullet = Markup`<span class="o_status d-inline-block o_status_green"></span>`;
+const redBullet = Markup`<span class="o_status d-inline-block o_status_red"></span>`;
 const star = Markup`<a style="color: gold;" class="fa fa-star"/>`;
 const clock = Markup`<a class="fa fa-clock-o" />`;
 

--- a/addons/project/static/src/scss/project_sharing/chatter.scss
+++ b/addons/project/static/src/scss/project_sharing/chatter.scss
@@ -22,6 +22,10 @@
             }
         }
 
+        .o_portal_chatter_avatar {
+            width: 45px;
+            height: 45px;
+        }
     }
 
     &.o-aside {

--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -4069,7 +4069,7 @@ var FieldColorPicker = FieldInteger.extend({
         _t('Green'),
         _t('Purple'),
     ],
-
+    widthInList: '1',
     /**
      * Prepares the rendering, since we are based on an input but not using it
      * setting tagName after parent init force the widget to not render an input

--- a/addons/web/static/src/legacy/scss/kanban_examples_dialog.scss
+++ b/addons/web/static/src/legacy/scss/kanban_examples_dialog.scss
@@ -9,6 +9,7 @@
         flex: 0 0 auto;
         border-right: 1px solid gray('300');
         background: white;
+        height: fit-content;
 
         > ul > li {
             margin: 0;

--- a/addons/web/static/src/legacy/scss/utils.scss
+++ b/addons/web/static/src/legacy/scss/utils.scss
@@ -288,6 +288,7 @@
             border-left-color: nth($o-colors, $size);
             &:after {
                 background-color: nth($o-colors, $size);
+                outline: 1px solid nth($o-colors, $size);
             }
         }
     }

--- a/addons/web/static/tests/legacy/views/list_tests.js
+++ b/addons/web/static/tests/legacy/views/list_tests.js
@@ -12807,6 +12807,29 @@ QUnit.module('Views', {
         list.destroy();
     });
 
+    QUnit.test('FieldColorPicker: dont overflow color picker in list', async function (assert) {
+        const list = await createView({
+            View: ListView,
+            model: 'foo',
+            data: this.data,
+            arch: `
+                <tree editable="top" string="Partners">
+                    <field name="date"/>
+                    <field name="int_field" widget="color_picker"/>
+                </tree>`,
+            domain: [['id', '<', 0]],
+       });
+        await testUtils.dom.click(list.el.querySelector('.o_list_button_add'))
+        const date_column_width = list.el.querySelector('.o_list_table thead th[data-name="date"]').style.width.replace('px', '');
+        const int_field_column_width = list.el.querySelector('.o_list_table thead th[data-name="int_field"]').style.width.replace('px', '');
+        // Default values for date and int fields are: date: '92px', integer: '74px'
+        // With the screen growing, the proportion is kept and thus int_field would remain smaller than date if
+        // the color_picker wouldn't have widthInList set to '1'. With that property set, int_field size will be bigger
+        // than date's one.
+        assert.ok(parseFloat(date_column_width) < parseFloat(int_field_column_width), "colorpicker should display properly (Horizontly)");
+        list.destroy();
+    });
+
 });
 
 });


### PR DESCRIPTION
* project, hr, web

In project,
-fixed  green and red icons are not visible in kanban example wizrad
-fixed border issue on project kanban cards when zooming

In hr,
- fixed job title on my profile is not aligned correctly

In web,
- fixed display issue with kanban examples wizard
- fixed color_picker widget alignment issue

task-2720976
closes: https://github.com/odoo/odoo/pull/83727
closes: https://github.com/odoo/enterprise/pull/23875