### PR TITLE
[13.0][FIX] account_facturx: Avoid division by zero

### DIFF
--- a/addons/account_facturx/data/facturx_templates.xml
+++ b/addons/account_facturx/data/facturx_templates.xml
@@ -44,7 +44,7 @@
                         <ram:NetPriceProductTradePrice>
                             <ram:ChargeAmount
                                 t-att-currencyID="currency.name"
-                                t-esc="format_monetary(line.price_subtotal/line.quantity, currency)"/>
+                                t-esc="format_monetary(line.price_subtotal/line.quantity if line.quantity else 0, currency)"/>
                         </ram:NetPriceProductTradePrice>
                     </ram:SpecifiedLineTradeAgreement>
 


### PR DESCRIPTION
Since #82993, you can get a division by zero error when having an invoice line with a quantity of 0.

Note that this is very common when doing vendor bills from purchase orders, as Odoo by default creates one line per PO line, invoiced or not, but with 0 quantity, depending if such line has been already invoiced.

@Tecnativa TT34257