### PR TITLE
[FIX] calendar: notification detail correct redirection

### DIFF
--- a/addons/calendar/static/src/js/calendar_controller.js
+++ b/addons/calendar/static/src/js/calendar_controller.js
@@ -13,6 +13,7 @@
         const self = this;
         // When clicking on "Add", create a new record in form view
         this.$buttons.on('click', 'button.o-calendar-button-new', () => {
+            // TODO: switch to ir.action.act_window in master
             return self.do_action('calendar.action_calendar_event_notify', {
                 additional_context: self.context,
             });

--- a/addons/calendar/static/src/js/services/calendar_notification_service.js
+++ b/addons/calendar/static/src/js/services/calendar_notification_service.js
@@ -61,11 +61,12 @@ export const calendarNotificationService = {
                             {
                                 name: env._t("Details"),
                                 onClick: async () => {
-                                    await action.doAction(
-                                        "calendar.action_calendar_event_notify",
-                                        {
-                                            resId: notif.event_id,
-                                        }
+                                    await action.doAction({
+                                        type: 'ir.actions.act_window',
+                                        res_model: 'calendar.event',
+                                        res_id: notif.event_id,
+                                        views: [[false, 'form']],
+                                    }
                                     );
                                     notificationRemove();
                                 },

--- a/addons/calendar/static/tests/calendar_notification_tests.js
+++ b/addons/calendar/static/tests/calendar_notification_tests.js
@@ -128,7 +128,7 @@ QUnit.module("Calendar Notification", (hooks) => {
                 start() {
                     return {
                         doAction(actionId) {
-                            assert.step(actionId);
+                            assert.step(actionId.type);
                             return Promise.resolve(true);
                         },
                         loadState(state, options) {
@@ -154,7 +154,7 @@ QUnit.module("Calendar Notification", (hooks) => {
             );
 
             await click(webClient.el.querySelectorAll(".o_notification_buttons .btn")[1]);
-            assert.verifySteps(["calendar.action_calendar_event_notify"]);
+            assert.verifySteps(["ir.actions.act_window"]);
             assert.containsNone(webClient.el, ".o_notification");
         }
     );

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -420,6 +420,7 @@
         groups="base.group_no_one"/>
 
     <!-- called in js from '/js/base_calendar.js' -->
+    <!-- TODO: remove in master -->
     <record id="action_calendar_event_notify" model="ir.actions.act_window">
         <field name="name">Meetings</field>
         <field name="res_model">calendar.event</field>


### PR DESCRIPTION
Step to reproduce:
- Create an event in calendar with reminder
- (Move the event to trigger the reminder)
- Click on 'Details'

Current Behaviour:
- Open a new event

Behaviour after PR:
- Open the event linked to the notification

opw-2761492

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
