### PR TITLE
[FIX] l10n_it_edi: do not mention the country code

### DIFF
--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -214,9 +214,13 @@ class AccountMove(models.Model):
             return False
 
         def get_vat_number(vat):
+            if vat[:2].isdecimal():
+                return vat.replace(' ', '')
             return vat[2:].replace(' ', '')
 
         def get_vat_country(vat):
+            if vat[:2].isdecimal():
+                return 'IT'
             return vat[:2].upper()
 
         def in_eu(partner):


### PR DESCRIPTION
Italians do not always mention the country code in the VAT number of the partner, but we can suppose in that case that it is within Italy.  Instead of IT0477472701, they would put just 0477472701.

Backport to V13 for ticket 
https://www.odoo.com/web#id=2717424&model=project.task

opw-2717424