### PR TITLE
[FIX] stock_landed_costs: use list not tuple

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -98,7 +98,7 @@ class LandedCost(models.Model):
             n = 5000
             cost.allowed_picking_ids = valued_picking_ids_per_company[cost.company_id.id][:n]
             for ids_chunk in tools.split_every(n, valued_picking_ids_per_company[cost.company_id.id][n:]):
-                cost.allowed_picking_ids = tuple((4, id_) for id_ in ids_chunk)
+                cost.allowed_picking_ids = [(4, id_) for id_ in ids_chunk]
 
     @api.model
     def create(self, vals):


### PR DESCRIPTION
ae96f0e introduced an issue because the update of the m2m used a `tuple`
instead of a `list`

How to reproduce:
* Apply only the (Python) code changes done in ae96f0e, keeping the same view
* On a clean v13 db with Landed costs (Accounting + Inventory +
   Purchase + demo data)
* Set n=1  (cannot be reproduced with 5000 unless we create enough
   dummy data)
* Confirm a Purchase
* Try to create a Landed cost
Traceback:
```
...
    return f(self, *args, **kwargs)
  File "/home/odoo/src/odoo/13.0/odoo/sql_db.py", line 250, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.UndefinedFunction: operator does not exist: integer = integer[]
LINE 1: ...FROM "stock_picking" WHERE (("stock_picking"."id" in (ARRAY[...
                                                             ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
