### PR TITLE
[FIX] hr_holidays: fix default duration when creating a new time off …

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar.js
@@ -86,34 +86,50 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
         // Handlers
         //--------------------------------------------------------------------------
 
+        _getNewTimeOffContext: function() {
+            let date_from = moment().set({
+                'hour': 0,
+                'minute': 0,
+                'second': 0
+            });
+            date_from.subtract(this.getSession().getTZOffset(date_from), 'minutes');
+            date_from = date_from.locale('en').format('YYYY-MM-DD HH:mm:ss');
+            let date_to = moment().set({
+                'hour': 23,
+                'minute': 59,
+                'second': 59
+            });
+            date_to.subtract(this.getSession().getTZOffset(date_to), 'minutes');
+            date_to = date_to.locale('en').format('YYYY-MM-DD HH:mm:ss');
+            return {
+                'default_date_from': date_from,
+                'default_date_to': date_to,
+                'lang': this.context.lang
+            }
+        },
+
         /**
          * Action: create a new time off request
          *
          * @private
          */
         _onNewTimeOff: function () {
-            let self = this;
-
-            self._rpc({
+            this._rpc({
                 model: 'ir.ui.view',
                 method: 'get_view_id',
                 args: ['hr_holidays.hr_leave_view_form_dashboard_new_time_off'],
-            }).then(function(ids) {
-                self.timeOffDialog = new dialogs.FormViewDialog(self, {
+            }).then((ids) => {
+                this.timeOffDialog = new dialogs.FormViewDialog(this, {
                     res_model: "hr.leave",
                     view_id: ids,
-                    context: {
-                        'default_date_from': moment().locale('en').format('YYYY-MM-DD'),
-                        'default_date_to': moment().add(1, 'days').locale('en').format('YYYY-MM-DD'),
-                        'lang': self.context.lang,
-                    },
+                    context: this._getNewTimeOffContext(),
                     title: _t("New time off"),
                     disable_multiple_selection: true,
-                    on_saved: function() {
-                        self.reload();
+                    on_saved: () => {
+                        this.reload();
                     },
                 });
-                self.timeOffDialog.open();
+                this.timeOffDialog.open();
             });
         },
 

--- a/addons/hr_holidays/static/src/js/time_off_calendar_employee.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar_employee.js
@@ -173,35 +173,51 @@ odoo.define('hr_holidays.employee.dashboard.views', function(require) {
         // Handlers
         //--------------------------------------------------------------------------
 
+        _getNewTimeOffContext: function() {
+            let date_from = moment().set({
+                'hour': 0,
+                'minute': 0,
+                'second': 0
+            });
+            date_from.subtract(this.getSession().getTZOffset(date_from), 'minutes');
+            date_from = date_from.format('YYYY-MM-DD HH:mm:ss');
+            let date_to = moment().set({
+                'hour': 23,
+                'minute': 59,
+                'second': 59
+            });
+            date_to.subtract(this.getSession().getTZOffset(date_to), 'minutes');
+            date_to = date_to.format('YYYY-MM-DD HH:mm:ss');
+            return {
+                'default_date_from': date_from,
+                'default_date_to': date_to,
+                'lang': this.context.lang,
+                'default_employee_id': this.context.employee_id[0],
+            }
+        },
+
         /**
          * Action: create a new time off request
          *
          * @private
          */
         _onNewTimeOff: function () {
-            let self = this;
-
-            self._rpc({
+            this._rpc({
                 model: 'ir.ui.view',
                 method: 'get_view_id',
                 args: ['hr_holidays.hr_leave_view_form_dashboard_new_time_off'],
-            }).then(function(ids) {
-                self.timeOffDialog = new dialogs.FormViewDialog(self, {
+            }).then((ids) => {
+                this.timeOffDialog = new dialogs.FormViewDialog(this, {
                     res_model: "hr.leave",
                     view_id: ids,
-                    context: {
-                        'default_employee_id': self.context.employee_id[0],
-                        'default_date_from': moment().format('YYYY-MM-DD'),
-                        'default_date_to': moment().add(1, 'days').format('YYYY-MM-DD'),
-                        'lang': self.context.lang,
-                    },
+                    context: this._getNewTimeOffContext(this),
                     title: _t("New time off"),
                     disable_multiple_selection: true,
-                    on_saved: function() {
-                        self.reload();
+                    on_saved: () => {
+                        this.reload();
                     },
                 });
-                self.timeOffDialog.open();
+                this.timeOffDialog.open();
             });
         },
 


### PR DESCRIPTION
…from dashboard

In the dashboard of Time Off, when clicking on New Time Off, there is a difference of
one day between the start and end date and the duration of the time off shows one day.

By default, when clicking on the New Time Off button, the start and end date should be
the same with a duration of one day.

task-2760487


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
