### PR TITLE
[FIX] safe_eval: show error correctly

### DIFF
--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -342,8 +342,7 @@ def safe_eval(expr, globals_dict=None, locals_dict=None, mode="eval", nocopy=Fal
         raise
     except ZeroDivisionError:
         raise
-    except Exception as e:
-        raise ValueError('%s: "%s" while evaluating\n%r' % (ustr(type(e)), ustr(e), expr))
+
 def test_python_expr(expr, mode="eval"):
     try:
         test_expr(expr, _SAFE_OPCODES, mode=mode)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
- create an action serveur with record._some_func()
- in _some_func() there are an error
--> Issue: the error message is impossible to read

**Current behavior before PR:**
![image](https://user-images.githubusercontent.com/16716992/152012739-fd80107e-c6fa-4d5b-8728-3de16b0eb541.png)

**Desired behavior after PR is merged:**
![image](https://user-images.githubusercontent.com/16716992/152012475-e6a102c2-0395-4d7f-8526-673c6ce7eb4e.png)


@odony @rco-odoo 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
