### PR TITLE
[FIX] web_editor: prevent traceback on create and quick discard mailing

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1215,6 +1215,10 @@ const Wysiwyg = Widget.extend({
             const eventName = elem.dataset.eventName;
             let colorpicker = null;
             const mutex = new concurrency.MutexedDropPrevious();
+            if (!elem.ownerDocument.defaultView) {
+                // In case the element is not in the DOM, don't do anything with it.
+                continue;
+            }
             // If the element is within an iframe, access the jquery loaded in
             // the iframe because it is the one who will trigger the dropdown
             // events (i.e hide.bs.dropdown and show.bs.dropdown).


### PR DESCRIPTION
In `mass_mailing`:

1. Click CREATE
2. As soon as it appears, click "DISCARD"
3. Wait a little bit

-> A traceback appeared.

That is because wysiwyg was still busy starting and, in that process, requested the window object of the iframe that was already removed.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
