### PR TITLE
[FIX] purchase: show correct date in mail

### DIFF
--- a/addons/purchase/data/mail_template_data.xml
+++ b/addons/purchase/data/mail_template_data.xml
@@ -52,7 +52,7 @@
         from <t t-out="object.company_id.name or ''">YourCompany</t>. 
         <br/><br/>
         <t t-if="object.date_planned">
-            The receipt is expected for <strong t-out="format_date(object.date_planned) or ''">05/05/2021</strong>.
+            The receipt is expected for <strong t-out="format_date(str(object.date_planned)) or ''">05/05/2021</strong>.
             <br/><br/>
             Could you please acknowledge the receipt of this order?
         </t>
@@ -84,7 +84,7 @@
         </t>
         is expected for 
         <t t-if="object.date_planned">
-            <strong t-out="format_date(object.date_planned) or ''">05/05/2021</strong>.
+            <strong t-out="format_date(str(object.date_planned)) or ''">05/05/2021</strong>.
         </t>
          <t t-else="">
             <strong>undefined</strong>.


### PR DESCRIPTION
Before this commit, we were passing `datetime.time` instance
in format_date which doesn't convert date according to
timezone so it might be wrong on different timezone.

with this commit, we are passing datetime as string so
it correctly converts according to timezone.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
