### PR TITLE
[FIX] mass_mailing: ensure font awesome icons in toolbar are displayed

### DIFF
--- a/addons/mass_mailing/views/assets.xml
+++ b/addons/mass_mailing/views/assets.xml
@@ -22,7 +22,7 @@
             * {
                 box-sizing: border-box !important;
             }
-            * h1, h2, h3, h4, h5, h6, p, td, th, div {
+            .o_layout :not(.fa) {
                 font-family: Arial, sans-serif !important;
             }
             /* Remove space around the email design. */


### PR DESCRIPTION
mass_mailing enforces a mail safe font but did so in a bit too agressive a way. This ensures it's limited to the content of the mail, and ignores font awesome icons.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
