### PR TITLE
[FIX] website: only apply default lazy loading on images in frontend

### DIFF
--- a/addons/mass_mailing/data/mass_mailing_data.xml
+++ b/addons/mass_mailing/data/mass_mailing_data.xml
@@ -35,7 +35,7 @@
             <field name="email" model="res.users" eval="obj().env.ref('base.user_admin').email"/>
             <field name="list_ids" eval="[(6,0,[ref('mass_mailing.mailing_list_data')])]"/>
         </record>
-        <!-- Snippets' Default Images (to be replaced by themes) -->
+        <!-- Snippets' Default Images -->
         <record id="mass_mailing.s_media_list_default_image_1" model="ir.attachment">
             <field name="public" eval="True"/>
             <field name="name">s_media_list_default_image_1.jpg</field>

--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -236,9 +236,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
 
             $img.attr("src", src);
         });
-        $container.find('.o_mail_block_cover .oe_img_bg').each(function () {
-            $(this).css('background-image', `url('/mass_mailing_themes/static/src/img/theme_${themeParams.name}/s_default_image_block_banner.jpg')`);
-        });
     },
     /**
      * Switch themes or import first theme.

--- a/addons/mass_mailing/views/snippets/s_cover.xml
+++ b/addons/mass_mailing/views/snippets/s_cover.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template id="s_cover" name="Cover">
         <div class="s_cover o_mail_snippet_general" data-snippet="s_cover">
-            <img src="/web/image/mass_mailing.s_default_image_block_banner" alt="Cover image" class="img-fluid w-100 mx-auto"/>
+            <img src="/mass_mailing/static/src/img/theme_default/s_default_image_block_banner.jpg" alt="Cover image" class="img-fluid w-100 mx-auto"/>
         </div>
     </template>
 </odoo>

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -56,16 +56,15 @@ class IrQWeb(models.AbstractModel):
 
         atts = super(IrQWeb, self)._post_processing_att(tagName, atts, options)
 
-        if tagName == 'img' and 'loading' not in atts:
+        website = ir_http.get_request_website()
+        if not website and options.get('website_id'):
+            website = self.env['website'].browse(options['website_id'])
+        if website and tagName == 'img' and 'loading' not in atts:
             atts['loading'] = 'lazy'  # default is auto
 
         if options.get('inherit_branding') or options.get('rendering_bundle') or \
            options.get('edit_translations') or options.get('debug') or (request and request.session.debug):
             return atts
-
-        website = ir_http.get_request_website()
-        if not website and options.get('website_id'):
-            website = self.env['website'].browse(options['website_id'])
 
         if not website:
             return atts

--- a/addons/website/tests/test_qweb.py
+++ b/addons/website/tests/test_qweb.py
@@ -18,6 +18,7 @@ class TestQweb(TransactionCaseWithUserDemo):
                            {}, 'init', False, 'test')
 
     def test_qweb_post_processing_att(self):
+        website = self.env.ref('website.default_website')
         t = self.env['ir.ui.view'].create({
             'name': 'test',
             'type': 'qweb',
@@ -30,7 +31,7 @@ class TestQweb(TransactionCaseWithUserDemo):
                 <img src="http://test.external.img/img.png" loading="lazy"/>
                 <img src="http://test.external.img/img2.png" loading="lazy"/>
             """
-        rendered = self.env['ir.qweb']._render(t.id, {'url': 'http://test.external.img/img2.png'})
+        rendered = self.env['ir.qweb']._render(t.id, {'url': 'http://test.external.img/img2.png'}, website_id=website.id)
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_qweb_cdn(self):


### PR DESCRIPTION
The `loading="lazy"` attribute was set by default on all images but this affected the `mass_mailing` module as well while that attribute doesn't work in emails and can cause some issues in edition.

One known such issue this addresses is to be reproduced as follows:

1. Create a new mail
2. Drop the "cover" snippet

It has height 0 so it won't load until another snippet (with a non-zero height) is dropped.

task-2761074

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
