### PR TITLE
[FIX] point_of_sale: product name on delivery slip from pos order

### DIFF
--- a/addons/point_of_sale/models/__init__.py
+++ b/addons/point_of_sale/models/__init__.py
@@ -18,6 +18,7 @@ from . import res_partner
 from . import res_company
 from . import res_config_settings
 from . import stock_picking
+from . import stock_rule
 from . import stock_warehouse
 from . import pos_payment
 from . import pos_payment_method

--- a/addons/point_of_sale/models/stock_rule.py
+++ b/addons/point_of_sale/models/stock_rule.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = 'stock.rule'
+
+    def _get_stock_move_values(self, product_id, product_qty, product_uom, location_id, name, origin, company_id, values):
+        move_values = super()._get_stock_move_values(product_id, product_qty, product_uom, location_id, name, origin, company_id, values)
+        if values.get('product_description_variants') and values.get('group_id') and values['group_id'].pos_order_id:
+            move_values['description_picking'] = values['product_description_variants']
+        return move_values


### PR DESCRIPTION
Delivery slip created from a POS order contains the product name 3 times

Steps to reproduce:
1. Install Point of Sale app
2. On the Point of Sale dashboard, open 'Shop' settings (with the three
dots on the top right corner)
3. Check Ship Later in Inventory
4. Open a POS session, add a product to an order and go to the payment
5. Select a payment method and a customer, check the option "Ship Later"
 and then validate the order
6. Quit the POS session and go to Point of Sale > Orders > Orders
7. Open the created order and access its picking with the smart button
8. Print the delivery slip
9. The name of the product is printed 3 times

Solution:
Override `_get_stock_move_values` in point_of_sale in order to overwrite
the value of `description_picking`.

Problem:
`product_description_variants` doesn't hold the same value whether it's
in sales or in point_of_sale. In Sales it describes the variants of the
product but in point_of_sale, it is the full product name i.e. the
product name and the variants used.

opw-2736443