### PR TITLE
[FIX] mail: remove chatter flickering when rendering form

### DIFF
--- a/addons/mail/static/src/widgets/form_renderer/form_renderer.js
+++ b/addons/mail/static/src/widgets/form_renderer/form_renderer.js
@@ -27,6 +27,12 @@ FormRenderer.include({
          * This is set when arch contains `div.oe_chatter`.
          */
         this._chatterContainerTarget = undefined;
+        /**
+         * This jQuery element will be set when rendering the form view, and
+         * used as a hook to insert the ChatterContainer in the right place,
+         * when applying the rendering into the DOM.
+         */
+        this.$chatterContainerHook = undefined;
         // Do not load chatter in form view dialogs
         this._isFromFormViewDialog = params.isFromFormViewDialog;
     },
@@ -105,12 +111,12 @@ FormRenderer.include({
      * @returns {jQuery.Element}
      */
     _makeChatterContainerTarget() {
-        if (this._chatterContainerTarget) {
-            return $(this._chatterContainerTarget);
+        if (!this._chatterContainerTarget) {
+            this._chatterContainerTarget = document.createElement("div");
+            this._chatterContainerTarget.classList.add("o_FormRenderer_chatterContainer");
         }
-        const $el = $('<div class="o_FormRenderer_chatterContainer"/>');
-        this._chatterContainerTarget = $el[0];
-        return $el;
+        this.$chatterContainerHook = $('<div class="o_FormRenderer_chatterContainer"/>');
+        return this.$chatterContainerHook;
     },
     /**
      * Mount the chatter
@@ -141,6 +147,18 @@ FormRenderer.include({
             return this._makeChatterContainerTarget();
         }
         return this._super(...arguments);
+    },
+    /**
+     * The last rendering of the form view has just been applied into the DOM,
+     * so we replace our chatter container hook by the actual chatter container.
+     *
+     * @override
+     */
+    _updateView() {
+        this._super(...arguments);
+        if (this._hasChatter()) {
+            this.$chatterContainerHook.replaceWith(this._chatterContainerTarget);
+        }
     },
     /**
      * Overrides the function to render the chatter once the form view is

--- a/addons/project/static/src/project_sharing/views/form/renderer.js
+++ b/addons/project/static/src/project_sharing/views/form/renderer.js
@@ -25,30 +25,7 @@ export default FormRenderer.extend({
             project_sharing_id: session.project_id,
         };
     },
-    _makeChatterContainerTarget() {
-        const $el = $('<div class="o_FormRenderer_chatterContainer"/>');
-        this._chatterContainerTarget = $el[0];
-        return $el;
-    },
     _mountChatterContainerComponent() {
         this._chatterContainerComponent.appendTo(this._chatterContainerTarget);
-    },
-    _renderNode(node) {
-        if (node.tag === 'div' && node.attrs.class === 'oe_project_sharing_chatter') {
-            let isVisible = true;
-            if (node.attrs.modifiers && node.attrs.modifiers.invisible) {
-                const record = this._getRecord(this.state.id);
-                if (record) {
-                    isVisible = !record.evalModifiers(node.attrs.modifiers).invisible;
-                }
-            }
-            if (isVisible) {
-                if (this._isFromFormViewDialog) {
-                    return $('<div/>');
-                }
-                return this._makeChatterContainerTarget();
-            }
-        }
-        return this._super(...arguments);
     },
 });


### PR DESCRIPTION
Before this commit, when a form view was re-rendered (e.g. when
switching to "edit" or "readonly" modes, when using the pager...),
the chatter briefly disappeared and then reappeared, which produced
a flickering. This has been introduced by the adaptation of the JS
codebase to owl 2 [1]: when the form view had to be re-rendered,
we reused the DOM element containing the chatter in the new
rendering (done in memory), which was thus detached from the DOM.
That element was re-inserted into the DOM later on, alongside the
rest of the newly rendered elements.

This commit fixes the issue by using a specific "hook" element when
rendering the form view, and replacing that hook by the actual
(unchanged) chatter container element when the rendering is done
and the DOM is patched.

[1] edd79ff560cf321ebd0488e4917abb7424fea1bb

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
