### PR TITLE
[IMP] account: put country_code field in debit note and reversal wizard

### DIFF
--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -28,6 +28,7 @@ class AccountMoveReversal(models.TransientModel):
         help='Choose how you want to credit this invoice. You cannot "modify" nor "cancel" if the invoice is already reconciled.')
     journal_id = fields.Many2one('account.journal', string='Use Specific Journal', help='If empty, uses the journal of the journal entry to be reversed.', check_company=True)
     company_id = fields.Many2one('res.company', required=True, readonly=True)
+    country_code = fields.Char(related='company_id.country_id.code')
 
     # computed fields
     residual = fields.Monetary(compute="_compute_from_moves")

--- a/addons/account_debit_note/wizard/account_debit_note.py
+++ b/addons/account_debit_note/wizard/account_debit_note.py
@@ -25,6 +25,7 @@ class AccountDebitNote(models.TransientModel):
     # computed fields
     move_type = fields.Char(compute="_compute_from_moves")
     journal_type = fields.Char(compute="_compute_from_moves")
+    country_code = fields.Char(related='move_ids.company_id.country_id.code')
 
     @api.model
     def default_get(self, fields):


### PR DESCRIPTION
Preparation for a later PR where we use the country_code field to only show fields in the debit note and reversal wizard based on the country of the company

Backport of https://github.com/odoo/odoo/pull/83986/commits/44226366e3bb657ee5299662a788b8a07b16431f