### PR TITLE
[FIX] web: created css class for mt32 and mb32

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -21,7 +21,7 @@
                         <span t-if="o.name != '/'" t-field="o.name"/>
                     </h2>
 
-                    <div id="informations" class="row mt32 mb32">
+                    <div id="informations" class="row mt-4 mb-4">
                         <div class="col-auto col-3 mw-100 mb-2" t-if="o.invoice_date" name="invoice_date">
                             <strong>Invoice Date:</strong>
                             <p class="m-0" t-field="o.invoice_date"/>


### PR DESCRIPTION
Reproduction:
1. Create an invoice, then save and confirm it
2. Print the invoice
3. The CSS spacing does not work in the PDF report

Reason: V13 uses Bootstrap 3 but Odoo V14 uses Bootstrap 4. In
Bootstrap 4, the margin class is defined in a different way. To fix the
missing issue of mt32 (margin-top:32px), a customized class named mt32
is created in report.scss

opw-2654880

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
