### PR TITLE
[FIX] product: Flush also dates on pricelist items

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -93,7 +93,10 @@ class Pricelist(models.Model):
     def _compute_price_rule_get_items(self, products_qty_partner, date, uom_id, prod_tmpl_ids, prod_ids, categ_ids):
         self.ensure_one()
         # Load all rules
-        self.env['product.pricelist.item'].flush(['price', 'currency_id', 'company_id', 'active'])
+        self.env['product.pricelist.item'].flush([
+	            'categ_id', 'product_tmpl_id', 'product_id', 'pricelist_id',
+	            'date_start', 'date_end', 'applied_on', 'min_quantity', 'active'
+	        ])
         self.env.cr.execute(
             """
             SELECT


### PR DESCRIPTION
Due to https://github.com/odoo/odoo/commit/d9758ae87dd68ae00c91f95567e143b1ea09bd88
if in a same transaction, pricelist date_start/date_end are modified,
evaluating _compute_price_rule_get_items() can load a deactivated pricelist item.

@rco-odoo 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
