### PR TITLE
[IMP]  sale_coupon: `_filter_not_ordered_reward_programs` performance

### DIFF
--- a/addons/sale_coupon/models/coupon_program.py
+++ b/addons/sale_coupon/models/coupon_program.py
@@ -147,14 +147,17 @@ class CouponProgram(models.Model):
         Returns the programs when the reward is actually in the order lines
         """
         programs = self.env['coupon.program']
+        order_products = order.order_line.product_id
         for program in self:
-            if program.reward_type == 'product' and \
-               not order.order_line.filtered(lambda line: line.product_id == program.reward_product_id):
+            if program.reward_type == 'product' and program.reward_product_id not in order_products:
                 continue
-            elif program.reward_type == 'discount' and program.discount_apply_on == 'specific_products' and \
-               not order.order_line.filtered(lambda line: line.product_id in program.discount_specific_product_ids):
+            elif (
+                program.reward_type == 'discount'
+                and program.discount_apply_on == 'specific_products'
+                and not any(discount_product in order_products for discount_product in program.discount_specific_product_ids)
+            ):
                 continue
-            programs |= program
+            programs += program
         return programs
 
     @api.model


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

1) Avoid filtering on the whole sale.order.line recordset every time, just to check if the products is in the order.

2) Use `+=` instead of `|=` to build the result. `+=` is much more efficient and we can trust the result is not going to have duplicates anyway, since we're looping through the recordset.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
