### PR TITLE
[FIX] http_routing: mitigate key does not exist in context for lang

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -402,7 +402,7 @@ class IrHttp(models.AbstractModel):
             if nearest_lang:
                 lang = Lang._lang_get(nearest_lang)
             else:
-                nearest_ctx_lg = not is_a_bot and cls.get_nearest_lang(request.env.context['lang'])
+                nearest_ctx_lg = not is_a_bot and cls.get_nearest_lang(request.env.context.get('lang'))
                 nearest_ctx_lg = nearest_ctx_lg in lang_codes and nearest_ctx_lg
                 preferred_lang = Lang._lang_get(cook_lang or nearest_ctx_lg)
                 lang = preferred_lang or cls._get_default_lang()


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

**Use Case:**

Google Spreadsheet Odoo Script Access (XML-RPC API), ~~not sure which change triggered this behavior, but~~ there was and is a point of failure in case no lang context key is defined.

EDIT:
Using the wrong configuration for the base url in Google Spreadsheets like https://yourdomain.tld/ instead of https://yourdomain.tld will trigger this error...

**Current behavior before PR:**
<details>
  <summary>Traceback</summary>

```
﻿Error on request:
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/werkzeug/serving.py", line 270, in run_wsgi
    execute(self.server.app)
  File "/usr/local/lib/python3.6/site-packages/werkzeug/serving.py", line 258, in execute
    application_iter = app(environ, start_response)
  File "/opt/odoo/custom/src/odoo/odoo/service/wsgi_server.py", line 140, in application
    return ProxyFix(application_unproxied)(environ, start_response)
  File "/usr/local/lib/python3.6/site-packages/werkzeug/contrib/fixers.py", line 152, in __call__
    return self.app(environ, start_response)
  File "/opt/odoo/custom/src/odoo/odoo/service/wsgi_server.py", line 117, in application_unproxied
    result = odoo.http.root(environ, start_response)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1287, in __call__
    return self.dispatch(environ, start_response)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1257, in __call__
    return self.app(environ, start_wrapped)
  File "/usr/local/lib/python3.6/site-packages/werkzeug/wsgi.py", line 766, in __call__
    return self.app(environ, start_response)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1456, in dispatch
    result = ir_http._dispatch()
  File "/opt/odoo/custom/src/odoo/addons/website_sale/models/ir_http.py", line 15, in _dispatch
    return super(IrHttp, cls)._dispatch()
  File "/opt/odoo/custom/src/odoo/addons/website/models/ir_http.py", line 172, in _dispatch
    response = super(Http, cls)._dispatch()
  File "/opt/odoo/custom/src/odoo/addons/auth_signup/models/ir_http.py", line 19, in _dispatch
    return super(Http, cls)._dispatch()
  File "/opt/odoo/custom/src/odoo/addons/web_editor/models/ir_http.py", line 21, in _dispatch
    return super(IrHttp, cls)._dispatch()
  File "/opt/odoo/custom/src/odoo/addons/utm/models/ir_http.py", line 29, in _dispatch
    response = super(IrHttp, cls)._dispatch()
  File "/opt/odoo/custom/src/odoo/addons/http_routing/models/ir_http.py", line 469, in _dispatch
    cls._add_dispatch_parameters(func)
  File "/opt/odoo/custom/src/odoo/addons/website/models/ir_http.py", line 211, in _add_dispatch_parameters
    super(Http, cls)._add_dispatch_parameters(func)
  File "/opt/odoo/custom/src/odoo/addons/http_routing/models/ir_http.py", line 405, in _add_dispatch_parameters
    nearest_ctx_lg = not is_a_bot and cls.get_nearest_lang(request.env.context['lang'])
KeyError: 'lang'
```

</details>

**Desired behavior after PR is merged:**
No Traceback

Info: @wt-io-it

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
