### PR TITLE
[FIX] hr_holidays: bring back Time Off Popover

### DIFF
--- a/addons/hr_holidays/static/src/dashboard/time_off_card.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.xml
@@ -58,7 +58,7 @@
         <div class="o_timeoff_info">
             <Popover position="'right'" popoverClass="'o_timeoff_popover'">
                 <span class="fa fa-question-circle-o"/>
-                <t t-set="opened">
+                <t t-set-slot="opened">
                     <ul>
                         <li>Allocated: <span t-esc="props.allocated"/></li>
                         <li>Approved: <span t-esc="props.approved"/></li>


### PR DESCRIPTION
The Time Off Popover was no longer showing the days allocated/planned/etc.
since odoo/odoo#80156.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
