### PR TITLE
[IMP] l10n_pt: add hash field for Portuguese invoicing

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -730,6 +730,7 @@ class AccountJournal(models.Model):
     default_debit_account_id = fields.Many2one('account.account', string='Default Debit Account',
         domain="[('deprecated', '=', False), ('company_id', '=', company_id)]", help="It acts as a default account for debit amount", ondelete='restrict')
     restrict_mode_hash_table = fields.Boolean(string="Lock Posted Entries with Hash",
+        compute="_compute_restrict_mode_hash_table",
         help="If ticked, the accounting entry or invoice receives a hash as soon as it is posted and cannot be modified anymore.")
     sequence_id = fields.Many2one('ir.sequence', string='Entry Sequence',
         help="This field contains the information related to the numbering of the journal entries of this journal.", required=True, copy=False)
@@ -806,6 +807,10 @@ class AccountJournal(models.Model):
             record.alias_name = record.alias_id.alias_name
             
     _inverse_alias_name = _inverse_type
+
+    def _compute_restrict_mode_hash_table(self):
+        for move in self:
+            move.restrict_mode_hash_table = False
 
     # do not depend on 'sequence_id.date_range_ids', because
     # sequence_id._get_current_sequence() may invalidate it!

--- a/addons/l10n_pt/__init__.py
+++ b/addons/l10n_pt/__init__.py
@@ -3,3 +3,5 @@
 
 # Copyright (C) 2012 Thinkopen Solutions, Lda. All Rights Reserved
 # http://www.thinkopensolutions.com.
+
+from . import models

--- a/addons/l10n_pt/models/__init__.py
+++ b/addons/l10n_pt/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- encoding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import account_move

--- a/addons/l10n_pt/models/__init__.py
+++ b/addons/l10n_pt/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_move
+from . import account

--- a/addons/l10n_pt/models/account.py
+++ b/addons/l10n_pt/models/account.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.journal'
+
+    def _compute_restrict_mode_hash_table(self):
+        for move in self:
+            if move.company_id.country_id.code == 'PT':
+                move.restrict_mode_hash_table = True

--- a/addons/l10n_pt/models/account_move.py
+++ b/addons/l10n_pt/models/account_move.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from hashlib import sha256
 
 from odoo import fields, models, _
 from odoo.exceptions import UserError
@@ -15,51 +16,35 @@ class AccountMove(models.Model):
         invisible=True,
         copy=False,
         store=True)
-    digital_signature = fields.Char(
-        string='Digital signature (hash)',
-        readonly=True,
-        invisible=True,
-        copy=False,
-        store=True)
 
-    def create_hash(self):
-        """Initialize the hash of the invoice, once."""
+    def _get_new_hash(self, secure_seq_number):
+        """ Returns the hash to write on journal entries when they get posted"""
+        self.ensure_one()
+        #get the only one exact previous move in the securisation sequence
+        prev_move = self.search([('state', '=', 'posted'),
+                                 ('type', '=', self.type),
+                                 ('company_id', '=', self.company_id.id),
+                                 ('journal_id', '=', self.journal_id.id),
+                                 ('secure_sequence_number', '!=', 0),
+                                 ('secure_sequence_number', '=', int(secure_seq_number) - 1)])
+        if prev_move and len(prev_move) != 1:
+            raise UserError(
+               _('An error occured when computing the inalterability. Impossible to get the unique previous posted journal entry.'))
 
-        def get_previous_hash(move_id, move_type):
-            """Return the hash/digital signature of the previous invoice of the same type"""
-            self._cr.execute("""
-                SELECT *
-                  FROM account_move
-                 WHERE
-                       type = %s AND
-                       state = 'posted' AND
-                       id != %s
-              ORDER BY system_entry_date DESC
-                 LIMIT 1
-            """, [move_type, move_id])
-            result = self._cr.fetchall()
-            if result:
-                result = result[0]  # Get first (and only) element
-                previous_document = self.env['account.move'].browse(result[0])
-                return previous_document.digital_signature
-            return ""
+        self.system_entry_date = datetime.now()
+        invoice_date = self.invoice_date.strftime('%Y-%m-%d')
+        system_entry_date = self.system_entry_date.strftime("%Y-%m-%dT%H:%M:%S")
+        invoice_no = self.type + ' ' + self.name
+        gross_total = float_repr(self.amount_total, 2)
+        previous_hash = prev_move.inalterable_hash if prev_move else ""
+        message = f"{invoice_date};{system_entry_date};{invoice_no};{gross_total};{previous_hash}"
+        return self._compute_hash(message)
 
-        def compute_digital_signature(data):
-            return "TODO"
-
-        for move in self:
-            move.system_entry_date = datetime.now()
-            invoice_date = move.invoice_date.strftime('%Y-%m-%d')
-            system_entry_date = move.system_entry_date.strftime("%Y-%m-%dT%H:%M:%S")
-            invoice_no = move.type + ' ' + move.name
-            gross_total = float_repr(move.amount_total, 2)
-            previous_hash = get_previous_hash(move.id, move.type)
-            message = f"{invoice_date};{system_entry_date};{invoice_no};{gross_total};{previous_hash}"
-            move.digital_signature = compute_digital_signature(message)
-
-    def action_post(self):
-        super().action_post()
-        self.create_hash()
+    def _compute_hash(self, message):
+        self.ensure_one()
+        # This is only temporary
+        hash_string = sha256(message.encode()).hexdigest()
+        return hash_string
 
     def button_draft(self):
         raise UserError(_("Sorry, you cannot reset to draft a posted invoice"))

--- a/addons/l10n_pt/models/account_move.py
+++ b/addons/l10n_pt/models/account_move.py
@@ -3,7 +3,7 @@
 
 from odoo import fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools import datetime, float_repr, format_date
+from odoo.tools import datetime, float_repr
 
 
 class AccountMove(models.Model):
@@ -30,12 +30,12 @@ class AccountMove(models.Model):
         """Initialize the hash of the invoice, once."""
 
         def get_previous_hash():
-            self._cr.execute("SELECT * from account_move WHERE type = 'out_invoice' ORDER BY system_entry_date DESC LIMIT 1")
-            result = self._cr.fetchall()[0]
-            print(result)
-            print(type(result))
-            if result is not None:
-                return result.digital_signature
+            self._cr.execute("SELECT * from account_move WHERE type = 'out_invoice' AND state = 'posted' AND id != %s ORDER BY system_entry_date DESC LIMIT 1", [self.id])
+            result = self._cr.fetchall()
+            if result:
+                result = result[0]  # Get first (and only) element
+                previous_document = self.env['account.move'].browse(result[0])
+                return previous_document.digital_signature
             return ""
 
         self.init_system_entry_date()

--- a/addons/l10n_pt/models/account_move.py
+++ b/addons/l10n_pt/models/account_move.py
@@ -16,21 +16,27 @@ class AccountMove(models.Model):
         copy=False,
         store=True)
     digital_signature = fields.Char(
-        string='Digital signature',
+        string='Digital signature (hash)',
         readonly=True,
         invisible=True,
         copy=False,
         store=True)
 
-    def init_system_entry_date(self):
-        """Initialize the System Entry Date"""
-        self.system_entry_date = datetime.now()
-
     def create_hash(self):
         """Initialize the hash of the invoice, once."""
 
-        def get_previous_hash():
-            self._cr.execute("SELECT * from account_move WHERE type = 'out_invoice' AND state = 'posted' AND id != %s ORDER BY system_entry_date DESC LIMIT 1", [self.id])
+        def get_previous_hash(move_id, move_type):
+            """Return the hash/digital signature of the previous invoice of the same type"""
+            self._cr.execute("""
+                SELECT *
+                  FROM account_move
+                 WHERE
+                       type = %s AND
+                       state = 'posted' AND
+                       id != %s
+              ORDER BY system_entry_date DESC
+                 LIMIT 1
+            """, [move_type, move_id])
             result = self._cr.fetchall()
             if result:
                 result = result[0]  # Get first (and only) element
@@ -38,22 +44,22 @@ class AccountMove(models.Model):
                 return previous_document.digital_signature
             return ""
 
-        self.init_system_entry_date()
-        invoice_date = self.invoice_date.strftime('%Y-%m-%d')
-        system_entry_date = self.system_entry_date.strftime("%Y-%m-%dT%H:%M:%S")
-        invoice_no = self.type + ' ' + self.name
-        gross_total = float_repr(self.amount_total, 2)
-        previous_hash = get_previous_hash()
-        message = f"{invoice_date};{system_entry_date};{invoice_no};{gross_total};{previous_hash}"
-        # TODO: self.digital_signature = rsa(message)
-        self.digital_signature = message
+        def compute_digital_signature(data):
+            return "TODO"
+
+        for move in self:
+            move.system_entry_date = datetime.now()
+            invoice_date = move.invoice_date.strftime('%Y-%m-%d')
+            system_entry_date = move.system_entry_date.strftime("%Y-%m-%dT%H:%M:%S")
+            invoice_no = move.type + ' ' + move.name
+            gross_total = float_repr(move.amount_total, 2)
+            previous_hash = get_previous_hash(move.id, move.type)
+            message = f"{invoice_date};{system_entry_date};{invoice_no};{gross_total};{previous_hash}"
+            move.digital_signature = compute_digital_signature(message)
 
     def action_post(self):
         super().action_post()
         self.create_hash()
-        for move in self:
-            print(move.system_entry_date)
-            print(move.digital_signature)
 
     def button_draft(self):
         raise UserError(_("Sorry, you cannot reset to draft a posted invoice"))

--- a/addons/l10n_pt/models/account_move.py
+++ b/addons/l10n_pt/models/account_move.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+from odoo.exceptions import UserError
+from odoo.tools import datetime, float_repr, format_date
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    system_entry_date = fields.Datetime(
+        string='System Entry Date',
+        readonly=True,
+        invisible=True,
+        copy=False,
+        store=True)
+    digital_signature = fields.Char(
+        string='Digital signature',
+        readonly=True,
+        invisible=True,
+        copy=False,
+        store=True)
+
+    def init_system_entry_date(self):
+        """Initialize the System Entry Date"""
+        self.system_entry_date = datetime.now()
+
+    def create_hash(self):
+        """Initialize the hash of the invoice, once."""
+
+        def get_previous_hash():
+            self._cr.execute("SELECT * from account_move WHERE type = 'out_invoice' ORDER BY system_entry_date DESC LIMIT 1")
+            result = self._cr.fetchall()[0]
+            print(result)
+            print(type(result))
+            if result is not None:
+                return result.digital_signature
+            return ""
+
+        self.init_system_entry_date()
+        invoice_date = self.invoice_date.strftime('%Y-%m-%d')
+        system_entry_date = self.system_entry_date.strftime("%Y-%m-%dT%H:%M:%S")
+        invoice_no = self.type + ' ' + self.name
+        gross_total = float_repr(self.amount_total, 2)
+        previous_hash = get_previous_hash()
+        message = f"{invoice_date};{system_entry_date};{invoice_no};{gross_total};{previous_hash}"
+        # TODO: self.digital_signature = rsa(message)
+        self.digital_signature = message
+
+    def action_post(self):
+        super().action_post()
+        self.create_hash()
+        for move in self:
+            print(move.system_entry_date)
+            print(move.digital_signature)
+
+    def button_draft(self):
+        raise UserError(_("Sorry, you cannot reset to draft a posted invoice"))


### PR DESCRIPTION
This commits adds two new fields necessary for Portuguese invoicing:
- The digital signature (hash field) which is required to be shown on the invoice and used in SAFT
- The SystemEntryDate which is used to compute the digital signature and is also exported in SAFT

Link: https://info.portaldasfinancas.gov.pt/pt/docs/Conteudos_1pagina/Documents/QR_Code_Technical_Specifications.pdf
