### PR TITLE
[FIX] resource: update default calendar timezone on first admin login

### DIFF
--- a/addons/resource/models/res_users.py
+++ b/addons/resource/models/res_users.py
@@ -12,3 +12,13 @@ class ResUsers(models.Model):
     resource_calendar_id = fields.Many2one(
         'resource.calendar', 'Default Working Hours',
         related='resource_ids.calendar_id', readonly=False)
+
+    def write(self, vals):
+        rslt = super().write(vals)
+
+        # If the timezone of the admin user gets set on their first login, also update the timezone of the default working calendar
+        if (vals.get('tz') and len(self) == 1 and not self.env.user.login_date 
+            and self.env.user == self.env.ref('base.user_admin') and self == self.env.user):
+            self.resource_calendar_id.tz = vals['tz']
+
+        return rslt


### PR DESCRIPTION
When the admin user logs in for the first time, their timezone can be updated based on the cookies of their browser.
In such case, the timezone of the default working calendar should be updated too.

Related: https://github.com/odoo/odoo/pull/83262/

Task 2759592
