### PR TITLE
[FIX] point_of_sale: Fix crash in ClientListScreen

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -5,7 +5,7 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
     const { useListener } = require('web.custom_hooks');
-    const { isRpcError } = require('point_of_sale.utils');
+    const { isConnectionError } = require('point_of_sale.utils');
 
     /**
      * Render this screen using `showTempScreen` to select client.
@@ -163,7 +163,7 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
                 this.state.detailIsShown = false;
                 this.render();
             } catch (error) {
-                if (isRpcError(error) && error.message.code < 0) {
+                if (isConnectionError(error)) {
                     await this.showPopup('OfflineErrorPopup', {
                         title: this.env._t('Offline'),
                         body: this.env._t('Unable to save changes.'),


### PR DESCRIPTION
In some cases load_new_partners returns a rejected promise
with an argument of type string, which causes a crash in
the catch which considers that it is an rpc error using
error.message.code and this is an error because error is
a string in the case of a reject on load_new_partners

opw-2679837