### PR TITLE
[FIX] digest: fix email from

### DIFF
--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -146,7 +146,11 @@ class Digest(models.Model):
         # create a mail_mail based on values, without attachments
         mail_values = {
             'auto_delete': True,
-            'email_from': self.company_id.partner_id.email_formatted if self.company_id else self.env.user.email_formatted,
+            'email_from': (
+                self.company_id.partner_id.email_formatted
+                or self.env.user.email_formatted
+                or self.env.ref('base.user_root').email_formatted
+            ),
             'email_to': user.email_formatted,
             'body_html': full_mail,
             'state': 'outgoing',


### PR DESCRIPTION
PURPOSE

Currently, in digest if your company does not have
an email address set than every digest will crash
as Odoo tries to use this as the "From".

SPECIFICATION

after this PR, If your company does not have
an email address set, than it fallback on the admin.

task-id: 2729780
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
