### PR TITLE
[FIX] l10n_ar, l10n_ec, l10n_pe: use fiscal country

### DIFF
--- a/addons/l10n_ar/models/res_company.py
+++ b/addons/l10n_ar/models/res_company.py
@@ -33,7 +33,7 @@ class ResCompany(models.Model):
     def _localization_use_documents(self):
         """ Argentinean localization use documents """
         self.ensure_one()
-        return True if self.country_id.code == "AR" else super()._localization_use_documents()
+        return self.account_fiscal_country_id.code == "AR" or super()._localization_use_documents()
 
     @api.constrains('l10n_ar_afip_responsibility_type_id')
     def _check_accounting_info(self):

--- a/addons/l10n_ec/models/res_company.py
+++ b/addons/l10n_ec/models/res_company.py
@@ -7,6 +7,4 @@ class ResCompany(models.Model):
 
     def _localization_use_documents(self):
         self.ensure_one()
-        if self.country_id.code == "EC":
-            return True
-        return super(ResCompany, self)._localization_use_documents()
+        return self.account_fiscal_country_id.code == "EC" or super(ResCompany, self)._localization_use_documents()

--- a/addons/l10n_pe/models/res_company.py
+++ b/addons/l10n_pe/models/res_company.py
@@ -9,4 +9,4 @@ class ResCompany(models.Model):
     def _localization_use_documents(self):
         # OVERRIDE
         self.ensure_one()
-        return self.country_id.code == "PE" or super()._localization_use_documents()
+        return self.account_fiscal_country_id.code == "PE" or super()._localization_use_documents()


### PR DESCRIPTION
Currently all latam localizations except Chile use country_id in _localization_use_documents().
account_fiscal_country_id should be used instead in all modules.

Task: 2761248

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
