### PR TITLE
[FIX] account: Mobile cannot add journal items

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -91,7 +91,7 @@
             <field name="name">account.move.line.kanban</field>
             <field name="model">account.move.line</field>
             <field name="arch" type="xml">
-                <kanban class="o_kanban_mobile" create="false" group_create="false">
+                <kanban class="o_kanban_mobile" create="true" group_create="false">
                     <field name="company_currency_id"/>
                     <field name="partner_id"/>
                     <templates>


### PR DESCRIPTION
Current behavior:
When using the Odoo mobile app you couldn't add journal items in a journal entry

Steps to reproduce:
-Go to the mobile app -> Accounting app
-Go in journal entries and try to add a journal item
-There is no option to add a journal entry

opw-2739536

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
