### PR TITLE
Invoice (account.move) clean up & performance improvements

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -109,6 +109,7 @@ You could use this simplified accounting in case you work with an (external) acc
             'account/static/src/js/tours/account.js',
             'account/static/src/js/bills_upload.js',
             'account/static/src/js/account_selection.js',
+            'account/static/src/js/account_move_form.js',
         ],
         'web.assets_frontend': [
             'account/static/src/js/account_portal_sidebar.js',

--- a/addons/account/demo/account_demo.py
+++ b/addons/account/demo/account_demo.py
@@ -320,7 +320,7 @@ class AccountChartTemplate(models.Model):
             created.line_ids._onchange_account_id()
 
             created._recompute_dynamic_lines(
-                recompute_all_taxes=True,
+                recompute_taxes=True,
                 recompute_tax_base_amount=True,
             )
 

--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -1271,3 +1271,11 @@ class AccountBankStatementLine(models.Model):
                 'to_check': False,
                 'line_ids': [(5, 0)] + [(0, 0, line_vals) for line_vals in st_line._prepare_move_line_default_vals()],
             })
+
+# For optimization purpose, creating the reverse relation of m2o in _inherits saves
+# a lot of SQL queries
+class AccountMove(models.Model):
+    _name = "account.move"
+    _inherit = ['account.move']
+
+    statement_line_ids = fields.One2many('account.bank.statement.line', 'move_id', string='Statements')

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3537,8 +3537,12 @@ class AccountMoveLine(models.Model):
         string='Unit Price', digits='Product Price',
         compute='_compute_price_unit', store=True, readonly=False, precompute=True)
     discount = fields.Float(string='Discount (%)', digits='Discount', default=0.0)
-    debit = fields.Monetary(string='Debit', default=0.0, currency_field='company_currency_id')
-    credit = fields.Monetary(string='Credit', default=0.0, currency_field='company_currency_id')
+    debit = fields.Monetary(
+        string='Debit', currency_field='company_currency_id',
+        compute='_compute_debit', store=True, readonly=False, precompute=True)
+    credit = fields.Monetary(
+        string='Credit', currency_field='company_currency_id',
+        compute='_compute_credit', store=True, readonly=False, precompute=True)
     balance = fields.Monetary(string='Balance', store=True,
         currency_field='company_currency_id',
         compute='_compute_balance',
@@ -4126,7 +4130,7 @@ class AccountMoveLine(models.Model):
 
         return self.move_id.move_type in ('in_refund', 'out_refund')
 
-    @api.onchange('amount_currency', 'currency_id', 'debit', 'credit', 'tax_ids', 'account_id', 'price_unit', 'quantity')
+    @api.depends('amount_currency', 'currency_id', 'debit', 'credit', 'tax_ids', 'account_id', 'price_unit', 'quantity')
     def _onchange_mark_recompute_taxes(self):
         ''' Recompute the dynamic onchange based on taxes.
         If the edited line is a tax line, don't recompute anything as the user must be able to
@@ -4197,17 +4201,17 @@ class AccountMoveLine(models.Model):
                 continue
             line.update(line._get_fields_onchange_balance())
 
-    @api.onchange('debit')
-    def _onchange_debit(self):
-        if self.debit:
-            self.credit = 0.0
-        self._onchange_balance()
+    @api.depends('debit')
+    def _compute_credit(self):
+        lines_with_debit = self.filtered(lambda l: l.debit)
+        lines_with_debit.credit = 0.0
+        lines_with_debit._onchange_balance()
 
-    @api.onchange('credit')
-    def _onchange_credit(self):
-        if self.credit:
-            self.debit = 0.0
-        self._onchange_balance()
+    @api.depends('credit')
+    def _compute_debit(self):
+        lines_with_credit = self.filtered(lambda l: l.credit)
+        lines_with_credit.debit = 0.0
+        lines_with_credit._onchange_balance()
 
     @api.onchange('amount_currency')
     def _onchange_amount_currency(self):

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -1017,3 +1017,11 @@ class AccountPayment(models.Model):
             'res_id': self.destination_journal_id.id,
         }
         return action
+
+# For optimization purpose, creating the reverse relation of m2o in _inherits saves
+# a lot of SQL queries
+class AccountMove(models.Model):
+    _name = "account.move"
+    _inherit = ['account.move']
+
+    payment_ids = fields.One2many('account.payment', 'move_id', string='Payments')

--- a/addons/account/static/src/js/account_move_form.js
+++ b/addons/account/static/src/js/account_move_form.js
@@ -1,0 +1,65 @@
+odoo.define('account.move.form', function (require) {
+"use strict";
+
+var core = require('web.core');
+var FormController = require('web.FormController');
+var FormRenderer = require('web.FormRenderer');
+var FormView = require('web.FormView');
+var view_registry = require('web.view_registry');
+
+var _lt = core._lt;
+
+var AccountMoveFormController = FormController.extend({
+    custom_events: _.extend({}, FormController.prototype.custom_events, {
+        save_on_tab_switch: '_saveOnTabSwitch',
+    }),
+
+    _saveOnTabSwitch: async function() {
+        var self = this;
+        await self.saveRecord(this.handle, {
+            stayInEdit: true,
+            reload: true,
+        }).then(() => {
+            this.displayNotification({
+                type: 'info',
+                message: _lt('The invoice has been saved'),
+            });
+        });
+        await this.reload();
+    },
+
+    start: function () {
+        return this._super.apply(this, arguments);
+    }
+});
+
+var AccountMoveFormRenderer = FormRenderer.extend({
+    _renderTagNotebook: function (node) {
+        var self = this;
+        var $result = this._super.apply(this, arguments);
+        var $nav_items = $result.find('ul.nav-tabs li.nav-item').slice(0, 2);
+        _.each($nav_items, (nav_item) => {
+            $(nav_item).find('a').click(function (event) {
+                event.preventDefault();
+                self.trigger_up('save_on_tab_switch');
+            });
+        })
+        return $result
+    }
+});
+
+var AccountMoveFormView = FormView.extend({
+    config: _.extend({}, FormView.prototype.config, {
+        Controller: AccountMoveFormController,
+        Renderer: AccountMoveFormRenderer,
+    }),
+});
+
+view_registry.add('account_move_form', AccountMoveFormView);
+
+return {
+    Controller: AccountMoveFormController,
+    Renderer: AccountMoveFormRenderer,
+};
+
+});

--- a/addons/account/static/src/js/account_move_form.js
+++ b/addons/account/static/src/js/account_move_form.js
@@ -19,11 +19,6 @@ var AccountMoveFormController = FormController.extend({
         await self.saveRecord(this.handle, {
             stayInEdit: true,
             reload: true,
-        }).then(() => {
-            this.displayNotification({
-                type: 'info',
-                message: _lt('The invoice has been saved'),
-            });
         });
         await this.reload();
     },

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -463,8 +463,6 @@ class TestAccountMove(AccountTestInvoicingCommon):
             debit_line.tax_ids.clear()
             debit_line.tax_ids.add(self.included_percent_tax)
 
-            self.assertTrue(debit_line.recompute_tax_line)
-
         # Create a third account.move.line with credit amount.
         with move_form.line_ids.new() as credit_line:
             credit_line.name = 'credit_line_1'

--- a/addons/account/tests/test_invoice_taxes.py
+++ b/addons/account/tests/test_invoice_taxes.py
@@ -354,7 +354,6 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             credit_line.tax_ids.clear()
             credit_line.tax_ids.add(sale_tax)
 
-            self.assertTrue(credit_line.recompute_tax_line)
 
         # Balance the journal entry.
         with move_form.line_ids.new() as credit_line:
@@ -382,8 +381,6 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             credit_line.credit = 1000.0
             credit_line.tax_ids.clear()
             credit_line.tax_ids.add(sale_tax)
-
-            self.assertTrue(credit_line.recompute_tax_line)
 
         # Balance the journal entry.
         with move_form.line_ids.new() as debit_line:
@@ -447,8 +444,6 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             credit_line.tax_ids.clear()
             credit_line.tax_ids.add(purch_tax)
 
-            self.assertTrue(credit_line.recompute_tax_line)
-
         # Balance the journal entry.
         with move_form.line_ids.new() as credit_line:
             credit_line.name = 'balance'
@@ -475,8 +470,6 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             credit_line.credit = 1000.0
             credit_line.tax_ids.clear()
             credit_line.tax_ids.add(purch_tax)
-
-            self.assertTrue(credit_line.recompute_tax_line)
 
         # Balance the journal entry.
         with move_form.line_ids.new() as debit_line:

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -594,9 +594,10 @@
             <field name="name">account.move.form</field>
             <field name="model">account.move</field>
             <field name="arch" type="xml">
-                <form string="Account Entry">
+                <form string="Account Entry" js_class="account_move_form">
                     <header>
                         <!-- Post -->
+                        <button name="create_invoice" string="Flamegraph" type="object"/>
                         <button name="action_post" string="Post" class="oe_highlight"
                                 type="object" groups="account.group_account_invoice" data-hotkey="v"
                                 attrs="{'invisible': ['|', '|', ('state', '!=', 'draft'), ('auto_post', '=', True), ('move_type', '!=', 'entry')]}"/>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -905,8 +905,6 @@
                                         <field name="partner_id" invisible="1"/>
                                         <field name="amount_currency" invisible="1"/>
                                         <field name="currency_id" invisible="1"/>
-                                        <field name="debit" invisible="1"/>
-                                        <field name="credit" invisible="1"/>
                                         <field name="date" invisible="1"/>
                                         <field name="date_maturity" invisible="1"/>
 
@@ -917,7 +915,6 @@
                                         <field name="tax_base_amount" invisible="1"/>
                                         <field name="company_id" invisible="1"/>
                                         <field name="company_currency_id" invisible="1"/>
-                                        <field name="recompute_tax_line" invisible="1" force_save="1"/>
                                         <field name="display_type" force_save="1" invisible="1"/>
                                         <field name="is_rounding_line" invisible="1"/>
                                         <field name="exclude_from_invoice_tab" invisible="1"/>
@@ -981,8 +978,6 @@
                                         <field name="partner_id" invisible="1"/>
                                         <field name="amount_currency" invisible="1"/>
                                         <field name="currency_id" invisible="1"/>
-                                        <field name="debit" invisible="1"/>
-                                        <field name="credit" invisible="1"/>
                                         <field name="date" invisible="1"/>
                                         <field name="date_maturity" invisible="1"/>
 
@@ -993,7 +988,6 @@
                                         <field name="tax_base_amount" invisible="1"/>
                                         <field name="company_id" invisible="1"/>
                                         <field name="company_currency_id" invisible="1"/>
-                                        <field name="recompute_tax_line" invisible="1" force_save="1"/>
                                         <field name="display_type" force_save="1" invisible="1"/>
                                         <field name="is_rounding_line" invisible="1"/>
                                         <field name="exclude_from_invoice_tab" invisible="1"/>
@@ -1153,7 +1147,6 @@
                                         <field name="tax_base_amount" invisible="1" force_save="1"/>
                                         <field name="company_id" invisible="1"/>
                                         <field name="company_currency_id" invisible="1"/>
-                                        <field name="recompute_tax_line" invisible="1" force_save="1"/>
                                         <field name="display_type" force_save="1" invisible="1"/>
                                         <field name="is_rounding_line" invisible="1"/>
                                         <field name="exclude_from_invoice_tab" invisible="1"/>
@@ -1178,7 +1171,6 @@
                                         <field name="credit" sum="Total Credit"/>
                                         <field name="tax_ids" string="Taxes Applied" widget="many2many_tags" options="{'no_create': True}"/>
                                         <field name="date_maturity" required="0" invisible="context.get('view_no_maturity', False)"/>
-                                        <field name="recompute_tax_line" invisible="1" readonly="1"/>
                                       </group>
                                     </form>
                                 </field>

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -382,6 +382,9 @@ class Cursor(BaseCursor):
             query_lower = self._obj.query.decode().lower()
             res_from = re_from.match(query_lower)
             if res_from:
+                # if res_from.group(1)=='account_payment':
+                #     import pudb
+                #     pudb.set_trace()
                 self.sql_from_log.setdefault(res_from.group(1), [0, 0])
                 self.sql_from_log[res_from.group(1)][0] += 1
                 self.sql_from_log[res_from.group(1)][1] += delay


### PR DESCRIPTION
[WIP] Use computed fields instead of onchange, no more ORM hacks: Proof of Concept

Performance comparison: (~2x faster at creation & line onchange)

1/ create invoice with 2000 lines, 1 tax per line:
- master:        37s
- this branch: 17s

2/ onchange invoice line (measured on 10th line):
- master:        228ms (5 rpc queries)
- this branch: 106ms (4 RPC queries)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
