### PR TITLE
[FIX] hr_holidays : allow company leave second allocation

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -972,7 +972,7 @@ class HolidaysRequest(models.Model):
     def _validate_leave_request(self):
         """ Validate time off requests (holiday_type='employee')
         by creating a calendar event and a resource time off. """
-        holidays = self.filtered(lambda request: request.holiday_type == 'employee')
+        holidays = self.filtered(lambda request: request.holiday_type == 'employee' and request.employee_id)
         holidays._create_resource_leave()
         meeting_holidays = holidays.filtered(lambda l: l.holiday_status_id.create_calendar_meeting)
         if meeting_holidays:

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -529,3 +529,34 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'date_to': '2021-09-08',
             'number_of_days': 3,
         })
+
+    def test_company_leaves(self):
+        # First expired allocation
+        allocation = self.env['hr.leave.allocation'].create({
+            'name': 'Allocation',
+            'holiday_type': 'company',
+            'mode_company_id': self.env.company.id,
+            'holiday_status_id': self.holidays_type_1.id,
+            'number_of_days': 20,
+            'state': 'confirm',
+            'date_from': '2021-01-01',
+        })
+        allocation.action_validate()
+
+        req1_form = Form(self.env['hr.leave'].sudo())
+        req1_form.employee_ids.add(self.employee_emp)
+        req1_form.employee_ids.add(self.employee_hrmanager)
+        req1_form.holiday_status_id = self.holidays_type_1
+        req1_form.request_date_from = fields.Date.to_date('2021-12-06')
+        req1_form.request_date_to = fields.Date.to_date('2021-12-08')
+
+        self.assertEqual(req1_form.number_of_days, 3)
+        req1_form.save().action_approve()
+
+        req2_form = Form(self.env['hr.leave'].sudo())
+        req2_form.employee_ids.add(self.employee_hruser)
+        req2_form.holiday_status_id = self.holidays_type_1
+        req2_form.request_date_from = fields.Date.to_date('2021-12-06')
+        req2_form.request_date_to = fields.Date.to_date('2021-12-08')
+
+        self.assertEqual(req2_form.number_of_days, 3)


### PR DESCRIPTION
Steps :
Create a Leave Allocation :
	Mode : "By Company" (just to give it to every employee).
	Duration : 6 days
Create a Leave for 2 Employees A and B for week W.
Approve it.
Create a Leave for another Employee C for week W and next moday.

Issue:
Duration is 1. As a side effect, employee C still has 5 days left.

Cause:
At validation, requests with multpile employee create one leave per employee.
Then, a resource.calendar.leave is created fro eachone, including the firstone.
When creating the next request, _leave_intervals_batch looks for resource.calendar.leaves
with resource_id = C or False (which means several resources), that has been taken.
It finds the leaves taken by A and B, so it considers C is off too.

Fix:
We don't create a resource.calendar.leave for the multiple employee request.

opw:2739324

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
