### PR TITLE
[IMP] * : unify vat display with qweb contact widget

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -15,10 +15,7 @@
                 </t>
                 <div t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}' groups="account.group_delivery_invoice_address"/>
                 <t t-set="address">
-                    <address t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}' groups="!account.group_delivery_invoice_address"/>
-                    <div t-if="o.partner_id.vat" class="mt-2">
-                        <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-esc="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
-                        <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/></div>
+                    <address t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "vat"], "no_marker": True}' groups="!account.group_delivery_invoice_address"/>
                 </t>
                 <div class="page">
                     <h2 class="mt-4">

--- a/addons/l10n_ca/views/report_invoice.xml
+++ b/addons/l10n_ca/views/report_invoice.xml
@@ -1,6 +1,6 @@
 <odoo>
     <template id="l10n_ca_report_invoice_document_inherit" inherit_id="account.report_invoice_document">
-        <div t-if="o.partner_id.vat" position="after">
+        <div t-field="o.partner_id" position="after">
             <t t-if="o.company_id.account_fiscal_country_id.code == 'CA' and o.partner_id.l10n_ca_pst" class="mt16">
                 <div>PST: <span t-field="o.partner_id.l10n_ca_pst"/></div>
             </t>

--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -507,12 +507,8 @@
             <div class="row">
                 <div class="col-4" name="company_address">
                     <div t-field="company.partner_id"
-                         t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'
+                         t-options='{"widget": "contact", "fields": ["address", "name", "vat"], "no_marker": true}'
                     />
-                    <p t-if="company.partner_id.vat">
-                        <t t-out="o.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>:
-                        <span t-field="company.partner_id.vat"/>
-                    </p>
                 </div>
                 <div class="col-4" name="qr_code"/>
                 <div class="col-4" name="company_address" dir="rtl" style="text-align:right">
@@ -525,11 +521,7 @@
              t-att-data-oe-lang="o and o.env.context.get('lang')">
             <div class="pt-5">
                 <t t-set="address">
-                    <address t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}' class="mb-0"/>
-                    <p t-if="o.partner_id.vat">
-                        <t t-out="o.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>:
-                        <span t-field="o.partner_id.vat"/>
-                    </p>
+                    <address t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "vat"], "no_marker": True}' class="mb-0"/>
                 </t>
                 <t t-call="web.address_layout"/>
             </div>

--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -2,10 +2,10 @@
 <odoo>
     <template id="l10n_in_report_invoice_document_inherit" inherit_id="account.report_invoice_document">
 
-        <xpath expr="//span[@t-field='o.partner_id.vat']" position="attributes">
+        <xpath expr="//address[@t-field='o.partner_id']" position="attributes">
             <attribute name="t-if">o.company_id.account_fiscal_country_id.code != 'IN'</attribute>
         </xpath>
-        <xpath expr="//span[@t-field='o.partner_id.vat']" position="after">
+        <xpath expr="//address[@t-field='o.partner_id']" position="after">
             <span t-field="o.l10n_in_gstin" t-if="o.company_id.account_fiscal_country_id.code == 'IN'"/>
         </xpath>
         <xpath expr="//t[@t-set='address']" position="inside">

--- a/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
+++ b/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
@@ -22,11 +22,7 @@
                         <div>
                             <span><strong>Customer Address:</strong></span>
                             <div t-field="o.partner_id"
-                                   t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-                            <p t-if="o.partner_id.vat">
-                                <t t-set="default_vat_label">VAT</t>
-                                <t t-esc="o.company_id.account_fiscal_country_id.vat_label or default_vat_label"/>: <span t-field="o.partner_id.vat"/>
-                            </p>
+                                 t-options='{"widget": "contact", "fields": ["address", "name", "phone", "vat"], "no_marker": True, "phone_icons": True}'/>
                         </div>
                     </div>
                 </div>

--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -5,8 +5,7 @@
         <t t-set="o" t-value="o.with_context(lang=o.partner_id.lang)"/>
         <t t-set="address">
             <div t-field="o.partner_id"
-            t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-            <p t-if="o.partner_id.vat"><t t-esc="o.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="o.partner_id.vat"/></p>
+                 t-options='{"widget": "contact", "fields": ["address", "name", "phone", "vat"], "no_marker": True, "phone_icons": True}'/>
         </t>
         <t t-if="o.dest_address_id">
             <t t-set="information_block">

--- a/addons/purchase/report/purchase_quotation_templates.xml
+++ b/addons/purchase/report/purchase_quotation_templates.xml
@@ -6,8 +6,7 @@
         <t t-set="forced_vat" t-value="o.fiscal_position_id.foreign_vat"/> <!-- So that it appears in the footer of the report instead of the company VAT if it's set -->
         <t t-set="address">
             <div t-field="o.partner_id"
-            t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-            <p t-if="o.partner_id.vat"><t t-esc="o.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="o.partner_id.vat"/></p>
+                 t-options='{"widget": "contact", "fields": ["address", "name", "phone", "vat"], "no_marker": True, "phone_icons": True}'/>
         </t>
         <t t-if="o.dest_address_id">
             <t t-set="information_block">

--- a/addons/repair/report/repair_templates_repair_order.xml
+++ b/addons/repair/report/repair_templates_repair_order.xml
@@ -10,14 +10,12 @@
                     <div t-if="o.partner_invoice_id">
                         <strong t-if="o.address_id != o.partner_invoice_id">Invoice address: </strong>
                         <div t-field="o.partner_invoice_id" 
-                            t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-                        <p t-if="o.partner_invoice_id.vat"><t t-esc="o.company_id.country_id.vat_label or 'Tax ID'"/>: <span t-field="o.partner_invoice_id.vat"/></p>
+                             t-options='{"widget": "contact", "fields": ["address", "name", "phone", "vat"], "no_marker": True, "phone_icons": True}'/>
                     </div>
                     <t t-if="o.address_id != o.partner_invoice_id">
                         <strong>Shipping address :</strong>
                         <div t-field="o.address_id" 
-                            t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-                        <p t-if="o.address_id.vat"><t t-esc="o.company_id.country_id.vat_label or 'Tax ID'"/>: <span t-field="o.address_id.vat"/></p>
+                             t-options='{"widget": "contact", "fields": ["address", "name", "phone", "vat"], "no_marker": True, "phone_icons": True}'/>
                     </t>
                 </t>
                 <t t-set="address">

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -34,8 +34,7 @@
                             </div>
                             <div t-if="partner" name="partner_header">
                                 <div t-field="partner.self"
-                                    t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-                                <p t-if="partner.sudo().vat"><t t-esc="o.company_id.country_id.vat_label or 'Tax ID'"/>: <span t-field="partner.sudo().vat"/></p>
+                                     t-options='{"widget": "contact", "fields": ["address", "name", "phone", "vat"], "no_marker": True, "phone_icons": True}'/>
                             </div>
                         </div>
                     </div>

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -37,8 +37,7 @@
                                     </div>
                                     <div t-if="o.partner_id" name="partner_header">
                                         <div t-field="o.partner_id"
-                                           t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-                                        <p t-if="o.sudo().partner_id.vat"><t t-esc="o.company_id.country_id.vat_label or 'Tax ID'"/>: <span t-field="o.sudo().partner_id.vat"/></p>
+                                             t-options='{"widget": "contact", "fields": ["address", "name", "phone", "vat"], "no_marker": True, "phone_icons": True}'/>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
The contact widget supports displaying VAT but it was added manually in the reports after contact. This commit fixes this behavior and results in fewer code and an easier way for the l10n modules which may modify VAT display.

Supplies Task No: [2735448](https://www.odoo.com/web?debug#id=2735448&cids=1&menu_id=4722&action=4043&model=project.task&view_type=form) (not directly)

related enterprise PR: [25195](https://github.com/odoo/enterprise/pull/25195)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
