### PR TITLE
[FIX] point_of_sale: Receipt not centered when printed

### DIFF
--- a/addons/point_of_sale/static/src/js/printers.js
+++ b/addons/point_of_sale/static/src/js/printers.js
@@ -99,7 +99,7 @@ var PrinterMixin = {
             html2canvas(self.receipt[0], {
                 onparsed: function(queue) {
                     queue.stack.ctx.height = Math.ceil(self.receipt.outerHeight() + self.receipt.offset().top);
-                    queue.stack.ctx.width = Math.ceil(self.receipt.outerWidth() + self.receipt.offset().left);
+                    queue.stack.ctx.width = Math.ceil(self.receipt.outerWidth() + 2 * self.receipt.offset().left);
                 },
                 onrendered: function (canvas) {
                     $('.pos-receipt-print').empty();


### PR DESCRIPTION
When printing the receip in the POS, the right margin was not equal to the left margin.
Introduce by https://github.com/odoo/odoo/pull/83130/commits/e14af37eb20453df8643b73f6007d6c986398b47

opw:2743902