### PR TITLE
[FIX] pos_gift_card: giftcard popup text too long

### DIFF
--- a/addons/pos_gift_card/static/src/css/giftCard.css
+++ b/addons/pos_gift_card/static/src/css/giftCard.css
@@ -34,10 +34,13 @@
 }
 
 .giftCardPopupButton {
-    width: 50% !important;
-    margin: 6px;
+    width: auto !important;
+    height: auto !important;
+    padding: 10px;
 }
 
 .giftCardPopupConfirmButton {
-    width: 40% !important;
+    flex-grow: 1;
+    height: auto !important;
+    padding: 10px;
 }


### PR DESCRIPTION
Current behavior:
When using DE language in PoS. The text from giftcart popupbutton was tool long and was out of the button

Steps to reproduce:
- Change language to DE
- Open PoS and giftcard popup

opw-2744369

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
