### PR TITLE
[FIX] point_of_sale: epson kitchen printer cannot render

### DIFF
--- a/addons/pos_epson_printer_restaurant/static/src/js/multiprint.js
+++ b/addons/pos_epson_printer_restaurant/static/src/js/multiprint.js
@@ -16,7 +16,7 @@ var _super_posmodel = models.PosModel.prototype;
 models.PosModel = models.PosModel.extend({
     create_printer: function (config) {
         if (config.printer_type === "epson_epos") {
-            return new EpsonPrinter(config.epson_printer_ip);
+            return new EpsonPrinter(config.epson_printer_ip, this);
         } else {
             return _super_posmodel.create_printer.apply(this, arguments);
         }


### PR DESCRIPTION
When printer of type Epson are created for kitchen the pos model is not
passed, and so the rendering of the receipt does not working for
printers added that way.

We are now correctly passing the pos model.

OPW-2745009

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
