### PR TITLE
[FIX] website_forum: prevent crash when trying to create a forum

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.editor.js
+++ b/addons/website_forum/static/src/js/website_forum.editor.js
@@ -8,9 +8,13 @@ var Dialog = require('web.Dialog');
 var _t = core._t;
 
 var ForumCreateDialog = Dialog.extend({
-    xmlDependencies: Dialog.prototype.xmlDependencies.concat(
-        ['/website_forum/static/src/xml/website_forum_templates.xml']
-    ),
+    xmlDependencies: Dialog.prototype.xmlDependencies.concat([
+        // TODO Move the toolbar template out of the website_forum_templates
+        // file in master. This way the unnecessary dependency of the creation
+        // dialog widget on the editor templates can be removed.
+        '/web_editor/static/src/xml/editor.xml',
+        '/website_forum/static/src/xml/website_forum_templates.xml',
+    ]),
     template: 'website_forum.add_new_forum',
     events: _.extend({}, Dialog.prototype.events, {
         'change input[name="privacy"]': '_onPrivacyChanged',

--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -13,6 +13,9 @@ var _t = core._t;
 publicWidget.registry.websiteForum = publicWidget.Widget.extend({
     selector: '.website_forum',
     xmlDependencies: [
+        // TODO Move the toolbar template out of the website_forum_templates
+        // file in master, as explained by the comment in the creation dialog
+        // widget.
         '/web_editor/static/src/xml/editor.xml',
         '/website_forum/static/src/xml/website_forum_templates.xml',
         '/website_forum/static/src/xml/website_forum_share_templates.xml',


### PR DESCRIPTION
An extra xml dependency was inadvertently added in the `ForumCreateDialog` in commit 740168ce8d27da3d6a7156d2d79655a898394923 by inheriting the `web_editor.toolbar template`, since the file where it is inherited is an xml dependency of the `ForumCreateDialog` widget. While the dependency is correctly loaded in the public widget it is not in the creation dialog widget, resulting in a crash.

Furthermore, the `ForumCreateDialog` widget does not actually need this template and neither does the public widget need the other templates already present in the same file at the time of the mentioned commit. However, since this is a fix in stable, this commit leaves the templates in their respective files, only adding the missing dependency in the `ForumCreateDialog` widget, preventing the crash whenever the creation dialog is loaded.