### PR TITLE
[FIX] website_twitter: remove unused twitter reload buttons

### DIFF
--- a/addons/website_twitter/static/src/js/website.twitter.animation.js
+++ b/addons/website_twitter/static/src/js/website.twitter.animation.js
@@ -108,6 +108,7 @@ publicWidget.registry.twitter = publicWidget.Widget.extend({
      */
     destroy: function () {
         this._stopScrolling();
+        this.$el.find('.twitter_timeline').empty();
         this._super.apply(this, arguments);
     },
 

--- a/addons/website_twitter/static/src/js/website.twitter.animation.js
+++ b/addons/website_twitter/static/src/js/website.twitter.animation.js
@@ -23,6 +23,7 @@ publicWidget.registry.twitter = publicWidget.Widget.extend({
         var self = this;
         var $timeline = this.$('.twitter_timeline');
 
+        this.offsets = [];
         $timeline.append('<center><div><img src="/website_twitter/static/src/img/loadtweet.gif"></div></center>');
         var def = this._rpc({route: '/website_twitter/get_favorites'}).then(function (data) {
             $timeline.empty();
@@ -96,7 +97,8 @@ publicWidget.registry.twitter = publicWidget.Widget.extend({
                     totalWidth += $(area).outerWidth(true);
                 });
                 $scrollableArea.width(totalWidth);
-                $scrollWrapper.scrollLeft(index*180);
+                $scrollWrapper.scrollLeft(index * 180);
+                self.offsets.push(index * 180);
             });
             self._startScrolling();
         });
@@ -120,14 +122,16 @@ publicWidget.registry.twitter = publicWidget.Widget.extend({
      * @private
      */
     _startScrolling: function () {
+        const self = this;
+
         if (!this.$scroller) {
             return;
         }
-        _.each(this.$scroller.find('.scrollWrapper'), function (el) {
+        _.each(this.$scroller.find('.scrollWrapper'), function (el, index) {
             var $wrapper = $(el);
             $wrapper.data('getNextElementWidth', true);
             $wrapper.data('autoScrollingInterval', setInterval(function () {
-                $wrapper.scrollLeft($wrapper.scrollLeft() + 1);
+                $wrapper.scrollLeft(++self.offsets[index]);
                 if ($wrapper.data('getNextElementWidth')) {
                     $wrapper.data('swapAt', $wrapper.data('scrollableArea').children(':first').outerWidth(true));
                     $wrapper.data('getNextElementWidth', false);
@@ -135,7 +139,8 @@ publicWidget.registry.twitter = publicWidget.Widget.extend({
                 if ($wrapper.data('swapAt') <= $wrapper.scrollLeft()) {
                     var swap_el = $wrapper.data('scrollableArea').children(':first').detach();
                     $wrapper.data('scrollableArea').append(swap_el);
-                    $wrapper.scrollLeft($wrapper.scrollLeft() - swap_el.outerWidth(true));
+                    self.offsets[index] -= swap_el.outerWidth(true);
+                    $wrapper.scrollLeft(self.offsets[index]);
                     $wrapper.data('getNextElementWidth', true);
                 }
             }, 20));

--- a/addons/website_twitter/static/src/js/website.twitter.editor.js
+++ b/addons/website_twitter/static/src/js/website.twitter.editor.js
@@ -12,39 +12,24 @@ sOptions.registry.twitter = sOptions.Class.extend({
      * @override
      */
     start: function () {
-        var self = this;
-        var $configuration = dom.renderButton({
+        const $configuration = dom.renderButton({
             attrs: {
-                class: 'btn-primary d-none',
+                class: 'btn-primary d-none s_twitter_reload_btn',
                 contenteditable: 'false',
             },
             text: _t("Reload"),
-        });
-        $configuration.appendTo(document.body).on('click', function (ev) {
+        }).appendTo(this.$target).on('click', (ev) => {
             ev.preventDefault();
             ev.stopPropagation();
-            self._rpc({route: '/website_twitter/reload'});
+            this._rpc({route: '/website_twitter/reload'});
         });
-        this.$target.on('mouseover.website_twitter', function () {
-            var $selected = $(this);
-            var position = $selected.offset();
-            $configuration.removeClass('d-none').offset({
-                top: $selected.outerHeight() / 2
-                        + position.top
-                        - $configuration.outerHeight() / 2,
-                left: $selected.outerWidth() / 2
-                        + position.left
-                        - $configuration.outerWidth() / 2,
-            });
-        }).on('mouseleave.website_twitter', function (e) {
-            var current = document.elementFromPoint(e.clientX, e.clientY);
-            if (current === $configuration[0]) {
-                return;
-            }
+        this.$target.on('mouseover.website_twitter', (ev) => {
+            $configuration.removeClass('d-none');
+        }).on('mouseout.website_twitter', (ev) => {
             $configuration.addClass('d-none');
         });
-        this.$target.on('click.website_twitter', '.lnk_configure', function (e) {
-            window.location = e.currentTarget.href;
+        this.$target.on('click.website_twitter', '.lnk_configure', (ev) => {
+            window.location = ev.currentTarget.href;
         });
         this.trigger_up('widgets_stop_request', {
             $target: this.$target,
@@ -63,6 +48,7 @@ sOptions.registry.twitter = sOptions.Class.extend({
     destroy: function () {
         this._super.apply(this, arguments);
         this.$target.off('.website_twitter');
+        this.$target[0].querySelector('.s_twitter_reload_btn').remove();
     },
 });
 });

--- a/addons/website_twitter/static/src/js/website.twitter.editor.js
+++ b/addons/website_twitter/static/src/js/website.twitter.editor.js
@@ -21,7 +21,12 @@ sOptions.registry.twitter = sOptions.Class.extend({
         }).appendTo(this.$target).on('click', (ev) => {
             ev.preventDefault();
             ev.stopPropagation();
-            this._rpc({route: '/website_twitter/reload'});
+            this._rpc({route: '/website_twitter/reload'}).then(() => {
+                // Restart the twitter animation widget.
+                this.trigger_up('widgets_start_request', {
+                    $target: this.$target,
+                });
+            });
         });
         this.$target.on('mouseover.website_twitter', (ev) => {
             $configuration.removeClass('d-none');
@@ -31,16 +36,7 @@ sOptions.registry.twitter = sOptions.Class.extend({
         this.$target.on('click.website_twitter', '.lnk_configure', (ev) => {
             window.location = ev.currentTarget.href;
         });
-        this.trigger_up('widgets_stop_request', {
-            $target: this.$target,
-        });
         return this._super.apply(this, arguments);
-    },
-    /**
-     * @override
-     */
-    cleanForSave: function () {
-        this.$target.find('.twitter_timeline').empty();
     },
     /**
      * @override

--- a/addons/website_twitter/static/src/scss/website_twitter.edit_mode.scss
+++ b/addons/website_twitter/static/src/scss/website_twitter.edit_mode.scss
@@ -1,0 +1,10 @@
+.editor_enable .twitter {
+    position: relative;
+    .s_twitter_reload_btn {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        cursor: pointer !important;
+    }
+}

--- a/addons/website_twitter/static/tests/tours/twitter_scroller_reload_button.js
+++ b/addons/website_twitter/static/tests/tours/twitter_scroller_reload_button.js
@@ -1,0 +1,30 @@
+odoo.define('website_twitter.tour.twitter_scroller_reload_button', function (require) {
+'use strict';
+
+var tour = require('web_tour.tour');
+var base = require('web_editor.base');
+
+tour.register('twitter_scroller_reload_button', {
+    test: true,
+    url: '/?enable_editor=1',
+    wait_for: base.ready(),
+}, [{
+    trigger: '#snippet_feature .oe_snippet:has(span:contains("Twitter Scroller")) .oe_snippet_thumbnail',
+    content: 'Drag the Twitter Scroller snippet and drop it in your page.',
+    run: 'drag_and_drop #wrap',
+    }, {
+    trigger: '#wrap .twitter',
+    content: 'Activate the Twitter Scroller snippet editor.',
+}, {
+    trigger: '#wrap .twitter:has(.btn span:contains("Reload"))',
+    content: 'Check if the reload button was added to the DOM.',
+}, {
+    trigger: '.oe_snippet_remove:last',
+    content: 'Remove the twitter scroller snippet.',
+},
+{
+    trigger: '#wrap:not(:has(.btn span:contains("Reload")))',
+    content: 'Check if the reload button was removed from the DOM.',
+}]);
+
+});

--- a/addons/website_twitter/tests/__init__.py
+++ b/addons/website_twitter/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import test_snippet

--- a/addons/website_twitter/tests/test_snippet.py
+++ b/addons/website_twitter/tests/test_snippet.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo
+import odoo.tests
+
+
+@odoo.tests.common.tagged('post_install', '-at_install')
+class TestSnippet(odoo.tests.HttpCase):
+    def test_01_twitter_scroller_reload_button(self):
+        self.start_tour("/", "twitter_scroller_reload_button", login='admin')

--- a/addons/website_twitter/views/website_twitter_snippet_templates.xml
+++ b/addons/website_twitter/views/website_twitter_snippet_templates.xml
@@ -30,8 +30,17 @@
         </xpath>
     </template>
     <template id="twitter_editor" inherit_id="website.assets_editor">
+        <xpath expr="//link[last()]" position="after">
+            <link rel="stylesheet" type="text/scss" href="/website_twitter/static/src/scss/website_twitter.edit_mode.scss"/>
+        </xpath>
         <xpath expr="//script[last()]" position="after">
             <script type="text/javascript" src="/website_twitter/static/src/js/website.twitter.editor.js"/>
+        </xpath>
+    </template>
+
+    <template id="twitter_tests" inherit_id="web.assets_tests">
+        <xpath expr="." position="inside">
+            <script type="text/javascript" src="/website_twitter/static/tests/tours/twitter_scroller_reload_button.js"/>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
When removing a twitter scroller snippet, the reload button introduced by 0152bea512d868cbb0d9adf33cdbf98bc2030a0f is left in the dom. The problem is resolved by removing it in `cleanForSave`.