### PR TITLE
[FIX] mail: modify url redirection to doc (mail servers)

### DIFF
--- a/addons/mail/views/res_config_settings_views.xml
+++ b/addons/mail/views/res_config_settings_views.xml
@@ -31,7 +31,7 @@
                             </div>
                             <div class="o_setting_right_pane">
                                 <label for="external_email_server_default"/>
-                                <a href="https://www.odoo.com/documentation/14.0/applications/productivity/discuss/advanced/email_servers.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/14.0/applications/general/email_communication/email_servers.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted" id="external_email_server_default">
                                     Configure your own email servers
                                 </div>


### PR DESCRIPTION
Documentation structure was modified to point out to a new subtree:
    content/applications/general/email_communication/email_server

Related task:2619564
Documentation PR:1092

