### PR TITLE
[FIX] web_editor: prevent horizontal overflow of toolbar in website

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -510,8 +510,7 @@ body.editor_enable.editor_has_snippets {
             .btn {
                 @extend %we-generic-button;
                 display: flex;
-                padding-top: $o-we-sidebar-content-field-height * .12;
-                padding-bottom: $o-we-sidebar-content-field-height * .12;
+                padding: ($o-we-sidebar-content-field-height * .12) ($o-we-sidebar-content-field-button-group-button-spacing - 2);
             }
 
             we-customizeblock-option {


### PR DESCRIPTION
Since the introduction of the strikethrough button, the text toolbar overflowed website's sidebar. This reduces their size so they don't overflow.

task-2758967

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
