### PR TITLE
[FIX] pos_sale: add user group check

### DIFF
--- a/addons/pos_sale/views/stock_template.xml
+++ b/addons/pos_sale/views/stock_template.xml
@@ -2,16 +2,18 @@
 <odoo>
     <template id="message_body" inherit_id="stock.message_body">
         <xpath expr="//t[contains(@t-if, 'move.state')]" position="inside">
-            <t t-set="pos_orders" t-value="move.sale_line_id.pos_order_line_ids.mapped('order_id')" />
-            <t t-if="len(pos_orders)">
-                <li>
-                    Delivered from
-                    <t t-foreach="pos_orders" t-as="pos_order">
-                        <a href="#" t-att-data-oe-model="pos_order._name" t-att-data-oe-id="pos_order.id">
-                            <t t-esc="pos_order.display_name" />
-                        </a><span t-if="pos_orders.ids[-1:] != pos_order.ids">, </span>
-                    </t>
-                </li>
+            <t groups="point_of_sale.group_pos_user">
+                <t t-set="pos_orders" t-value="move.sale_line_id.pos_order_line_ids.mapped('order_id')" />
+                <t t-if="len(pos_orders)">
+                    <li>
+                        Delivered from
+                        <t t-foreach="pos_orders" t-as="pos_order">
+                            <a href="#" t-att-data-oe-model="pos_order._name" t-att-data-oe-id="pos_order.id">
+                                <t t-esc="pos_order.display_name" />
+                            </a><span t-if="pos_orders.ids[-1:] != pos_order.ids">, </span>
+                        </t>
+                    </li>
+                </t>
             </t>
         </xpath>
     </template>


### PR DESCRIPTION
Steps to reproduce the bug:
- Install pos_sale
- Connect as Admin
- Create a SO with qty > 1
- Create a new user and give him:
    - “Administrator” access to inventory
    - no access to POS
- Connect with this user
- Go to the SO created by the admin > delivery
- Try to validate a partial delivery and create a backorder

Problem:
Traceback is triggered, because we are trying to read the `pos_order_line_ids` field while the user does not have access to POS

opw-2746938




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
