### PR TITLE
[FIX] website_slides: prevent error when no completed_template selected

### DIFF
--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -99,11 +99,12 @@ class ChannelUsersRelation(models.Model):
         for record in self:
             template = record.channel_id.completed_template_id
             if template:
-                records = template_to_records.setdefault(template, self.env['slide.channel.partner'])
-                records += record
+                template_to_records.setdefault(template, self.env['slide.channel.partner'])
+                template_to_records[template] += record
 
+        record_email_values = dict()
         for template, records in template_to_records.items():
-            record_email_values = template.generate_email(self.ids, ['subject', 'body_html', 'email_from', 'partner_to'])
+            record_email_values.update(template.generate_email(records.ids, ['subject', 'body_html', 'email_from', 'partner_to']))
 
         mail_mail_values = []
         for record in self:

--- a/addons/website_slides/tests/common.py
+++ b/addons/website_slides/tests/common.py
@@ -2,10 +2,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import common
-from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.addons.mail.tests.common import mail_new_test_user, MockEmail
 
 
-class SlidesCase(common.TransactionCase):
+class SlidesCase(common.TransactionCase, MockEmail):
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
### Current behavior
If no completed template (`completed_template_id`) is selected in the options of an elearning course, an error occurs when a user completes this course.

### Steps
- Install elearning
- (*with demo data*) Go to a course (e.g. Basics of Gardening)
- Remove the selected "Completion Email" then save
- Complete the course

### Reason 
We are trying to access a `record_email_values` value here [1] but no value is assigned to `record_email_values` unless we have a completed_template [2].

[1] : https://github.com/odoo/odoo/blob/f4d83f31c12cb13d626bcaaa619c0f3be680cdbc/addons/website_slides/models/slide_channel.py#L110
[2] : https://github.com/odoo/odoo/blob/f4d83f31c12cb13d626bcaaa619c0f3be680cdbc/addons/website_slides/models/slide_channel.py#L105-L106

OPW-2753078