### PR TITLE
[REV] web_editor: revert add image in editable rather than in toolbar

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1059,7 +1059,6 @@ const Wysiwyg = Widget.extend({
     },
     _configureToolbar: function (options) {
         const $toolbar = this.toolbar.$el;
-        $toolbar.on('mousedown', e => e.preventDefault());
         const openTools = e => {
             e.preventDefault();
             e.stopImmediatePropagation();


### PR DESCRIPTION
This fix resulted in another bug as links could not longer be edited.

This reverts commit 57701b2125f7de4fc543bd9c10642a5c11fa32b8.