### PR TITLE
[FIX] membership: wrong view arch

### DIFF
--- a/addons/membership/views/partner_views.xml
+++ b/addons/membership/views/partner_views.xml
@@ -91,9 +91,9 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_tree"/>
             <field name="arch" type="xml">
-                <tree string="Contacts">
+                <field name="category_id" position="after">
                     <field name="membership_state" optional="hide"/>
-                </tree>
+                </field>
             </field>
         </record>
 


### PR DESCRIPTION
Wrong arch caused the following error when user language is not English

```
ValueError: Không tìm thấy phần tử '<tree string="Liên hệ">' trong giao
diện cha

View name: res.partner.tree.form.inherit
Error context:
 view: ir.ui.view(2867,)
 xmlid: membership.view_partner_tree
 view.model: res.partner
 view.parent: ir.ui.view(115,)
```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
