### PR TITLE
[IMP] pos_adyen: handle adyen payment request by push notification

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -58,6 +58,7 @@ class PosController(http.Controller):
             'session_info': session_info,
             'login_number': pos_session.login(),
             'pos_session_id': pos_session.id,
+            'pos_broadcast_enabled': pos_session.config_id._is_pos_broadcast_allowed(),
         }
         response = request.render('point_of_sale.index', context)
         response.headers['Cache-Control'] = 'no-store'

--- a/addons/point_of_sale/static/src/js/Popups/OfflineErrorPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/OfflineErrorPopup.js
@@ -22,6 +22,7 @@ odoo.define('point_of_sale.OfflineErrorPopup', function(require) {
         cancelText: _lt('Cancel'),
         title: _lt('Offline Error'),
         body: _lt('Either the server is inaccessible or browser is not connected online.'),
+        noDuplicate: true,
     };
 
     Registries.Component.add(OfflineErrorPopup);

--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -376,12 +376,17 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
             const payment_terminal = line.payment_method.payment_terminal;
             line.set_payment_status('waiting');
 
-            const isPaymentSuccessful = await payment_terminal.send_payment_request(line.cid);
-            if (isPaymentSuccessful) {
-                line.set_payment_status('done');
-                line.can_be_reversed = payment_terminal.supports_reversals;
-            } else {
-                line.set_payment_status('retry');
+            try {
+                const isPaymentSuccessful = await payment_terminal.send_payment_request(line.cid);
+                line.setStatusAfterPaymentStatusValidation(isPaymentSuccessful);
+            } catch (error) {
+                // We catch the error of the payment_terminal but we just log it.
+                // At the moment, there is no common convention on how to handle
+                // error.
+                // IMPROVEMENT: Make the handling of payment request more robust, such that
+                // result and error should be handled in this function, not in the payment
+                // interface. Same improvements should be done with cancel and reverse.
+                console.error(error);
             }
         }
         async _sendPaymentCancel({ detail: line }) {

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -106,6 +106,9 @@ class PosGlobalState extends PosModel {
         this.default_pricelist = null;
         this.order_sequence = 1;
 
+        // This is needed to start the longpolling in the ui. This is set during _processData.
+        this.posBroadcastChannel = false;
+
         // Object mapping the order's name (which contains the uid) to it's server_id after
         // validation (order paid then sent to the backend).
         this.validated_orders_name_server_id_map = {};
@@ -218,6 +221,7 @@ class PosGlobalState extends PosModel {
     }
     _loadPoSConfig() {
         this.db.set_uuid(this.config.uuid);
+        this.posBroadcastChannel = `pos_config_${this.config.id}`;
     }
     _loadResPartner() {
         this.db.add_partners(this.partners);

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2137,7 +2137,7 @@ class Payment extends PosModel {
             cid: this.cid,
             amount: this.get_amount(),
             name: this.name,
-            ticket: this.ticket,
+            ticket: owl.markup(this.ticket),
         };
     }
     // If payment status is a non-empty string, then it is an electronic payment.
@@ -2380,7 +2380,7 @@ class Order extends PosModel {
                     qweb.default_dict = _.clone(QWeb.default_dict);
                     qweb.add_template('<templates><t t-name="subreceipt">'+subreceipt+'</t></templates>');
 
-                return qweb.render('subreceipt',{'pos':self.pos,'order':self, 'receipt': receipt}) ;
+                return owl.markup(qweb.render('subreceipt',{'pos':self.pos,'order':self, 'receipt': receipt}));
             }
         }
 

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2146,6 +2146,20 @@ class Payment extends PosModel {
     is_electronic() {
         return Boolean(this.get_payment_status());
     }
+    /**
+     * Properly set the status of an electronic payment when the payment request is done.
+     * @param {boolean} isSuccessfulRequest
+     */
+    setStatusAfterPaymentStatusValidation(isSuccessfulRequest) {
+        if (isSuccessfulRequest) {
+            this.set_payment_status('done');
+            if (this.payment_method.payment_terminal) {
+                this.can_be_reversed = this.payment_method.payment_terminal.supports_reversals;
+            }
+        } else {
+            this.set_payment_status('retry');
+        }
+    }
 }
 Registries.Model.add(Payment);
 

--- a/addons/point_of_sale/static/src/js/pos_env.js
+++ b/addons/point_of_sale/static/src/js/pos_env.js
@@ -18,4 +18,22 @@ pos_env.barcode_reader = new BarcodeReader({ env: pos_env, proxy: pos_env.proxy 
 pos_env.posbus = new owl.EventBus();
 pos_env.posMutex = new concurrency.Mutex();
 
+// create a different bus that is responsible for broadcasted pos messages.
+pos_env.posBroadcastBus = new owl.EventBus();
+
+/**
+ * Broadcast a message to every open pos ui from the same config.
+ * Use the `onPosBroadcast` to catch the broadcasted message.
+ *
+ * @param {str} messageName
+ * @param {any} messageValue
+ */
+pos_env.broadcastPosMessage = function (messageName, messageValue) {
+    return this.services.rpc({
+        model: 'pos.config',
+        method: 'broadcast_pos_message',
+        args: [[this.pos.config.id], messageName, messageValue],
+    });
+}
+
 export default pos_env;

--- a/addons/point_of_sale/views/pos_assets_index.xml
+++ b/addons/point_of_sale/views/pos_assets_index.xml
@@ -32,6 +32,7 @@
                 'login_number': login_number,
                 'pos_session_id': pos_session_id,
                 'debug': debug,
+                'pos_broadcast_enabled': pos_broadcast_enabled,
             })"/>;
             odoo.loadTemplatesPromise = fetch(`/web/webclient/qweb/${odoo.__session_info__.cache_hashes.qweb}?bundle=web.assets_qweb`).then(doc => doc.text());
         </script>

--- a/addons/pos_adyen/controllers/main.py
+++ b/addons/pos_adyen/controllers/main.py
@@ -2,6 +2,7 @@
 import logging
 import pprint
 import json
+import re
 from odoo import fields, http
 from odoo.http import request
 
@@ -28,5 +29,21 @@ class PosAdyenController(http.Controller):
                 payment_method.adyen_latest_diagnosis = data['SaleToPOIResponse']['MessageHeader']['ServiceID']
             else:
                 payment_method.adyen_latest_response = json.dumps(data)
+
+                # Notify the pos ui that the payment status of the last payment request has been received.
+                pos_config = self._get_pos_config(data['SaleToPOIResponse']['MessageHeader']['SaleID'])
+                if pos_config:
+                    message_value = [payment_method.id, payment_method.get_latest_adyen_status(data['SaleToPOIResponse']['MessageHeader']['SaleID'])]
+                    pos_config.broadcast_pos_message('adyen-payment-status-received', message_value)
+                else:
+                    _logger.error("received a message for a terminal that doesn't belong in a pos config: %s", terminal_identifier)
+
         else:
             _logger.error('received a message for a terminal not registered in Odoo: %s', terminal_identifier)
+
+    def _get_pos_config(self, sale_id: str):
+        regex = re.compile(r'ID: (\d*)')
+        mo = regex.search(sale_id)
+        if mo:
+            config_id = int(mo.group(1))
+            return request.env['pos.config'].sudo().browse(config_id)

--- a/addons/pos_adyen/static/src/js/Chrome.js
+++ b/addons/pos_adyen/static/src/js/Chrome.js
@@ -1,0 +1,58 @@
+/* @odoo-module */
+'use strict';
+
+import Chrome from 'point_of_sale.Chrome';
+import Registries from 'point_of_sale.Registries';
+import { onPosBroadcast } from 'point_of_sale.custom_hooks';
+
+const PosAdyenChrome = Chrome => class PosAdyenChrome extends Chrome {
+    setup() {
+        super.setup(...arguments);
+        onPosBroadcast('adyen-payment-status-received', this._onAdyenPaymentStatusReceived);
+    }
+    /**
+     * When receiving payment status, we identify the order from the status and
+     * find a pending payment. Then, validate the status with the pending payment.
+     */
+    _onAdyenPaymentStatusReceived([paymentMethodId, paymentStatus]) {
+        const paymentMethod = this.env.pos.payment_methods.find(pm => pm.id == paymentMethodId);
+        const order = paymentMethod.payment_terminal.identifyOrder(paymentStatus);
+
+        if (!order) {
+            // Order containing the pending payment might have been deleted.
+            if (paymentStatus.latest_response.SaleToPOIResponse.PaymentResponse.Response.Result == 'Success') {
+                // This means that a successful payment status was received for a deleted order.
+                // I don't see how to reach this from the UI. In case it's reached, we show an error dialog.
+                // One possibility is that the payment status took time to reach the server, and when the
+                // notification is received, the corresponding order might have been deleted or it has been
+                // synced to the server.
+                // IMPROVEMENT: How about writing a message in the order in case it's in the database?
+                this.showPopup('ErrorPopup', {
+                    title: this.env._t('Order not found'),
+                    body: this.env._t(
+                        'Order corresponding to the received payment notification might have been deleted.'
+                    ),
+                });
+            }
+            return;
+        }
+
+        const pendingPayment = order.get_paymentlines().find(payment => payment.payment_method.id == paymentMethod.id && !payment.is_done());
+
+        if (!pendingPayment) {
+            // I don't see how to reach this code.
+            return;
+        }
+
+        if (paymentMethod.payment_terminal.hasWaitingPaymentRequest) {
+            paymentMethod.payment_terminal.handleAsyncPaymentStatus(paymentStatus, order, pendingPayment);
+        } else {
+            const result = paymentMethod.payment_terminal.validatePaymentStatus(paymentStatus, order, pendingPayment);
+            pendingPayment.setStatusAfterPaymentStatusValidation(result);
+        }
+    }
+}
+
+Registries.Component.extend(Chrome, PosAdyenChrome);
+
+export default Chrome

--- a/addons/pos_adyen/static/src/js/PaymentScreen.js
+++ b/addons/pos_adyen/static/src/js/PaymentScreen.js
@@ -22,7 +22,7 @@ const PosAdyenPaymentScreen = (PaymentScreen) => class PosAdyenPaymentScreen ext
 
             if (pendingAdyenPayment) {
                 const paymentTerminal = pendingAdyenPayment.payment_method.payment_terminal;
-                const status = await this.pos.env.services.rpc({
+                const status = await this.env.services.rpc({
                     model: 'pos.payment.method',
                     method: 'get_latest_adyen_status',
                     args: [[paymentTerminal.payment_method.id], paymentTerminal._adyen_get_sale_id()],

--- a/addons/pos_adyen/static/src/js/PaymentScreen.js
+++ b/addons/pos_adyen/static/src/js/PaymentScreen.js
@@ -1,36 +1,85 @@
-odoo.define('pos_adyen.PaymentScreen', function(require) {
-    "use strict";
+/* @odoo-module */
 
-    const PaymentScreen = require('point_of_sale.PaymentScreen');
-    const Registries = require('point_of_sale.Registries');
-    const { onMounted } = owl;
+import PaymentScreen from 'point_of_sale.PaymentScreen';
+import Registries from 'point_of_sale.Registries';
 
-    const PosAdyenPaymentScreen = PaymentScreen => class extends PaymentScreen {
-        setup() {
+const PosAdyenPaymentScreen = (PaymentScreen) => class PosAdyenPaymentScreen extends PaymentScreen {
+    setup() {
         super.setup();
-            onMounted(() => {
-                const pendingPaymentLine = this.currentOrder.paymentlines.find(
-                    paymentLine => paymentLine.payment_method.use_payment_terminal === 'adyen' &&
-                        (!paymentLine.is_done() && paymentLine.get_payment_status() !== 'pending')
-                );
-                if (pendingPaymentLine) {
-                    const paymentTerminal = pendingPaymentLine.payment_method.payment_terminal;
-                    paymentTerminal.set_most_recent_service_id(pendingPaymentLine.terminalServiceId);
-                    pendingPaymentLine.set_payment_status('waiting');
-                    paymentTerminal.start_get_status_polling().then(isPaymentSuccessful => {
-                        if (isPaymentSuccessful) {
-                            pendingPaymentLine.set_payment_status('done');
-                            pendingPaymentLine.can_be_reversed = paymentTerminal.supports_reversals;
-                        } else {
-                            pendingPaymentLine.set_payment_status('retry');
-                        }
-                    });
+        owl.onMounted(this._onMounted);
+    }
+    /**
+     * When opening payment screen, check if there is a pending payment.
+     * If there is, check the latest status from the backend.
+     * If the status corresponds to the currently selected order, try to
+     * validate the pending payment with the payment status.
+     */
+    async _onMounted() {
+        try {
+            const pendingAdyenPayment = this.currentOrder
+                .get_paymentlines()
+                .find((payment) => payment.payment_method.use_payment_terminal == 'adyen' && !payment.is_done());
+
+            if (pendingAdyenPayment) {
+                const paymentTerminal = pendingAdyenPayment.payment_method.payment_terminal;
+                const status = await this.pos.env.services.rpc({
+                    model: 'pos.payment.method',
+                    method: 'get_latest_adyen_status',
+                    args: [[paymentTerminal.payment_method.id], paymentTerminal._adyen_get_sale_id()],
+                });
+                const order = paymentTerminal.identifyOrder(status);
+                if (order && order.uid == this.currentOrder.uid) {
+                    const result = paymentTerminal.validatePaymentStatus(status, this.currentOrder, pendingAdyenPayment);
+                    pendingAdyenPayment.setStatusAfterPaymentStatusValidation(result);
+                } else {
+                    this.showNotification(this.env._t('Order corresponding to the payment status was not found.'));
                 }
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    }
+    /**
+     * @override
+     * Prevent sending payment request if there is a pending adyen payment from other order.
+     */
+    async _sendPaymentRequest({ detail: line }) {
+        const paymentMethod = line.payment_method;
+        if (paymentMethod.use_payment_terminal != 'adyen') {
+            return super._sendPaymentRequest(...arguments);
+        }
+
+        // At this point, payment method is adyen.
+        if (!paymentMethod.payment_terminal) {
+            return;
+        }
+
+        if (paymentMethod.payment_terminal.hasWaitingPaymentRequest || this._hasOtherPendingPayment(paymentMethod)) {
+            return this.showPopup('ErrorPopup', {
+                title: this.env._t('Not allowed'),
+                body: this.env._t('There is a pending payment request from other order.'),
             });
         }
-    };
 
-    Registries.Component.extend(PaymentScreen, PosAdyenPaymentScreen);
+        return super._sendPaymentRequest(...arguments);
+    }
 
-    return PaymentScreen;
-});
+    _hasOtherPendingPayment(paymentMethod) {
+        return (
+            this.env.pos.orders
+                .filter((order) => order.uid != this.currentOrder.uid)
+                .reduce(
+                    (payments, order) => [
+                        ...payments,
+                        ...order
+                            .get_paymentlines()
+                            .filter((payment) => payment.payment_method.id == paymentMethod.id && !payment.is_done()),
+                    ],
+                    []
+                ).length > 0
+        );
+    }
+
+};
+
+Registries.Component.extend(PaymentScreen, PosAdyenPaymentScreen);

--- a/addons/pos_adyen/static/src/js/TicketScreen.js
+++ b/addons/pos_adyen/static/src/js/TicketScreen.js
@@ -1,0 +1,17 @@
+/* @odoo-module */
+
+import TicketScreen from 'point_of_sale.TicketScreen';
+import Registries from 'point_of_sale.Registries';
+
+const PosAdyenTicketScreen = (TicketScreen) => class PosAdyenTicketScreen extends TicketScreen {
+    async _onBeforeDeleteOrder(order) {
+        const pendingAdyenPayments = order.get_paymentlines().filter(payment => payment.payment_method.use_payment_terminal == 'adyen' && !payment.is_done());
+        for (const pendingPayment of pendingAdyenPayments) {
+            const paymentTerminal = pendingPayment.payment_method.payment_terminal;
+            paymentTerminal.send_payment_cancel(order, pendingPayment.cid);
+        }
+        return super._onBeforeDeleteOrder(order);
+    }
+};
+
+Registries.Component.extend(TicketScreen, PosAdyenTicketScreen);

--- a/addons/pos_adyen/static/src/js/models.js
+++ b/addons/pos_adyen/static/src/js/models.js
@@ -13,16 +13,13 @@ const PosAdyenPayment = (Payment) => class PosAdyenPayment extends Payment {
     //@override
     export_as_JSON() {
         const json = super.export_as_JSON(...arguments);
-        json.terminal_service_id = this.terminalServiceId;
+        json.terminalServiceId = this.terminalServiceId;
         return json;
     }
     //@override
     init_from_JSON(json) {
         super.init_from_JSON(...arguments);
-        this.terminalServiceId = json.terminal_service_id;
-    }
-    setTerminalServiceId(id) {
-        this.terminalServiceId = id;
+        this.terminalServiceId = json.terminalServiceId;
     }
 }
 Registries.Model.extend(Payment, PosAdyenPayment);

--- a/addons/pos_adyen/static/src/js/payment_adyen.js
+++ b/addons/pos_adyen/static/src/js/payment_adyen.js
@@ -153,7 +153,7 @@ var PaymentAdyen = PaymentInterface.extend({
     },
 
     _call_adyen: function (data, operation) {
-        return rpc.query({
+        return this.pos.env.services.rpc({
             model: 'pos.payment.method',
             method: 'proxy_adyen_request',
             args: [[this.payment_method.id], data, operation],

--- a/addons/pos_adyen/static/src/js/payment_adyen.js
+++ b/addons/pos_adyen/static/src/js/payment_adyen.js
@@ -2,7 +2,6 @@ odoo.define('pos_adyen.payment', function (require) {
 "use strict";
 
 var core = require('web.core');
-var rpc = require('web.rpc');
 var PaymentInterface = require('point_of_sale.PaymentInterface');
 const { Gui } = require('point_of_sale.Gui');
 


### PR DESCRIPTION
Instead of eager polling of payment status of a payment request at
every 5.5 secs for some number of tries, we are now using the longpolling
bus service to receive in the POS UI the payment status in near real-time.

Basically, when adyen server notifies the backend for the payment status,
the payment status will be automatically broadcasted. Open POS UI will
receive the notification and will handle it accordingly.

For robustness, the combinations of the following sets of possibilities are
taken into account:

* UI actions during payment
  - Wait for the payment status at the payment screen.
  - Go back to product screen - pay - then to payment screen.
  - Go back to product screen - then to payment screen - pay.
  - While pending payment, go back to backend ui - pay - open pos - payment
    screen.
  - While pending payment, go back to backend ui - open pos - payment screen -
    pay.
  - While pending payment, open another order and try to make another payment.
    * It shouldn't be allowed.
  - Normal payment but cancel the payment before the status is received.
  - Order with pending payment is deleted.
  - Pending payment is deleted.

* Payment terminal actions
  - Pay immediately
  - Payment error in the terminal
  - Wait long until payment is cancelled in the terminal. This is possible.
    Results to payment error.

Notable payment terminal action that is not considered:
  - Successful in terminal but the server is not notified (or the notification
    took so long.)
    * Workaround: The cashier can just cancel the pending payment.

TASK-ID: 2659918

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
