### PR TITLE
[FIX] web_editor: resize favicon preview

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -797,6 +797,11 @@ img::selection {
     // buttons in the popover
     user-select: none;
 
+    .o_we_preview_favicon > img {
+        max-height: 16px;
+        max-width: 16px;
+    }
+
     .o_we_url_link {
         word-break: break-all;
     }


### PR DESCRIPTION
Steps to reproduce:

  - Install Website
  - Go to Settings -> Website
  - Replace favicon with a 'big' image
  - Go to Website and edit any page
  - Click on Home

Issue:

  Favicon preview in popover is too big.

Solution:

  Set a max height/width for favicon preview (16x16).

opw-2744522