### PR TITLE
[FIX] stock_account: stock interim in bills without inventory valuation

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -227,7 +227,8 @@ class AccountMoveLine(models.Model):
         self = self.with_context(force_company=self.move_id.journal_id.company_id.id)
         if self.product_id.type == 'product' \
             and self.move_id.company_id.anglo_saxon_accounting \
-            and self.move_id.is_purchase_document():
+            and self.move_id.is_purchase_document() \
+            and not self.product_id.product_tmpl_id._is_cost_method_standard():
             fiscal_position = self.move_id.fiscal_position_id
             accounts = self.product_id.product_tmpl_id.get_product_accounts(fiscal_pos=fiscal_position)
             if accounts['stock_input']:


### PR DESCRIPTION
Activate Anglo-saxon accounting
Have a category [CAT] with 'manual' inventory valuation and costing
method 'standard'
Have a product [PROD] with category [CAT]
Make a Vendor Bill, add [PROD] on a line

Issue: The default account for the new line will be the Stock Interim account
and not the Expenses

opw-2657971

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
