### PR TITLE
[FIX] mass_mailing: missing view online link

### DIFF
--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -179,7 +179,7 @@
 </template>
 
 <template id="s_mail_block_header_view" name="View Online">
-    <div class="o_mail_snippet_general o_snippet_view_in_browser pt16 pb16 px-3 text-center">
+    <div class="o_mail_snippet_general o_snippet_view_in_browser">
         <a href="/view">
             View Online
         </a>


### PR DESCRIPTION
Currently, when creating a new mail and choosing the yellow solar template
as a mail body, there is an option to view online it
which does not contain a link.

so this commit fixes the above issue.

Task Id: 2739674