### PR TITLE
[FIX] im_livechat, mail: hide call buttons for chat with visitor

### DIFF
--- a/addons/im_livechat/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/im_livechat/static/src/components/discuss/tests/discuss_tests.js
@@ -352,6 +352,32 @@ QUnit.test('invite button should be present on livechat', async function (assert
     );
 });
 
+QUnit.test('call buttons should not be present on livechat', async function (assert) {
+    assert.expect(1);
+
+    this.data['mail.channel'].records.push(
+        {
+            anonymous_name: "Visitor 11",
+            channel_type: 'livechat',
+            id: 11,
+            livechat_operator_id: this.data.currentPartnerId,
+            members: [this.data.currentPartnerId, this.data.publicPartnerId],
+        },
+    );
+    await this.start({
+        discuss: {
+            params: {
+                default_active_id: 'mail.channel_11',
+            },
+        },
+    });
+    assert.containsNone(
+        document.body,
+        '.o_ThreadViewTopbar_callButton',
+        "Call buttons should not be visible in top bar when livechat is active thread"
+    );
+});
+
 });
 });
 });

--- a/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.xml
+++ b/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.xml
@@ -49,7 +49,7 @@
                     <t t-if="threadViewTopbar.thread and threadViewTopbar.thread === messaging.starred">
                         <button class="o_ThreadViewTopbar_unstarAllButton btn btn-secondary" t-att-disabled="threadViewTopbar.threadView.messages.length === 0" t-on-click="threadViewTopbar.onClickUnstarAll">Unstar all</button>
                     </t>
-                    <t t-if="threadViewTopbar.thread and threadViewTopbar.thread.model === 'mail.channel' and threadViewTopbar.thread.rtcSessions.length === 0">
+                    <t t-if="threadViewTopbar.thread and threadViewTopbar.thread.hasCallFeature and threadViewTopbar.thread.rtcSessions.length === 0">
                         <button class="o_ThreadViewTopbar_callButton o_ThreadViewTopbar_button o-active" t-att-disabled="threadViewTopbar.thread.hasPendingRtcRequest" title="Start a Call" t-on-click="_onClickPhone">
                             <i class="fa fa-lg fa-phone"/>
                         </button>

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1466,6 +1466,14 @@ function factory(dependencies) {
          * @private
          * @returns {boolean}
          */
+        _computeHasCallFeature() {
+            return ['channel', 'chat', 'group'].includes(this.channel_type);
+        }
+
+        /**
+         * @private
+         * @returns {boolean}
+         */
         _computeHasInviteFeature() {
             return this.model === 'mail.channel';
         }
@@ -2231,6 +2239,12 @@ function factory(dependencies) {
          */
         hasActivities: attr({
             default: false,
+        }),
+        /**
+         * Determines whether the RTC call feature should be displayed.
+         */
+        hasCallFeature: attr({
+            compute: '_computeHasCallFeature',
         }),
         /**
          * States whether this thread should has the invite feature. Only makes


### PR DESCRIPTION
**Current behavior before PR:**

In Discuss topbar, call buttons are added to allow call and video between
channel members. Those buttons were also added to live chat channels but any
voice call or video call features are not available for visitors.

**Desired behavior after PR is merged:**

Call buttons will not appear in Discuss top bar for live chat channels.

**Task**-2744224
