### PR TITLE
[FIX] project: translate 'assignee' in the view for shared project wi…

### DIFF
--- a/addons/project/i18n/project.pot
+++ b/addons/project/i18n/project.pot
@@ -856,6 +856,16 @@ msgid "Assign to Me"
 msgstr ""
 
 #. module: project
+#: model_terms:ir.ui.view,help:project.project_sharing_project_task_view_kanban
+msgid " assignee"
+msgstr ""
+
+#. module: project
+#: model_terms:ir.ui.view,help:project.project_sharing_project_task_view_kanban
+msgid " assignees"
+msgstr ""
+
+#. module: project
 #. openerp-web
 #: code:addons/project/static/src/js/project_task_kanban_examples.js:0
 #, python-format

--- a/addons/project/views/project_sharing_views.xml
+++ b/addons/project/views/project_sharing_views.xml
@@ -98,8 +98,11 @@
                                 <div class="oe_kanban_bottom_right" t-if="!selection_mode">
                                     <span t-if="record.portal_user_names.raw_value.length > 0" class="pr-2" t-att-title="record.portal_user_names.raw_value">
                                         <t t-set="user_count" t-value="record.portal_user_names.raw_value.split(',').length"/>
-                                        <t t-set="display_nb_assignees" t-value="user_count + ' assignee' + (user_count > 1 ? 's' : '')"/>
-                                        <t t-out="display_nb_assignees"/>
+                                        <t t-out="user_count"/>
+                                        <t t-if="user_count > 1"> assignees</t>
+                                        <t t-else=""> assignee</t>
+                                        <t t-if="1 == 0" t-set="display_nb_assignees" t-value="user_count + ' assignee' + (user_count > 1 ? 's' : '')"/>
+                                        <t t-if="1 == 0" t-out="display_nb_assignees"/>
                                     </span>
                                     <field name="kanban_state" widget="state_selection"/>
                                     <!-- TODO: [XBO] remove me in master -->


### PR DESCRIPTION
…th portal user

In the kanban view related to shared project with portal user, the term 'assignee' is not translated
in user language.

With this commit, this term will be translated based on the user language.

opw-2746504
