### PR TITLE
[FIX] mail: correct starred count computation in private channels

### DIFF
--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -143,7 +143,7 @@ class Users(models.Model):
             'partner_root': partner_root.sudo().mail_partner_format().get(partner_root),
             'public_partners': list(self.env.ref('base.group_public').sudo().with_context(active_test=False).users.partner_id.mail_partner_format().values()),
             'shortcodes': self.env['mail.shortcode'].sudo().search_read([], ['source', 'substitution', 'description']),
-            'starred_counter': self.partner_id._get_starred_count(),
+            'starred_counter': self.env['mail.message'].search_count([('starred_partner_ids', 'in', self.partner_id.ids)]),
         }
         return values
 

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -99,7 +99,7 @@ class TestDiscussFullPerformance(TransactionCase):
         self.maxDiff = None
         self.users[0].flush()
         self.users[0].invalidate_cache()
-        with self.assertQueryCount(emp=90):  # ent: 89
+        with self.assertQueryCount(emp=93):  # ent: 89
             init_messaging = self.users[0].with_user(self.users[0])._init_messaging()
 
         self.assertEqual(init_messaging, {

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -7,8 +7,8 @@ from unittest.mock import patch
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.test_mail.tests.common import TestMailCommon
 from odoo.addons.test_mail.models.test_mail_models import MailTestSimple
-from odoo.exceptions import AccessError
-from odoo.tools import mute_logger, formataddr
+from odoo.exceptions import AccessError, UserError
+from odoo.tools import is_html_empty, mute_logger, formataddr
 from odoo.tests import tagged, users
 
 
@@ -26,6 +26,75 @@ class TestMessageValues(TestMailCommon):
             'alias_contact': 'followers',
         })
         cls.Message = cls.env['mail.message'].with_user(cls.user_employee)
+
+    @users('employee')
+    def test_empty_message(self):
+        """ Test that message is correctly considered as empty (see `_filter_empty()`).
+        Message considered as empty if:
+            - no body or empty body
+            - AND no subtype or no subtype description
+            - AND no tracking values
+            - AND no attachment
+
+        Check _update_content behavior when voiding messages (cleanup side
+        records: stars, notifications).
+        """
+        note_subtype = self.env.ref('mail.mt_note')
+        _attach_1 = self.env['ir.attachment'].with_user(self.user_employee).create({
+            'name': 'Attach1',
+            'datas': 'bWlncmF0aW9uIHRlc3Q=',
+            'res_id': 0,
+            'res_model': 'mail.compose.message',
+        })
+        record = self.env['mail.test.track'].create({'name': 'EmptyTesting'})
+        self.flush_tracking()
+        record.message_subscribe(partner_ids=self.partner_admin.ids, subtype_ids=note_subtype.ids)
+        message = record.message_post(
+            attachment_ids=_attach_1.ids,
+            body='Test',
+            message_type='comment',
+            subtype_id=note_subtype.id,
+        )
+        message.write({'starred_partner_ids': [(4, self.partner_admin.id)]})
+
+        # check content
+        self.assertEqual(len(message.attachment_ids), 1)
+        self.assertFalse(is_html_empty(message.body))
+        self.assertEqual(len(message.sudo().notification_ids), 1)
+        self.assertEqual(message.notified_partner_ids, self.partner_admin)
+        self.assertEqual(message.starred_partner_ids, self.partner_admin)
+        self.assertFalse(message.sudo().tracking_value_ids)
+
+        # Reset body case
+        message._update_content('<p><br /></p>', attachment_ids=message.attachment_ids.ids)
+        self.assertTrue(is_html_empty(message.body))
+        self.assertFalse(message.sudo()._filter_empty(), 'Still having attachments')
+
+        # Subtype content
+        note_subtype.write({'description': 'Very important discussions'})
+        message._update_content('', None)
+        self.assertFalse(message.attachment_ids)
+        self.assertEqual(message.notified_partner_ids, self.partner_admin)
+        self.assertEqual(message.starred_partner_ids, self.partner_admin)
+        self.assertFalse(message.sudo()._filter_empty(), 'Subtype with description')
+
+        # Completely void now
+        note_subtype.write({'description': ''})
+        self.assertEqual(message.sudo()._filter_empty(), message)
+        message._update_content('', None)
+        self.assertFalse(message.notified_partner_ids)
+        self.assertFalse(message.starred_partner_ids)
+
+        # test tracking values
+        record.write({'user_id': self.user_admin.id})
+        self.flush_tracking()
+        tracking_message = record.message_ids[0]
+        self.assertFalse(tracking_message.attachment_ids)
+        self.assertTrue(is_html_empty(tracking_message.body))
+        self.assertFalse(tracking_message.subtype_id.description)
+        self.assertFalse(tracking_message.sudo()._filter_empty(), 'Has tracking values')
+        with self.assertRaises(UserError, msg='Tracking values prevent from updating content'):
+            tracking_message._update_content('', None)
 
     @mute_logger('odoo.models.unlink')
     def test_mail_message_format(self):


### PR DESCRIPTION
### Current behavior
The starred messages counter takes into account the starred messages of a private channel even if we no longer have access to this channel. Happens with deleted messages too

### Steps
- Install Discuss
- Create a Private Channel and invite Marc Demo to join it then send him a message
- *As Marc Demo*, star the message then leave the channel
-> Starred counter still shows 1
*For deleted messages:*
- Join the private channel again
- Delete the starred message (with Mitchell Admin?)
-> Starred counter still shows 1 for Marc Demo

### Reason
Starred message count is computed by a raw sql [1] which only counts partner's occurrences, without taking into account the message's state and/or the associated channel.

With this changes : 
- It doesn't take empty messages into account by checking if
  - `body` is empty (according to this commit [2], message body is emptied on delete), 
  - `subtype_id` is present and it has a `description`
  - it has `attachment_ids` or `tracking_value_ids`
- It doesn't take into account messages from a private channel which we no longer have access to by checking if the channel is **not** private or if the user is part of the private channel

[1] : https://github.com/odoo/odoo/blob/2c1c6b1373c238216fda1e2d9d2f00b5d16c8ca3/addons/mail/models/res_partner.py#L49-L51
[2] : [776d1ee08b805ca49d5f9c8f0f581e71aee359aa](https://github.com/odoo/odoo/commit/776d1ee08b805ca49d5f9c8f0f581e71aee359aa#diff-d8c083f5dcae590cd8445cfac7558d13c8a4049e3af602f66985ebca0473fbddR41-R43)

OPW-2742092