### PR TITLE
[IMP] account: add separate settings for digitalization and OUT invoices

### DIFF
--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -116,7 +116,7 @@ class ResConfigSettings(models.TransientModel):
     module_product_margin = fields.Boolean(string="Allow Product Margin")
     module_l10n_eu_oss = fields.Boolean(string="EU Intra-community Distance Selling")
     module_account_taxcloud = fields.Boolean(string="Account TaxCloud")
-    module_account_invoice_extract = fields.Boolean(string="Bill Digitalization")
+    module_account_invoice_extract = fields.Boolean(string="Document Digitalization")
     module_snailmail_account = fields.Boolean(string="Snailmail")
     tax_exigibility = fields.Boolean(string='Cash Basis', related='company_id.tax_exigibility', readonly=False)
     tax_cash_basis_journal_id = fields.Many2one('account.journal', related='company_id.tax_cash_basis_journal_id', string="Tax Cash Basis Journal", readonly=False)

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -386,22 +386,6 @@
                         </div>
                         <h2>Vendor Bills</h2>
                         <div class="row mt16 o_settings_container" id="account_vendor_bills">
-                            <div class="col-12 col-lg-6 o_setting_box" id="account_ocr_settings">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_account_invoice_extract" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane" id="digitalizeocr">
-                                    <label for="module_account_invoice_extract"/>
-                                    <div class="text-muted">
-                                        Digitalize your scanned or PDF vendor bills with OCR and Artificial Intelligence
-                                    </div>
-                                    <div id="msg_invoice_extract" class="content-group" attrs="{'invisible': [('module_account_invoice_extract', '=', False)]}">
-                                        <div class="text-warning mt16 mb4">
-                                            Save this page and come back here to set up the feature.
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
                             <div class="col-xs-12 col-md-6 o_setting_box" id="show_purchase_receipts">
                                 <div class="o_setting_left_pane">
                                     <field name="group_show_purchase_receipts" widget="upgrade_boolean"/>
@@ -439,6 +423,26 @@
                                     <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
                                     <div class="text-muted">
                                         Pay your bills in one-click using Euro SEPA Service
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <h2>Digitalization</h2>
+                        <div class="row mt16 o_settings_container" id="account_digitalization">
+                            <div class="col-12 col-lg-6 o_setting_box" id="account_ocr_settings">
+                                <div class="o_setting_left_pane">
+                                    <field name="module_account_invoice_extract" widget="upgrade_boolean"/>
+                                </div>
+                                <div class="o_setting_right_pane" id="digitalizeocr">
+                                    <label for="module_account_invoice_extract"/>
+                                    <div class="text-muted">
+                                        Digitalize your scanned or PDF documents with OCR and Artificial Intelligence
+                                    </div>
+                                    <div id="msg_invoice_extract" class="content-group" attrs="{'invisible': [('module_account_invoice_extract', '=', False)]}">
+                                        <div class="text-warning mt16 mb4">
+                                            Save this page and come back here to set up the feature.
+                                        </div>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
The settings that determines the digitalization mode (disabled, manual
or automatic) used to be common for both vendor bills and customer
invoices.
As many users only want to use the service on vendor bills and not on
customer invoices, the settings has been split for both types of
invoices.

Task: 2751408