### PR TITLE
[FIX] web: BasicModel: contexts order

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -3503,15 +3503,15 @@ var BasicModel = AbstractModel.extend({
                 }
             }
         }
-        if (options.additionalContext) {
-            context.add(options.additionalContext);
-        }
         if (element.rawContext) {
             var rawContext = new Context(element.rawContext);
             var evalContext = this._getEvalContext(this.localData[element.parentID]);
             evalContext.id = evalContext.id || false;
             rawContext.set_eval_context(evalContext);
             context.add(rawContext);
+        }
+        if (options.additionalContext) {
+            context.add(options.additionalContext);
         }
 
         return context.eval();

--- a/addons/web/static/tests/legacy/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields/field_one2many_tests.js
@@ -10092,6 +10092,46 @@ QUnit.module('fields', {}, function () {
             form.destroy();
             assert.verifySteps(["willUnmount 1"]);
         });
+
+        QUnit.test('combine contexts on o2m field and create tags', async function (assert) {
+            assert.expect(1);
+
+            const form = await createView({
+                View: FormView,
+                model: 'partner',
+                data: this.data,
+                arch: `
+                    <form>
+                        <sheet>
+                            <field name="turtles" context="{'default_turtle_foo': 'hard', 'default_turtle_bar': True}">
+                                <tree editable="bottom">
+                                    <control>
+                                        <create name="add_soft_shell_turtle" context="{'default_turtle_foo': 'soft', 'default_turtle_int': 2}"/>
+                                    </control>
+                                </tree>
+                            </field>
+                        </sheet>
+                    </form>
+                `,
+                mockRPC: function (route, args) {
+                    if (args.method === 'onchange') {
+                        if (args.model === 'turtle') {
+                            assert.deepEqual(args.kwargs.context, {
+                                    default_turtle_foo: 'soft',
+                                    default_turtle_bar: true,
+                                    default_turtle_int: 2,
+                                },
+                                'combined context should have the default_turtle_foo value from the <create>');
+                        }
+                    }
+                    return this._super.apply(this, arguments);
+                }
+            });
+
+            await testUtils.dom.click(form.$('.o_field_x2many_list_row_add a:eq(0)'));
+
+            form.destroy();
+        });
     });
 });
 });


### PR DESCRIPTION
When combining the context for an RPC, the
additional context is being added before the raw
context.

Because of this, a use case such as:
   - A o2m field with a context {'field': 'a'}
     with a tree editable view below it
   - That view defines controls to create lines,
     which would change the context key 'field' to
     another value.
=> The field context key would take precedence on
the creates key, making it impossible to override
that key in specific circumstances.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
