### PR TITLE
[FIX] web_enterprise: close the burger menu on the new dialog

### DIFF
--- a/addons/sale_project/views/project_sharing_views.xml
+++ b/addons/sale_project/views/project_sharing_views.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
                 <field name="display_sale_order_button" invisible="1"/>
-                <button class="d-none d-md-inline oe_stat_button"
+                <button class="oe_stat_button"
                         type="object" name="action_project_sharing_view_so" icon="fa-dollar"
                         attrs="{'invisible': [('display_sale_order_button', '=', False)]}"
                         string="Sales Order"/>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -36,7 +36,7 @@
                 <button name="action_create_invoice" string="Create Invoice" type="object" class="btn-secondary" groups="sales_team.group_sale_salesman_all_leads" attrs="{'invisible': ['|', ('has_any_so_with_nothing_to_invoice', '=', False), ('has_any_so_to_invoice', '=', True)]}" data-hotkey="w"/>
             </xpath>
             <xpath expr="//button[@name='%(project.project_update_all_action)d']" position="after">
-                <button class="d-none d-md-inline oe_stat_button"
+                <button class="oe_stat_button"
                         type="object" name="action_view_sos" icon="fa-dollar"
                         attrs="{'invisible': ['|', ('allow_billable', '=', False), ('sale_order_count', '=', 0)]}"
                         groups="sales_team.group_sale_salesman_all_leads">

--- a/addons/web/static/src/webclient/burger_menu/burger_menu.js
+++ b/addons/web/static/src/webclient/burger_menu/burger_menu.js
@@ -61,8 +61,9 @@ export class BurgerMenu extends Component {
     _toggleUserMenu() {
         this.state.isUserMenuOpened = !this.state.isUserMenuOpened;
     }
-    _onMenuClicked(menu) {
-        this.menuRepo.selectMenu(menu);
+    async _onMenuClicked(menu) {
+        await this.menuRepo.selectMenu(menu);
+        this._closeBurger();
     }
     _onSwipeStart(ev) {
         this.swipeStartX = ev.changedTouches[0].clientX;

--- a/addons/web/static/tests/mobile/burger_menu_tests.js
+++ b/addons/web/static/tests/mobile/burger_menu_tests.js
@@ -122,3 +122,38 @@ QUnit.test("Burger menu closes when an action is requested", async (assert) => {
     assert.containsNone(document.body, ".o_burger_menu");
     assert.containsOnce(document.body, ".o_kanban_view");
 });
+
+QUnit.test("Burger menu closes when click on menu item", async (assert) => {
+    serverData.actions[1].target = 'new';
+    serverData.menus[1].children = [99];
+    serverData.menus[99] = {
+        id: 99,
+        children: [],
+        name: "SubMenu",
+        appID: 1,
+        actionID: 1,
+        xmlid: "",
+        webIconData: undefined,
+        webIcon: false,
+    };
+    await createWebClient({ serverData });
+    await click(document.body, ".o_navbar_apps_menu .dropdown-toggle");
+    await legacyExtraNextTick();
+    await click(document.body, ".o_app:nth-of-type(2)");
+    await legacyExtraNextTick();
+
+    assert.containsNone(document.body, ".o_burger_menu");
+
+    await click(document.body, ".o_mobile_menu_toggle");
+    assert.containsOnce(document.body, ".o_burger_menu");
+    assert.strictEqual(
+        document.body.querySelector(
+            ".o_burger_menu .o_burger_menu_app .o_menu_sections .dropdown-item"
+        ).textContent,
+        "SubMenu"
+    );
+    await click(document.body, ".o_burger_menu .o_burger_menu_app .o_menu_sections .dropdown-item");
+    await legacyExtraNextTick();
+    await legacyExtraNextTick();
+    assert.containsNone(document.body, ".o_burger_menu");
+});


### PR DESCRIPTION
[FIX] web_enterprise: close the burger menu on the new dialog

When the wizard (new dialog) is opened on the burger menu item, the burger menu does
not close. The burger menu appears on the wizard. It is fixed.

Reproduction Steps
-Installed project application
-Reporting -> Burndown Chart

task-2739646