### PR TITLE
[FIX] web_editor: keep cursor in empty inline tag

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1764,7 +1764,7 @@ export class OdooEditor extends EventTarget {
             }
             stepIndex--;
         }
-    };
+    }
 
     // TOOLBAR
     // =======

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -222,6 +222,7 @@ export class OdooEditor extends EventTarget {
         if (editable.innerHTML.trim() === '') {
             editable.innerHTML = '<p><br></p>';
         }
+        this.initElementForEdition(editable);
 
         // Convention: root node is ID root.
         editable.oid = 'root';
@@ -1340,11 +1341,7 @@ export class OdooEditor extends EventTarget {
         }
         if (joinWith) {
             const el = closestElement(joinWith);
-            const { zws } = fillEmpty(el);
-            if (zws) {
-                // ZWS selection in OdooEditor is not working in current version of firefox (since v93.0)
-                setSelection(zws, 0, zws, this.isFirefox ? 0 : nodeSize(zws));
-            }
+            fillEmpty(el);
         }
     }
 
@@ -1444,6 +1441,20 @@ export class OdooEditor extends EventTarget {
             return false;
         }
         if (!sel.isCollapsed && BACKSPACE_FIRST_COMMANDS.includes(method)) {
+            let range = getDeepRange(this.editable, {sel, splitText: true, select: true, correctTripleClick: true});
+            if (range &&
+                range.startContainer === range.endContainer &&
+                range.endContainer.nodeType === Node.TEXT_NODE &&
+                range.cloneContents().textContent === '\u200B'
+            ) {
+                // We Collapse the selection and bypass deleteRange
+                // if the range content is only one ZWS.
+                sel.collapseToStart();
+                if (BACKSPACE_ONLY_COMMANDS.includes(method)) {
+                    this._applyRawCommand(method);
+                }
+                return;
+            }
             this.deleteRange(sel);
             if (BACKSPACE_ONLY_COMMANDS.includes(method)) {
                 return true;
@@ -1569,6 +1580,21 @@ export class OdooEditor extends EventTarget {
             serializeSelection(
                 useCache ? this._latestComputedSelection : this._computeHistorySelection(),
             ) || {};
+    }
+    /**
+     * Return true if the latest computed selection was inside an empty inline tag
+     *
+     * @private
+     * @return {boolean}
+     */
+    _isLatestComputedSelectionInsideEmptyInlineTag() {
+        if (!this._latestComputedSelection) {
+            return false;
+        }
+        const anchorNode = this._latestComputedSelection.anchorNode;
+        const focusNode = this._latestComputedSelection.focusNode;
+        const parentTextContent = anchorNode.parentElement? anchorNode.parentElement.textContent : null;
+        return anchorNode === focusNode && (parentTextContent === '' || parentTextContent === '\u200B')
     }
     /**
      * Get the step index in the history to undo.
@@ -2155,12 +2181,28 @@ export class OdooEditor extends EventTarget {
                 const selection = this.document.getSelection();
                 // Detect that text was selected and change behavior only if it is the case,
                 // since it is the only text insertion case that may cause problems.
-                if (anchorNodeOid !== focusNodeOid || anchorOffset !== focusOffset) {
+                const wasTextSelected = anchorNodeOid !== focusNodeOid || anchorOffset !== focusOffset;
+                // Unit tests events are not trusted by the browser,
+                // the insertText has to be done manualy.
+                const isUnitTests = !ev.isTrusted && this.testMode;
+                // we cannot trust the browser to keep the selection inside empty tags.
+                const latestSelectionInsideEmptyTag = this._isLatestComputedSelectionInsideEmptyInlineTag();
+                if (wasTextSelected || isUnitTests || latestSelectionInsideEmptyTag) {
                     ev.preventDefault();
-                    this._applyRawCommand('oDeleteBackward');
+                    if (!isUnitTests) {
+                        // First we need to undo the character inserted by the browser.
+                        // Since the unit test Event is not trusted by the browser, we don't
+                        // need to undo the char during the unit tests.
+                        // @see https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted
+                        this._applyRawCommand('oDeleteBackward');
+                    }
+                    if (latestSelectionInsideEmptyTag) {
+                        // Restore the selection inside the empty Element.
+                        const selectionBackup = this._latestComputedSelection;
+                        setSelection(selectionBackup.anchorNode, selectionBackup.anchorOffset);
+                    }
                     insertText(selection, ev.data);
-                    const range = selection.getRangeAt(0);
-                    setSelection(range.endContainer, range.endOffset);
+                    selection.collapseToEnd();
                 }
                 // Check for url after user insert a space so we won't transform an incomplete url.
                 if (
@@ -2283,6 +2325,22 @@ export class OdooEditor extends EventTarget {
             this.editable.contains(selection.anchorNode) &&
             this.editable.contains(selection.focusNode);
     }
+
+    /**
+     * Returns true if the current selection content is only one ZWS
+     *
+     * @private
+     * @param {Object} selection
+     * @returns {boolean}
+     */
+    _isSelectionOnlyZws(selection) {
+        let range = selection.getRangeAt(0);
+        if (selection.isCollapsed || !range) {
+            return false;
+        }
+        return range.cloneContents().textContent === '\u200B';
+    }
+
     getCurrentCollaborativeSelection() {
         const selection = this._latestComputedSelection || this._computeHistorySelection();
         if (!selection) return;
@@ -2302,8 +2360,60 @@ export class OdooEditor extends EventTarget {
         this.cleanForSave();
         this.observerActive();
     }
+
+    /**
+     * initialise the provided element to be ready for edition
+     *
+     */
+    initElementForEdition(element = this.editable) {
+        // Flag elements with forced contenteditable=false.
+        // We need the flag to be able to leave the contentEditable
+        // at the end of the edition (see cleanForSave())
+        for (const el of element.querySelectorAll('[contenteditable="false"]')) {
+            el.setAttribute('oe-keep-contenteditable', '');
+        }
+    }
+
     cleanForSave(element = this.editable) {
+        sanitize(element);
+
         this._pluginCall('cleanForSave', [element]);
+        // Clean the remaining ZeroWidthspaces added by the `fillEmpty` function
+        // ( contain "oe-zws-empty-inline" attr)
+        // If the element contain more than just a ZWS,
+        // we remove it and clean the attribute.
+        // If the element have a class,
+        // we only remove the attribute to ensure we don't break some style.
+        // Otherwise we remove the entire inline element.
+        for (const emptyElement of element.querySelectorAll('[oe-zws-empty-inline]')) {
+            if (emptyElement.textContent.length === 1 && emptyElement.textContent.includes('\u200B')) {
+                if (emptyElement.classList.length > 0) {
+                    emptyElement.removeAttribute('oe-zws-empty-inline');
+                } else {
+                    emptyElement.remove();
+                }
+            } else {
+                emptyElement.textContent = emptyElement.textContent.replace('\u200B', '');
+                emptyElement.removeAttribute('oe-zws-empty-inline');
+            }
+        }
+        // Remove contenteditable=false on elements
+        for (const el of element.querySelectorAll('[contenteditable="false"]')) {
+            if (!el.hasAttribute('oe-keep-contenteditable')) {
+                el.removeAttribute('contenteditable');
+            }
+        }
+        // Remove oe-keep-contenteditable on elements
+        for (const el of element.querySelectorAll('[oe-keep-contenteditable]')) {
+            el.removeAttribute('oe-keep-contenteditable');
+        }
+
+        // Remove Zero Width Spzces on Font awesome elements
+        const faSelector = 'i.fa,span.fa,i.fab,span.fab,i.fad,span.fad,i.far,span.far';
+        for (const el of element.querySelectorAll(faSelector)) {
+            el.textContent = el.textContent.replace('\u200B', '');
+        }
+
     }
     /**
      * Handle the hint preview for the commandbar.

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/deleteForward.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/deleteForward.js
@@ -1,6 +1,5 @@
 /** @odoo-module **/
 import {
-    childNodeIndex,
     findNode,
     isContentTextNode,
     isVisibleEmpty,
@@ -14,14 +13,54 @@ import {
     rightLeafOnlyNotBlockNotEditablePath,
     rightLeafOnlyPathNotBlockNotEditablePath,
     isNotEditableNode,
+    splitTextNode,
+    prepareUpdate,
+    isVisibleStr,
+    isInPre,
+    fillEmpty,
+    setSelection,
+    isZWS,
+    childNodeIndex, boundariesOut
 } from '../utils/utils.js';
 
-Text.prototype.oDeleteForward = function (offset) {
-    if (offset < this.length) {
-        this.oDeleteBackward(offset + 1);
-    } else {
-        HTMLElement.prototype.oDeleteForward.call(this.parentNode, childNodeIndex(this) + 1);
+Text.prototype.oDeleteForward = function (offset, alreadyMoved = false) {
+    const parentNode = this.parentNode;
+
+    if (offset === this.nodeValue.length) {
+        // Delete at the end of a text node is not a specific case to
+        // handle, let the element implementation handle it.
+        HTMLElement.prototype.oDeleteForward.call(this, offset, alreadyMoved);
+        return;
     }
+
+    // Get the size of the unicode character to remove.
+    const charSize = [...this.nodeValue.slice(0, offset + 1)].pop().length;
+    // Split around the character where the delete occurs.
+    const firstSplitOffset = splitTextNode(this, offset);
+    const secondSplitOffset = splitTextNode(parentNode.childNodes[firstSplitOffset], charSize);
+    const middleNode = parentNode.childNodes[firstSplitOffset];
+
+    // Do remove the character, then restore the state of the surrounding parts.
+    const restore = prepareUpdate(parentNode, firstSplitOffset, parentNode, secondSplitOffset);
+    const isSpace = !isVisibleStr(middleNode) && !isInPre(middleNode);
+    const isZWS = middleNode.nodeValue === '\u200B';
+    middleNode.remove();
+    restore();
+
+    // If the removed element was not visible content, propagate the delete.
+    if (
+        isZWS ||
+        (isSpace &&
+        getState(parentNode, firstSplitOffset, DIRECTIONS.RIGHT).cType !== CTYPES.CONTENT)
+    ) {
+        parentNode.oDeleteForward(firstSplitOffset, alreadyMoved);
+        if (isZWS) {
+            fillEmpty(parentNode);
+        }
+        return;
+    }
+    fillEmpty(parentNode);
+    setSelection(parentNode, firstSplitOffset);
 };
 
 HTMLElement.prototype.oDeleteForward = function (offset) {
@@ -29,6 +68,42 @@ HTMLElement.prototype.oDeleteForward = function (offset) {
         isVisibleEmpty(node) || isContentTextNode(node) || isNotEditableNode(node);
 
     const firstLeafNode = findNode(rightLeafOnlyNotBlockNotEditablePath(this, offset), filterFunc);
+    if (firstLeafNode &&
+        isZWS(firstLeafNode) &&
+        this.parentElement.hasAttribute('oe-zws-empty-inline')
+    ) {
+        const grandparent = this.parentElement.parentElement;
+        if (!grandparent) {
+            return;
+        }
+
+        const parentIndex = childNodeIndex(this.parentElement);
+        const restore = prepareUpdate(...boundariesOut(this.parentElement));
+        this.parentElement.remove();
+        restore();
+        HTMLElement.prototype.oDeleteForward.call(grandparent, parentIndex);
+        return;
+    }
+    if (
+        this.hasAttribute &&
+        this.hasAttribute('oe-zws-empty-inline') &&
+        (
+            isZWS(this) ||
+            (this.textContent === '' && this.childNodes.length === 0)
+        )
+    ) {
+        const parent = this.parentElement;
+        if (!parent) {
+            return;
+        }
+
+        const index = childNodeIndex(this);
+        const restore = prepareUpdate(...boundariesOut(this));
+        this.remove();
+        restore();
+        HTMLElement.prototype.oDeleteForward.call(parent, index);
+        return;
+    }
 
     if (firstLeafNode && (isFontAwesome(firstLeafNode) || isNotEditableNode(firstLeafNode))) {
         firstLeafNode.remove();

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
@@ -104,6 +104,30 @@ class Sanitize {
             node = nodeP;
         }
 
+        // Remove zero-width spaces added by `fillEmpty` when there is content.
+        if (
+            node.nodeType === Node.TEXT_NODE &&
+            node.textContent.includes('\u200B') &&
+            (
+                node.textContent.length > 1 ||
+                // There can be multiple ajacent text nodes, in which case the
+                // zero-width space is not needed either, despite being alone
+                // (length === 1) in its own text node.
+                Array.from(node.parentNode.childNodes).find(
+                    sibling =>
+                        sibling !== node &&
+                        sibling.nodeType === Node.TEXT_NODE &&
+                        sibling.length > 0
+                )
+            ) &&
+            !isBlock(node.parentElement)
+        ) {
+            const restoreCursor = preserveCursor(this.root.ownerDocument);
+            node.textContent = node.textContent.replace('\u200B', '');
+            node.parentElement.removeAttribute("oe-zws-empty-inline");
+            restoreCursor();
+        }
+
         // Remove empty blocks in <li>
         if (node.nodeName === 'P' && node.parentElement.tagName === 'LI') {
             const next = node.nextSibling;

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
@@ -13,6 +13,7 @@ import {
     isMediaElement,
     getDeepRange,
     isUnbreakable,
+    isUnremovable
 } from './utils.js';
 
 const NOT_A_NUMBER = /[^\d]/g;
@@ -51,11 +52,11 @@ export function areSimilarElements(node, node2) {
     ) {
         return false;
     }
-    if (node.tagName == 'LI' && node.classList.contains('oe-nested')) {
+    if (node.tagName === 'LI' && node.classList.contains('oe-nested')) {
         return (
             node.lastElementChild &&
             node2.firstElementChild &&
-            getListMode(node.lastElementChild) == getListMode(node2.firstElementChild)
+            getListMode(node.lastElementChild) === getListMode(node2.firstElementChild)
         );
     }
     if (['UL', 'OL'].includes(node.tagName)) {
@@ -104,7 +105,7 @@ class Sanitize {
         }
 
         // Remove empty blocks in <li>
-        if (node.nodeName == 'P' && node.parentElement.tagName == 'LI') {
+        if (node.nodeName === 'P' && node.parentElement.tagName === 'LI') {
             const next = node.nextSibling;
             const pnode = node.parentElement;
             if (isEmptyBlock(node)) {

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -1076,6 +1076,7 @@ export function isContentTextNode(node) {
  * will always return 'true' while it is sometimes invisible.
  *
  * @param {Node} node
+ * @param {boolean} areBlocksAlwaysVisible
  * @returns {boolean}
  */
 export function isVisible(node, areBlocksAlwaysVisible = true) {
@@ -1439,7 +1440,7 @@ export function clearEmpty(node) {
 }
 
 export function setTagName(el, newTagName) {
-    if (el.tagName == newTagName) {
+    if (el.tagName === newTagName) {
         return el;
     }
     var n = document.createElement(newTagName);
@@ -1578,6 +1579,7 @@ export function prepareUpdate(...args) {
  * @param {HTMLElement} el
  * @param {number} offset
  * @param {number} direction @see DIRECTIONS.LEFT @see DIRECTIONS.RIGHT
+ * @param {CTYPES} leftCType
  * @returns {Object}
  */
 export function getState(el, offset, direction, leftCType) {

--- a/addons/web_editor/static/lib/odoo-editor/test/editor-test.html
+++ b/addons/web_editor/static/lib/odoo-editor/test/editor-test.html
@@ -8,6 +8,16 @@
         <title>Odoo Editor tests</title>
 
         <link rel="stylesheet" href="lib/mocha.css" />
+        <style type="text/css">
+            b.zws {
+                background-color: #c00;
+                color: white;
+                border-radius: 3px;
+                padding: 1px 3px;
+                font-size: 8px;
+                vertical-align: middle;
+            }
+        </style>
         <script src="../src/utils/DOMPurify.js"></script>
         <script src="lib/mocha.js"></script>
         <script src="lib/chai.js"></script>

--- a/addons/web_editor/static/lib/odoo-editor/test/editor-test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/editor-test.js
@@ -25,6 +25,37 @@ mocha.run(failures => {
     } else {
         console.log('test successful');
     }
+
+    // Clean report of successful tests to ease DEV / debug
+    // just add ?clean=1
     const reportEl = document.getElementById('mocha-report');
     window.scrollTo(0, window.scrollY + reportEl.getBoundingClientRect().top);
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('clean')) {
+        console.log('Successful tests have been removed.');
+        const report = document.querySelector("#mocha-report");
+
+        let hr = document.createElement("hr");
+        report.prepend(hr);
+        let h1 = document.createElement("h1");
+        h1.textContent = "Clean : Successfull tests have been removed.";
+        report.prepend(h1);
+
+        const passedTests = report.querySelectorAll('.test.pass');
+        for (let el of passedTests) {
+            el.remove();
+        }
+
+        const cleanUl = function () {
+            const emptyUl = report.querySelectorAll('ul:empty');
+            for (let ul of emptyUl) {
+                ul.parentElement.remove();
+            }
+        };
+        for (let i = 4; i > 0; i--) {
+            cleanUl();
+        }
+
+        report.outerHTML = report.outerHTML.replaceAll('//zws//', '<b class="zws">zws</b>');
+    }
 });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/align.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/align.test.js
@@ -28,7 +28,9 @@ describe('Align', () => {
         it('should not align left a non-editable node', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>ab</p><div contenteditable="false"><p>c[]d</p></div>',
+                contentBeforeEdit: '<p>ab</p><div contenteditable="false" oe-keep-contenteditable=""><p>c[]d</p></div>',
                 stepFunction: justifyLeft,
+                contentAfterEdit: '<p>ab</p><div contenteditable="false" oe-keep-contenteditable=""><p>c[]d</p></div>',
                 contentAfter: '<p>ab</p><div contenteditable="false"><p>c[]d</p></div>',
             });
         });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/autostep.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/autostep.test.js
@@ -5,8 +5,13 @@ const timeoutPromise = ms =>
         setTimeout(() => resolve(), ms);
     });
 
-const appendSpan = element => {
+const appendSpan = (element, id = 1) => {
+    // The ID is necessary to prevent the editor to merge elements together:
+    // If multiple spans are sibblings and nothing differentiates them,
+    // the Editor will try to merge them.
     const span = document.createElement('SPAN');
+    span.id = 'id-' + id;
+    span.textContent = '*';
     element.append(span);
 };
 
@@ -38,7 +43,7 @@ describe('Autostep', () => {
                     );
                 });
             },
-            contentAfter: '<p>a[]<span></span></p>',
+            contentAfter: '<p>a[]<span id="id-1">*</span></p>',
         });
     });
     it('should not record a change not made through the editor itself', async function () {
@@ -63,7 +68,7 @@ describe('Autostep', () => {
                     );
                 });
             },
-            contentAfter: '<p>a[]<span></span></p>',
+            contentAfter: '<p>a[]<span id="id-1">*</span></p>',
         });
     });
     it('should record changes not made through the editor itself once reactivated', async function () {
@@ -79,9 +84,9 @@ describe('Autostep', () => {
                 await timeoutPromise(20);
 
                 editor.automaticStepUnactive('test');
-                appendSpan(editor.editable.querySelector('p'));
+                appendSpan(editor.editable.querySelector('p'), 1);
                 editor.automaticStepActive('test');
-                appendSpan(editor.editable.querySelector('p'));
+                appendSpan(editor.editable.querySelector('p'), 2);
 
                 await timeoutPromise(120).then(() => {
                     window.chai.assert.strictEqual(
@@ -91,7 +96,7 @@ describe('Autostep', () => {
                     );
                 });
             },
-            contentAfter: '<p>a[]<span></span><span></span></p>',
+            contentAfter: '<p>a[]<span id="id-1">*</span><span id="id-2">*</span></p>',
         });
     });
     it('should record a change not made through the editor itself if not everyone has reactivated autostep', async function () {
@@ -102,10 +107,10 @@ describe('Autostep', () => {
                 const originalHistoryLength = editor._historySteps.length;
                 editor.automaticStepUnactive('test');
                 editor.automaticStepUnactive('test2');
-                appendSpan(editor.editable.querySelector('p'));
+                appendSpan(editor.editable.querySelector('p'), 1);
                 editor.automaticStepActive('test');
 
-                appendSpan(editor.editable.querySelector('p'));
+                appendSpan(editor.editable.querySelector('p'), 2);
 
                 await timeoutPromise(120).then(() => {
                     window.chai.assert.strictEqual(
@@ -115,7 +120,7 @@ describe('Autostep', () => {
                     );
                 });
             },
-            contentAfter: '<p>a[]<span></span><span></span></p>',
+            contentAfter: '<p>a[]<span id="id-1">*</span><span id="id-2">*</span></p>',
         });
     });
 
@@ -133,11 +138,11 @@ describe('Autostep', () => {
 
                 editor.automaticStepUnactive('test');
                 editor.automaticStepUnactive('test2');
-                appendSpan(editor.editable.querySelector('p'));
+                appendSpan(editor.editable.querySelector('p'), 1);
                 editor.automaticStepActive('test');
-                appendSpan(editor.editable.querySelector('p'));
+                appendSpan(editor.editable.querySelector('p'), 2);
                 editor.automaticStepActive('test2');
-                appendSpan(editor.editable.querySelector('p'));
+                appendSpan(editor.editable.querySelector('p'), 3);
 
                 await timeoutPromise(120).then(() => {
                     window.chai.assert.strictEqual(
@@ -147,7 +152,7 @@ describe('Autostep', () => {
                     );
                 });
             },
-            contentAfter: '<p>a[]<span></span><span></span><span></span></p>',
+            contentAfter: '<p>a[]<span id="id-1">*</span><span id="id-2">*</span><span id="id-3">*</span></p>',
         });
     });
 });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -2251,7 +2251,7 @@ X[]
                 it('should insert line breaks outside the edges of an anchor', async () => {
                     const pressEnter = editor => {
                         editor.document.execCommand('insertParagraph');
-                    }
+                    };
                     await testEditor(BasicEditor, {
                         contentBefore: '<div>ab<a>[]cd</a></div>',
                         stepFunction: pressEnter,
@@ -2729,7 +2729,7 @@ X[]
                 contentAfter: '<p>a<span><span style="color: tomato;">[b</span><span><span style="color: tomato;">c]</span>d</span>e</span>f</p>',
             });
         });
-    })
+    });
 
     describe('setTagName', () => {
         describe('to paragraph', () => {

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -85,6 +85,81 @@ describe('Editor', () => {
                         contentAfter: '<p>[]abc</p>',
                     });
                 });
+                it('should ignore ZWS', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>ab[]\u200Bc</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<p>ab[]</p>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>de[]\u200B</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<p>de[]</p>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>[]\u200Bf</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<p>[]<br></p>',
+                    });
+                });
+                it('should delete through ZWS and Empty Inline', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>a[]b<span class="style">c</span>de</p>',
+                        stepFunction: async editor => {
+                            await deleteForward(editor);
+                            await deleteForward(editor);
+                            await deleteForward(editor);
+                        },
+                        contentAfter: '<p>a[]e</p>',
+                    });
+                });
+                it('ZWS: should delete element content but keep cursor in', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>ab<span class="style">[]cd</span>ef</p>',
+                        stepFunction: async editor => {
+                            await deleteForward(editor);
+                            await deleteForward(editor);
+                        },
+                        contentAfterEdit: '<p>ab<span class="style" oe-zws-empty-inline="">[]\u200B</span>ef</p>',
+                        contentAfter: '<p>ab<span class="style">[]\u200B</span>ef</p>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>ab<span class="style">[]cd</span>ef</p>',
+                        stepFunction: async editor => {
+                            await deleteForward(editor);
+                            await deleteForward(editor);
+                            await insertText(editor, 'x');
+                        },
+                        contentAfter: '<p>ab<span class="style">x[]</span>ef</p>',
+                    });
+                });
+                it('should ignore ZWS and merge', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p><span class="removeme" oe-zws-empty-inline="">[]\u200B</span><b>ab</b></p>',
+                        contentBeforeEdit: '<p><span class="removeme" oe-zws-empty-inline="">[]\u200B</span><b>ab</b></p>',
+                        stepFunction: async editor => {
+                            await deleteForward(editor);
+                            await insertText(editor, 'x');
+                        },
+                        contentAfter: '<p><b>x[]b</b></p>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p><span class="removeme" oe-zws-empty-inline="">[]\u200B</span><span>cd</span></p>',
+                        stepFunction: async editor => {
+                            await deleteForward(editor);
+                            await insertText(editor, 'x');
+                        },
+                        contentAfter: '<p><span>x[]d</span></p>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p><span class="removeme" oe-zws-empty-inline="">[]\u200B</span><br><b>ef</b></p>',
+                        stepFunction: async editor => {
+                            await deleteForward(editor);
+                            await insertText(editor, 'x');
+                        },
+                        contentAfter: '<p><b>x[]ef</b></p>',
+                    });
+                });
                 it('should not break unbreakables', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore:
@@ -753,12 +828,62 @@ X[]
                     contentAfter: '<p>ab[]ef</p>',
                 });
             });
-            it('should not delete styling nodes if not selected', async () => {
+            it('should delete empty nodes ', async () => {
                 // Forward selection
                 await testEditor(BasicEditor, {
                     contentBefore: '<h1><font>[abcdef]</font></h1>',
                     stepFunction: deleteForward,
-                    contentAfter: '<h1><font>[]</font><br></h1>',
+                    contentAfter: '<h1>[]<br></h1>',
+                });
+            });
+            it('should not delete styling nodes if not selected', async () => {
+                // deleteForward selection
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span class="style-class">[bcde]</span>f</p>',
+                    stepFunction: deleteForward,
+                    contentAfter: '<p>a<span class="style-class">[]\u200B</span>f</p>',
+                });
+                // deleteBackward selection
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span class="style-class">[bcde]</span>f</p>',
+                    stepFunction: deleteBackward,
+                    contentAfter: '<p>a<span class="style-class">[]\u200B</span>f</p>',
+                });
+            });
+            it('should delete styling nodes when delete if empty', async () => {
+                // deleteBackward selection
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab <span class="style-class">[cd]</span> ef</p>',
+                    stepFunction: async editor => {
+                        await deleteBackward(editor);
+                        await deleteBackward(editor);
+                    },
+                    contentAfter: '<p>ab[]&nbsp;ef</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>uv<span class="style-class">[wx]</span>yz</p>',
+                    stepFunction: async editor => {
+                        await deleteBackward(editor);
+                        await deleteBackward(editor);
+                    },
+                    contentAfter: '<p>u[]yz</p>',
+                });
+                // deleteForward selection
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab <span class="style-class">[cd]</span> ef</p>',
+                    stepFunction: async editor => {
+                        await deleteForward(editor);
+                        await deleteForward(editor);
+                    },
+                    contentAfter: '<p>ab []ef</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>uv<span class="style-class">[wx]</span>yz</p>',
+                    stepFunction: async editor => {
+                        await deleteForward(editor);
+                        await deleteForward(editor);
+                    },
+                    contentAfter: '<p>uv[]z</p>',
                 });
             });
             it('should delete across two paragraphs', async () => {
@@ -892,7 +1017,7 @@ X[]
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>ab<b class="oe_unremovable">[cd]</b>ef</p>',
                     stepFunction: deleteForward,
-                    contentAfter: '<p>ab<b class="oe_unremovable">[\u200B]</b>ef</p>',
+                    contentAfter: '<p>ab<b class="oe_unremovable">[]\u200B</b>ef</p>',
                 });
             });
         });
@@ -961,6 +1086,118 @@ X[]
                         contentBefore: '<p><br></p><p>[]abc</p>',
                         stepFunction: deleteBackward,
                         contentAfter: '<p>[]abc</p>',
+                    });
+                });
+                it('should ignore ZWS', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>ab\u200B[]c</p>',
+                        stepFunction: deleteBackward,
+                        contentAfter: '<p>a[]c</p>',
+                    });
+                });
+                it('should keep inline block', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div><p>ab</p><br><span>c[]</span></div>',
+                        stepFunction: deleteBackward,
+                        contentAfterEdit: '<div><p>ab</p><br><span oe-zws-empty-inline="">[]\u200B</span></div>',
+                        contentAfter: '<div><p>ab</p><br>[]</div>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div><p>uv</p><br><span class="style">w[]</span></div>',
+                        stepFunction: deleteBackward,
+                        contentAfterEdit: '<div><p>uv</p><br><span class="style" oe-zws-empty-inline="">[]\u200B</span></div>',
+                        contentAfter: '<div><p>uv</p><br><span class="style">[]\u200B</span></div>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div><p>cd</p><br><span>e[]</span></div>',
+                        stepFunction: async editor => {
+                            await deleteBackward(editor);
+                            await insertText(editor, 'x');
+                        },
+                        contentAfterEdit: '<div><p>cd</p><br><span>x[]</span></div>',
+                        contentAfter: '<div><p>cd</p><br><span>x[]</span></div>',
+                    });
+                });
+                it('should delete through ZWS and Empty Inline', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>ab<span class="style">c</span>d[]e</p>',
+                        stepFunction: async editor => {
+                            await deleteBackward(editor);
+                            await deleteBackward(editor);
+                            await deleteBackward(editor);
+                        },
+                        contentAfter: '<p>a[]e</p>',
+                    });
+                });
+                it('ZWS: should delete element content but keep cursor in', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>uv<i style="color:red">w[]</i>xy</p>',
+                        stepFunction: async editor => {
+                            await deleteBackward(editor);
+                            await insertText(editor, 'i');
+                        },
+                        contentAfterEdit: '<p>uv<i style="color:red">i[]</i>xy</p>',
+                        contentAfter: '<p>uv<i style="color:red">i[]</i>xy</p>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>ab<span class="style">cd[]</span>ef</p>',
+                        stepFunction: async editor => {
+                            await deleteBackward(editor);
+                            await deleteBackward(editor);
+                        },
+                        contentAfterEdit: '<p>ab<span class="style" oe-zws-empty-inline="">[]\u200B</span>ef</p>',
+                        contentAfter: '<p>ab<span class="style">[]\u200B</span>ef</p>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>ab<span class="style">cd[]</span>ef</p>',
+                        stepFunction: async editor => {
+                            await deleteBackward(editor);
+                            await deleteBackward(editor);
+                            await insertText(editor, 'x');
+                        },
+                        contentAfterEdit: '<p>ab<span class="style">x[]</span>ef</p>',
+                        contentAfter: '<p>ab<span class="style">x[]</span>ef</p>',
+                    });
+                });
+                it('should ignore ZWS and merge', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p><b>ab</b><span class="removeme" oe-zws-empty-inline="">[]\u200B</span></p>',
+                        stepFunction: async editor => {
+                            await deleteBackward(editor);
+                            await insertText(editor, 'x');
+                        },
+                        contentAfter: '<p><b>ax[]</b></p>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p><span>cd</span><span class="removeme" oe-zws-empty-inline="">[]\u200B</span></p>',
+                        stepFunction: async editor => {
+                            await deleteBackward(editor);
+                            await insertText(editor, 'x');
+                        },
+                        contentAfter: '<p><span>cx[]</span></p>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p><b>ef</b><br><span class="removeme" oe-zws-empty-inline="">[]\u200B</span></p>',
+                        stepFunction: async editor => {
+                            await deleteBackward(editor);
+                            await insertText(editor, 'x');
+                        },
+                        contentAfter: '<p><b>efx[]</b></p>',
+                    });
+                });
+                it('should ignore ZWS and merge', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div><p>ab</p><span>[]\u200B</span></div>',
+                        stepFunction: deleteBackward,
+                        contentAfter: '<div><p>ab[]</p></div>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div><p>cd</p><br><span>[]\u200B</span></div>',
+                        stepFunction: async editor => {
+                            await deleteBackward(editor);
+                            await insertText(editor, 'x');
+                        },
+                        contentAfter: '<div><p>cd</p>x[]</div>',
                     });
                 });
                 it('should not break unbreakables', async () => {
@@ -1767,6 +2004,43 @@ X[]
             });
         });
         describe('Selection not collapsed', () => {
+            it('ZWS : should keep inline block', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div><p>ab <span class="style">[c]</span> d</p></div>',
+                    stepFunction: async editor => {
+                        await deleteBackward(editor);
+                    },
+                    contentAfterEdit: '<div><p>ab <span class="style" oe-zws-empty-inline="">[]\u200B</span> d</p></div>',
+                    contentAfter: '<div><p>ab <span class="style">[]\u200B</span> d</p></div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div><p>ab <span class="style">[c]</span> d</p></div>',
+                    stepFunction: async editor => {
+                        await deleteBackward(editor);
+                        await insertText(editor, 'x');
+                    },
+                    contentAfterEdit: '<div><p>ab <span class="style">x[]</span> d</p></div>',
+                    contentAfter: '<div><p>ab <span class="style">x[]</span> d</p></div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div><p>ab<span class="style">[c]</span>d</p></div>',
+                    stepFunction: async editor => {
+                        await deleteBackward(editor);
+                        await insertText(editor, 'x');
+                    },
+                    contentAfterEdit: '<div><p>ab<span class="style">x[]</span>d</p></div>',
+                    contentAfter: '<div><p>ab<span class="style">x[]</span>d</p></div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div><p>ab <span class="style">[cde]</span> f</p></div>',
+                    stepFunction: async editor => {
+                        await deleteBackward(editor);
+                        await insertText(editor, 'x');
+                    },
+                    contentAfterEdit: '<div><p>ab <span class="style">x[]</span> f</p></div>',
+                    contentAfter: '<div><p>ab <span class="style">x[]</span> f</p></div>',
+                });
+            });
             it('should delete part of the text within a paragraph', async () => {
                 // Forward selection
                 await testEditor(BasicEditor, {
@@ -1965,7 +2239,7 @@ X[]
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>ab<b class="oe_unremovable">[cd]</b>ef</p>',
                     stepFunction: deleteBackward,
-                    contentAfter: '<p>ab<b class="oe_unremovable">[\u200B]</b>ef</p>',
+                    contentAfter: '<p>ab<b class="oe_unremovable">[]\u200B</b>ef</p>',
                 });
             });
         });
@@ -2366,6 +2640,27 @@ X[]
                     contentBefore: '<p>]abcd[</p>',
                     stepFunction: insertParagraphBreak,
                     contentAfter: '<p><br></p><p>[]<br></p>',
+                });
+            });
+        });
+    });
+
+    describe('insertLineBreak', () => {
+        describe('Selection not collapsed', () => {
+            it('should insert a char into an empty span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab<span>[]\u200B</span>cd</p>',
+                    stepFunction: async editor => {
+                        await insertText(editor, 'x');
+                    },
+                    contentAfter: '<p>ab<span>x[]</span>cd</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>uv <span>[]\u200B</span> wx</p>',
+                    stepFunction: async editor => {
+                        await insertText(editor, 'y');
+                    },
+                    contentAfter: '<p>uv <span>y[]</span> wx</p>',
                 });
             });
         });
@@ -3091,12 +3386,12 @@ X[]
                 await testEditor(OdooEditor, {
                     contentBefore: '<p>[]</p>',
                     stepFunction: async editor => {
-                        insertText(editor, 'a');
-                        insertText(editor, 'b');
-                        insertText(editor, 'c');
+                        await insertText(editor, 'a');
+                        await insertText(editor, 'b');
+                        await insertText(editor, 'c');
                         undo(editor);
                         undo(editor);
-                        insertText(editor, 'd');
+                        await insertText(editor, 'd');
                         undo(editor);
                         undo(editor);
                         redo(editor);
@@ -3109,12 +3404,12 @@ X[]
                 await testEditor(OdooEditor, {
                     contentBefore: '<p>[]</p>',
                     stepFunction: async editor => {
-                        insertText(editor, 'a');
-                        insertText(editor, 'b');
-                        insertText(editor, 'c');
+                        await insertText(editor, 'a');
+                        await insertText(editor, 'b');
+                        await insertText(editor, 'c');
                         undo(editor);
                         undo(editor);
-                        insertText(editor, 'd');
+                        await insertText(editor, 'd');
                         undo(editor);
                         redo(editor);
                         redo(editor);

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/fontAwesome.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/fontAwesome.test.js
@@ -5,98 +5,114 @@ describe('FontAwesome', () => {
         it('should parse an old-school fontawesome', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p><i class="fa fa-star"></i></p>',
-                contentAfter: '<p><i class="fa fa-star" contenteditable="false">\u200b</i></p>',
+                contentBeforeEdit: '<p><i class="fa fa-star" contenteditable="false">\u200b</i></p>',
+                contentAfter: '<p><i class="fa fa-star"></i></p>',
             });
         });
         it('should parse a brand fontawesome', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p><i class="fab fa-opera"></i></p>',
-                contentAfter: '<p><i class="fab fa-opera" contenteditable="false">\u200b</i></p>',
+                contentBeforeEdit: '<p><i class="fab fa-opera" contenteditable="false">\u200b</i></p>',
+                contentAfter: '<p><i class="fab fa-opera"></i></p>',
             });
         });
         it('should parse a duotone fontawesome', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p><i class="fad fa-bus-alt"></i></p>',
-                contentAfter: '<p><i class="fad fa-bus-alt" contenteditable="false">\u200b</i></p>',
+                contentBeforeEdit: '<p><i class="fad fa-bus-alt" contenteditable="false">\u200b</i></p>',
+                contentAfter: '<p><i class="fad fa-bus-alt"></i></p>',
             });
         });
         it('should parse a light fontawesome', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p><i class="fab fa-accessible-icon"></i></p>',
-                contentAfter:
+                contentBeforeEdit:
                     '<p><i class="fab fa-accessible-icon" contenteditable="false">\u200b</i></p>',
+                contentAfter: '<p><i class="fab fa-accessible-icon"></i></p>',
             });
         });
         it('should parse a regular fontawesome', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p><i class="far fa-money-bill-alt"></i></p>',
-                contentAfter:
+                contentBeforeEdit:
                     '<p><i class="far fa-money-bill-alt" contenteditable="false">\u200b</i></p>',
+                contentAfter: '<p><i class="far fa-money-bill-alt"></i></p>',
             });
         });
         it('should parse a solid fontawesome', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p><i class="fa fa-pastafarianism"></i></span></p>',
-                contentAfter:
+                contentBeforeEdit:
                     '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i></p>',
+                contentAfter: '<p><i class="fa fa-pastafarianism"></i></p>',
             });
         });
         it('should parse a fontawesome in a <span>', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p><span class="fa fa-pastafarianism"></span></p>',
-                contentAfter:
+                contentBeforeEdit:
                     '<p><span class="fa fa-pastafarianism" contenteditable="false">\u200b</span></p>',
+                contentAfter: '<p><span class="fa fa-pastafarianism"></span></p>',
             });
         });
         it('should parse a fontawesome in a <i>', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p><i class="fa fa-pastafarianism"></i></i></p>',
-                contentAfter:
+                contentBeforeEdit:
                     '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i></p>',
+                contentAfter: '<p><i class="fa fa-pastafarianism"></i></p>',
             });
         });
         it('should parse a fontawesome with more classes', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p><i class="red fa bordered fa-pastafarianism big"></i></p>',
-                contentAfter:
+                contentBeforeEdit:
                     '<p><i class="red fa bordered fa-pastafarianism big" contenteditable="false">\u200b</i></p>',
+                contentAfter: '<p><i class="red fa bordered fa-pastafarianism big"></i></p>',
             });
         });
         it('should parse a fontawesome with multi-line classes', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: `<p><i class="fa
                                 fa-pastafarianism"></i></p>`,
-                contentAfter: `<p><i class="fa
+                contentBeforeEdit: `<p><i class="fa
                                 fa-pastafarianism" contenteditable="false">\u200b</i></p>`,
+                contentAfter: `<p><i class="fa
+                                fa-pastafarianism"></i></p>`,
             });
         });
         it('should parse a fontawesome with more multi-line classes', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: `<p><i class="red fa bordered
                                 big fa-pastafarianism scary"></i></p>`,
-                contentAfter: `<p><i class="red fa bordered
+                contentBeforeEdit: `<p><i class="red fa bordered
                                 big fa-pastafarianism scary" contenteditable="false">\u200b</i></p>`,
+                contentAfter: `<p><i class="red fa bordered
+                                big fa-pastafarianism scary"></i></p>`,
             });
         });
         it('should parse a fontawesome at the beginning of a paragraph', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p><i class="fa fa-pastafarianism"></i>a[b]c</p>',
-                contentAfter:
+                contentBeforeEdit:
                     '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>a[b]c</p>',
+                contentAfter: '<p><i class="fa fa-pastafarianism"></i>a[b]c</p>',
             });
         });
         it('should parse a fontawesome in the middle of a paragraph', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>a[b]c<i class="fa fa-pastafarianism"></i>def</p>',
-                contentAfter:
+                contentBeforeEdit:
                     '<p>a[b]c<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>def</p>',
+                contentAfter: '<p>a[b]c<i class="fa fa-pastafarianism"></i>def</p>',
             });
         });
         it('should parse a fontawesome at the end of a paragraph', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>a[b]c<i class="fa fa-pastafarianism"></i></p>',
-                contentAfter:
+                contentBeforeEdit:
                     '<p>a[b]c<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i></p>',
+                contentAfter: '<p>a[b]c<i class="fa fa-pastafarianism"></i></p>',
             });
         });
         /** not sure this is necessary, keep for now in case it is
@@ -185,6 +201,7 @@ describe('FontAwesome', () => {
                 it('should delete a fontawesome', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>ab[]<i class="fa fa-pastafarianism"></i>cd</p>',
+                        contentBeforeEdit: '<p>ab[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>cd</p>',
                         stepFunction: deleteForward,
                         contentAfter: '<p>ab[]cd</p>',
                     });
@@ -192,54 +209,66 @@ describe('FontAwesome', () => {
                 it('should not delete a fontawesome', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>ab<i class="fa fa-pastafarianism"></i>[]cd</p>',
+                        contentBeforeEdit: '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]cd</p>',
                         stepFunction: deleteForward,
-                        contentAfter:
+                        contentAfterEdit:
                             '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]d</p>',
+                        contentAfter: '<p>ab<i class="fa fa-pastafarianism"></i>[]d</p>',
                     });
                 });
                 it('should not delete a fontawesome after multiple deleteForward', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>ab[]cde<i class="fa fa-pastafarianism"></i>fghij</p>',
+                        contentBeforeEdit: '<p>ab[]cde<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>fghij</p>',
                         stepFunction: async editor => {
                             await deleteForward(editor);
                             await deleteForward(editor);
                             await deleteForward(editor);
                         },
-                        contentAfter:
+                        contentAfterEdit:
                             '<p>ab[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>fghij</p>',
+                        contentAfter: '<p>ab[]<i class="fa fa-pastafarianism"></i>fghij</p>',
                     });
                 });
                 it('should not delete a fontawesome after one deleteForward with spaces', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>ab[] <i class="fa fa-pastafarianism"></i> cd</p>',
+                        contentBeforeEdit: '<p>ab[] <i class="fa fa-pastafarianism" contenteditable="false">\u200b</i> cd</p>',
                         stepFunction: async editor => {
                             await deleteForward(editor);
                         },
-                        contentAfter:
+                        contentAfterEdit:
                             '<p>ab[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i> cd</p>',
+                        contentAfter:
+                            '<p>ab[]<i class="fa fa-pastafarianism"></i> cd</p>',
                     });
                 });
                 it('should not delete a fontawesome after multiple deleteForward with spaces', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>a[]b <i class="fa fa-pastafarianism"></i> cd</p>',
+                        contentBeforeEdit: '<p>a[]b <i class="fa fa-pastafarianism" contenteditable="false">\u200b</i> cd</p>',
                         stepFunction: async editor => {
                             await deleteForward(editor);
                             await deleteForward(editor);
                         },
-                        contentAfter:
+                        contentAfterEdit:
                             '<p>a[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i> cd</p>',
+                        contentAfter:
+                            '<p>a[]<i class="fa fa-pastafarianism"></i> cd</p>',
                     });
                 });
                 it('should not delete a fontawesome after multiple deleteForward with spaces inside a <span>', async () => {
                     await testEditor(BasicEditor, {
-                        contentBefore:
-                            '<div><span>ab[]c </span><i class="fa fa-star"></i> def</div>',
+                        contentBefore: '<div><span>ab[]c </span><i class="fa fa-star"></i> def</div>',
+                        contentBeforeEdit:
+                            '<div><span>ab[]c </span><i class="fa fa-star" contenteditable="false">\u200b</i> def</div>',
                         stepFunction: async editor => {
                             await deleteForward(editor);
                             await deleteForward(editor);
                         },
-                        contentAfter:
+                        contentAfterEdit:
                             '<div><span>ab[]</span><i class="fa fa-star" contenteditable="false">\u200b</i> def</div>',
+                        contentAfter: '<div><span>ab[]</span><i class="fa fa-star"></i> def</div>',
                     });
                 });
             });
@@ -269,57 +298,71 @@ describe('FontAwesome', () => {
                 it('should delete a fontawesome', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>ab<i class="fa fa-pastafarianism"></i>[]cd</p>',
+                        contentBeforeEdit:
+                            '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]cd</p>',
                         stepFunction: deleteBackward,
                         contentAfter: '<p>ab[]cd</p>',
                     });
                 });
                 it('should delete a fontawesome before a span', async () => {
                     await testEditor(BasicEditor, {
-                        contentBefore:
-                            '<p>ab<i class="fa fa-pastafarianism"></i><span>[]cd</span></p>',
+                        contentBefore: '<p>ab<i class="fa fa-pastafarianism"></i><span>[]cd</span></p>',
+                        contentBeforeEdit:
+                            '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i><span>[]cd</span></p>',
                         stepFunction: deleteBackward,
                         contentAfter: '<p>ab<span>[]cd</span></p>',
                     });
                 });
                 it('should not delete a fontawesome before a span', async () => {
                     await testEditor(BasicEditor, {
-                        contentBefore:
-                            '<p>ab<i class="fa fa-pastafarianism"></i><span>c[]d</span></p>',
+                        contentBefore: '<p>ab<i class="fa fa-pastafarianism"></i><span>c[]d</span></p>',
+                        contentBeforeEdit:
+                            '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i><span>c[]d</span></p>',
                         stepFunction: deleteBackward,
-                        contentAfter:
+                        contentAfterEdit:
                             '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i><span>[]d</span></p>',
+                        contentAfter: '<p>ab<i class="fa fa-pastafarianism"></i><span>[]d</span></p>',
                     });
                 });
                 it('should not delete a fontawesome', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>ab[]<i class="fa fa-pastafarianism"></i>cd</p>',
+                        contentBeforeEdit:
+                            '<p>ab[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>cd</p>',
                         stepFunction: deleteBackward,
-                        contentAfter:
+                        contentAfterEdit:
                             '<p>a[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>cd</p>',
+                        contentAfter: '<p>a[]<i class="fa fa-pastafarianism"></i>cd</p>',
                     });
                 });
                 it('should not delete a fontawesome after multiple deleteBackward', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>abcde<i class="fa fa-pastafarianism"></i>fgh[]ij</p>',
+                        contentBeforeEdit:
+                            '<p>abcde<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>fgh[]ij</p>',
                         stepFunction: async editor => {
                             await deleteBackward(editor);
                             await deleteBackward(editor);
                             await deleteBackward(editor);
                         },
-                        contentAfter:
+                        contentAfterEdit:
                             '<p>abcde<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]ij</p>',
+                        contentAfter: '<p>abcde<i class="fa fa-pastafarianism"></i>[]ij</p>',
                     });
                 });
                 it('should not delete a fontawesome after multiple deleteBackward with spaces', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>abcde <i class="fa fa-pastafarianism"></i> fg[]hij</p>',
+                        contentBeforeEdit:
+                            '<p>abcde <i class="fa fa-pastafarianism" contenteditable="false">\u200b</i> fg[]hij</p>',
                         stepFunction: async editor => {
                             await deleteBackward(editor);
                             await deleteBackward(editor);
                             await deleteBackward(editor);
                         },
-                        contentAfter:
+                        contentAfterEdit:
                             '<p>abcde <i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]hij</p>',
+                        contentAfter: '<p>abcde <i class="fa fa-pastafarianism"></i>[]hij</p>',
                     });
                 });
             });
@@ -350,8 +393,9 @@ describe('FontAwesome', () => {
                 stepFunction: async editor => {
                     editor.execCommand('insertFontAwesome', 'fa fa-star');
                 },
-                contentAfter:
+                contentAfterEdit:
                     '<p><i class="fa fa-star" contenteditable="false">\u200b</i>[]abc</p>',
+                contentAfter: '<p><i class="fa fa-star"></i>[]abc</p>',
             });
         });
         it('should insert a fontAwesome within an element', async () => {
@@ -360,8 +404,9 @@ describe('FontAwesome', () => {
                 stepFunction: async editor => {
                     editor.execCommand('insertFontAwesome', 'fa fa-star');
                 },
-                contentAfter:
+                contentAfterEdit:
                     '<p>ab<i class="fa fa-star" contenteditable="false">\u200b</i>[]cd</p>',
+                contentAfter: '<p>ab<i class="fa fa-star"></i>[]cd</p>',
             });
         });
         it('should insert a fontAwesome at the end of an element', async () => {
@@ -370,8 +415,9 @@ describe('FontAwesome', () => {
                 stepFunction: async editor => {
                     editor.execCommand('insertFontAwesome', 'fa fa-star');
                 },
-                contentAfter:
+                contentAfterEdit:
                     '<p>abc<i class="fa fa-star" contenteditable="false">\u200b</i>[]</p>',
+                contentAfter: '<p>abc<i class="fa fa-star"></i>[]</p>',
             });
         });
         it('should insert a fontAwesome after', async () => {
@@ -380,18 +426,23 @@ describe('FontAwesome', () => {
                 stepFunction: async editor => {
                     editor.execCommand('insertFontAwesome', 'fa fa-star');
                 },
-                contentAfter:
+                contentAfterEdit:
                     '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>c<i class="fa fa-star" contenteditable="false">\u200b</i>[]d</p>',
+                contentAfter:
+                    '<p>ab<i class="fa fa-pastafarianism"></i>c<i class="fa fa-star"></i>[]d</p>',
             });
         });
         it('should insert a fontAwesome before', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>ab[]<i class="fa fa-pastafarianism"></i>cd</p>',
+                contentBeforeEdit: '<p>ab[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>cd</p>',
                 stepFunction: async editor => {
                     editor.execCommand('insertFontAwesome', 'fa fa-star');
                 },
-                contentAfter:
+                contentAfterEdit:
                     '<p>ab<i class="fa fa-star" contenteditable="false">\u200b</i>[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>cd</p>',
+                contentAfter:
+                    '<p>ab<i class="fa fa-star"></i>[]<i class="fa fa-pastafarianism"></i>cd</p>',
             });
         });
         it.skip('should insert a fontAwesome and replace the icon', async () => {
@@ -401,7 +452,7 @@ describe('FontAwesome', () => {
                     editor.execCommand('insertFontAwesome', 'fa fa-star');
                 },
                 contentAfter:
-                    '<p>abs<i class="fa fa-star" contenteditable="false">\u200b</i>[]cd</p>',
+                    '<p>abs<i class="fa fa-star"></i>[]cd</p>',
             });
         });
     });
@@ -409,21 +460,25 @@ describe('FontAwesome', () => {
         it('should insert a character before', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>ab[]<i class="fa fa-pastafarianism"></i>cd</p>',
+                contentBeforeEdit: '<p>ab[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>cd</p>',
                 stepFunction: async editor => {
                     await insertText(editor, 's');
                 },
-                contentAfter:
+                contentAfterEdit:
                     '<p>abs[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>cd</p>',
+                contentAfter: '<p>abs[]<i class="fa fa-pastafarianism"></i>cd</p>',
             });
         });
         it('should insert a character after', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>ab<i class="fa fa-pastafarianism"></i>[]cd</p>',
+                contentBeforeEdit: '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]cd</p>',
                 stepFunction: async editor => {
                     await insertText(editor, 's');
                 },
-                contentAfter:
+                contentAfterEdit:
                     '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>s[]cd</p>',
+                contentAfter: '<p>ab<i class="fa fa-pastafarianism"></i>s[]cd</p>',
             });
         });
         it.skip('should insert a character and replace the icon', async () => {

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/insertHTML.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/insertHTML.test.js
@@ -8,8 +8,9 @@ describe('insetHTML', () => {
                 stepFunction: async editor => {
                     await editor.execCommand('insertHTML', '<i class="fa fa-pastafarianism"></i>');
                 },
-                contentAfter:
-                    '<p><i class="fa fa-pastafarianism" contenteditable="false">​</i>[]<br></p>',
+                contentAfterEdit:
+                    '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]<br></p>',
+                contentAfter: '<p><i class="fa fa-pastafarianism"></i>[]<br></p>',
             });
         });
         it('should insert html after an empty paragraph', async () => {
@@ -18,8 +19,9 @@ describe('insetHTML', () => {
                 stepFunction: async editor => {
                     await editor.execCommand('insertHTML', '<i class="fa fa-pastafarianism"></i>');
                 },
-                contentAfter:
-                    '<p><br></p><i class="fa fa-pastafarianism" contenteditable="false">​</i>[]',
+                contentAfterEdit:
+                    '<p><br></p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]',
+                contentAfter: '<p><br></p><i class="fa fa-pastafarianism"></i>[]',
             });
         });
         it('should insert html between two letters', async () => {
@@ -28,8 +30,9 @@ describe('insetHTML', () => {
                 stepFunction: async editor => {
                     await editor.execCommand('insertHTML', '<i class="fa fa-pastafarianism"></i>');
                 },
-                contentAfter:
-                    '<p>a<i class="fa fa-pastafarianism" contenteditable="false">​</i>[]b<br></p>',
+                contentAfterEdit:
+                    '<p>a<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]b<br></p>',
+                contentAfter: '<p>a<i class="fa fa-pastafarianism"></i>[]b<br></p>',
             });
         });
         it('should insert html in an empty editable', async () => {
@@ -38,7 +41,8 @@ describe('insetHTML', () => {
                 stepFunction: async editor => {
                     await editor.execCommand('insertHTML', '<i class="fa fa-pastafarianism"></i>');
                 },
-                contentAfter: '<i class="fa fa-pastafarianism" contenteditable="false">​</i>[]<br>',
+                contentAfterEdit: '<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]<br>',
+                contentAfter: '<i class="fa fa-pastafarianism"></i>[]<br>',
             });
         });
         it('should insert html in between naked text in the editable', async () => {
@@ -47,8 +51,9 @@ describe('insetHTML', () => {
                 stepFunction: async editor => {
                     await editor.execCommand('insertHTML', '<i class="fa fa-pastafarianism"></i>');
                 },
-                contentAfter:
-                    'a<i class="fa fa-pastafarianism" contenteditable="false">​</i>[]b<br>',
+                contentAfterEdit:
+                    'a<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]b<br>',
+                contentAfter: 'a<i class="fa fa-pastafarianism"></i>[]b<br>',
             });
         });
         it('should insert several html nodes in between naked text in the editable', async () => {
@@ -68,7 +73,8 @@ describe('insetHTML', () => {
                 stepFunction: async editor => {
                     await editor.execCommand('insertHTML', '<i class="fa fa-pastafarianism"></i>');
                 },
-                contentAfter: '<i class="fa fa-pastafarianism" contenteditable="false">​</i>[]<br>',
+                contentAfterEdit: '<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]<br>',
+                contentAfter: '<i class="fa fa-pastafarianism"></i>[]<br>',
             });
         });
         it('should delete selection and insert html in its place', async () => {
@@ -77,8 +83,9 @@ describe('insetHTML', () => {
                 stepFunction: async editor => {
                     await editor.execCommand('insertHTML', '<i class="fa fa-pastafarianism"></i>');
                 },
-                contentAfter:
-                    'a<i class="fa fa-pastafarianism" contenteditable="false">​</i>[]c<br>',
+                contentAfterEdit:
+                    'a<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]c<br>',
+                contentAfter: 'a<i class="fa fa-pastafarianism"></i>[]c<br>',
             });
         });
     });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/utils.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/utils.test.js
@@ -35,7 +35,15 @@ import {
 } from '../../src/utils/utils.js';
 import { BasicEditor, testEditor } from '../utils.js';
 
+const cleanTestHtml = () => {
+    const testElements = document.querySelectorAll('body>div[contenteditable=true]');
+    Array.prototype.forEach.call(testElements, function(node) {
+        node.parentNode.removeChild(node);
+    });
+    return true;
+};
 const insertTestHtml = innerHtml => {
+    cleanTestHtml();
     const container = document.createElement('DIV');
     container.setAttribute('contenteditable', true);
     container.innerHTML = innerHtml;
@@ -1409,6 +1417,7 @@ describe('Utils', () => {
                 const result = isVisible(textNode);
 
                 window.chai.expect(result).to.be.ok;
+                cleanTestHtml();
             });
         });
     });
@@ -1462,6 +1471,13 @@ describe('Utils', () => {
             const result = splitAroundUntil(cde, p.childNodes[1]);
             window.chai.expect(result.every(node => node === undefined)).to.be.ok;
             window.chai.expect(p.outerHTML).to.eql('<p>a<font>b<span>cde</span>f</font>g</p>');
+        });
+    });
+
+    describe('CleanUp Html', () => {
+        it('should not affect future tests => clean', () => {
+            const res = cleanTestHtml();
+            window.chai.expect(res).to.be.true;
         });
     });
 });

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1908,7 +1908,6 @@ const Wysiwyg = Widget.extend({
         // remove ZeroWidthSpace from odoo field value
         // ZeroWidthSpace may be present from OdooEditor edition process
         let escapedHtml = this._getEscapedElement($el).prop('outerHTML');
-        escapedHtml = escapedHtml.replace(/[\u200B-\u200D\uFEFF]/g, '');
 
         return this._rpc({
             model: 'ir.ui.view',


### PR DESCRIPTION
Ensure the user can keep typing inside a newly emptied inline tag.

Some changes had to be made to the deleteForward and backward commands,
to ensure the new behaviors.

task-2622455

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
