### PR TITLE
[FIX] product: allow basic users to print product labels

### DIFF
--- a/addons/product/security/ir.model.access.csv
+++ b/addons/product/security/ir.model.access.csv
@@ -26,4 +26,4 @@ access_product_attribute_custom_value_manager,product.attribute.custom value man
 access_product_product_attribute_manager,product.template.attribute value manager,model_product_template_attribute_value,base.group_system,1,1,1,1
 access_product_template_attribute_exclusion_manager,product.template.attribute exclusion manager,model_product_template_attribute_exclusion,base.group_system,1,1,1,1
 access_product_template_attribute_line_manager,product.template.attribute line manager,model_product_template_attribute_line,base.group_system,1,1,1,1
-access_product_label_layout_user,product.label.layout.user,model_product_label_layout,base.group_system,1,1,1,1
+access_product_label_layout_user,product.label.layout.user,model_product_label_layout,base.group_user,1,1,1,1


### PR DESCRIPTION
Steps to reproduce the bug:
- Login as Marc Demo
- Go to any product and try to print labels

Problem:
An access error is triggered, the basic user needs to have the access rights "Administration / Settings" to be able to print product labels

Solution:
Administrators and basic users should be able to print product labels

opw-2746963




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
