### PR TITLE
[IMP] mail: improve test covage of odoo/odoo@003e1395ac8dd25cd1a8971c…

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2611,10 +2611,7 @@ class MailThread(models.AbstractModel):
         for group_name, group_func, group_data in groups:
             group_data.setdefault('notification_group_name', group_name)
             group_data.setdefault('notification_is_customer', False)
-            is_thread_notification = msg_vals and (
-                    msg_vals.get('model', self._name) != 'mail.thread' and
-                    (msg_vals.get('res_id', self.ids[0] if self.ids else False) is not False)
-            )
+            is_thread_notification = self._notify_get_recipients_thread_info(msg_vals=msg_vals)['is_thread_notification']
             group_data.setdefault('has_button_access', is_thread_notification)
             group_button_access = group_data.setdefault('button_access', {})
             group_button_access.setdefault('url', access_link)
@@ -2635,6 +2632,15 @@ class MailThread(models.AbstractModel):
                 result.append(group_data)
 
         return result
+
+    def _notify_get_recipients_thread_info(self, msg_vals=None):
+        """ Tool method to compute thread info used in ``_notify_classify_recipients``
+        and its sub-methods. """
+        res_model = msg_vals['model'] if msg_vals and 'model' in msg_vals else self._name
+        res_id = msg_vals['res_id'] if msg_vals and 'res_id' in msg_vals else self.ids[0] if self.ids else False
+        return {
+            'is_thread_notification': res_model and (res_model != 'mail.thread') and res_id
+        }
 
     @api.model
     def _notify_get_reply_to_on_records(self, default=None, records=None, company=None, doc_names=None):

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -130,6 +130,40 @@ class TestMessagePost(TestMailCommon, TestRecipients):
         self.assertNotIn('body', emp_info['button_access']['url'])
         self.assertNotIn('subject', emp_info['button_access']['url'])
 
+        # test when notifying on non-records (e.g. MailThread._message_notify())
+        for model, res_id in ((self.test_record._name, False),
+                              (self.test_record._name, 0),  # browse(0) does not return a valid recordset
+                              (False, self.test_record.id),
+                              (False, False),
+                              ('mail.thread', False),
+                              ('mail.thread', self.test_record.id)):
+            msg_vals.update({
+                'model': model,
+                'res_id': res_id,
+            })
+            # note that msg_vals wins over record on which method is called
+            notify_msg_vals = dict(msg_vals, **link_vals)
+            classify_res = self.test_record._notify_classify_recipients(
+                pdata, 'Test', msg_vals=notify_msg_vals)
+            # find back information for partner
+            partner_info = next(item for item in classify_res if item['recipients'] == self.partner_1.ids)
+            emp_info = next(item for item in classify_res if item['recipients'] == self.partner_employee.ids)
+            # check there is no access button
+            self.assertFalse(partner_info['has_button_access'])
+            self.assertFalse(emp_info['has_button_access'])
+
+            # test on falsy records (False model cannot be browsed, skipped)
+            if model:
+                record_falsy = self.env[model].browse(res_id)
+                classify_res = record_falsy._notify_classify_recipients(
+                    pdata, 'Test', msg_vals=notify_msg_vals)
+                # find back information for partner
+                partner_info = next(item for item in classify_res if item['recipients'] == self.partner_1.ids)
+                emp_info = next(item for item in classify_res if item['recipients'] == self.partner_employee.ids)
+                # check there is no access button
+                self.assertFalse(partner_info['has_button_access'])
+                self.assertFalse(emp_info['has_button_access'])
+
     @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_post_needaction(self):
         (self.user_employee | self.user_admin).write({'notification_type': 'inbox'})
@@ -430,25 +464,3 @@ class TestMessagePost(TestMailCommon, TestRecipients):
                 subject='About %s' % test_record.name,
                 body_content=test_record.name,
                 attachments=[('first.txt', b'My first attachment', 'text/plain'), ('second.txt', b'My second attachment', 'text/plain')])
-
-    @mute_logger('odoo.addons.mail.models.mail_mail')
-    def test_post_notify_no_button(self):
-        pdata = self._generate_notify_recipients(self.partner_employee)
-        msg_vals = {
-            'body': 'Message body',
-            'model': False,
-            'res_id': False,
-            'subject': 'Message subject',
-        }
-        link_vals = {
-            'token': 'token_val',
-            'access_token': 'access_token_val',
-            'auth_signup_token': 'auth_signup_token_val',
-            'auth_login': 'auth_login_val',
-        }
-        notify_msg_vals = dict(msg_vals, **link_vals)
-        classify_res = self.env[self.test_record._name]._notify_classify_recipients(pdata, 'Test', msg_vals=notify_msg_vals)
-        # find back information for partner
-        partner_info = next(item for item in classify_res)
-        # check there is sno access button
-        self.assertFalse(partner_info['has_button_access'])


### PR DESCRIPTION
…e45d33368a6b3dde

odo/odoo@003e1395ac8dd25cd1a8971ce45d33368a6b3dde fixed a bug in email layout button computation for
non thread records. Fix was backported in 13 (see odoo/odoo#83416) with some
other improvements: adding a tool method (to ease forward port after 15.1+)
and more tests.

This commit is the forward port of changes done in backport. Trust me, I am an
engineer.

Task-2747046
