### PR TITLE
[FIX] tests: wait for futures before clearing browser

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1345,6 +1345,8 @@ class ChromeBrowser:
                 registrations => Promise.all(registrations.map(r => r.unregister()))
             )
         """, 'awaitPromise': True})
+        # wait for the screenshot or whatever
+        wait(self._responses.values())
         self._logger.info('Deleting cookies and clearing local storage')
         self._websocket_request('Network.clearBrowserCache')
         self._websocket_request('Network.clearBrowserCookies')
@@ -1352,7 +1354,7 @@ class ChromeBrowser:
         self.navigate_to('about:blank', wait_stop=True)
         # hopefully after navigating to about:blank there's no event left
         self._frames.clear()
-        # wait for the screenshot or whatever
+        # wait for the clearing requests to finish in case the browser is re-used
         wait(self._responses.values())
         self._responses.clear()
         self._result.cancel()


### PR DESCRIPTION
When a test fails and asks for a screenshot, it seems that in some
conditions, the browser has already navigated to the blank page when
capturing the screenshot, resulting in a useless blank screenshot.

With this commit, all the futures are awaited to avoid this race
condition.
