### PR TITLE
[FIX] website: prevent input and datepicker interaction in edit mode

### DIFF
--- a/addons/website/static/src/scss/website.edit_mode.scss
+++ b/addons/website/static/src/scss/website.edit_mode.scss
@@ -153,3 +153,19 @@ table.editorbar-panel {
         cursor: pointer;
     }
 }
+
+// Inputs in editable zones should not be possible to interact with.
+// TODO as this was done as a fix in 13.0, this only targets the inputs of
+// specific snippets and even targets snippets of other apps (which do not
+// declare files for edit mode only). In master it should be refactored to
+// target all inputs and/or target specific snippets in their own app.
+.editor_enable {
+    .s_website_form, .s_wsale_products_searchbar_input, .js_subscribe, .js_follow_alias {
+        input {
+            pointer-events: none;
+        }
+    }
+    .s_website_form [data-toggle="datetimepicker"] {
+        pointer-events: none;
+    }
+}


### PR DESCRIPTION
Before this commit, during edit mode, the user was able to interact with
form elements. It was somehow prevented by some JS code by losing the
focus immediatly but it was not enough: if typing quickly the user was
able to type text. But the real problem was the user seeing the input
focused for half a second then not anymore, making him think a bug
occured. Worse, the datepickers of the form snippet were able to be used
entirely during edit mode, making the user think it is possible to
configure a default value (which is not true in 13.0). In following
versions, the bug is indeed worse as it messes up with the default
values configuration.

This commit fixes that via CSS, still allowing a click on the elements
to be considered as a click on the parent, but preventing to focus our
snippet inputs (this fix is limited to our own snippets as stable fix).
Note: the JS code which prevents the focus right now was not found (if
it even exists...) but it would not be ok to remove it in stable anyway.
More investigation and review will be done once this reaches master.

task-2523496