### PR TITLE
[IMP] stock_account: allow unlink all SVL in large database

### DIFF
--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -25,7 +25,7 @@ class StockValuationLayer(models.Model):
     remaining_qty = fields.Float(readonly=True, digits='Product Unit of Measure')
     remaining_value = fields.Monetary('Remaining Value', readonly=True)
     description = fields.Char('Description', readonly=True)
-    stock_valuation_layer_id = fields.Many2one('stock.valuation.layer', 'Linked To', readonly=True, check_company=True)
+    stock_valuation_layer_id = fields.Many2one('stock.valuation.layer', 'Linked To', readonly=True, check_company=True, index='btree_not_null')
     stock_valuation_layer_ids = fields.One2many('stock.valuation.layer', 'stock_valuation_layer_id')
     stock_move_id = fields.Many2one('stock.move', 'Stock Move', readonly=True, check_company=True, index=True)
     account_move_id = fields.Many2one('account.move', 'Journal Entry', readonly=True, check_company=True)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In large database, if SVL are wrong after a migration, it is impossible to remove all SVL (CPU time limit).

@amoyaux 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
