### PR TITLE
[FIX] google_spreadsheet: migrate to new api (v3 -> v4)

### DIFF
--- a/addons/google_spreadsheet/models/google_drive.py
+++ b/addons/google_spreadsheet/models/google_drive.py
@@ -20,11 +20,11 @@ class GoogleDrive(models.Model):
 
     def get_google_scope(self):
         scope = super(GoogleDrive, self).get_google_scope()
-        return '%s https://spreadsheets.google.com/feeds' % scope
+        return '%s https://www.googleapis.com/auth/spreadsheets' % scope
 
     @api.model
     def write_config_formula(self, attachment_id, spreadsheet_key, model, domain, groupbys, view_id):
-        access_token = self.get_access_token(scope='https://spreadsheets.google.com/feeds')
+        access_token = self.get_access_token(scope='https://www.googleapis.com/auth/spreadsheets')
 
         fields = self.env[model].fields_view_get(view_id=view_id, view_type='tree')
         doc = etree.XML(fields.get('arch'))
@@ -50,33 +50,18 @@ class GoogleDrive(models.Model):
             config_formula = '=oe_settings("%s";"%s")' % (url, dbname)
         else:
             config_formula = '=oe_settings("%s";"%s";"%s";"%s")' % (url, dbname, username, password)
-        request = '''<feed xmlns="http://www.w3.org/2005/Atom"
-      xmlns:batch="http://schemas.google.com/gdata/batch"
-      xmlns:gs="http://schemas.google.com/spreadsheets/2006">
-  <id>https://spreadsheets.google.com/feeds/cells/{key}/od6/private/full</id>
-  <entry>
-    <batch:id>A1</batch:id>
-    <batch:operation type="update"/>
-    <id>https://spreadsheets.google.com/feeds/cells/{key}/od6/private/full/R1C1</id>
-    <link rel="edit" type="application/atom+xml"
-      href="https://spreadsheets.google.com/feeds/cells/{key}/od6/private/full/R1C1"/>
-    <gs:cell row="1" col="1" inputValue="{formula}"/>
-  </entry>
-  <entry>
-    <batch:id>A2</batch:id>
-    <batch:operation type="update"/>
-    <id>https://spreadsheets.google.com/feeds/cells/{key}/od6/private/full/R60C15</id>
-    <link rel="edit" type="application/atom+xml"
-      href="https://spreadsheets.google.com/feeds/cells/{key}/od6/private/full/R60C15"/>
-    <gs:cell row="60" col="15" inputValue="{config}"/>
-  </entry>
-</feed>''' .format(key=spreadsheet_key, formula=misc.html_escape(formula), config=misc.html_escape(config_formula))
-
+        request = {
+            "valueInputOption": "USER_ENTERED",
+            "data": [
+                {"range": "A1", "values": [[formula]]},
+                {"range": "O60", "values": [[config_formula]]},
+            ]
+        }
         try:
             req = requests.post(
-                'https://spreadsheets.google.com/feeds/cells/%s/od6/private/full/batch?%s' % (spreadsheet_key, werkzeug.url_encode({'v': 3, 'access_token': access_token})),
-                data=request.encode('utf-8'),
-                headers={'content-type': 'application/atom+xml', 'If-Match': '*'},
+                'https://sheets.googleapis.com/v4/spreadsheets/%s/values:batchUpdate?%s' % (spreadsheet_key, werkzeug.url_encode({'access_token': access_token})),
+                data=json.dumps(request),
+                headers={'content-type': 'application/json', 'If-Match': '*'},
                 timeout=TIMEOUT,
             )
         except IOError:


### PR DESCRIPTION
Steps to Reproduce:

  - Install 'account' module
  - Go to Settings and set a token for Google Drive
  - Activate Google Spreadsheet
  - Go to Invoicing -> Invoices
  - Under Search bar, click on Favorites -> Add to Google Spreadsheet

Issue:

  A spreadsheet does open but with no data (no formula or config).

Cause:

  The V3 API we were using was turned down in August 2021 and therefore
  not able to use the api to write on the spreadsheet.
  https://cloud.google.com/blog/products/g-suite/migrate-your-apps-use-latest-sheets-api)

Note: In case that the system parameters `​google_drive_client_id` and
`google_drive_client_secret` has been changed (and therefore also the
default templates), it must be ensured that the `client` has the
Google Sheet API (v4) activated and the scope
`[https://www.googleapis.com/auth/spreadsheets`](https://www.googleapis.com/auth/spreadsheets%60) set.

API activation and configuration available here :
https://console.developers.google.com/apis/dashboard?project=[PROJECT]
https://console.developers.google.com/apis/credentials/consent/edit?project=[PROJECT]
**[PROJECT]** : Google project that will be linked to `​google_drive_client_id`.

opw-[2633951](https://www.odoo.com/web#id=2633951&view_type=form&model=project.task)