### PR TITLE
Remove v12 view_type

### DIFF
--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -201,7 +201,6 @@ class Inventory(models.Model):
             'name': _('Product Moves'),
             'type': 'ir.actions.act_window',
             'res_model': 'stock.move.line',
-            'view_type': 'list',
             'view_mode': 'list,form',
             'domain': domain,
         }


### PR DESCRIPTION
Clean up of `view_type` which is removed from v13


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
