### PR TITLE
[IMP] website_slides: Task 2742087, more user-friendly page when acce…

### DIFF
--- a/addons/website_slides/__manifest__.py
+++ b/addons/website_slides/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'eLearning',
-    'version': '2.6',
+    'version': '2.7',
     'sequence': 125,
     'summary': 'Manage and publish an eLearning platform',
     'website': 'https://www.odoo.com/app/elearning',

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -14,7 +14,7 @@ from odoo.addons.http_routing.models.ir_http import slug, unslug
 from odoo.addons.website.controllers.main import QueryURL
 from odoo.addons.website.models.ir_http import sitemap_qs2dom
 from odoo.addons.website_profile.controllers.main import WebsiteProfile
-from odoo.exceptions import AccessError, ValidationError, UserError
+from odoo.exceptions import AccessError, ValidationError, UserError, MissingError
 from odoo.http import request
 from odoo.osv import expression
 
@@ -420,6 +420,29 @@ class WebsiteSlides(WebsiteProfile):
             ('karma', '>', 0),
             ('website_published', '=', True)], ['id'], limit=3, order='karma desc')
 
+    def _get_user_slide_authorization(self, slide_id):
+        """ Get authorization status for the current user to access the given slide along with some data.
+        :return: Dict in the form:
+        {
+            'status': authorized|not_found|not_authorized,
+            'slide': the slide corresponding to the slide_id (only if status != 'not_found')
+            'channel_id': id of the channel containing the slide (only if status != 'not_found')
+        }
+        """
+        status = 'authorized'
+        try:
+            slide_model = request.env['slide.slide']
+            slide_model.check_access_rights('read')
+            slide = slide_model.browse(slide_id)
+            slide.check_access_rule('read')
+        except (AccessError, MissingError):
+            try:
+                slide = request.env['slide.slide'].sudo().browse([slide_id])
+            except MissingError:
+                return {'status': 'not_found'}
+            status = 'not_authorized'
+        return {'status': status, 'slide': slide, 'channel_id': slide.sudo().channel_id.id}
+
     @http.route([
         '/slides/<model("slide.channel"):channel>',
         '/slides/<model("slide.channel"):channel>/page/<int:page>',
@@ -489,6 +512,16 @@ class WebsiteSlides(WebsiteProfile):
         elif uncategorized:
             query_string = "?search_uncategorized=1"
 
+        errors = {'access_error': False}
+        if request.params.get('access_error') == 'course_content' and request.params.get('access_error_slide_id'):
+            # Access are re-verified to support use case where the user refresh the page after an update of their access
+            user_slide_authorization = self._get_user_slide_authorization(int(request.params.get('access_error_slide_id')))
+            if user_slide_authorization['status'] == 'not_authorized':
+                errors.update({
+                    'access_error': 'course_content',
+                    'access_error_content_name': request.params.get('access_error_slide_name'),
+                })
+
         render_values = self._slide_render_context_base()
         render_values.update({
             'channel': channel,
@@ -507,6 +540,7 @@ class WebsiteSlides(WebsiteProfile):
             'pager': pager,
             # display upload modal
             'enable_slide_upload': 'enable_slide_upload' in kw,
+            ** errors,
             ** self._slide_channel_prepare_review_values(channel),
         })
 
@@ -735,6 +769,24 @@ class WebsiteSlides(WebsiteProfile):
 
         values.pop('channel', None)
         return request.render("website_slides.slide_main", values)
+
+    @http.route('/slides/slide/<int:slide_id>/share', type='http', auth="public", website=True, sitemap=False)
+    def slide_shared_view(self, slide_id, **kwargs):
+        user_slide_authorization = self._get_user_slide_authorization(slide_id)
+        status = user_slide_authorization['status']
+        if status == 'not_found':
+            raise werkzeug.exceptions.NotFound()
+
+        if status == 'authorized':
+            return request.redirect(
+                '%s?%s' % (user_slide_authorization['slide'].website_url, werkzeug.urls.url_encode(kwargs)))
+
+        channel_id = user_slide_authorization['channel_id']
+        return request.redirect('/slides/%s?%s' % (channel_id, werkzeug.urls.url_encode({
+            'access_error': 'course_content',
+            'access_error_slide_id': slide_id,
+            'access_error_slide_name': user_slide_authorization['slide'].name,
+        })))
 
     @http.route('''/slides/slide/<model("slide.slide"):slide>/pdf_content''',
                 type='http', auth="public", website=True, sitemap=False)

--- a/addons/website_slides/data/mail_template_data.xml
+++ b/addons/website_slides/data/mail_template_data.xml
@@ -13,13 +13,13 @@
                         <center><strong t-out="object.name or ''">Trees</strong></center>
                         <t t-if="object.image_1024">
                             <div style="padding: 16px 8px 16px 8px; text-align: center;">
-                                <a t-att-href="object.website_url">
+                                <a t-att-href="object.website_share_url">
                                 <img t-att-alt="object.name" t-attf-src="{{ ctx.get('base_url') }}/web/image/slide.slide/{{ object.id }}/image_1024" style="height:auto; width:150px; margin: 16px;"/>
                             </a>
                         </div>
                         </t>
                         <div style="padding: 16px 8px 16px 8px; text-align: center;">
-                            <a t-att-href="object.website_url"
+                            <a t-att-href="object.website_share_url"
                                 style="background-color: #875a7b; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px;">View content</a>
                         </div>
                         Enjoy this exclusive content!
@@ -45,12 +45,12 @@
                         Hello<br/><br/>
                         <t t-out="user.name or ''">Mitchell Admin</t> shared the <t t-out="object.slide_category or ''">document</t> <strong t-out="object.name or ''">Trees</strong> with you!
                         <div style="margin: 16px 8px 16px 8px; text-align: center;">
-                            <a t-att-href="(object.website_url + '?fullscreen=1') if ctx.get('fullscreen') else object.website_url">
+                            <a t-att-href="(object.website_share_url + '?fullscreen=1') if ctx.get('fullscreen') else object.website_share_url">
                                 <img t-att-alt="object.name" t-attf-src="{{ ctx.get('base_url') }}/web/image/slide.slide/{{ object.id }}/image_1024" style="height:auto; width:150px; margin: 16px;"/>
                             </a>
                         </div>
                         <div style="padding: 16px 8px 16px 8px; text-align: center;">
-                            <a t-att-href="(object.website_url + '?fullscreen=1') if ctx.get('fullscreen') else object.website_url"
+                            <a t-att-href="(object.website_share_url + '?fullscreen=1') if ctx.get('fullscreen') else object.website_share_url"
                                 style="background-color: #875a7b; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px;">View <strong t-out="object.name or ''">Trees</strong></a>
                         </div>
                         <t t-if="user.signature">

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -202,6 +202,7 @@ class Slide(models.Model):
     embed_code = fields.Html('Embed Code', readonly=True, compute='_compute_embed_code', sanitize=False)
     embed_code_external = fields.Html('External Embed Code', readonly=True, compute='_compute_embed_code', sanitize=False,
         help="Same as 'Embed Code' but used to embed the content on an external website.")
+    website_share_url = fields.Char('Share URL', compute='_compute_website_share_url')
     # views
     embed_ids = fields.One2many('slide.embed', 'slide_id', string="External Slide Embeds")
     embed_count = fields.Integer('# of Embeds', compute='_compute_embed_counts')
@@ -552,6 +553,14 @@ class Slide(models.Model):
             if slide.id:  # avoid to perform a slug on a not yet saved record in case of an onchange.
                 base_url = slide.channel_id.get_base_url()
                 slide.website_url = '%s/slides/slide/%s' % (base_url, slug(slide))
+
+    @api.depends('is_published')
+    def _compute_website_share_url(self):
+        self.website_share_url = False
+        for slide in self:
+            if slide.id:  # ensure we can build the URL
+                base_url = slide.channel_id.get_base_url()
+                slide.website_share_url = '%s/slides/slide/%s/share' % (base_url, slide.id)
 
     @api.depends('channel_id.can_publish')
     def _compute_can_publish(self):

--- a/addons/website_slides/static/src/xml/website_slides_share.xml
+++ b/addons/website_slides/static/src/xml/website_slides_share.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-
     <t t-name="website.slide.share.modal">
         <div>
             <t t-call="website.slide.share.socialmedia"/>
@@ -12,15 +11,15 @@
             <div class="col-12 col-lg-6 mb-4">
                 <h5 class="mt-0 mb-2">Share on Social Networks</h5>
                 <div class="btn-group" role="group">
-                    <a t-attf-href="https://www.facebook.com/sharer/sharer.php?u=#{window.location.href}" class="btn border bg-white o_wslides_js_social_share" social-key="facebook" aria-label="Share on Facebook" title="Share on Facebook"><i class="fa fa-facebook-square fa-fw"/></a>
-                    <a t-attf-href="https://twitter.com/intent/tweet?text=#{widget.slide.name}&amp;url=#{window.location.href}" class="btn border bg-white o_wslides_js_social_share"  social-key="twitter" aria-label="Share on Twitter" title="Share on Twitter"><i class="fa fa-twitter fa-fw"/></a>
-                    <a t-attf-href="http://www.linkedin.com/sharing/share-offsite/?url=#{window.location.href}" social-key="linkedin" class="btn border bg-white o_wslides_js_social_share" aria-label="Share on LinkedIn" title="Share on LinkedIn"><i class="fa fa-linkedin fa-fw"/></a>
+                    <a t-attf-href="https://www.facebook.com/sharer/sharer.php?u=#{widget.slide.websiteShareUrl}" class="btn border bg-white o_wslides_js_social_share" social-key="facebook" aria-label="Share on Facebook" title="Share on Facebook"><i class="fa fa-facebook-square fa-fw"/></a>
+                    <a t-attf-href="https://twitter.com/intent/tweet?text=#{widget.slide.name}&amp;url=#{widget.slide.websiteShareUrl}" class="btn border bg-white o_wslides_js_social_share"  social-key="twitter" aria-label="Share on Twitter" title="Share on Twitter"><i class="fa fa-twitter fa-fw"/></a>
+                    <a t-attf-href="http://www.linkedin.com/sharing/share-offsite/?url=#{widget.slide.websiteShareUrl}" social-key="linkedin" class="btn border bg-white o_wslides_js_social_share" aria-label="Share on LinkedIn" title="Share on LinkedIn"><i class="fa fa-linkedin fa-fw"/></a>
                 </div>
             </div>
             <div class="col-12 col-lg-6">
                 <h5 class="mt-0 mb-2">Share Link</h5>
                 <div class="input-group">
-                    <input type="text" class="form-control o_wslides_js_share_link" t-att-value="window.location.href" readonly="readonly" onClick="this.select();" />
+                    <input type="text" class="form-control o_wslides_js_share_link" t-att-value="widget.slide.websiteShareUrl" readonly="readonly" onClick="this.select();" />
                     <div class="input-group-append">
                         <button class="btn btn-sm btn-primary o_clipboard_button" style="border-top-right-radius: 4px;border-bottom-right-radius: 4px;" >
                             <span class="fa fa-clipboard"> Copy Link</span>

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -171,6 +171,7 @@
             <!-- Share modal : here to avoid having text-white from o_wslides_course_header -->
             <t t-call="website_slides.slide_share_modal" t-if="channel.channel_type == 'documentation'">
                 <t t-set="record" t-value="channel"/>
+                <t t-set="website_share_url" t-value="channel.website_url"/>
             </t>
 
             <div class="o_wslides_course_main">
@@ -201,7 +202,13 @@
 
                             <div class="tab-content py-4 o_wslides_tabs_content mb-4" id="courseMainTabContent">
                                 <div t-att-class="'tab-pane fade %s' % ('show active' if active_tab == 'home' else '')" id="home" role="tabpanel" aria-labelledby="home-tab">
-                                    <div t-if="channel.channel_type == 'training'" class="mb-2 pt-1">
+                                    <!-- ==== Error notification ==== -->
+                                    <div t-if="access_error == 'course_content'" class="alert alert-danger alert-dismissable mb-1" role="alert">
+                                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">×</button>
+                                        You need to join this course to access &quot;<t t-out="access_error_content_name"/>&quot;.
+                                    </div>
+                                    <div t-if="channel.channel_type == 'training' and (channel_frontend_tags or channel.can_upload)"
+                                         class="mb-1 pt-1">
                                         <t t-if="channel_frontend_tags">
                                             <t t-foreach="channel_frontend_tags" t-as="channel_tag">
                                                 <span t-attf-class="badge o_wslides_channel_tag #{'o_tag_color_'+str(channel_tag.color)}" t-esc="channel_tag.name"/>
@@ -238,6 +245,7 @@
 
         <t t-call="website_slides.slide_share_modal">
             <t t-set="record" t-value="channel"/>
+            <t t-set="website_share_url" t-value="channel.website_url"/>
         </t>
     </t>
 </template>
@@ -351,7 +359,7 @@
             <t t-foreach="category_data" t-as="category">
                 <t t-set="category_id" t-value="category['id'] if category['id'] else None"/>
 
-                <li t-if="category['total_slides'] or channel.can_publish" t-att-class="'o_wslides_slide_list_category o_wslides_js_list_item mb-2' if category_id else 'mt-4'" t-att-data-slide-id="category_id" t-att-data-category-id="category_id">
+                <li t-if="category['total_slides'] or channel.can_publish" t-att-class="'o_wslides_slide_list_category o_wslides_js_list_item mb-2' if category_id else 'mt-1'" t-att-data-slide-id="category_id" t-att-data-category-id="category_id">
                     <div t-att-data-category-id="category_id"
                          t-att-class="'o_wslides_slide_list_category_header position-relative d-flex justify-content-between align-items-center mt8 %s %s' % ('bg-white shadow-sm border-bottom-0' if category_id else 'border-0', 'o_wslides_js_category py-0' if channel.can_upload else 'py-2')">
                         <div t-att-class="'d-flex align-items-center pl-3 %s' % ('o_wslides_slides_list_drag' if channel.can_publish else '')">

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -363,12 +363,13 @@
                             <h5 class="mt16">Share on Social Networks</h5>
                             <t t-call="website_slides.slide_share_social">
                                 <t t-set="record" t-value="slide"/>
+                                <t t-set="website_share_url" t-value="slide.website_share_url"/>
                             </t>
                         </div>
                         <div class="col-12 col-lg-6">
                             <t t-call="website_slides.slide_share_link">
                                 <t t-set="record" t-value="slide"/>
-                                <t t-set="website_url" t-value="slide.website_url"/>
+                                <t t-set="website_share_url" t-value="slide.website_share_url"/>
                             </t>
                         </div>
                     </div>

--- a/addons/website_slides/views/website_slides_templates_lesson_embed.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_embed.xml
@@ -45,7 +45,7 @@
                             <t t-if="is_external_embed">
                                 <t t-call="website_slides.slide_share_modal">
                                     <t t-set="record" t-value="slide"/>
-                                    <t t-set="website_url" t-value="slide.channel_id.website_url"/>
+                                    <t t-set="website_share_url" t-value="slide.channel_id.website_share_url"/>
                                     <t t-set="include_embed" t-value="True"/>
                                     <t t-set="embed_hide_starting_page" t-value="True"/>
                                 </t>

--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -117,7 +117,8 @@
                     t-att-data-completed="1 if slide_completed else 0"
                     t-att-data-embed-code="slide.embed_code if slide.slide_category in ['video', 'document', 'infographic'] else False"
                     t-att-data-is-member="is_member"
-                    t-att-data-session-answers="session_answers">
+                    t-att-data-session-answers="session_answers"
+                    t-att-data-website-share-url="slide.website_share_url">
                     <span class="ml-3">
                         <i t-if="slide_completed and is_member" class="o_wslides_slide_completed fa fa-check fa-fw text-success" t-att-data-slide-id="slide.id"/>
                         <i t-if="not slide_completed and is_member" class="fa fa-circle-thin fa-fw" t-att-data-slide-id="slide.id"/>
@@ -172,7 +173,8 @@
                                 t-att-data-is-quiz="1"
                                 t-att-data-completed="1 if slide_completed else 0"
                                 t-att-data-is-member="is_member"
-                                t-att-data-session-answers="session_answers">
+                                t-att-data-session-answers="session_answers"
+                                t-att-data-website-share-url="slide.website_share_url">
                                 <a t-if="can_access" class="o_wslides_fs_slide_quiz" href="#" t-att-index="i">
                                     <i class="fa fa-flag-checkered text-warning mr-2"/>Quiz
                                 </a>

--- a/addons/website_slides/views/website_slides_templates_utils.xml
+++ b/addons/website_slides/views/website_slides_templates_utils.xml
@@ -3,16 +3,20 @@
 
 <!-- Share on social networks -->
 <template id='slide_share_social' name="Slides Media Share">
+    <t t-if="not website_share_url">
+        <t t-set="website_share_url"
+           t-value="record.website_share_url if 'website_share_url' in record else record.website_url"/>
+    </t>
     <div class="btn-group" role="group">
-        <a t-attf-href="https://www.facebook.com/sharer/sharer.php?u=#{record.website_url}" class="btn border bg-white o_wslides_js_social_share"
+        <a t-attf-href="https://www.facebook.com/sharer/sharer.php?u=#{website_share_url}" class="btn border bg-white o_wslides_js_social_share"
             social-key="facebook" aria-label="Share on Facebook" title="Share on Facebook" target="_blank">
             <i class="fa fa-facebook-square fa-fw"/>
         </a>
-        <a t-attf-href="https://twitter.com/intent/tweet?text=#{record.name}&amp;url=#{record.website_url}" class="btn border bg-white o_wslides_js_social_share"
+        <a t-attf-href="https://twitter.com/intent/tweet?text=#{record.name}&amp;url=#{website_share_url}" class="btn border bg-white o_wslides_js_social_share"
             social-key="twitter" aria-label="Share on Twitter" title="Share on Twitter" target="_blank">
             <i class="fa fa-twitter fa-fw"/>
         </a>
-        <a t-attf-href="http://www.linkedin.com/sharing/share-offsite/?url=#{record.website_url}" class="btn border bg-white o_wslides_js_social_share"
+        <a t-attf-href="http://www.linkedin.com/sharing/share-offsite/?url=#{website_share_url}" class="btn border bg-white o_wslides_js_social_share"
             social-key="linkedin" aria-label="Share on LinkedIn" title="Share on LinkedIn" target="_blank">
             <i class="fa fa-linkedin fa-fw"/>
         </a>
@@ -21,9 +25,6 @@
 
 <!-- Share: social media -->
 <template id='slide_share_modal'>
-    <t t-if="not website_url">
-        <t t-set="website_url" t-value="record.website_url"/>
-    </t>
     <div class="modal fade" t-att-id="'slideChannelShareModal_%s' % record.id" tabindex="-1" role="dialog" aria-labelledby="slideChannelShareModalLabel" aria-hidden="true">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
@@ -55,10 +56,14 @@
 </template>
 
 <template id="slide_share_link">
+    <t t-if="not website_share_url">
+        <t t-set="website_share_url"
+           t-value="record.website_share_url if 'website_share_url' in record else record.website_url"/>
+    </t>
     <h5 class="mt-3">Share Link</h5>
     <div class="input-group">
         <input type="text" t-att-id="'wslides_share_link_id_%s' % record.id" class="form-control o_wslides_js_share_link" readonly="readonly" onclick="this.select();"
-            t-att-value="website_url"/>
+            t-att-value="website_share_url"/>
         <div class="input-group-append">
             <button t-att-id="'share_link_clipboard_button_id_%s' % record.id" class="btn btn-sm btn-primary o_clipboard_button" >
                 <span class="fa fa-clipboard"> Copy Text</span>


### PR DESCRIPTION
…ssing an unauthorized course content

Slide without the preview flag cannot be accessed for student not enrolled in the course.
In that case a special page is rendered with explanation and a link to the main page of the course (useful when sharing such page with someone who have not access to).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
