### PR TITLE
[FIX] account: partial revert of 9311b087e1cdcfd2e1c4ab4a559a55d517b542fa, for usability

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -267,14 +267,14 @@
                                 <field name="payment_method_line_id" required="1" options="{'no_create': True, 'no_open': True}"
                                        attrs="{'readonly': [('state', '!=', 'draft')]}"/>
 
-                                <field name="partner_bank_id" context="{'default_partner_id': partner_id}" string="Recipient Bank Account"
+                                <field name="partner_bank_id" context="{'default_partner_id': partner_id}" string="Customer Bank Account"
                                         attrs="{
                                             'invisible': ['|', '|', ('show_partner_bank_account', '=', False), ('partner_type','!=','customer'), ('is_internal_transfer', '=', True)],
                                             'required': [('require_partner_bank_account', '=', True), ('is_internal_transfer', '=', False)],
                                             'readonly': ['|', ('state', '!=', 'draft'), ('payment_type', '=', 'inbound')],
                                         }"/>
 
-                                <field name="partner_bank_id" context="{'default_partner_id': partner_id}" string="Recipient Bank Account"
+                                <field name="partner_bank_id" context="{'default_partner_id': partner_id}" string="Vendor Bank Account"
                                         attrs="{
                                             'invisible': ['|', '|', ('show_partner_bank_account', '=', False), ('partner_type','!=','supplier'), ('is_internal_transfer', '=', True)],
                                             'required': [('require_partner_bank_account', '=', True), ('is_internal_transfer', '=', False)],


### PR DESCRIPTION
The part of 9311b087e1cdcfd2e1c4ab4a559a55d517b542fa affecting  field labels on account.payment's form view was mistakenly merged. The actual fix regarding those labels is done in 15.0 here https://github.com/odoo/odoo/pull/83674 .