### PR TITLE
[FIX] sale: allow overriding portal domain

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -20,17 +20,25 @@ class CustomerPortal(CustomerPortal):
 
         SaleOrder = request.env['sale.order']
         if 'quotation_count' in counters:
-            values['quotation_count'] = SaleOrder.search_count([
-                ('message_partner_ids', 'child_of', [partner.commercial_partner_id.id]),
-                ('state', 'in', ['sent', 'cancel'])
-            ]) if SaleOrder.check_access_rights('read', raise_exception=False) else 0
+            values['quotation_count'] = SaleOrder.search_count(self._prepare_quotations_domain(partner)) \
+                if SaleOrder.check_access_rights('read', raise_exception=False) else 0
         if 'order_count' in counters:
-            values['order_count'] = SaleOrder.search_count([
-                ('message_partner_ids', 'child_of', [partner.commercial_partner_id.id]),
-                ('state', 'in', ['sale', 'done'])
-            ]) if SaleOrder.check_access_rights('read', raise_exception=False) else 0
+            values['order_count'] = SaleOrder.search_count(self._prepare_orders_domain(partner)) \
+                if SaleOrder.check_access_rights('read', raise_exception=False) else 0
 
         return values
+
+    def _prepare_quotations_domain(self, partner):
+        return [
+            ('message_partner_ids', 'child_of', [partner.commercial_partner_id.id]),
+            ('state', 'in', ['sent', 'cancel'])
+        ]
+
+    def _prepare_orders_domain(self, partner):
+        return [
+            ('message_partner_ids', 'child_of', [partner.commercial_partner_id.id]),
+            ('state', 'in', ['sale', 'done'])
+        ]
 
     def _order_get_page_view_values(self, order, access_token, **kwargs):
         values = {
@@ -75,10 +83,7 @@ class CustomerPortal(CustomerPortal):
         partner = request.env.user.partner_id
         SaleOrder = request.env['sale.order']
 
-        domain = [
-            ('message_partner_ids', 'child_of', [partner.commercial_partner_id.id]),
-            ('state', 'in', ['sent', 'cancel'])
-        ]
+        domain = self._prepare_quotations_domain(partner)
 
         searchbar_sortings = {
             'date': {'label': _('Order Date'), 'order': 'date_order desc'},
@@ -125,10 +130,7 @@ class CustomerPortal(CustomerPortal):
         partner = request.env.user.partner_id
         SaleOrder = request.env['sale.order']
 
-        domain = [
-            ('message_partner_ids', 'child_of', [partner.commercial_partner_id.id]),
-            ('state', 'in', ['sale', 'done'])
-        ]
+        domain = self._prepare_orders_domain(partner)
 
         searchbar_sortings = {
             'date': {'label': _('Order Date'), 'order': 'date_order desc'},


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Before this commit the only way to modify the domain is to completely override portal_my_quotes /portal_my_orders .

Current behavior before PR: Since this function is so big this is not clean/easy to do now. Besides of this we use twice the same domain written in two functions.

Desired behavior after PR is merged:
By creating a separate function we can simply override it and we can reuse the function on two places.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
