### PR TITLE
[FIX] mail: don't crash on delete already deleted chatter

### DIFF
--- a/addons/mail/static/src/components/chatter_container/chatter_container.js
+++ b/addons/mail/static/src/components/chatter_container/chatter_container.js
@@ -43,7 +43,7 @@ export class ChatterContainer extends Component {
      * @override
      */
     _onWillDestroy() {
-        if (this.chatter) {
+        if (this.chatter && this.chatter.exists()) {
             this.chatter.delete();
         }
     }


### PR DESCRIPTION
Since Owl 2 changes in compatibility layer, destroy hook is called from the
compatibility layer on a component already destroyed (from the documents mixin
in this case).

There is probably a fix to do in the compatibility layer, but the current PR is
an easy fix to avoid the crash on the documents app in the meantime.

task-2761082