### PR TITLE
[IMP] account: add a line type on account move lines

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -399,12 +399,12 @@ class AccountJournal(models.Model):
         self.env['account.move.line'].flush(['account_id', 'journal_id'])
         self.flush(['account_control_ids'])
         self._cr.execute("""
-            SELECT aml.id
+            SELECT aml.id, aml.line_type
             FROM account_move_line aml
             WHERE aml.journal_id in (%s)
             AND EXISTS (SELECT 1 FROM journal_account_control_rel rel WHERE rel.journal_id = aml.journal_id)
             AND NOT EXISTS (SELECT 1 FROM journal_account_control_rel rel WHERE rel.account_id = aml.account_id AND rel.journal_id = aml.journal_id)
-            AND aml.display_type IS NULL
+            AND COALESCE(aml.line_type, 'false') NOT IN ('invl_section', 'invl_note')
         """, tuple(self.ids))
         if self._cr.fetchone():
             raise ValidationError(_('Some journal items already exist in this journal but with other accounts than the allowed ones.'))
@@ -785,7 +785,7 @@ class AccountJournal(models.Model):
 
         domain = (domain or []) + [
             ('account_id', 'in', tuple(self.default_account_id.ids)),
-            ('display_type', 'not in', ('line_section', 'line_note')),
+            ('line_type', 'not in', ('invl_section', 'invl_note')),
             ('parent_state', '!=', 'cancel'),
         ]
         query = self.env['account.move.line']._where_calc(domain)
@@ -850,7 +850,7 @@ class AccountJournal(models.Model):
 
         domain = (domain or []) + [
             ('account_id', 'in', tuple(accounts.ids)),
-            ('display_type', 'not in', ('line_section', 'line_note')),
+            ('line_type', 'not in', ('invl_section', 'invl_note')),
             ('parent_state', '!=', 'cancel'),
             ('reconciled', '=', False),
             ('journal_id', '=', self.id),

--- a/addons/account/populate/account_move.py
+++ b/addons/account/populate/account_move.py
@@ -95,7 +95,7 @@ class AccountMove(models.Model):
             :param values (dict): the values already selected for the record.
             :return list: list of ORM create commands for the field line_ids
             """
-            def get_line(account, label, balance=None, balance_sign=False, exclude_from_invoice_tab=False):
+            def get_line(account, label, balance=None, balance_sign=False, line_type=False):
                 company_currency = account.company_id.currency_id
                 currency = self.env['res.currency'].browse(currency_id)
                 balance = balance or balance_sign * round(random.uniform(0, 1000))
@@ -108,7 +108,7 @@ class AccountMove(models.Model):
                     'partner_id': partner_id,
                     'currency_id': currency_id,
                     'amount_currency': amount_currency,
-                    'exclude_from_invoice_tab': exclude_from_invoice_tab,
+                    'line_type': line_type,
                 })
             move_type = values['move_type']
             date = values['date']
@@ -149,7 +149,7 @@ class AccountMove(models.Model):
                 account=random.choice(balance_account_ids),
                 balance=sum(l[2]['credit'] - l[2]['debit'] for l in lines),
                 label='balance',
-                exclude_from_invoice_tab=move_type in self.get_invoice_types(include_receipts=True),
+                line_type=False if move_type in self.get_invoice_types(include_receipts=True) else 'invl',
             )]
 
             return lines

--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -130,7 +130,7 @@ class AccountInvoiceReport(models.Model):
         return '''
             WHERE move.move_type IN ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')
                 AND line.account_id IS NOT NULL
-                AND NOT line.exclude_from_invoice_tab
+                AND COALESCE(line.line_type, 'false') LIKE 'invl%%'
         '''
 
 

--- a/addons/account/static/src/js/section_and_note_fields_backend.js
+++ b/addons/account/static/src/js/section_and_note_fields_backend.js
@@ -12,6 +12,18 @@ var fieldRegistry = require('web.field_registry');
 var ListFieldText = require('web.basic_fields').ListFieldText;
 var ListRenderer = require('web.ListRenderer');
 
+function IsSection(record) {
+    return record.data.line_type === 'invl_section' || record.data.display_type === 'line_section';
+}
+
+function IsNote(record) {
+    return record.data.line_type === 'invl_note' || record.data.display_type === 'line_note';
+}
+
+function GetClass(record) {
+    return IsSection(record) ? 'line_section' : IsNote(record) ? 'line_note' : '';
+}
+
 var SectionAndNoteListRenderer = ListRenderer.extend({
     /**
      * We want section and note to take the whole line (except handle and trash)
@@ -22,10 +34,7 @@ var SectionAndNoteListRenderer = ListRenderer.extend({
     _renderBodyCell: function (record, node, index, options) {
         var $cell = this._super.apply(this, arguments);
 
-        var isSection = record.data.display_type === 'line_section';
-        var isNote = record.data.display_type === 'line_note';
-
-        if (isSection || isNote) {
+        if (IsSection(record) || IsNote(record)) {
             if (node.attrs.widget === "handle") {
                 return $cell;
             } else if (node.attrs.name === "name") {
@@ -46,15 +55,14 @@ var SectionAndNoteListRenderer = ListRenderer.extend({
         return $cell;
     },
     /**
-     * We add the o_is_{display_type} class to allow custom behaviour both in JS and CSS.
+     * We add the o_is_{line_type} class to allow custom behaviour both in JS and CSS.
      *
      * @override
      */
     _renderRow: function (record, index) {
         var $row = this._super.apply(this, arguments);
-
-        if (record.data.display_type) {
-            $row.addClass('o_is_' + record.data.display_type);
+        if (IsSection(record) || IsNote(record)) {
+            $row.addClass('o_is_' + GetClass(record));
         }
 
         return $row;
@@ -94,8 +102,7 @@ var SectionAndNoteFieldOne2Many = FieldOne2Many.extend({
 // We want a FieldChar for section,
 // and a FieldText for the rest (product and note).
 var SectionAndNoteFieldText = function (parent, name, record, options) {
-    var isSection = record.data.display_type === 'line_section';
-    var Constructor = isSection ? FieldChar : ListFieldText;
+    var Constructor = IsSection(record) ? FieldChar : ListFieldText;
     return new Constructor(parent, name, record, options);
 };
 

--- a/addons/account/static/tests/section_and_note_tests.js
+++ b/addons/account/static/tests/section_and_note_tests.js
@@ -23,10 +23,10 @@ QUnit.module('section_and_note', {
             },
             invoice_line: {
                 fields: {
-                    display_type: {
+                    line_type: {
                         string: 'Type',
                         type: 'selection',
-                        selection: [['line_section', "Section"], ['line_note', "Note"]]
+                        selection: [['invl', 'Invoice line'], ['invl_rounding_line', 'Cash rounding line'], ['invl_section', 'Section line'], ['invl_note', 'Note line'], ['inv_tax_cash_rounding', 'Tax cash rounding line'], ['liquidity_line', 'Liquidity line'], ['counterpart_line', 'Counterpart line']]
                     },
                     invoice_id: {
                         string: "Invoice",
@@ -39,8 +39,8 @@ QUnit.module('section_and_note', {
                     },
                 },
                 records: [
-                    {id: 1, display_type: false, invoice_id: 1, name: 'product\n2 lines'},
-                    {id: 2, display_type: 'line_section', invoice_id: 1, name: 'section'},
+                    {id: 1, line_type: 'invl', invoice_id: 1, name: 'product\n2 lines'},
+                    {id: 2, line_type: 'invl_section', invoice_id: 1, name: 'section'},
                 ]
             },
         };
@@ -57,7 +57,7 @@ QUnit.module('section_and_note', {
                 '</form>',
             archs: {
                 'invoice_line,false,list': '<tree editable="bottom">' +
-                    '<field name="display_type" invisible="1"/>' +
+                    '<field name="line_type" invisible="1"/>' +
                     '<field name="name" widget="section_and_note_text"/>' +
                 '</tree>',
             },

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -411,7 +411,8 @@ class AccountTestInvoicingCommon(TransactionCase):
 
     def assertInvoiceValues(self, move, expected_lines_values, expected_move_values):
         def sort_lines(lines):
-            return lines.sorted(lambda line: (line.exclude_from_invoice_tab, not bool(line.tax_line_id), line.name or '', line.balance))
+            return lines.sorted(lambda line: (not line.is_invoice_line(), not bool(line.tax_line_id), line.name or '', line.balance))
+
         self.assertRecordValues(sort_lines(move.line_ids.sorted()), expected_lines_values)
         self.assertRecordValues(sort_lines(move.invoice_line_ids.sorted()), expected_lines_values[:len(move.invoice_line_ids)])
         self.assertRecordValues(move, [expected_move_values])

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -733,12 +733,14 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
                 'credit': 0,
                 'account_id': self.bank_journal_2.default_account_id.id,
                 'move_id': st_line.move_id.id,
+                'line_type': 'bank_statement_liquidity_line',
             },
             {
                 'debit': 0,
                 'credit': 1.0,
                 'account_id': self.company_data['default_account_revenue'].id,
                 'move_id': st_line.move_id.id,
+                'line_type': 'bank_statement_suspense_line',
             },
         ]
         with self.assertRaises(UserError), self.cr.savepoint():

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -510,7 +510,11 @@ class TestAccountMove(AccountTestInvoicingCommon):
             'invoice_date': fields.Date.from_string('2019-01-01'),
             'currency_id': self.currency_data['currency'].id,
             'invoice_payment_term_id': self.pay_terms_a.id,
-            'invoice_line_ids': [{}]
+            'invoice_line_ids': [(0, 0, {
+                'name': 'Product',
+                'quantity': 26,
+                'price_unit': 2391.0,
+            })]
         })
 
         move.currency_id.active = False

--- a/addons/account/tests/test_account_move_in_refund.py
+++ b/addons/account/tests/test_account_move_in_refund.py
@@ -35,6 +35,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 0.0,
             'credit': 800.0,
             'date_maturity': False,
+            'line_type': 'invl',
         }
         cls.product_line_vals_2 = {
             'name': cls.product_b.name,
@@ -54,6 +55,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 0.0,
             'credit': 160.0,
             'date_maturity': False,
+            'line_type': 'invl',
         }
         cls.tax_line_vals_1 = {
             'name': cls.tax_purchase_a.name,
@@ -73,6 +75,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 0.0,
             'credit': 144.0,
             'date_maturity': False,
+            'line_type': False,
         }
         cls.tax_line_vals_2 = {
             'name': cls.tax_purchase_b.name,
@@ -92,6 +95,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 0.0,
             'credit': 24.0,
             'date_maturity': False,
+            'line_type': False,
         }
         cls.term_line_vals_1 = {
             'name': '',
@@ -111,6 +115,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 1128.0,
             'credit': 0.0,
             'date_maturity': fields.Date.from_string('2019-01-01'),
+            'line_type': False,
         }
         cls.move_vals = {
             'partner_id': cls.partner_a.id,
@@ -478,6 +483,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 0.0,
                 'credit': 96.0,
                 'date_maturity': False,
+                'line_type': False,
             },
             {
                 'name': child_tax_1.name,
@@ -497,6 +503,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 0.0,
                 'credit': 64.0,
                 'date_maturity': False,
+                'line_type': False,
             },
             {
                 'name': child_tax_2.name,
@@ -516,6 +523,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 0.0,
                 'credit': 96.0,
                 'date_maturity': False,
+                'line_type': False,
             },
             {
                 **self.term_line_vals_1,
@@ -671,6 +679,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 0.04,
                 'credit': 0.0,
                 'date_maturity': False,
+                'line_type': 'inv_tax_cash_rounding',
             },
             {
                 **self.term_line_vals_1,

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -3278,7 +3278,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                     'tax_ids': [(6, 0, self.product_a.taxes_id.ids)],
                 }),
                 (0, 0, {
-                    'display_type': 'line_note',
+                    'line_type': 'invl_note',
                     'name': 'This is a note',
                     'account_id': False,
                 }),

--- a/addons/account/tests/test_account_move_out_refund.py
+++ b/addons/account/tests/test_account_move_out_refund.py
@@ -34,6 +34,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 1000.0,
             'credit': 0.0,
             'date_maturity': False,
+            'line_type': 'invl',
         }
         cls.product_line_vals_2 = {
             'name': cls.product_b.name,
@@ -53,6 +54,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 200.0,
             'credit': 0.0,
             'date_maturity': False,
+            'line_type': 'invl',
         }
         cls.tax_line_vals_1 = {
             'name': cls.tax_sale_a.name,
@@ -72,6 +74,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 180.0,
             'credit': 0.0,
             'date_maturity': False,
+            'line_type': False,
         }
         cls.tax_line_vals_2 = {
             'name': cls.tax_sale_b.name,
@@ -91,6 +94,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 30.0,
             'credit': 0.0,
             'date_maturity': False,
+            'line_type': False,
         }
         cls.term_line_vals_1 = {
             'name': '',
@@ -110,6 +114,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 0.0,
             'credit': 1410.0,
             'date_maturity': fields.Date.from_string('2019-01-01'),
+            'line_type': False,
         }
         cls.move_vals = {
             'partner_id': cls.partner_a.id,
@@ -477,6 +482,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 80.0,
                 'credit': 0.0,
                 'date_maturity': False,
+                'line_type': False,
             },
             {
                 'name': child_tax_1.name,
@@ -496,6 +502,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 120.0,
                 'credit': 0.0,
                 'date_maturity': False,
+                'line_type': False,
             },
             {
                 'name': child_tax_2.name,
@@ -515,6 +522,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 120.0,
                 'credit': 0.0,
                 'date_maturity': False,
+                'line_type': False,
             },
             {
                 **self.term_line_vals_1,
@@ -670,6 +678,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 0.0,
                 'credit': 0.04,
                 'date_maturity': False,
+                'line_type': 'inv_tax_cash_rounding',
             },
             {
                 **self.term_line_vals_1,

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -874,12 +874,12 @@
                                 <field name="invoice_line_ids"
                                        widget="section_and_note_one2many"
                                        mode="tree,kanban"
-                                       context="{'default_move_type': context.get('default_move_type'), 'journal_id': journal_id, 'default_partner_id': commercial_partner_id, 'default_currency_id': currency_id or company_currency_id}">
+                                       context="{'default_move_type': context.get('default_move_type'), 'journal_id': journal_id, 'default_partner_id': commercial_partner_id, 'default_currency_id': currency_id or company_currency_id, 'default_line_type': 'invl'}">
                                     <tree editable="bottom" string="Journal Items" default_order="sequence, date desc, move_name desc, id">
                                         <control>
                                             <create name="add_line_control" string="Add a line"/>
-                                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
-                                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                                            <create name="add_section_control" string="Add a section" context="{'default_line_type': 'invl_section'}"/>
+                                            <create name="add_note_control" string="Add a note" context="{'default_line_type': 'invl_note'}"/>
                                         </control>
 
                                         <!-- Displayed fields -->
@@ -897,7 +897,7 @@
                                                groups="account.group_account_readonly"
                                                options="{'no_create': True}"
                                                domain="[('deprecated', '=', False), ('user_type_id.type', 'not in', ('receivable', 'payable')), ('company_id', '=', parent.company_id), ('is_off_balance', '=', False)]"
-                                               attrs="{'required': [('display_type', '=', False)]}"/>
+                                               attrs="{'required': [('line_type', 'not in', ['invl_section', 'invl_note'])]}"/>
                                         <field name="analytic_account_id"
                                                domain="['|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"
                                                groups="analytic.group_analytic_accounting"
@@ -941,9 +941,7 @@
                                         <field name="company_id" invisible="1"/>
                                         <field name="company_currency_id" invisible="1"/>
                                         <field name="recompute_tax_line" invisible="1" force_save="1"/>
-                                        <field name="display_type" force_save="1" invisible="1"/>
-                                        <field name="is_rounding_line" invisible="1"/>
-                                        <field name="exclude_from_invoice_tab" invisible="1"/>
+                                        <field name="line_type" force_save="1" invisible="1"/>
                                         <field name="account_internal_type" invisible="1"/>
                                         <field name="account_internal_group" invisible="1"/>
                                     </tree>
@@ -959,8 +957,8 @@
                                         <field name="price_unit"/>
                                         <templates>
                                             <t t-name="kanban-box">
-                                                <div t-attf-class="oe_kanban_card oe_kanban_global_click pl-0 pr-0 {{ record.display_type.raw_value ? 'o_is_' + record.display_type.raw_value : '' }}">
-                                                    <t t-if="!record.display_type.raw_value">
+                                                <div t-attf-class="oe_kanban_card oe_kanban_global_click pl-0 pr-0 {{ ['invl_section', 'invl_note'].includes(record.line_type.raw_value) ? 'o_is_' + record.line_type.raw_value : '' }}">
+                                                    <t t-if="!['invl_section', 'invl_note'].includes(record.line_type.raw_value)">
                                                         <div class="row no-gutters">
                                                             <div class="col-2 pr-3">
                                                                 <img t-att-src="kanban_image('product.product', 'image_128', record.product_id.raw_value)" t-att-title="record.product_id.value" t-att-alt="record.product_id.value" style="max-width: 100%;"/>
@@ -989,7 +987,7 @@
                                                             </div>
                                                         </div>
                                                     </t>
-                                                    <t t-if="record.display_type.raw_value === 'line_section' || record.display_type.raw_value === 'line_note'">
+                                                    <t t-else="">
                                                         <div class="row">
                                                             <div class="col-12">
                                                                 <t t-esc="record.name.value"/>
@@ -1017,9 +1015,7 @@
                                         <field name="company_id" invisible="1"/>
                                         <field name="company_currency_id" invisible="1"/>
                                         <field name="recompute_tax_line" invisible="1" force_save="1"/>
-                                        <field name="display_type" force_save="1" invisible="1"/>
-                                        <field name="is_rounding_line" invisible="1"/>
-                                        <field name="exclude_from_invoice_tab" invisible="1"/>
+                                        <field name="line_type" force_save="1" invisible="1"/>
                                         <field name="account_internal_type" invisible="1"/>
                                         <field name="account_internal_group" invisible="1"/>
                                     </kanban>
@@ -1028,7 +1024,7 @@
                                     <form>
                                         <sheet>
                                             <field name="product_uom_category_id" invisible="1"/>
-                                            <field name="display_type" invisible="1"/>
+                                            <field name="line_type" invisible="1"/>
                                             <field name="parent_state" invisible="1"/>
                                             <group>
                                                 <field name="partner_id" invisible="1"/>
@@ -1048,9 +1044,9 @@
                                                 <field name="tax_ids" widget="many2many_tags"/>
                                                 <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
                                             </group>
-                                            <label for="name" string="Description" attrs="{'invisible': [('display_type', '!=', False)]}"/>
-                                            <label for="name" string="Section" attrs="{'invisible': [('display_type', '!=', 'line_section')]}"/>
-                                            <label for="name" string="Note" attrs="{'invisible': [('display_type', '!=', 'line_note')]}"/>
+                                            <label for="name" string="Description" attrs="{'invisible': [('line_type', '!=', False)]}"/>
+                                            <label for="name" string="Section" attrs="{'invisible': [('line_type', '!=', 'invl_section')]}"/>
+                                            <label for="name" string="Note" attrs="{'invisible': [('line_type', '!=', 'invl_note')]}"/>
                                             <field name="name" widget="text"/>
                                             <group>
                                                 <field name="price_subtotal" string="Subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
@@ -1089,12 +1085,12 @@
                                        mode="tree,kanban"
                                        context="{'default_move_type': context.get('default_move_type'), 'line_ids': line_ids, 'journal_id': journal_id, 'default_partner_id': commercial_partner_id, 'default_currency_id': currency_id or company_currency_id}"
                                        attrs="{'invisible': [('payment_state', '=', 'invoicing_legacy'), ('move_type', '!=', 'entry')]}">
-                                    <tree editable="bottom" string="Journal Items" decoration-muted="display_type in ('line_section', 'line_note')" default_order="sequence, date desc, move_name desc, id">
+                                    <tree editable="bottom" string="Journal Items" decoration-muted="line_type in ('invl_note', 'invl_section')" default_order="sequence, date desc, move_name desc, id">
                                         <!-- Displayed fields -->
                                         <field name="account_id"
                                                attrs="{
-                                                    'required': [('display_type', 'not in', ('line_section', 'line_note'))],
-                                                    'invisible': [('display_type', 'in', ('line_section', 'line_note'))],
+                                                    'required': [('line_type', 'not in', ('invl_note', 'invl_section'))],
+                                                    'invisible': [('line_type', 'in', ('invl_note', 'invl_section'))],
                                                }"
                                                domain="[('deprecated', '=', False), ('company_id', '=', parent.company_id)]" />
                                         <field name="partner_id"
@@ -1105,16 +1101,16 @@
                                                optional="hide"
                                                domain="['|', ('company_id', '=', parent.company_id), ('company_id', '=', False)]"
                                                groups="analytic.group_analytic_accounting"
-                                               attrs="{'invisible': [('display_type', 'in', ('line_section', 'line_note'))]}"/>
+                                               attrs="{'invisible': [('line_type', 'in', ('invl_note', 'invl_section'))]}"/>
                                         <field name="analytic_tag_ids"
                                                optional="show"
                                                groups="analytic.group_analytic_tags"
                                                widget="many2many_tags"
-                                               attrs="{'invisible': [('display_type', 'in', ('line_section', 'line_note'))]}"/>
+                                               attrs="{'invisible': [('line_type', 'in', ('invl_note', 'invl_section'))]}"/>
                                         <field name="date_maturity"
                                                optional="hide"
                                                invisible="context.get('view_no_maturity')"
-                                               attrs="{'invisible': [('display_type', 'in', ('line_section', 'line_note'))]}"/>
+                                               attrs="{'invisible': [('line_type', 'in', ('invl_note', 'invl_section'))]}"/>
                                         <field name="amount_currency"
                                                groups="base.group_multi_currency"
                                                optional="hide"/>
@@ -1129,7 +1125,7 @@
                                                force_save="1"
                                                attrs="{'readonly': [
                                                     '|', '|',
-                                                    ('display_type', 'in', ('line_section', 'line_note')),
+                                                    ('line_type', 'in', ('invl_note', 'invl_section')),
                                                     ('tax_line_id', '!=', False),
                                                     '&amp;',
                                                     ('parent.move_type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')),
@@ -1137,10 +1133,10 @@
                                                 ]}"/>
                                         <field name="debit"
                                                sum="Total Debit"
-                                               attrs="{'invisible': [('display_type', 'in', ('line_section', 'line_note'))]}"/>
+                                               attrs="{'invisible': [('line_type', 'in', ('invl_note', 'invl_section'))]}"/>
                                         <field name="credit"
                                                sum="Total Credit"
-                                               attrs="{'invisible': [('display_type', 'in', ('line_section', 'line_note'))]}"/>
+                                               attrs="{'invisible': [('line_type', 'in', ('invl_note', 'invl_section'))]}"/>
 
                                         <field name="tax_tag_ids"
                                                widget="many2many_tags"
@@ -1187,9 +1183,7 @@
                                         <field name="company_id" invisible="1"/>
                                         <field name="company_currency_id" invisible="1"/>
                                         <field name="recompute_tax_line" invisible="1" force_save="1"/>
-                                        <field name="display_type" force_save="1" invisible="1"/>
-                                        <field name="is_rounding_line" invisible="1"/>
-                                        <field name="exclude_from_invoice_tab" invisible="1"/>
+                                        <field name="line_type" force_save="1" invisible="1"/>
                                         <field name="account_internal_type" invisible="1"/>
                                         <field name="account_internal_group" invisible="1"/>
                                     </tree>
@@ -1403,7 +1397,7 @@
             <field name="context">{'journal_type':'general', 'search_default_group_by_move': 1, 'search_default_posted':1, 'name_groupby':1, 'create':0}</field>
             <field name="name">Journal Items</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('line_type', 'not in', ('invl_note', 'invl_section'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped"/>
             <field name="view_mode">tree,pivot,graph,form,kanban</field>
         </record>
@@ -1412,7 +1406,7 @@
             <field name="context">{'journal_type':'sales', 'search_default_group_by_move': 1, 'search_default_posted':1, 'search_default_sales':1, 'name_groupby':1, 'expand': 1}</field>
             <field name="name">Sales</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('line_type', 'not in', ('invl_note', 'invl_section'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_sales_purchases"/>
             <field name="view_mode">tree,pivot,graph,kanban</field>
         </record>
@@ -1421,7 +1415,7 @@
             <field name="context">{'journal_type':'purchase', 'search_default_group_by_move': 1, 'search_default_posted':1, 'search_default_purchases':1, 'name_groupby':1, 'expand': 1}</field>
             <field name="name">Purchases</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('line_type', 'not in', ('invl_note', 'invl_section'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_sales_purchases"/>
             <field name="view_mode">tree,pivot,graph,kanban</field>
         </record>
@@ -1430,7 +1424,7 @@
             <field name="context">{'journal_type':'bank', 'search_default_group_by_move': 1, 'search_default_posted':1, 'search_default_bank':1, 'search_default_cash':1, 'name_groupby':1, 'expand': 1}</field>
             <field name="name">Bank and Cash</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('line_type', 'not in', ('invl_note', 'invl_section'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_bank_cash"/>
             <field name="view_mode">tree,pivot,graph,kanban</field>
         </record>
@@ -1439,7 +1433,7 @@
             <field name="context">{'journal_type':'general', 'search_default_group_by_move': 1, 'search_default_posted':1, 'search_default_misc_filter':1, 'name_groupby':1, 'expand': 1}</field>
             <field name="name">Miscellaneous</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('line_type', 'not in', ('invl_note', 'invl_section'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_misc"/>
             <field name="view_mode">tree,pivot,graph,kanban</field>
         </record>
@@ -1448,7 +1442,7 @@
             <field name="context">{'journal_type':'general', 'search_default_group_by_account': 1, 'search_default_posted':1}</field>
             <field name="name">General Ledger</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('line_type', 'not in', ('invl_note', 'invl_section'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_general"/>
             <field name="search_view_id" ref="view_account_move_line_filter_with_root_selection"/>
             <field name="view_mode">tree,pivot,graph</field>
@@ -1458,7 +1452,7 @@
             <field name="context">{'journal_type':'general', 'search_default_group_by_partner': 1, 'search_default_posted':1, 'search_default_trade_payable':1, 'search_default_trade_receivable':1, 'search_default_unreconciled':1}</field>
             <field name="name">Partner Ledger</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('line_type', 'not in', ('invl_note', 'invl_section'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_partner"/>
             <field name="search_view_id" ref="view_account_move_line_filter"/>
             <field name="view_mode">tree,pivot,graph</field>
@@ -1467,7 +1461,7 @@
         <record id="action_account_moves_all_tree" model="ir.actions.act_window">
             <field name="name">Journal Items</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('line_type', 'not in', ('invl_note', 'invl_section'))]</field>
             <field name="context">{'search_default_partner_id': [active_id], 'default_partner_id': active_id, 'search_default_posted':1}</field>
             <field name="view_id" ref="view_move_line_tree"/>
         </record>
@@ -1476,7 +1470,7 @@
             <field name="context">{'journal_type':'general', 'search_default_posted':1}</field>
             <field name="name">Journal Items</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note')), ('parent_state', '!=', 'cancel')]</field>
+            <field name="domain">[('line_type', 'not in', ('invl_note', 'invl_section')), ('parent_state', '!=', 'cancel')]</field>
             <field name="view_id" ref="view_move_line_tree"/>
             <field name="view_mode">tree,pivot,graph,form,kanban</field>
         </record>

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -77,8 +77,8 @@
                                 <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
                                 <t t-set="current_subtotal" t-value="current_subtotal + line.price_total" groups="account.group_show_line_subtotals_tax_included"/>
 
-                                <tr t-att-class="'bg-200 font-weight-bold o_line_section' if line.display_type == 'line_section' else 'font-italic o_line_note' if line.display_type == 'line_note' else ''">
-                                    <t t-if="not line.display_type" name="account_invoice_line_accountable">
+                                <tr t-att-class="'bg-200 font-weight-bold o_line_section' if line.line_type == 'invl_section' else 'font-italic o_line_note' if line.line_type == 'invl_note' else ''">
+                                    <t t-if="line.line_type not in ['invl_note', 'invl_section']" name="account_invoice_line_accountable">
                                         <td name="account_invoice_line_name"><span t-field="line.name" t-options="{'widget': 'text'}"/></td>
                                         <td class="text-right">
                                             <span t-field="line.quantity"/>
@@ -98,21 +98,21 @@
                                             <span class="text-nowrap" t-field="line.price_total" groups="account.group_show_line_subtotals_tax_included"/>
                                         </td>
                                     </t>
-                                    <t t-if="line.display_type == 'line_section'">
+                                    <t t-if="line.line_type == 'invl_section'">
                                         <td colspan="99">
                                             <span t-field="line.name" t-options="{'widget': 'text'}"/>
                                         </td>
                                         <t t-set="current_section" t-value="line"/>
                                         <t t-set="current_subtotal" t-value="0"/>
                                     </t>
-                                    <t t-if="line.display_type == 'line_note'">
+                                    <t t-if="line.line_type == 'invl_note'">
                                         <td colspan="99">
                                             <span t-field="line.name" t-options="{'widget': 'text'}"/>
                                         </td>
                                     </t>
                                 </tr>
 
-                                <t t-if="current_section and (line_last or lines[line_index+1].display_type == 'line_section')">
+                                <t t-if="current_section and (line_last or lines[line_index+1].line_type == 'invl_section')">
                                     <tr class="is-subtotal text-right">
                                         <td colspan="99">
                                             <strong class="mr16">Subtotal</strong>

--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -299,7 +299,7 @@ class AccountMove(models.Model):
             return invoice_lines_tax_values_dict
 
         # Compute the taxes values for each invoice line.
-        invoice_lines = self.invoice_line_ids.filtered(lambda line: not line.display_type)
+        invoice_lines = self.invoice_line_ids.filtered(lambda line: not line.is_display_line())
         if filter_invl_to_apply:
             invoice_lines = invoice_lines.filtered(filter_invl_to_apply)
 
@@ -435,7 +435,7 @@ class AccountMove(models.Model):
         }
 
         # Invoice lines details.
-        for index, line in enumerate(self.invoice_line_ids.filtered(lambda line: not line.display_type), start=1):
+        for index, line in enumerate(self.invoice_line_ids.filtered(lambda line: not line.is_display_line()), start=1):
             line_vals = line._prepare_edi_vals_to_export()
             line_vals['index'] = index
             res['invoice_line_vals_list'].append(line_vals)

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -655,7 +655,7 @@ Or send your receipts at <a href="mailto:%(email)s?subject=Lunch%%20with%%20cust
                 'currency_id': expense.currency_id.id,
                 'expense_id': expense.id,
                 'partner_id': partner_id,
-                'exclude_from_invoice_tab': True,
+                'line_type': False,
             }
             move_line_values.append(move_line_dst)
 

--- a/addons/l10n_ar/tests/common.py
+++ b/addons/l10n_ar/tests/common.py
@@ -656,8 +656,8 @@ class TestAr(AccountTestInvoicingCommon):
                 invoice_form.currency_id = data.get('currency')
             for line in data.get('lines', [{}]):
                 with invoice_form.invoice_line_ids.new() as invoice_line_form:
-                    if line.get('display_type'):
-                        invoice_line_form.display_type = line.get('display_type')
+                    if line.get('line_type'):
+                        invoice_line_form.line_type = line.get('line_type')
                         invoice_line_form.name = line.get('name', 'not invoice line')
                     else:
                         invoice_line_form.product_id = line.get('product', self.product_iva_21)

--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -135,8 +135,8 @@ class AccountMove(models.Model):
         self.ensure_one()
         include_sii = self._l10n_cl_include_sii()
 
-        base_lines = self.line_ids.filtered(lambda x: not x.display_type and not x.exclude_from_invoice_tab)
-        tax_lines = self.line_ids.filtered(lambda x: not x.display_type and x.tax_repartition_line_id)
+        base_lines = self.line_ids.filtered(lambda x: x.is_invoice_line(with_display_line_check=True))
+        tax_lines = self.line_ids.filtered(lambda x: not x.is_display_line() and x.tax_repartition_line_id)
 
         base_line_vals_list = [x._convert_to_tax_base_line_dict() for x in base_lines]
         if include_sii:

--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -95,7 +95,7 @@ class AccountEdiFormat(models.Model):
         # on the same invoice, this can be deduced globally.
 
         recargo_tax_details = {} # Mapping between main tax and recargo tax details
-        invoice_lines = invoice.invoice_line_ids.filtered(lambda x: not x.display_type)
+        invoice_lines = invoice.invoice_line_ids.filtered(lambda x: not x.is_display_line())
         if filter_invl_to_apply:
             invoice_lines = invoice_lines.filtered(filter_invl_to_apply)
         for line in invoice_lines:
@@ -597,7 +597,7 @@ class AccountEdiFormat(models.Model):
 
         if not move.company_id.vat:
             res.append(_("VAT number is missing on company %s", move.company_id.display_name))
-        for line in move.invoice_line_ids.filtered(lambda line: not line.display_type):
+        for line in move.invoice_line_ids.filtered(lambda line: not line.is_display_line()):
             taxes = line.tax_ids.flatten_taxes_hierarchy()
             recargo_count = taxes.mapped('l10n_es_type').count('recargo')
             retention_count = taxes.mapped('l10n_es_type').count('retencion')

--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -251,8 +251,8 @@
                             <t t-set="current_subtotal" t-value="current_subtotal + line.price_total"
                                groups="account.group_show_line_subtotals_tax_included"/>
 
-                            <tr t-att-class="'bg-200 font-weight-bold o_line_section' if line.display_type == 'line_section' else 'font-italic o_line_note' if line.display_type == 'line_note' else ''">
-                                <t t-if="not line.display_type" name="account_invoice_line_accountable">
+                            <tr t-att-class="'bg-200 font-weight-bold o_line_section' if line.line_type == 'invl_section' else 'font-italic o_line_note' if line.line_type == 'invl_note' else ''">
+                                <t t-if="line.line_type not in ('invl_note', 'invl_section')" name="account_invoice_line_accountable">
                                     <td name="account_invoice_line_name">
                                         <t t-set="translation_name" t-value="line.with_context(lang='ar_001').product_id.name"/>
                                         <t t-if="line.product_id">
@@ -293,21 +293,21 @@
                                         <span class="text-nowrap" t-field="line.price_total"/>
                                     </td>
                                 </t>
-                                <t t-if="line.display_type == 'line_section'">
+                                <t t-if="line.line_type == 'invl_section'">
                                     <td colspan="99">
                                         <span t-field="line.name" t-options="{'widget': 'text'}"/>
                                     </td>
                                     <t t-set="current_section" t-value="line"/>
                                     <t t-set="current_subtotal" t-value="0"/>
                                 </t>
-                                <t t-if="line.display_type == 'line_note'">
+                                <t t-if="line.line_type == 'invl_note'">
                                     <td colspan="99">
                                         <span t-field="line.name" t-options="{'widget': 'text'}"/>
                                     </td>
                                 </t>
                             </tr>
 
-                            <t t-if="current_section and (line_last or lines[line_index+1].display_type == 'line_section')">
+                            <t t-if="current_section and (line_last or lines[line_index+1].line_type == 'invl_section')">
                                 <tr class="is-subtotal text-right">
                                     <td colspan="99">
                                         <strong class="mr16" style="display: inline-block">Subtotal/الإجمالي الفرعي</strong>

--- a/addons/l10n_id_efaktur/models/account_move.py
+++ b/addons/l10n_id_efaktur/models/account_move.py
@@ -62,11 +62,11 @@ class AccountMove(models.Model):
     def _constraint_kode_ppn(self):
         ppn_tag = self.env.ref('l10n_id.ppn_tag')
         for move in self.filtered(lambda m: m.l10n_id_kode_transaksi != '08'):
-            if any(ppn_tag.id in line.tax_tag_ids.ids for line in move.line_ids if line.exclude_from_invoice_tab is False and not line.display_type) \
-                    and any(ppn_tag.id not in line.tax_tag_ids.ids for line in move.line_ids if line.exclude_from_invoice_tab is False and not line.display_type):
+            if any(ppn_tag.id in line.tax_tag_ids.ids for line in move.line_ids if line.is_invoice_line(with_display_line_check=True)) \
+                    and any(ppn_tag.id not in line.tax_tag_ids.ids for line in move.line_ids if line.is_invoice_line(with_display_line_check=True)):
                 raise UserError(_('Cannot mix VAT subject and Non-VAT subject items in the same invoice with this kode transaksi.'))
         for move in self.filtered(lambda m: m.l10n_id_kode_transaksi == '08'):
-            if any(ppn_tag.id in line.tax_tag_ids.ids for line in move.line_ids if line.exclude_from_invoice_tab is False and not line.display_type):
+            if any(ppn_tag.id in line.tax_tag_ids.ids for line in move.line_ids if line.is_invoice_line(with_display_line_check=True)):
                 raise UserError('Kode transaksi 08 is only for non VAT subject items.')
 
     @api.constrains('l10n_id_tax_number')
@@ -178,7 +178,7 @@ class AccountMove(models.Model):
             eTax['REFERENSI'] = number_ref
             eTax['KODE_DOKUMEN_PENDUKUNG'] = '0'
 
-            lines = move.line_ids.filtered(lambda x: x.product_id.id == int(dp_product_id) and x.price_unit < 0 and not x.display_type)
+            lines = move.line_ids.filtered(lambda x: x.product_id.id == int(dp_product_id) and x.price_unit < 0 and not x.is_display_line())
             eTax['FG_UANG_MUKA'] = 0
             eTax['UANG_MUKA_DPP'] = int(abs(sum(lines.mapped(lambda l: round(l.price_subtotal, 0)))))
             eTax['UANG_MUKA_PPN'] = int(abs(sum(lines.mapped(lambda l: round(l.price_total - l.price_subtotal, 0)))))
@@ -194,7 +194,7 @@ class AccountMove(models.Model):
             # HOW TO ADD 2 line to 1 line for free product
             free, sales = [], []
 
-            for line in move.line_ids.filtered(lambda l: not l.exclude_from_invoice_tab and not l.display_type):
+            for line in move.line_ids.filtered(lambda l: l.is_invoice_line(with_display_line_check=True)):
                 # *invoice_line_unit_price is price unit use for harga_satuan's column
                 # *invoice_line_quantity is quantity use for jumlah_barang's column
                 # *invoice_line_total_price is bruto price use for harga_total's column

--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -64,7 +64,7 @@ class AccountEdiFormat(models.Model):
         error_message += self._l10n_in_validate_partner(move.company_id.partner_id, is_company=True)
         if not re.match("^.{1,16}$", move.name):
             error_message.append(_("Invoice number should not be more than 16 characters"))
-        for line in move.invoice_line_ids.filtered(lambda line: not (line.display_type or line.is_rounding_line)):
+        for line in move.invoice_line_ids.filtered(lambda line: not (line.is_display_line() or line.line_type in ['invl_cash_rounding', 'inv_tax_cash_rounding'])):
             if line.product_id:
                 hsn_code = self._l10n_in_edi_extract_digits(line.product_id.l10n_in_hsn_code)
                 if not hsn_code:
@@ -342,7 +342,7 @@ class AccountEdiFormat(models.Model):
         sign = invoice.is_inbound() and -1 or 1
         is_intra_state = invoice.l10n_in_state_id == invoice.company_id.state_id
         is_overseas = invoice.l10n_in_gst_treatment == "overseas"
-        lines = invoice.invoice_line_ids.filtered(lambda line: not (line.display_type or line.is_rounding_line))
+        lines = invoice.invoice_line_ids.filtered(lambda line: not (line.is_display_line() or line.line_type in ['invl_cash_rounding', 'inv_tax_cash_rounding']))
         invoice_line_tax_details = tax_details.get("invoice_line_tax_details")
         json_payload = {
             "Version": "1.1",
@@ -376,7 +376,7 @@ class AccountEdiFormat(models.Model):
                     + tax_details_by_code.get("state_cess_non_advol_amount", 0.00)) * sign,
                 ),
                 "RndOffAmt": self._l10n_in_round_value(
-                    sum(line.balance for line in invoice.invoice_line_ids if line.is_rounding_line)),
+                    sum(line.balance for line in invoice.invoice_line_ids if line.line_type in ['invl_cash_rounding', 'inv_tax_cash_rounding'])),
                 "TotInvVal": self._l10n_in_round_value(
                     (tax_details.get("base_amount") + tax_details.get("tax_amount")) * sign),
             },
@@ -439,7 +439,7 @@ class AccountEdiFormat(models.Model):
             }
 
         def l10n_in_filter_to_apply(tax_values):
-            if tax_values["base_line_id"].is_rounding_line:
+            if tax_values["base_line_id"].line_type in ['invl_cash_rounding', 'inv_tax_cash_rounding']:
                 return False
             return True
 

--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -158,7 +158,7 @@
                     <DatiBeniServizi>
                         <!-- Invoice lines. -->
                         <t t-set="line_counter" t-value="0"/>
-                        <t t-foreach="record.invoice_line_ids.filtered(lambda l: not l.display_type)" t-as="line">
+                        <t t-foreach="record.invoice_line_ids.filtered(lambda l: not l.is_display_line())" t-as="line">
                             <t t-set="line_counter" t-value="line_counter + 1"/>
                             <t t-call="l10n_it_edi.account_invoice_line_it_FatturaPA"/>
                         </t>

--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -114,7 +114,7 @@ class AccountEdiFormat(models.Model):
 
         # <2.2.1>
         for invoice_line in invoice.invoice_line_ids:
-            if not invoice_line.display_type and len(invoice_line.tax_ids) != 1:
+            if not invoice_line.is_display_line() and len(invoice_line.tax_ids) != 1:
                 raise UserError(_("You must select one and only one tax by line."))
 
         if any(line.quantity < 0 for line in invoice.invoice_line_ids):

--- a/addons/l10n_it_stock_ddt/models/account_invoice.py
+++ b/addons/l10n_it_stock_ddt/models/account_invoice.py
@@ -23,7 +23,7 @@ class AccountMove(models.Model):
             return {}
         line_count = 0
         invoice_line_pickings = {}
-        for line in self.invoice_line_ids.filtered(lambda l: not l.display_type):
+        for line in self.invoice_line_ids.filtered(lambda l: not l.is_display_line()):
             line_count += 1
             done_moves_related = line.sale_line_ids.mapped('move_ids').filtered(lambda m: m.state == 'done' and m.location_dest_id.usage == 'customer')
             if len(done_moves_related) <= 1:

--- a/addons/point_of_sale/models/account_payment.py
+++ b/addons/point_of_sale/models/account_payment.py
@@ -11,14 +11,10 @@ class AccountPayment(models.Model):
     force_outstanding_account_id = fields.Many2one("account.account", "Forced Outstanding Account", check_company=True)
     pos_session_id = fields.Many2one('pos.session', "POS Session")
 
-    def _get_valid_liquidity_accounts(self):
-        result = super()._get_valid_liquidity_accounts()
-        return result + (self.pos_payment_method_id.outstanding_account_id,)
-
-    @api.depends("force_outstanding_account_id")
-    def _compute_outstanding_account_id(self):
+    def _get_outstanding_account_id(self):
         """When force_outstanding_account_id is set, we use it as the outstanding_account_id."""
-        super()._compute_outstanding_account_id()
-        for payment in self:
-            if payment.force_outstanding_account_id:
-                payment.outstanding_account_id = payment.force_outstanding_account_id
+        self.ensure_one()
+        if self.force_outstanding_account_id:
+            return self.force_outstanding_account_id
+        else:
+            return super()._get_outstanding_account_id()

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -208,12 +208,12 @@ class PosOrder(models.Model):
                     'name': _('Price discount from %s -> %s',
                               float_repr(line.product_id.lst_price, self.currency_id.decimal_places),
                               float_repr(line.price_unit, self.currency_id.decimal_places)),
-                    'display_type': 'line_note',
+                    'line_type': 'invl_note',
                 }))
             if line.customer_note:
                 invoice_lines.append((0, None, {
                     'name': line.customer_note,
-                    'display_type': 'line_note',
+                    'line_type': 'invl_note',
                 }))
 
 
@@ -501,7 +501,7 @@ class PosOrder(models.Model):
         if self.config_id.cash_rounding:
             rounding_applied = float_round(self.amount_paid - self.amount_total,
                                            precision_rounding=new_move.currency_id.rounding)
-            rounding_line = new_move.line_ids.filtered(lambda line: line.is_rounding_line)
+            rounding_line = new_move.line_ids.filtered(lambda line: line.line_type in ['invl_cash_rounding', 'inv_tax_cash_rounding'])
             if rounding_line and rounding_line.debit > 0:
                 rounding_line_difference = rounding_line.debit + rounding_applied
             elif rounding_line and rounding_line.credit > 0:
@@ -533,7 +533,7 @@ class PosOrder(models.Model):
                         'currency_id': new_move.currency_id if new_move.currency_id != new_move.company_id.currency_id else False,
                         'company_id': new_move.company_id.id,
                         'company_currency_id': new_move.company_id.currency_id.id,
-                        'is_rounding_line': True,
+                        'line_type': 'invl_cash_rounding',
                         'sequence': 9999,
                         'name': new_move.invoice_cash_rounding_id.name,
                         'account_id': account_id,

--- a/addons/product_margin/models/product_product.py
+++ b/addons/product_margin/models/product_product.py
@@ -105,7 +105,7 @@ class ProductProduct(models.Model):
             company_id = self.env.context['force_company']
         else:
             company_id = self.env.company.id
-        self.env['account.move.line'].flush(['price_unit', 'quantity', 'balance', 'product_id', 'display_type'])
+        self.env['account.move.line'].flush(['price_unit', 'quantity', 'balance', 'product_id', 'line_type'])
         self.env['account.move'].flush(['state', 'payment_state', 'move_type', 'invoice_date', 'company_id'])
         self.env['product.template'].flush(['list_price'])
         sqlstr = """
@@ -134,8 +134,8 @@ class ProductProduct(models.Model):
                 AND i.move_type IN %s
                 AND i.invoice_date BETWEEN %s AND  %s
                 AND i.company_id = %s
-                AND l.display_type IS NULL
-                AND l.exclude_from_invoice_tab = false
+                AND COALESCE(l.line_type, 'false') LIKE 'invl%%' 
+                AND COALESCE(l.line_type, 'false') NOT IN ('invl_section', 'invl_note')
                 GROUP BY l.product_id
                 """.format(self.env['res.currency']._select_companies_rates())
         invoice_types = ('out_invoice', 'out_refund')

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1326,8 +1326,8 @@ class PurchaseOrderLine(models.Model):
         self.ensure_one()
         aml_currency = move and move.currency_id or self.currency_id
         date = move and move.date or fields.Date.today()
+        display_type_map = {'line_section': 'invl_section', 'line_note': 'invl_note'}
         res = {
-            'display_type': self.display_type,
             'sequence': self.sequence,
             'name': '%s: %s' % (self.order_id.name, self.name),
             'product_id': self.product_id.id,
@@ -1338,6 +1338,7 @@ class PurchaseOrderLine(models.Model):
             'analytic_account_id': self.account_analytic_id.id,
             'analytic_tag_ids': [(6, 0, self.analytic_tag_ids.ids)],
             'purchase_line_id': self.id,
+            'line_type': display_type_map.get(self.display_type, 'invl'),
         }
         if not move:
             return res

--- a/addons/purchase_stock/models/account_invoice.py
+++ b/addons/purchase_stock/models/account_invoice.py
@@ -139,8 +139,7 @@ class AccountMove(models.Model):
                         'account_id': debit_pdiff_account.id,
                         'analytic_account_id': line.analytic_account_id.id,
                         'analytic_tag_ids': [(6, 0, line.analytic_tag_ids.ids)],
-                        'exclude_from_invoice_tab': True,
-                        'is_anglo_saxon_line': True,
+                        'line_type': 'anglo_saxon_line',
                     }
                     vals.update(line._get_fields_onchange_subtotal(price_subtotal=vals['price_subtotal']))
                     lines_vals_list.append(vals)
@@ -159,8 +158,7 @@ class AccountMove(models.Model):
                         'account_id': line.account_id.id,
                         'analytic_account_id': line.analytic_account_id.id,
                         'analytic_tag_ids': [(6, 0, line.analytic_tag_ids.ids)],
-                        'exclude_from_invoice_tab': True,
-                        'is_anglo_saxon_line': True,
+                        'line_type': 'anglo_saxon_line',
                     }
                     vals.update(line._get_fields_onchange_subtotal(price_subtotal=vals['price_subtotal']))
                     lines_vals_list.append(vals)

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1288,7 +1288,7 @@ class SaleOrder(models.Model):
         :param optional_values: any parameter that should be added to the returned down payment section
         """
         down_payments_section_line = {
-            'display_type': 'line_section',
+            'line_type': 'invl_section',
             'name': _('Down Payments'),
             'product_id': False,
             'product_uom_id': False,

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1021,8 +1021,8 @@ class SaleOrderLine(models.Model):
         :param optional_values: any parameter that should be added to the returned invoice line
         """
         self.ensure_one()
+        display_type_map = {'line_section': 'invl_section', 'line_note': 'invl_note'}
         res = {
-            'display_type': self.display_type,
             'sequence': self.sequence,
             'name': self.name,
             'product_id': self.product_id.id,
@@ -1033,6 +1033,7 @@ class SaleOrderLine(models.Model):
             'tax_ids': [(6, 0, self.tax_id.ids)],
             'analytic_tag_ids': [(6, 0, self.analytic_tag_ids.ids)],
             'sale_line_ids': [(4, self.id)],
+            'line_type': display_type_map.get(self.display_type, 'invl'),
         }
         if self.order_id.analytic_account_id:
             res['analytic_account_id'] = self.order_id.analytic_account_id.id

--- a/addons/sale/models/utm_campaign.py
+++ b/addons/sale/models/utm_campaign.py
@@ -23,7 +23,7 @@ class UtmCampaign(models.Model):
             campaign.quotation_count = data_map.get(campaign.id, 0)
 
     def _compute_sale_invoiced_amount(self):
-        self.env['account.move.line'].flush(['balance', 'move_id', 'account_id', 'exclude_from_invoice_tab'])
+        self.env['account.move.line'].flush(['balance', 'move_id', 'account_id', 'line_type'])
         self.env['account.move'].flush(['state', 'campaign_id', 'move_type'])
         query = """SELECT move.campaign_id, -SUM(line.balance) as price_subtotal
                     FROM account_move_line line
@@ -32,7 +32,7 @@ class UtmCampaign(models.Model):
                         AND move.campaign_id IN %s
                         AND move.move_type IN ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')
                         AND line.account_id IS NOT NULL
-                        AND NOT line.exclude_from_invoice_tab
+                        AND COALESCE(line.line_type, 'false') LIKE 'invl%%'
                     GROUP BY move.campaign_id
                     """
 

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -408,7 +408,7 @@ class TestSaleOrder(TestSaleCommon):
         invoice = self.sale_order._create_invoices()
 
         # check note from SO has been pushed in invoice
-        self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda line: line.display_type == 'line_note')), 1, 'Note SO line should have been pushed to the invoice')
+        self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda line: line.line_type == 'invl_note')), 1, 'Note SO line should have been pushed to the invoice')
 
     def test_multi_currency_discount(self):
         """Verify the currency used for pricelist price & discount computation."""

--- a/addons/sale/tests/test_sale_refund.py
+++ b/addons/sale/tests/test_sale_refund.py
@@ -346,8 +346,8 @@ class TestSaleToInvoice(TestSaleCommon):
         payment.create_invoices()
 
         so_invoice = max(sale_order_refund.invoice_ids)
-        self.assertEqual(len(so_invoice.invoice_line_ids.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))), len(sale_order_refund.order_line), 'All lines should be invoiced')
-        self.assertEqual(len(so_invoice.invoice_line_ids.filtered(lambda l: l.display_type == 'line_section' and l.name == "Down Payments")), 1, 'A single section for downpayments should be present')
+        self.assertEqual(len(so_invoice.invoice_line_ids.filtered(lambda l: not (l.line_type == 'invl_section' and l.name == "Down Payments"))), len(sale_order_refund.order_line), 'All lines should be invoiced')
+        self.assertEqual(len(so_invoice.invoice_line_ids.filtered(lambda l: l.line_type == 'invl_section' and l.name == "Down Payments")), 1, 'A single section for downpayments should be present')
         self.assertEqual(so_invoice.amount_total, sale_order_refund.amount_total - sol_downpayment.price_unit, 'Downpayment should be applied')
         so_invoice.action_post()
 

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -117,8 +117,8 @@ class TestSaleToInvoice(TestSaleCommon):
         self.assertEqual(len(self.sale_order.invoice_ids), 3, 'Invoice should be created for the SO')
 
         invoice = max(self.sale_order.invoice_ids)
-        self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))), len(self.sale_order.order_line), 'All lines should be invoiced')
-        self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda l: l.display_type == 'line_section' and l.name == "Down Payments")), 1, 'A single section for downpayments should be present')
+        self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda l: not (l.line_type == 'invl_section' and l.name == "Down Payments"))), len(self.sale_order.order_line), 'All lines should be invoiced')
+        self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda l: l.line_type == 'invl_section' and l.name == "Down Payments")), 1, 'A single section for downpayments should be present')
         self.assertEqual(invoice.amount_total, self.sale_order.amount_total - sum(downpayment_line.mapped('price_unit')), 'Downpayment should be applied')
 
     def test_downpayment_percentage_tax_icl(self):
@@ -145,7 +145,7 @@ class TestSaleToInvoice(TestSaleCommon):
         self.assertEqual(downpayment_line.price_unit, self.sale_order.amount_total/2, 'downpayment should have the correct amount')
 
         invoice = self.sale_order.invoice_ids[0]
-        downpayment_aml = invoice.line_ids.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))[0]
+        downpayment_aml = invoice.line_ids.filtered(lambda l: not (l.line_type == 'invl_section' and l.name == "Down Payments"))[0]
         self.assertEqual(downpayment_aml.price_total, self.sale_order.amount_total/2, 'downpayment should have the correct amount')
         self.assertEqual(downpayment_aml.price_unit, self.sale_order.amount_total/2, 'downpayment should have the correct amount')
         invoice.action_post()
@@ -311,7 +311,7 @@ class TestSaleToInvoice(TestSaleCommon):
 
         invoice = sale_order.invoice_ids[0]
 
-        self.assertEqual(invoice.line_ids[0].display_type, 'line_section')
+        self.assertEqual(invoice.line_ids[0].line_type, 'invl_section')
 
     def test_qty_invoiced(self):
         """Verify uom rounding is correctly considered during qty_invoiced compute"""

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -676,8 +676,8 @@ class TestSaleMrpFlow(ValuationReconciliationTestCommon):
         self.invoice = move_form.save()
         self.invoice.action_post()
         aml = self.invoice.line_ids
-        aml_expense = aml.filtered(lambda l: l.is_anglo_saxon_line and l.debit > 0)
-        aml_output = aml.filtered(lambda l: l.is_anglo_saxon_line and l.credit > 0)
+        aml_expense = aml.filtered(lambda l: l.line_type == 'anglo_saxon_line' and l.debit > 0)
+        aml_output = aml.filtered(lambda l: l.line_type == 'anglo_saxon_line' and l.credit > 0)
         # Check that the cost of Good Sold entries are equal to 2* (2 * 20 + 1 * 10) = 100
         self.assertEqual(aml_expense.debit, 100, "Cost of Good Sold entry missing or mismatching")
         self.assertEqual(aml_output.credit, 100, "Cost of Good Sold entry missing or mismatching")
@@ -1747,8 +1747,8 @@ class TestSaleMrpFlow(ValuationReconciliationTestCommon):
 
         def check_cogs_entry_values(invoice, expected_value):
             aml = invoice.line_ids
-            aml_expense = aml.filtered(lambda l: l.is_anglo_saxon_line and l.debit > 0)
-            aml_output = aml.filtered(lambda l: l.is_anglo_saxon_line and l.credit > 0)
+            aml_expense = aml.filtered(lambda l: l.line_type == 'anglo_saxon_line' and l.debit > 0)
+            aml_output = aml.filtered(lambda l: l.line_type == 'anglo_saxon_line' and l.credit > 0)
             self.assertEqual(aml_expense.debit, expected_value, "Cost of Good Sold entry missing or mismatching for variant")
             self.assertEqual(aml_output.credit, expected_value, "Cost of Good Sold entry missing or mismatching for variant")
 

--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -32,7 +32,7 @@ class AccountMove(models.Model):
         if self.state == 'draft' or not self.invoice_date or self.move_type not in ('out_invoice', 'out_refund'):
             return res
 
-        current_invoice_amls = self.invoice_line_ids.filtered(lambda aml: not aml.display_type and aml.product_id and aml.quantity)
+        current_invoice_amls = self.invoice_line_ids.filtered(lambda aml: not aml.is_display_line() and aml.product_id and aml.quantity)
         all_invoices_amls = current_invoice_amls.sale_line_ids.invoice_lines.filtered(lambda aml: aml.move_id.state == 'posted').sorted(lambda aml: (aml.date, aml.move_name, aml.id))
         index = all_invoices_amls.ids.index(current_invoice_amls[:1].id) if current_invoice_amls[:1] in all_invoices_amls else 0
         previous_amls = all_invoices_amls[:index]
@@ -92,7 +92,7 @@ class AccountMoveLine(models.Model):
 
     def _sale_can_be_reinvoice(self):
         self.ensure_one()
-        return not self.is_anglo_saxon_line and super(AccountMoveLine, self)._sale_can_be_reinvoice()
+        return not self.line_type == 'anglo_saxon_line' and super(AccountMoveLine, self)._sale_can_be_reinvoice()
 
     def _stock_account_get_anglo_saxon_price_unit(self):
         self.ensure_one()

--- a/addons/sale_stock/tests/test_anglosaxon_account.py
+++ b/addons/sale_stock/tests/test_anglosaxon_account.py
@@ -29,7 +29,7 @@ class TestAngloSaxonAccounting(TestValuationReconciliation):
         company_a_invoice.with_context(allowed_company_ids=companies_with_b_first.ids).action_post()
 
         # check cost used for anglo_saxon_line is from company A
-        anglo_saxon_lines = company_a_invoice.line_ids.filtered('is_anglo_saxon_line')
+        anglo_saxon_lines = company_a_invoice.line_ids.filtered(lambda l: l.line_type == 'anglo_saxon_line')
         self.assertRecordValues(anglo_saxon_lines, [
             {'debit': 0.0, 'credit': company_a_standard_price},
             {'debit': company_a_standard_price, 'credit': 0.0},

--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -66,7 +66,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_total)
         self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_residual)
         self.assertEqual(len(invoice.mapped("line_ids")), 4)
-        self.assertEqual(len(invoice.mapped("line_ids").filtered("is_anglo_saxon_line")), 2)
+        self.assertEqual(len(invoice.mapped("line_ids").filtered(lambda l: l.line_type == 'anglo_saxon_line')), 2)
         self.assertEqual(len(invoice.mapped("line_ids.currency_id")), 2)
 
     def test_fifo_perpetual_01_mc_01(self):
@@ -91,7 +91,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_total)
         self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_residual)
         self.assertEqual(len(invoice.mapped("line_ids")), 4)
-        self.assertEqual(len(invoice.mapped("line_ids").filtered("is_anglo_saxon_line")), 2)
+        self.assertEqual(len(invoice.mapped("line_ids").filtered(lambda l: l.line_type == 'anglo_saxon_line')), 2)
         self.assertEqual(len(invoice.mapped("line_ids.currency_id")), 2)
 
     def test_average_perpetual_01_mc_01(self):
@@ -116,5 +116,5 @@ class TestAccountMove(AccountTestInvoicingCommon):
         self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_total)
         self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_residual)
         self.assertEqual(len(invoice.mapped("line_ids")), 4)
-        self.assertEqual(len(invoice.mapped("line_ids").filtered("is_anglo_saxon_line")), 2)
+        self.assertEqual(len(invoice.mapped("line_ids").filtered(lambda l: l.line_type == 'anglo_saxon_line')), 2)
         self.assertEqual(len(invoice.mapped("line_ids.currency_id")), 2)

--- a/addons/stock_account/tests/test_anglo_saxon_valuation_reconciliation_common.py
+++ b/addons/stock_account/tests/test_anglo_saxon_valuation_reconciliation_common.py
@@ -86,7 +86,7 @@ class ValuationReconciliationTestCommon(AccountTestInvoicingCommon):
 
         valuation_line = stock_moves.mapped('account_move_ids.line_ids').filtered(lambda x: x.account_id.id == interim_account_id)
 
-        if invoice.is_purchase_document() and any(l.is_anglo_saxon_line for l in invoice_line):
+        if invoice.is_purchase_document() and any(l.line_type == 'anglo_saxon_line' for l in invoice_line):
             self.assertEqual(len(invoice_line), 2, "Only two line2 should have been written by invoice in stock input account")
             self.assertTrue(valuation_line.reconciled or invoice_line[0].reconciled or invoice_line[1].reconciled, "The valuation and invoice line should have been reconciled together.")
         else:

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -1039,7 +1039,7 @@ class TestAngloSaxonAccounting(TestStockValuationCommon):
                 line.quantity = 1
         reverse_invoice.action_post()
 
-        anglo_lines = reverse_invoice.line_ids.filtered(lambda l: l.is_anglo_saxon_line)
+        anglo_lines = reverse_invoice.line_ids.filtered(lambda l: l.line_type == 'anglo_saxon_line')
         self.assertEqual(len(anglo_lines), 2)
         self.assertEqual(abs(anglo_lines[0].balance), 10)
         self.assertEqual(abs(anglo_lines[1].balance), 10)


### PR DESCRIPTION
There is a few use case where we need to filter aml based on some
specificities, such as liquidity/counterpart lines on payment,
cash rounding lines, display lines,...

This change aim to standardize this by adding a line_type field that
would allow to specify the line purpose, making it easy to filter
where needed but also to extend if needed.

Task id #2747764

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
