### PR TITLE
[FIX] sale: Allow user to edit sale_report

### DIFF
--- a/addons/sale/report/sale_report_templates.xml
+++ b/addons/sale/report/sale_report_templates.xml
@@ -166,14 +166,14 @@
 
             <div class="oe_structure"/>
 
-            <p t-field="doc.note" />
-            <p t-if="not is_html_empty(doc.payment_term_id.note)">
+            <div t-field="doc.note" />
+            <div t-if="not is_html_empty(doc.payment_term_id.note)">
                 <span t-field="doc.payment_term_id.note"/>
-            </p>
-            <p id="fiscal_position_remark" t-if="doc.fiscal_position_id and not is_html_empty(doc.fiscal_position_id.sudo().note)">
+            </div>
+            <div id="fiscal_position_remark" t-if="doc.fiscal_position_id and not is_html_empty(doc.fiscal_position_id.sudo().note)">
                 <strong>Fiscal Position Remark:</strong>
                 <span t-field="doc.fiscal_position_id.sudo().note"/>
-            </p>
+            </div>
         </div>
     </t>
 </template>


### PR DESCRIPTION
For now adding a new field after `payment_term_id.note` is impossible because of a traceback
this is due to the content of note which contains HTML inside a P tag and the payment_term_id.note is inside a P tag too which is forbidden

https://stackoverflow.com/questions/4291467/nesting-block-level-elements-inside-the-p-tag-right-or-wrong/4291608

opw-2739941