### PR TITLE
[FIX] stock_account: fix expected singleton error on post

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -123,10 +123,10 @@ class AccountMove(models.Model):
                 debit_interim_account = accounts['stock_output']
                 credit_expense_account = accounts['expense']
                 if not credit_expense_account:
-                    if self.type == 'out_refund':
-                        credit_expense_account = self.journal_id.default_credit_account_id
+                    if move.type == 'out_refund':
+                        credit_expense_account = move.journal_id.default_credit_account_id
                     else: # out_invoice/out_receipt
-                        credit_expense_account = self.journal_id.default_debit_account_id
+                        credit_expense_account = move.journal_id.default_debit_account_id
                 if not debit_interim_account or not credit_expense_account:
                     continue
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

While calling `_stock_account_prepare_anglo_saxon_out_lines_vals`, the
references to `self` can cause a 'Expected singleton' error if the recordset
contains more than one record.

By replacing `self` with the iteration object `move`, this error is averted.

Related PR: https://github.com/odoo/odoo/pull/83739/

Traceback:
```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/14.0/odoo/service/server.py", line 1199, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/home/odoo/src/odoo/14.0/odoo/modules/registry.py", line 89, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/home/odoo/src/odoo/14.0/odoo/modules/loading.py", line 475, in load_modules
    migrations.migrate_module(package, 'end')
  File "/home/odoo/src/odoo/14.0/odoo/modules/migration.py", line 180, in migrate_module
    migrate(self.cr, installed_version)
  File "/tmp/tmpae3wx5o6/migrations/account/saas~13.4.1.1/end-09-payment-refactoring.py", line 618, in migrate
    util.iter_browse(env["account.move"].with_context(**ctx), ids, chunk_size=1024).action_post()
  File "/tmp/tmpae3wx5o6/migrations/util/orm.py", line 197, in caller
    return [getattr(chnk, attr)(*args, **kwargs) for chnk in chain(it, self._end())]
  File "/tmp/tmpae3wx5o6/migrations/util/orm.py", line 197, in <listcomp>
    return [getattr(chnk, attr)(*args, **kwargs) for chnk in chain(it, self._end())]
  File "/home/odoo/src/odoo/14.0/addons/sale/models/account_move.py", line 14, in action_post
    res = super(AccountMove, self).action_post()
  File "/home/odoo/src/odoo/14.0/addons/account/models/account_move.py", line 2715, in action_post
    self._post(soft=False)
  File "/home/odoo/src/enterprise/14.0/l10n_mx_edi_landing/models/account_move.py", line 26, in _post
    return super()._post(soft)
  File "/home/odoo/src/enterprise/14.0/l10n_mx_edi/models/account_move.py", line 456, in _post
    return super()._post(soft=soft)
  File "/home/odoo/src/odoo/14.0/addons/sale/models/account_invoice.py", line 75, in _post
    posted = super()._post(soft)
  File "/home/odoo/src/odoo/14.0/addons/purchase_stock/models/account_invoice.py", line 171, in _post
    return super()._post(soft)
  File "/home/odoo/src/enterprise/14.0/account_reports/models/account_activity.py", line 75, in _post
    return super()._post(soft)
  File "/home/odoo/src/odoo/14.0/addons/stock_account/models/account_move.py", line 49, in _post
    self.env['account.move.line'].create(self._stock_account_prepare_anglo_saxon_out_lines_vals())
  File "/home/odoo/src/odoo/14.0/addons/stock_account/models/account_move.py", line 158, in _stock_account_prepare_anglo_saxon_out_lines_vals
    'account_id': credit_expense_account.id,
  File "/home/odoo/src/odoo/14.0/odoo/fields.py", line 3821, in __get__
    raise ValueError("Expected singleton: %s" % record)
ValueError: Expected singleton: account.account(1383, 38, 30)
```

Current behavior before PR:

The error was detected in an upgrade from v13 and has also been fixed in v14.

Desired behavior after PR is merged:

Error is fixed.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
