### PR TITLE
[FIX] mail: prevents overflow in the discuss element

### DIFF
--- a/addons/mail/static/src/components/discuss_container/discuss_container.xml
+++ b/addons/mail/static/src/components/discuss_container/discuss_container.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.DiscussContainer" owl="1">
-        <div class="o_DiscussContainer d-flex flex-grow-1">
+        <div class="o_DiscussContainer d-flex flex-grow-1 flex-column">
             <Discuss t-if="messaging and messaging.discuss and messaging.discuss.discussView and messaging.isInitialized" className="'flex-grow-1'" localId="messaging.discuss.discussView.localId"/>
             <div t-else="" class="o_DiscussContainer_spinner d-flex flex-grow-1 align-items-center justify-content-center">
                 <i class="o_DiscussContainer_spinnerIcon fa fa-circle-o-notch fa-spin me-2"/>Please wait...


### PR DESCRIPTION
Before this commit* the flex parent of the discuss element
was no longer in the `column` direction, which caused an overflow in
some of its children elements, like the topBar and the composer.

This commit fixes this issue by setting the `flex-direction` of the
discuss parent to its former value.

* since https://github.com/odoo/odoo/commit/cbe1bc809538f690115e1632448258663e1f52e4
