### PR TITLE
[FIX] web_editor: prevent traceback on destroy link tools

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -177,6 +177,7 @@ export class OdooEditor extends EventTarget {
         // --------------
 
         this.document = options.document || document;
+        this.isDestroyed = false;
 
         this.isMobile = matchMedia('(max-width: 767px)').matches;
         this.isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
@@ -346,6 +347,7 @@ export class OdooEditor extends EventTarget {
         this._resizeObserver.disconnect();
         clearInterval(this._snapshotInterval);
         this._pluginCall('destroy', []);
+        this.isDestroyed = true;
     }
 
     sanitize() {

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -66,7 +66,9 @@ const LinkTools = Link.extend({
         this.$button.removeClass('active');
         this.options.wysiwyg.odooEditor.observerActive();
         this.applyLinkToDom(this._getData());
-        this.options.wysiwyg.odooEditor.historyStep();
+        if (!this.options.wysiwyg.odooEditor.isDestroyed) {
+            this.options.wysiwyg.odooEditor.historyStep();
+        }
         this._observer.disconnect();
         this._super(...arguments);
     },


### PR DESCRIPTION
When saving a mailing with the link tools open, link tools' destroy is called after OdooEditor's destroy, causing a traceback when link tools tries to set a history step.

task-2733825

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
