### PR TITLE
[FIX] website: remove autocomplete from inputs in page properties

### DIFF
--- a/addons/website/static/src/xml/website.pageProperties.xml
+++ b/addons/website/static/src/xml/website.pageProperties.xml
@@ -162,7 +162,8 @@
                             <input type="password" id="visibility_password"
                                    t-att-value='widget.page.visibility_password'
                                    t-att-required="widget.page.visibility == 'password' ? 'required' : None"
-                                   class="form-control show_visibility_password"/>
+                                   class="form-control show_visibility_password"
+                                   autocomplete="new-password"/>
                             <t t-if="widget.page.hasSingleGroup">
                                 <div class="ml-1 input-group-prepend show_group_id">
                                     <div class="input-group-text"><i class="fa fa-group"></i></div>


### PR DESCRIPTION
Before this commit, on Chrome browser, the page url input and the
visiblity password input were autocompleted with the user's login and
password in the page properties options.

After this commit, they are no longer.

Regarding the url input page, it seems to be because Chrome considers
that the first text input located before a password input in the DOM is
a login input.

task-2502747

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
