### PR TITLE
[IMP] fleet, hr_fleet: improve assignment logs view

### DIFF
--- a/addons/fleet/models/fleet_vehicle_assignation_log.py
+++ b/addons/fleet/models/fleet_vehicle_assignation_log.py
@@ -13,13 +13,3 @@ class FleetVehicleAssignationLog(models.Model):
     driver_id = fields.Many2one('res.partner', string="Driver", required=True)
     date_start = fields.Date(string="Start Date")
     date_end = fields.Date(string="End Date")
-
-    def action_open_vehicle(self):
-        self.ensure_one()
-        return {
-            'type': 'ir.actions.act_window',
-            'res_model': 'fleet.vehicle',
-            'res_id': self.vehicle_id.id,
-            'view_mode': 'form',
-            'context': dict(self.env.context, create=False),
-        }

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -536,10 +536,9 @@
         <field name="arch" type="xml">
             <tree string="Assignment Logs" editable="bottom">
                 <field name="vehicle_id" />
+                <field name="driver_id" widget="many2one_avatar" string="Current Driver" />
                 <field name="date_start"/>
                 <field name="date_end"/>
-                <field name="driver_id" widget="many2one_avatar" string="Current Driver" />
-                <button name="action_open_vehicle" type="object" string="Vehicle Details" class="btn-primary" />
             </tree>
         </field>
     </record>

--- a/addons/hr_fleet/__manifest__.py
+++ b/addons/hr_fleet/__manifest__.py
@@ -17,6 +17,14 @@
     'demo': [
         'data/hr_fleet_demo.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'hr_fleet/static/src/js/attachment_kanban.js',
+        ],
+        'web.assets_qweb': [
+            'hr_fleet/static/src/xml/attachment_kanban.xml',
+        ],
+    },
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/hr_fleet/data/hr_fleet_demo.xml
+++ b/addons/hr_fleet/data/hr_fleet_demo.xml
@@ -29,4 +29,10 @@
     <record id="fleet.vehicle_5" model="fleet.vehicle">
         <field name="driver_employee_id" ref="hr.employee_jep"/>
     </record>
+
+    <!-- recompute driver_employee_id as we assigned a proper address_home_id to some employees -->
+    <function model="fleet.vehicle.assignation.log" name="_compute_driver_employee_id">
+        <value model="fleet.vehicle.assignation.log" eval="obj().search([('driver_employee_id', '=', False), ('driver_id', '!=', False)]).ids"/>
+    </function>
+
 </odoo>

--- a/addons/hr_fleet/models/employee.py
+++ b/addons/hr_fleet/models/employee.py
@@ -21,7 +21,7 @@ class Employee(models.Model):
         return {
             "type": "ir.actions.act_window",
             "res_model": "fleet.vehicle.assignation.log",
-            "views": [[False, "tree"], [False, "form"]],
+            "views": [[self.env.ref("hr_fleet.fleet_vehicle_assignation_log_employee_view_list").id, "tree"], [False, "form"]],
             "domain": [("driver_employee_id", "in", self.ids)],
             "context": dict(self._context, default_driver_id=self.user_id.partner_id.id, default_driver_employee_id=self.id),
             "name": "History Employee Cars",

--- a/addons/hr_fleet/models/fleet_vehicle.py
+++ b/addons/hr_fleet/models/fleet_vehicle.py
@@ -117,3 +117,8 @@ class FleetVehicle(models.Model):
             'view_mode': 'form',
             'res_id': self.driver_employee_id.id,
         }
+
+    def open_assignation_logs(self):
+        action = super().open_assignation_logs()
+        action['views'] = [[self.env.ref('hr_fleet.fleet_vehicle_assignation_log_view_list').id, 'tree']]
+        return action

--- a/addons/hr_fleet/models/fleet_vehicle_assignation_log.py
+++ b/addons/hr_fleet/models/fleet_vehicle_assignation_log.py
@@ -29,6 +29,7 @@ class FleetVehicleAssignationLog(models.Model):
     def action_get_attachment_view(self):
         self.ensure_one()
         res = self.env['ir.actions.act_window']._for_xml_id('base.action_attachment')
+        res['views'] = [[self.env.ref('hr_fleet.view_attachment_kanban_inherit_hr').id, 'kanban']]
         res['domain'] = [('res_model', '=', 'fleet.vehicle.assignation.log'), ('res_id', 'in', self.ids)]
         res['context'] = {'default_res_model': 'fleet.vehicle.assignation.log', 'default_res_id': self.id}
         return res

--- a/addons/hr_fleet/static/src/js/attachment_kanban.js
+++ b/addons/hr_fleet/static/src/js/attachment_kanban.js
@@ -1,0 +1,57 @@
+/** @odoo-module */
+
+import KanbanController from 'web.KanbanController';
+import KanbanView from 'web.KanbanView';
+import viewRegistry from 'web.view_registry';
+import { qweb } from 'web.core';
+import config from 'web.config'
+
+const HRFleetKanbanController = KanbanController.extend({
+    buttons_template: 'HRFleetKanbanView.buttons',
+    events: _.extend({}, KanbanController.prototype.events, {
+        'click .o_button_upload_fleet_attachment': '_onUpload',
+        'change .o_fleet_documents_upload .o_form_binary_form': '_onAddAttachment',
+    }),
+    /**
+     * @override
+     */
+        init: function () {
+        this._super.apply(this, arguments);
+        this.isMobile = config.device.isMobileDevice;
+    },
+
+    start: function () {
+        // define a unique uploadId and a callback method
+        this.fileUploadID = _.uniqueId('hr_fleet_document_upload');
+        $(window).on(this.fileUploadID, () => this.trigger_up('reload'));
+        return this._super.apply(this, arguments);
+    },
+
+    _onUpload: function (event) {
+        // If hidden upload form doesn't exist, create it
+        var $formContainer = this.$('.o_content').find('.o_fleet_documents_upload');
+        if (!$formContainer.length) {
+            $formContainer = $(qweb.render('HRFleet.DocumentsHiddenUploadForm', {widget: this}));
+            $formContainer.appendTo(this.$('.o_content'));
+        }
+        // Trigger the input to select a file
+        this.$('.o_fleet_documents_upload .o_input_file').click();
+    },
+
+    _onAddAttachment: function(ev) {
+        // Auto submit form once we've selected an attachment
+        const $input = $(ev.currentTarget).find('input.o_input_file');
+        if ($input.val() !== '') {
+            const $binaryForm = this.$('.o_fleet_documents_upload form.o_form_binary_form');
+            $binaryForm.submit();
+        }
+    }
+});
+
+const HRFleetKanbanView = KanbanView.extend({
+    config: _.extend({}, KanbanView.prototype.config, {
+        Controller: HRFleetKanbanController,
+    }),
+})
+
+viewRegistry.add('hr_fleet_kanban_view', HRFleetKanbanView);

--- a/addons/hr_fleet/static/src/xml/attachment_kanban.xml
+++ b/addons/hr_fleet/static/src/xml/attachment_kanban.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates>
+    <t t-name="HRFleet.DocumentsHiddenUploadForm">
+        <div class="d-none o_fleet_documents_upload">
+            <t t-call="HiddenInputFile">
+                <t t-set="multi_upload" t-value="true"/>
+                <t t-set="fileupload_id" t-value="widget.fileUploadID"/>
+                <t t-set="fileupload_action" t-translation="off">/web/binary/upload_attachment</t>
+                <input type="hidden" name="model" t-att-value="'fleet.vehicle.assignation.log'"/>
+                <input type="hidden" name="id" t-att-value="widget.initialState.context.active_id"/>
+            </t>
+        </div>
+    </t>
+    <t t-extend="KanbanView.buttons" t-name="HRFleetKanbanView.buttons">
+        <t t-jquery="button[t-attf-class*=o-kanban-button-new]" t-operation="replace">
+            <button type="button" t-att-class="'d-none d-md-block btn' + (!widget.isMobile ? ' btn-primary' : 'btn-secondary') + ' o_button_upload_fleet_attachment'">
+                Upload
+            </button>
+        </t>
+    </t>
+</templates>

--- a/addons/hr_fleet/views/fleet_vehicle_views.xml
+++ b/addons/hr_fleet/views/fleet_vehicle_views.xml
@@ -11,16 +11,39 @@
         </field>
     </record>
 
+    <!-- main view for fleet-->
     <record id="fleet_vehicle_assignation_log_view_list" model="ir.ui.view">
         <field name="name">fleet.vehicle.assignation.log.view.tree.inherit.hr.fleet</field>
         <field name="model">fleet.vehicle.assignation.log</field>
+        <field name="mode">primary</field>
         <field name="inherit_id" ref="fleet.fleet_vehicle_assignation_log_view_list" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='driver_id']" position="after">
-                <field name="driver_employee_id" widget="many2one_avatar" optional="hide"/>
-                <field name="attachment_number" string=" "/>
+            <field name="vehicle_id" position="attributes">
+                <attribute name="optional">hide</attribute>
+            </field>
+            <field name="driver_id" position="after">
+                <field name="driver_employee_id" widget="many2one_avatar"/>
+            </field>
+            <field name="date_end" position="after">
+                <field name="attachment_number" optional="show" />
                 <button name="action_get_attachment_view" string="Attachments" type="object" icon="fa-paperclip"/>
-            </xpath>
+            </field>
+        </field>
+    </record>
+
+    <!-- for employee cars -->
+    <record id="fleet_vehicle_assignation_log_employee_view_list" model="ir.ui.view">
+        <field name="name">fleet.vehicle.assignation.log.view.tree.inherit.hr.fleet</field>
+        <field name="model">fleet.vehicle.assignation.log</field>
+        <field name="mode">primary</field>
+        <field name="inherit_id" ref="fleet.fleet_vehicle_assignation_log_view_list" />
+        <field name="arch" type="xml">
+            <field name="driver_id" position="replace" />
+            <field name="date_end" position="after">
+                <field name="driver_id" string="Current Driver" optional="hide"/>
+                <field name="attachment_number" optional="show" />
+                <button name="action_get_attachment_view" string="Attachments" type="object" icon="fa-paperclip" />
+            </field>
         </field>
     </record>
 

--- a/addons/hr_fleet/views/fleet_vehicle_views.xml
+++ b/addons/hr_fleet/views/fleet_vehicle_views.xml
@@ -82,4 +82,16 @@
             </xpath>
         </field>
     </record>
+
+    <record id="view_attachment_kanban_inherit_hr" model="ir.ui.view">
+       <field name="name">ir.attachment.kanban.inherit.hr</field>
+       <field name="model">ir.attachment</field>
+       <field name="inherit_id" ref="mail.view_document_file_kanban"/>
+       <field name="mode">primary</field>
+       <field name="arch" type="xml">
+           <xpath expr="//kanban" position="attributes">
+                <attribute name="js_class">hr_fleet_kanban_view</attribute>
+            </xpath>
+       </field>
+   </record>
 </odoo>


### PR DESCRIPTION
Assignment logs list view can be accessed both from fleet and from hr_fleet,
however they show many repeating fields and, for this reason, this commit
improves these views by leaving the repeating fields as optional="hide".

task-2742923

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
