### PR TITLE
[IMP] mrp: fix cancel and qty propagation post backorder refactor

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1664,6 +1664,8 @@ class MrpProduction(models.Model):
         # We need to adapt `duration_expected` on both the original workorders and their
         # backordered workorders. To do that, we use the original `duration_expected` and the
         # ratio of the quantity produced and the quantity to produce.
+        workorders_to_cancel = self.env['mrp.workorder']
+        workorders_to_update = self.env['mrp.workorder']
         for production in self:
             initial_qty = initial_qty_by_production[production]
             initial_workorder_remaining_qty = []
@@ -1675,15 +1677,21 @@ class MrpProduction(models.Model):
 
             # Adapt quantities produced
             for workorder in production.workorder_ids:
-                initial_workorder_remaining_qty.append(max(workorder.qty_produced - workorder.qty_production, 0))
+                initial_workorder_remaining_qty.append(max(initial_qty - workorder.qty_reported_from_previous_wo - workorder.qty_produced, 0))
                 workorder.qty_produced = min(workorder.qty_produced, workorder.qty_production)
-            workorders_len = len(bo.workorder_ids)
+            workorders_len = len(production.workorder_ids)
             for index, workorder in enumerate(bo.workorder_ids):
-                remaining_qty = initial_workorder_remaining_qty[index // workorders_len]
+                remaining_qty = initial_workorder_remaining_qty[index % workorders_len]
+                workorder.qty_reported_from_previous_wo = max(workorder.qty_production - remaining_qty, 0)
                 if remaining_qty:
-                    workorder.qty_produced = max(workorder.qty_production, remaining_qty)
                     initial_workorder_remaining_qty[index % workorders_len] = max(remaining_qty - workorder.qty_produced, 0)
-
+                    if workorders_to_update[-1:].production_id != workorder.production_id:
+                        workorders_to_update += workorder
+                else:
+                    workorders_to_cancel += workorder
+        workorders_to_cancel.action_cancel()
+        for workorder in workorders_to_update:
+            workorder.state = 'ready' if workorder.next_work_order_id.production_availability == 'assigned' else 'waiting'
         backorders.workorder_ids._action_confirm()
 
         return self.env['mrp.production'].browse(production_ids)

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -147,6 +147,8 @@ class MrpWorkorder(models.Model):
     json_popover = fields.Char('Popover Data JSON', compute='_compute_json_popover')
     show_json_popover = fields.Boolean('Show Popover?', compute='_compute_json_popover')
     consumption = fields.Selection(related='production_id.consumption')
+    qty_reported_from_previous_wo = fields.Float('Carried Quantity', digits='Product Unit of Measure', copy=False,
+        help="The quantity already produced awaiting allocation in the backorders chain.")
 
     @api.depends('production_availability')
     def _compute_state(self):
@@ -705,10 +707,10 @@ class MrpWorkorder(models.Model):
         action['res_id'] = self.id
         return action
 
-    @api.depends('qty_production', 'qty_produced')
+    @api.depends('qty_production', 'qty_reported_from_previous_wo', 'qty_produced')
     def _compute_qty_remaining(self):
         for wo in self:
-            wo.qty_remaining = float_round(wo.qty_production - wo.qty_produced, precision_rounding=wo.production_id.product_uom_id.rounding)
+            wo.qty_remaining = max(float_round(wo.qty_production - wo.qty_reported_from_previous_wo - wo.qty_produced, precision_rounding=wo.production_id.product_uom_id.rounding), 0)
 
     def _get_duration_expected(self, alternative_workcenter=False, ratio=1):
         self.ensure_one()

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -2375,3 +2375,137 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(workorder.time_ids[1].duration, real_duration_under_expected, "Original time tracking should be unchanged")
         self.assertEqual(workorder.time_ids[0].loss_type, 'productive', "Remaining time tracking should be productive")
         self.assertEqual(workorder.time_ids[0].duration, real_duration_decreased - real_duration_under_expected, "Time tracking duration should have been reduced to reflect new shorter duration")
+
+    def test_propagate_quantity_on_backorders(self):
+        """Create a MO for a product with several work orders.
+        Produce different quantities to test quantity propagation and workorder cancellation.
+        """
+
+        # setup test
+
+        work_center_1 = self.env['mrp.workcenter'].create({"name": "WorkCenter 1"})
+        work_center_2 = self.env['mrp.workcenter'].create({"name": "WorkCenter2"})
+        work_center_3 = self.env['mrp.workcenter'].create({"name": "WorkCenter3"})
+
+        product = self.env['product.template'].create({"name": "Finished Product"})
+        component_1 = self.env['product.template'].create({"name": "Component 1", "type": "product"})
+        component_2 = self.env['product.template'].create({"name": "Component 2", "type": "product"})
+        component_3 = self.env['product.template'].create({"name": "Component 3", "type": "product"})
+
+        self.env['stock.quant'].create({
+            "product_id": component_1.product_variant_id.id,
+            "location_id": 8,
+            "quantity": 100
+        })
+        self.env['stock.quant'].create({
+            "product_id": component_2.product_variant_id.id,
+            "location_id": 8,
+            "quantity": 100
+        })
+        self.env['stock.quant'].create({
+            "product_id": component_3.product_variant_id.id,
+            "location_id": 8,
+            "quantity": 100
+        })
+
+        self.env['mrp.bom'].create({
+            "product_tmpl_id": product.id,
+            "product_id": False,
+            "product_qty": 1,
+            "bom_line_ids": [
+                [0, 0, {"product_id": component_1.product_variant_id.id, "product_qty": 1}],
+                [0, 0, {"product_id": component_2.product_variant_id.id, "product_qty": 1}],
+                [0, 0, {"product_id": component_3.product_variant_id.id, "product_qty": 1}]
+            ],
+            "operation_ids": [
+                [0, 0, {"name": "Operation 1", "workcenter_id": work_center_1.id}],
+                [0, 0, {"name": "Operation 2", "workcenter_id": work_center_2.id}],
+                [0, 0, {"name": "Operation 3", "workcenter_id": work_center_3.id}]
+            ]
+        })
+
+        # create a manufacturing order for 20 products
+
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = product.product_variant_id
+        mo_form.product_qty = 20
+        mo = mo_form.save()
+
+        self.assertEqual(mo.state, 'draft')
+        mo.action_confirm()
+
+        wo_1, wo_2, wo_3 = mo.workorder_ids
+        self.assertEqual(mo.state, 'confirmed')
+        self.assertEqual(wo_1.state, 'ready')
+
+        # produce 20 / 10 / 5 on workorders, create backorder
+
+        wo_1.button_start()
+        wo_1.qty_producing = 20
+        self.assertEqual(mo.state, 'progress')
+        wo_1.button_finish()
+
+        wo_2.button_start()
+        wo_2.qty_producing = 10
+        wo_2.button_finish()
+
+        wo_3.button_start()
+        wo_3.qty_producing = 5
+        wo_3.button_finish()
+
+        self.assertEqual(mo.state, 'to_close')
+        mo.button_mark_done()
+
+        bo = self.env['mrp.production.backorder'].create({
+            "mrp_production_backorder_line_ids": [
+                [0, 0, {"mrp_production_id": mo.id, "to_backorder": True}]
+            ]
+        })
+        bo.action_backorder()
+
+        self.assertEqual(mo.state, 'done')
+
+        mo_2 = mo.procurement_group_id.mrp_production_ids - mo
+        wo_4, wo_5, wo_6 = mo_2.workorder_ids
+
+        self.assertEqual(wo_4.state, 'cancel')
+
+        # produce 10 / 5, create backorder
+
+        wo_5.button_start()
+        wo_5.qty_producing = 10
+        self.assertEqual(mo_2.state, 'progress')
+        wo_5.button_finish()
+
+        wo_6.button_start()
+        wo_6.qty_producing = 5
+        wo_6.button_finish()
+
+        self.assertEqual(mo_2.state, 'to_close')
+        mo_2.button_mark_done()
+
+        bo = self.env['mrp.production.backorder'].create({
+            "mrp_production_backorder_line_ids": [
+                [0, 0, {"mrp_production_id": mo_2.id, "to_backorder": True}]
+            ]
+        })
+        bo.action_backorder()
+
+        self.assertEqual(mo_2.state, 'done')
+
+        mo_3 = mo.procurement_group_id.mrp_production_ids - (mo | mo_2)
+        wo_7, wo_8, wo_9 = mo_3.workorder_ids
+
+        self.assertEqual(wo_7.state, 'cancel')
+        self.assertEqual(wo_8.state, 'cancel')
+
+        # produce 10 and finish work
+
+        wo_9.button_start()
+        wo_9.qty_producing = 10
+        self.assertEqual(mo_3.state, 'progress')
+        wo_9.button_finish()
+
+        self.assertEqual(mo_3.state, 'to_close')
+        mo_3.button_mark_done()
+        self.assertEqual(mo_3.state, 'done')

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -87,7 +87,7 @@
                 <field name="state" widget="badge" decoration-warning="state == 'progress'" decoration-success="state == 'done'" decoration-info="state not in ('progress', 'done', 'cancel')"
                   attrs="{'invisible': [('production_state', '=', 'draft')], 'column_invisible': [('parent.state', '=', 'draft')]}"/>
                 <button name="button_start" type="object" string="Start" class="btn-success"
-                  attrs="{'invisible': ['|', '|', '|', ('production_state','in', ('draft', 'done', 'cancel')), ('working_state', '=', 'blocked'), ('state', '=', 'done'), ('is_user_working', '!=', False)]}"/>
+                  attrs="{'invisible': ['|', '|', '|', ('production_state','in', ('draft', 'done', 'cancel')), ('working_state', '=', 'blocked'), ('state', 'in', ('done', 'cancel')), ('is_user_working', '!=', False)]}"/>
                 <button name="button_pending" type="object" string="Pause" class="btn-warning"
                   attrs="{'invisible': ['|', '|', ('production_state', 'in', ('draft', 'done', 'cancel')), ('working_state', '=', 'blocked'), ('is_user_working', '=', False)]}"/>
                 <button name="button_finish" type="object" string="Done" class="btn-success"


### PR DESCRIPTION
[IMP] mrp: fix cancel and qty propagation post backorder refactor

Re-integrate code from 37681e9d2e24663691b4be022f34c29c7126d9f6
lost with f11fcf6bb403e3b830c37e5c9b4c2fcda9452a57
allowing different quantities to be recorded on work orders
and generate back orders with correct quantities on back work orders
(cancelled if no remaining quantity). 

task: 2751230


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
