### PR TITLE
[FIX] l10n_ar: document number inverse

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -199,7 +199,8 @@ class AccountMove(models.Model):
 
         to_review = self.filtered(
             lambda x: x.journal_id.type == 'sale' and x.l10n_latam_document_type_id and x.l10n_latam_document_number and
-            (x.l10n_latam_manual_document_number or not x.highest_name))
+            (x.l10n_latam_manual_document_number or not x.highest_name)
+            and x.l10n_latam_document_type_id.country_id.code == 'AR')
         for rec in to_review:
             number = rec.l10n_latam_document_type_id._format_document_number(rec.l10n_latam_document_number)
             current_pos = int(number.split("-")[0])


### PR DESCRIPTION
latam task 724
---

We updated the inverse method to only be applied when the document number is an Argentinean one.
This solve the traceback error we were having for Peru localization.

### Description of the issue/feature this PR addresses:

When AR and PE localizations are installed at the same time and logged in the PE company we are trying to set the document number of the invoice we receive a traceback error.

### Current behavior before PR:

The traceback error does not let us create/validate the PE invoice. This is because a logic that was designed for AR was affecting to PE invoice.

![image](https://user-images.githubusercontent.com/7593953/152364082-6587442d-7d87-4bc1-a4af-cd0ac2b26f33.png)

### Desired behavior after PR is merged:

Now the PE invoice can be created/validated and the document number can be set without raising any error.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
