### PR TITLE
[FIX] hr: read the fields of the right model

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -167,7 +167,8 @@ class HrEmployeePrivate(models.Model):
         if self.check_access_rights('read', raise_exception=False):
             return super(HrEmployeePrivate, self)._read(fields)
 
-        res = self.env['hr.employee.public'].browse(self.ids).read(fields)
+        public_fields = set(fields).intersection(self.env['hr.employee.public']._fields.keys())
+        res = self.env['hr.employee.public'].browse(self.ids).read(public_fields)
         for r in res:
             record = self.browse(r['id'])
             record._update_cache({k:v for k,v in r.items() if k in fields}, validate=False)


### PR DESCRIPTION
Steps to reproduce the bug:
- Install `point_of_sale` and `l10n_in_hr_payroll`
- Connect as Admin with an Indian company
- Go to POS app > shop > settings > Enable `Authorized Employees` option
- Create a new user and give him:
    - “User” access to POS
    - No access to HR
- Connect with the new user
- Try to open a new POS session

Problem:
An error is triggered, when the user does not have HR access rights, we read  the `hr.employee` fields from the `hr.employee.public` model, while some fields are specific to `hr.employee`, as the case for the field `uan`: https://github.com/odoo/enterprise/blob/15.0/l10n_in_hr_payroll/models/hr_employee.py#L10

Solution:
Only read similar fields of both models

opw-2760303



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
