### PR TITLE
[IMP] CRM: traceback in lead merge

### DIFF
--- a/addons/crm/data/crm_lead_merge_template.xml
+++ b/addons/crm/data/crm_lead_merge_template.xml
@@ -13,19 +13,22 @@
                 <div t-if="lead.expected_revenue">
                     <span>Expected Revenues:</span>
                     <span t-if="lead.expected_revenue">
-                        <span t-field="lead.expected_revenue"
+                        <span t-if="lead.company_currency" t-field="lead.expected_revenue"
                             t-options='{"widget": "monetary", "display_currency": lead.company_currency}'/>
+                        <span t-else="" t-out="lead.expected_revenue"/>
                         <span t-if="lead.recurring_revenue" groups="crm.group_use_recurring_revenues"> + </span>
                     </span>
                     <span t-if="lead.recurring_revenue" groups="crm.group_use_recurring_revenues">
-                        <span t-field="lead.recurring_revenue"
+                        <span t-if="lead.company_currency" t-field="lead.recurring_revenue"
                             t-options='{"widget": "monetary", "display_currency": lead.company_currency}'/>
+                        <span t-else="" t-out="lead.recurring_revenue"/>
                         <span t-field="lead.recurring_plan.name"/>
                     </span>
                 </div>
                 <div t-elif="lead.recurring_revenue" groups="crm.group_use_recurring_revenues">
-                    <span t-field="lead.recurring_revenue"
+                    <span t-if="lead.company_currency" t-field="lead.recurring_revenue"
                         t-options='{"widget": "monetary", "display_currency": lead.company_currency}'/>
+                    <span t-else="" t-out="lead.recurring_revenue"/>
                     <span t-field="lead.recurring_plan.name"/>
                 </div>
                 <div t-if="lead.probability">

--- a/addons/website_crm/data/crm_lead_merge_template.xml
+++ b/addons/website_crm/data/crm_lead_merge_template.xml
@@ -8,7 +8,7 @@
 
     <xpath expr="//div[@name='marketing']" position="inside">
         <div t-if="lead.visitor_ids">
-            Web Visitors: <t t-out="', '.join(lead.visitor_ids.mapped('name'))"/>
+            Web Visitors: <t t-out="', '.join(lead.visitor_ids.mapped('display_name'))"/>
         </div>
     </xpath>
 </template>


### PR DESCRIPTION
Right now, if we try to merge crm leads and few of the
details are not available, traceback was thrown. For ex-
 - When lead does not have a company or the company does not have
   currency set
 - When the visitor name is not set

This PR fixes both of the tracebacks and thus allows users
to merge the leads in these cases.

taskID-2745017