### PR TITLE
[FIX] web_editor: fix missing strikethrough in editor

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -68,6 +68,7 @@ const KEYBOARD_TYPES = { VIRTUAL: 'VIRTUAL', PHYSICAL: 'PHYSICAL', UNKNOWN: 'UKN
 const IS_KEYBOARD_EVENT_UNDO = ev => ev.key === 'z' && (ev.ctrlKey || ev.metaKey);
 const IS_KEYBOARD_EVENT_REDO = ev => ev.key === 'y' && (ev.ctrlKey || ev.metaKey);
 const IS_KEYBOARD_EVENT_BOLD = ev => ev.key === 'b' && (ev.ctrlKey || ev.metaKey);
+const IS_KEYBOARD_EVENT_STRIKETHROUGH = ev => ev.key === '5' && (ev.ctrlKey || ev.metaKey);
 
 const CLIPBOARD_BLACKLISTS = {
     unwrap: ['.Apple-interchange-newline', 'DIV'], // These elements' children will be unwrapped.
@@ -2238,6 +2239,11 @@ export class OdooEditor extends EventTarget {
             ev.preventDefault();
             ev.stopPropagation();
             this.execCommand('bold');
+        } else if (IS_KEYBOARD_EVENT_STRIKETHROUGH(ev)) {
+            // Ctrl-5 / Ctrl-shift-(
+            ev.preventDefault();
+            ev.stopPropagation();
+            this.execCommand('strikeThrough');
         }
     }
     /**

--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -50,6 +50,7 @@
                 <div id="bold" data-call="bold" title="Toggle bold" class="btn fa fa-bold fa-fw"></div>
                 <div id="italic" data-call="italic" title="Toggle italic" class="btn fa fa-italic fa-fw"></div>
                 <div id="underline" data-call="underline" title="Toggle underline" class="btn fa fa-underline fa-fw"></div>
+                <div id="strikethrough" data-call="strikeThrough" title="Toggle strikethrough" class="btn fa fa-strikethrough fa-fw"></div>
                 <div id="removeFormat" data-call="removeFormat" title="Remove format" class="btn fa fa-eraser fa-fw"></div>
             </div>
 


### PR DESCRIPTION
[FIX] web_editor: fix missing strikethrough in editor

Strikethrough option was missing in the editor toolbar.

* Added the option in the toolbar.
* Added the keyboard shortcut (CTRL+5)

task-2754007

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
