### PR TITLE
[FIX] test_lint: properly gives optional argument

### DIFF
--- a/odoo/addons/test_lint/tests/test_ecmascript.py
+++ b/odoo/addons/test_lint/tests/test_ecmascript.py
@@ -39,7 +39,7 @@ class TestECMAScriptVersion(lint_case.LintCase):
         ]
 
         _logger.info('Testing %s js files', len(files_to_check))
-        cmd = [es_check, MAX_ES_VERSION, '--module'] + files_to_check
+        cmd = [es_check, MAX_ES_VERSION] + files_to_check + ['--module']
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = process.communicate()
         self.assertEqual(process.returncode, 0, msg=out.decode())


### PR DESCRIPTION
The es-check help specify that the `--module` optional argument as to be
given at the end of the cli. After an update to version `6.2.1` it led
to errors on runbot's where the Dockerfile was updated.  The error was
like if the `--module` cli argument was not given at all.  e.g.: `error:
SyntaxError: 'import' and 'export' may appear only with 'sourceType:
module'`

With this commit, the argument is given at the end of the cli as
expected.
