### PR TITLE
[FIX] website_sale : apply discount pricelist when default for customer

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -85,7 +85,7 @@ class Website(models.Model):
             it might not be website compliant (eg: it is not selectable anymore,
             it is a backend pricelist, it is not active anymore..).
             """
-            return (not show_visible or pl.selectable or pl.id in (current_pl, order_pl))
+            return (not show_visible or pl.selectable or pl.id in (current_pl, order_pl, partner_pl))
 
         # Note: 1. pricelists from all_pl are already website compliant (went through
         #          `_get_website_pricelists_domain`)


### PR DESCRIPTION
Steps :
Create a Pricelist ("Discount") :
	Discount : 50%
	Selectable : False
	Promo code : DISCOUNT
Make another one selectable ("Base")
	and delete the other ones.
Go to Contacts > Portal :
	Pricelist : "Discount"
With Portal, log in the website and go to shop.
Notice you cannot choose your pricelist.
Select a product, confirm and add the promo code DISCOUNT.
It applies. Now go back to the e-shop, it applies for each product.
Notice you can now choose your pricelist : Base or Discount.
If you click on Base, it applies and you cannot choose your pricelist
anymore.

Issue :
It is not consistent that a pricelist automaticly applies for a customer
when creating a SO, but doesn't when  he is logged on a website.
A promo code is a workaround, but it is not the easiest way.
Also, when he uses the code, he can choose his pricelist. Better give
him this choice, and doing so, allow him to see the final prices
immediately.

Fix :
Add the partner pricelist to the visible pricelist.

opw: 2744544

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
