### PR TITLE
[FIX] base_geolocalize : adapt geocoordinates to partner address

### DIFF
--- a/addons/base_geolocalize/models/res_partner.py
+++ b/addons/base_geolocalize/models/res_partner.py
@@ -5,6 +5,17 @@ class ResPartner(models.Model):
     _inherit = "res.partner"
 
     date_localization = fields.Date(string='Geolocation Date')
+    partner_latitude = fields.Float(compute="_compute_geo_coordinates", readonly=False, store=True)
+    partner_longitude = fields.Float(compute="_compute_geo_coordinates", readonly=False, store=True)
+
+    @api.depends('street', 'zip', 'city', 'state_id', 'country_id')
+    def _compute_geo_coordinates(self):
+        for partner in self:
+            if not (partner.city and partner.country_id):
+                partner.partner_latitude = 0.0
+                partner.partner_longitude = 0.0
+            else:
+                partner.geo_localize()
 
     @api.model
     def _geo_localize(self, street='', zip='', city='', state='', country=''):


### PR DESCRIPTION
Steps :
Install Field Service and Contacts.
Create a FSM task > Customer : Demo.
Note that the displayed address is his Demo's current one.
Click Navigate To : it points this same address.
Go to Contacts > Demo > change the address and return to task.
Note that the displayed address is his Demo's new one. (Or else refresh)

Issue :
Click Navigate To : it points the OLD address.

Cause :
action_fsm_navigate calls partner.geo_localize
only if partner has no geocoordinates.
Yet he still have the old coordinates.

Fix :
Call when the address changes and not in action_fsm_navigate.

opw: 2743926

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
