### PR TITLE
[IMP] hr_skills: ensure Progress is positive

### DIFF
--- a/addons/hr_skills/models/hr_skills.py
+++ b/addons/hr_skills/models/hr_skills.py
@@ -74,6 +74,10 @@ class SkillLevel(models.Model):
     level_progress = fields.Integer(string="Progress", help="Progress from zero knowledge (0%) to fully mastered (100%).")
     default_level = fields.Boolean(help="If checked, this level will be the default one selected when choosing this skill.")
 
+    _sql_constraints = [
+        ('check_level_progress', 'CHECK(level_progress BETWEEN 0 AND 100)', "Progress should be a number between 0 and 100."),
+    ]
+
     def name_get(self):
         if not self._context.get('from_skill_level_dropdown'):
             return super().name_get()


### PR DESCRIPTION
It was possible to have negative Progress on a skill, which doesn't make
sense.

Here we ensure it's a valid percentage between 0 and 100 inclusive.

TaskID: 2762009

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
