### PR TITLE
[FIX] mail : sign correctly when author is not user

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -22,6 +22,7 @@ from email import message_from_string, policy
 from lxml import etree
 from werkzeug import urls
 from xmlrpc import client as xmlrpclib
+from markupsafe import Markup
 
 from odoo import _, api, exceptions, fields, models, tools, registry, SUPERUSER_ID, Command
 from odoo.exceptions import MissingError
@@ -2345,9 +2346,8 @@ class MailThread(models.AbstractModel):
             user = author_user
             if add_sign:
                 signature = user.signature
-        else:
-            if add_sign:
-                signature = "<p>-- <br/>%s</p>" % author.name
+        elif add_sign and author.name:
+                signature = Markup("<p>-- <br/>%s</p>") % author.name
 
         # company value should fall back on env.company if:
         # - no company_id field on record

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -15,6 +15,8 @@ from odoo.tests import tagged
 from odoo.tools import mute_logger, formataddr
 from odoo.tests.common import users
 
+from markupsafe import escape
+
 
 @tagged('mail_post')
 class TestMessagePost(TestMailCommon, TestRecipients):
@@ -95,6 +97,18 @@ class TestMessagePost(TestMailCommon, TestRecipients):
         found_mail = self._new_mails
         self.assertNotIn(signature, found_mail.body_html)
         self.assertEqual(found_mail.body_html.count(signature), 0)
+
+    @users('employee')
+    def test_notify_mail_add_signature_no_author_user_or_no_user(self):
+        self.test_message.author_id = self.env['res.partner'].sudo().create({
+            'name': 'Steve',
+        }).id
+        template_values = self.test_record._notify_prepare_template_context(self.test_message, {})
+        self.assertNotEqual(escape(template_values['signature']), escape('<p>-- <br/>Steve</p>'))
+
+        self.test_message.author_id = None
+        template_values = self.test_record._notify_prepare_template_context(self.test_message, {})
+        self.assertEqual(template_values['signature'], '')
 
     @users('employee')
     def test_notify_prepare_template_context_company_value(self):


### PR DESCRIPTION
Steps :
- Make sure the Admin is notified by mail;
- Set an Alias Domain for the company.
- Create a Project with an Alias e-mail address.
- Send an e-mail to this alias.

Issues :
In the admin mailbox, see the signature is: `<p>-- <br/>False</p>`, which means two issues.
- It is not unescaped from Html.
- The content of the signature is 'False'.

Cause :
When no user is related to the sender of the mail, we manually set a signature.
- It was written between html tags, so it should be sanitized.
- Its content was author.name, yet author is a partner, so if there is
no partner, name is False.

Fix :
- Sanitize the html code of the signature.
- If there is no partner for this sender, use email_from, or else ''.

opw-2728483

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
