### PR TITLE
[FIX] mail: update main attachment if move values have changed

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1934,7 +1934,7 @@ class MailThread(models.AbstractModel):
         return new_message
 
     def _message_set_main_attachment_id(self, attachment_ids):  # todo move this out of mail.thread
-        if not self._abstract and attachment_ids and not self.message_main_attachment_id:
+        if not self._abstract and attachment_ids:
             all_attachments = self.env['ir.attachment'].browse([attachment_tuple[1] for attachment_tuple in attachment_ids])
             prioritary_attachments = all_attachments.filtered(lambda x: x.mimetype.endswith('pdf')) \
                                      or all_attachments.filtered(lambda x: x.mimetype.startswith('image')) \


### PR DESCRIPTION
Steps to reproduce:

- Make an invoice for a customer
- Post it and click on "Send & Print" button
- Reset to draft and edit the quantity of the product
- Post again and click again on "Send & Print" button

Issue:

The main attachment on the move is the first one, with the first values,
instead of the one with the updated values. This leads to issue when
sending followup report with attachment, as we send the main attachment.

We delete the conditional statement which prevent to set the main
attachment if there is already one, as we can not check if there was
a change on the move.

opw-2749663

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
