### PR TITLE
[FIX] base: attachment copy ACL

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -495,7 +495,6 @@ class IrAttachment(models.Model):
         return super(IrAttachment, self).write(vals)
 
     def copy(self, default=None):
-        self.check('write')
         if not (default or {}).keys() & {'datas', 'db_datas'}:
             # ensure the content is kept and recomputes checksum/store_fname
             default = dict(default or {}, datas=self.datas)
@@ -538,9 +537,11 @@ class IrAttachment(models.Model):
             # creating multiple attachments on a single record.
             record_tuple = (values.get('res_model'), values.get('res_id'))
             record_tuple_set.add(record_tuple)
-        for record_tuple in record_tuple_set:
-            (res_model, res_id) = record_tuple
-            self.check('create', values={'res_model':res_model, 'res_id':res_id})
+
+        # don't use possible contextual recordset for check, see commit for details
+        Attachments = self.browse()
+        for res_model, res_id in record_tuple_set:
+            Attachments.check('create', values={'res_model':res_model, 'res_id':res_id})
         return super(IrAttachment, self).create(vals_list)
 
     def _post_add_create(self):


### PR DESCRIPTION
Currently, `Attachment.copy` incurs an *explicit* check for write access on the underlying record.

This doesn't necessarily make sense e.g. a user copying an attachment from a template to an email may not have write access to the template, but that should not be an issue. And indeed if the copy is performed "by hand" (read then create) things work fine.

Since both `read` and `create` are checked, the explicit `copy` check doesn't seem necessary. Drop it, and try to add some tests around `copy`.

A secondary issue is that the `check` in `create` was performed in the context of the `self` being copied, leading to the same issue as `copy` being repeated (that is, `a.copy()` would call `a.create()` which would call `a.check('write')`, even though we're semantically creating a record from scratch). The behavior is really intended for `write` where we want to check if we have `write` access to both the "source" and the "destination" records.

Explicitly opt-out of having any source data in the `create` before performing the `check` calls, this way we correctly and only check for the validity of the destination.

issue 2746483
