### PR TITLE
[FIX] website: require palette to be closed before showing options steps

### DIFF
--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -73,9 +73,12 @@ function changeImage(snippet, position = "bottom") {
 
 /**
     wTourUtils.changeOption('HeaderTemplate', '[data-name="header_alignment_opt"]', _t('alignment')),
+    By default, prevents the step from being active if a palette is opened.
+    Set allowPalette to true to select options within a palette.
 */
-function changeOption(optionName, weName = '', optionTooltipLabel = '', position = "bottom") {
-    const option_block = `we-customizeblock-option[class='snippet-option-${optionName}']`
+function changeOption(optionName, weName = '', optionTooltipLabel = '', position = "bottom", allowPalette = false) {
+    const noPalette = allowPalette ? '' : '.o_we_customize_panel:not(:has(.o_we_so_color_palette.o_we_widget_opened))';
+    const option_block = `${noPalette} we-customizeblock-option[class='snippet-option-${optionName}']`;
     return {
         trigger: `${option_block} ${weName}, ${option_block} [title='${weName}']`,
         content: Markup(_.str.sprintf(_t("<b>Click</b> on this option to change the %s of the block."), optionTooltipLabel)),
@@ -84,8 +87,9 @@ function changeOption(optionName, weName = '', optionTooltipLabel = '', position
     };
 }
 
-function selectNested(trigger, optionName, alt_trigger = null, optionTooltipLabel = '', position = "top") {
-    const option_block = `we-customizeblock-option[class='snippet-option-${optionName}']`;
+function selectNested(trigger, optionName, alt_trigger = null, optionTooltipLabel = '', position = "top", allowPalette = false) {
+    const noPalette = allowPalette ? '' : '.o_we_customize_panel:not(:has(.o_we_so_color_palette.o_we_widget_opened))';
+    const option_block = `${noPalette} we-customizeblock-option[class='snippet-option-${optionName}']`;
     return {
         trigger: trigger,
         content: Markup(_.str.sprintf(_t("<b>Select</b> a %s."), optionTooltipLabel)),

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -69,7 +69,7 @@ function checkAndUpdateBackgroundColor({
 
     if (changeType) {
         steps.push(switchTo(changeType));
-        steps.push(wTourUtils.changeOption('ColoredLevelBackground', `.o_we_color_btn[data-color="${change}"]`));
+        steps.push(wTourUtils.changeOption('ColoredLevelBackground', `.o_we_color_btn[data-color="${change}"]`, 'background color', 'top', true));
         steps.push({
             trigger: finalSelector,
             content: "The selected colors have been applied (CC AND (BG or GRADIENT))",
@@ -182,6 +182,11 @@ wTourUtils.clickOnSnippet(snippets[0]),
 }),
 
 // Now, add an image on top of that color combination + gradient
+{
+    // Close the palette before selecting a media.
+    trigger: '.snippet-option-ColoredLevelBackground we-title',
+    content: 'Close palette',
+},
 wTourUtils.changeOption('ColoredLevelBackground', '[data-name="bg_image_toggle_opt"]'),
 {
     trigger: '.o_existing_attachment_cell img',
@@ -343,7 +348,7 @@ switchTo('gradient'),
     checkNoBg: 'black-75',
     checkGradient: gradients[1],
 }),
-wTourUtils.changeOption('ColoredLevelBackground', '[data-name="bg_image_toggle_opt"]'),
+wTourUtils.changeOption('ColoredLevelBackground', '[data-name="bg_image_toggle_opt"]', 'image toggle', 'top', true),
 {
     trigger: `.${snippets[0].id}.o_cc.o_cc1[style*="background-image: ${gradients[1]}"]`,
     run: () => null,


### PR DESCRIPTION
Before this commit the target of options and nested options tour steps
could be hidden under an opened palette.

After this commit the tips of options and nested options tour steps
require that no palette is opened.
An 'allowPalette' parameter can be used to remove this condition, for
example if 'changeOption' is used to select an option within the
palette during a test tour.
A step is added to close the color palette - which, while opened,
prevents the next `changeOption` step from being activated.

task-2728994 (was task-2675252)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
