### PR TITLE
[FIX][15.0] pad: HTML is malformed when combining text type and Markup instance

### DIFF
--- a/addons/pad/py_etherpad/__init__.py
+++ b/addons/pad/py_etherpad/__init__.py
@@ -2,6 +2,8 @@
 import requests
 import logging
 
+from markupsafe import Markup
+
 from odoo.tools import html2plaintext
 
 _logger = logging.getLogger(__name__)
@@ -179,7 +181,7 @@ class EtherpadLiteClient:
     def setHtmlFallbackText(self, padID, html):
         try:
             # Prevents malformed HTML errors
-            html_wellformed = '<html><body>' + html + '</body></html>'
+            html_wellformed = Markup("<html><body>%s</body></html>") % html
             return self.setHtml(padID, html_wellformed)
         except Exception:
             _logger.exception('Falling back to setText. SetHtml failed with message:')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
Malformed HTML will receive a warning to the console log

Desired behavior after PR is merged:
Sets the text of a pad based on HTML, HTML must be well-formed

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
