### PR TITLE
[ADD] l10n_it_edi_sdicoop: user settings for demo mode

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -18,6 +18,7 @@ _logger = logging.getLogger(__name__)
 
 
 DEFAULT_SERVER_URL = 'https://l10n-it-edi.api.odoo.com'
+TEST_SERVER_URL = 'https://l10n-it-edi-demo.api.odoo.com'
 TIMEOUT = 30
 
 

--- a/addons/l10n_it_edi/views/l10n_it_view.xml
+++ b/addons/l10n_it_edi/views/l10n_it_view.xml
@@ -78,13 +78,11 @@
                         </div>
                         <group>
                             <field name="l10n_it_has_eco_index" string="Company listed on the register of companies"/>
-                        </group>
-                        <group attrs="{'invisible': [('l10n_it_has_eco_index', '=', False)]}">
-                            <field name="l10n_it_eco_index_office"/>
-                            <field name="l10n_it_eco_index_number"/>
-                            <field name="l10n_it_eco_index_share_capital"/>
-                            <field name="l10n_it_eco_index_sole_shareholder"/>
-                            <field name="l10n_it_eco_index_liquidation_state"/>
+                            <field name="l10n_it_eco_index_office" attrs="{'invisible': [('l10n_it_has_eco_index', '=', False)]}"/>
+                            <field name="l10n_it_eco_index_number" attrs="{'invisible': [('l10n_it_has_eco_index', '=', False)]}"/>
+                            <field name="l10n_it_eco_index_share_capital" attrs="{'invisible': [('l10n_it_has_eco_index', '=', False)]}"/>
+                            <field name="l10n_it_eco_index_sole_shareholder" attrs="{'invisible': [('l10n_it_has_eco_index', '=', False)]}"/>
+                            <field name="l10n_it_eco_index_liquidation_state" attrs="{'invisible': [('l10n_it_has_eco_index', '=', False)]}"/>
                         </group>
                     </group>
                     <group>
@@ -95,9 +93,7 @@
                         </div>
                         <group>
                             <field name="l10n_it_has_tax_representative" string="Company have a tax representative"/>
-                        </group>
-                        <group attrs="{'invisible': [('l10n_it_has_tax_representative', '=', False)]}">
-                            <field name="l10n_it_tax_representative_partner_id"/>
+                            <field name="l10n_it_tax_representative_partner_id" attrs="{'invisible': [('l10n_it_has_tax_representative', '=', False)]}"/>
                         </group>
                     </group>
                 </page>

--- a/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
+++ b/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
@@ -89,7 +89,10 @@ class AccountEdiFormat(models.Model):
         res.extend(self._l10n_it_edi_check_invoice_configuration(move))
 
         if not self._get_proxy_user(move.company_id):
-            res.append(_("You must accept the terms and conditions in the settings to use FatturaPA."))
+            res.append(_("You need to register before you can use FatturaPA"
+                         " to send and receive electronic invoices.\n\n"
+                         "Select from the menu:\n"
+                         "Settings -> Electronic Document Invoicing -> Register"))
 
         return res
 

--- a/addons/l10n_it_edi_sdicoop/models/res_config_settings.py
+++ b/addons/l10n_it_edi_sdicoop/models/res_config_settings.py
@@ -8,19 +8,21 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     is_edi_proxy_active = fields.Boolean(compute='_compute_is_edi_proxy_active')
-    l10n_it_edi_sdicoop_demo_mode = fields.Boolean(compute='_compute_l10n_it_edi_sdicoop_demo_mode',
-                                           inverse='_set_l10n_it_edi_sdicoop_demo_mode',
-                                           readonly=False)
+    l10n_it_edi_sdicoop_demo_mode = fields.Selection(
+        [('demo', 'Demo'), ('official', 'Official')],
+        compute='_compute_l10n_it_edi_sdicoop_demo_mode',
+        inverse='_set_l10n_it_edi_sdicoop_demo_mode',
+        readonly=False)
 
     @api.depends("is_edi_proxy_active")
     def _compute_l10n_it_edi_sdicoop_demo_mode(self):
         server_url = self.env['ir.config_parameter'].get_param('account_edi_proxy_client.edi_server_url', DEFAULT_SERVER_URL)
         for config in self:
-            config.l10n_it_edi_sdicoop_demo_mode = (server_url == TEST_SERVER_URL)
+            config.l10n_it_edi_sdicoop_demo_mode = ('demo' if server_url == TEST_SERVER_URL else 'official')
 
     def _set_l10n_it_edi_sdicoop_demo_mode(self):
         for config in self:
-            url = TEST_SERVER_URL if config.l10n_it_edi_sdicoop_demo_mode else DEFAULT_SERVER_URL
+            url = TEST_SERVER_URL if config.l10n_it_edi_sdicoop_demo_mode == 'demo' else DEFAULT_SERVER_URL
             self.env['ir.config_parameter'].set_param('account_edi_proxy_client.edi_server_url', url)
 
     @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')

--- a/addons/l10n_it_edi_sdicoop/models/res_config_settings.py
+++ b/addons/l10n_it_edi_sdicoop/models/res_config_settings.py
@@ -1,12 +1,27 @@
 # -*- coding: utf-8 -*-
 
 from odoo import api, models, fields
+from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import DEFAULT_SERVER_URL, TEST_SERVER_URL
 
 
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     is_edi_proxy_active = fields.Boolean(compute='_compute_is_edi_proxy_active')
+    l10n_it_edi_sdicoop_demo_mode = fields.Boolean(compute='_compute_l10n_it_edi_sdicoop_demo_mode',
+                                           inverse='_set_l10n_it_edi_sdicoop_demo_mode',
+                                           readonly=False)
+
+    @api.depends("is_edi_proxy_active")
+    def _compute_l10n_it_edi_sdicoop_demo_mode(self):
+        server_url = self.env['ir.config_parameter'].get_param('account_edi_proxy_client.edi_server_url', DEFAULT_SERVER_URL)
+        for config in self:
+            config.l10n_it_edi_sdicoop_demo_mode = (server_url == TEST_SERVER_URL)
+
+    def _set_l10n_it_edi_sdicoop_demo_mode(self):
+        for config in self:
+            url = TEST_SERVER_URL if config.l10n_it_edi_sdicoop_demo_mode else DEFAULT_SERVER_URL
+            self.env['ir.config_parameter'].set_param('account_edi_proxy_client.edi_server_url', url)
 
     @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
     def _compute_is_edi_proxy_active(self):

--- a/addons/l10n_it_edi_sdicoop/views/res_config_settings_views.xml
+++ b/addons/l10n_it_edi_sdicoop/views/res_config_settings_views.xml
@@ -37,9 +37,6 @@
                             </div>
                         </div>
                         <div class="col-12 col-lg-6 o_setting_box">
-                            <div class="o_setting_left_pane">
-                                <field name="l10n_it_edi_sdicoop_demo_mode"/>
-                            </div>
                             <div class="o_setting_right_pane">
                                 <div class="content-group">
                                     <span class="o_form_label">
@@ -48,6 +45,9 @@
                                     <div class="text-muted">
                                         Odoo will send the e-invoices to a non-production service, so that the feature can be freely tested by the user.
                                     </div>
+                                    <field name="l10n_it_edi_sdicoop_demo_mode"
+                                           widget="radio"
+                                           options="{'horizontal': true}"/>
                                 </div>
                             </div>
                         </div>

--- a/addons/l10n_it_edi_sdicoop/views/res_config_settings_views.xml
+++ b/addons/l10n_it_edi_sdicoop/views/res_config_settings_views.xml
@@ -36,6 +36,21 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="l10n_it_edi_sdicoop_demo_mode"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <div class="content-group">
+                                    <span class="o_form_label">
+                                        Fattura Elettronica test mode
+                                    </span>
+                                    <div class="text-muted">
+                                        Odoo will send the e-invoices to a non-production service, so that the feature can be freely tested by the user.
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </xpath>

--- a/addons/l10n_it_edi_sdicoop/views/res_config_settings_views.xml
+++ b/addons/l10n_it_edi_sdicoop/views/res_config_settings_views.xml
@@ -43,7 +43,7 @@
                                         Fattura Elettronica test mode
                                     </span>
                                     <div class="text-muted">
-                                        Odoo will send the e-invoices to a non-production service, so that the feature can be freely tested by the user.
+                                        Odoo will send the invoices to a non-production service for demo purposes.
                                     </div>
                                     <field name="l10n_it_edi_sdicoop_demo_mode"
                                            widget="radio"


### PR DESCRIPTION
- A new flag is added to the Setting `l10n_it_edi_sdicoop_demo_mode` that is computed from the `ir.config_parameter` `account_edi_proxy_client.edi_server_url`.

  If the flag is **on**, Odoo will point to a test IAP server   (https://l10n-it-edi-demo.api.odoo.com) for l10n_it_edi_sdicoop.

  If the flag is **off**, Odoo will point to the production IAP server (https://l10n-it-edi.api.odoo.com)

- Some minor UI rework for the EDI parameters on `res.company`

![immagine](https://user-images.githubusercontent.com/1665365/153237920-761ad57f-11cc-49ea-8514-caa32f667249.png)

- Changed the error message on missing Proxy registration - but not the title (it comes from `account_edi` so it's common to all EDIs)

![immagine](https://user-images.githubusercontent.com/1665365/153244720-8fdad2da-958d-4ca0-abdd-2e69be2daed5.png)
