### PR TITLE
[FIX] website_event: add missing ir.model.access

### DIFF
--- a/addons/website_event/security/ir.model.access.csv
+++ b/addons/website_event/security/ir.model.access.csv
@@ -1,5 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_event_event,event.event,model_event_event,,1,0,0,0
+access_event_event_ticket,event.event.ticket,event.model_event_event_ticket,,1,0,0,0
 access_event_type,event.type,event.model_event_type,,0,0,0,0
 access_event_tag_category,event.tag.category,event.model_event_tag_category,,1,0,0,0
 access_event_tag,event.tag,event.model_event_tag,,1,0,0,0


### PR DESCRIPTION
There isn't `ir.model.access` on `event.event.ticket` for public and
portal users, but there is already the `ir.rule` to check the access.

In master, It causes an issue now, since https://github.com/odoo/odoo/pull/82896,
the `description` field of `event.event.ticket` isn't prefetch anymore
by the sudoed `event_registrations_open`
compute (that fill the cache with ticket data in sudo).
It crashes single app build:
https://runbot.odoo.com/runbot/build/12473674

We prefer to backport it in stable, there are maybe some corners where
it will raise an Exception and for sake of correctness.