### PR TITLE
[FIX] website: fix matching of search term and fuzzy term

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1531,7 +1531,7 @@ class Website(models.Model):
             fuzzy_term = self._search_find_fuzzy_term(search_details, search)
             if fuzzy_term:
                 count, results = self._search_exact(search_details, fuzzy_term, limit, order)
-                if fuzzy_term == search:
+                if fuzzy_term.lower() == search.lower():
                     fuzzy_term = False
             else:
                 count, results = self._search_exact(search_details, search, limit, order)

--- a/addons/website/tests/test_fuzzy.py
+++ b/addons/website/tests/test_fuzzy.py
@@ -210,3 +210,15 @@ class TestAutoComplete(TransactionCase):
         self.assertEqual(1, suggestions['results_count'], "Text data contains one page with 'long url'")
         self.assertEqual(1, len(suggestions['results']), "Single result must be present")
         self.assertEqual(url, suggestions['results'][0]['website_url'], 'URL must not be truncated')
+
+    def test_06_case_insensitive_results(self):
+        """ Tests an autocomplete with exact match and more than the maximum
+        number of results.
+        """
+        suggestions = self._autocomplete("Many")
+        self.assertEqual(6, suggestions['results_count'], "Test data contains six pages with 'Many'")
+        self.assertEqual(5, len(suggestions['results']), "Results must be limited to 5")
+        self.assertFalse(suggestions['fuzzy_search'], "Expects an exact match")
+        for result in suggestions['results']:
+            self._check_highlight("many", result['name'])
+            self._check_highlight("many", result['description'])


### PR DESCRIPTION
Prior to this commit, when a user searches with an upper case search
term of more than 3 characters, the search was considered as a fuzzy
search even if the result was an exact match.

Since the search is always lowered when there are more than 3
characters, the search is considered as fuzzy only when the search and
fuzzy term are case insensitively distinct.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
