### PR TITLE
[FIX] crm: sync the email / phone with the partner

### DIFF
--- a/addons/crm/static/src/js/crm_form.js
+++ b/addons/crm/static/src/js/crm_form.js
@@ -19,9 +19,36 @@ odoo.define("crm.crm_form", function (require) {
          * We check if the stage_id field was altered and if we need to display a rainbowman
          * message.
          *
+         * This method will also simulate a real "force_save" on the email and phone
+         * when needed. The "force_save" attribute only works on readonly field. For our
+         * use case, we need to write the email and the phone even if the user didn't
+         * change them, to synchronize those values with the partner (so the email / phone
+         * inverse method can be called).
+         *
+         * We base this synchronization on the value of "ribbon_message", which is a
+         * computed field that hold a value whenever we need to synch.
+         *
          * @override
          */
-        saveRecord: function () {
+        saveRecord: function (recordID, options) {
+            recordID = recordID || this.handle;
+            const localData = this.model.localData[recordID];
+            const changes = localData._changes || {};
+
+            const needsSynchronization = changes.ribbon_message === undefined
+                ? localData.data.ribbon_message // original value
+                : changes.ribbon_message; // new value
+
+            if (needsSynchronization && changes.email_from === undefined && localData.data.email_from) {
+                changes.email_from = localData.data.email_from;
+            }
+            if (needsSynchronization && changes.phone === undefined && localData.data.phone) {
+                changes.phone = localData.data.phone;
+            }
+            if (!localData._changes && Object.keys(changes).length) {
+                localData._changes = changes;
+            }
+
             return this._super(...arguments).then((modifiedFields) => {
                 if (modifiedFields.indexOf('stage_id') !== -1) {
                     this._checkRainbowmanMessage(this.renderer.state.res_id)

--- a/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
+++ b/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
@@ -1,0 +1,68 @@
+odoo.define('crm.crm_email_and_phone_propagation', function (require) {
+    'use strict';
+
+    const tour = require('web_tour.tour');
+
+    tour.register('crm_email_and_phone_propagation_edit_save', {
+        test: true,
+        url: '/web',
+    }, [
+        tour.stepUtils.showAppsMenuItem(),
+        {
+            trigger: '.o_app[data-menu-xmlid="crm.crm_menu_root"]',
+            content: 'open crm app',
+        }, {
+            trigger: '.o_kanban_record .o_kanban_record_title span:contains(Test Lead Propagation)',
+            content: 'Open the first lead',
+            run: 'click',
+        }, {
+            trigger: '.o_form_button_edit',
+            extra_trigger: '.o_lead_opportunity_form.o_form_readonly',
+            content: 'Edit the lead',
+            run: 'click',
+        }, {
+            trigger: '.o_form_button_save',
+            extra_trigger: '.o_form_editable input[name="email_from"]',
+            content: 'Save the lead',
+            run: 'click',
+        }, {
+            trigger: '.o_form_readonly',
+        },
+    ]);
+
+    tour.register('crm_email_and_phone_propagation_remove_email_and_phone', {
+        test: true,
+        url: '/web',
+    }, [
+        tour.stepUtils.showAppsMenuItem(),
+        {
+            trigger: '.o_app[data-menu-xmlid="crm.crm_menu_root"]',
+            content: 'open crm app',
+        }, {
+            trigger: '.o_kanban_record .o_kanban_record_title span:contains(Test Lead Propagation)',
+            content: 'Open the first lead',
+            run: 'click',
+        }, {
+            trigger: '.o_form_button_edit',
+            content: 'Edit the lead',
+            run: 'click',
+        }, {
+            trigger: '.o_form_editable input[name="email_from"]',
+            extra_trigger: '.o_form_editable input[name="phone"]',
+            content: 'Remove the email and the phone',
+            run: function () {
+                $('input[name="email_from"]').val('').trigger("change");
+                $('input[name="phone"]').val('').trigger("change");
+            },
+        }, {
+            trigger: '.o_form_button_save',
+            // wait the the warning message to be visible
+            extra_trigger: '.o_form_sheet_bg .alert:not(.o_invisible_modifier) span[name="ribbon_message"]',
+            content: 'Save the lead',
+            run: 'click',
+        }, {
+            trigger: '.o_form_readonly',
+        },
+    ]);
+
+});

--- a/addons/crm/views/assets.xml
+++ b/addons/crm/views/assets.xml
@@ -11,6 +11,7 @@
     <template id="assets_tests" name="CRM Assets Tests" inherit_id="web.assets_tests">
         <xpath expr="." position="inside">
             <script type="text/javascript" src="/crm/static/tests/tours/crm_rainbowman.js"></script>
+            <script type="text/javascript" src="/crm/static/tests/tours/crm_email_and_phone_propagation.js"></script>
         </xpath>
     </template>
     <template id="qunit_suite" name="crm tests" inherit_id="web.qunit_suite_tests">


### PR DESCRIPTION
Bug
===
If we
1. Open a lead with an email but without partner
2. Set a partner without email on the lead
3. The warning "The email will be propagated" is visible
4. When saving the form, the email is not propagated even if the
   warning message was visible

Solution
========
The reason is that, as the email was not changed, the inverse method
of this field was not called and so the email was not propagated.

The best solution would be to use "force_save" on those fields. But
this feature only works on readonly fields.

So, we simulate a real "force_save" on the email / phone, directly in
JS. That way the inverse will be called, and if necessary, the email /
phone will be propagated. 

Task-2704904

Co-authored-by: flch-odoo <flch@odoo.com>