### PR TITLE
[FIX] microsoft_calendar: fetch full description

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -99,7 +99,7 @@ class Meeting(models.Model):
         values = {
             **default_values,
             'name': microsoft_event.subject or _("(No title)"),
-            'description': microsoft_event.bodyPreview,
+            'description': microsoft_event.body['content'],
             'location': microsoft_event.location and microsoft_event.location.get('displayName') or False,
             'user_id': microsoft_event.owner(self.env).id,
             'privacy': sensitivity_o2m.get(microsoft_event.sensitivity, self.default_get(['privacy'])['privacy']),

--- a/addons/microsoft_calendar/utils/microsoft_calendar.py
+++ b/addons/microsoft_calendar/utils/microsoft_calendar.py
@@ -33,7 +33,7 @@ class MicrosoftCalendarService():
     @requires_auth_token
     def get_events(self, sync_token=None, token=None, timeout=TIMEOUT):
         url = "/v1.0/me/calendarView/delta"
-        headers = {'Content-type': 'application/json', 'Authorization': 'Bearer %s' % token, 'Prefer': 'odata.maxpagesize=50'}
+        headers = {'Content-type': 'application/json', 'Authorization': 'Bearer %s' % token, 'Prefer': 'odata.maxpagesize=50,outlook.body-content-type="text"'}
         params = {}
         if sync_token:
             params['$deltatoken'] = sync_token


### PR DESCRIPTION
Step to reproduce:
- Create a event in outlook with a long description
- Load the event in Odoo

Current Behaviour:
- Odoo use the body preview to get the event description
If the body is longer then, the description in Odoo is incomplete.

Behaviour after PR:
- Change fetch option to get description as text
- Use body['content']  as description which is the full body.

opw-2746358

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
