### PR TITLE
[FIX] web: load search panel after switching view type

### DIFF
--- a/addons/web/static/src/legacy/js/views/search_panel_model_extension.js
+++ b/addons/web/static/src/legacy/js/views/search_panel_model_extension.js
@@ -157,12 +157,15 @@
          * @override
          */
         importState(importedState) {
-            this.initialStateImport = Boolean(importedState && !this.state.sections);
+            this.initialStateImport = false;
             super.importState(...arguments);
             if (importedState) {
                 this.state.sections = new Map(this.state.sections);
                 for (const section of this.state.sections.values()) {
                     section.values = new Map(section.values);
+                    if ([...section.values.keys()].some(e => e !== false)) {
+                        this.initialStateImport = true;
+                    }
                     if (section.groups) {
                         section.groups = new Map(section.groups);
                         for (const group of section.groups.values()) {

--- a/addons/web/static/tests/search/search_panel_tests.js
+++ b/addons/web/static/tests/search/search_panel_tests.js
@@ -2234,6 +2234,40 @@ QUnit.module("Search", (hooks) => {
         }
     );
 
+    QUnit.test(
+        "categories and filters are loaded when switching from a view without the search panel",
+        async (assert) => {
+            assert.expect(5);
+
+            // set the pivot view as the default view
+            serverData.actions[1].views = [
+                [false, "pivot"],
+                [false, "kanban"],
+                [false, "list"],
+            ];
+
+            const webclient = await createWebClient({
+                serverData,
+                async mockRPC(route, {method}) {
+                    if (/search_panel_/.test(method || route)) {
+                        assert.step(method || route);
+                    }
+                },
+            });
+
+            await doAction(webclient, 1);
+            assert.verifySteps([]);
+
+            await switchView(webclient, "list");
+            await legacyExtraNextTick();
+            assert.verifySteps(["search_panel_select_range", "search_panel_select_multi_range"]);
+
+            await switchView(webclient, "kanban");
+            await legacyExtraNextTick();
+            assert.verifySteps([]);
+        }
+    );
+
     QUnit.test("scroll position is kept when switching between controllers", async (assert) => {
         assert.expect(6);
 


### PR DESCRIPTION
Steps to follow

  - Go to the Rental app
  - Switch to the pivot view
  - Refresh the page
  - Switch to the list view
  -> The search panel has not been correctly loaded

Solution

  Check if the section values contain any value other than the default one.
  If not, they need to be loaded.

opw-2710619