### PR TITLE
[FIX] *: change duration widget to time_float

### DIFF
--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -328,7 +328,7 @@
                 </tr>
                 <tr t-if="channel.total_time">
                     <th class="border-top-0">Completion Time</th>
-                    <td class="border-top-0"><t class="font-weight-bold" t-esc="channel.total_time" t-options="{'widget': 'duration', 'unit': 'hour', 'round': 'minute'}"/></td>
+                    <td class="border-top-0"><t class="font-weight-bold" t-esc="channel.total_time" t-options="{'widget': 'float_time', 'unit': 'hour', 'round': 'minute'}"/></td>
                 </tr>
                 <tr>
                     <th>Members</th>

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -329,7 +329,7 @@
         </div>
         <div class="card-footer bg-white text-600 px-3">
             <div class="d-flex justify-content-between align-items-center">
-                <small t-if="channel.total_time" class="font-weight-bold" t-esc="channel.total_time" t-options="{'widget': 'duration', 'unit': 'hour', 'round': 'minute'}"/>
+                <small t-if="channel.total_time" class="font-weight-bold" t-esc="channel.total_time" t-options="{'widget': 'float_time', 'unit': 'hour', 'round': 'minute'}"/>
                 <div class="d-flex flex-grow-1 justify-content-end">
                     <t t-if="channel.is_member and channel.completed">
                         <span class="badge badge-pill badge-success pull-right py-1 px-2"><i class="fa fa-check"/> Completed</span>


### PR DESCRIPTION
There are multiple instance in the code where a widget called 'duration' is used.
This widget doesn't exist and due to some magic end up with the rendering function of Many2One
which correctly render positive duration but negative duration with minute != 0 are set to <givenTime> - 1h

An exemple of this is the timesheet report in V15 (see opw-2752342)
Step to reproduce:
- Timesheet
- List View
- Set a value to '-1:30'
- Print report

Current Behaviour:
- Value is shown as '-2:30'

Behaviour after PR:
- Value is correctly computed in `field_utils.formatFloatTime()`

This PR start in V13 to fully clean the different still supported verion of Odoo
and will be updated at each FW-Port to change values.

opw-2752342

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
