### PR TITLE
[FIX] mrp: clean default_mo_ids when making backorder

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1417,6 +1417,9 @@ class MrpProduction(models.Model):
 
     def _get_backorder_mo_vals(self):
         self.ensure_one()
+        if not self.procurement_group_id:
+            # in the rare case that the procurement group has been removed somehow, create a new one
+            self.procurement_group_id = self.env["procurement.group"].create({'name': self.name})
         next_seq = max(self.procurement_group_id.mrp_production_ids.mapped("backorder_sequence"), default=1)
         return {
             'name': self._get_name_backorder(self.name, next_seq + 1),

--- a/addons/mrp/wizard/mrp_consumption_warning.py
+++ b/addons/mrp/wizard/mrp_consumption_warning.py
@@ -29,11 +29,13 @@ class MrpConsumptionWarning(models.TransientModel):
             wizard.consumption = "strict" in consumption_map and "strict" or "warning" in consumption_map and "warning" or "flexible"
 
     def action_confirm(self):
+        ctx = dict(self.env.context)
+        ctx.pop('default_mrp_production_ids', None)
         action_from_do_finish = False
         if self.env.context.get('from_workorder'):
             if self.env.context.get('active_model') == 'mrp.workorder':
                 action_from_do_finish = self.env['mrp.workorder'].browse(self.env.context.get('active_id')).do_finish()
-        action_from_mark_done = self.mrp_production_ids.with_context(skip_consumption=True).button_mark_done()
+        action_from_mark_done = self.mrp_production_ids.with_context(ctx, skip_consumption=True).button_mark_done()
         return action_from_do_finish or action_from_mark_done
 
     def action_cancel(self):

--- a/addons/mrp/wizard/mrp_production_backorder.py
+++ b/addons/mrp/wizard/mrp_production_backorder.py
@@ -34,5 +34,7 @@ class MrpProductionBackorder(models.TransientModel):
         return self.mrp_production_ids.with_context(skip_backorder=True).button_mark_done()
 
     def action_backorder(self):
+        ctx = dict(self.env.context)
+        ctx.pop('default_mrp_production_ids', None)
         mo_ids_to_backorder = self.mrp_production_backorder_line_ids.filtered(lambda l: l.to_backorder).mrp_production_id.ids
-        return self.mrp_production_ids.with_context(skip_backorder=True, mo_ids_to_backorder=mo_ids_to_backorder).button_mark_done()
+        return self.mrp_production_ids.with_context(ctx, skip_backorder=True, mo_ids_to_backorder=mo_ids_to_backorder).button_mark_done()


### PR DESCRIPTION
Steps to reproduce:
- create 2 stored products: "Test Manufacture" and "Test Component",
- create reordering rule (RR),e.g. min=1, max=5, for "Test Component"
  and set its route = Manufacture
- create 2 BoMs:
  - 1 for "Test Manufacture" that has component = "Test Component"
  - 1 for "Test Component" that has any component (e.g. screw)
- create + confirm a MO for "Test Manufacture" w/ product_qty = 5
- cancel the auto-generated MO (via RR) for "Test Component"
- set qty_producing=1 for "Test Manufacture" + validate + create
  backorder
- 2 new MOs are created: 2 new MOs, the backordered MO + the RR MO

Expected result: backordered MO linked to original MO via
  "procurement_group_id"
Actual result: original MO is linked to RR MO via "procurement_group_id"

Issue is due to "default_mrp_production_ids" in context during backorder
wizard creation which is reused by the RR MO's create, which calls a
procurement_group.create() that also reuses the same context. This
context makes it so the newly created procurement group is linked to
both the RR MO and the original MO. Therefore we remove this default
value from the context.

There is a rare case that a user may remove the procurement group of the
original MO. Therefore to ensure that generated backorders are still
linked to the original MO, we ensure that a MO has a new procurement
group created + assigned that will be used by its backorders. We ignore
the case where a procurement group is removed after backorders have
already been created because there's not much we can do about that.

Fixes: odoo/odoo#83742



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
