### PR TITLE
[IMP] mail: rename composer view "hasFocus" to "isFocused"

### DIFF
--- a/addons/mail/static/src/components/composer/composer.xml
+++ b/addons/mail/static/src/components/composer/composer.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.Composer" owl="1">
         <div class="o_Composer"
             t-att-class="{
-                'o-focused': composerView and composerView.hasFocus,
+                'o-focused': composerView and composerView.isFocused,
                 'o-has-current-partner-avatar': props.hasCurrentPartnerAvatar,
                 'o-has-footer': hasFooter,
                 'o-has-header': hasHeader,

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.js
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.js
@@ -145,7 +145,7 @@ export class ComposerTextInput extends Component {
         }
         if (this.composerView.composer.isLastStateChangeProgrammatic) {
             this._textareaRef.el.value = this.composerView.composer.textInputContent;
-            if (this.composerView.hasFocus) {
+            if (this.composerView.isFocused) {
                 this._textareaRef.el.setSelectionRange(
                     this.composerView.composer.textInputCursorStart,
                     this.composerView.composer.textInputCursorEnd,
@@ -189,7 +189,7 @@ export class ComposerTextInput extends Component {
         if (!this.composerView) {
             return;
         }
-        this.composerView.update({ hasFocus: true });
+        this.composerView.update({ isFocused: true });
     }
 
     /**
@@ -200,7 +200,7 @@ export class ComposerTextInput extends Component {
             return;
         }
         this.saveStateInStore();
-        this.composerView.update({ hasFocus: false });
+        this.composerView.update({ isFocused: false });
     }
 
     /**

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -978,9 +978,6 @@ registerModel({
             readonly: true,
             required: true,
         }),
-        hasFocus: attr({
-            default: false,
-        }),
         /**
          * States whether there is any result currently found for the current
          * suggestion delimiter and search term, if applicable.
@@ -994,6 +991,9 @@ registerModel({
          * into view.
          */
         hasToScrollToActiveSuggestion: attr({
+            default: false,
+        }),
+        isFocused: attr({
             default: false,
         }),
         /**

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -184,7 +184,7 @@ registerModel({
             if (this.lastVisibleMessage !== this.lastMessage) {
                 return;
             }
-            if (!this.hasComposerFocus) {
+            if (!this.isComposerFocused) {
                 // FIXME condition should not be on "composer is focused" but "threadView is active"
                 // See task-2277543
                 return;
@@ -336,9 +336,6 @@ registerModel({
         extraClass: attr({
             related: 'threadViewer.extraClass',
         }),
-        hasComposerFocus: attr({
-            related: 'composerView.hasFocus',
-        }),
         /**
          * Determines whether this thread viewer has a member list.
          * Only makes sense if thread.hasMemberListFeature is true.
@@ -359,6 +356,9 @@ registerModel({
          */
         hasTopbar: attr({
             related: 'threadViewer.hasTopbar',
+        }),
+        isComposerFocused: attr({
+            related: 'composerView.isFocused',
         }),
         /**
          * States whether `this.threadCache` is currently loading messages.
@@ -514,7 +514,7 @@ registerModel({
             methodName: '_onThreadCacheIsLoadingChanged',
         }),
         new OnChange({
-            dependencies: ['hasComposerFocus', 'lastMessage', 'thread.lastNonTransientMessage', 'lastVisibleMessage', 'threadCache'],
+            dependencies: ['isComposerFocused', 'lastMessage', 'thread.lastNonTransientMessage', 'lastVisibleMessage', 'threadCache'],
             methodName: '_computeThreadShouldBeSetAsSeen',
         }),
     ],


### PR DESCRIPTION
Consistency in naming with other models.

Part of task-2694206, split from main PR to ease its diff