### PR TITLE
[FIX] web: no error on focused date field destruction

### DIFF
--- a/addons/web/static/src/js/widgets/date_picker.js
+++ b/addons/web/static/src/js/widgets/date_picker.js
@@ -78,6 +78,7 @@ var DateWidget = Widget.extend({
             window.removeEventListener('wheel', this._onScroll, true);
         }
         this.__libInput++;
+        this.$input.blur(); // force blur before widget is destroyed
         this.$el.datetimepicker('destroy');
         this.__libInput--;
         this._super.apply(this, arguments);

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -3721,6 +3721,30 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.test('focused date field should cause no error on destroy', async function (assert) {
+        assert.expect(2);
+
+        var originalParameters = _.clone(core._t.database.parameters);
+        _.extend(core._t.database.parameters, {date_format: '%d.%m:%Y'});
+
+        var list = await createView({
+            View: ListView,
+            model: 'partner',
+            data: this.data,
+            arch: '<tree editable="top"><field name="date"/></tree>',
+            domain: [(1, '=', 0)],
+            context: {'default_date': '2020-01-20 00:00:00'},
+        });
+
+        await testUtils.dom.click(list.$('.o_list_button_add'));
+        assert.containsOnce(list, '.o_data_row');
+        await testUtils.fields.triggerKeydown($(document.activeElement), 'escape');
+        assert.containsNone(list, '.o_data_row');
+
+        list.destroy();
+        core._t.database.parameters = originalParameters;
+    });
+
     QUnit.module('FieldDatetime');
 
     QUnit.test('datetime field in form view', async function (assert) {


### PR DESCRIPTION

Scenario:

- be in a french language
- go on timesheet list view
- create new lien with a date like 20/01/2022
- press ESC to cancel line

=> Error "Erreur CORS inconnue" is shown

Cause:

In DateWidget.destroy():

- we destroy datetimepicker object
- we removeChild the widget from DOM

The removeChild causes a blur that will be intercepted by tempusdominus
`$('document').on('blur.datetimepicker', '.datetimepicker-input')` but
since the datetimepicker instance is destroyed, a new one is created
that will parse the date with american format (month/day/year) and throw
an error.datetimepicke Error that is not catched by DateWidget since the
widget is being destroyed.

note: without fix, the added test fails with "Body still contains
undesirable elements: [code of error modal]".

opw-2656557
