### PR TITLE
[FIX] account: show tax reports of company's country

### DIFF
--- a/addons/account/wizard/wizard_tax_adjustments.py
+++ b/addons/account/wizard/wizard_tax_adjustments.py
@@ -11,6 +11,9 @@ class TaxAdjustments(models.TransientModel):
     def _get_default_journal(self):
         return self.env['account.journal'].search([('type', '=', 'general')], limit=1).id
 
+    def _domain_tax_report(self):
+        return [('tag_name', '!=', None), ('report_id.country_id', '=', self.env.company.account_tax_fiscal_country_id.id)]
+
     reason = fields.Char(string='Justification', required=True)
     journal_id = fields.Many2one('account.journal', string='Journal', required=True, default=_get_default_journal, domain=[('type', '=', 'general')])
     date = fields.Date(required=True, default=fields.Date.context_today)
@@ -20,10 +23,10 @@ class TaxAdjustments(models.TransientModel):
                                         domain="[('deprecated', '=', False), ('is_off_balance', '=', False)]")
     amount = fields.Monetary(currency_field='company_currency_id', required=True)
     adjustment_type = fields.Selection([('debit', 'Applied on debit journal item'), ('credit', 'Applied on credit journal item')], string="Adjustment Type", required=True)
-    tax_report_line_id = fields.Many2one(string="Report Line", comodel_name='account.tax.report.line', required=True, help="The report line to make an adjustment for.")
+    tax_report_line_id = fields.Many2one(string="Report Line", comodel_name='account.tax.report.line', required=True, help="The report line to make an adjustment for.",
+                                         domain=_domain_tax_report)
     company_currency_id = fields.Many2one('res.currency', readonly=True, default=lambda x: x.env.company.currency_id)
     report_id = fields.Many2one(string="Report", related='tax_report_line_id.report_id')
-
 
     def create_move(self):
         move_line_vals = []

--- a/addons/account/wizard/wizard_tax_adjustments_view.xml
+++ b/addons/account/wizard/wizard_tax_adjustments_view.xml
@@ -11,7 +11,7 @@
             </h1>
             <group>
                 <field name="report_id" invisible="1"/>
-                <field name="tax_report_line_id" widget="selection" domain="[('tag_name', '!=', None)]"/>
+                <field name="tax_report_line_id" widget="selection"/>
             </group>
             <group>
                 <group>


### PR DESCRIPTION
The tax adjustment wizard shows tax reports of countries other than the current company's country

Steps to reproduce:
1. Install Accounting
2. Go to Accounting > Configuration > Management > Tax Reports
3. Create a report for another country than the current company and add
 a line with a tag name
4. Go to Accounting > Accounting > Actions > Tax Adjustements (in debug
mode)
5. The created tax report line is suggested but it shouldn't

Solution:
Put the domain of `tax_report_line_id` in python and add a filter on the
country

opw-2760337