### PR TITLE
[FIX] (sale_)coupon: properly handle empty rule_products_domain

### DIFF
--- a/addons/coupon/models/coupon_program.py
+++ b/addons/coupon/models/coupon_program.py
@@ -133,16 +133,20 @@ class CouponProgram(models.Model):
             return True
 
     def _is_valid_product(self, product):
-        # NOTE: if you override this method, think of also overriding _get_valid_products
-        # we also encourage the use of _get_valid_products as its execution is faster
-        if self.rule_products_domain:
-            domain = ast.literal_eval(self.rule_products_domain) + [('id', '=', product.id)]
-            return bool(self.env['product.product'].search_count(domain))
-        else:
-            return True
+        """Check if the given product is valid for the program.
+
+        :param product: record of product.product
+        :rtype: bool
+        """
+        return bool(self._get_valid_products(product))
 
     def _get_valid_products(self, products):
-        if self.rule_products_domain:
+        """Get valid products for the program.
+
+        :param products: records of product.product
+        :return: valid products recordset
+        """
+        if self.rule_products_domain and self.rule_products_domain != "[]":
             domain = ast.literal_eval(self.rule_products_domain)
             return products.filtered_domain(domain)
         return products

--- a/addons/sale_coupon/models/coupon_program.py
+++ b/addons/sale_coupon/models/coupon_program.py
@@ -126,7 +126,7 @@ class CouponProgram(models.Model):
             products_qties[line.product_id] += line.product_uom_qty
         valid_program_ids = list()
         for program in self:
-            if not program.rule_products_domain:
+            if not program.rule_products_domain or program.rule_products_domain == "[]":
                 valid_program_ids.append(program.id)
                 continue
             valid_products = program._get_valid_products(products)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
The `domain` widget pretty much sets `"[]"` as value when no domain is chosen, so `bool(self.rule_products_domain)` is not enough. It should check against `"[]"` too.

There's no difference in UX, as the result is the same, but it does save some cpu time in useless filtering afterwards

Moreover, replaced the `search_count` in `_is_valid_product` by simply using `_get_valid_products`, that has better performance thanks to `filtered_domain`.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
