### PR TITLE
[FIX] website_crm_partner_assign: be consistent with data grade

### DIFF
--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -285,7 +285,7 @@ class WebsiteCrmPartnerAssign(WebsitePartnerPage):
 
         # search partners matching current search parameters
         partner_ids = partner_obj.sudo().search(
-            base_partner_domain, order="grade_sequence ASC, implemented_count DESC, display_name ASC, id ASC",
+            base_partner_domain, order="grade_sequence DESC, implemented_count DESC, display_name ASC, id ASC",
             offset=pager['offset'], limit=self._references_per_page)
         partners = partner_ids.sudo()
 


### PR DESCRIPTION
In data, Gold have bigger sequence than Silver.
We want promote 'better' partner first.


Related to https://github.com/odoo/odoo/commit/b28aae2


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
