### PR TITLE
[FIX] hr: Fix timezone issue on last_activity_time computation

### DIFF
--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -95,7 +95,7 @@ class HrEmployeeBase(models.AbstractModel):
                 last_activity_datetime = last_presence.replace(tzinfo=UTC).astimezone(timezone(tz)).replace(tzinfo=None)
                 employee.last_activity = last_activity_datetime.date()
                 if employee.last_activity == fields.Date.today():
-                    employee.last_activity_time = format_time(self.env, last_activity_datetime, time_format='short')
+                    employee.last_activity_time = format_time(self.env, last_presence, time_format='short')
                 else:
                     employee.last_activity_time = False
             else:


### PR DESCRIPTION
Purpose
=======

for example: in Europe/Brussels timezone, the presence
hour of an employee using this timezone is up with one hour.

The issue is that we give a localized time to format_time pretending
it's not (removing the tzinfo), so it's converted twice.

Specification
=============
To solve the issue, just give the time in UTC to format_time.

opw-2741634