### PR TITLE
[FIX] account: bank account config company_id

### DIFF
--- a/addons/account/wizard/setup_wizards.py
+++ b/addons/account/wizard/setup_wizards.py
@@ -73,8 +73,8 @@ class SetupBarBankConfigWizard(models.TransientModel):
     new_journal_name = fields.Char(default=lambda self: self.linked_journal_id.name, inverse='set_linked_journal_id', required=True, help='Will be used to name the Journal related to this bank account')
     linked_journal_id = fields.Many2one(string="Journal",
         comodel_name='account.journal', inverse='set_linked_journal_id',
-        compute="_compute_linked_journal_id", check_company=True,
-        domain="[('type','=','bank'), ('bank_account_id', '=', False), ('company_id', '=', company_id)]")
+        compute="_compute_linked_journal_id",
+        domain=lambda self: [('type', '=', 'bank'), ('bank_account_id', '=', False), ('company_id', '=', self.env.company.id)])
     bank_bic = fields.Char(related='bank_id.bic', readonly=False, string="Bic")
     num_journals_without_account = fields.Integer(default=lambda self: self._number_unlinked_journal())
 


### PR DESCRIPTION
When trying to set up a new bank account using the bank account wizard,
there is an issue with the check company on the linked_journal_id field.

The check will make sure that the company on that field is either false
or the same as the company on the record. But with a recent change in
68f4534aa5d0c6d900128c93f5a2289c06bb3d14 the bank account company_id will be the one from the linked partner.
As the partners for companies have an empty company_id, this check does
not make a lot of sense anymore, as it would be wrong in most cases.
(We expect a journal with the currently selected company, but the bank
account will in most cases have an empty company_id)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
