### PR TITLE
[IMP] web: boot: do not wait 5s to log module info

### DIFF
--- a/addons/web/static/src/boot.js
+++ b/addons/web/static/src/boot.js
@@ -362,16 +362,14 @@
 
     // Automatically log errors detected when loading modules
     window.addEventListener("load", function logWhenLoaded() {
-        setTimeout(function () {
-            var len = jobPromises.length;
-            Promise.all(jobPromises).then(function () {
-                if (len === jobPromises.length) {
-                    odoo.log();
-                } else {
-                    logWhenLoaded();
-                }
-            });
-        }, 5000);
+        const len = jobPromises.length;
+        Promise.all(jobPromises).then(function () {
+            if (len === jobPromises.length) {
+                odoo.log();
+            } else {
+                logWhenLoaded();
+            }
+        });
     });
 
     /**


### PR DESCRIPTION
Since [1], the test suite waits for 5s to start running. It's
really annoying when you run the suite in your browser, to debug
a single test or a sub suite. Waiting for 5s to determine whether
all modules can be loaded or not is not necessary anymore since
all assets coming from the same bundle are loaded in a single
file, even in debug=assets. This is true under the assumption that
there's no js module in assets_common requiring a module in another
assets bundle, which seems reasonnable.

[1] 468eb84fb413c97d3ae101a7b639d4bac6d0231d

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
