### PR TITLE
[FIX] web: Domain arrayToString support 'in' operator

### DIFF
--- a/addons/web/static/src/js/core/domain.js
+++ b/addons/web/static/src/js/core/domain.js
@@ -250,21 +250,21 @@ var Domain = collections.Tree.extend({
      */
     arrayToString: function (domain) {
         if (_.isString(domain)) return domain;
-        const parts = (domain || []).map(part => {
-            if (_.isArray(part)) { // e.g. ['name', 'ilike', 'foo'] or ['is_active', '=', true]
-                return "[" + part.map(c => {
-                    switch (c) {
-                        case null: return "None";
-                        case true: return "True";
-                        case false: return "False";
-                        default: return JSON.stringify(c);
+
+        function jsToPy(p) {
+            switch (p) {
+                case null: return "None";
+                case true: return "True";
+                case false: return "False";
+                default:
+                    if (Array.isArray(p)) {
+                        return `[${p.map(jsToPy)}]`;
                     }
-                }).join(',') + "]";
-            } else { // e.g. '|' or '&'
-                return JSON.stringify(part);
+                    return JSON.stringify(p);
             }
-        });
-        return "[" + parts.join(',') + "]";
+        }
+
+        return `[${(domain || []).map(jsToPy)}]`;
     },
     /**
      * Converts a string representation of the Python prefix-array

--- a/addons/web/static/tests/core/domain_tests.js
+++ b/addons/web/static/tests/core/domain_tests.js
@@ -144,7 +144,7 @@ QUnit.module('core', {}, function () {
     });
 
     QUnit.test("arrayToString", function (assert) {
-        assert.expect(7);
+        assert.expect(14);
 
         const arrayToString = Domain.prototype.arrayToString;
 
@@ -155,8 +155,18 @@ QUnit.module('core', {}, function () {
         assert.strictEqual(arrayToString([['name', '=', 'null']]), '[["name","=","null"]]');
         assert.strictEqual(arrayToString([['name', '=', 'false']]), '[["name","=","false"]]');
         assert.strictEqual(arrayToString([['name', '=', 'true']]), '[["name","=","true"]]');
-
+        assert.strictEqual(arrayToString([['name', 'in', [true, false]]]), '[["name","in",[True,False]]]');
+        assert.strictEqual(arrayToString([['name', 'in', [null]]]), '[["name","in",[None]]]');
+        
+        assert.strictEqual(arrayToString([['name', 'in', ["foo", "bar"]]]), '[["name","in",["foo","bar"]]]');
+        assert.strictEqual(arrayToString([['name', 'in', [1, 2]]]), '[["name","in",[1,2]]]');
         assert.strictEqual(arrayToString(), '[]');
+
+        assert.strictEqual(arrayToString(['&', ['name', '=', 'foo'], ['type', '=', 'bar']]), '["&",["name","=","foo"],["type","=","bar"]]');
+        assert.strictEqual(arrayToString(['|', ['name', '=', 'foo'], ['type', '=', 'bar']]), '["|",["name","=","foo"],["type","=","bar"]]');
+
+        // string domains are not processed
+        assert.strictEqual(arrayToString('[["name", "ilike", "foo"]]'), '[["name", "ilike", "foo"]]');
     });
 
     QUnit.test("like, =like, ilike and =ilike", function (assert) {


### PR DESCRIPTION
The function `arrayToString` did not properly support domains containing
arrays of booleans, for instance `[["val", "in", [true, false]]]`. The
array containing the boolean was directly JSON stringified without being
converted to its python equivalent.

Co-authored-by: Lucas Lefèvre <lul@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
