### PR TITLE
[ADD] mail, sms: reset template button

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -68,6 +68,7 @@ For more specific needs, you may also assign custom-defined actions
         'wizard/mail_resend_message_views.xml',
         'wizard/mail_template_preview_views.xml',
         'wizard/mail_wizard_invite_views.xml',
+        'wizard/mail_template_reset_views.xml',
         'views/fetchmail_views.xml',
         'views/mail_message_subtype_views.xml',
         'views/mail_tracking_views.xml',

--- a/addons/mail/models/__init__.py
+++ b/addons/mail/models/__init__.py
@@ -13,6 +13,7 @@ from . import mail_composer_mixin
 from . import mail_thread
 from . import mail_thread_blacklist
 from . import mail_thread_cc
+from . import template_reset_mixin
 
 # mail models
 from . import fetchmail

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -15,7 +15,7 @@ _logger = logging.getLogger(__name__)
 class MailTemplate(models.Model):
     "Templates for sending email"
     _name = "mail.template"
-    _inherit = ['mail.render.mixin']
+    _inherit = ['mail.render.mixin', 'template.reset.mixin']
     _description = 'Email Templates'
     _order = 'name'
 

--- a/addons/mail/models/template_reset_mixin.py
+++ b/addons/mail/models/template_reset_mixin.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+
+from lxml import etree
+
+from odoo import api, fields, models, tools, _
+from odoo.exceptions import UserError
+from odoo.modules import get_module_resource
+from odoo.modules.module import get_resource_from_path, get_resource_path
+from odoo.tools.convert import xml_import
+from odoo.tools.misc import file_open
+from odoo.tools.translate import TranslationFileReader
+
+
+class TemplateResetMixin(models.AbstractModel):
+    _name = "template.reset.mixin"
+    _description = 'Template Reset Mixin'
+
+    template_fs = fields.Char(
+        string='Template Filename', copy=False,
+        help="""File from where the template originates. Used to reset broken template.""")
+
+    # -------------------------------------------------------------------------
+    # OVERRIDE METHODS
+    # -------------------------------------------------------------------------
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if 'template_fs' not in vals and 'install_filename' in self.env.context:
+                # we store the relative path to the resource instead of the absolute path, if found
+                # (it will be missing e.g. when importing data-only modules using base_import_module)
+                path_info = get_resource_from_path(self.env.context['install_filename'])
+                if path_info:
+                    vals['template_fs'] = '/'.join(path_info[0:2])
+        return super().create(vals_list)
+
+    def _load_records_write(self, values):
+        # OVERRIDE to make the fields blank that are not present in xml record
+        if self.env.context.get('reset_template'):
+            # We don't want to change anything for magic columns, values present in XML record, and
+            # special fields self.CONCURRENCY_CHECK_FIELD (__last_update) and 'template_fs'
+            fields_in_xml_record = values.keys()
+            fields_not_to_touch = set(models.MAGIC_COLUMNS) | fields_in_xml_record | {self.CONCURRENCY_CHECK_FIELD, 'template_fs'}
+            fields_to_empty = self._fields.keys() - fields_not_to_touch
+            # For the fields not defined in xml record, if they have default values, we should not
+            # enforce empty values for them and the default values should be kept
+            field_defaults = self.default_get(list(fields_to_empty))
+            # Update the values to be written and include the default values, prevent fields with
+            # default values from being empty
+            values.update(field_defaults)
+            fields_to_empty = fields_to_empty - set(field_defaults.keys())
+            # Finally, update the values with fields that should be empty
+            values.update(dict.fromkeys(fields_to_empty, False))
+        return super()._load_records_write(values)
+
+    # -------------------------------------------------------------------------
+    # RESET TEMPLATE
+    # -------------------------------------------------------------------------
+
+    def _override_translation_term(self, module_name, xml_ids):
+        processed_base_langs = []
+        trans_to_remove = []
+        for code, _ in self.env['res.lang'].get_installed():
+            lang_code = tools.get_iso_codes(code)
+            translation_processed = False
+            # In case of sub languages (e.g fr_BE), load the base language first, (e.g fr.po) and
+            # then load the main translation file (e.g fr_BE.po)
+
+            # Step 1: reset translation terms with base language file
+            if '_' in lang_code:
+                base_lang_code = lang_code.split('_')[0]
+                base_trans_file = get_module_resource(module_name, 'i18n', base_lang_code + '.po')
+                if base_trans_file:
+                    if base_lang_code not in processed_base_langs:
+                        processed_base_langs.append(base_lang_code)
+                        translation_processed = self._process_translation_data(base_trans_file, code, xml_ids)
+
+            # Step 2: reset translation file with main language file (can possibly override the
+            # terms coming from the base language)
+            trans_file = get_module_resource(module_name, 'i18n', lang_code + '.po')
+            if trans_file:
+                translation_processed = self._process_translation_data(trans_file, code, xml_ids)
+
+            # If no translation data available to update, unlink custom translated terms linked to template
+            if not translation_processed:
+                trans_to_remove.append(code)
+
+        if trans_to_remove:
+            self.env['ir.translation'].search([
+                ('name', 'like', f'{self._name},%'),
+                ('res_id', '=', self.id),
+                ('lang', 'in', trans_to_remove),
+                ('module', 'in', [module_name, False]),
+            ]).unlink()
+
+    def _process_translation_data(self, trans_file, lang, xml_ids):
+        """Populates the ir_translation table.
+
+        :param trans_file: path to a translation file to open, e.g. {addon_path}/mail/i18n/es.po
+        :param lang: language code of the translations contained in `trans_file`
+                     language must be present and activated in the database
+
+        :return Boolean: True if translation data is available and processed, False otherwise
+        """
+        with file_open(trans_file, mode='rb', filter_ext=(".po",)) as fileobj:
+            translation_processed = False
+            reader = TranslationFileReader(fileobj)
+            # Process a single PO entry
+            for row in reader:
+                if row.get('imd_name') in xml_ids:
+                    translation_processed = True
+                    # copy Translation from Source to Destination object
+                    self.env['ir.translation']._set_ids(
+                        row['name'], 'model', lang, self._ids, row.get('value', ''), row['src'],
+                    )
+            return translation_processed
+
+    def reset_template(self):
+        """Resets the Template with values given in source file. We ignore the case of
+        template being overridden in another modules because it is extremely less likely
+        to happen. This method also tries to reset the translation terms for the current
+        user lang (all langs are not supported due to costly file operation). """
+        expr = "//*[local-name() = $tag and (@id = $xml_id or @id = $external_id)]"
+        templates_with_missing_source = []
+        for template in self.filtered('template_fs'):
+            external_id = template.get_external_id().get(template.id)
+            module, xml_id = external_id.split('.')
+            fullpath = get_resource_path(*template.template_fs.split('/'))
+            if fullpath:
+                doc = etree.parse(fullpath)
+                for rec in doc.xpath(expr, tag='record', xml_id=xml_id, external_id=external_id):
+                    # We don't have a way to pass context while loading record from a file, so we use this hack
+                    # to pass the context key that is needed to reset the fields not available in data file
+                    rec.set('context', json.dumps({'reset_template': 'True'}))
+                    obj = xml_import(template.env.cr, module, {}, mode='init', xml_filename=fullpath)
+                    obj._tag_record(rec)
+                    template._override_translation_term(module, [xml_id, external_id])
+            else:
+                templates_with_missing_source.append(template.display_name)
+        if templates_with_missing_source:
+            raise UserError(_("The following email templates could not be reset because their related source files could not be found:\n- %s", "\n- ".join(templates_with_missing_source)))

--- a/addons/mail/security/ir.model.access.csv
+++ b/addons/mail/security/ir.model.access.csv
@@ -61,4 +61,5 @@ access_res_users_settings_all,res.users.settings,model_res_users_settings,,0,0,0
 access_res_users_settings_user,res.users.settings,model_res_users_settings,base.group_user,1,1,1,1
 access_res_users_settings_volumes_all,res.users.settings.volumes,model_res_users_settings_volumes,,0,0,0,0
 access_res_users_settings_volumes_user,res.users.settings.volumes,model_res_users_settings_volumes,base.group_user,1,1,1,1
+access_mail_template_reset,access.mail.template.reset,model_mail_template_reset,mail.group_mail_template_editor,1,1,1,1
 ir_actions_report_access_user,ir.actions.report.access.user,base.model_ir_actions_report,base.group_user,1,0,0,0

--- a/addons/mail/tests/test_mail_template.xml
+++ b/addons/mail/tests/test_mail_template.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="mail_template_test_attachment" model="ir.attachment">
+        <field name="datas">bWlncmF0aW9uIHRlc3Q=</field>
+        <field name="name">YourCompany2022.doc</field>
+    </record>
+
+    <record id="mail_template_test" model="mail.template">
+        <field name="name">Mail: Test Mail Template</field>
+        <field name="model_id" ref="base.model_res_users"/>
+        <field name="email_from">"{{ object.company_id.name }}" &lt;{{ (object.company_id.email or user.email) }}&gt;</field>
+        <field name="email_to">{{ object.email_formatted }}</field>
+        <field name="body_html" type="html">
+            <div>Hello Odoo</div>
+        </field>
+        <field name="lang">{{ object.lang }}</field>
+        <field name="attachment_ids" eval="[(6, 0, [ref('mail_template_test_attachment')])]"/>
+    </record>
+</odoo>

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -6,6 +6,13 @@
             <field name="model">mail.template</field>
             <field name="arch" type="xml">
                 <form string="Templates">
+                    <header>
+                        <field name="template_fs" invisible="1"/>
+                        <button string="Reset Template"
+                                name="%(mail_template_reset_action)d" type="action"
+                                groups="mail.group_mail_template_editor"
+                                attrs="{'invisible': [('template_fs', '=', False)]}"/>
+                    </header>
                     <sheet>
                         <div class="oe_button_box" name="button_box">
                             <field name="ref_ir_act_window" invisible="1"/>

--- a/addons/mail/wizard/__init__.py
+++ b/addons/mail/wizard/__init__.py
@@ -7,4 +7,5 @@ from . import mail_blacklist_remove
 from . import mail_compose_message
 from . import mail_resend_message
 from . import mail_template_preview
+from . import mail_template_reset
 from . import mail_wizard_invite

--- a/addons/mail/wizard/mail_template_reset.py
+++ b/addons/mail/wizard/mail_template_reset.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+
+
+class MailTemplateReset(models.TransientModel):
+    _name = 'mail.template.reset'
+    _description = 'Mail Template Reset'
+
+    template_ids = fields.Many2many('mail.template')
+
+    def reset_template(self):
+        if not self.template_ids:
+            return False
+        self.template_ids.reset_template()
+        if self.env.context.get('params', {}).get('view_type') == 'list':
+            next_action = {'type': 'ir.actions.client', 'tag': 'reload'}
+        else:
+            next_action = {'type': 'ir.actions.act_window_close'}
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'type': 'success',
+                'message': _('Mail Templates have been reset'),
+                'next': next_action,
+            }
+        }

--- a/addons/mail/wizard/mail_template_reset_views.xml
+++ b/addons/mail/wizard/mail_template_reset_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="mail_template_reset_view_form" model="ir.ui.view">
+        <field name="name">mail.template.reset.view.form</field>
+        <field name="model">mail.template.reset</field>
+        <field name="priority">1000</field>
+        <field name="arch" type="xml">
+            <form>
+                <div>
+                    Are you sure you want to reset these email templates to their original configuration? Changes and translations will be lost.
+                </div>
+                <footer>
+                    <button string="Proceed" class="btn btn-primary" type="object" name="reset_template" data-hotkey="q"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="z"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="mail_template_reset_action" model="ir.actions.act_window">
+        <field name="name">Reset Mail Template</field>
+        <field name="res_model">mail.template.reset</field>
+        <field name="binding_model_id" ref="mail.model_mail_template"/>
+        <field name="binding_view_types">list</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="context">{
+            'default_template_ids': active_ids
+        }</field>
+        <field name="view_id" ref="mail_template_reset_view_form"/>
+    </record>
+</odoo>

--- a/addons/sms/__manifest__.py
+++ b/addons/sms/__manifest__.py
@@ -23,6 +23,7 @@ The service is provided by the In App Purchase Odoo platform.
         'wizard/sms_composer_views.xml',
         'wizard/sms_template_preview_views.xml',
         'wizard/sms_resend_views.xml',
+        'wizard/sms_template_reset_views.xml',
         'views/ir_actions_server_views.xml',
         'views/mail_notification_views.xml',
         'views/res_config_settings_views.xml',

--- a/addons/sms/models/sms_template.py
+++ b/addons/sms/models/sms_template.py
@@ -7,7 +7,7 @@ from odoo import api, fields, models, _
 class SMSTemplate(models.Model):
     "Templates for sending SMS"
     _name = "sms.template"
-    _inherit = ['mail.render.mixin']
+    _inherit = ['mail.render.mixin', 'template.reset.mixin']
     _description = 'SMS Templates'
 
     _unrestricted_rendering = True

--- a/addons/sms/security/ir.model.access.csv
+++ b/addons/sms/security/ir.model.access.csv
@@ -8,3 +8,4 @@ access_sms_composer,access.sms.composer,model_sms_composer,base.group_user,1,1,1
 access_sms_resend_recipient,access.sms.resend.recipient,model_sms_resend_recipient,base.group_user,1,1,1,0
 access_sms_resend,access.sms.resend,model_sms_resend,base.group_user,1,1,1,0
 access_sms_template_preview,access.sms.template.preview,model_sms_template_preview,base.group_user,1,1,1,0
+access_sms_template_reset,access.sms.template.reset,model_sms_template_reset,mail.group_mail_template_editor,1,1,1,1

--- a/addons/sms/tests/test_sms_template.xml
+++ b/addons/sms/tests/test_sms_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sms_template_test" model="sms.template">
+        <field name="model_id" ref="base.model_res_partner"/>
+        <field name="body" type="html">
+            <div>Hello Odoo</div>
+        </field>
+    </record>
+</odoo>

--- a/addons/sms/views/sms_template_views.xml
+++ b/addons/sms/views/sms_template_views.xml
@@ -5,6 +5,13 @@
         <field name="model">sms.template</field>
         <field name="arch" type="xml">
             <form string="SMS Templates">
+                <header>
+                    <field name="template_fs" invisible="1"/>
+                    <button string="Reset Template"
+                            name="%(sms_template_reset_action)d" type="action"
+                            groups="base.group_system"
+                            attrs="{'invisible': [('template_fs', '=', False)]}"/>
+                </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <field name="sidebar_action_id" invisible="1"/>

--- a/addons/sms/wizard/__init__.py
+++ b/addons/sms/wizard/__init__.py
@@ -3,3 +3,4 @@
 from . import sms_composer
 from . import sms_resend
 from . import sms_template_preview
+from . import sms_template_reset

--- a/addons/sms/wizard/sms_template_reset.py
+++ b/addons/sms/wizard/sms_template_reset.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+
+
+class SMSTemplateReset(models.TransientModel):
+    _name = 'sms.template.reset'
+    _description = 'SMS Template Reset'
+
+    template_ids = fields.Many2many('sms.template')
+
+    def reset_template(self):
+        if not self.template_ids:
+            return False
+        self.template_ids.reset_template()
+        if self.env.context.get('params', {}).get('view_type') == 'list':
+            next_action = {'type': 'ir.actions.client', 'tag': 'reload'}
+        else:
+            next_action = {'type': 'ir.actions.act_window_close'}
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'type': 'success',
+                'message': _('SMS Templates have been reset'),
+                'next': next_action,
+            }
+        }

--- a/addons/sms/wizard/sms_template_reset_views.xml
+++ b/addons/sms/wizard/sms_template_reset_views.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="sms_template_reset_view_form" model="ir.ui.view">
+        <field name="name">sms.template.reset.view.form</field>
+        <field name="model">sms.template.reset</field>
+        <field name="priority">1000</field>
+        <field name="arch" type="xml">
+            <form>
+                <div>
+                    Are you sure you want to reset these sms templates to their original configuration? Changes and translations will be lost.
+                </div>
+                <footer>
+                    <button string="Proceed" class="btn btn-primary" type="object" name="reset_template" data-hotkey="q"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="z"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+	<record id="sms_template_reset_action" model="ir.actions.act_window">
+        <field name="name">Reset SMS Template</field>
+        <field name="res_model">sms.template.reset</field>
+        <field name="binding_model_id" ref="sms.model_sms_template"/>
+        <field name="binding_view_types">list</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="context">{
+            'default_template_ids': active_ids
+        }</field>
+        <field name="view_id" ref="sms_template_reset_view_form"/>
+    </record>
+</odoo>


### PR DESCRIPTION
Current behavior before PR:

- Sometimes user breaks their Mail/SMS templates and have no way to go back to the
original one easily. They don't have any option to reset the template.

Desired behavior after PR is merged:

- Added a new "Reset Template" button
- now user can reset the Mail/SMS template to its first version.
- also it will update the translation of the template
- added a New "Reset Mail Templates/Reset SMS Templates" action to edit multiple templates

Task: https://www.odoo.com/web?debug=assets#id=2231977&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
