### PR TITLE
[FIX] website: ensure order of we-matrix's events

### DIFF
--- a/addons/website/static/src/snippets/s_chart/options.js
+++ b/addons/website/static/src/snippets/s_chart/options.js
@@ -438,18 +438,7 @@ options.registry.InnerChart = options.Class.extend({
      * @param {Event} ev
      */
     _onMatrixInputFocusOut: function (ev) {
-        // Sometimes, an input is focusout for internal reason (like an undo
-        // recording) then focused again manually in the same JS stack
-        // execution. In that case, the blur should not trigger an option
-        // selection as the user did not leave the input. We thus defer the blur
-        // handling to then check that the target is indeed still blurred before
-        // executing the actual option selection.
-        setTimeout(() => {
-            if (ev.currentTarget === document.activeElement) {
-                return;
-            }
-            this._reloadGraph();
-        });
+        this._reloadGraph();
     },
     /**
      * Set the selected cell/header and display the related remove button


### PR DESCRIPTION
This commit ensures that changes are applied in the same order as the
events are triggered on the we-matrix. This was not the case because of
another bug we had to consider and which is not there anymore, this is
why this fix is done in 15.0 and not before.

This commit is the continuation of [1] which applied the same change for
we-input.

[1]: https://github.com/odoo/odoo/pull/79295/commits/be96612c753e8c2ec857972f03473f94eb853017

task-2761187

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
