### PR TITLE
[FIX] account: intrastat code isn't set

### DIFF
--- a/addons/account/models/__init__.py
+++ b/addons/account/models/__init__.py
@@ -23,3 +23,4 @@ from . import digest
 from . import res_users
 from . import ir_actions_report
 from . import mail_thread
+from . import res_country

--- a/addons/account/models/res_country.py
+++ b/addons/account/models/res_country.py
@@ -1,0 +1,13 @@
+# coding: utf-8
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ResCountry(models.Model):
+    _inherit = 'res.country'
+
+    # adding abstract method to be overridden
+    def _set_intrastat_from_partner():
+        pass
+


### PR DESCRIPTION
If applied, this commit will fix the following bug by adding
intrastat country to generated invoices if the partner country is
an intrastat country.

Steps to reproduce:

1- install subscriptions - intrastat
2- Create a user u from an intrastat country
3- Create a new subscription for u with a payment plan
4- edit the payment plan to anything other than manual
5- click on "Generate Invoice" action button
6- the generated Invoice doesn't have intrastat country set

Bug:

the ```intrastat_country_id``` is not being set while creating
the invoice

Fix:

Add intrastat_country_id to invoice


linked to: https://github.com/odoo/enterprise/pull/24095

OPW-2693107

