### PR TITLE
[FIX] web_editor: ensure fontawesome icons displayed on buttons

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -271,10 +271,12 @@ body.editor_enable.editor_has_snippets {
             border-radius: 0;
             padding: 0.375rem 0.75rem;
             font-size: $o-we-font-size;
-            font-family: $o-we-font-family;
             font-weight: 400;
             line-height: 1;
 
+            &:not(.fa) {
+                font-family: $o-we-font-family;
+            }
             &.btn-primary {
                 @include button-variant($o-brand-primary, $o-brand-primary);
             }
@@ -548,7 +550,7 @@ body.editor_enable.editor_has_snippets {
                         position: absolute !important;
                         padding: 0;
 
-                        we-button {
+                        we-button:not(.fa) {
                             text-align: left;
                             font-family: Roboto, "Montserrat", "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
                             font-size: 12px;


### PR DESCRIPTION
The undo-redo buttons on top of the snippets menu of mass_mailing had no icon when website was not installed. This was because there was css forcing the font family to something other than fontawesome. This ensures we don't do that for elements with the "fa" class.

task-2746002

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
