### PR TITLE
[FIX] *: change labels of `res.country.state` relational field from 'State' to 'Fed. State' to avoid confusing

### DIFF
--- a/addons/adyen_platforms/i18n/adyen_platforms.pot
+++ b/addons/adyen_platforms/i18n/adyen_platforms.pot
@@ -1031,6 +1031,10 @@ msgstr ""
 #: model:ir.model.fields,field_description:adyen_platforms.field_adyen_account__state_id
 #: model:ir.model.fields,field_description:adyen_platforms.field_adyen_address_mixin__state_id
 #: model:ir.model.fields,field_description:adyen_platforms.field_adyen_shareholder__state_id
+msgid "Fed. State"
+msgstr ""
+
+#. module: adyen_platforms
 #: model_terms:ir.ui.view,arch_db:adyen_platforms.adyen_account_view_form
 #: model_terms:ir.ui.view,arch_db:adyen_platforms.adyen_bank_account_view_form
 #: model_terms:ir.ui.view,arch_db:adyen_platforms.adyen_shareholder_view_form

--- a/addons/adyen_platforms/models/adyen_account.py
+++ b/addons/adyen_platforms/models/adyen_account.py
@@ -23,7 +23,7 @@ class AdyenAddressMixin(models.AbstractModel):
 
     country_id = fields.Many2one('res.country', string='Country', domain=[('code', 'in', ADYEN_AVAILABLE_COUNTRIES)], required=True)
     country_code = fields.Char(related='country_id.code')
-    state_id = fields.Many2one('res.country.state', string='State', domain="[('country_id', '=?', country_id)]")
+    state_id = fields.Many2one('res.country.state', string='Fed. State', domain="[('country_id', '=?', country_id)]")
     state_code = fields.Char(related='state_id.code')
     city = fields.Char('City', required=True)
     zip = fields.Char('ZIP', required=True)

--- a/addons/base_address_city/i18n/base_address_city.pot
+++ b/addons/base_address_city/i18n/base_address_city.pot
@@ -118,7 +118,7 @@ msgstr ""
 
 #. module: base_address_city
 #: model:ir.model.fields,field_description:base_address_city.field_res_city__state_id
-msgid "State"
+msgid "Fed. State"
 msgstr ""
 
 #. module: base_address_city

--- a/addons/base_address_city/models/res_city.py
+++ b/addons/base_address_city/models/res_city.py
@@ -13,4 +13,4 @@ class City(models.Model):
     zipcode = fields.Char("Zip")
     country_id = fields.Many2one('res.country', string='Country', required=True)
     state_id = fields.Many2one(
-        'res.country.state', 'State', domain="[('country_id', '=', country_id)]")
+        'res.country.state', 'Fed. State', domain="[('country_id', '=', country_id)]")

--- a/addons/crm/i18n/crm.pot
+++ b/addons/crm/i18n/crm.pot
@@ -2693,7 +2693,7 @@ msgstr ""
 #: model:crm.lead.scoring.frequency.field,name:crm.frequency_field_state_id
 #: model:ir.model.fields,field_description:crm.field_crm_lead__state_id
 #: model_terms:ir.ui.view,arch_db:crm.crm_lead_view_form
-msgid "State"
+msgid "Fed. State"
 msgstr ""
 
 #. module: crm

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -184,7 +184,7 @@ class Lead(models.Model):
     zip = fields.Char('Zip', change_default=True, compute='_compute_partner_address_values', readonly=False, store=True)
     city = fields.Char('City', compute='_compute_partner_address_values', readonly=False, store=True)
     state_id = fields.Many2one(
-        "res.country.state", string='State',
+        "res.country.state", string='Fed. State',
         compute='_compute_partner_address_values', readonly=False, store=True,
         domain="[('country_id', '=?', country_id)]")
     country_id = fields.Many2one(

--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -1071,7 +1071,7 @@ msgstr ""
 #. module: l10n_ar
 #: model:ir.model.fields,field_description:l10n_ar.field_account_invoice_report__l10n_ar_state_id
 #: model_terms:ir.ui.view,arch_db:l10n_ar.view_account_invoice_report_search_inherit
-msgid "State"
+msgid "Fed. State"
 msgstr ""
 
 #. module: l10n_ar

--- a/addons/l10n_ar/report/invoice_report.py
+++ b/addons/l10n_ar/report/invoice_report.py
@@ -6,7 +6,7 @@ class AccountInvoiceReport(models.Model):
 
     _inherit = 'account.invoice.report'
 
-    l10n_ar_state_id = fields.Many2one('res.country.state', 'State', readonly=True)
+    l10n_ar_state_id = fields.Many2one('res.country.state', 'Fed. State', readonly=True)
     date = fields.Date(readonly=True, string="Accounting Date")
 
     _depends = {

--- a/addons/l10n_in/models/port_code.py
+++ b/addons/l10n_in/models/port_code.py
@@ -12,7 +12,7 @@ class L10nInPortCode(models.Model):
 
     code = fields.Char(string="Port Code", required=True)
     name = fields.Char(string="Port", required=True)
-    state_id = fields.Many2one('res.country.state', string="State")
+    state_id = fields.Many2one('res.country.state', string="Fed. State")
 
     _sql_constraints = [
         ('code_uniq', 'unique (code)', 'The Port Code must be unique!')

--- a/addons/snailmail/i18n/snailmail.pot
+++ b/addons/snailmail/i18n/snailmail.pot
@@ -597,7 +597,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:snailmail.field_snailmail_letter__state_id
 #: model:ir.model.fields,field_description:snailmail.field_snailmail_letter_missing_required_fields__state_id
 #: model_terms:ir.ui.view,arch_db:snailmail.snailmail_letter_missing_required_fields
-msgid "State"
+msgid "Fed. State"
 msgstr ""
 
 #. module: snailmail

--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -62,7 +62,7 @@ class SnailmailLetter(models.Model):
     street2 = fields.Char('Street2')
     zip = fields.Char('Zip')
     city = fields.Char('City')
-    state_id = fields.Many2one("res.country.state", string='State')
+    state_id = fields.Many2one("res.country.state", string='Fed. State')
     country_id = fields.Many2one('res.country', string='Country')
 
     @api.depends('reference', 'partner_id')

--- a/addons/snailmail/wizard/snailmail_letter_missing_required_fields.py
+++ b/addons/snailmail/wizard/snailmail_letter_missing_required_fields.py
@@ -12,7 +12,7 @@ class SnailmailLetterMissingRequiredFields(models.TransientModel):
     street2 = fields.Char('Street2')
     zip = fields.Char('Zip')
     city = fields.Char('City')
-    state_id = fields.Many2one("res.country.state", string='State')
+    state_id = fields.Many2one("res.country.state", string='Fed. State')
     country_id = fields.Many2one('res.country', string='Country')
 
     @api.model

--- a/addons/snailmail/wizard/snailmail_letter_missing_required_fields_views.xml
+++ b/addons/snailmail/wizard/snailmail_letter_missing_required_fields_views.xml
@@ -15,7 +15,7 @@
                         <field name="street" placeholder="Street..." class="o_address_street"/>
                         <field name="street2" placeholder="Street 2..." class="o_address_street"/>
                         <field name="city" placeholder="City" class="o_address_city"/>
-                        <field name="state_id" class="o_address_state" placeholder="State" options='{"no_open": True}'/>
+                        <field name="state_id" class="o_address_state" placeholder="Fed. State" options='{"no_open": True}'/>
                         <field name="zip" placeholder="ZIP" class="o_address_zip"/>
                         <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                     </div>

--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -12427,6 +12427,13 @@ msgstr ""
 #. module: base
 #: model:ir.model.fields,field_description:base.field_res_bank__state
 #: model:ir.model.fields,field_description:base.field_res_company__state_id
+#: model:ir.model.fields,field_description:base.field_res_partner__state_id
+#: model:ir.model.fields,field_description:base.field_res_users__state_id
+#: model_terms:ir.ui.view,arch_db:base.res_partner_view_form_private
+#: model_terms:ir.ui.view,arch_db:base.view_company_form
+#: model_terms:ir.ui.view,arch_db:base.view_partner_address_form
+#: model_terms:ir.ui.view,arch_db:base.view_partner_form
+#: model_terms:ir.ui.view,arch_db:base.view_res_bank_form
 msgid "Fed. State"
 msgstr ""
 
@@ -22525,16 +22532,9 @@ msgstr ""
 #. module: base
 #: model:ir.model.fields,field_description:base.field_base_language_export__state
 #: model:ir.model.fields,field_description:base.field_base_partner_merge_automatic_wizard__state
-#: model:ir.model.fields,field_description:base.field_res_partner__state_id
-#: model:ir.model.fields,field_description:base.field_res_users__state_id
-#: model_terms:ir.ui.view,arch_db:base.res_partner_view_form_private
-#: model_terms:ir.ui.view,arch_db:base.view_company_form
 #: model_terms:ir.ui.view,arch_db:base.view_country_state_form
 #: model_terms:ir.ui.view,arch_db:base.view_country_state_tree
 #: model_terms:ir.ui.view,arch_db:base.view_module_filter
-#: model_terms:ir.ui.view,arch_db:base.view_partner_address_form
-#: model_terms:ir.ui.view,arch_db:base.view_partner_form
-#: model_terms:ir.ui.view,arch_db:base.view_res_bank_form
 msgid "State"
 msgstr ""
 
@@ -22565,7 +22565,7 @@ msgstr ""
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_res_country__state_ids
-msgid "States"
+msgid "Fed. States"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -63,7 +63,7 @@ class Country(models.Model):
     phone_code = fields.Integer(string='Country Calling Code')
     country_group_ids = fields.Many2many('res.country.group', 'res_country_res_country_group_rel',
                          'res_country_id', 'res_country_group_id', string='Country Groups')
-    state_ids = fields.One2many('res.country.state', 'country_id', string='States')
+    state_ids = fields.One2many('res.country.state', 'country_id', string='Fed. States')
     name_position = fields.Selection([
             ('before', 'Before Address'),
             ('after', 'After Address'),

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -196,7 +196,7 @@ class Partner(models.Model):
     street2 = fields.Char()
     zip = fields.Char(change_default=True)
     city = fields.Char()
-    state_id = fields.Many2one("res.country.state", string='State', ondelete='restrict', domain="[('country_id', '=?', country_id)]")
+    state_id = fields.Many2one("res.country.state", string='Fed. State', ondelete='restrict', domain="[('country_id', '=?', country_id)]")
     country_id = fields.Many2one('res.country', string='Country', ondelete='restrict')
     partner_latitude = fields.Float(string='Geo Latitude', digits=(16, 5))
     partner_longitude = fields.Float(string='Geo Longitude', digits=(16, 5))

--- a/odoo/addons/base/views/res_bank_views.xml
+++ b/odoo/addons/base/views/res_bank_views.xml
@@ -20,7 +20,7 @@
                                     <field name="street" placeholder="Street..." class="o_address_street"/>
                                     <field name="street2" placeholder="Street 2..." class="o_address_street"/>
                                     <field name="city" placeholder="City" class="o_address_city"/>
-                                    <field name="state" class="o_address_state" placeholder="State" options='{"no_open": True}'/>
+                                    <field name="state" class="o_address_state" placeholder="Fed. State" options='{"no_open": True}'/>
                                     <field name="zip" placeholder="ZIP" class="o_address_zip"/>
                                     <field name="country" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                 </div>

--- a/odoo/addons/base/views/res_company_views.xml
+++ b/odoo/addons/base/views/res_company_views.xml
@@ -24,7 +24,7 @@
                                         <field name="street" placeholder="Street..." class="o_address_street"/>
                                         <field name="street2" placeholder="Street 2..." class="o_address_street"/>
                                         <field name="city" placeholder="City" class="o_address_city"/>
-                                        <field name="state_id" class="o_address_state" placeholder="State" options='{"no_open": True}'/>
+                                        <field name="state_id" class="o_address_state" placeholder="Fed. State" options='{"no_open": True}'/>
                                         <field name="zip" placeholder="ZIP" class="o_address_zip"/>
                                         <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True}'/>
                                     </div>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -125,7 +125,7 @@
                                 <field name="street" placeholder="Street..." class="o_address_street"/>
                                 <field name="street2" placeholder="Street 2..." class="o_address_street"/>
                                 <field name="city" placeholder="City" class="o_address_city"/>
-                                <field name="state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}" context="{'default_country_id': country_id}"/>
+                                <field name="state_id" class="o_address_state" placeholder="Fed. State" options="{'no_open': True, 'no_quick_create': True}" context="{'default_country_id': country_id}"/>
                                 <field name="zip" placeholder="ZIP" class="o_address_zip"/>
                                 <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                             </div>
@@ -192,7 +192,7 @@
                                     attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
                                 <field name="city" placeholder="City" class="o_address_city"
                                     attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
-                                <field name="state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}"
+                                <field name="state_id" class="o_address_state" placeholder="Fed. State" options="{'no_open': True, 'no_quick_create': True}"
                                     attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}" context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}"/>
                                 <field name="zip" placeholder="ZIP" class="o_address_zip"
                                     attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
@@ -309,7 +309,7 @@
                                                         <field name="street" placeholder="Street..." class="o_address_street"/>
                                                         <field name="street2" placeholder="Street 2..." class="o_address_street"/>
                                                         <field name="city" placeholder="City" class="o_address_city"/>
-                                                        <field name="state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}" context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}"/>
+                                                        <field name="state_id" class="o_address_state" placeholder="Fed. State" options="{'no_open': True, 'no_quick_create': True}" context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}"/>
                                                         <field name="zip" placeholder="ZIP" class="o_address_zip"/>
                                                         <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                                     </div>
@@ -377,7 +377,7 @@
                                         <field name="street" placeholder="Street..." class="o_address_street"/>
                                         <field name="street2" placeholder="Street 2..." class="o_address_street"/>
                                         <field name="city" placeholder="City" class="o_address_city"/>
-                                        <field name="state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}" context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}"/>
+                                        <field name="state_id" class="o_address_state" placeholder="Fed. State" options="{'no_open': True, 'no_quick_create': True}" context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}"/>
                                         <field name="zip" placeholder="ZIP" class="o_address_zip"/>
                                         <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                     </div>


### PR DESCRIPTION
In some languages, there are two or more different words for "state:province" and "state:status". For example in Vietnamese:
1. State (with the meaning of federal state or province): "Bang" or "Tỉnh"
2. State (with the meaning of status): "Tình trạng" or "Trạng thái"

To solve the issue, this PR changed all the "State" that means "federal state / province" into "Fed. State".



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
