### PR TITLE
[FIX] website: handle RequestUID case in slug

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -264,7 +264,7 @@ class ModelConverter(ModelConverter):
             # limited support for negative IDs due to our slug pattern, assume abs() if not found
             if not env[self.model].browse(record_id).exists():
                 record_id = abs(record_id)
-        return env[self.model].browse(record_id)
+        return env[self.model].with_context(_converter_value=value).browse(record_id)
 
 
 class IrHttp(models.AbstractModel):

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -74,7 +74,7 @@ class Http(models.AbstractModel):
     def _slug_matching(cls, adapter, endpoint, **kw):
         for arg in kw:
             if isinstance(kw[arg], models.BaseModel):
-                kw[arg] = kw[arg].with_user(request.uid)
+                kw[arg] = kw[arg].with_context(slug_matching=True)
         qs = request.httprequest.query_string.decode('utf-8')
         return adapter.build(endpoint, kw) + (qs and '?%s' % qs or '')
 
@@ -366,6 +366,11 @@ class Http(models.AbstractModel):
 
 
 class ModelConverter(ModelConverter):
+
+    def to_url(self, value):
+        if hasattr(value, 'env') and value.env.context.get('slug_matching'):
+            return value.env.context.get('_converter_value', str(value.id))
+        return super().to_url(value)
 
     def generate(self, uid, dom=None, args=None):
         Model = request.env[self.model].with_user(uid)


### PR DESCRIPTION
Before this commit, a 308 on a route with a modelconverter for a model
that have a seo_name field will crash with an exception:
Cannot iterate on RequestUID

Another simplest solution was to use a with_user(SUPERUSER_ID) but in this case
it bypass the security set and display the name of the record even if not yet
published.

How to reproduce:

Create a 308 from /shop/<product> to /mag/<product>
Unpublish product 10
Try to access /shop/product-10

You have an unmanaged '500 internal error"
because slug_matching -> build -> to_url -> slug with a record with Requestuid
as env._uid.

X-original-commit: https://github.com/odoo/odoo/commit/4ac2cab96655a3c5e673b0a04be5599dba507850

cherry-pick: https://github.com/odoo/odoo/commit/2ecc538d516ea30254b8152e8e48c912c0c86695

opw-2749686

Backport of https://github.com/odoo/odoo/pull/64889
