### PR TITLE
[FIX] account: fix account type constraint on bank journals

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -198,12 +198,14 @@ class AccountAccount(models.Model):
         self._cr.execute('''
             SELECT journal.id
             FROM account_journal journal
-            WHERE journal.payment_credit_account_id in %(credit_account)s
-            OR journal.payment_debit_account_id in %(debit_account)s ;
-        ''', {
-            'credit_account': tuple(accounts.ids),
-            'debit_account': tuple(accounts.ids)
-        })
+            WHERE (
+                journal.payment_credit_account_id IN %(accounts)s
+                AND journal.payment_credit_account_id != journal.default_account_id
+                ) OR (
+                journal.payment_debit_account_id IN %(accounts)s
+                AND journal.payment_debit_account_id != journal.default_account_id
+            )
+        ''', {'accounts': tuple(accounts.ids)})
 
         rows = self._cr.fetchall()
         if rows:


### PR DESCRIPTION
The issue here is to be able to change the type of bank account
on the bank journal, e.g. changing from type "Current Assets" to "Bank and Cash".

Previously, a ValidationError would be raised :
"This account is configured in %(journal_names)s journal(s) (ids %(journal_ids)s)
as payment debit or credit account.
This means that this account's type should be reconcilable."

But in some cases, the client might decide not to reconcile.
And the error did not take into account the case when the bank account
and the outstanding account are the same.

opw-2738777

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
