### PR TITLE
[FIX] orm: Groupby not using start_week

### DIFF
--- a/addons/web/tests/test_read_progress_bar.py
+++ b/addons/web/tests/test_read_progress_bar.py
@@ -76,16 +76,16 @@ class TestReadProgressBar(common.TransactionCase):
             {'x_country_id': c1.id, 'x_date': '2021-05-20', 'x_state': 'foo'},
             {'x_country_id': c1.id, 'x_date': '2021-05-21', 'x_state': 'foo'},
             {'x_country_id': c1.id, 'x_date': '2021-05-22', 'x_state': 'foo'},
-            {'x_country_id': c1.id, 'x_date': '2021-05-23', 'x_state': 'bar'},
             # week 22
+            {'x_country_id': c1.id, 'x_date': '2021-05-23', 'x_state': 'bar'},
             {'x_country_id': c1.id, 'x_date': '2021-05-24', 'x_state': 'baz'},
             {'x_country_id': c2.id, 'x_date': '2021-05-25', 'x_state': 'foo'},
             {'x_country_id': c2.id, 'x_date': '2021-05-26', 'x_state': 'bar'},
             {'x_country_id': c2.id, 'x_date': '2021-05-27', 'x_state': 'bar'},
             {'x_country_id': c2.id, 'x_date': '2021-05-28', 'x_state': 'baz'},
             {'x_country_id': c2.id, 'x_date': '2021-05-29', 'x_state': 'baz'},
-            {'x_country_id': c3.id, 'x_date': '2021-05-30', 'x_state': 'foo'},
             # week 23
+            {'x_country_id': c3.id, 'x_date': '2021-05-30', 'x_state': 'foo'},
             {'x_country_id': c3.id, 'x_date': '2021-05-31', 'x_state': 'foo'},
             {'x_country_id': c3.id, 'x_date': '2021-06-01', 'x_state': 'baz'},
             {'x_country_id': c3.id, 'x_date': '2021-06-02', 'x_state': 'baz'},
@@ -106,9 +106,9 @@ class TestReadProgressBar(common.TransactionCase):
         # check date aggregation and format
         result = self.env['x_progressbar'].read_progress_bar([], 'x_date:week', progress_bar)
         self.assertEqual(result, {
-            'W21 2021': {'foo': 3, 'bar': 1, 'baz': 0},
-            'W22 2021': {'foo': 2, 'bar': 2, 'baz': 3},
-            'W23 2021': {'foo': 1, 'bar': 0, 'baz': 3},
+            'W21 2021': {'foo': 3, 'bar': 0, 'baz': 0},
+            'W22 2021': {'foo': 1, 'bar': 3, 'baz': 3},
+            'W23 2021': {'foo': 2, 'bar': 0, 'baz': 3},
         })
 
         # add a computed field on model


### PR DESCRIPTION
Current behavior:
Using a language that has a week start day different than monday.
When you tried to group a view by week (e.g. Timesheets) the records are correctly grouped by weeks,
but the weeks are starting on monday instead of the day selected in the language.

Steps to reproduce:
- Use a language that has a start week day different than monday (e.g. enUS)
- Go in a tree view with some records (e.g. Timesheets)
- Group the records by weeks
- Every group start on monday despite the week start day being sunday.

opw-2687651

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
