### PR TITLE
[FIX] hr_timesheet : forbid archived/deleted empl to create timesheets

### DIFF
--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -225,6 +225,7 @@ class TestTimesheet(TestCommonTimesheet):
             'task_id': self.task1.id,
             'name': 'my first timesheet',
             'unit_amount': 4,
+            'employee_id': self.user_employee.employee_id.id
         })
 
         timesheet_count1 = Timesheet.search_count([('project_id', '=', self.project_customer.id)])
@@ -299,6 +300,7 @@ class TestTimesheet(TestCommonTimesheet):
             'task_id': self.task1.id,
             'name': 'my only timesheet',
             'unit_amount': 4,
+            'employee_id': self.user_employee.employee_id.id
         })
 
         self.assertEqual(timesheet_entry.partner_id, self.partner, "The timesheet entry's partner should be equal to the task's partner/customer")
@@ -321,8 +323,8 @@ class TestTimesheet(TestCommonTimesheet):
                 'time_spent': 1.15,
                 'task_id': self.task1.id,
             })
-        self.assertEqual(wizard_min.save_timesheet().unit_amount, 1, "The timesheet's duration should be 1h (Minimum Duration = 60').")
-        self.assertEqual(wizard_round.save_timesheet().unit_amount, 1.25, "The timesheet's duration should be 1h15 (Rounding = 15').")
+        self.assertEqual(wizard_min.with_user(self.user_employee).save_timesheet().unit_amount, 1, "The timesheet's duration should be 1h (Minimum Duration = 60').")
+        self.assertEqual(wizard_round.with_user(self.user_employee).save_timesheet().unit_amount, 1.25, "The timesheet's duration should be 1h15 (Rounding = 15').")
 
     def test_task_with_timesheet_project_change(self):
         '''This test checks that no error is raised when moving a task that contains timesheet to another project.

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -535,12 +535,14 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
             'partner_id': self.partner_a.id,
             'planned_hours': 10,
         })
+        employee = self.env['hr.employee'].create({'name': 'Maurice'})
 
         Timesheet.create({
             'project_id': self.project_global.id,
             'task_id': task.id,
             'name': 'my first timesheet',
             'unit_amount': 4,
+            'employee_id': employee.id,
         })
 
         timesheet_count1 = Timesheet.search_count([('project_id', '=', self.project_global.id)])
@@ -585,6 +587,7 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
             'task_id': task.id,
             'name': 'my second timesheet',
             'unit_amount': 6,
+            'employee_id': employee.id,
         })
 
         self.assertEqual(Timesheet.search_count([('project_id', '=', self.project_template.id)]), 2, "2 timesheets in project_template")


### PR DESCRIPTION
Steps :
- --without-demo=all
- Archive your employee, go to your timesheets and add time on a task T line
- Go to task T and note that a line have been added without any employe
- Delete your employee and do the same thing.
- Note the same thing.

Fix :
- At creation of aal, check that employee is active.

opw-2740228

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
