### PR TITLE
[IMP] account: put country_code field in debit note and reversal wizard

### DIFF
--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -38,6 +38,7 @@ class AccountMoveReversal(models.TransientModel):
     )
     company_id = fields.Many2one('res.company', required=True, readonly=True)
     available_journal_ids = fields.Many2many('account.journal', compute='_compute_available_journal_ids')
+    country_code = fields.Char(related='company_id.country_id.code')
 
     # computed fields
     residual = fields.Monetary(compute="_compute_from_moves")

--- a/addons/account_debit_note/wizard/account_debit_note.py
+++ b/addons/account_debit_note/wizard/account_debit_note.py
@@ -25,6 +25,7 @@ class AccountDebitNote(models.TransientModel):
     # computed fields
     move_type = fields.Char(compute="_compute_from_moves")
     journal_type = fields.Char(compute="_compute_from_moves")
+    country_code = fields.Char(related='move_ids.company_id.country_id.code')
 
     @api.model
     def default_get(self, fields):


### PR DESCRIPTION
Preparation for a later PR where we use the country_code field to only show fields in the debit note and reversal wizard based on the country of the company

Backport of https://github.com/odoo/odoo/pull/83986/commits/44226366e3bb657ee5299662a788b8a07b16431f

