### PR TITLE
[FIX] web_editor: prevent height 0 on mailing

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -544,7 +544,7 @@ function formatTables($editable) {
             height = parent.style.getPropertyValue('height');
         }
         if (parent) {
-            parent.style.setProperty('height', '0');
+            parent.style.setProperty('height', $(parent).height());
         }
     }
     // Align self and justify content don't work on table cells.


### PR DESCRIPTION
When saving a mailing (mass_mailing) with invalid fields, the mailing ended up having a height of 0. This is because some changes from convert_inline are applied inline and may be incompatible with the grid structure of the mailing. This was the case with height=0 applied on the mail layout element as a result of it having a child with a height expressed in percents. Rather than set the height to 0, we now set it to whatever the height was measured to be.

task-2734605

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
