### PR TITLE
[FIX] sale: Change default_lst_price to default_list_price

### DIFF
--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -472,7 +472,7 @@
                                             'pricelist': parent.pricelist_id,
                                             'uom':product_uom,
                                             'company_id': parent.company_id,
-                                            'default_lst_price': price_unit,
+                                            'default_list_price': price_unit,
                                             'default_description_sale': name
                                         }"
                                         domain="[('sale_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
In v.14 and before, 'lst_price' was used for the product.product form and 'list_price' for product.template form.
However, in v.15, both use 'list_price'.
Having default_lst_price to 0 in the context of the creation of the product_id from the sale.order.form will trigger the inverse function _set_product_lst_price(), and will overwrite 'list_price' set on the product.product form.

This changed was already made for the product.template form that already used the default_list_price field in v.13 in PR https://github.com/odoo/odoo/pull/49934

Current behavior before PR:
https://watch.screencastify.com/v/5Goz2T3xZmWA3q2Xo3c3
When creating a product from the sale.order.form, the list_price field was overwrited to 0.

Desired behavior after PR is merged:
https://watch.screencastify.com/v/5Goz2T3xZmWA3q2Xo3c3
list_price stay the same.

OPW-2738244

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
