### PR TITLE
[FIX] account_bank_statement: prevent to get the current statement as previous statement

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -205,8 +205,9 @@ class AccountBankStatement(models.Model):
             # First one is in case we are creating a new record, in that case that new record does
             # not have any id yet. However if we are updating an existing record, the domain date <= st.date
             # will find the record itself, so we have to add a condition in the search to ignore self.id
-            if not isinstance(st.id, models.NewId):
-                domain.extend(['|', '&', ('id', '<', st.id), ('date', '=', st.date), '&', ('id', '!=', st.id), ('date', '!=', st.date)])
+            st_id = st.id.origin if isinstance(st.id, models.NewId) else st.id
+            if st_id:
+                domain.extend(['|', '&', ('id', '<', st_id), ('date', '=', st.date), '&', ('id', '!=', st_id), ('date', '!=', st.date)])
             previous_statement = self.search(domain, limit=1, order='date desc, id desc')
             st.previous_statement_id = previous_statement.id
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Step to reproduce:
Create and save a bank statement
Edit and change the date to a later date.

Current behavior before PR:
The ending balance become the starting balance.
When changing the date, odoo search for the previous statement and gets the previous ending balance as the new starting balance.
But due to an error, it can get the previous statement as if it was also the current statement.
After saving, the previous statement is recompute but not the starting/ending balances.

![2022-02-10_22-28](https://user-images.githubusercontent.com/25034353/153500602-096db879-99ae-469a-b417-949859f134b5.png)
![2022-02-10_22-31](https://user-images.githubusercontent.com/25034353/153500607-4e8b8423-6395-4b3f-a07b-07e104f592c5.png)
![2022-02-10_22-34](https://user-images.githubusercontent.com/25034353/153500608-1c11664e-1de0-459f-97f2-3af788d23a62.png)



Desired behavior after PR is merged:
When change the date, the current statement is excluded on search for starting balance.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
