### PR TITLE
[FIX] stock: update qty in inventory report mode

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -243,8 +243,7 @@ class StockQuant(models.Model):
             self = self.sudo()
             res = super(StockQuant, self).write(vals)
             if res and self.env.context.get('inventory_report_mode'):
-                # update context to prevent recursive write call
-                self.with_context({'inventory_report_mode': False}).action_apply_inventory()
+                self.action_apply_inventory()
             return res
         return super(StockQuant, self).write(vals)
 
@@ -297,6 +296,8 @@ class StockQuant(models.Model):
         return action
 
     def action_apply_inventory(self):
+        # Update the context to prevent recursive call from write method
+        self = self.with_context({'inventory_report_mode': False})
         products_tracked_without_lot = []
         for quant in self:
             rounding = quant.product_uom_id.rounding

--- a/addons/stock/tests/test_quant_inventory_mode.py
+++ b/addons/stock/tests/test_quant_inventory_mode.py
@@ -226,6 +226,20 @@ class TestEditableQuant(TransactionCase):
         quant.action_apply_inventory()
         self.assertEqual(quant.quantity, 8)
 
+    def test_edit_quant_4(self):
+        """ Update the quantity with the inventory report mode """
+        default_wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        default_stock_location = default_wh.lot_stock_id
+        quant = self.Quant.create({
+            'product_id': self.product.id,
+            'location_id': default_stock_location.id,
+            'inventory_quantity': 100,
+        })
+        quant.action_apply_inventory()
+        self.assertEqual(self.product.qty_available, 100)
+        quant.with_context(inventory_report_mode=True).inventory_quantity_auto_apply = 75
+        self.assertEqual(self.product.qty_available, 75)
+
     def test_sn_warning(self):
         """ Checks that a warning is given when reusing an existing SN
         in inventory mode.


### PR DESCRIPTION
It is currently not possible to update the quantity of a product from
the inventory report

To reproduce the issue:
1. Create a storable product P
2. Update its on hand quantity to 100
3. Inventory > Reporting > Inventory Report
4. On the line for P, update to quantity to 75

Error: The quantity becomes 0 instead of 75

When setting the quantity from the inventory report, the client calls
the `write` method with the context key `inventory_report_mode` defined
and equal to `True`
This `write` leads to `_set_inventory_quantity` which triggers
`action_apply_inventory` (without disabling the context key!):
https://github.com/odoo/odoo/blob/8b155b695823dfa954464ad0d5dd07445ece2471/addons/stock/models/stock_quant.py#L150-L158
At the end of the inventory update, it resets the field
`inventory_quantity` to 0:
https://github.com/odoo/odoo/blob/8b155b695823dfa954464ad0d5dd07445ece2471/addons/stock/models/stock_quant.py#L592
To do so, the `write` method is called again and here is the issue:
https://github.com/odoo/odoo/blob/8b155b695823dfa954464ad0d5dd07445ece2471/addons/stock/models/stock_quant.py#L244-L248
Once `inventory_quantity` is updated, since `inventory_report_mode` is
still in the context and equal to `True`, `action_apply_inventory` is
called again. Then, when applying again the inventory, it will consider
the value of `inventory_quantity` (i.e., `0`) to define the new
quantity.

OPW-2737437
OPW-2746201