### PR TITLE
[FIX] web: fix the traceback

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -720,7 +720,8 @@ class ExportXlsxWriter:
         # Write main header
         for i, fieldname in enumerate(self.field_names):
             self.write(0, i, fieldname, self.header_style)
-        self.worksheet.set_column(0, i, 30) # around 220 pixels
+        if self.field_names:
+            self.worksheet.set_column(0, i, 30) # around 220 pixels
 
     def close(self):
         self.workbook.close()


### PR DESCRIPTION
Problem occurs when we try to export report data and click
'I want to update data (import-compatible export)'.
We might end up exporting data when only field to export
is - External ID (id).

To reproduce an issue (for example):
Go to Time Off/Reporting/by Type; Remove filters from search.
Select couple records, then Action/Export.
On the wizard, click on 'I want to update data (import-compatible export)'.
Click on External ID from 'Available fields' to add it to 'Fields to export'.
Click export.

It gives traceback -
File "/data/build/odoo/addons/web/controllers/main.py", line 710,
 in write_header self.worksheet.set_column(0, i, 30) # around 220 pixels
UnboundLocalError: local variable 'i' referenced before assignment

task - 2687370

