### PR TITLE
[FIX] pos_gift_card: Access error gift card

### DIFF
--- a/addons/pos_gift_card/models/gift_card.py
+++ b/addons/pos_gift_card/models/gift_card.py
@@ -21,7 +21,7 @@ class GiftCard(models.Model):
     def _compute_balance(self):
         super()._compute_balance()
         for record in self:
-            confirmed_line = record.redeem_pos_order_line_ids.filtered(
+            confirmed_line = record.redeem_pos_order_line_ids.sudo().filtered(
                 lambda l: l.order_id.state in ('paid', 'done', 'invoiced')
             )
             balance = record.balance


### PR DESCRIPTION
Current behavior:
When trying to open the gift card list you get an access error if one of the cards has been used in another company.
This error appears because you cannot access SO from another company and the used gift cards were linked to a SO.
So shouldn't be able to use a gift card that was created in another company.

Steps to reproduce:
- Create a gift card in company A
- Use it in company B
- Try to access it from company A

opw-2732973

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
