### PR TITLE
[FIX] pos_sale: do not unlink downpayment lines

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -82,3 +82,8 @@ class SaleOrderLine(models.Model):
             return sale_line_uom._compute_quantity(qty, product_uom, False)
         elif direction == 'p2s':
             return product_uom._compute_quantity(qty, sale_line_uom, False)
+
+    def unlink(self):
+        # do not delete downpayment lines created from pos
+        pos_downpayment_lines = self.filtered(lambda line: line.is_downpayment and line.sudo().pos_order_line_ids)
+        return super(SaleOrderLine, self - pos_downpayment_lines).unlink()


### PR DESCRIPTION
1. Create a SO in Sales App.
2. Open POS session.
3. Load the SO in POS.
4. Select "Apply a Down Payment". Insert any percentage (eg: 50%). Pay
5. Go back to SO in Sales App.
6. Deliver the product.
7. Create an Invoice and apply the down payment.
8. Open the draft invoice and delete it.

Downpayment made on POS is unlinked and cannot be reinvoiced.

This change will avoid deleting the downpayment if it is coming from the
POS. As that the order is validated in the process, it should
be not possible to modify/delete it anymore

opw-2744281

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
