### PR TITLE
[FIX] project: allow regular user to share project in edit mode

### DIFF
--- a/addons/project/models/project_collaborator.py
+++ b/addons/project/models/project_collaborator.py
@@ -23,8 +23,6 @@ class ProjectCollaborator(models.Model):
     def create(self, vals_list):
         collaborator = self.env['project.collaborator'].search([], limit=1)
         project_collaborators = super().create(vals_list)
-        non_authenticated_collaborator = project_collaborators.partner_id.filtered(lambda partner: not partner.user_ids)
-        non_authenticated_collaborator._create_portal_users()
         if not collaborator:
             self._toggle_project_sharing_portal_rules(True)
         return project_collaborators

--- a/addons/project/models/res_partner.py
+++ b/addons/project/models/res_partner.py
@@ -30,13 +30,14 @@ class ResPartner(models.Model):
                     partner.task_count += group['partner_id_count']
                 partner = partner.parent_id
 
+# Deprecated: remove me in MASTER
     def _create_portal_users(self):
         partners_without_user = self.filtered(lambda partner: not partner.user_ids)
         if not partners_without_user:
             return self.env['res.users']
         created_users = self.env['res.users']
         for partner in partners_without_user:
-            created_users += self.env['res.users'].with_context(no_reset_password=True)._create_user_from_template({
+            created_users += self.env['res.users'].with_context(no_reset_password=True).sudo()._create_user_from_template({
                 'email': email_normalize(partner.email),
                 'login': email_normalize(partner.email),
                 'partner_id': partner.id,


### PR DESCRIPTION
If a user without Administration/Settings rights tries to share a
project in edit mode with a collaborator, an access rights error is
currently raised when creating the portal user. We should allow this
user to share the project without error instead.

Description of the issue/feature this PR addresses:
opw-2744210

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
