### PR TITLE
[FIX] pos_hr: profile picture in POS UI

### DIFF
--- a/addons/pos_hr/static/src/js/CashierName.js
+++ b/addons/pos_hr/static/src/js/CashierName.js
@@ -12,6 +12,14 @@ odoo.define('pos_hr.CashierName', function (require) {
                 super.setup();
                 useBarcodeReader({ cashier: this.barcodeCashierAction });
             }
+            //@Override
+            get avatar() {
+                if (this.env.pos.config.module_pos_hr) {
+                    const cashier = this.env.pos.get_cashier();
+                    return `/web/image/hr.employee/${cashier.id}/avatar_128`;
+                }
+                return super.avatar;
+            }
         };
 
     Registries.Component.extend(CashierName, PosHrCashierName);


### PR DESCRIPTION
With this commit, the picture used will be the employee one if there's no user attached to it

task-id: 2719656