### PR TITLE
[IMP] mass_mailing: wording improvements

### DIFF
--- a/addons/mass_mailing/data/mailing_data_templates.xml
+++ b/addons/mass_mailing/data/mailing_data_templates.xml
@@ -9,10 +9,10 @@
                 </p>
                 <p t-else="">The winner has already been sent. Use <b>Compare Version</b> to get an overview of this A/B testing campaign.</p>
             </t>
-            <t t-elif="mailing.ab_testing_mailings_count >= 2">
+            <t t-elif="ab_testing_count >= 2">
                 <p>
                     A sample of <b><t t-out="mailing.ab_testing_pc"/>% of recipients</b> will receive this <b><t t-out="mailing.mailing_type_description"/></b>, and <t t-out="other_ab_testing_pc"/>% receive one of the
-                    <b><t t-out="mailing.ab_testing_mailings_count - 1"/> other versions</b> from the same campaign.
+                    <b><t t-out="ab_testing_count - 1"/> other versions</b> from the same campaign.
                 </p>
                 <p>
 		    <t t-if="mailing.ab_testing_winner_selection == 'manual'">Don't forget to send your prefered version</t>

--- a/addons/mass_mailing/data/mass_mailing_data.xml
+++ b/addons/mass_mailing/data/mass_mailing_data.xml
@@ -26,6 +26,7 @@
             <field name="interval_type">days</field>
             <field name="numbercall">-1</field>
             <field name="doall" eval="True"/>
+            <field name="active" eval="True"/>
         </record>
         <record id="mailing_list_data" model="mailing.list">
             <field name="name">Newsletter</field>

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -767,6 +767,7 @@ class MassMailing(models.Model):
         other_ab_testing_pc = sum([mailing.ab_testing_pc for mailing in other_ab_testing_mailings])
         return {
             'mailing': self,
+            'ab_testing_count': self.ab_testing_mailings_count,
             'ab_testing_winner_selection_description': self._get_ab_testing_winner_selection()['description'],
             'other_ab_testing_pc': other_ab_testing_pc,
             'remaining_ab_testing_pc': 100 - (other_ab_testing_pc + self.ab_testing_pc),

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -751,6 +751,8 @@ class MassMailing(models.Model):
         final_mailing = self.copy({
             'ab_testing_pc': 100,
         })
+        # Add suffix on name to show it's the final mailing
+        final_mailing.name = "%s %s" % (self.subject, _('(final)'))
         final_mailing.action_launch()
         action = self.env['ir.actions.act_window']._for_xml_id('mass_mailing.action_ab_testing_open_winner_mailing')
         action['res_id'] = final_mailing.id

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -221,7 +221,7 @@ class MassMailing(models.Model):
         for mass_mailing in self:
             total = self.env[mass_mailing.mailing_model_real].search_count(mass_mailing._parse_mailing_domain())
             if mass_mailing.ab_testing_pc < 100:
-                total = int(total / 100.0 * mass_mailing.ab_testing_pc)
+                total = int(total / 100.0 * mass_mailing.ab_testing_pc) or 1 if total else 0
             mass_mailing.total = total
 
     def _compute_clicks_ratio(self):
@@ -894,7 +894,7 @@ class MassMailing(models.Model):
         # randomly choose a fragment
         if self.ab_testing_enabled and self.ab_testing_pc < 100:
             contact_nbr = self.env[self.mailing_model_real].search_count(mailing_domain)
-            topick = int(contact_nbr / 100.0 * self.ab_testing_pc)
+            topick = int(contact_nbr / 100.0 * self.ab_testing_pc) or 1 if contact_nbr else 0
             if self.campaign_id and self.ab_testing_enabled:
                 already_mailed = self.campaign_id._get_mailing_recipients()[self.campaign_id.id]
             else:

--- a/addons/mass_mailing/models/res_config_settings.py
+++ b/addons/mass_mailing/models/res_config_settings.py
@@ -21,9 +21,3 @@ class ResConfigSettings(models.TransientModel):
     def _onchange_mass_mailing_outgoing_mail_server(self):
         if not self.mass_mailing_outgoing_mail_server:
             self.mass_mailing_mail_server_id = False
-
-    def set_values(self):
-        super().set_values()
-        ab_test_cron = self.env.ref('mass_mailing.ir_cron_mass_mailing_ab_testing').sudo()
-        if ab_test_cron and ab_test_cron.active != self.group_mass_mailing_campaign:
-            ab_test_cron.active = self.group_mass_mailing_campaign

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -290,22 +290,19 @@
                                         <field name="ab_testing_mailings_count" invisible="1"/>
                                         <field name="ab_testing_completed" invisible="1"/>
                                         <field name="ab_testing_description" nolabel="1"/>
-                                        <div attrs="{'invisible': ['|', ('ab_testing_mailings_count', '&lt;', 2), ('ab_testing_enabled', '=', False)]}">
+                                        <div id="ab_test_buttons" attrs="{'invisible': ['|', ('ab_testing_mailings_count', '&lt;', 2), ('ab_testing_enabled', '=', False)]}">
                                             <button name="action_compare_versions" type="object" class="btn btn-link d-block">
                                                 <i class="fa fa-bar-chart"/> Compare Version
                                             </button>
                                             <button name="action_duplicate" type="object" class="btn btn-link d-block" attrs="{'invisible': [('ab_testing_completed', '=', True)]}">
                                                 <i class="fa fa-copy"/> Create an Alternative
                                             </button>
-                                            <button name="action_send_winner_mailing" type="object" class="btn btn-link d-block" attrs="{'invisible': [('ab_testing_completed', '=', True)]}">
-                                                <i class="fa fa-envelope"/> <span name="ab_test_manual" attrs="{'invisible': [('ab_testing_winner_selection', '!=', 'manual')]}">
-                                                    Send this version to remaining recipients
-                                                </span> <span name="ab_test_auto" attrs="{'invisible': [('ab_testing_winner_selection', '=', 'manual')]}">
-                                                    Send Winner Now
-                                                </span>
+                                            <button name="action_send_winner_mailing" type="object" class="btn btn-link d-block"
+                                                attrs="{'invisible': ['|', ('ab_testing_completed', '=', True), ('ab_testing_winner_selection', '=', 'manual')]}">
+                                                <i class="fa fa-envelope"/> Send Winner Now
                                             </button>
                                             <button name="action_select_as_winner" type="object" class="btn btn-link d-block"
-                                                attrs="{'invisible': ['|', ('ab_testing_completed', '!=', False), ('ab_testing_winner_selection', '!=', 'manual')]}">
+                                                attrs="{'invisible': [('ab_testing_completed', '=', True)]}">
                                                 <i class="fa fa-envelope"/> Send this as winner
                                             </button>
                                         </div>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -73,7 +73,7 @@
                         <field name="state" readonly="1" widget="statusbar"/>
                     </header>
                     <div class="alert alert-info text-center" role="alert"
-                        attrs="{'invisible': ['&amp;','&amp;','&amp;','&amp;','&amp;',('state', '!=', 'in_queue'),('sent', '=', 0),('canceled', '=', 0),('scheduled', '=', 0),('failed', '=', 0),('warning_message', '=', False)]}">
+                        attrs="{'invisible': ['&amp;','&amp;','&amp;','&amp;','&amp;',('state', 'not in', ['in_queue', 'done']),('sent', '=', 0),('canceled', '=', 0),('scheduled', '=', 0),('failed', '=', 0),('warning_message', '=', False)]}">
                         <div class="o_mails_canceled" attrs="{'invisible': [('canceled', '=', 0)]}">
                             <button class="btn-link py-0"
                                     name="action_view_traces_canceled"
@@ -103,6 +103,9 @@
                                     <span name="sent">emails have been sent.</span>
                                 </strong>
                             </button>
+                            <strong class="d-block" attrs="{'invisible': [('ab_testing_enabled', '=', False), ('sent', '!=', 0)]}">
+                                <span name="ab_test_text">There wasn't enough recipients given to test this mailing in the A/B testing campaign.</span>
+                            </strong>
                         </div>
                         <div class="o_mails_failed" attrs="{'invisible': ['|', ('state', '!=', 'done'), ('failed', '=', 0)]}">
                             <button class="btn-link py-0"

--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -47,6 +47,7 @@ class Mailing(models.Model):
     # opt_out_link
     sms_allow_unsubscribe = fields.Boolean('Include opt-out link', default=False)
     # A/B Testing
+    ab_testing_sms_count = fields.Integer(related="campaign_id.ab_testing_sms_count")
     ab_testing_sms_winner_selection = fields.Selection(related="campaign_id.ab_testing_sms_winner_selection", default="clicks_ratio", readonly=False, copy=True)
 
     @api.depends('mailing_type')
@@ -335,6 +336,7 @@ class Mailing(models.Model):
         values = super()._get_ab_testing_description_values()
         if self.mailing_type == 'sms':
             values.update({
+                'ab_testing_count': self.ab_testing_sms_count,
                 'ab_testing_winner_selection': self.ab_testing_sms_winner_selection,
             })
         return values

--- a/addons/mass_mailing_sms/models/utm.py
+++ b/addons/mass_mailing_sms/models/utm.py
@@ -18,6 +18,7 @@ class UtmCampaign(models.Model):
         groups="mass_mailing.group_mass_mailing_user")
 
     # A/B Testing
+    ab_testing_sms_count = fields.Integer("A/B Test SMS #", compute="_compute_mailing_sms_count")
     ab_testing_sms_winner_selection = fields.Selection([
         ('manual', 'Manual'),
         ('clicks_ratio', 'Highest Click Rate')], string="SMS Winner Selection", default="clicks_ratio")
@@ -32,8 +33,25 @@ class UtmCampaign(models.Model):
 
     @api.depends('mailing_sms_ids')
     def _compute_mailing_sms_count(self):
+        if self.ids:
+            sms_data = self.env['mailing.mailing'].read_group(
+                [('campaign_id', 'in', self.ids), ('mailing_type', '=', 'sms')],
+                ['campaign_id', 'ab_testing_enabled'],
+                ['campaign_id', 'ab_testing_enabled'],
+                lazy=False,
+            )
+            ab_testing_mapped_data = {}
+            mapped_data = {}
+            for data in sms_data:
+                if data['ab_testing_enabled']:
+                    ab_testing_mapped_data.setdefault(data['campaign_id'][0], []).append(data['__count'])
+                mapped_data.setdefault(data['campaign_id'][0], []).append(data['__count'])
+        else:
+            mapped_data = dict()
+            ab_testing_mapped_data = dict()
         for campaign in self:
-            campaign.mailing_sms_count = len(campaign.mailing_sms_ids)
+            campaign.mailing_sms_count = sum(mapped_data.get(campaign.id, []))
+            campaign.ab_testing_sms_count = sum(ab_testing_mapped_data.get(campaign.id, []))
 
     def action_create_mass_sms(self):
         action = self.env["ir.actions.actions"]._for_xml_id("mass_mailing.action_create_mass_mailings_from_campaign")

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -159,6 +159,9 @@
                     ('mail_server_available', '=', False)], 'readonly': [('state', 'in', ('sending', 'done'))]}</attribute>
             </xpath>
             <!-- A/B Testing -->
+            <xpath expr="//field[@name='ab_testing_mailings_count']" position="after">
+                <field name="ab_testing_sms_count" invisible="1"/>
+            </xpath>
             <xpath expr="//field[@name='ab_testing_winner_selection']" position="after">
                 <label for="ab_testing_sms_winner_selection" string="Winner Selection"
                     attrs="{'invisible': ['|', ('ab_testing_enabled', '=', False), ('mailing_type', '!=', 'sms')]}"/>
@@ -169,18 +172,20 @@
                  <field name="ab_testing_schedule_datetime"
                         attrs="{'required': [('ab_testing_enabled', '=', True), ('ab_testing_winner_selection', '!=', 'manual'), ('ab_testing_sms_winner_selection', '!=', 'manual')], 'readonly': ['|', ('ab_testing_enabled', '=', False), ('state', '!=', 'draft')], 'invisible': ['|', '|', ('ab_testing_enabled', '=', False), ('ab_testing_winner_selection', '=', 'manual'), ('ab_testing_sms_winner_selection', '=', 'manual')]}"/>
             </xpath>
-            <xpath expr="//span[@name='ab_test_manual']" position="attributes">
-                <attribute name="attrs">{'invisible': ['|', ('ab_testing_winner_selection', '!=', 'manual'),
-                    ('ab_testing_sms_winner_selection', '!=', 'manual')]}</attribute>
+            <xpath expr="//div[@id='ab_test_buttons']" position="attributes">
+                <attribute name="attrs">{'invisible': ['|', ('ab_testing_enabled', '=', False), '&amp;',
+                    ('ab_testing_mailings_count', '&lt;', 2),
+                    ('ab_testing_sms_count', '&lt;', 2)]}</attribute>
             </xpath>
-            <xpath expr="//span[@name='ab_test_auto']" position="attributes">
-                <attribute name="attrs">{'invisible': [('ab_testing_winner_selection', '=', 'manual'),
-                    ('ab_testing_sms_winner_selection', '=', 'manual')]}</attribute>
-            </xpath>
-            <xpath expr="//button[@name='action_select_as_winner']" position="attributes">
-                <attribute name="attrs">{'invisible': ['|', ('ab_testing_completed', '!=', False), '|',
+            <xpath expr="//button[@name='action_send_winner_mailing']" position="attributes">
+                <attribute name="attrs">{'invisible': ['|', ('ab_testing_completed', '=', True), '|',
                     ('ab_testing_winner_selection', '=', 'manual'),
                     ('ab_testing_sms_winner_selection', '=', 'manual')]}</attribute>
+            </xpath>
+            <xpath expr="//button[@name='action_duplicate'][hasclass('btn-primary')]" position="attributes">
+                <attribute name="attrs">{'invisible': ['|', '|', ('ab_testing_enabled', '=', False),
+                    ('ab_testing_mailings_count', '&gt;=', 2),
+                    ('ab_testing_sms_count', '&gt;=', 2)]}</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
- Add an alert message for A/B testing when no mail is sent in the
form view with the chatter.
- Add "(final)" to the source name of the final and winner A/B test mail.

task-2651846