### PR TITLE
[FIX] core: do not try to translate empty html attributes

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -264,7 +264,7 @@ def translate_xml_node(node, callback, parse, serialize):
 
         # translate the attributes of the node
         for key, val in node.attrib.items():
-            if val and key in TRANSLATED_ATTRS and TRANSLATED_ATTRS[key](node):
+            if nonspace(val) and key in TRANSLATED_ATTRS and TRANSLATED_ATTRS[key](node):
                 node.set(key, callback(val.strip()) or val)
 
     process(node)


### PR DESCRIPTION
Error revealed by 1fe4b0cc1981382cc3d944ec44276f0aee90945d