### PR TITLE
[FIX] mrp: BoM report By-Products spacing

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -74,6 +74,7 @@ class ReportBomStructure(models.AbstractModel):
             'bom_id': bom_id,
             'currency': self.env.company.currency_id,
             'byproducts': lines,
+            'extra_column_count': self._get_extra_column_count(),
         }
         return self.env.ref('mrp.report_mrp_byproduct_line')._render({'data': values})
 


### PR DESCRIPTION
Before this commit, in the BoM Structure & Cost report, the By-Products line quantity, product cost and BoM cost were misaligned.
The issue happens once the `mrp_mpl` module is installed because then, the number of columns changes.