### PR TITLE
[FIX] mail: click on link in a message preview while replying

### DIFF
--- a/addons/mail/static/src/models/message_view/message_view.js
+++ b/addons/mail/static/src/models/message_view/message_view.js
@@ -16,6 +16,9 @@ function factory(dependencies) {
             this.update({
                 isHighlighted: true,
                 highlightTimeout: this.env.browser.setTimeout(() => {
+                    if (!this.exists()) {
+                        return;
+                    }
                     this.update({ isHighlighted: false });
                 }, 2000),
             });


### PR DESCRIPTION
When clicking on a mention (or a link) within the preview of the
message we're replying to, there was a traceback because we tried
to update a component which has already been deleted.

task-id: 2747321

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
