### PR TITLE
[IMP] account, point_of_sale: add new type of tax

### DIFF
--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -138,11 +138,12 @@
                         <group>
                             <field name="type_tax_use"/>
                             <field name="tax_scope"/>
-                            <label for="amount" attrs="{'invisible':[('amount_type','not in', ('fixed', 'percent', 'division'))]}"/>
-                            <div attrs="{'invisible':[('amount_type','not in', ('fixed', 'percent', 'division'))]}">
+                            <label for="amount" attrs="{'invisible':[('amount_type','not in', ('fixed', 'percent', 'division', 'fixed/percent'))]}"/>
+                            <div attrs="{'invisible':[('amount_type','not in', ('fixed', 'percent', 'division', 'fixed/percent'))]}">
                                 <field name="amount" class="oe_inline" nolabel="1"/>
                                 <span class="o_form_label oe_inline" attrs="{'invisible':[('amount_type','=','fixed')]}">%</span>
                             </div>
+                            <field name="fixed_amount" class="oe_inline" attrs="{'invisible':[('amount_type','!=','fixed/percent')], 'required':[('amount_type', '=', 'fixed/percent')]}"/>
                         </group>
                     </group>
                     <notebook>

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1700,7 +1700,7 @@ class PosSession(models.Model):
                 'domain': [('company_id', '=', self.company_id.id)],
                 'fields': [
                     'name', 'real_amount', 'price_include', 'include_base_amount', 'is_base_affected',
-                    'amount_type', 'children_tax_ids'
+                    'amount_type', 'children_tax_ids', 'fixed_amount'
                 ],
             },
         }


### PR DESCRIPTION
In this commit, we add a new type that does tax calculation in fixed/percent
and takes the higher one.

Tax is 21% or 4170 INR per 1000 qty which is high

Product | QTY | Unit Price | Total without tax | Tax amount
========|=====|============|===================|===========
A          | 10    | 100.0         | 1000.0            | 417.0
B          | 50    | 100.0         | 5000.0            | 1050.0

In first-line tax calculation is
21% of 1000 = 210.0
100(QTY) * 4.17 = 417.0
Tax value is 417.0 (based on qty because the value is higher than the percentage
calculation)

In second-line tax calculation is
21% of 5000 = 1050.0
100(QTY) * 4.17 = 417.0
Tax value is 1050.0 (based on percentage because the value is higher than
qty base calculation)

task-2741537
PR: #84518

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
