### PR TITLE
[IMP] account: improve discount fields in move view

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -706,7 +706,7 @@
                                         <field name="quantity"/>
                                         <field name="product_uom_id" string="UoM" groups="uom.group_uom" optional="show"/>
                                         <field name="price_unit" string="Price"/>
-                                        <field name="discount" string="Disc.%" groups="base.group_no_one" optional="show"/>
+                                        <field name="discount" string="Disc.%" optional="hide"/>
                                         <field name="tax_ids" widget="many2many_tags"
                                                domain="[('type_tax_use', '=?', parent.invoice_filter_type_domain), ('company_id', '=', parent.company_id)]"
                                                context="{'append_type_to_tax_name': not parent.invoice_filter_type_domain}"
@@ -831,7 +831,7 @@
                                                 <field name="quantity"/>
                                                 <field name="product_uom_id" groups="uom.group_uom"/>
                                                 <field name="price_unit"/>
-                                                <field name="discount" groups="product.group_discount_per_so_line"/>
+                                                <field name="discount" string="Disc.%"/>
                                                 <field name="currency_id" invisible="1"/>
                                             </group>
                                             <group>

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -1169,9 +1169,6 @@
                               groups="sale.group_delivery_invoice_address"
                               attrs="{'invisible': [('type', 'not in', ('out_invoice', 'out_refund', 'out_receipt'))]}"/>
                    </xpath>
-                    <xpath expr="//field[@name='invoice_line_ids']//field[@name='discount']" position="attributes">
-                        <attribute name="groups">product.group_discount_per_so_line</attribute>
-                    </xpath>
                     <xpath expr="//group[@name='sale_info_group']/field[@name='invoice_user_id']" position="after">
                         <field name="team_id" kanban_view_ref="%(sales_team.crm_team_view_kanban)s"/>
                     </xpath>


### PR DESCRIPTION
As of now, the discount field is either only shown in
debug mode or if the sale module is installed and a
setting is set in sale.
This field should be shown in the view, and not depend
on a setting from another app.
This is especially true as it could be filled by the ocr
or when uploading from an edi, and it would be inconsistent
if the user couldn't display it.

Task id #2758965

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
