### PR TITLE
[IMP] account: clarify credit note creation message

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2062,7 +2062,7 @@ class AccountMove(models.Model):
 
     def _creation_subtype(self):
         # OVERRIDE
-        if self.move_type in ('out_invoice', 'out_refund', 'out_receipt'):
+        if self.move_type in ('out_invoice', 'out_receipt'):
             return self.env.ref('account.mt_invoice_created')
         else:
             return super(AccountMove, self)._creation_subtype()


### PR DESCRIPTION
Task: 2760136

Currently, when a credit note is created there is a message in the chatter "Invoice created", which is not coherent.
- Credit Note creation message should be "Credit Note created"



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
