### PR TITLE
[FIX] stock_picking_batch: wave traceback

### DIFF
--- a/addons/stock_picking_batch/models/stock_move_line.py
+++ b/addons/stock_picking_batch/models/stock_move_line.py
@@ -67,7 +67,10 @@ class StockMoveLine(models.Model):
                     picking_to_wave_vals['move_lines'] += [Command.link(move.id)]
                     continue
                 # Split the move
-                qty = sum(move_lines.mapped('product_qty'))
+                if move.from_immediate_transfer:
+                    qty = sum(move_lines.mapped('qty_done'))
+                else:
+                    qty = sum(move_lines.mapped('product_qty'))
                 new_move = move._split(qty)
                 new_move[0]['move_line_ids'] = [Command.set(move_lines.ids)]
                 picking_to_wave_vals['move_lines'] += [Command.create(new_move[0])]

--- a/addons/stock_picking_batch/models/stock_move_line.py
+++ b/addons/stock_picking_batch/models/stock_move_line.py
@@ -67,7 +67,7 @@ class StockMoveLine(models.Model):
                     picking_to_wave_vals['move_lines'] += [Command.link(move.id)]
                     continue
                 # Split the move
-                qty = sum(lines.mapped('product_qty'))
+                qty = sum(move_lines.mapped('product_qty'))
                 new_move = move._split(qty)
                 new_move[0]['move_line_ids'] = [Command.set(move_lines.ids)]
                 picking_to_wave_vals['move_lines'] += [Command.create(new_move[0])]

--- a/addons/stock_picking_batch/models/stock_move_line.py
+++ b/addons/stock_picking_batch/models/stock_move_line.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 from odoo import _, fields, models
 from odoo import Command
+from odoo.tools.float_utils import float_compare
 
 
 class StockMoveLine(models.Model):
@@ -41,15 +42,30 @@ class StockMoveLine(models.Model):
             })
         line_by_picking = defaultdict(lambda: self.env['stock.move.line'])
         for line in self:
-            # if not wave and line.orig_picking_id.is_wave:
-                # continue
             line_by_picking[line.picking_id] |= line
         picking_to_wave_vals_list = []
         for picking, lines in line_by_picking.items():
             # Move the entire picking if all the line are taken
-            if lines == picking.move_line_ids:
-                wave.picking_ids = [Command.link(picking.id)]
-                continue
+            line_by_move = defaultdict(lambda: self.env['stock.move.line'])
+            qty_by_move = defaultdict(float)
+            for line in lines:
+                move = line.move_id
+                line_by_move[move] |= line
+                if move.from_immediate_transfer:
+                    qty = line.product_uom_id._compute_quantity(line.qty_done, line.product_id.uom_id, rounding_method='HALF-UP')
+                else:
+                    qty = line.product_qty
+                qty_by_move[line.move_id] += qty
+
+            if lines == picking.move_line_ids and lines.move_id == picking.move_lines:
+                move_complete = True
+                for move, qty in qty_by_move.items():
+                    if float_compare(move.product_qty, qty, precision_rounding=move.product_uom.rounding) != 0:
+                        move_complete = False
+                        break
+                if move_complete:
+                    wave.picking_ids = [Command.link(picking.id)]
+                    continue
 
             # Split the picking in two part to extract only line that are taken on the wave
             picking_to_wave_vals = picking.copy_data({
@@ -57,9 +73,6 @@ class StockMoveLine(models.Model):
                 'move_line_ids': [],
                 'batch_id': wave.id,
             })[0]
-            line_by_move = defaultdict(lambda: self.env['stock.move.line'])
-            for line in lines:
-                line_by_move[line.move_id] |= line
             for move, move_lines in line_by_move.items():
                 picking_to_wave_vals['move_line_ids'] += [Command.link(line.id) for line in lines]
                 # if all the line of a stock move are taken we change the picking on the stock move
@@ -67,10 +80,7 @@ class StockMoveLine(models.Model):
                     picking_to_wave_vals['move_lines'] += [Command.link(move.id)]
                     continue
                 # Split the move
-                if move.from_immediate_transfer:
-                    qty = sum(move_lines.mapped('qty_done'))
-                else:
-                    qty = sum(move_lines.mapped('product_qty'))
+                qty = qty_by_move[move]
                 new_move = move._split(qty)
                 new_move[0]['move_line_ids'] = [Command.set(move_lines.ids)]
                 picking_to_wave_vals['move_lines'] += [Command.create(new_move[0])]

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -3,6 +3,7 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
+from odoo.osv.expression import AND
 from odoo.tools.float_utils import float_compare, float_is_zero, float_round
 
 class StockPickingBatch(models.Model):
@@ -75,9 +76,10 @@ class StockPickingBatch(models.Model):
                 domain_states.append('draft')
             domain = [
                 ('company_id', '=', batch.company_id.id),
-                ('immediate_transfer', '=', False),
                 ('state', 'in', domain_states),
             ]
+            if not batch.is_wave:
+                domain = AND([domain, [('immediate_transfer', '=', False)]])
             if batch.picking_type_id:
                 domain += [('picking_type_id', '=', batch.picking_type_id.id)]
             batch.allowed_picking_ids = self.env['stock.picking'].search(domain)

--- a/addons/stock_picking_batch/tests/test_wave_picking.py
+++ b/addons/stock_picking_batch/tests/test_wave_picking.py
@@ -291,6 +291,56 @@ class TestBatchPicking(TransactionCase):
         self.assertEqual(lines.batch_id, wave)
         self.assertEqual(dozen_move.product_uom_qty, 0.58)
 
+    def test_wave_mutliple_move_lines(self):
+        self.productA = self.env['product.product'].create({
+            'name': 'Product Test A',
+            'type': 'product',
+            'categ_id': self.env.ref('product.product_category_all').id,
+        })
+        picking = self.env['stock.picking'].create({
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out,
+            'company_id': self.env.company.id,
+            'immediate_transfer': True,
+        })
+        ml1 = self.env['stock.move.line'].create({
+            'product_id': self.productA.id,
+            'qty_done': 5,
+            'product_uom_id': self.productA.uom_id.id,
+            'picking_id': picking.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+        })
+        self.env['stock.move.line'].create({
+            'product_id': self.productA.id,
+            'qty_done': 5,
+            'product_uom_id': self.productA.uom_id.id,
+            'picking_id': picking.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+        })
+
+        ml2 = self.env['stock.move.line'].create({
+            'product_id': self.productA.id,
+            'qty_done': 5,
+            'product_uom_id': self.productA.uom_id.id,
+            'picking_id': picking.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+        })
+        picking.action_confirm()
+
+        ml1._add_to_wave()
+        wave = self.env['stock.picking.batch'].search([
+            ('is_wave', '=', True)
+        ])
+        self.assertFalse(picking.batch_id)
+        self.assertEqual(ml1.picking_id.batch_id.id, wave.id)
+        self.assertEqual(ml1.picking_id.move_lines.product_uom_qty, 5)
+        self.assertEqual(ml2.picking_id.id, picking.id)
+        self.assertEqual(ml2.picking_id.move_lines.product_uom_qty, 10)
+
     def test_wave_trigger_errors(self):
         with self.assertRaises(UserError):
             lines = self.picking_client_1.move_line_ids

--- a/addons/stock_picking_batch/tests/test_wave_picking.py
+++ b/addons/stock_picking_batch/tests/test_wave_picking.py
@@ -261,7 +261,6 @@ class TestBatchPicking(TransactionCase):
 
         for i in range(12):
             self.env['stock.quant']._update_available_quantity(self.productB, self.stock_location, 1.0, lot_id=sns[i])
-
         dozen_move = self.env['stock.move'].create({
             'name': self.productB.name,
             'product_id': self.productB.id,


### PR DESCRIPTION
Usecase to reproduce:

Create a transfer with 3 moves for 3 products:

A - qty 60 (2 move lines, each move line has a quantity of 30)
B - qty 40 (2 move lines, each move line has a quantity of 20)
C - qty 40 (2 move lines, each move line has a quantity of 20)
Create a new wave picking containing the first move lines of each product (3 move lines)

Traceback

The error is due since it take all the `stock.move.line` from the
picking instead of the `stock.move` that is browsed

Fix #83450