### PR TITLE
[Fix] web: breadcrumbs with readonly Many2One links

### DIFF
--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -89,10 +89,14 @@ var FieldMany2One = AbstractField.extend({
     }),
     events: _.extend({}, AbstractField.prototype.events, {
         'click input': '_onInputClick',
+        'click': '_onLinkClick',
         'focusout input': '_onInputFocusout',
         'keyup input': '_onInputKeyup',
         'click .o_external_button': '_onExternalButtonClick',
     }),
+    quickEditExclusion: [
+        '.o_form_uri',
+    ],
     AUTOCOMPLETE_DELAY: 200,
     SEARCH_MORE_LIMIT: 320,
     isQuickEditable: true,
@@ -746,13 +750,11 @@ var FieldMany2One = AbstractField.extend({
      * @override
      * @param {MouseEvent} event
      */
-    _onClick: function (event) {
+    _onLinkClick: function (event) {
         var self = this;
         if (this.mode === 'readonly') {
             event.preventDefault();
-            if (this.noOpen) {
-                this._super(...arguments);
-            } else {
+            if (!this.noOpen) {
                 event.stopPropagation();
                 this._rpc({
                     model: this.field.relation,

--- a/addons/web/static/tests/legacy/fields/relational_fields/field_many2one_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields/field_many2one_tests.js
@@ -10,6 +10,8 @@ var StandaloneFieldManagerMixin = require('web.StandaloneFieldManagerMixin');
 var testUtils = require('web.test_utils');
 var Widget = require('web.Widget');
 
+const { legacyExtraNextTick } = require("@web/../tests/helpers/utils");
+const { createWebClient, doAction } = require('@web/../tests/webclient/helpers');
 const { browser } = require('@web/core/browser/browser');
 const { patchWithCleanup } = require('@web/../tests/helpers/utils');
 const cpHelpers = require('@web/../tests/search/helpers');
@@ -3658,6 +3660,70 @@ QUnit.module('fields', {}, function () {
             assert.containsOnce(form, 'th:not(.o_list_record_remove_header)',
                 "should be 1 column after the value change");
             form.destroy();
+        });
+
+        QUnit.test('many2one links form view call', async function (assert) {
+            assert.expect(5);
+
+            let serverData = {};
+            serverData.models = this.data;
+            serverData.models['turtle'].records[1].product_id = 37;
+            serverData.views= {
+                "partner,false,form": '<form string="Partners"> <field name="turtles"/> </form>',
+                "partner,false,search": '<search></search>',
+                'turtle,false,list':`
+                        <tree readonly="1">
+                            <field name="product_id" widget="product_configurator"/>
+                        </tree>`,
+                "product,false,search": '<search></search>',
+                "product,false,form": '<form></form>',
+            }
+            serverData.actions= {
+                1: {
+                    name: 'Partner',
+                    res_model: 'partner',
+                    res_id: 1,
+                    type: 'ir.actions.act_window',
+                    views: [[false, 'form']],
+                }
+            }
+
+            const webClient = await createWebClient({
+                serverData,
+                legacyParams: { withLegacyMockServer: true },
+                mockRPC: function (route, args){
+                     if (args.method === 'get_formview_action'){
+                        assert.step('get_formview_action')
+                        return {
+                            type: "ir.actions.act_window",
+                            res_model: "product",
+                            view_type: "form",
+                            view_mode: "form",
+                            views: [[false, "form"]],
+                            target: "current",
+                            res_id: args[0],
+                        };
+                     }
+                }
+            });
+            await doAction(webClient, 1);
+
+            assert.containsOnce(webClient, 'a.o_form_uri',
+                "should display 1 m2o link in form");
+
+            assert.containsN(webClient, '.breadcrumb-item', 1,
+                "Should only contain one breadcrumb at the start");
+
+            await testUtils.dom.click($(webClient.el).find('a.o_form_uri'));
+
+            await legacyExtraNextTick();
+
+            assert.verifySteps(['get_formview_action'])
+
+            assert.containsN(webClient, '.breadcrumb-item', 2,
+                "Should contain 2 breadcrumbs after the clicking on the link");
+
+            webClient.destroy();
         });
 
         QUnit.module('Many2OneAvatar');


### PR DESCRIPTION
Step to reproduce:
- Open 'Sales'
- Open a SO
- Click on the product link in the OrderLine tree

Current Behaviour:
- Breadcrumbs are cleared
Since https://github.com/odoo/odoo/commit/cefd6ade293e6cfa8ec405f55c6d4d7194f36e7e the onClick is only triggered in form view

Behaviour after PR:
- Breadcrumbs are not cleared
Link are now trigger via another click action '_onLinkClick' and quickEdit does not trigger on URL click

opw-2748041

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
