### PR TITLE
[14.0][FIX] account: add date in JSON data for payment widget on account.move

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1566,6 +1566,7 @@ class AccountMove(models.Model):
                     'position': move.currency_id.position,
                     'digits': [69, move.currency_id.decimal_places],
                     'payment_date': fields.Date.to_string(line.date),
+                    'payment_date_formatted': format_date(self.env, line.date),
                 })
 
             if not payments_widget_vals['content']:

--- a/addons/account/static/src/xml/account_payment.xml
+++ b/addons/account/static/src/xml/account_payment.xml
@@ -16,8 +16,11 @@
                         <td>
                             <a title="assign to invoice" role="button" class="oe_form_field btn btn-link outstanding_credit_assign" t-att-data-id="line.id" style="margin-right: 10px;" href="#" data-toggle="tooltip">Add</a>
                         </td>
+                        <td style="max-width: 20em;">
+                            <div class="oe_form_field" style="margin-right: 10px; text-overflow: ellipsis; overflow: hidden; white-space: nowrap;"><t t-esc="line.payment_date_formatted"></t></div>
+                        </td>
                         <td style="max-width: 30em;">
-                            <div class="oe_form_field" style="margin-right: 30px; text-overflow: ellipsis; overflow: hidden; white-space: nowrap;" t-att-title="line.date" data-toggle="tooltip"><t t-esc="line.journal_name"></t></div>
+                            <div class="oe_form_field" style="margin-right: 10px; text-overflow: ellipsis; overflow: hidden; white-space: nowrap;"><t t-esc="line.journal_name"></t></div>
                         </td>
                     </t>
                     <t t-if="!outstanding">


### PR DESCRIPTION
With this PR, the date pop-up works on the outstanding payment widget of invoice form view:

![bug_payment_widget_odoo14](https://user-images.githubusercontent.com/1157917/152997195-8a74665f-4f2d-4665-9f14-bcb38e8bd1f9.png)

Without this PR, the date pop-up doesn't show up.

Here is the corresponding XML code that shows the date pop-up: https://github.com/odoo/odoo/blob/14.0/addons/account/static/src/xml/account_payment.xml#L20


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
