### PR TITLE
[FIX] account_edi_ubl(_bis3): OrderReference should refer to the PO o…

### DIFF
--- a/addons/account_edi_ubl/data/ubl_templates.xml
+++ b/addons/account_edi_ubl/data/ubl_templates.xml
@@ -120,8 +120,8 @@
                 <cbc:Note t-if="note" t-esc="note"/>
                 <cbc:DocumentCurrencyCode t-esc="record.currency_id.name"/>
                 <cbc:BuyerReference t-esc="record.commercial_partner_id.name"/>
-                <cac:OrderReference t-if="record.invoice_origin">
-                    <cbc:ID t-esc="record.invoice_origin"/>
+                <cac:OrderReference t-if="record.ref">
+                    <cbc:ID t-esc="record.ref"/>
                 </cac:OrderReference>
                 <cac:AccountingSupplierParty t-call="account_edi_ubl.export_ubl_invoice_partner">
                     <t t-set="partner_vals" t-value="supplier_vals"/>

--- a/addons/account_edi_ubl_bis3/data/bis3_templates.xml
+++ b/addons/account_edi_ubl_bis3/data/bis3_templates.xml
@@ -121,8 +121,8 @@
                 <cbc:TaxCurrencyCode t-if="record.currency_id != record.company_currency_id"
                                      t-esc="record.company_currency_id.name"/>
                 <cbc:BuyerReference t-esc="record.commercial_partner_id.name"/>
-                <cac:OrderReference t-if="record.invoice_origin">
-                    <cbc:ID t-esc="record.invoice_origin"/>
+                <cac:OrderReference t-if="record.ref">
+                    <cbc:ID t-esc="record.ref"/>
                 </cac:OrderReference>
                 <cac:AccountingSupplierParty t-call="account_edi_ubl_bis3.export_bis3_invoice_partner">
                     <t t-set="partner_vals" t-value="supplier_vals"/>

--- a/addons/l10n_be_edi/tests/test_efff_export.py
+++ b/addons/l10n_be_edi/tests/test_efff_export.py
@@ -44,7 +44,7 @@ class TestUBLBE(AccountEdiTestCommon):
             'invoice_payment_term_id': self.pay_terms_b.id,
             'invoice_date': '2017-01-01',
             'date': '2017-01-01',
-            'invoice_origin': 'test invoice origin',
+            'ref': 'test invoice ref',
             'narration': 'test narration',
             'invoice_line_ids': [(0, 0, {
                 'price_unit': 1000.0,
@@ -76,7 +76,7 @@ class TestUBLBE(AccountEdiTestCommon):
                 <Note>test narration</Note>
                 <DocumentCurrencyCode>EUR</DocumentCurrencyCode>
                 <OrderReference>
-                    <ID>test invoice origin</ID>
+                    <ID>test invoice ref</ID>
                 </OrderReference>
                 <AdditionalDocumentReference>
                     <ID>efff_BE0477472701_INV201700001.pdf</ID>


### PR DESCRIPTION
…f the customer

According to https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-invoice/cac-OrderReference/
the cbc:ID in the Order Reference should be the PO number of the customer.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
