### PR TITLE
[IMP] payment(_*): search only once for the transaction

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -605,43 +605,44 @@ class PaymentTransaction(models.Model):
             **custom_create_values,
         })
 
-    @api.model
-    def _handle_feedback_data(self, provider, data):
-        """ Match the transaction with the feedback data, update its state and return it.
+    def _handle_notification_data(self, provider, notification_data):
+        """ Match the transaction with the notification data, update its state and return it.
 
         :param str provider: The provider of the acquirer that handled the transaction
-        :param dict data: The feedback data sent by the provider
+        :param dict notification_data: The notification data sent by the provider
         :return: The transaction
         :rtype: recordset of `payment.transaction`
         """
-        tx = self._get_tx_from_feedback_data(provider, data)
-        tx._process_feedback_data(data)
+        tx = self._get_tx_from_notification_data(provider, notification_data)
+        tx._process_notification_data(notification_data)
         tx._execute_callback()
         return tx
 
-    @api.model
-    def _get_tx_from_feedback_data(self, provider, data):
-        """ Find the transaction based on the feedback data.
+    def _get_tx_from_notification_data(self, provider, notification_data):
+        """ Find the transaction based on the notification data.
 
-        For an acquirer to handle transaction post-processing, it must overwrite this method and
-        return the transaction matching the data.
+        For an acquirer to handle transaction processing, it must overwrite this method and return
+        the transaction matching the notification data.
 
         :param str provider: The provider of the acquirer that handled the transaction
-        :param dict data: The feedback data sent by the acquirer
+        :param dict notification_data: The notification data sent by the provider
         :return: The transaction if found
         :rtype: recordset of `payment.transaction`
         """
         return self
 
-    def _process_feedback_data(self, data):
-        """ Update the transaction state and the acquirer reference based on the feedback data.
+    def _process_notification_data(self, notification_data):
+        """ Update the transaction state and the acquirer reference based on the notification data.
 
-        For an acquirer to handle transaction post-processing, it must overwrite this method and
-        process the feedback data.
+        This method should normally never be called directly. The correct method to call upon
+        receiving notification data is `_handle_notification_data`.
+
+        For an acquirer to handle transaction processing, it must overwrite this method and process
+        the notification data.
 
         Note: self.ensure_one()
 
-        :param dict data: The feedback data sent by the acquirer
+        :param dict notification_data: The notification data sent by the provider
         :return: None
         """
         self.ensure_one()

--- a/addons/payment_alipay/controllers/main.py
+++ b/addons/payment_alipay/controllers/main.py
@@ -29,13 +29,13 @@ class AlipayController(http.Controller):
         _logger.info("handling redirection from Alipay with data:\n%s", pprint.pformat(data))
 
         # Check the integrity of the notification
-        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
+        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
             'alipay', data
         )
         self._verify_notification_signature(data, tx_sudo)
 
         # Handle the notification data
-        request.env['payment.transaction'].sudo()._handle_feedback_data('alipay', data)
+        tx_sudo._handle_notification_data('alipay', data)
         return request.redirect('/payment/status')
 
     @http.route(_webhook_url, type='http', auth='public', methods=['POST'], csrf=False)
@@ -51,14 +51,14 @@ class AlipayController(http.Controller):
         _logger.info("notification received from Alipay with data:\n%s", pprint.pformat(data))
         try:
             # Check the origin and integrity of the notification
-            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
+            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
                 'alipay', data
             )
             self._verify_notification_origin(data, tx_sudo)
             self._verify_notification_signature(data, tx_sudo)
 
             # Handle the notification data
-            request.env['payment.transaction'].sudo()._handle_feedback_data('alipay', data)
+            tx_sudo._handle_notification_data('alipay', data)
         except ValidationError:  # Acknowledge the notification to avoid getting spammed
             _logger.exception("unable to handle the notification data; skipping to acknowledge")
 

--- a/addons/payment_alipay/tests/test_alipay.py
+++ b/addons/payment_alipay/tests/test_alipay.py
@@ -141,11 +141,13 @@ class AlipayTest(AlipayCommon, PaymentHttpCommon):
     def _test_alipay_feedback_processing(self):
         # Unknown transaction
         with self.assertRaises(ValidationError):
-            self.env['payment.transaction']._handle_feedback_data('alipay', self.NOTIFICATION_DATA)
+            self.env['payment.transaction']._handle_notification_data(
+                'alipay', self.NOTIFICATION_DATA
+            )
 
         # Confirmed transaction
         tx = self.create_transaction('redirect')
-        self.env['payment.transaction']._handle_feedback_data('alipay', self.NOTIFICATION_DATA)
+        self.env['payment.transaction']._handle_notification_data('alipay', self.NOTIFICATION_DATA)
         self.assertEqual(tx.state, 'done')
         self.assertEqual(tx.acquirer_reference, self.NOTIFICATION_DATA['trade_no'])
 
@@ -155,7 +157,7 @@ class AlipayTest(AlipayCommon, PaymentHttpCommon):
         payload = dict(
             self.NOTIFICATION_DATA, out_trade_no=self.reference, trade_status='TRADE_CLOSED'
         )
-        self.env['payment.transaction']._handle_feedback_data('alipay', payload)
+        self.env['payment.transaction']._handle_notification_data('alipay', payload)
         self.assertEqual(tx.state, 'cancel')
 
     @mute_logger('odoo.addons.payment_alipay.controllers.main')
@@ -188,7 +190,7 @@ class AlipayTest(AlipayCommon, PaymentHttpCommon):
             '._verify_notification_signature'
         ) as signature_check_mock, patch(
             'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_feedback_data'
+            '._handle_notification_data'
         ):
             self._make_http_post_request(url, data=self.NOTIFICATION_DATA)
             self.assertEqual(origin_check_mock.call_count, 1)

--- a/addons/payment_authorize/controllers/main.py
+++ b/addons/payment_authorize/controllers/main.py
@@ -56,10 +56,4 @@ class AuthorizeController(http.Controller):
             "payment request response for transaction with reference %s:\n%s",
             reference, pprint.pformat(response_content)
         )
-        # As the API has no redirection flow, we always know the reference of the transaction.
-        # Still, we prefer to simulate the matching of the transaction by crafting dummy feedback
-        # data in order to go through the centralized `_handle_feedback_data` method.
-        feedback_data = {'reference': tx_sudo.reference, 'response': response_content}
-        request.env['payment.transaction'].sudo()._handle_feedback_data(
-            'authorize', feedback_data
-        )
+        tx_sudo._handle_notification_data('authorize', {'response': response_content})

--- a/addons/payment_buckaroo/controllers/main.py
+++ b/addons/payment_buckaroo/controllers/main.py
@@ -38,13 +38,13 @@ class BuckarooController(http.Controller):
 
         # Check the integrity of the notification
         received_signature = data.get('brq_signature')
-        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
+        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
             'buckaroo', data
         )
         self._verify_notification_signature(raw_data, received_signature, tx_sudo)
 
         # Handle the notification data
-        request.env['payment.transaction'].sudo()._handle_feedback_data('buckaroo', data)
+        tx_sudo._handle_notification_data('buckaroo', data)
         return request.redirect('/payment/status')
 
     @http.route(_webhook_url, type='http', auth='public', methods=['POST'], csrf=False)
@@ -62,13 +62,13 @@ class BuckarooController(http.Controller):
         try:
             # Check the integrity of the notification
             received_signature = data.get('brq_signature')
-            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
+            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
                 'buckaroo', data
             )
             self._verify_notification_signature(raw_data, received_signature, tx_sudo)
 
             # Handle the notification data
-            request.env['payment.transaction'].sudo()._handle_feedback_data('buckaroo', data)
+            tx_sudo._handle_notification_data('buckaroo', data)
         except ValidationError:  # Acknowledge the notification to avoid getting spammed
             _logger.exception("unable to handle the notification data; skipping to acknowledge")
         return ''

--- a/addons/payment_buckaroo/tests/test_buckaroo.py
+++ b/addons/payment_buckaroo/tests/test_buckaroo.py
@@ -43,10 +43,10 @@ class BuckarooTest(BuckarooCommon, PaymentHttpCommon):
     def test_feedback_processing(self):
         notification_data = BuckarooController._normalize_data_keys(self.SYNC_NOTIFICATION_DATA)
         tx = self.create_transaction(flow='redirect')
-        tx._handle_feedback_data('buckaroo', notification_data)
+        tx._handle_notification_data('buckaroo', notification_data)
         self.assertEqual(tx.state, 'done')
         self.assertEqual(tx.acquirer_reference, notification_data.get('brq_transactions'))
-        tx._handle_feedback_data('buckaroo', notification_data)
+        tx._handle_notification_data('buckaroo', notification_data)
         self.assertEqual(tx.state, 'done', 'Buckaroo: validation did not put tx into done state')
         self.assertEqual(tx.acquirer_reference, notification_data.get('brq_transactions'))
 
@@ -58,7 +58,7 @@ class BuckarooTest(BuckarooCommon, PaymentHttpCommon):
             brq_statuscode='2',
             brq_signature='b8e54e26b2b5a5e697b8ed5085329ea712fd48b2',
         ))
-        self.env['payment.transaction']._handle_feedback_data('buckaroo', notification_data)
+        self.env['payment.transaction']._handle_notification_data('buckaroo', notification_data)
         self.assertEqual(tx.state, 'error')
 
     @mute_logger('odoo.addons.payment_buckaroo.controllers.main')

--- a/addons/payment_mollie/controllers/main.py
+++ b/addons/payment_mollie/controllers/main.py
@@ -29,25 +29,25 @@ class MollieController(http.Controller):
         will satisfy any specification of the `SameSite` attribute, the session of the user will be
         retrieved and with it the transaction which will be immediately post-processed.
 
-        :param dict data: The feedback data (only `id`) and the transaction reference (`ref`)
+        :param dict data: The notification data (only `id`) and the transaction reference (`ref`)
                           embedded in the return URL
         """
         _logger.info("handling redirection from Mollie with data:\n%s", pprint.pformat(data))
-        request.env['payment.transaction'].sudo()._handle_feedback_data('mollie', data)
+        request.env['payment.transaction'].sudo()._handle_notification_data('mollie', data)
         return request.redirect('/payment/status')
 
     @http.route(_webhook_url, type='http', auth='public', methods=['POST'], csrf=False)
     def mollie_webhook(self, **data):
         """ Process the notification data sent by Mollie to the webhook.
 
-        :param dict data: The feedback data (only `id`) and the transaction reference (`ref`)
+        :param dict data: The notification data (only `id`) and the transaction reference (`ref`)
                           embedded in the return URL
         :return: An empty string to acknowledge the notification
         :rtype: str
         """
         _logger.info("notification received from Mollie with data:\n%s", pprint.pformat(data))
         try:
-            request.env['payment.transaction'].sudo()._handle_feedback_data('mollie', data)
+            request.env['payment.transaction'].sudo()._handle_notification_data('mollie', data)
         except ValidationError:  # Acknowledge the notification to avoid getting spammed
             _logger.exception("unable to handle the notification data; skipping to acknowledge")
         return ''  # Acknowledge the notification

--- a/addons/payment_ogone/controllers/main.py
+++ b/addons/payment_ogone/controllers/main.py
@@ -42,13 +42,13 @@ class OgoneController(http.Controller):
 
         # Check the integrity of the notification
         received_signature = data.get('SHASIGN')
-        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
+        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
             'ogone', data
         )
         self._verify_notification_signature(raw_data, received_signature, tx_sudo)
 
         # Handle the notification data
-        request.env['payment.transaction'].sudo()._handle_feedback_data('ogone', data)
+        tx_sudo._handle_notification_data('ogone', data)
         return request.redirect('/payment/status')
 
     @staticmethod

--- a/addons/payment_ogone/tests/test_ogone.py
+++ b/addons/payment_ogone/tests/test_ogone.py
@@ -122,7 +122,7 @@ class OgoneTest(OgoneCommon, PaymentHttpCommon):
             '._verify_notification_signature'
         ) as signature_check_mock, patch(
             'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_feedback_data'
+            '._handle_notification_data'
         ):
             self._make_http_post_request(url, data=self.NOTIFICATION_DATA)
             self.assertEqual(signature_check_mock.call_count, 1)

--- a/addons/payment_paypal/controllers/main.py
+++ b/addons/payment_paypal/controllers/main.py
@@ -50,7 +50,7 @@ class PaypalController(http.Controller):
             pass  # Redirect them to the status page to browse the (currently) draft transaction
         else:
             # Check the origin of the notification
-            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
+            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
                 'paypal', pdt_data
             )
             try:
@@ -59,9 +59,7 @@ class PaypalController(http.Controller):
                 _logger.exception("could not verify the origin of the PDT; discarding it")
             else:
                 # Handle the notification data
-                request.env['payment.transaction'].sudo()._handle_feedback_data(
-                    'paypal', notification_data
-                )
+                tx_sudo._handle_notification_data('paypal', notification_data)
 
         return request.redirect('/payment/status')
 
@@ -144,13 +142,13 @@ class PaypalController(http.Controller):
         _logger.info("notification received from PayPal with data:\n%s", pprint.pformat(data))
         try:
             # Check the origin and integrity of the notification
-            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
+            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
                 'paypal', data
             )
             self._verify_webhook_notification_origin(data, tx_sudo)
 
             # Handle the notification data
-            request.env['payment.transaction'].sudo()._handle_feedback_data('paypal', data)
+            tx_sudo._handle_notification_data('paypal', data)
         except ValidationError:  # Acknowledge the notification to avoid getting spammed
             _logger.exception("unable to handle the notification data; skipping to acknowledge")
         return ''

--- a/addons/payment_paypal/tests/test_paypal.py
+++ b/addons/payment_paypal/tests/test_paypal.py
@@ -83,11 +83,11 @@ class PaypalTest(PaypalCommon, PaymentHttpCommon):
     def test_feedback_processing(self):
         # Unknown transaction
         with self.assertRaises(ValidationError):
-            self.env['payment.transaction']._handle_feedback_data('paypal', self.NOTIFICATION_DATA)
+            self.env['payment.transaction']._handle_notification_data('paypal', self.NOTIFICATION_DATA)
 
         # Confirmed transaction
         tx = self.create_transaction('redirect')
-        self.env['payment.transaction']._handle_feedback_data('paypal', self.NOTIFICATION_DATA)
+        self.env['payment.transaction']._handle_notification_data('paypal', self.NOTIFICATION_DATA)
         self.assertEqual(tx.state, 'done')
         self.assertEqual(tx.acquirer_reference, self.NOTIFICATION_DATA['txn_id'])
 
@@ -100,7 +100,7 @@ class PaypalTest(PaypalCommon, PaymentHttpCommon):
             payment_status='Pending',
             pending_reason='multi_currency',
         )
-        self.env['payment.transaction']._handle_feedback_data('paypal', payload)
+        self.env['payment.transaction']._handle_notification_data('paypal', payload)
         self.assertEqual(tx.state, 'pending')
         self.assertEqual(tx.state_message, payload['pending_reason'])
 
@@ -150,7 +150,7 @@ class PaypalTest(PaypalCommon, PaymentHttpCommon):
             '._verify_webhook_notification_origin'
         ) as origin_check_mock, patch(
             'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_feedback_data'
+            '._handle_notification_data'
         ):
             self._make_http_post_request(url, data=self.NOTIFICATION_DATA)
             self.assertEqual(origin_check_mock.call_count, 1)

--- a/addons/payment_payulatam/controllers/main.py
+++ b/addons/payment_payulatam/controllers/main.py
@@ -15,5 +15,5 @@ class PayuLatamController(http.Controller):
     @http.route(_return_url, type='http', auth='public', methods=['GET'])
     def payulatam_return(self, **data):
         _logger.info("handling redirection from PayU Latam with data:\n%s", pprint.pformat(data))
-        request.env['payment.transaction'].sudo()._handle_feedback_data('payulatam', data)
+        request.env['payment.transaction'].sudo()._handle_notification_data('payulatam', data)
         return request.redirect('/payment/status')

--- a/addons/payment_payulatam/tests/test_payulatam.py
+++ b/addons/payment_payulatam/tests/test_payulatam.py
@@ -124,12 +124,14 @@ class PayULatamTest(PayULatamCommon):
 
         # should raise error about unknown tx
         with self.assertRaises(ValidationError):
-            self.env['payment.transaction']._handle_feedback_data('payulatam', payulatam_post_data)
+            self.env['payment.transaction']._handle_notification_data(
+                'payulatam', payulatam_post_data
+            )
 
         tx = self.create_transaction(flow='redirect')
 
         # Validate the transaction ('pending' state)
-        self.env['payment.transaction']._handle_feedback_data('payulatam', payulatam_post_data)
+        self.env['payment.transaction']._handle_notification_data('payulatam', payulatam_post_data)
         self.assertEqual(tx.state, 'pending', 'Payulatam: wrong state after receiving a valid pending notification')
         self.assertEqual(tx.state_message, payulatam_post_data['message'], 'Payulatam: wrong state message after receiving a valid pending notification')
         self.assertEqual(tx.acquirer_reference, 'b232989a-4aa8-42d1-bace-153236eee791', 'Payulatam: wrong txn_id after receiving a valid pending notification')
@@ -141,7 +143,7 @@ class PayULatamTest(PayULatamCommon):
 
         # Validate the transaction ('approved' state)
         payulatam_post_data['lapTransactionState'] = 'APPROVED'
-        self.env['payment.transaction']._handle_feedback_data('payulatam', payulatam_post_data)
+        self.env['payment.transaction']._handle_notification_data('payulatam', payulatam_post_data)
         self.assertEqual(tx.state, 'done', 'Payulatam: wrong state after receiving a valid pending notification')
         self.assertEqual(tx.acquirer_reference, 'b232989a-4aa8-42d1-bace-153236eee791', 'Payulatam: wrong txn_id after receiving a valid pending notification')
 

--- a/addons/payment_payumoney/controllers/main.py
+++ b/addons/payment_payumoney/controllers/main.py
@@ -37,13 +37,13 @@ class PayUMoneyController(http.Controller):
         _logger.info("handling redirection from PayU money with data:\n%s", pprint.pformat(data))
 
         # Check the integrity of the notification
-        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
+        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
             'payumoney', data
         )
         self._verify_notification_signature(data, tx_sudo)
 
         # Handle the notification data
-        request.env['payment.transaction'].sudo()._handle_feedback_data('payumoney', data)
+        tx_sudo._handle_notification_data('payumoney', data)
         return request.redirect('/payment/status')
 
     @staticmethod

--- a/addons/payment_sips/controllers/main.py
+++ b/addons/payment_sips/controllers/main.py
@@ -37,13 +37,13 @@ class SipsController(http.Controller):
         _logger.info("handling redirection from SIPS with data:\n%s", pprint.pformat(data))
 
         # Check the integrity of the notification
-        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
+        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
             'sips', data
         )
         self._verify_notification_signature(data, tx_sudo)
 
         # Handle the notification data
-        request.env['payment.transaction'].sudo()._handle_feedback_data('sips', data)
+        tx_sudo._handle_notification_data('sips', data)
         return request.redirect('/payment/status')
 
     @http.route(_webhook_url, type='http', auth='public', methods=['POST'], csrf=False)
@@ -57,13 +57,13 @@ class SipsController(http.Controller):
         _logger.info("notification received from SIPS with data:\n%s", pprint.pformat(data))
         try:
             # Check the integrity of the notification
-            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
+            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
                 'sips', data
             )
             self._verify_notification_signature(data, tx_sudo)
 
             # Handle the notification data
-            request.env['payment.transaction'].sudo()._handle_feedback_data('sips', data)
+            tx_sudo._handle_notification_data('sips', data)
         except ValidationError:
             _logger.exception("unable to handle the notification data; skipping to acknowledge")
         return ''

--- a/addons/payment_sips/tests/test_sips.py
+++ b/addons/payment_sips/tests/test_sips.py
@@ -70,11 +70,13 @@ class SipsTest(SipsCommon, PaymentHttpCommon):
     def test_feedback_processing(self):
         # Unknown transaction
         with self.assertRaises(ValidationError):
-            self.env['payment.transaction']._handle_feedback_data('sips', self.NOTIFICATION_DATA)
+            self.env['payment.transaction']._handle_notification_data(
+                'sips', self.NOTIFICATION_DATA
+            )
 
         # Confirmed transaction
         tx = self.create_transaction('redirect')
-        self.env['payment.transaction']._handle_feedback_data('sips', self.NOTIFICATION_DATA)
+        self.env['payment.transaction']._handle_notification_data('sips', self.NOTIFICATION_DATA)
         self.assertEqual(tx.state, 'done')
         self.assertEqual(tx.acquirer_reference, self.reference)
 
@@ -87,7 +89,7 @@ class SipsTest(SipsCommon, PaymentHttpCommon):
             Data=self.NOTIFICATION_DATA['Data'].replace(old_reference, self.reference)
                                                .replace('responseCode=00', 'responseCode=12')
         )
-        self.env['payment.transaction']._handle_feedback_data('sips', payload)
+        self.env['payment.transaction']._handle_notification_data('sips', payload)
         self.assertEqual(tx.state, 'cancel')
 
     @mute_logger('odoo.addons.payment_sips.controllers.main')
@@ -112,7 +114,7 @@ class SipsTest(SipsCommon, PaymentHttpCommon):
             '._verify_notification_signature'
         ) as signature_check_mock, patch(
             'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_feedback_data'
+            '._handle_notification_data'
         ):
             self._make_http_post_request(url, data=self.NOTIFICATION_DATA)
             self.assertEqual(signature_check_mock.call_count, 1)

--- a/addons/payment_stripe/tests/test_stripe.py
+++ b/addons/payment_stripe/tests/test_stripe.py
@@ -60,7 +60,7 @@ class StripeTest(StripeCommon, PaymentHttpCommon):
             return_value={},
         ), patch(
             'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_feedback_data'
+            '._handle_notification_data'
         ):
             self._make_json_request(url, data=self.NOTIFICATION_DATA)
             self.assertEqual(signature_check_mock.call_count, 1)

--- a/addons/payment_test/controllers/main.py
+++ b/addons/payment_test/controllers/main.py
@@ -18,4 +18,6 @@ class PaymentTestController(http.Controller):
             'reference': reference,
             'cc_summary': customer_input[-4:],
         }
-        request.env['payment.transaction'].sudo()._handle_feedback_data('test', fake_api_response)
+        request.env['payment.transaction'].sudo()._handle_notification_data(
+            'test', fake_api_response
+        )

--- a/addons/payment_transfer/controllers/main.py
+++ b/addons/payment_transfer/controllers/main.py
@@ -15,5 +15,5 @@ class TransferController(http.Controller):
     @http.route(_accept_url, type='http', auth='public', methods=['POST'], csrf=False)
     def transfer_form_feedback(self, **post):
         _logger.info("handling redirection from Transfer with data:\n%s", pprint.pformat(post))
-        request.env['payment.transaction'].sudo()._handle_feedback_data('transfer', post)
+        request.env['payment.transaction'].sudo()._handle_notification_data('transfer', post)
         return request.redirect('/payment/status')

--- a/addons/payment_transfer/models/payment_transaction.py
+++ b/addons/payment_transfer/models/payment_transaction.py
@@ -31,21 +31,20 @@ class PaymentTransaction(models.Model):
             'reference': self.reference,
         }
 
-    @api.model
-    def _get_tx_from_feedback_data(self, provider, data):
+    def _get_tx_from_notification_data(self, provider, notification_data):
         """ Override of payment to find the transaction based on transfer data.
 
         :param str provider: The provider of the acquirer that handled the transaction
-        :param dict data: The transfer feedback data
+        :param dict notification_data: The notification feedback data
         :return: The transaction if found
         :rtype: recordset of `payment.transaction`
         :raise: ValidationError if the data match no transaction
         """
-        tx = super()._get_tx_from_feedback_data(provider, data)
-        if provider != 'transfer':
+        tx = super()._get_tx_from_notification_data(provider, notification_data)
+        if provider != 'transfer' or len(tx) == 1:
             return tx
 
-        reference = data.get('reference')
+        reference = notification_data.get('reference')
         tx = self.search([('reference', '=', reference), ('provider', '=', 'transfer')])
         if not tx:
             raise ValidationError(
@@ -53,15 +52,15 @@ class PaymentTransaction(models.Model):
             )
         return tx
 
-    def _process_feedback_data(self, data):
+    def _process_notification_data(self, notification_data):
         """ Override of payment to process the transaction based on transfer data.
 
         Note: self.ensure_one()
 
-        :param dict data: The transfer feedback data
+        :param dict notification_data: The transfer data
         :return: None
         """
-        super()._process_feedback_data(data)
+        super()._process_notification_data(notification_data)
         if self.provider != 'transfer':
             return
 


### PR DESCRIPTION
Before this commit, most acquirers needed to run several successive
searches for the transaction whose reference was received by a
controller in notification data. This is because the security checks
run on the notification data require access to the acquirer through the
transaction record which was immediately discarded.

Starting with this commit, all `*_feedback_data` method are no longer
decorated with `api.model` and can use the transaction record they're
called on if provided. They are also renamed to `*_notification_data`.

task-2737144

See also:
- https://github.com/odoo/enterprise/pull/23938