### PR TITLE
[IMP] l10n_no: update Norwegian tax report

### DIFF
--- a/addons/l10n_no/__manifest__.py
+++ b/addons/l10n_no/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name" : "Norway - Accounting",
-    "version" : "2.0",
+    "version" : "2.1",
     "author" : "Rolv Råen",
     'category': 'Accounting/Localizations/Account Charts',
     "description": """This is the module to manage the accounting chart for Norway in Odoo.

--- a/addons/l10n_no/data/account_tax_data.xml
+++ b/addons/l10n_no/data/account_tax_data.xml
@@ -19,7 +19,7 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2711'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_14')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_1')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
@@ -31,7 +31,7 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2711'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_14')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_1')],
                 }),
             ]"/>
         </record>
@@ -44,6 +44,7 @@
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_0"/>
+            <field name="active" eval="False"/>
             <field name="invoice_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
@@ -78,26 +79,26 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_3')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_3')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2701'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_3_tax')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_3_tax')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_3')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_3')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2701'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_3_tax')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_3_tax')],
                 }),
             ]"/>
         </record>
@@ -114,7 +115,7 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_6')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_5')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
@@ -125,7 +126,7 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_6')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_5')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
@@ -146,7 +147,7 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_1')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_6')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
@@ -157,7 +158,7 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_1')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_6')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
@@ -213,7 +214,7 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2713'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_15')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_11')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
@@ -225,7 +226,7 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2713'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_15')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_11')],
                 }),
             ]"/>
         </record>
@@ -234,10 +235,11 @@
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">12 Inngående mva råfisk 11%</field>
             <field name="description">Fradrag for inngående mva</field>
-            <field name="amount">11</field>
+            <field name="amount">11.11</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_15"/>
+            <field name="active" eval="False"/>
             <field name="invoice_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
@@ -246,8 +248,8 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2713'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_15')],
+                    'account_id': ref('chart2710'),
+                    'plus_report_line_ids': [ref('tax_report_line_code_12')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
@@ -258,8 +260,8 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2713'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_15')],
+                    'account_id': ref('chart2710'),
+                    'minus_report_line_ids': [ref('tax_report_line_code_12')],
                 }),
             ]"/>
         </record>
@@ -281,7 +283,7 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2714'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_16')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_13')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
@@ -293,7 +295,7 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2714'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_16')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_13')],
                 }),
             ]"/>
         </record>
@@ -315,7 +317,7 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2711'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_17')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_14')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
@@ -327,7 +329,7 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2711'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_17')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_14')],
                 }),
             ]"/>
         </record>
@@ -349,7 +351,7 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2713'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_18')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_15')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
@@ -361,7 +363,7 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2713'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_18')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_15')],
                 }),
             ]"/>
         </record>
@@ -468,26 +470,26 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_4')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_31')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2703'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_4_tax')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_31_tax')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_4')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_31')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2703'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_4_tax')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_31_tax')],
                 }),
             ]"/>
         </record>
@@ -496,34 +498,35 @@
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">32 Utgående mva råfisk 11%</field>
             <field name="description">Utgående mva</field>
-            <field name="amount">11</field>
+            <field name="amount">11.11</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
             <field name="tax_group_id" ref="tax_group_15"/>
+            <field name="active" eval="False"/>
             <field name="invoice_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_4')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_32')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2703'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_4_tax')],
+                    'account_id': ref('chart2700'),
+                    'plus_report_line_ids': [ref('tax_report_line_code_32_tax')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_4')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_32')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2703'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_4_tax')],
+                    'account_id': ref('chart2700'),
+                    'minus_report_line_ids': [ref('tax_report_line_code_32_tax')],
                 }),
             ]"/>
         </record>
@@ -540,43 +543,44 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_5')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_33')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2704'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_5_tax')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_33_tax')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_5')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_33')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2704'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_5_tax')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_33_tax')],
                 }),
             ]"/>
         </record>
 
         <record id="tax18" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
-            <field name="name">51 Innenlands omsetning med omvendt avgiftsplikt nullsats 0%</field>
-            <field name="description">Innlands omsetning med omvendt avgiftsplikt</field>
+            <field name="name">51 Salg av klimakvoter og gull til næringsdrivende 0%</field>
+            <field name="description">Salg av klimakvoter og gull til næringsdrivende</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
             <field name="tax_group_id" ref="tax_group_0"/>
+            <field name="active" eval="False"/>
             <field name="invoice_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_7')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_51')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
@@ -587,7 +591,7 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_7')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_51')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
@@ -608,7 +612,7 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_8')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_52')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
@@ -619,7 +623,7 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_8')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_52')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
@@ -640,26 +644,38 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_9')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_81')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2711'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_9_tax'), ref('account_tax_report_line_post_17')],
+                    'account_id': ref('chart2741'),
+                    'plus_report_line_ids': [ref('tax_report_line_code_81_tax')],
+                }),
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart2727'),
+                    'plus_report_line_ids': [ref('tax_report_line_code_81_tax')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_9')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_81')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2701'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_9_tax'), ref('account_tax_report_line_post_17')],
+                    'account_id': ref('chart2741'),
+                    'minus_report_line_ids': [ref('tax_report_line_code_81_tax')],
+                }),
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart2727'),
+                    'minus_report_line_ids': [ref('tax_report_line_code_81_tax')],
                 }),
             ]"/>
         </record>
@@ -676,26 +692,26 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_9')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_82')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2701'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_9_tax')],
+                    'account_id': ref('chart2741'),
+                    'plus_report_line_ids': [ref('tax_report_line_code_82_tax')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_9')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_82')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2701'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_9_tax')],
+                    'account_id': ref('chart2741'),
+                    'minus_report_line_ids': [ref('tax_report_line_code_82_tax')],
                 }),
             ]"/>
         </record>
@@ -712,26 +728,38 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_10')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_83')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2713'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_10_tax')],
+                    'account_id': ref('chart2742'),
+                    'plus_report_line_ids': [ref('tax_report_line_code_83_tax')],
+                }),
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart2728'),
+                    'plus_report_line_ids': [ref('tax_report_line_code_83_tax')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_10')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_83')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2703'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_10_tax')],
+                    'account_id': ref('chart2742'),
+                    'minus_report_line_ids': [ref('tax_report_line_code_83_tax')],
+                }),
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart2728'),
+                    'minus_report_line_ids': [ref('tax_report_line_code_83_tax')],
                 }),
             ]"/>
         </record>
@@ -748,26 +776,26 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_10')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_84')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2703'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_10_tax')],
+                    'account_id': ref('chart2742'),
+                    'plus_report_line_ids': [ref('tax_report_line_code_84_tax')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_10')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_84')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2703'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_10_tax')],
+                    'account_id': ref('chart2742'),
+                    'minus_report_line_ids': [ref('tax_report_line_code_84_tax')],
                 }),
             ]"/>
         </record>
@@ -784,7 +812,7 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_11')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_85')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
@@ -795,7 +823,7 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_11')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_85')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
@@ -816,26 +844,38 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_12')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_86')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2712'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_12_tax'), ref('account_tax_report_line_post_17')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_86_tax')],
+                }),
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart2702'),
+                    'plus_report_line_ids': [ref('tax_report_line_code_86_tax')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_12')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_86')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
+                    'account_id': ref('chart2712'),
+                    'minus_report_line_ids': [ref('tax_report_line_code_86_tax')],
+                }),
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
                     'account_id': ref('chart2702'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_12_tax'), ref('account_tax_report_line_post_17')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_86_tax')],
                 }),
             ]"/>
         </record>
@@ -852,26 +892,26 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_12')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_87')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2702'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_12_tax')],
+                    'account_id': ref('chart2712'),
+                    'plus_report_line_ids': [ref('tax_report_line_code_87_tax')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_12')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_87')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2702'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_12_tax')],
+                    'account_id': ref('chart2712'),
+                    'minus_report_line_ids': [ref('tax_report_line_code_87_tax')],
                 }),
             ]"/>
         </record>
@@ -884,30 +924,43 @@
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_12"/>
+            <field name="active" eval="False"/>
             <field name="invoice_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_12')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_88')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart2712'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_12_tax'), ref('account_tax_report_line_post_17')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_88_tax')],
+                }),
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart2702'),
+                    'plus_report_line_ids': [ref('tax_report_line_code_88_tax')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_12')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_88')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
+                    'account_id': ref('chart2712'),
+                    'minus_report_line_ids': [ref('tax_report_line_code_88_tax')],
+                }),
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
                     'account_id': ref('chart2702'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_12_tax'), ref('account_tax_report_line_post_17')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_88_tax')],
                 }),
             ]"/>
         </record>
@@ -920,30 +973,31 @@
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_12"/>
+            <field name="active" eval="False"/>
             <field name="invoice_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_12')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_89')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2702'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_12_tax')],
+                    'account_id': ref('chart2712'),
+                    'plus_report_line_ids': [ref('tax_report_line_code_89_tax')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_12')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_89')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2702'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_12_tax')],
+                    'account_id': ref('chart2712'),
+                    'minus_report_line_ids': [ref('tax_report_line_code_89_tax')],
                 }),
             ]"/>
         </record>
@@ -956,30 +1010,43 @@
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_25"/>
+            <field name="active" eval="False"/>
             <field name="invoice_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_13')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_91')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2712'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_13_tax'), ref('account_tax_report_line_post_14')],
+                    'account_id': ref('chart2711'),
+                    'plus_report_line_ids': [ref('tax_report_line_code_91_tax')],
+                }),
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart2701'),
+                    'plus_report_line_ids': [ref('tax_report_line_code_91_tax')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_13')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_91')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2702'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_13_tax'), ref('account_tax_report_line_post_14')],
+                    'account_id': ref('chart2711'),
+                    'minus_report_line_ids': [ref('tax_report_line_code_91_tax')],
+                }),
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart2701'),
+                    'minus_report_line_ids': [ref('tax_report_line_code_91_tax')],
                 }),
             ]"/>
         </record>
@@ -992,30 +1059,31 @@
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_25"/>
+            <field name="active" eval="False"/>
             <field name="invoice_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_13')],
+                    'plus_report_line_ids': [ref('tax_report_line_code_92')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2702'),
-                    'plus_report_line_ids': [ref('account_tax_report_line_post_13_tax')],
+                    'account_id': ref('chart2711'),
+                    'plus_report_line_ids': [ref('tax_report_line_code_92_tax')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_13')],
+                    'minus_report_line_ids': [ref('tax_report_line_code_92')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('chart2702'),
-                    'minus_report_line_ids': [ref('account_tax_report_line_post_13_tax')],
+                    'account_id': ref('chart2711'),
+                    'minus_report_line_ids': [ref('tax_report_line_code_92_tax')],
                 }),
             ]"/>
         </record>

--- a/addons/l10n_no/data/account_tax_report_data.xml
+++ b/addons/l10n_no/data/account_tax_report_data.xml
@@ -1,290 +1,474 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <!-- Tax report for Norway (January 2022)
+         Tax codes are related to the SAF-T codes  -->
+
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.no"/>
     </record>
 
-    <record id="account_tax_report_line_samlet_omsetning" model="account.tax.report.line">
-        <field name="name">A. Samlet omsetning, uttak og innførsel</field>
+    <record id="tax_report_line_sales_goods_services_homeland" model="account.tax.report.line">
+        <!-- Sales of goods and services in Norway -->
+        <field name="name">Salg av varer og tjenester i Norge</field>
+        <field name="sequence" eval="0"/>
+        <field name="report_id" ref="tax_report"/>
+        <field name="formula">None</field>
+    </record>
+
+    <record id="tax_report_line_code_3" model="account.tax.report.line">
+        <!-- Sales and withdrawals of goods and services (high rate 25%) - base -->
+        <field name="name">3 Salg og uttak av varer og tjenester (høy sats 25%) - grunnlag</field>
+        <field name="tag_name">3 Base</field>
+        <field name="code">BASE_3</field>
+        <field name="sequence" eval="0"/>
+        <field name="parent_id" ref="tax_report_line_sales_goods_services_homeland"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_code_3_tax" model="account.tax.report.line">
+        <!-- Sales and withdrawals of goods and services (high rate 25%) - tax -->
+        <field name="name">3 Salg og uttak av varer og tjenester (høy sats 25%) - avgift</field>
+        <field name="tag_name">3 Tax</field>
+        <field name="code">TAX_3</field>
         <field name="sequence" eval="1"/>
+        <field name="parent_id" ref="tax_report_line_sales_goods_services_homeland"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_post_1" model="account.tax.report.line">
-        <field name="name">Post 1 Samlet omsetning og uttak utenfor merverdiavgiftsloven</field>
-        <field name="tag_name">Post 1</field>
-        <field name="code">NOTAX_01</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_samlet_omsetning"/>
+    <record id="tax_report_line_code_31" model="account.tax.report.line">
+        <!-- Sales and withdrawals of goods and services (middle rate 15%) - base -->
+        <field name="name">31 Salg og uttak av varer og tjenester (middels sats 15%) - grunnlag</field>
+        <field name="tag_name">31 Base</field>
+        <field name="code">BASE_31</field>
+        <field name="sequence" eval="2"/>
+        <field name="parent_id" ref="tax_report_line_sales_goods_services_homeland"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_post_2" model="account.tax.report.line">
-        <field name="name">Post 2 Samlet omsetning og uttak innenfor merverdiavgiftloven og innførsel</field>
-        <field name="formula">NOTAX_03+NOTAX_04+NOTAX_05+NOTAX_06+NOTAX_07+NOTAX_08</field>
-        <field name="code">NOTAX_02</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_samlet_omsetning"/>
+    <record id="tax_report_line_code_31_tax" model="account.tax.report.line">
+        <!-- Sales and withdrawals of goods and services (middle rate 15%) - tax -->
+        <field name="name">31 Salg og uttak av varer og tjenester (middels sats 15%) - avgift</field>
+        <field name="tag_name">31 Tax</field>
+        <field name="code">TAX_31</field>
+        <field name="sequence" eval="3"/>
+        <field name="parent_id" ref="tax_report_line_sales_goods_services_homeland"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_innenlands_omsetning" model="account.tax.report.line">
-        <field name="name">B. Innenlands omsetning og uttak</field>
+    <record id="tax_report_line_code_33" model="account.tax.report.line">
+        <!-- Sales and withdrawals of goods and services (low rate 12%) - base -->
+        <field name="name">33 Salg og uttak av varer og tjenester (lav sats 12%) - grunnlag</field>
+        <field name="tag_name">33 Base</field>
+        <field name="code">BASE_33</field>
+        <field name="sequence" eval="4"/>
+        <field name="parent_id" ref="tax_report_line_sales_goods_services_homeland"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_code_33_tax" model="account.tax.report.line">
+        <!-- Sales and withdrawals of goods and services (low rate 12%) - tax -->
+        <field name="name">33 Salg og uttak av varer og tjenester (lav sats 12%) - avgift</field>
+        <field name="tag_name">33 Tax</field>
+        <field name="code">TAX_33</field>
+        <field name="sequence" eval="5"/>
+        <field name="parent_id" ref="tax_report_line_sales_goods_services_homeland"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_code_5" model="account.tax.report.line">
+        <!-- Sales and withdrawals of goods and services that are exempt from VAT (0%) -->
+        <field name="name">5 Salg og uttak av varer og tjenester som er fritatt for merverdiavgift (0%)</field>
+        <field name="tag_name">5 Base</field>
+        <field name="code">BASE_5</field>
+        <field name="sequence" eval="6"/>
+        <field name="parent_id" ref="tax_report_line_sales_goods_services_homeland"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_code_6" model="account.tax.report.line">
+        <!-- Sale of goods and services that are exempt from the VAT Act (0%) -->
+        <field name="name">6 Salg av varer og tjenester som er unntatt merverdiavgiftsloven (0%)</field>
+        <field name="tag_name">6 Base</field>
+        <field name="code">BASE_6</field>
+        <field name="sequence" eval="7"/>
+        <field name="parent_id" ref="tax_report_line_sales_goods_services_homeland"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_sales_goods_services_abroad" model="account.tax.report.line">
+        <!-- Sales of goods and services to other countries -->
+        <field name="name">Salg av varer og tjenester til utlandet</field>
         <field name="sequence" eval="2"/>
         <field name="report_id" ref="tax_report"/>
+        <field name="formula">None</field>
     </record>
 
-    <record id="account_tax_report_line_post_3" model="account.tax.report.line">
-        <field name="name">Post 3 Innenlands omsetning og uttak, og beregnet avgift 25 %</field>
-        <field name="tag_name">Post 3 Base</field>
-        <field name="code">NOTAX_03</field>
+    <record id="tax_report_line_code_52" model="account.tax.report.line">
+        <!-- Sales of goods and services abroad that are exempt from VAT (0%) -->
+        <field name="name">52 Salg av varer og tjenester til utlandet som er fritatt for merverdiavgift (0%)</field>
+        <field name="tag_name">52 Base</field>
+        <field name="code">BASE_52</field>
         <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innenlands_omsetning"/>
+        <field name="parent_id" ref="tax_report_line_sales_goods_services_abroad"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_post_3_tax" model="account.tax.report.line">
-        <field name="name">Post 3 Innenlands omsetning og uttak, og beregnet avgift 25 % Tax</field>
-        <field name="tag_name">Post 3 Tax</field>
-        <field name="code">NOTAX_03_1</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innenlands_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_4" model="account.tax.report.line">
-        <field name="name">Post 4 Innenlands omsetning og uttak, og beregnet avgift 15 %</field>
-        <field name="tag_name">Post 4 Base</field>
-        <field name="code">NOTAX_04</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innenlands_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_4_tax" model="account.tax.report.line">
-        <field name="name">Post 4 Innenlands omsetning og uttak, og beregnet avgift 15 % Tax</field>
-        <field name="tag_name">Post 4 Tax</field>
-        <field name="code">NOTAX_04_1</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innenlands_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_5" model="account.tax.report.line">
-        <field name="name">Post 5 Innenlands omsetning og uttak, og beregnet avgift 12 %</field>
-        <field name="tag_name">Post 5 Base</field>
-        <field name="code">NOTAX_05</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innenlands_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_5_tax" model="account.tax.report.line">
-        <field name="name">Post 5 Innenlands omsetning og uttak, og beregnet avgift 12 % Tax</field>
-        <field name="tag_name">Post 5 Tax</field>
-        <field name="code">NOTAX_05_1</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innenlands_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_6" model="account.tax.report.line">
-        <field name="name">Post 6 Innenlands omsetning og uttak fritatt for merverdiavgift</field>
-        <field name="tag_name">Post 6</field>
-        <field name="code">NOTAX_06</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innenlands_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_7" model="account.tax.report.line">
-        <field name="name">Post 7 Innenlands omsetning med omvendt avgiftsplikt</field>
-        <field name="tag_name">Post 7</field>
-        <field name="code">NOTAX_07</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innenlands_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_utforsel" model="account.tax.report.line">
-        <field name="name">C. Utførsel</field>
+    <record id="tax_report_line_purchases_goods_services_homeland" model="account.tax.report.line">
+        <!-- Purchases of goods and services in Norway -->
+        <field name="name">Kjøp av varer og tjenester i Norge</field>
         <field name="sequence" eval="3"/>
         <field name="report_id" ref="tax_report"/>
+        <field name="formula">None</field>
     </record>
 
-    <record id="account_tax_report_line_post_8" model="account.tax.report.line">
-        <field name="name">Post 8 Utførsel av varer og tjenester fritatt for merverdiavgift</field>
-        <field name="tag_name">Post 8</field>
-        <field name="code">NOTAX_08</field>
+    <record id="tax_report_line_code_1" model="account.tax.report.line">
+        <!-- Purchase of goods and services with a right to deduct (high rate 25%) -->
+        <field name="name">1 Kjøp av varer og tjenester med fradragsrett (høy sats 25%)</field>
+        <field name="tag_name">1 Tax</field>
+        <field name="code">TAX_1</field>
         <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_utforsel"/>
+        <field name="parent_id" ref="tax_report_line_purchases_goods_services_homeland"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_innforsel_av_varer" model="account.tax.report.line">
-        <field name="name">D. Innførsel av varer</field>
+    <record id="tax_report_line_code_11" model="account.tax.report.line">
+        <!-- Purchase of goods and services with a right to deduct (middle rate 15%) -->
+        <field name="name">11 Kjøp av varer og tjenester med fradragsrett (middels sats 15%)</field>
+        <field name="tag_name">11 Tax</field>
+        <field name="code">TAX_11</field>
+        <field name="sequence" eval="1"/>
+        <field name="parent_id" ref="tax_report_line_purchases_goods_services_homeland"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_code_13" model="account.tax.report.line">
+        <!-- Purchase of goods and services with a right to deduct (low rate 12%) -->
+        <field name="name">13 Kjøp av varer og tjenester med fradragsrett (lav sats 12%)</field>
+        <field name="tag_name">13 Tax</field>
+        <field name="code">TAX_13</field>
+        <field name="sequence" eval="2"/>
+        <field name="parent_id" ref="tax_report_line_purchases_goods_services_homeland"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_purchases_goods_abroad" model="account.tax.report.line">
+        <!-- Purchases of goods from abroad (import) -->
+        <field name="name">Kjøp av varer fra utlandet (import)</field>
         <field name="sequence" eval="4"/>
         <field name="report_id" ref="tax_report"/>
+        <field name="formula">None</field>
     </record>
 
-    <record id="account_tax_report_line_post_9" model="account.tax.report.line">
-        <field name="name">Post 9 Innførsel av varer, og beregnet avgift 25 %</field>
-        <field name="tag_name">Post 9 Base</field>
-        <field name="code">NOTAX_09</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innforsel_av_varer"/>
+    <record id="tax_report_line_code_14" model="account.tax.report.line">
+        <!-- Deduction on purchases of goods from abroad (VAT paid on import, high rate 25%) -->
+        <field name="name">14 Fradrag på kjøp av varer fra utlandet (merverdiavgift betalt ved innførsel, høy sats 25%)</field>
+        <field name="tag_name">14 Tax</field>
+        <field name="code">TAX_14</field>
+        <field name="sequence" eval="100"/>
+        <field name="parent_id" ref="tax_report_line_purchases_goods_abroad"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_post_9_tax" model="account.tax.report.line">
-        <field name="name">Post 9 Innførsel av varer, og beregnet avgift 25 % Tax</field>
-        <field name="tag_name">Post 9 Tax</field>
-        <field name="code">NOTAX_09_1</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innforsel_av_varer"/>
+    <record id="tax_report_line_code_15" model="account.tax.report.line">
+        <!-- Deduction on purchases of goods from abroad (VAT paid on import, middle rate 15%) -->
+        <field name="name">15 Fradrag på kjøp av varer fra utlandet (merverdiavgift betalt ved innførsel, middels sats 15%)</field>
+        <field name="tag_name">15 Tax</field>
+        <field name="code">TAX_15</field>
+        <field name="sequence" eval="200"/>
+        <field name="parent_id" ref="tax_report_line_purchases_goods_abroad"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_post_10" model="account.tax.report.line">
-        <field name="name">Post 10 Innførsel av varer, og beregnet avgift 15 %</field>
-        <field name="tag_name">Post 10 Base</field>
-        <field name="code">NOTAX_10</field>
+    <record id="tax_report_line_code_81" model="account.tax.report.line">
+        <!-- Purchase of goods from abroad with a right to deduct (high rate 25%) - base -->
+        <field name="name">81 Kjøp av varer fra utlandet med fradragsrett (høy sats 25%) - grunnlag</field>
+        <field name="tag_name">81 Base</field>
+        <field name="code">BASE_81</field>
         <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innforsel_av_varer"/>
+        <field name="parent_id" ref="tax_report_line_purchases_goods_abroad"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_post_10_tax" model="account.tax.report.line">
-        <field name="name">Post 10 Innførsel av varer, og beregnet avgift 15 % Tax</field>
-        <field name="tag_name">Post 10 Tax</field>
-        <field name="code">NOTAX_10_1</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innforsel_av_varer"/>
+    <record id="tax_report_line_code_81_tax" model="account.tax.report.line">
+        <!-- Purchase of goods from abroad with a right to deduct (high rate 25%) - tax -->
+        <field name="name">81 Kjøp av varer fra utlandet med fradragsrett (høy sats 25%) - avgift</field>
+        <field name="tag_name">81 Tax</field>
+        <field name="code">TAX_81</field>
+        <field name="sequence" eval="1"/>
+        <field name="parent_id" ref="tax_report_line_purchases_goods_abroad"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_post_11" model="account.tax.report.line">
-        <field name="name">Post 11 Innførsel av varer som det ikke skal beregnes merverdiavgift av</field>
-        <field name="tag_name">Post 11</field>
-        <field name="code">NOTAX_11</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innforsel_av_varer"/>
+    <record id="tax_report_line_code_82" model="account.tax.report.line">
+        <!-- Purchase of goods from abroad without the right to deduct (high rate 25%) - base -->
+        <field name="name">82 Kjøp av varer fra utlandet uten fradragsrett (høy sats 25%) - grunnlag</field>
+        <field name="tag_name">82 Base</field>
+        <field name="code">BASE_82</field>
+        <field name="sequence" eval="2"/>
+        <field name="parent_id" ref="tax_report_line_purchases_goods_abroad"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_kjop_med_omvendt_avgiftsplikt" model="account.tax.report.line">
-        <field name="name">E. Kjøp med omvendt avgiftsplikt</field>
+    <record id="tax_report_line_code_82_tax" model="account.tax.report.line">
+        <!-- Purchase of goods from abroad without the right to deduct (high rate 25%) - tax -->
+        <field name="name">82 Kjøp av varer fra utlandet uten fradragsrett (høy sats 25%) - avgift</field>
+        <field name="tag_name">82 Tax</field>
+        <field name="code">TAX_82</field>
+        <field name="sequence" eval="3"/>
+        <field name="parent_id" ref="tax_report_line_purchases_goods_abroad"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_code_83" model="account.tax.report.line">
+        <!-- Purchase of goods from abroad with a right to deduct (middle rate 15%) - base -->
+        <field name="name">83 Kjøp av varer fra utlandet med fradragsrett (middels sats 15%) - grunnlag</field>
+        <field name="tag_name">83 Base</field>
+        <field name="code">BASE_83</field>
+        <field name="sequence" eval="4"/>
+        <field name="parent_id" ref="tax_report_line_purchases_goods_abroad"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_code_83_tax" model="account.tax.report.line">
+        <!-- Purchase of goods from abroad with a right to deduct (middle rate 15%) - tax -->
+        <field name="name">83 Kjøp av varer fra utlandet med fradragsrett (middels sats 15%) - avgift</field>
+        <field name="tag_name">83 Tax</field>
+        <field name="code">TAX_83</field>
+        <field name="sequence" eval="5"/>
+        <field name="parent_id" ref="tax_report_line_purchases_goods_abroad"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_code_84" model="account.tax.report.line">
+        <!-- Purchase of goods from abroad without the right to deduct (middle rate 15%) - base -->
+        <field name="name">84 Kjøp av varer fra utlandet som er uten fradragsrett (middels sats 15%) - grunnlag</field>
+        <field name="tag_name">84 Base</field>
+        <field name="code">BASE_84</field>
+        <field name="sequence" eval="6"/>
+        <field name="parent_id" ref="tax_report_line_purchases_goods_abroad"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_code_84_tax" model="account.tax.report.line">
+        <!-- Purchase of goods from abroad without the right to deduct (middle rate 15%) - tax -->
+        <field name="name">84 Kjøp av varer fra utlandet som er uten fradragsrett (middels sats 15%) - avgift</field>
+        <field name="tag_name">84 Tax</field>
+        <field name="code">TAX_84</field>
+        <field name="sequence" eval="7"/>
+        <field name="parent_id" ref="tax_report_line_purchases_goods_abroad"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_code_85" model="account.tax.report.line">
+        <!-- Purchase of goods from abroad for which VAT is not to be calculated (zero rate 0%) -->
+        <field name="name">85 Kjøp av varer fra utlandet som det ikke skal beregnes merverdiavgift på (nullsats 0%)</field>
+        <field name="tag_name">85 Base</field>
+        <field name="code">BASE_85</field>
+        <field name="sequence" eval="8"/>
+        <field name="parent_id" ref="tax_report_line_purchases_goods_abroad"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_purchases_services_abroad" model="account.tax.report.line">
+        <!-- Purchases of services from abroad (import) -->
+        <field name="name">Kjøp av tjenester fra utlandet (import)</field>
         <field name="sequence" eval="5"/>
         <field name="report_id" ref="tax_report"/>
+        <field name="formula">None</field>
     </record>
 
-    <record id="account_tax_report_line_post_12" model="account.tax.report.line">
-        <field name="name">Post 12 Tjenester kjøpt fra utlandet, og beregnet avgift 25 %</field>
-        <field name="tag_name">Post 12 Base</field>
-        <field name="code">NOTAX_12</field>
+    <record id="tax_report_line_code_86" model="account.tax.report.line">
+        <!-- Purchase of services from abroad with a right to deduct (high rate 25%) - base -->
+        <field name="name">86 Kjøp av tjenester fra utlandet med fradragsrett (høy sats 25%) - grunnlag</field>
+        <field name="tag_name">86 Base</field>
+        <field name="code">BASE_86</field>
         <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_kjop_med_omvendt_avgiftsplikt"/>
+        <field name="parent_id" ref="tax_report_line_purchases_services_abroad"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_post_12_tax" model="account.tax.report.line">
-        <field name="name">Post 12 Tjenester kjøpt fra utlandet, og beregnet avgift 25 % Tax</field>
-        <field name="tag_name">Post 12 Tax</field>
-        <field name="code">NOTAX_12_1</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_kjop_med_omvendt_avgiftsplikt"/>
+    <record id="tax_report_line_code_86_tax" model="account.tax.report.line">
+        <!-- Purchase of services from abroad with a right to deduct (high rate 25%) - tax -->
+        <field name="name">86 Kjøp av tjenester fra utlandet med fradragsrett (høy sats 25%) - avgift</field>
+        <field name="tag_name">86 Tax</field>
+        <field name="code">TAX_86</field>
+        <field name="sequence" eval="1"/>
+        <field name="parent_id" ref="tax_report_line_purchases_services_abroad"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_post_13" model="account.tax.report.line">
-        <field name="name">Post 13 Innenlands kjøp av varer og tjenester, og beregnet avgift 25 %</field>
-        <field name="tag_name">Post 13 Base</field>
-        <field name="code">NOTAX_13</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_kjop_med_omvendt_avgiftsplikt"/>
+    <record id="tax_report_line_code_87" model="account.tax.report.line">
+        <!-- Purchase of services from abroad without the right to deduct (high rate 25%) - base -->
+        <field name="name">87 Kjøp av tjenester fra utlandet uten fradragsrett (høy sats 25%) - grunnlag</field>
+        <field name="tag_name">87 Base</field>
+        <field name="code">BASE_87</field>
+        <field name="sequence" eval="2"/>
+        <field name="parent_id" ref="tax_report_line_purchases_services_abroad"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_post_13_tax" model="account.tax.report.line">
-        <field name="name">Post 13 Innenlands kjøp av varer og tjenester, og beregnet avgift 25 % Tax</field>
-        <field name="tag_name">Post 13 Tax</field>
-        <field name="code">NOTAX_13_1</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_kjop_med_omvendt_avgiftsplikt"/>
+    <record id="tax_report_line_code_87_tax" model="account.tax.report.line">
+        <!-- Purchase of services from abroad without the right to deduct (high rate 25%) - tax -->
+        <field name="name">87 Kjøp av tjenester fra utlandet uten fradragsrett (høy sats 25%) - avgift</field>
+        <field name="tag_name">87 Tax</field>
+        <field name="code">TAX_87</field>
+        <field name="sequence" eval="3"/>
+        <field name="parent_id" ref="tax_report_line_purchases_services_abroad"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_fradragsberettigen_innenlands" model="account.tax.report.line">
-        <field name="name">F. Fradragsberettiget innenlands inngående avgift</field>
+    <record id="tax_report_line_code_88" model="account.tax.report.line">
+        <!-- Purchase of services from abroad with a right to deduct (low rate 12%) - base -->
+        <field name="name">88 Kjøp av tjenester fra utlandet med fradragsrett (lav sats 12%) - grunnlag</field>
+        <field name="tag_name">88 Base</field>
+        <field name="code">BASE_88</field>
+        <field name="sequence" eval="4"/>
+        <field name="parent_id" ref="tax_report_line_purchases_services_abroad"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_code_88_tax" model="account.tax.report.line">
+        <!-- Purchase of services from abroad with a right to deduct (low rate 12%) - tax -->
+        <field name="name">88 Kjøp av tjenester fra utlandet med fradragsrett (lav sats 12%) - avgift</field>
+        <field name="tag_name">88 Tax</field>
+        <field name="code">TAX_88</field>
+        <field name="sequence" eval="5"/>
+        <field name="parent_id" ref="tax_report_line_purchases_services_abroad"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_code_89" model="account.tax.report.line">
+        <!-- Purchase of services from abroad without the right to deduct (low rate 12%) - base -->
+        <field name="name">89 Kjøp av tjenester fra utlandet uten fradragsrett (lav sats 12%) - grunnlag</field>
+        <field name="tag_name">89 Base</field>
+        <field name="code">BASE_89</field>
+        <field name="sequence" eval="6"/>
+        <field name="parent_id" ref="tax_report_line_purchases_services_abroad"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_code_89_tax" model="account.tax.report.line">
+        <!-- Purchase of services from abroad without the right to deduct (low rate 12%) - tax -->
+        <field name="name">89 Kjøp av tjenester fra utlandet uten fradragsrett (lav sats 12%) - avgift</field>
+        <field name="tag_name">89 Tax</field>
+        <field name="code">TAX_89</field>
+        <field name="sequence" eval="7"/>
+        <field name="parent_id" ref="tax_report_line_purchases_services_abroad"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_fish_etc" model="account.tax.report.line">
+        <!-- Fish etc. -->
+        <field name="name">Fisk mv.</field>
         <field name="sequence" eval="6"/>
         <field name="report_id" ref="tax_report"/>
+        <field name="formula">None</field>
     </record>
 
-    <record id="account_tax_report_line_post_14" model="account.tax.report.line">
-        <field name="name">Post 14 Fradragsberettiget innenlands inngående avgift 25 %</field>
-        <field name="tag_name">Post 14</field>
-        <field name="code">NOTAX_14</field>
+    <record id="tax_report_line_code_12" model="account.tax.report.line">
+        <!-- Purchase of fish and other marine wildlife resources (11.11%) -->
+        <field name="name">12 Kjøp av fisk og andre marine viltlevende ressurser (11,11%)</field>
+        <field name="tag_name">12 Tax</field>
+        <field name="code">TAX_12</field>
         <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_fradragsberettigen_innenlands"/>
+        <field name="parent_id" ref="tax_report_line_fish_etc"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_post_15" model="account.tax.report.line">
-        <field name="name">Post 15 Fradragsberettiget innenlands inngående avgift 15 %</field>
-        <field name="tag_name">Post 15</field>
-        <field name="code">NOTAX_15</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_fradragsberettigen_innenlands"/>
+    <record id="tax_report_line_code_32" model="account.tax.report.line">
+        <!-- Sales of fish and other marine wildlife resources (11.11%) - base -->
+        <field name="name">32 Salg av fisk og andre marine viltlevende ressurser (11,11%) - grunnlag</field>
+        <field name="tag_name">32 Base</field>
+        <field name="code">BASE_32</field>
+        <field name="sequence" eval="1"/>
+        <field name="parent_id" ref="tax_report_line_fish_etc"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_post_16" model="account.tax.report.line">
-        <field name="name">Post 16 Fradragsberettiget innenlands inngående avgift 12 %</field>
-        <field name="tag_name">Post 16</field>
-        <field name="code">NOTAX_16</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_fradragsberettigen_innenlands"/>
+    <record id="tax_report_line_code_32_tax" model="account.tax.report.line">
+        <!-- Sales of fish and other marine wildlife resources (11.11%) - tax -->
+        <field name="name">32 Salg av fisk og andre marine viltlevende ressurser (11,11%) - avgift</field>
+        <field name="tag_name">32 Tax</field>
+        <field name="code">TAX_32</field>
+        <field name="sequence" eval="2"/>
+        <field name="parent_id" ref="tax_report_line_fish_etc"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_fradragsberettiget_innforselsmerverdiavgift" model="account.tax.report.line">
-        <field name="name">G. Fradragsberettiget innførselsmerverdiavgift</field>
+    <record id="tax_report_line_emission_and_gold" model="account.tax.report.line">
+        <!-- Emission allowances and gold -->
+        <field name="name">Klimakvoter og gull</field>
         <field name="sequence" eval="7"/>
         <field name="report_id" ref="tax_report"/>
+        <field name="formula">None</field>
     </record>
 
-    <record id="account_tax_report_line_post_17" model="account.tax.report.line">
-        <field name="name">Post 17 Fradragsberettiget innførselsmerverdiavgift 25 %</field>
-        <field name="tag_name">Post 17</field>
-        <field name="code">NOTAX_17</field>
+    <record id="tax_report_line_code_51" model="account.tax.report.line">
+        <!-- Sale of climate quotas and gold to businesses (0%) -->
+        <field name="name">51 Salg av klimakvoter og gull til næringsdrivende (0%)</field>
+        <field name="tag_name">51 Base</field>
+        <field name="code">BASE_51</field>
         <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_fradragsberettiget_innforselsmerverdiavgift"/>
+        <field name="parent_id" ref="tax_report_line_emission_and_gold"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_post_18" model="account.tax.report.line">
-        <field name="name">Post 18 Fradragsberettiget innførselsmerverdiavgift 15 %</field>
-        <field name="tag_name">Post 18</field>
-        <field name="code">NOTAX_18</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_fradragsberettiget_innforselsmerverdiavgift"/>
+    <record id="tax_report_line_code_91" model="account.tax.report.line">
+        <!-- Purchase of climate quotas and gold with a right to deduct (high rate 25%) - base -->
+        <field name="name">91 Kjøp av klimakvoter og gull med fradragsrett (høy sats 25%) - grunnlag</field>
+        <field name="tag_name">91 Base</field>
+        <field name="code">BASE_91</field>
+        <field name="sequence" eval="1"/>
+        <field name="parent_id" ref="tax_report_line_emission_and_gold"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 
-    <record id="account_tax_report_line_sum" model="account.tax.report.line">
-        <field name="name">H. Sum</field>
+    <record id="tax_report_line_code_91_tax" model="account.tax.report.line">
+        <!-- Purchase of climate quotas and gold with a right to deduct (high rate 25%) - tax -->
+        <field name="name">91 Kjøp av klimakvoter og gull med fradragsrett (høy sats 25%) - avgift</field>
+        <field name="tag_name">91 Tax</field>
+        <field name="code">TAX_91</field>
+        <field name="sequence" eval="2"/>
+        <field name="parent_id" ref="tax_report_line_emission_and_gold"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_code_92" model="account.tax.report.line">
+        <!-- Purchase of climate quotas and gold without the right to deduct (high rate 25%) - base -->
+        <field name="name">92 Kjøp av klimakvoter og gull uten fradragsrett (høy sats 25%) - grunnlag</field>
+        <field name="tag_name">92 Base</field>
+        <field name="code">BASE_92</field>
+        <field name="sequence" eval="3"/>
+        <field name="parent_id" ref="tax_report_line_emission_and_gold"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_code_92_tax" model="account.tax.report.line">
+        <!-- Purchase of climate quotas and gold without the right to deduct (high rate 25%) - base -->
+        <field name="name">92 Kjøp av klimakvoter og gull uten fradragsrett (høy sats 25%) - avgift</field>
+        <field name="tag_name">92 Tax</field>
+        <field name="code">TAX_92</field>
+        <field name="sequence" eval="4"/>
+        <field name="parent_id" ref="tax_report_line_emission_and_gold"/>
+        <field name="report_id" ref="tax_report"/>
+    </record>
+
+    <record id="tax_report_line_sum" model="account.tax.report.line">
+        <field name="name">Sum</field>
         <field name="sequence" eval="8"/>
         <field name="report_id" ref="tax_report"/>
+        <field name="formula">None</field>
     </record>
 
-    <record id="account_tax_report_line_post_19" model="account.tax.report.line">
-        <field name="name">Post 19 Avgift å betale</field>
-        <field name="formula">NOTAX_03_1+NOTAX_04_1+NOTAX_05_1+NOTAX_09_1+NOTAX_10_1+NOTAX_12_1+NOTAX_13_1-NOTAX_14-NOTAX_15-NOTAX_16-NOTAX_17-NOTAX_18</field>
-        <field name="code">NOTAX_19</field>
+    <record id="tax_report_line_to_be_paid" model="account.tax.report.line">
+        <!-- Tax to be paid -->
+        <field name="name">Avgift å betale</field>
+        <field name="formula">TAX_3+TAX_31+TAX_32+TAX_33+TAX_81+TAX_82+TAX_83+TAX_84+TAX_86+TAX_87+TAX_88+TAX_89+TAX_91+TAX_92-TAX_1-TAX_11-TAX_12-TAX_13-TAX_14-TAX_15</field>
+        <field name="code">SUM</field>
         <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_sum"/>
+        <field name="parent_id" ref="tax_report_line_sum"/>
         <field name="report_id" ref="tax_report"/>
     </record>
 

--- a/addons/l10n_no/i18n/l10n_no.pot
+++ b/addons/l10n_no/i18n/l10n_no.pot
@@ -1,0 +1,92 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_no
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 15.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-02-09 14:29+0000\n"
+"PO-Revision-Date: 2023-02-09 14:29+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_no
+#: model:ir.model.fields,field_description:l10n_no.field_account_bank_statement_import_journal_creation__invoice_reference_model
+#: model:ir.model.fields,field_description:l10n_no.field_account_journal__invoice_reference_model
+msgid "Communication Standard"
+msgstr ""
+
+#. module: l10n_no
+#: model:ir.model,name:l10n_no.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: l10n_no
+#: model:ir.model,name:l10n_no.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: l10n_no
+#: model:ir.model,name:l10n_no.model_account_journal
+msgid "Journal"
+msgstr ""
+
+#. module: l10n_no
+#: model:ir.model,name:l10n_no.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_no
+#: model:account.tax.group,name:l10n_no.tax_group_0
+msgid "MVA 0%"
+msgstr ""
+
+#. module: l10n_no
+#: model:account.tax.group,name:l10n_no.tax_group_10
+msgid "MVA 10%"
+msgstr ""
+
+#. module: l10n_no
+#: model:account.tax.group,name:l10n_no.tax_group_12
+msgid "MVA 12%"
+msgstr ""
+
+#. module: l10n_no
+#: model:account.tax.group,name:l10n_no.tax_group_15
+msgid "MVA 15%"
+msgstr ""
+
+#. module: l10n_no
+#: model:account.tax.group,name:l10n_no.tax_group_25
+msgid "MVA 25%"
+msgstr ""
+
+#. module: l10n_no
+#: model:ir.model.fields.selection,name:l10n_no.selection__account_journal__invoice_reference_model__no
+msgid "Norway"
+msgstr ""
+
+#. module: l10n_no
+#: model:ir.ui.menu,name:l10n_no.account_reports_no_statements_menu
+msgid "Norwegian Statements"
+msgstr ""
+
+#. module: l10n_no
+#: model:ir.model.fields,field_description:l10n_no.field_res_company__l10n_no_bronnoysund_number
+#: model:ir.model.fields,field_description:l10n_no.field_res_partner__l10n_no_bronnoysund_number
+#: model:ir.model.fields,field_description:l10n_no.field_res_users__l10n_no_bronnoysund_number
+msgid "Register of Legal Entities (Brønnøysund Register Center)"
+msgstr ""
+
+#. module: l10n_no
+#: model:ir.model.fields,help:l10n_no.field_account_bank_statement_import_journal_creation__invoice_reference_model
+#: model:ir.model.fields,help:l10n_no.field_account_journal__invoice_reference_model
+msgid ""
+"You can choose different models for each type of reference. The default one "
+"is the Odoo reference."
+msgstr ""

--- a/addons/l10n_no/i18n/nb_NO.po
+++ b/addons/l10n_no/i18n/nb_NO.po
@@ -1,0 +1,92 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_no
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 15.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-02-09 14:29+0000\n"
+"PO-Revision-Date: 2023-02-09 14:29+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_no
+#: model:ir.model.fields,field_description:l10n_no.field_account_bank_statement_import_journal_creation__invoice_reference_model
+#: model:ir.model.fields,field_description:l10n_no.field_account_journal__invoice_reference_model
+msgid "Communication Standard"
+msgstr "Kommunikasjonsstandard"
+
+#. module: l10n_no
+#: model:ir.model,name:l10n_no.model_res_company
+msgid "Companies"
+msgstr "Bedrifter"
+
+#. module: l10n_no
+#: model:ir.model,name:l10n_no.model_res_partner
+msgid "Contact"
+msgstr "Kontakt"
+
+#. module: l10n_no
+#: model:ir.model,name:l10n_no.model_account_journal
+msgid "Journal"
+msgstr ""
+
+#. module: l10n_no
+#: model:ir.model,name:l10n_no.model_account_move
+msgid "Journal Entry"
+msgstr "Journalpost"
+
+#. module: l10n_no
+#: model:account.tax.group,name:l10n_no.tax_group_0
+msgid "MVA 0%"
+msgstr ""
+
+#. module: l10n_no
+#: model:account.tax.group,name:l10n_no.tax_group_10
+msgid "MVA 10%"
+msgstr ""
+
+#. module: l10n_no
+#: model:account.tax.group,name:l10n_no.tax_group_12
+msgid "MVA 12%"
+msgstr ""
+
+#. module: l10n_no
+#: model:account.tax.group,name:l10n_no.tax_group_15
+msgid "MVA 15%"
+msgstr ""
+
+#. module: l10n_no
+#: model:account.tax.group,name:l10n_no.tax_group_25
+msgid "MVA 25%"
+msgstr ""
+
+#. module: l10n_no
+#: model:ir.model.fields.selection,name:l10n_no.selection__account_journal__invoice_reference_model__no
+msgid "Norway"
+msgstr "Norge"
+
+#. module: l10n_no
+#: model:ir.ui.menu,name:l10n_no.account_reports_no_statements_menu
+msgid "Norwegian Statements"
+msgstr "Norske uttalelser"
+
+#. module: l10n_no
+#: model:ir.model.fields,field_description:l10n_no.field_res_company__l10n_no_bronnoysund_number
+#: model:ir.model.fields,field_description:l10n_no.field_res_partner__l10n_no_bronnoysund_number
+#: model:ir.model.fields,field_description:l10n_no.field_res_users__l10n_no_bronnoysund_number
+msgid "Register of Legal Entities (Brønnøysund Register Center)"
+msgstr "Brønnøysundregistrene"
+
+#. module: l10n_no
+#: model:ir.model.fields,help:l10n_no.field_account_bank_statement_import_journal_creation__invoice_reference_model
+#: model:ir.model.fields,help:l10n_no.field_account_journal__invoice_reference_model
+msgid ""
+"You can choose different models for each type of reference. The default one "
+"is the Odoo reference."
+msgstr ""

--- a/addons/l10n_no/migrations/2.1/post-migrate_update_taxes.py
+++ b/addons/l10n_no/migrations/2.1/post-migrate_update_taxes.py
@@ -1,0 +1,6 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.addons.account.models.chart_template import update_taxes_from_templates
+
+
+def migrate(cr, version):
+    update_taxes_from_templates(cr, 'l10n_no.no_chart_template')


### PR DESCRIPTION
The Norwegian tax report is outdated as of January 2022 and currently displays values that do not fit directly into the new mandatory reporting system set up by the Norwegian Tax Authorities.

The changes here aim to support the XML generation of the tax report (PR: https://github.com/odoo/enterprise/pull/23041).

~~While at it, also change the translation (base text for taxes in english, with a translation in norwegian).~~
Can't do that in stable, since it requires a new dependency (`l10n_multilang`)

Changes:
  - Update tax report tax lines to match the required fields
  - ~~Tax base text changed to english~~
  - ~~Add translation in norwegian~~

Task id=2667013

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
