### PR TITLE
[FIX] stock: set default value for inventory_quantity_set

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -109,7 +109,7 @@ class StockQuant(models.Model):
     inventory_date = fields.Date(
         'Scheduled Date', compute='_compute_inventory_date', store=True, readonly=False,
         help="Next date the On Hand Quantity should be counted.")
-    inventory_quantity_set = fields.Boolean(store=True, compute='_compute_inventory_quantity_set', readonly=False)
+    inventory_quantity_set = fields.Boolean(store=True, compute='_compute_inventory_quantity_set', readonly=False, default=False)
     is_outdated = fields.Boolean('Quantity has been moved since last count', compute='_compute_is_outdated')
     user_id = fields.Many2one(
         'res.users', 'Assigned To', help="User assigned to do product count.")


### PR DESCRIPTION
When a quant is creating, for instance thanks to an internal transfer,
some of these computed fields will have an incorrect value

To reproduce the issue:
1. In Settings, enable "Storage Locations"
2. Create a storable product P
3. Update P's quantity: 100 P in WH/Stock
4. Process an internal transfer
    - From: WH/Stock
    - To: WH/Stock/Shelf 1
    - Operations: 10 x P
5. Consult the on hand quantities of P

Error: There is a new line with 10 x P in WH/Stock/Shelf 1, which is
correct. However, the Counted Quantity field is defined and equal to 0,
and so does the Difference field with a value of -10. These two fields
should not be shown.

When validating the internal transfer, a new quant is created for the
location "Shelf 1". However, there isn't any value for the field
`inventory_quantity_set`. Therefore, at the end of the transfer
validation process, when the `flush` method is called, since
`inventory_quantity_set` is a computed field, its  `compute` method is
called and define the value to `True`:
https://github.com/odoo/odoo/blob/8b155b695823dfa954464ad0d5dd07445ece2471/addons/stock/models/stock_quant.py#L134-L136
This explains why, on front-end, the Counted Quantity and Difference
fields are displayed.

OPW-2733937