### PR TITLE
[fix] sale_project: sales order botton not visible in mobile view

### DIFF
--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -19,7 +19,7 @@
         <field name="inherit_id" ref="project.edit_project"/>
         <field name="arch" type="xml">
             <div class="oe_button_box" position="inside">
-                <button class="d-none d-md-inline oe_stat_button" 
+                <button class="oe_stat_button"
                     type="object" name="action_view_so" icon="fa-dollar" 
                     attrs="{'invisible': [('sale_order_id', '=', False)]}" 
                     groups="sales_team.group_sale_salesman"


### PR DESCRIPTION
before this commit,
sales order state botton of project.project form view  is not visible in mobile
view.

after this commit,
sales order state botton is visible in mobile view.

ID-2739646

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
