### PR TITLE
[15.0][FIX] event: badge report dates in event's tz

### DIFF
--- a/addons/event/report/event_event_templates.xml
+++ b/addons/event/report/event_event_templates.xml
@@ -17,16 +17,16 @@
                     <div class="o_event_foldable_badge_ticket_wrapper_top page">
                         <h5 class="o_event_foldable_badge_event_name font-weight-bold text-center" t-field="event.name"/>
                         <div class="text-center o_event_foldable_badge_font_small">
-                            <span itemprop="startDate" t-esc="event.date_begin.date()"
+                            <span itemprop="startDate" t-field="event.date_begin" t-options='{"widget": "datetime", "date_only": True}'
                                 class="font-weight-bold"/>
-                            <span itemprop="startDateTime" t-esc="event.date_begin"
+                            <span itemprop="startDateTime" t-field="event.date_begin"
                                 class="font-weight-bold"
                                 t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True}'/>
                             <span class="fa fa-arrow-right o_event_foldable_badge_font_faded"/>
                             <span t-if="not event.is_one_day"
-                                itemprop="endDate" t-esc="event.date_end.date()"
+                                itemprop="endDate" t-field="event.date_end" t-options='{"widget": "datetime", "date_only": True}'
                                 class="font-weight-bold"/>
-                            <span itemprop="endDateTime" t-esc="event.date_end"
+                            <span itemprop="endDateTime" t-field="event.date_end"
                                 class="font-weight-bold"
                                 t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True}'/>
                         </div>
@@ -115,16 +115,16 @@
                                     Event Ticket For
                                 </div>
                                 <h5 class="o_event_full_page_ticket_event_name font-weight-bold py-0 my-0" t-field="event.name"/>
-                                <span itemprop="startDate" t-esc="event.date_begin.date()"
+                                <span itemprop="startDate" t-field="event.date_begin" t-options='{"widget": "datetime", "date_only": True}'
                                     class="font-weight-bold"/>
-                                <span itemprop="startDateTime" t-esc="event.date_begin"
+                                <span itemprop="startDateTime" t-field="event.date_begin"
                                     class="font-weight-bold"
                                     t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True}'/>
                                 <span class="fa fa-arrow-right o_event_full_page_ticket_font_faded"/>
                                 <span t-if="not event.is_one_day"
-                                    itemprop="endDate" t-esc="event.date_end.date()"
+                                    itemprop="endDate" t-field="event.date_end" t-options='{"widget": "datetime", "date_only": True}'
                                     class="font-weight-bold"/>
-                                <span itemprop="endDateTime" t-esc="event.date_end"
+                                <span itemprop="endDateTime" t-field="event.date_end"
                                     class="font-weight-bold"
                                     t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True}'/>
                                 <div t-if="event.address_id" class="o_event_full_page_ticket_font_faded">


### PR DESCRIPTION
**Steps to reproduce:**

1. Create an event with a remote TZ (e.g: 'Japan').
2. Create and confirm an attendee for this event.
3. Check the registration confirmation email and report.

![image](https://user-images.githubusercontent.com/1914185/152528647-ee38287c-97c0-4c7f-8002-41206ac4e865.png)
![image](https://user-images.githubusercontent.com/1914185/152528711-8d807cde-2de4-4dae-a646-a7766a8e3689.png)


**Current behaviour:**

* The dates in the email are in the event's tz.
* The dates in the report are in the user's tz.

![image](https://user-images.githubusercontent.com/1914185/152528750-1cc86223-fb81-40c6-be57-26881823605f.png)
![image](https://user-images.githubusercontent.com/1914185/152528793-1535b9b7-01c4-4971-956b-7888378176aa.png)


**Expected behaviour:**

* Both dates should be consistent and be in the event's tz.

![image](https://user-images.githubusercontent.com/1914185/152530179-8633d5c4-4d3a-4769-83c6-f827d0816da7.png)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
