### PR TITLE
[IMP] note: Allow company specific notes

### DIFF
--- a/addons/note/models/note.py
+++ b/addons/note/models/note.py
@@ -42,6 +42,7 @@ class Note(models.Model):
 
     name = fields.Text(
         compute='_compute_name', string='Note Summary', store=True, readonly=False)
+    company_id = fields.Many2one('res.company')
     user_id = fields.Many2one('res.users', string='Owner', default=lambda self: self.env.uid)
     memo = fields.Html('Note Content')
     sequence = fields.Integer('Sequence')

--- a/addons/note/security/note_security.xml
+++ b/addons/note/security/note_security.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0"?>
 <odoo noupdate="1">
+    <record id="ir_rule_note_note_multi_company" model="ir.rule">
+        <field name="name">Note - Multi-Company</field>
+        <field name="model_id" ref="model_note_note"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+    </record>
+
     <record id="note_note_rule_global" model="ir.rule">
         <field name="name">Only followers can access a sticky notes</field>
         <field name="model_id" ref="model_note_note"/>

--- a/addons/note/views/note_views.xml
+++ b/addons/note/views/note_views.xml
@@ -170,10 +170,11 @@
             <form string="Note" class="oe_form_nomargin o_note_form_view">
                 <header>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" placeholder="Tags"/>
+                    <field name="company_id" groups="base.group_multi_company"/>
                     <field name="stage_id" domain="[('user_id','=',uid)]" widget="statusbar" options="{'clickable': '1'}"/>
                 </header>
                 <sheet>
-                  <field name="memo" type="html" class="oe_memo" default_focus="1" options="{'resizable': false, 'collaborative': true}"/>
+                    <field name="memo" type="html" class="oe_memo" default_focus="1" options="{'resizable': false, 'collaborative': true}"/>
                 </sheet>
                 <div class="oe_chatter">
                     <field name="message_follower_ids"/>


### PR DESCRIPTION
Purpose
=======

Allow to restrict note to users having access to a specific company

For example, when creating a new company, it create a "Useful Links" note
that is used on the payroll dashboard (With granted access to payroll officers
who belongs to this company).

This note should be restricted to people having access to the company,
and shouldn't be mixed all the time for people having multi company accesses.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
