### PR TITLE
[FIX] project : not allow portal to assign himself on task

### DIFF
--- a/addons/project/views/project_sharing_views.xml
+++ b/addons/project/views/project_sharing_views.xml
@@ -152,7 +152,7 @@
             <form string="Project Sharing: Task" class="o_form_project_tasks">
                 <header>
                     <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight"
-                            attrs="{'invisible' : &quot;[('user_ids', 'in', [uid])]&quot;}" data-hotkey="q"/>
+                            attrs="{'invisible' : &quot;[('user_ids', 'in', [uid])]&quot;}" data-hotkey="q" groups="base.group_user"/>
                     <button name="action_unassign_me" string="Unassign Me" type="object" class="oe_highlight"
                             attrs="{'invisible' : &quot;[('user_ids', 'not in', [uid])]&quot;}" data-hotkey="q"/>
                     <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False), ('stage_id', '=', False)]}" />


### PR DESCRIPTION
Steps :
Create a project and a task.
Share editable with Deco Addict.
Collaborators > Deco Addict > Grant Portal Access.
Users > Deco Addict : change password.
Log in with Deco Addict.
Go to the task.

Issue :
You can assign yourself to the task.
This doesn't make sens as even an internal cannot assign a portal.

Fix :
Make this button available only for base.group_user.

opw: 2753908

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
