### PR TITLE
[IMP] account_check_printing: improve perf of computed preferred pm

### DIFF
--- a/addons/account_check_printing/models/account_move.py
+++ b/addons/account_check_printing/models/account_move.py
@@ -3,6 +3,7 @@
 
 
 from odoo import models, fields, api
+from odoo.tools.sql import column_exists, create_column
 
 
 class AccountMove(models.Model):
@@ -14,6 +15,15 @@ class AccountMove(models.Model):
         compute='_compute_preferred_payment_method_idd',
         store=True,
     )
+
+    def _auto_init(self):
+        """ Create column for `preferred_payment_method_id` to avoid having it
+        computed by the ORM on installation. Since `property_payment_method_id` is
+        introduced in this module, there is no need for UPDATE
+        """
+        if not column_exists(self.env.cr, "account_move", "preferred_payment_method_id"):
+            create_column(self.env.cr, "account_move", "preferred_payment_method_id", "int4")
+        return super()._auto_init()
 
     @api.depends('partner_id')
     def _compute_preferred_payment_method_idd(self):


### PR DESCRIPTION
When install the module on a db with huge amount of account move,
prefetching data when accessing `partner_id` of first move iteration is
costly and should be avoided.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
