### PR TITLE
[FIX] 15.0-Point_of_Sale, send correct value to Pos_epson_printer

### DIFF
--- a/addons/pos_epson_printer_restaurant/static/src/js/multiprint.js
+++ b/addons/pos_epson_printer_restaurant/static/src/js/multiprint.js
@@ -16,7 +16,7 @@ var _super_posmodel = models.PosModel.prototype;
 models.PosModel = models.PosModel.extend({
     create_printer: function (config) {
         if (config.printer_type === "epson_epos") {
-            return new EpsonPrinter(config.epson_printer_ip);
+            return new EpsonPrinter(config.epson_printer_ip, this);
         } else {
             return _super_posmodel.create_printer.apply(this, arguments);
         }


### PR DESCRIPTION
When EpsonPrinter was called for printing order, it was only given ip, but not 'pos' value. Because of this, whenever user tries to print Order in restaurant printer, they get error saying that self.pos is undefined. Once we send "this" to EpsonPrinter, problem gets solved.

continuation of https://github.com/odoo/odoo/pull/82656

fixes OPW-2746953



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
