### PR TITLE
[FIX] mail: correctly load chatter related data for archived records

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -394,7 +394,7 @@ class DiscussController(http.Controller):
     @http.route('/mail/thread/data', methods=['POST'], type='json', auth='user')
     def mail_thread_data(self, thread_model, thread_id, request_list, **kwargs):
         res = {}
-        thread = request.env[thread_model].search([('id', '=', thread_id)])
+        thread = request.env[thread_model].with_context(active_test=False).search([('id', '=', thread_id)])
         if 'activities' in request_list:
             res['activities'] = thread.activity_ids.activity_format()
         if 'attachments' in request_list:


### PR DESCRIPTION
With a recent commit[1], we now gather the chatter related data with a
single controller ('/mail/thread/data') which was a bit scattered
previously. With this controller, instead of searching in dedicated
model, we now simply use the main document/record itself and it's
fields whenever possible. For example, previously for the followers,
we used to search data from 'mail.followers' model, but now we simply
use `message_follower_ids` field of the record itself.

The problem with this approach is, if the record is archived, we won't
be able to fetch the related data. That leads to empty follower list/
activities and a trackback while getting suggested recipients.

This PR fixes the issue by loading the record even if it's
archived, and thus fetching the data required by chatter.

commit[1] - https://github.com/odoo/odoo/commit/e0913197ac84b25b40e7599a6432362141d104c9

TaskID-2748030

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
