### PR TITLE
[FIX] website_form: fix form ids generation

### DIFF
--- a/addons/website_form/static/src/snippets/s_website_form/options.js
+++ b/addons/website_form/static/src/snippets/s_website_form/options.js
@@ -59,7 +59,7 @@ const FormEditor = options.Class.extend({
      * @returns {string} The new ID
      */
     _generateUniqueID() {
-        return Math.random().toString(36).substring(2, 15);
+        return `o${Math.random().toString(36).substring(2, 15)}`;
     },
     /**
      * Returns a field object


### PR DESCRIPTION
In order to respect the good practices of HTML, it is preferable that
the IDs of HTML elements do not start with a number. This makes it
easier to handle CSS selectors etc.

see https://github.com/odoo/odoo/pull/80217#discussion_r787636826

task-2760205

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
