### PR TITLE
[IMP] Add report footer style variable

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -326,7 +326,7 @@
             <t t-out="0"/>
         </div>
 
-        <div t-attf-class="o_company_#{company.id}_layout footer o_background_footer">
+        <div t-attf-class="o_company_#{company.id}_layout footer o_background_footer" t-att-style="report_footer_style">
             <div class="text-center">
                 <ul class="list-inline">
                     <div t-field="company.report_footer"/>
@@ -366,7 +366,7 @@
             <t t-out="0"/>
         </div>
 
-        <div t-attf-class="footer o_boxed_footer o_company_#{company.id}_layout">
+        <div t-attf-class="footer o_boxed_footer o_company_#{company.id}_layout" t-att-style="report_footer_style">
             <div class="text-center">
                 <div t-field="company.report_footer"/>
                 <div t-if="report_type == 'pdf'">
@@ -405,7 +405,7 @@
             <t t-out="0"/>
         </div>
 
-        <div t-attf-class="footer o_clean_footer o_company_#{company.id}_layout">
+        <div t-attf-class="footer o_clean_footer o_company_#{company.id}_layout" t-att-style="report_footer_style">
             <div class="row">
                 <div class="col-4">
                     <span t-field="company.report_footer"/>
@@ -453,7 +453,7 @@
             <t t-out="0"/>
         </div>
 
-        <div t-attf-class="footer o_standard_footer o_company_#{company.id}_layout">
+        <div t-attf-class="footer o_standard_footer o_company_#{company.id}_layout" t-att-style="report_footer_style">
             <div class="text-center" style="border-top: 1px solid black;">
                 <ul class="list-inline mb4">
                     <div t-field="company.report_footer"/>
@@ -505,7 +505,7 @@
             </t>
         </t>
 
-        <div class="header">
+        <div class="header" t-att-style="report_header_style">
             <div class="row">
                 <div class="col-3">
                     <span t-esc="context_timestamp(datetime.datetime.now()).strftime('%Y-%m-%d %H:%M')"/>

--- a/doc/cla/individual/SkiBY.md
+++ b/doc/cla/individual/SkiBY.md
@@ -1,0 +1,9 @@
+Belarus, 2021-10-04
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Sergei Ruzki sergei.ruzki@gmail.com https://github.com/SkiBY


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Small improvement of basic report templates.

Current behavior before PR:
You can not pass style variable when you call report template. To modify it or hide footer i.e. you need to go deeper and not so like it is with header

Desired behavior after PR is merged:
You can hide report footer by set a variable like

    <t t-call="web.external_layout">
      <t t-set="report_footer_style">display: none;</t>
    </t>



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
