### PR TITLE
[FIX] point_of_sale: Receipt not centered when printed

### DIFF
--- a/addons/point_of_sale/static/src/js/printers.js
+++ b/addons/point_of_sale/static/src/js/printers.js
@@ -99,7 +99,7 @@ var PrinterMixin = {
             html2canvas(self.receipt[0], {
                 onparsed: function(queue) {
                     queue.stack.ctx.height = Math.ceil(self.receipt.outerHeight() + self.receipt.offset().top);
-                    queue.stack.ctx.width = Math.ceil(self.receipt.outerWidth() + self.receipt.offset().left);
+                    queue.stack.ctx.width = Math.ceil(self.receipt.outerWidth() + 2 * self.receipt.offset().left);
                 },
                 onrendered: function (canvas) {
                     $('.pos-receipt-print').empty();


### PR DESCRIPTION
When printing the receip in the POS, the right margin was not equal to the left margin.
Introduce by https://github.com/odoo/odoo/pull/83130/commits/e14af37eb20453df8643b73f6007d6c986398b47

opw:2743902

closes odoo/odoo#83960

X-original-commit: 26a55d017687190d7b45e3f6f86ba4fc86d81b71
Signed-off-by: Masereel Pierre <pim@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
