### PR TITLE
[ADD] base, auth_totp: backport method `_mfa_type` for easier override

### DIFF
--- a/addons/auth_totp/models/res_users.py
+++ b/addons/auth_totp/models/res_users.py
@@ -35,11 +35,18 @@ class Users(models.Model):
         type(self).SELF_READABLE_FIELDS = self.SELF_READABLE_FIELDS + ['totp_enabled', 'totp_trusted_device_ids']
         return init_res
 
+    def _mfa_type(self):
+        r = super()._mfa_type()
+        if r is not None:
+            return r
+        if self.totp_enabled:
+            return 'totp'
+
     def _mfa_url(self):
         r = super()._mfa_url()
         if r is not None:
             return r
-        if self.totp_enabled:
+        if self._mfa_type() == 'totp':
             return '/web/login/totp'
 
     @api.depends('totp_secret')

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -999,6 +999,10 @@ class Users(models.Model):
             return 'base/static/img/user-slash.png'
         return super()._get_placeholder_filename(field=field)
 
+    def _mfa_type(self):
+        """ If an MFA method is enabled, returns its type as a string. """
+        return
+
     def _mfa_url(self):
         """ If an MFA method is enabled, returns the URL for its second step. """
         return


### PR DESCRIPTION
Backport of the method `_mfa_type` of odoo/odoo#83256
for an easier override. To be able to determine or change the 2-factor
authentication method easily for users