### PR TITLE
[FIX] mass_mailing(_sms): fix A/B testing usability

### DIFF
--- a/addons/mass_mailing/data/mailing_data_templates.xml
+++ b/addons/mass_mailing/data/mailing_data_templates.xml
@@ -9,10 +9,10 @@
                 </p>
                 <p t-else="">The winner has already been sent. Use <b>Compare Version</b> to get an overview of this A/B testing campaign.</p>
             </t>
-            <t t-elif="mailing.ab_testing_mailings_count >= 2">
+            <t t-elif="ab_testing_count >= 2">
                 <p>
                     A sample of <b><t t-out="mailing.ab_testing_pc"/>% of recipients</b> will receive this <b><t t-out="mailing.mailing_type_description"/></b>, and <t t-out="other_ab_testing_pc"/>% receive one of the
-                    <b><t t-out="mailing.ab_testing_mailings_count - 1"/> other versions</b> from the same campaign.
+                    <b><t t-out="ab_testing_count - 1"/> other versions</b> from the same campaign.
                 </p>
                 <p>
 		    <t t-if="mailing.ab_testing_winner_selection == 'manual'">Don't forget to send your prefered version</t>

--- a/addons/mass_mailing/data/mass_mailing_data.xml
+++ b/addons/mass_mailing/data/mass_mailing_data.xml
@@ -24,6 +24,7 @@
             <field name="interval_type">days</field>
             <field name="numbercall">-1</field>
             <field name="doall" eval="True"/>
+            <field name="active" eval="False"/>
         </record>
         <record id="mailing_list_data" model="mailing.list">
             <field name="name">Newsletter</field>

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -200,7 +200,7 @@ class MassMailing(models.Model):
         for mass_mailing in self:
             total = self.env[mass_mailing.mailing_model_real].search_count(mass_mailing._parse_mailing_domain())
             if mass_mailing.ab_testing_pc < 100:
-                total = int(total / 100.0 * mass_mailing.ab_testing_pc)
+                total = int(total / 100.0 * mass_mailing.ab_testing_pc) or 1 if total else 0
             mass_mailing.total = total
 
     def _compute_clicks_ratio(self):
@@ -799,7 +799,7 @@ class MassMailing(models.Model):
         # randomly choose a fragment
         if self.ab_testing_enabled and self.ab_testing_pc < 100:
             contact_nbr = self.env[self.mailing_model_real].search_count(mailing_domain)
-            topick = int(contact_nbr / 100.0 * self.ab_testing_pc)
+            topick = int(contact_nbr / 100.0 * self.ab_testing_pc) or 1 if contact_nbr else 0
             if self.campaign_id and self.ab_testing_enabled:
                 already_mailed = self.campaign_id._get_mailing_recipients()[self.campaign_id.id]
             else:

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -672,6 +672,7 @@ class MassMailing(models.Model):
         other_ab_testing_pc = sum([mailing.ab_testing_pc for mailing in other_ab_testing_mailings])
         return {
             'mailing': self,
+            'ab_testing_count': self.ab_testing_mailings_count,
             'ab_testing_winner_selection_description': self._get_ab_testing_winner_selection()['description'],
             'other_ab_testing_pc': other_ab_testing_pc,
             'remaining_ab_testing_pc': 100 - (other_ab_testing_pc + self.ab_testing_pc),

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -255,22 +255,19 @@
                                         <field name="ab_testing_mailings_count" invisible="1"/>
                                         <field name="ab_testing_completed" invisible="1"/>
                                         <field name="ab_testing_description" nolabel="1"/>
-                                        <div attrs="{'invisible': ['|', ('ab_testing_mailings_count', '&lt;', 2), ('ab_testing_enabled', '=', False)]}">
+                                        <div id="ab_test_buttons" attrs="{'invisible': ['|', ('ab_testing_mailings_count', '&lt;', 2), ('ab_testing_enabled', '=', False)]}">
                                             <button name="action_compare_versions" type="object" class="btn btn-link d-block">
                                                 <i class="fa fa-bar-chart"/> Compare Version
                                             </button>
                                             <button name="action_duplicate" type="object" class="btn btn-link d-block" attrs="{'invisible': [('ab_testing_completed', '=', True)]}">
                                                 <i class="fa fa-copy"/> Create an Alternative
                                             </button>
-                                            <button name="action_send_winner_mailing" type="object" class="btn btn-link d-block" attrs="{'invisible': [('ab_testing_completed', '=', True)]}">
-                                                <i class="fa fa-envelope"/> <span name="ab_test_manual" attrs="{'invisible': [('ab_testing_winner_selection', '!=', 'manual')]}">
-                                                    Send this version to remaining recipients
-                                                </span> <span name="ab_test_auto" attrs="{'invisible': [('ab_testing_winner_selection', '=', 'manual')]}">
-                                                    Send Winner Now
-                                                </span>
+                                            <button name="action_send_winner_mailing" type="object" class="btn btn-link d-block"
+                                                attrs="{'invisible': ['|', ('ab_testing_completed', '=', True), ('ab_testing_winner_selection', '=', 'manual')]}">
+                                                <i class="fa fa-envelope"/> Send Winner Now
                                             </button>
                                             <button name="action_select_as_winner" type="object" class="btn btn-link d-block"
-                                                attrs="{'invisible': ['|', ('ab_testing_completed', '!=', False), ('ab_testing_winner_selection', '!=', 'manual')]}">
+                                                attrs="{'invisible': [('ab_testing_completed', '=', True)]}">
                                                 <i class="fa fa-envelope"/> Send this as winner
                                             </button>
                                         </div>

--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -47,6 +47,7 @@ class Mailing(models.Model):
     # opt_out_link
     sms_allow_unsubscribe = fields.Boolean('Include opt-out link', default=False)
     # A/B Testing
+    ab_testing_sms_count = fields.Integer(related="campaign_id.ab_testing_sms_count")
     ab_testing_sms_winner_selection = fields.Selection(related="campaign_id.ab_testing_sms_winner_selection", default="clicks_ratio", readonly=False, copy=True)
 
     @api.depends('mailing_type')
@@ -333,6 +334,7 @@ class Mailing(models.Model):
         values = super()._get_ab_testing_description_values()
         if self.mailing_type == 'sms':
             values.update({
+                'ab_testing_count': self.ab_testing_sms_count,
                 'ab_testing_winner_selection': self.ab_testing_sms_winner_selection,
             })
         return values

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -153,6 +153,9 @@
                     ('mail_server_available', '=', False)], 'readonly': [('state', 'in', ('sending', 'done'))]}</attribute>
             </xpath>
             <!-- A/B Testing -->
+            <xpath expr="//field[@name='ab_testing_mailings_count']" position="after">
+                <field name="ab_testing_sms_count" invisible="1"/>
+            </xpath>
             <xpath expr="//field[@name='ab_testing_winner_selection']" position="after">
                 <label for="ab_testing_sms_winner_selection" string="Winner Selection"
                     attrs="{'invisible': ['|', ('ab_testing_enabled', '=', False), ('mailing_type', '!=', 'sms')]}"/>
@@ -163,18 +166,20 @@
                  <field name="ab_testing_schedule_datetime"
                         attrs="{'required': [('ab_testing_enabled', '=', True), ('ab_testing_winner_selection', '!=', 'manual'), ('ab_testing_sms_winner_selection', '!=', 'manual')], 'readonly': ['|', ('ab_testing_enabled', '=', False), ('state', '!=', 'draft')], 'invisible': ['|', '|', ('ab_testing_enabled', '=', False), ('ab_testing_winner_selection', '=', 'manual'), ('ab_testing_sms_winner_selection', '=', 'manual')]}"/>
             </xpath>
-            <xpath expr="//span[@name='ab_test_manual']" position="attributes">
-                <attribute name="attrs">{'invisible': ['|', ('ab_testing_winner_selection', '!=', 'manual'),
-                    ('ab_testing_sms_winner_selection', '!=', 'manual')]}</attribute>
+            <xpath expr="//div[@id='ab_test_buttons']" position="attributes">
+                <attribute name="attrs">{'invisible': ['|', ('ab_testing_enabled', '=', False), '&amp;',
+                    ('ab_testing_mailings_count', '&lt;', 2),
+                    ('ab_testing_sms_count', '&lt;', 2)]}</attribute>
             </xpath>
-            <xpath expr="//span[@name='ab_test_auto']" position="attributes">
-                <attribute name="attrs">{'invisible': [('ab_testing_winner_selection', '=', 'manual'),
-                    ('ab_testing_sms_winner_selection', '=', 'manual')]}</attribute>
-            </xpath>
-            <xpath expr="//button[@name='action_select_as_winner']" position="attributes">
-                <attribute name="attrs">{'invisible': ['|', ('ab_testing_completed', '!=', False), '|',
+            <xpath expr="//button[@name='action_send_winner_mailing']" position="attributes">
+                <attribute name="attrs">{'invisible': ['|', ('ab_testing_completed', '=', True), '|',
                     ('ab_testing_winner_selection', '=', 'manual'),
                     ('ab_testing_sms_winner_selection', '=', 'manual')]}</attribute>
+            </xpath>
+            <xpath expr="//button[@name='action_duplicate'][hasclass('btn-primary')]" position="attributes">
+                <attribute name="attrs">{'invisible': ['|', '|', ('ab_testing_enabled', '=', False),
+                    ('ab_testing_mailings_count', '&gt;=', 2),
+                    ('ab_testing_sms_count', '&gt;=', 2)]}</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
This PR fix some issue with the A/B testing feature:

- The cron for A/B testing should be desactivated at installation
- The description and the buttons for A/B testing should match the mailing type
- When there are not enough recipients for the A/B testing percentage, we try to pick at least 1 recipients instead of 0


task-2651846