### PR TITLE
[FIX] web_editor: ensure uploaded images in backend are not public

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1004,7 +1004,7 @@ const Wysiwyg = Widget.extend({
         const restoreSelection = preserveCursor(this.odooEditor.document);
 
         const $node = $(params.node);
-        const $editable = $(OdooEditorLib.closestElement(range.startContainer, '.o_editable'));
+        const $editable = $(this.odooEditor.editable);
         const model = $editable.data('oe-model');
         const field = $editable.data('oe-field');
         const type = $editable.data('oe-type');


### PR DESCRIPTION
When uploading an image in the editor, we go through `_attachment_create`, which sets the image to public if `res_model` is
`ir.ui.view` (the default if none was passed). Because of a wrong reference to the editable DOM element (which contains the `res_model` as data), when instantiating the media dialog, we were passing no `res_model`. As a result, when saving an attachment, no `res_model` was passed to `_attachment_create` and the attachment was made public. Attachments in the backend should not be public and should be linked to the proper model.

task-2759034

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
