### PR TITLE
[IMP/REF] test_lint, *: improve test_eslint, enable some linting rules

### DIFF
--- a/addons/base_automation/static/tests/base_automation_error_dialog.js
+++ b/addons/base_automation/static/tests/base_automation_error_dialog.js
@@ -13,10 +13,8 @@ import { makeFakeRPCService, makeFakeLocalizationService } from "@web/../tests/h
 import { RPCError } from "@web/core/network/rpc_service";
 
 import { BaseAutomationErrorDialog } from "../src/js/base_automation_error_dialog";
-import { patchWithCleanup } from "@web/../tests/helpers/utils";
+import { patchWithCleanup,getFixture, mount, nextTick } from "@web/../tests/helpers/utils";
 import { DialogContainer } from "@web/core/dialog/dialog_container";
-import { getFixture, mount } from "@web/../tests/helpers/utils";
-import { nextTick } from "@web/../tests/helpers/utils";
 
 const { onMounted } = owl;
 

--- a/addons/hr/static/src/js/m2x_avatar_employee.js
+++ b/addons/hr/static/src/js/m2x_avatar_employee.js
@@ -2,9 +2,13 @@
 
 import fieldRegistry from 'web.field_registry';
 
-import { Many2OneAvatarUser, KanbanMany2OneAvatarUser, KanbanMany2ManyAvatarUser, ListMany2ManyAvatarUser } from '@mail/js/m2x_avatar_user';
-import { Many2ManyAvatarUser } from '@mail/js/m2x_avatar_user';
-import { KanbanMany2ManyTagsAvatar, ListMany2ManyTagsAvatar } from 'web.relational_fields';
+import {
+    Many2OneAvatarUser,
+    KanbanMany2OneAvatarUser,
+    KanbanMany2ManyAvatarUser,
+    ListMany2ManyAvatarUser,
+    Many2ManyAvatarUser,
+} from '@mail/js/m2x_avatar_user';
 
 
 // This module defines variants of the Many2OneAvatarUser and Many2ManyAvatarUser

--- a/addons/mail/static/src/main.js
+++ b/addons/mail/static/src/main.js
@@ -6,8 +6,7 @@ import { MessagingService } from '@mail/services/messaging/messaging';
 import { SystrayService } from '@mail/services/systray_service/systray_service';
 import { DiscussWidget } from '@mail/widgets/discuss/discuss';
 
-import { action_registry } from 'web.core';
-import { serviceRegistry } from 'web.core';
+import { serviceRegistry, action_registry } from 'web.core';
 
 serviceRegistry.add('chat_window', ChatWindowService);
 serviceRegistry.add('dialog', DialogService);

--- a/addons/mail/static/tests/activity_tests.js
+++ b/addons/mail/static/tests/activity_tests.js
@@ -5,10 +5,9 @@ import ActivityView from '@mail/js/views/activity/activity_view';
 import testUtils from 'web.test_utils';
 import domUtils from 'web.dom';
 
-import { getFixture, legacyExtraNextTick, patchWithCleanup } from "@web/../tests/helpers/utils";
+import { getFixture, legacyExtraNextTick, patchWithCleanup, click } from "@web/../tests/helpers/utils";
 import { createWebClient, doAction } from "@web/../tests/webclient/helpers";
 import { session } from '@web/session';
-import { click } from "@web/../tests/helpers/utils";
 
 let serverData;
 let target;

--- a/addons/point_of_sale/static/src/js/db.js
+++ b/addons/point_of_sale/static/src/js/db.js
@@ -185,7 +185,7 @@ var PosDB = core.Class.extend({
     add_products: function(products){
         var stored_categories = this.product_by_category_id;
 
-        if(!products instanceof Array){
+        if(!(products instanceof Array)){
             products = [products];
         }
         for(var i = 0, len = products.length; i < len; i++){

--- a/addons/web/static/src/core/network/download.js
+++ b/addons/web/static/src/core/network/download.js
@@ -1,8 +1,7 @@
 /** @odoo-module **/
 
 import { _lt } from "../l10n/translation";
-import { makeErrorFromResponse } from "@web/core/network/rpc_service";
-import { ConnectionLostError } from "@web/core/network/rpc_service";
+import { makeErrorFromResponse, ConnectionLostError } from "@web/core/network/rpc_service";
 import { browser } from "@web/core/browser/browser";
 
 // -----------------------------------------------------------------------------
@@ -490,8 +489,8 @@ download._download = (options) => {
                 const filename = header ? parse(header).parameters.filename : null;
                 _download(xhr.response, filename, mimetype);
                 return resolve(filename);
-
-            } else if (xhr.status === 502) { // If Odoo is behind another server (nginx)
+            } else if (xhr.status === 502) {
+                // If Odoo is behind another server (nginx)
                 reject(new ConnectionLostError());
             } else {
                 const decoder = new FileReader();
@@ -502,18 +501,20 @@ download._download = (options) => {
                         doc.body.children.length === 0 ? doc.body.childNodes : doc.body.children;
 
                     let error;
-                    try { // a Serialized python Error
+                    try {
+                        // a Serialized python Error
                         const node = nodes[1] || nodes[0];
                         error = JSON.parse(node.textContent);
                     } catch (e) {
                         error = {
                             message: "Arbitrary Uncaught Python Exception",
                             data: {
-                                debug: `${xhr.status}` + `\n` +
-                                   `${nodes.length > 0 ? nodes[0].textContent : ""}
-                                    ${nodes.length > 1 ? nodes[1].textContent : ""}`
+                                debug:
+                                    `${xhr.status}` +
+                                    `\n` +
+                                    `${nodes.length > 0 ? nodes[0].textContent : ""}
+                                    ${nodes.length > 1 ? nodes[1].textContent : ""}`,
                             },
-
                         };
                     }
                     error = makeErrorFromResponse(error);

--- a/addons/web/static/src/legacy/js/core/utils.js
+++ b/addons/web/static/src/legacy/js/core/utils.js
@@ -633,7 +633,7 @@ var utils = Object.assign({
 
         if (typeof(node) === 'string') {
             return sindent + node.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-        } else if (typeof(node.tag) !== 'string' || !node.children instanceof Array || !node.attrs instanceof Object) {
+        } else if (typeof(node.tag) !== 'string' || node.children && !(node.children instanceof Array) || node.attrs && !(node.attrs instanceof Object)) {
             throw new Error(
                 _.str.sprintf(_t("Node [%s] is not a JSONified XML node"),
                             JSON.stringify(node)));

--- a/addons/web/static/src/legacy/js/public/public_root.js
+++ b/addons/web/static/src/legacy/js/public/public_root.js
@@ -2,14 +2,13 @@
 
 import ajax from 'web.ajax';
 import dom from 'web.dom';
-import env from 'web.public_env';
+import legacyEnv from 'web.public_env';
 import session from 'web.session';
 import utils from 'web.utils';
 import publicWidget from 'web.public.widget';
 import { registry } from '@web/core/registry';
 
 import AbstractService from "web.AbstractService";
-import legacyEnv from "web.public_env";
 import lazyloader from "web.public.lazyloader";
 
 import {
@@ -68,7 +67,7 @@ export const PublicRoot = publicWidget.RootWidget.extend({
      */
     init: function () {
         this._super.apply(this, arguments);
-        this.env = env;
+        this.env = legacyEnv;
         this.publicWidgets = [];
     },
     /**

--- a/addons/web/static/src/search/favorite_menu/favorite_menu.js
+++ b/addons/web/static/src/search/favorite_menu/favorite_menu.js
@@ -5,8 +5,7 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { FACET_ICONS } from "../utils/misc";
 import { registry } from "@web/core/registry";
-import { useBus } from "@web/core/utils/hooks";
-import { useService } from "@web/core/utils/hooks";
+import { useBus, useService } from "@web/core/utils/hooks";
 
 const { Component } = owl;
 const favoriteMenuRegistry = registry.category("favoriteMenu");

--- a/addons/web/static/tests/search/search_model_tests.js
+++ b/addons/web/static/tests/search/search_model_tests.js
@@ -1,8 +1,7 @@
 /** @odoo-module **/
 
-import { patchDate } from "@web/../tests/helpers/utils";
+import { patchDate, patchWithCleanup } from "@web/../tests/helpers/utils";
 import { makeWithSearch, setupControlPanelServiceRegistry } from "./helpers";
-import { patchWithCleanup } from "@web/../tests/helpers/utils";
 
 const { Component, xml } = owl;
 

--- a/addons/web/static/tests/setup.js
+++ b/addons/web/static/tests/setup.js
@@ -1,8 +1,7 @@
 /** @odoo-module **/
 
-import core from "web.core";
+import core, { _t } from "web.core";
 import session from "web.session";
-import { _t } from "web.core";
 import { browser, makeRAMLocalStorage } from "@web/core/browser/browser";
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
 import { legacyProm } from "web.test_legacy";

--- a/addons/web_tour/static/tests/debug_manager_tests.js
+++ b/addons/web_tour/static/tests/debug_manager_tests.js
@@ -9,9 +9,8 @@ import { uiService } from "@web/core/ui/ui_service";
 
 import { click, getFixture, mount } from "@web/../tests/helpers/utils";
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
-import { makeFakeLocalizationService } from "@web/../tests/helpers/mock_services";
+import { makeFakeLocalizationService, fakeCommandService } from "@web/../tests/helpers/mock_services";
 import { DebugMenuParent } from "@web/../tests/core/debug/debug_manager_tests";
-import { fakeCommandService } from "@web/../tests/helpers/mock_services";
 
 const debugRegistry = registry.category("debug");
 let target;

--- a/addons/website_payment/static/src/js/website_payment_form.js
+++ b/addons/website_payment/static/src/js/website_payment_form.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
-import core from 'web.core';
-import {_t} from 'web.core';
+import core, { _t } from 'web.core';
 import checkoutForm from 'payment.checkout_form';
 
 checkoutForm.include({

--- a/odoo/addons/test_assetsbundle/tests/test_js_transpiler.py
+++ b/odoo/addons/test_assetsbundle/tests/test_js_transpiler.py
@@ -249,6 +249,9 @@ import Line9  from "test.Dialog";
 import  { Line10, Notification }  from 'test.Dialog2';
 
 import * as Line11 from "test.Dialog";
+import Default1, { Named1 } from "legacy.module";
+import Default1, { Named1 } from "@new_module/file";
+import Default2, * as Star1 from "test.Dialog";
 import "test.Dialog";
 
 import Line12  from "@test.Dialog"; //HELLO
@@ -281,6 +284,11 @@ const Line9 = require("test.Dialog");
 const { Line10, Notification } = require('test.Dialog2');
 
 const Line11 = require("test.Dialog");
+const Default1 = require("legacy.module");
+const { Named1 } = Default1;
+const { Named1 , [Symbol.for("default")]: Default1 } = require("@new_module/file");
+const Star1 = require("test.Dialog");
+const Default2 = Star1[Symbol.for("default")];
 require("test.Dialog");
 
 const Line12 = require("@test.Dialog")[Symbol.for("default")]; //HELLO

--- a/odoo/addons/test_lint/tests/eslintrc
+++ b/odoo/addons/test_lint/tests/eslintrc
@@ -15,6 +15,7 @@
         "no-debugger": ["error"],
         "no-dupe-class-members": ["error"],
         "no-unsafe-negation": ["error"],
+        "no-duplicate-imports": ["error"],
         "valid-typeof": ["error"]
     },
     "globals": {

--- a/odoo/addons/test_lint/tests/eslintrc
+++ b/odoo/addons/test_lint/tests/eslintrc
@@ -13,7 +13,9 @@
         "no-restricted-globals": ["error", "event", "self"],
         "no-const-assign": ["error"],
         "no-debugger": ["error"],
-        "no-dupe-class-members": ["error"]
+        "no-dupe-class-members": ["error"],
+        "no-unsafe-negation": ["error"],
+        "valid-typeof": ["error"]
     },
     "globals": {
         "owl": "readonly",

--- a/odoo/addons/test_lint/tests/eslintrc
+++ b/odoo/addons/test_lint/tests/eslintrc
@@ -1,0 +1,36 @@
+{
+    "env": {
+        "browser": true,
+        "es2017": true
+    },
+    "parserOptions": {
+        "ecmaVersion": 2019,
+        "sourceType": "module"
+    },
+    "root": true,
+    "rules": {
+        "no-undef": "error",
+        "no-restricted-globals": ["error", "event", "self"],
+        "no-const-assign": ["error"],
+        "no-debugger": ["error"],
+        "no-dupe-class-members": ["error"]
+    },
+    "globals": {
+        "owl": "readonly",
+        "odoo": "readonly",
+        "$": "readonly",
+        "jQuery": "readonly",
+        "_": "readonly",
+        "Chart": "readonly",
+        "fuzzy": "readonly",
+        "QWeb2": "readonly",
+        "Popover": "readonly",
+        "StackTrace": "readonly",
+        "QUnit": "readonly",
+        "luxon": "readonly",
+        "moment": "readonly",
+        "py": "readonly",
+        "ClipboardJS": "readonly",
+        "globalThis": "readonly"
+    }
+}

--- a/odoo/tools/js_transpiler.py
+++ b/odoo/tools/js_transpiler.py
@@ -12,8 +12,10 @@ the original source need to be supported by the browsers.
 """
 
 import re
+import logging
 from functools import partial
 
+_logger = logging.getLogger(__name__)
 
 def transpile_javascript(url, content):
     """
@@ -30,6 +32,8 @@ def transpile_javascript(url, content):
     steps = [
         convert_legacy_default_import,
         convert_basic_import,
+        convert_default_and_named_import,
+        convert_default_and_star_import,
         convert_default_import,
         convert_star_import,
         convert_unnamed_relative_import,
@@ -460,6 +464,44 @@ def convert_default_import(content):
     return IMPORT_DEFAULT.sub(repl, content)
 
 
+IS_PATH_LEGACY_RE = re.compile(r"""(?P<quote>["'`])([^@\."'`][^"'`]*)(?P=quote)""")
+
+IMPORT_DEFAULT_AND_NAMED_RE = re.compile(r"""
+    ^
+    (?P<space>\s*)                                  # space and empty line
+    import\s+                                       # import
+    (?P<default_export>\w+)\s*,\s*                  # default variable name,
+    (?P<named_exports>{(\s*\w+\s*,?\s*)+})\s*       # { a, b, c as x, ... }
+    from\s*                                         # from
+    (?P<path>(?P<quote>["'`])([^"'`]+)(?P=quote))   # "file path" ("some/path")
+    """, re.MULTILINE | re.VERBOSE)
+
+
+def convert_default_and_named_import(content):
+    """
+    Transpile default and named import on one line.
+
+    .. code-block:: javascript
+
+        // before
+        import something, { a } from "some/path";
+        import somethingElse, { b } from "legacy.module";
+        // after
+        const { a , [Symbol.for("default")]: something } = require("some/path");
+        const somethingElse = require("legacy.module");
+        const { b } = somethingElse;
+    """
+    def repl(matchobj):
+        is_legacy = IS_PATH_LEGACY_RE.match(matchobj['path'])
+        new_object = matchobj["named_exports"].replace(" as ", ": ")
+        if is_legacy:
+            return f"""{matchobj['space']}const {matchobj['default_export']} = require({matchobj['path']});
+{matchobj['space']}const {new_object} = {matchobj['default_export']}"""
+        new_object = f"""{new_object[:-1]}, [Symbol.for("default")]: {matchobj['default_export']} }}"""
+        return f"{matchobj['space']}const {new_object} = require({matchobj['path']})"
+    return IMPORT_DEFAULT_AND_NAMED_RE.sub(repl, content)
+
+
 RELATIVE_REQUIRE_RE = re.compile(r"""
     require\((?P<quote>["'`])([^@"'`]+)(?P=quote)\)  # require("some/path")
     """, re.VERBOSE)
@@ -514,6 +556,34 @@ def convert_star_import(content):
     """
     repl = r"\g<space>const \g<identifier> = require(\g<path>)"
     return IMPORT_STAR.sub(repl, content)
+
+
+IMPORT_DEFAULT_AND_STAR = re.compile(r"""
+    ^(?P<space>\s*)                 # indentation
+    import\s+                       # import
+    (?P<default_export>\w+)\s*,\s*  # default export name,
+    \*\s+as\s+                      # * as
+    (?P<named_exports_alias>\w+)    # alias
+    \s*from\s*                      # from
+    (?P<path>[^;\n]+)               # path
+""", re.MULTILINE | re.VERBOSE)
+
+
+def convert_default_and_star_import(content):
+    """
+    Transpile import star.
+
+    .. code-block:: javascript
+
+        // before
+        import something, * as name from "some/path";
+        // after
+        const name = require("some/path");
+        const something = name[Symbol.for("default")];
+    """
+    repl = r"""\g<space>const \g<named_exports_alias> = require(\g<path>);
+\g<space>const \g<default_export> = \g<named_exports_alias>[Symbol.for("default")]"""
+    return IMPORT_DEFAULT_AND_STAR.sub(repl, content)
 
 
 IMPORT_UNNAMED_RELATIVE_RE = re.compile(r"""


### PR DESCRIPTION
The commits contained in this PR make it easier to add new eslint rules by breaking the eslint config into an eslintrc file, and enables some rules. Some work was done to allow some of these rules to be enabled, and offending code was adapted.