### PR TITLE
[FIX] account: bank suspense accounts

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -104,7 +104,7 @@ class AccountJournal(models.Model):
              "allowing finding the right account.", string='Suspense Account',
         domain=lambda self: "[('deprecated', '=', False), ('company_id', '=', company_id), \
                              ('user_type_id.type', 'not in', ('receivable', 'payable')), \
-                             ('user_type_id', '=', %s)]" % self.env.ref('account.data_account_type_current_liabilities').id)
+                             ('user_type_id', '=', %s)]" % self.env.ref('account.data_account_type_current_assets').id)
     restrict_mode_hash_table = fields.Boolean(string="Lock Posted Entries with Hash",
         help="If ticked, the accounting entry or invoice receives a hash as soon as it is posted and cannot be modified anymore.")
     sequence = fields.Integer(help='Used to order Journals in the dashboard view', default=10)


### PR DESCRIPTION
Step to reproduce:
- Install account_accountant
- Go to Accounting / Configuration / Accounting / Journals
- Create a Journals in Accounting
- Select a type as "Bank"

Issue:
Since this PR: https://github.com/odoo/odoo/pull/81071, the bank suspense account has been changed from `Current Liabilities` type to `Current Assets`, but isn't being correctly updated in the journals view.

Solution:
In the domain of the `suspense_account_id`, we should use `data_account_type_current_assets` for the `user_type_id` instead  of `data_account_type_current_liabilities`.

opw-2715621


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
