### PR TITLE
[IMP] survey: hide unused column_nb from the survey_question view

### DIFF
--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -176,7 +176,7 @@
                             </group>
                             <group>
                                 <group string="Display" attrs="{'invisible':[('question_type','not in',['simple_choice', 'multiple_choice'])]}">
-                                    <field name="column_nb" string="Number of columns"/>
+                                    <field name="column_nb" string="Number of columns" invisible="1"/>
                                     <field name="allow_value_image"/>
                                 </group>
                                 <group string="Conditional Display" attrs="{'invisible': [('questions_selection', '=', 'random')]}">


### PR DESCRIPTION
This commit hides the '"column_nb" field on the survey form.
Indeed, that option is currently not taken into account in the survey design.
A second PR will follow to properly remove the field (which can't be done in
stable).

More details at https://github.com/odoo/odoo/pull/83645

Task-2730409