### PR TITLE
[IMP] l10n_es: Make deprecated tag inactive

### DIFF
--- a/addons/l10n_es/data/account_tax_data.xml
+++ b/addons/l10n_es/data/account_tax_data.xml
@@ -247,6 +247,7 @@
         <!--Not used anymore since Q3 2021; replaced by grids 120, 122, 123 and 124-->
         <field name="name">mod303[61]</field>
         <field name="applicability">taxes</field>
+        <field name="active" eval="False"/>
         <field name="country_id" ref="base.es"/>
     </record>
     <record id="mod_303_120" model="account.account.tag">


### PR DESCRIPTION
Starting january 2022, grid 61 is removed from mod 303. Making the tag inactive ensures we don't show it anymore.

Doc: https://sede.agenciatributaria.gob.es/Sede/ayuda/disenos-registro/modelos-300-399.html
