### PR TITLE
[IMP] project: improve empty help content for activity type

### DIFF
--- a/addons/project/views/mail_activity_views.xml
+++ b/addons/project/views/mail_activity_views.xml
@@ -7,6 +7,13 @@
         <field name="view_mode">tree,form</field>
         <field name="domain">['|', ('res_model', '=', False), ('res_model', '=', 'project.task')]</field>
         <field name="context">{'default_res_model': 'project.task'}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No activity types found. Let's create one!
+            </p><p>
+                Those represent the different categories of things you have to do (e.g. "Call" or "Send email").
+            </p>
+        </field>
     </record>
     <menuitem id="project_menu_config_activity_type"
         action="mail_activity_type_action_config_project_types"


### PR DESCRIPTION
The purpose of the commit is to improve the empty help content on the activity type menu.

task-2737428
