### PR TITLE
[FIX] (website_)event_booth_sale: fix e-commerce displayed price

### DIFF
--- a/addons/event_booth_sale/models/event_booth_category.py
+++ b/addons/event_booth_sale/models/event_booth_category.py
@@ -37,6 +37,7 @@ class EventBoothCategory(models.Model):
             if category.product_id and category.product_id.list_price:
                 category.price = category.product_id.list_price + category.product_id.price_extra
 
+    @api.depends_context('pricelist', 'quantity')
     @api.depends('product_id', 'price')
     def _compute_price_reduce(self):
         for category in self:

--- a/addons/event_booth_sale/models/event_booth_category.py
+++ b/addons/event_booth_sale/models/event_booth_category.py
@@ -22,6 +22,10 @@ class EventBoothCategory(models.Model):
     price_reduce = fields.Float(
         string='Price Reduce', compute='_compute_price_reduce',
         compute_sudo=True, digits='Product Price')
+    price_reduce_taxinc = fields.Float(
+        string='Price Reduce Tax inc', compute='_compute_price_reduce_taxinc',
+        compute_sudo=True
+    )
     image_1920 = fields.Image(compute='_compute_image_1920', readonly=False, store=True)
 
     @api.depends('product_id')
@@ -45,6 +49,14 @@ class EventBoothCategory(models.Model):
             list_price = product.list_price + product.price_extra
             discount = (list_price - product.price) / list_price if list_price else 0.0
             category.price_reduce = (1.0 - discount) * category.price
+
+    @api.depends_context('pricelist', 'quantity')
+    @api.depends('product_id', 'price_reduce')
+    def _compute_price_reduce_taxinc(self):
+        for category in self:
+            tax_ids = category.product_id.taxes_id
+            taxes = tax_ids.compute_all(category.price_reduce, category.currency_id, 1.0, product=category.product_id)
+            category.price_reduce_taxinc = taxes['total_included']
 
     def _init_column(self, column_name):
         """ Initialize product_id for existing columns when installing sale

--- a/addons/event_booth_sale/tests/test_event_booth_sale.py
+++ b/addons/event_booth_sale/tests/test_event_booth_sale.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+from odoo.addons.event_booth_sale.tests.common import TestEventBoothSaleCommon
+from odoo.tests.common import users
+from odoo.tools import float_compare
+
+
+class TestEventBoothSale(TestEventBoothSaleCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestEventBoothSale, cls).setUpClass()
+
+        cls.booth_1 = cls.env['event.booth'].create({
+            'name': 'Test Booth 1',
+            'booth_category_id': cls.event_booth_category_1.id,
+            'event_id': cls.event_0.id,
+        })
+
+        cls.booth_2 = cls.env['event.booth'].create({
+            'name': 'Test Booth 2',
+            'booth_category_id': cls.event_booth_category_1.id,
+            'event_id': cls.event_0.id,
+        })
+
+    @users('user_sales_salesman')
+    def test_event_booth_prices_with_sale_order(self):
+        pricelist = self.env['product.pricelist'].sudo().create({
+            'name': 'Test Pricelist',
+            'currency_id': self.env.ref('base.USD').id,
+        })
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.event_customer.id,
+            'pricelist_id': pricelist.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.event_booth_product.id,
+                    'event_id': self.event_0.id,
+                    'event_booth_category_id': self.event_booth_category_1.id,
+                    'event_booth_pending_ids': (self.booth_1 + self.booth_2).ids
+                })
+            ]
+        })
+
+        self.assertEqual(self.event_booth_product.list_price, self.booth_1.price,
+                         "Booth price should be equal from product price.")
+        # Here we expect the price to be the sum of the booth ($40.0)
+        self.assertEqual(float_compare(sale_order.amount_untaxed, 40.0, precision_rounding=0.1), 0,
+                         "Untaxed amount should be the sum of the booths prices.")
+
+        self.event_booth_category_1.write({'price': 100.0})
+        sale_order.update_prices()
+
+        self.assertNotEqual(self.event_booth_product.list_price, self.booth_1.price,
+                            "Booth price should be different from product price.")
+        # Here we expect the price to be the sum of the booth ($200.0)
+        self.assertEqual(float_compare(sale_order.amount_untaxed, 200.0, precision_rounding=0.1), 0,
+                         "Untaxed amount should be the sum of the booths prices.")

--- a/addons/event_booth_sale/tests/test_event_booth_sale.py
+++ b/addons/event_booth_sale/tests/test_event_booth_sale.py
@@ -25,15 +25,21 @@ class TestEventBoothSale(TestEventBoothSaleCommon):
             'event_id': cls.event_0.id,
         })
 
+        cls.tax_10 = cls.env['account.tax'].sudo().create({
+            'name': 'Tax 10',
+            'amount': 10,
+        })
+
+        cls.pricelist = cls.env['product.pricelist'].sudo().create({
+            'name': 'Test Pricelist',
+        })
+
     @users('user_sales_salesman')
     def test_event_booth_prices_with_sale_order(self):
-        pricelist = self.env['product.pricelist'].sudo().create({
-            'name': 'Test Pricelist',
-            'currency_id': self.env.ref('base.USD').id,
-        })
+        self.event_booth_product.taxes_id = self.tax_10
         sale_order = self.env['sale.order'].create({
             'partner_id': self.event_customer.id,
-            'pricelist_id': pricelist.id,
+            'pricelist_id': self.pricelist.id,
             'order_line': [
                 Command.create({
                     'product_id': self.event_booth_product.id,
@@ -44,17 +50,25 @@ class TestEventBoothSale(TestEventBoothSaleCommon):
             ]
         })
 
-        self.assertEqual(self.event_booth_product.list_price, self.booth_1.price,
+        self.assertEqual(self.booth_1.price, self.event_booth_product.list_price,
                          "Booth price should be equal from product price.")
+        self.assertEqual(self.event_booth_category_1.with_context(pricelist=self.pricelist.id).price_reduce_taxinc, 22.0,
+                         "Booth price reduce tax should be equal to its price with 10% taxes ($20.0 + $2.0)")
         # Here we expect the price to be the sum of the booth ($40.0)
         self.assertEqual(float_compare(sale_order.amount_untaxed, 40.0, precision_rounding=0.1), 0,
-                         "Untaxed amount should be the sum of the booths prices.")
+                         "Untaxed amount should be the sum of the booths prices ($40.0).")
+        self.assertEqual(float_compare(sale_order.amount_total, 44.0, precision_rounding=0.1), 0,
+                         "Total amount should be the sum of the booths prices with 10% taxes ($40.0 + $4.0)")
 
         self.event_booth_category_1.write({'price': 100.0})
         sale_order.update_prices()
 
-        self.assertNotEqual(self.event_booth_product.list_price, self.booth_1.price,
+        self.assertNotEqual(self.booth_1.price, self.event_booth_product.list_price,
                             "Booth price should be different from product price.")
+        self.assertEqual(self.event_booth_category_1.with_context(pricelist=self.pricelist.id).price_reduce_taxinc, 110.0,
+                         "Booth price reduce tax should be equal to its price with 10% taxes ($100.0 + $10.0)")
         # Here we expect the price to be the sum of the booth ($200.0)
         self.assertEqual(float_compare(sale_order.amount_untaxed, 200.0, precision_rounding=0.1), 0,
-                         "Untaxed amount should be the sum of the booths prices.")
+                         "Untaxed amount should be the sum of the booths prices ($200.0).")
+        self.assertEqual(float_compare(sale_order.amount_total, 220.0, precision_rounding=0.1), 0,
+                         "Total amount should be the sum of the booths prices with 10% taxes ($200.0 + $20.0).")

--- a/addons/website_event_booth_sale/__manifest__.py
+++ b/addons/website_event_booth_sale/__manifest__.py
@@ -17,7 +17,10 @@ Use the e-commerce to sell your event booths.
     'assets': {
         'web.assets_frontend': [
             '/website_event_booth_sale/static/src/js/booth_register.js',
-        ]
+        ],
+        'web.assets_tests': [
+            '/website_event_booth_sale/static/tests/tours/website_event_booth.js',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/website_event_booth_sale/models/sale_order.py
+++ b/addons/website_event_booth_sale/models/sale_order.py
@@ -29,20 +29,22 @@ class SaleOrder(models.Model):
             order_line = self.env['sale.order.line'].sudo().search([
                 ('id', 'in', self.order_line.ids),
                 ('event_booth_pending_ids', 'in', event_booth_pending_ids)])
-            booths = self.env['event.booth'].browse(event_booth_pending_ids)
-            new_registration_ids = [Command.create({
-                                        'event_booth_id': booth.id,
-                                        **kwargs.get('registration_values'),
-                                    }) for booth in booths]
-            if order_line:
-                event_booth_registration_ids = [Command.delete(reg.id)
-                                                for reg in order_line.event_booth_registration_ids] + new_registration_ids
-            else:
-                event_booth_registration_ids = new_registration_ids
+            booths = self.env['event.booth'].browse(event_booth_pending_ids).with_context(pricelist=self.pricelist_id.id)
+            if order_line.event_booth_pending_ids.ids != event_booth_pending_ids:
+                new_registrations_commands = [Command.create({
+                                            'event_booth_id': booth.id,
+                                            **kwargs.get('registration_values'),
+                                        }) for booth in booths]
+                if order_line:
+                    event_booth_registrations_command = [Command.delete(reg.id) for reg in
+                                                         order_line.event_booth_registration_ids] + new_registrations_commands
+                else:
+                    event_booth_registrations_command = new_registrations_commands
+                values['event_booth_registration_ids'] = event_booth_registrations_command
 
             values.update(
                 event_id=booths.event_id.id,
-                event_booth_registration_ids=event_booth_registration_ids,
+                price_unit=sum(booth.booth_category_id.price_reduce for booth in booths),
                 name=booths._get_booth_multiline_description,
             )
 
@@ -51,8 +53,13 @@ class SaleOrder(models.Model):
     def _cart_update(self, product_id=None, line_id=None, add_qty=0, set_qty=0, **kwargs):
         values = {}
         product = self.env['product.product'].browse(product_id)
-        if product.detailed_type == 'event_booth' and set_qty > 1:
-            set_qty = 1
-            values['warning'] = _('You cannot manually change the quantity of an Event Booth product.')
+        if product.detailed_type == 'event_booth' and line_id:
+            if set_qty > 1:
+                set_qty = 1
+                values['warning'] = _('You cannot manually change the quantity of an Event Booth product.')
+            if add_qty == 0 and not kwargs.get('event_booth_pending_ids'):
+                # when updating the pricelist, the website_sale module call this method without the 'event.booth' ids
+                # -> we manually set the argument to make sure the price is updated in '_website_product_id_change'
+                kwargs['event_booth_pending_ids'] = self.env['sale.order.line'].browse(line_id).event_booth_pending_ids.ids
         values.update(super(SaleOrder, self)._cart_update(product_id, line_id, add_qty, set_qty, **kwargs))
         return values

--- a/addons/website_event_booth_sale/static/src/js/booth_register.js
+++ b/addons/website_event_booth_sale/static/src/js/booth_register.js
@@ -13,7 +13,7 @@ BoothRegistration.include({
     //--------------------------------------------------------------------------
 
     _onChangeBoothType(ev) {
-        this.categoryPrice = parseFloat($(ev.currentTarget).data('price-reduce'));
+        this.categoryPrice = parseFloat($(ev.currentTarget).data('price'));
         return this._super.apply(this, arguments);
     },
 

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
@@ -36,11 +36,19 @@ tour.register('website_event_booth_tour', {
     trigger: 'tr#order_total_untaxed .oe_currency_value:containsExact(200.00)',
     run: function () {},
 }, {
+    content: 'Check if the tax is correct',
+    trigger: 'tr#order_total_taxes .oe_currency_value:containsExact(20.00)',
+    run: function () {},
+}, {
     content: 'Click confirm to continue',
     trigger: 'a[role="button"] span:contains("Confirm")',
 }, {
     content: 'Check if the price is correct',
     trigger: 'tr#order_total_untaxed .oe_currency_value:containsExact(200.00)',
+    run: function () {},
+}, {
+    content: 'Check if the total price is correct',
+    trigger: 'tr#order_total .oe_currency_value:containsExact(220.00)',
     run: function () {},
 },
 ]);

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
@@ -1,0 +1,46 @@
+/** @odoo-module **/
+
+import tour from 'web_tour.tour';
+
+tour.register('website_event_booth_tour', {
+    test: true,
+    url: '/event',
+}, [
+{
+    content: 'Open "Test Event Booths" event',
+    trigger: 'h5.card-title span:contains("Test Event Booths")',
+}, {
+    content: 'Go to "Get A Booth" page',
+    trigger: 'li.nav-item a:has(span:contains("Get A Booth"))',
+}, {
+    content: 'Select the first two booths',
+    trigger: '.o_wbooth_booths input[name="event_booth_ids"]',
+    run: function () {
+        $('.o_wbooth_booths input[name="event_booth_ids"]:lt(2)').click();
+    },
+}, {
+    content: 'Confirm the booths by clicking the submit button',
+    trigger: 'button.o_wbooth_registration_submit',
+}, {
+    content: 'Fill in your contact information',
+    trigger: 'input[name="contact_name"]',
+    run: function () {
+        $('input[name="contact_name"]').val('John Doe');
+        $('input[name="contact_email"]').val('jdoe@example.com');
+    },
+}, {
+    content: 'Submit your informations',
+    trigger: 'button[type="submit"]',
+}, {
+    content: 'Check if the price is correct',
+    trigger: 'tr#order_total_untaxed .oe_currency_value:containsExact(200.00)',
+    run: function () {},
+}, {
+    content: 'Click confirm to continue',
+    trigger: 'a[role="button"] span:contains("Confirm")',
+}, {
+    content: 'Check if the price is correct',
+    trigger: 'tr#order_total_untaxed .oe_currency_value:containsExact(200.00)',
+    run: function () {},
+},
+]);

--- a/addons/website_event_booth_sale/tests/__init__.py
+++ b/addons/website_event_booth_sale/tests/__init__.py
@@ -2,4 +2,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_event_booth_sale
-from . import test_event_internals

--- a/addons/website_event_booth_sale/tests/test_event_booth_sale.py
+++ b/addons/website_event_booth_sale/tests/test_event_booth_sale.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime, timedelta
+
+from odoo import Command, fields
+from odoo.tests import HttpCase
+from odoo.tests.common import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteEventBoothSale(HttpCase):
+
+    def setUp(self):
+        super().setUp()
+        self.booth_product = self.env['product.product'].create({
+            'name': 'Test Booth Product',
+            'description_sale': 'Mighty Booth Description',
+            'list_price': 20,
+            'standard_price': 60.0,
+            'detailed_type': 'event_booth',
+        })
+        self.event_booth_category = self.env['event.booth.category'].create({
+            'name': 'Standard',
+            'description': '<p>Standard</p>',
+            'product_id': self.booth_product.id,
+            'price': 100.0,
+        })
+        self.event_type = self.env['event.type'].create({
+            'name': 'Booth Type',
+            'event_type_booth_ids': [
+                Command.create({
+                    'name': 'Standard 1',
+                    'booth_category_id': self.event_booth_category.id,
+                }),
+                Command.create({
+                    'name': 'Standard 2',
+                    'booth_category_id': self.event_booth_category.id,
+                }),
+                Command.create({
+                    'name': 'Standard 3',
+                    'booth_category_id': self.event_booth_category.id,
+                }),
+            ],
+        })
+        self.env['event.event'].create({
+            'name': 'Test Event Booths',
+            'event_type_id': self.event_type.id,
+            'date_begin': fields.Datetime.to_string(datetime.today() + timedelta(days=1)),
+            'date_end': fields.Datetime.to_string(datetime.today() + timedelta(days=15)),
+            'website_published': True,
+            'website_menu': True,
+            'booth_menu': True,
+        })
+
+    def test_tour(self):
+        self.start_tour('/event', 'website_event_booth_tour', login='portal')

--- a/addons/website_event_booth_sale/tests/test_event_booth_sale.py
+++ b/addons/website_event_booth_sale/tests/test_event_booth_sale.py
@@ -13,11 +13,17 @@ class TestWebsiteEventBoothSale(HttpCase):
 
     def setUp(self):
         super().setUp()
+        self.env['ir.config_parameter'].sudo().set_param('account.show_line_subtotals_tax_selection', 'tax_included')
+        self.tax = self.env['account.tax'].sudo().create({
+            'name': 'Tax 10',
+            'amount': 10,
+        })
         self.booth_product = self.env['product.product'].create({
             'name': 'Test Booth Product',
             'description_sale': 'Mighty Booth Description',
             'list_price': 20,
             'standard_price': 60.0,
+            'taxes_id': [(6, 0, [self.tax.id])],
             'detailed_type': 'event_booth',
         })
         self.event_booth_category = self.env['event.booth.category'].create({

--- a/addons/website_event_booth_sale/views/event_booth_templates.xml
+++ b/addons/website_event_booth_sale/views/event_booth_templates.xml
@@ -3,13 +3,20 @@
 
     <template id="event_booth_registration" inherit_id="website_event_booth.event_booth_registration">
         <xpath expr="//h5[@name='booth_category_name']" position="after">
-            <span t-if="booth_category.price" class="font-weight-normal text-muted" t-field="booth_category.price_reduce"
-                  t-options="{'widget': 'monetary', 'display_currency': website.pricelist_id.currency_id}"
-                  groups="account.group_show_line_subtotals_tax_excluded"/>
+            <t t-if="booth_category.price">
+                <span t-field="booth_category.price_reduce" class="font-weight-normal text-muted"
+                      t-options="{'widget': 'monetary', 'display_currency': website.pricelist_id.currency_id}"
+                      groups="account.group_show_line_subtotals_tax_excluded"/>
+                <span t-field="booth_category.price_reduce_taxinc" class="font-weight-normal text-muted"
+                      t-options="{'widget': 'monetary', 'display_currency': website.pricelist_id.currency_id}"
+                      groups="account.group_show_line_subtotals_tax_included"/>
+            </t>
             <span t-else="" class="font-weight-normal text-muted">Free</span>
         </xpath>
         <xpath expr="//input[@name='booth_category_id']" position="attributes">
-            <attribute name="t-att-data-price-reduce">booth_category.price_reduce or '0'</attribute>
+            <attribute name="t-att-data-price">
+                (booth_category.price_reduce_taxinc if env.user.has_group('account.group_show_line_subtotals_tax_included')
+                else booth_category.price_reduce) or '0'</attribute>
         </xpath>
         <xpath expr="//div[@name='booth_registration_submit']" position="before">
             <div class="row o_wbooth_booth_total_price d-none">


### PR DESCRIPTION
PURPOSE

Since this change (odoo#75843), the displayed price on the e-commerce
was the product price and not the sum of the prices of all the
selected booths. This commit fix the issue.

LINKS

Task-2657480





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
