### PR TITLE
[FIX] hr_timesheet: increased precision when using the wizard to save the time used

### DIFF
--- a/addons/hr_timesheet/wizard/project_task_create_timesheet.py
+++ b/addons/hr_timesheet/wizard/project_task_create_timesheet.py
@@ -12,7 +12,7 @@ class ProjectTaskCreateTimesheet(models.TransientModel):
 
     _sql_constraints = [('time_positive', 'CHECK(time_spent > 0)', 'The timesheet\'s time must be positive' )]
 
-    time_spent = fields.Float('Time', digits=(16, 2))
+    time_spent = fields.Float('Time')
     description = fields.Char('Description')
     task_id = fields.Many2one(
         'project.task', "Task", required=True,


### PR DESCRIPTION
When you start the time counter from a task and then stop it, the wizard opens to adjust the time used, the value entered there is rounded to two decimal places creating an inaccuracy when saving the data in the database.

Impacted versions:
14.0
15.0

Steps to reproduce:
- Create a new task
- Start timer from ticket button
- Stop timer from ticket button
- Correct the time in wizard
- Save

Current behavior:
In database, value in account_analytic_line is saved with 2 decimals

Expected behavior:
Save with full decimal precision

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
