### PR TITLE
[FIX] account: add default return for `_compute_amount`

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -282,6 +282,8 @@ class AccountTax(models.Model):
         # <=> new_base * (1 - tax_amount) = base
         if self.amount_type == 'division' and price_include:
             return base_amount - (base_amount * (self.amount / 100))
+        # default value for custom amount_type
+        return 0.0
 
     def json_friendly_compute_all(self, price_unit, currency_id=None, quantity=1.0, product_id=None, partner_id=None, is_refund=False):
         """ Called by the reconciliation to compute taxes on writeoff during bank reconciliation


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The function `_compute_amount` on `account.tax` returns None if the value of
`amount_type` is not a standard Odoo value. During normal use, this will never
be the case, and if the value is  modified by a custom module the method is
overridden in its code to account for that case.

During an upgrade, however, custom modules are not available. During the tests,
if a field needs to be computed using that function, it will break with
`TypeError: unsupported operand type(s) for /: 'NoneType' and 'float'`

Adding a default return to the function in case the `amount_type` is not
recognised will help prevent this.

Current behavior before PR:
Desired behavior after PR is merged:

Behavior should be the same since this is a corner case for upgrades.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
