### PR TITLE
[Fix] ondelete parameter on many2one not always filled in

### DIFF
--- a/doc/cla/individual/qrillet.md
+++ b/doc/cla/individual/qrillet.md
@@ -1,0 +1,11 @@
+France, 2022-02-09
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Quentin Rillet quentin.rillet@enovea.net https://github.com/quentinrillet

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2952,7 +2952,7 @@ class BaseModel(metaclass=MetaModel):
                 if not field.required:
                     _logger.warning("Field %s with delegate=True must be required.", field)
                     field.required = True
-                if field.ondelete.lower() not in ('cascade', 'restrict'):
+                if (field.ondelete or "").lower() not in ('cascade', 'restrict'):
                     field.ondelete = 'cascade'
                 type(self)._inherits = {**self._inherits, field.comodel_name: field.name}
                 self.pool[field.comodel_name]._inherits_children.add(self._name)


### PR DESCRIPTION
Issue: When updating a module with a many2one, the ondelete field is not always filled in.

I fix it like line 2943. 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
