### PR TITLE
[FIX] gamification: stop notifying users on intermediate ranks

### DIFF
--- a/addons/gamification/models/gamification_karma_rank.py
+++ b/addons/gamification/models/gamification_karma_rank.py
@@ -42,8 +42,8 @@ class KarmaRank(models.Model):
     def write(self, vals):
         if 'karma_min' in vals:
             previous_ranks = self.env['gamification.karma.rank'].search([], order="karma_min DESC").ids
-            low = min(vals['karma_min'], self.karma_min)
-            high = max(vals['karma_min'], self.karma_min)
+            low = min(vals['karma_min'], min(self.mapped('karma_min')))
+            high = max(vals['karma_min'], max(self.mapped('karma_min')))
 
         res = super(KarmaRank, self).write(vals)
 

--- a/addons/gamification/models/gamification_karma_rank.py
+++ b/addons/gamification/models/gamification_karma_rank.py
@@ -35,8 +35,10 @@ class KarmaRank(models.Model):
     @api.model_create_multi
     def create(self, values_list):
         res = super(KarmaRank, self).create(values_list)
-        users = self.env['res.users'].sudo().search([('karma', '>', 0)])
-        users._recompute_rank()
+        if any(res.mapped('karma_min')) > 0:
+            users = self.env['res.users'].sudo().search([('karma', '>=', max(min(res.mapped('karma_min')), 1))])
+            if users:
+                users._recompute_rank()
         return res
 
     def write(self, vals):
@@ -50,8 +52,8 @@ class KarmaRank(models.Model):
         if 'karma_min' in vals:
             after_ranks = self.env['gamification.karma.rank'].search([], order="karma_min DESC").ids
             if previous_ranks != after_ranks:
-                users = self.env['res.users'].sudo().search([('karma', '>', 0)])
+                users = self.env['res.users'].sudo().search([('karma', '>=', max(low, 1))])
             else:
-                users = self.env['res.users'].sudo().search([('karma', '>=', low), ('karma', '<=', high)])
+                users = self.env['res.users'].sudo().search([('karma', '>=', max(low, 1)), ('karma', '<=', high)])
             users._recompute_rank()
         return res

--- a/addons/gamification/models/res_users.py
+++ b/addons/gamification/models/res_users.py
@@ -180,6 +180,10 @@ WHERE sub.user_id IN %%s""" % {
         """
             Method that can be called on a batch of users with the same new rank
         """
+        if self.env.context.get('install_mode', False):
+            # avoid sending emails in install mode (prevents spamming users when creating data ranks)
+            return
+
         template = self.env.ref('gamification.mail_template_data_new_rank_reached', raise_if_not_found=False)
         if template:
             for u in self:


### PR DESCRIPTION
Purpose
=======
Change order of demo data to avoid sending an email for every
intermediate rank for each user.
Order is now descending so `_recompute_rank` is only called on highest
rank and not from smallest to biggest.

Task-2746929
