### PR TITLE
[FIX] event_sale: Added a domain condition on attendee_count in SO

### DIFF
--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -40,7 +40,8 @@ class SaleOrder(models.Model):
 
     def _compute_attendee_count(self):
         sale_orders_data = self.env['event.registration'].read_group(
-            [('sale_order_id', 'in', self.ids)],
+            [('sale_order_id', 'in', self.ids),
+             ('state', '!=', 'cancel')],
             ['sale_order_id'], ['sale_order_id']
         )
         attendee_count_data = {


### PR DESCRIPTION
Reproduction:
1. Start the process to buy (register) 2 tickets for an event
2. Go back to “review order” and reduce the quantity to 1
3. Sign up with a new portal user and create an account
4. Change the number of tickets to 2

Reason: the seats_expected in event.event has a different computation
logic from the attendee_count in sale.order. In event.event, the
seats_expected does not count canceled registrations. In sale.order, the
attendee_count counts the canceled registrations. But they are both
shown as "Attendees" in the statinfo widget of form views

Fix: Added a domain condition to filter out canceled registrations when
computing attendee_count in SO

opw-2739310


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
