### PR TITLE
[FIX] sale_stock,procurement_jit: not assign backorders

### DIFF
--- a/addons/procurement_jit/stock_picking.py
+++ b/addons/procurement_jit/stock_picking.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    def _needs_automatic_assign(self):
+        self.ensure_one()
+        if self.sale_id:
+            return True
+        return super()._needs_automatic_assign()

--- a/addons/procurement_jit/tests/__init__.py
+++ b/addons/procurement_jit/tests/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import sale
-from . import stock_picking
+from . import test_sale_stock

--- a/addons/procurement_jit/tests/test_sale_stock.py
+++ b/addons/procurement_jit/tests/test_sale_stock.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.sale.tests.test_sale_common import TestCommonSaleNoChart
+from odoo.tests import Form
+
+
+class TestSaleStockOnly(TestCommonSaleNoChart):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestSaleStockOnly, cls).setUpClass()
+
+        cls.setUpClassicProducts()
+
+    def test_automatic_assign(self):
+        """
+        This test ensures that when a picking is generated from a SO, the quantities are
+        automatically reserved (the automatic reservation should only happen when `procurement_jit`
+        is installed)
+        """
+        product = self.product_map['prod_del']
+        product.type = 'product'
+        self.env['stock.quant']._update_available_quantity(product, self.env.ref('stock.stock_location_stock'), 3)
+
+        so_form = Form(self.env['sale.order'])
+        so_form.partner_id = self.partner_customer_usd
+        with so_form.order_line.new() as line:
+            line.product_id = product
+            line.product_uom_qty = 3
+        so = so_form.save()
+        so.action_confirm()
+
+        picking = so.picking_ids
+        self.assertEqual(picking.state, 'assigned')
+        self.assertEqual(picking.move_lines.reserved_availability, 3.0)
+
+        picking.move_lines.quantity_done = 1
+        action = picking.button_validate()
+        wizard = self.env[action['res_model']].browse(action['res_id'])
+        wizard.process()
+
+        backorder = picking.backorder_ids
+        self.assertEqual(backorder.state, 'assigned')
+        self.assertEqual(backorder.move_lines.reserved_availability, 2.0)

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -125,6 +125,13 @@ class StockPicking(models.Model):
 
         return super(StockPicking, self)._log_less_quantities_than_expected(moves)
 
+    def _needs_automatic_assign(self):
+        self.ensure_one()
+        if self.sale_id:
+            return False
+        return super()._needs_automatic_assign()
+
+
 class ProductionLot(models.Model):
     _inherit = 'stock.production.lot'
 

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1025,9 +1025,14 @@ class Picking(models.Model):
                 moves_to_backorder.write({'picking_id': backorder_picking.id})
                 moves_to_backorder.move_line_ids.package_level_id.write({'picking_id':backorder_picking.id})
                 moves_to_backorder.mapped('move_line_ids').write({'picking_id': backorder_picking.id})
-                backorder_picking.action_assign()
+                if backorder_picking._needs_automatic_assign():
+                    backorder_picking.action_assign()
                 backorders |= backorder_picking
         return backorders
+
+    def _needs_automatic_assign(self):
+        self.ensure_one()
+        return True
 
     def _log_activity_get_documents(self, orig_obj_changes, stream_field, stream, sorted_method=False, groupby_method=False):
         """ Generic method to log activity. To use with


### PR DESCRIPTION
When the reservation is manual, the quantities in backorders are still
assigned automatically

To reproduce the issue:
1. In Settings, set "Reservation" to "Manually or based on automatic
scheduler"
2. Create a storable product P with an on-hand quantity equal to 3
3. Create and confirm a SO with 3 x P
4. On the associated delivery order, set the done quantity to 1 and
validate it (with backorder)
    - Note: When opening the delivery order, the reserved quantity is 0,
which is correct
5. Open the backorder

Error: the reserved quantity is 2, it should be 0

By default, when confirming a picking, if a backorder is created, the
latter is assigned by default. In case of a picking associated to a SO,
the default behavior (i.e., without the module `procurement_jit`) should
be the opposite

OPW-2703234