### PR TITLE
[FIX] account: Use the company of the env instead user company.

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -286,7 +286,7 @@ class ResPartner(models.Model):
               AND NOT acc.deprecated AND acc.company_id = %s
               AND move.state = 'posted'
             GROUP BY partner.id
-            HAVING %s * COALESCE(SUM(aml.amount_residual), 0) ''' + operator + ''' %s''', (account_type, self.env.user.company_id.id, sign, operand))
+            HAVING %s * COALESCE(SUM(aml.amount_residual), 0) ''' + operator + ''' %s''', (account_type, self.env.company.id, sign, operand))
         res = self._cr.fetchall()
         if not res:
             return [('id', '=', '0')]


### PR DESCRIPTION
For this case is wrong use the company of the user, because you may in other company at this moment and the search is not
working properly.
The way to solve this is use the "env" company as use in the computed method.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
