### PR TITLE
[FIX] (purchase_)mrp: Correct links with MO and PO

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1956,9 +1956,7 @@ class MrpProduction(models.Model):
         else:
             user_id = self.env.user
 
-        origs = {}
-        for move in self.move_raw_ids:
-            origs.setdefault(move.bom_line_id.id, []).extend(move.move_orig_ids.ids)
+        origs = self._prepare_merge_orig_links()
         dests = {}
         for move in self.move_finished_ids:
             dests.setdefault(move.byproduct_id.id, []).extend(move.move_dest_ids.ids)
@@ -1977,17 +1975,24 @@ class MrpProduction(models.Model):
         production._create_workorder()
 
         for move in production.move_raw_ids:
-            move.move_orig_ids = [Command.set(origs[move.bom_line_id.id])]
+            for field, vals in origs[move.bom_line_id.id].items():
+                move[field] = vals
         for move in production.move_finished_ids:
             move.move_dest_ids = [Command.set(dests[move.byproduct_id.id])]
-        production.move_dest_ids = [Command.set(sum(list(dests.values()), []))]
+
+        self.move_dest_ids.created_production_id = production.id
 
         self.procurement_group_id.stock_move_ids.group_id = production.procurement_group_id
 
         if 'confirmed' in self.mapped('state'):
-            production.action_confirm()
+            production.move_raw_ids._adjust_procure_method()
+            (production.move_raw_ids | production.move_finished_ids).write({'state': 'confirmed'})
+            production.workorder_ids._action_confirm()
+            production.state = 'confirmed'
 
         self.with_context(skip_activity=True)._action_cancel()
+        for p in self:
+            p._message_log(body=_('This production has been merge in %s', production.display_name))
 
         return {
             'type': 'ir.actions.act_window',
@@ -2124,3 +2129,15 @@ class MrpProduction(models.Model):
             raise UserError(_('You can only merge manufacturing with the same operation type'))
         # TODO explode and check no quantity has been edited
         return True
+
+    def _prepare_merge_orig_links(self):
+        origs = defaultdict(dict)
+        for move in self.move_raw_ids:
+            if not move.move_orig_ids:
+                continue
+            origs[move.bom_line_id.id].setdefault('move_orig_ids', set()).update(move.move_orig_ids.ids)
+        for vals in origs.values():
+            if not vals.get('move_orig_ids'):
+                continue
+            vals['move_orig_ids'] = [Command.set(vals['move_orig_ids'])]
+        return origs

--- a/addons/purchase_mrp/models/mrp_production.py
+++ b/addons/purchase_mrp/models/mrp_production.py
@@ -43,3 +43,10 @@ class MrpProduction(models.Model):
         if not iterate_key and move_raw_id.created_purchase_line_id:
             iterate_key = 'created_purchase_line_id'
         return iterate_key
+
+    def _prepare_merge_orig_links(self):
+        origs = super()._prepare_merge_orig_links()
+        for move in self.move_raw_ids:
+            if move.created_purchase_line_id:
+                origs[move.bom_line_id.id]['created_purchase_line_id'] = move.created_purchase_line_id
+        return origs


### PR DESCRIPTION
Fine tuning of commit 6acfb2e630c2dce477b4e000aa84aafc0c5431c5
It correctly merge the purchase.order in case of direct link and
avoid to relaunch the procurement.

It also correctly set the created_production_id if the demand come
from a SO