### PR TITLE
[FIX] stock: select dest location of a SML

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -208,6 +208,8 @@ class StockMoveLine(models.Model):
                 packaging=self.move_id.product_packaging_id, additional_qty=additional_qty)
 
     def _get_default_dest_location(self):
+        if not self.user_has_groups('stock.group_stock_storage_categories'):
+            return self.location_dest_id[:1]
         if self.env.context.get('default_location_dest_id'):
             return self.env['stock.location'].browse([self.env.context.get('default_location_dest_id')])
         return (self.move_id.location_dest_id or self.picking_id.location_dest_id or self.location_dest_id)[0]


### PR DESCRIPTION
On a SML, when setting the done quantity, the onchange may change the
destination location selected by the user

To reproduce the issue:
1. In Settings:
    - Enable "Storage Locations"
    - (Then, ensure "Storage Categories" is disabled)
2. Inventory > Operations Types, edit "Internal Transfers":
    - Enable "Show Detailed Operations"
3. Create an internal transfer IT:
    - From: WH/Stock
    - To: WH/Stock
4. Add a detailed operations to IT:
    - Product: anyone
    - To: WH/Stock/Shelf 1
    - Done: 1

Error: One the field "Done" is modified, the "To" changes and becomes
"WH/Stock". This location should not change (it should be
"WH/Stock/Shelf 1")

When setting the done quantity, an onchange recomputes the destination
location of the SML. To do so, it uses a initial location and searches
among its children. Here is the issue: when "Storage Categories" is
disabled, this initial location should be the one selected by the user.

OPW-2704665