### PR TITLE
[FIX] web_editor: properly add image in editable rather than in toolbar

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1050,6 +1050,7 @@ const Wysiwyg = Widget.extend({
 
     _configureToolbar: function (options) {
         const $toolbar = this.toolbar.$el;
+        $toolbar.on('mousedown', e => e.preventDefault());
         const openTools = e => {
             e.preventDefault();
             e.stopImmediatePropagation();


### PR DESCRIPTION
In mass_mailing, when clicking the media button in the toolbar, the image would end up being added to the media button itself rather than at the selection. That is because the selection had been replaced by the button. This fixes it by preventing default behavior of the mousedown event on toolbar (thereby preventing the change of selection).

task-2745984

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
