### PR TITLE
[IMP]: web: take into account the js_class attrib.

### DIFF
--- a/addons/web/static/src/js/views/view_dialogs.js
+++ b/addons/web/static/src/js/views/view_dialogs.js
@@ -184,7 +184,6 @@ var FormViewDialog = ViewDialog.extend({
     open: function () {
         var self = this;
         var _super = this._super.bind(this);
-        var FormView = view_registry.get('form');
         var fields_view_def;
         if (this.options.fields_view) {
             fields_view_def = Promise.resolve(this.options.fields_view);
@@ -196,6 +195,9 @@ var FormViewDialog = ViewDialog.extend({
             var refinedContext = _.pick(self.context, function (value, key) {
                 return key.indexOf('_view_ref') === -1;
             });
+            var parsedXML = new DOMParser().parseFromString(viewInfo.arch, "text/xml");
+            var key = parsedXML.documentElement.getAttribute('js_class')  || 'form';
+            var FormView = view_registry.get(key);
             var formview = new FormView(viewInfo, {
                 modelName: self.res_model,
                 context: refinedContext,


### PR DESCRIPTION
Load the custom form view from the registry
instead of the normal form view if the js_class attribute is specified.


Current behavior before PR: FormViewDialog does not take into account the js_class attribute

Desired behavior after PR is merged: custom view forms will be loaded in form view dialogs too




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
