### PR TITLE
[FIX] mail: prevent crash when destroying during attachment upload

### DIFF
--- a/addons/mail/static/src/models/file_uploader/file_uploader.js
+++ b/addons/mail/static/src/models/file_uploader/file_uploader.js
@@ -105,7 +105,7 @@ registerModel({
                 });
                 return;
             }
-            return this.messaging.models['Attachment'].insert({
+            return (composer || thread).messaging.models['Attachment'].insert({
                 composer: composer && replace(composer),
                 originThread: (!composer && thread) ? replace(thread) : undefined,
                 ...attachmentData,


### PR DESCRIPTION
File uploader might be deleted because it is linked to views, but the process of
upload should still happen for the related thread.