### PR TITLE
[FIX] account: Mobile cannot add jounral items

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -91,7 +91,7 @@
             <field name="name">account.move.line.kanban</field>
             <field name="model">account.move.line</field>
             <field name="arch" type="xml">
-                <kanban class="o_kanban_mobile" create="false" group_create="false">
+                <kanban class="o_kanban_mobile" create="true" group_create="false">
                     <field name="company_currency_id"/>
                     <field name="partner_id"/>
                     <templates>

--- a/addons/mail/static/src/components/attachment_box/attachment_box.js
+++ b/addons/mail/static/src/components/attachment_box/attachment_box.js
@@ -42,6 +42,7 @@ export class AttachmentBox extends Component {
      */
     _onAttachmentCreated(ev) {
         // FIXME Could be changed by spying attachments count (task-2252858)
+        debugger;
         this.trigger('o-attachments-changed');
     }
 

--- a/addons/mail/static/src/components/file_uploader/file_uploader.js
+++ b/addons/mail/static/src/components/file_uploader/file_uploader.js
@@ -154,6 +154,7 @@ export class FileUploader extends Component {
             originThread: (!composer && thread) ? replace(thread) : undefined,
             ...attachmentData,
         });
+        debugger;
         this.trigger('o-attachment-created', { attachment });
     }
 


### PR DESCRIPTION
Current behavior:
When using the Odoo mobile app you couldn't add journal items in a journal entry

Steps to reproduce:
- Go to the mobile app -> Accounting app
- Go in journal entries and try to add a journal item
- There is no option to add a journal entry

opw-2739536
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
