### PR TITLE
[FIX] web_editor: restore transitions when finding a gradient background

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -3587,6 +3587,7 @@ const SnippetOptionWidget = Widget.extend({
                     // if editing the other).
                     const parts = backgroundImageCssToParts(styles['background-image']);
                     if (parts.gradient) {
+                        _restoreTransitions();
                         return parts.gradient;
                     }
                 }


### PR DESCRIPTION
Since [1] the class `o_we_force_no_transition` was not removed when
selecting a snippet when the background color was a gradient. (It was
however removed when selecting a background color.)

After this commit the class is removed in that situation just like for
any other `data-select-style` attribute.

[1]: https://github.com/odoo/odoo/commit/a48a30f954afcb6ff3a59c4f32b05fd0c2cfcd2b

task-2633169

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
