### PR TITLE
[IMP] website_crm_partner_assign: allow archiving partner activation

### DIFF
--- a/addons/website_crm_partner_assign/__manifest__.py
+++ b/addons/website_crm_partner_assign/__manifest__.py
@@ -5,7 +5,7 @@
     'name': 'Resellers',
     'category': 'Website/Website',
     'summary': 'Publish your resellers/partners and forward leads to them',
-    'version': '1.1',
+    'version': '1.2',
     'description': """
 This module allows to publish your resellers/partners on your website and to forward incoming leads/opportunities to them.
 

--- a/addons/website_crm_partner_assign/models/res_partner_activation.py
+++ b/addons/website_crm_partner_assign/models/res_partner_activation.py
@@ -11,3 +11,4 @@ class ResPartnerActivation(models.Model):
 
     sequence = fields.Integer('Sequence')
     name = fields.Char('Name', required=True)
+    active = fields.Boolean(default=True)

--- a/addons/website_crm_partner_assign/views/res_partner_activation_views.xml
+++ b/addons/website_crm_partner_assign/views/res_partner_activation_views.xml
@@ -21,7 +21,19 @@
             <tree string="Activation" editable="bottom">
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
+                <field name="active" widget="boolean_toggle"/>
             </tree>
+        </field>
+    </record>
+
+    <record id="res_partner_activation_view_search" model="ir.ui.view">
+        <field name="name">res.partner.activation.view.search</field>
+        <field name="model">res.partner.activation</field>
+        <field name="arch" type="xml">
+            <search string="Activation">
+                <field name="name" string="Partner Activation"/>
+                <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
+            </search>
         </field>
     </record>
 


### PR DESCRIPTION
Right now, there is no way to archive partner activations.

In this PR, a new field active is added to enable users to archive the partner activations.

taskID: 2753985