### PR TITLE
[FIX] account_reports, l10n_it_reports: carryover fix

### DIFF
--- a/addons/l10n_it/models/account_tax_report.py
+++ b/addons/l10n_it/models/account_tax_report.py
@@ -32,7 +32,7 @@ class AccountTaxReportLine(models.AbstractModel):
         if amount_in_euro <= 25.82:
             return (None, 0)
         else:
-            return None
+            return (None, None)
 
     def vp14_credit_carryover_condition(self, options, line_amount, carried_over_amount):
         """


### PR DESCRIPTION
There is an issue with the Italian carryover, line vp14b.
Use case:
 - Month 1, have a value of 25 in this line => will trigger a carryover to line vp7
 - Month 2, add more value to vp14b so that it goes above 25.82.
   This will set the bound as None, and thus this will not impact the carryover.
This is wrong, because then the next month we will see a value of 25 in vp7
while it should be 0.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
