### PR TITLE
[FIX] account_edi_factux: net price is take primarily

### DIFF
--- a/addons/account_edi_facturx/models/account_edi_format.py
+++ b/addons/account_edi_facturx/models/account_edi_format.py
@@ -241,17 +241,17 @@ class AccountEdiFormat(models.Model):
                             invoice_line_form.quantity = float(line_elements[0].text)
 
                         # Price Unit.
-                        line_elements = element.xpath('.//ram:GrossPriceProductTradePrice/ram:ChargeAmount', namespaces=tree.nsmap)
+                        line_elements = element.xpath('.//ram:NetPriceProductTradePrice/ram:ChargeAmount', namespaces=tree.nsmap)
                         if line_elements:
-                            quantity_elements = element.xpath('.//ram:GrossPriceProductTradePrice/ram:BasisQuantity', namespaces=tree.nsmap)
+                            quantity_elements = element.xpath('.//ram:NetPriceProductTradePrice/ram:BasisQuantity', namespaces=tree.nsmap)
                             if quantity_elements:
                                 invoice_line_form.price_unit = float(line_elements[0].text) / float(quantity_elements[0].text)
                             else:
                                 invoice_line_form.price_unit = float(line_elements[0].text)
                         else:
-                            line_elements = element.xpath('.//ram:NetPriceProductTradePrice/ram:ChargeAmount', namespaces=tree.nsmap)
+                            line_elements = element.xpath('.//ram:GrossPriceProductTradePrice/ram:ChargeAmount', namespaces=tree.nsmap)
                             if line_elements:
-                                quantity_elements = element.xpath('.//ram:NetPriceProductTradePrice/ram:BasisQuantity', namespaces=tree.nsmap)
+                                quantity_elements = element.xpath('.//ram:GrossPriceProductTradePrice/ram:BasisQuantity', namespaces=tree.nsmap)
                                 if quantity_elements:
                                     invoice_line_form.price_unit = float(line_elements[0].text) / float(quantity_elements[0].text)
                                 else:


### PR DESCRIPTION
How to reproduce the bug:

- Install the account app
- Get a FacturX invoice with a discount on item
- Upload the invoice
- Check that the price of the discounted item takes the
  discount into account

Bug:

If you want to upload a FacturX invoice that contains a discount,
Odoo will take the original price into account instead of the
discounted one.

opw-2705291

Signed-off-by: Adrien Minet <admi@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
