### PR TITLE
[FIX] hr_timesheet : force employee when creating a timesheet

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -47,7 +47,7 @@ class AccountAnalyticLine(models.Model):
         'project.project', 'Project', domain=_domain_project_id,
         compute='_compute_project_id', store=True, readonly=False)
     user_id = fields.Many2one(compute='_compute_user_id', store=True, readonly=False)
-    employee_id = fields.Many2one('hr.employee', "Employee", domain=_domain_employee_id)
+    employee_id = fields.Many2one('hr.employee', "Employee", domain=_domain_employee_id, context={'active_test': False})
     department_id = fields.Many2one('hr.department', "Department", compute='_compute_department_id', store=True, compute_sudo=True)
     encoding_uom_id = fields.Many2one('uom.uom', compute='_compute_encoding_uom_id')
     partner_id = fields.Many2one(compute='_compute_partner_id', store=True, readonly=False)
@@ -122,15 +122,20 @@ class AccountAnalyticLine(models.Model):
         # Although this make a second loop on the vals, we need to wait the preprocess as it could change the company_id in the vals
         # TODO To be refactored in master
         company_ids_in_vals = list({vals['company_id'] for vals in vals_list if vals.get('company_id', False)})
-        employees = self.env['hr.employee'].search([('user_id', 'in', user_ids), ('company_id', 'in', [self.env.company.id] + company_ids_in_vals)])
+        employees = self.env['hr.employee'].with_context(active_test=False).search([('user_id', 'in', user_ids), ('company_id', 'in', [self.env.company.id] + company_ids_in_vals)])
         user_map = defaultdict(dict)
         for employee in employees:
             user_map[employee.company_id.id][employee.user_id.id] = employee.id
 
+        employee_ids = set()
         for vals in vals_list:
             # compute employee only for timesheet lines, makes no sense for other lines
-            if not vals.get('employee_id') and vals.get('project_id'):
-                vals['employee_id'] = user_map[vals.get('company_id', self.env.company.id)].get(vals.get('user_id', default_user_id), False)
+            if vals.get('project_id'):
+                if not vals.get('employee_id'):
+                    vals['employee_id'] = user_map[vals.get('company_id', self.env.company.id)].get(vals.get('user_id', default_user_id), False)
+                employee_ids.add(vals['employee_id'])
+        if employee_ids and any(not employee_id for employee_id in employee_ids):
+            raise AccessError("Each timesheet should be linked to an employee.")
 
         lines = super(AccountAnalyticLine, self).create(vals_list)
         for line, values in zip(lines, vals_list):

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -224,6 +224,7 @@ class TestTimesheet(TestCommonTimesheet):
             'task_id': self.task1.id,
             'name': 'my first timesheet',
             'unit_amount': 4,
+            'user_id': self.user_employee.id,
         })
 
         timesheet_count1 = Timesheet.search_count([('project_id', '=', self.project_customer.id)])
@@ -298,6 +299,7 @@ class TestTimesheet(TestCommonTimesheet):
             'task_id': self.task1.id,
             'name': 'my only timesheet',
             'unit_amount': 4,
+            'user_id': self.user_employee.id,
         })
 
         self.assertEqual(timesheet_entry.partner_id, self.partner, "The timesheet entry's partner should be equal to the task's partner/customer")

--- a/addons/sale_timesheet/tests/test_sale_service.py
+++ b/addons/sale_timesheet/tests/test_sale_service.py
@@ -576,6 +576,7 @@ class TestSaleService(TestCommonSaleTimesheet):
             'project_id': self.project_task_rate.id,
             'task_id': task.id,
             'unit_amount': 1,
+            'employee_id': self.employee_user.id,
         })
         self.assertEqual(task.remaining_hours_so, 1, "Before the creation of a timesheet, the remaining hours was 2 hours, when we timesheet 1 hour, the remaining hours should be equal to 1 hour.")
         self.assertEqual(prepaid_service_sol.remaining_hours, task.remaining_hours_so, "The remaining hours on the SOL should also be equal to 1 hour.")
@@ -595,6 +596,7 @@ class TestSaleService(TestCommonSaleTimesheet):
             'unit_amount': 1,
             'so_line': prepaid_service_sol.id,
             'is_so_line_edited': True,
+            'employee_id': self.employee_user.id,
         })
         self.assertEqual(timesheet.so_line, prepaid_service_sol, "The SOL should be the same than one containing the prepaid service product.")
         self.assertEqual(prepaid_service_sol.remaining_hours, 2, "The remaining hours should not change.")

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -490,6 +490,7 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
 
     def test_transfert_project(self):
         """ Transfert task with timesheet to another project. """
+        self.env.user.employee_id = self.env['hr.employee'].create({'user_id': self.env.uid})
         Timesheet = self.env['account.analytic.line']
         Task = self.env['project.task']
         today = Date.context_today(self.env.user)


### PR DESCRIPTION
- Bug 1

Steps :
Archive your employee, go to your timesheets and add time on a task T line
Go to task T and note that a line have been added without any employe

Cause :
By default, views do not show archived values.

Fix :
Show archived employees with context key 'test_active=False'.

- Bug 2 :

Steps :
Delete your employee, go to your timesheets and add time on a task T line
Go to task T and note that a line have been added without any employe

Cause :
If this employee do not exist, the timesheet has no employee,
which does not make sense.

Fix :
At creation of aal, check that timesheets have an employee.

opw: 2740228

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
