### PR TITLE
[FIX] sale, purchase: set customer/supplier_rank when creating SO/PO

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -186,9 +186,17 @@ class PurchaseOrder(models.Model):
             if 'date_order' in vals:
                 seq_date = fields.Datetime.context_timestamp(self, fields.Datetime.to_datetime(vals['date_order']))
             vals['name'] = self.env['ir.sequence'].with_context(force_company=company_id).next_by_code('purchase.order', sequence_date=seq_date) or '/'
+
+        partner = self.env['res.partner'].browse(vals.get('partner_id'))
+        if not partner.supplier_rank:
+            partner._increase_rank('supplier_rank')
         return super(PurchaseOrder, self.with_context(company_id=company_id)).create(vals)
 
     def write(self, vals):
+        if 'partner_id' in vals:
+            partner = self.env['res.partner'].browse(vals.get('partner_id'))
+            if not partner.supplier_rank:
+                partner._increase_rank('supplier_rank')
         res = super(PurchaseOrder, self).write(vals)
         if vals.get('date_planned'):
             self.order_line.filtered(lambda line: not line.display_type).date_planned = vals['date_planned']

--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -477,7 +477,19 @@ class SaleOrder(models.Model):
             vals['partner_invoice_id'] = vals.setdefault('partner_invoice_id', addr['invoice'])
             vals['partner_shipping_id'] = vals.setdefault('partner_shipping_id', addr['delivery'])
             vals['pricelist_id'] = vals.setdefault('pricelist_id', partner.property_product_pricelist and partner.property_product_pricelist.id)
+        partner = self.env['res.partner'].browse(vals.get('partner_id'))
+        if not partner.customer_rank:
+            partner._increase_rank('customer_rank')
         result = super(SaleOrder, self).create(vals)
+        return result
+
+    def write(self, vals):
+        if 'partner_id' in vals:
+            partner = self.env['res.partner'].browse(vals.get('partner_id'))
+            if not partner.customer_rank:
+                partner._increase_rank('customer_rank')
+
+        result = super(SaleOrder, self).write(vals)
         return result
 
     def _write(self, values):


### PR DESCRIPTION
Reproduce(SO):
1) create a contact
2) go to sales, generate a quote & confirm
3) customer_rank is not set on contact
4) create invoice from the SO
5) customer_rank is set on contact

1) Create a contact directly from a quote
2) customer_rank is set on contact, no invoice needed

Similar issue for PO

Reason: Currently the customer_rank is increased when a new customer is created in a sales order or an invoice is posted to an existing customer. However, customer_rank should be set to 1 as soon as a SO is created for an existing contact with customer_rank == 0. For PO, the supplier_rank should be set to 1 as soon as a PO is created for an existing contact with supplier_rank == 0.

opw-2733844



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
