### PR TITLE
Update `create` doc on allowed `vals_list` types

### DIFF
--- a/doc/cla/individual/AdrianTeng.md
+++ b/doc/cla/individual/AdrianTeng.md
@@ -1,0 +1,10 @@
+
+Hong Kong, 10/02/2022
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Adrian TENG adrian@teng.io https://github.com/AdrianTeng

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3970,7 +3970,7 @@ Fields:
         The new records are initialized using the values from the list of dicts
         ``vals_list``, and if necessary those from :meth:`~.default_get`.
 
-        :param list vals_list:
+        :param Union[list[dict], dict] vals_list:
             values for the model's fields, as a list of dictionaries::
 
                 [{'field_name': field_value, ...}, ...]


### PR DESCRIPTION
Though `create` actually accepts taking a `dict`, and this is stated in the details description in the docstring, because the param type is currently only `list`, when you do pass a `dict` into `create`, your IDE (such as PyCharm) might warn you on this:

<img width="677" alt="image" src="https://user-images.githubusercontent.com/6933071/153350475-70fd466a-b12c-4cf5-8256-0b400bb756b8.png">


With this change IDE would understands both types are allow and stops complaining.

<img width="659" alt="image" src="https://user-images.githubusercontent.com/6933071/153350522-77e06e7c-4ed7-4217-8bff-bd7b4e20d049.png">


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
