### PR TITLE
[FIX] web_editor: fix shape animation loss

### DIFF
--- a/addons/web_editor/static/image_shapes/line/organic_1_line.svg
+++ b/addons/web_editor/static/image_shapes/line/organic_1_line.svg
@@ -13,5 +13,7 @@
   </svg><svg viewBox="0 0 1 1" id="preview" preserveAspectRatio="none">
     <use xlink:href="#filterPath" fill="darkgrey"></use>
   </svg>
-  <image xlink:href="" clip-path="url(#clip-path)"></image>
+  <image xlink:href="" clip-path="url(#clip-path)">
+    <animateMotion dur="1ms" repeatCount="indefinite"/>
+  </image>
 </svg>

--- a/addons/web_editor/static/image_shapes/line/oval_2_line.svg
+++ b/addons/web_editor/static/image_shapes/line/oval_2_line.svg
@@ -14,5 +14,7 @@
   </svg><svg viewBox="0 0 1 1" id="preview" preserveAspectRatio="none">
     <use xlink:href="#filterPath" fill="darkgrey"></use>
   </svg>
-  <image xlink:href="" clip-path="url(#clip-path)"></image>
+  <image xlink:href="" clip-path="url(#clip-path)">
+    <animateMotion dur="1ms" repeatCount="indefinite"/>
+  </image>
 </svg>

--- a/addons/web_editor/static/image_shapes/line/oval_3_pattern_line.svg
+++ b/addons/web_editor/static/image_shapes/line/oval_3_pattern_line.svg
@@ -47,5 +47,7 @@
   </svg><svg viewBox="0 0 1 1" id="preview" preserveAspectRatio="none">
     <use xlink:href="#filterPath" fill="darkgrey"></use>
   </svg>
-  <image xlink:href="" clip-path="url(#clip-path)"></image>
+  <image xlink:href="" clip-path="url(#clip-path)">
+    <animateMotion dur="1ms" repeatCount="indefinite"/>
+  </image>
 </svg>

--- a/addons/web_editor/static/image_shapes/pattern/organic_3_pattern_cross.svg
+++ b/addons/web_editor/static/image_shapes/pattern/organic_3_pattern_cross.svg
@@ -81,5 +81,7 @@
   </svg><svg viewBox="0 0 1 1" id="preview" preserveAspectRatio="none">
     <use xlink:href="#filterPath" fill="darkgrey"></use>
   </svg>
-  <image xlink:href="" clip-path="url(#clip-path)"></image>
+  <image xlink:href="" clip-path="url(#clip-path)">
+    <animateMotion dur="1ms" repeatCount="indefinite"/>
+  </image>
 </svg>

--- a/addons/web_editor/static/image_shapes/pattern/organic_4_pattern_caps.svg
+++ b/addons/web_editor/static/image_shapes/pattern/organic_4_pattern_caps.svg
@@ -162,5 +162,7 @@
   </svg><svg viewBox="0 0 1 1" id="preview" preserveAspectRatio="none">
     <use xlink:href="#filterPath" fill="darkgrey"></use>
   </svg>
-  <image xlink:href="" clip-path="url(#clip-path)"></image>
+  <image xlink:href="" clip-path="url(#clip-path)">
+    <animateMotion dur="1ms" repeatCount="indefinite"/>
+  </image>
 </svg>

--- a/addons/web_editor/static/image_shapes/solid/blob_1_solid_rd.svg
+++ b/addons/web_editor/static/image_shapes/solid/blob_1_solid_rd.svg
@@ -14,5 +14,13 @@
     </svg><svg viewBox="0 0 1 1" id="preview" preserveAspectRatio="none">
         <use xlink:href="#filterPath" fill="darkgrey"></use>
     </svg>
-    <image xlink:href="" clip-path="url(#clip-path)"></image>
+    <image xlink:href="" clip-path="url(#clip-path)">
+        <!--
+            TODO: improve this:
+            The <animateMotion... /> hack is used on <image/> to force content
+            animation and prevent GIF animation loss when non-animated shapes
+            are applied (on Safari & FF).
+        -->
+        <animateMotion dur="1ms" repeatCount="indefinite"/>
+    </image>
 </svg>

--- a/addons/web_editor/static/image_shapes/solid/blob_2_solid_str.svg
+++ b/addons/web_editor/static/image_shapes/solid/blob_2_solid_str.svg
@@ -12,5 +12,7 @@
   </svg><svg viewBox="0 0 1 1" id="preview" preserveAspectRatio="none">
     <use xlink:href="#filterPath" fill="darkgrey"></use>
   </svg>
-  <image xlink:href="" clip-path="url(#clip-path)"></image>
+  <image xlink:href="" clip-path="url(#clip-path)">
+    <animateMotion dur="1ms" repeatCount="indefinite"/>
+  </image>
 </svg>

--- a/addons/web_editor/static/image_shapes/solid/blob_3_solid_rd.svg
+++ b/addons/web_editor/static/image_shapes/solid/blob_3_solid_rd.svg
@@ -14,5 +14,7 @@
     </svg><svg viewBox="0 0 1 1" id="preview" preserveAspectRatio="none">
         <use xlink:href="#filterPath" fill="darkgrey"></use>
     </svg>
-    <image xlink:href="" clip-path="url(#clip-path)"></image>
+    <image xlink:href="" clip-path="url(#clip-path)">
+        <animateMotion dur="1ms" repeatCount="indefinite"/>
+    </image>
 </svg>

--- a/addons/web_editor/static/image_shapes/solid/oval_1_solid_rd.svg
+++ b/addons/web_editor/static/image_shapes/solid/oval_1_solid_rd.svg
@@ -13,5 +13,7 @@
   </svg><svg viewBox="0 0 1 1" id="preview" preserveAspectRatio="none">
     <use xlink:href="#filterPath" fill="darkgrey"></use>
   </svg>
-  <image xlink:href="" clip-path="url(#clip-path)"></image>
+  <image xlink:href="" clip-path="url(#clip-path)">
+    <animateMotion dur="1ms" repeatCount="indefinite"/>
+  </image>
 </svg>


### PR DESCRIPTION
To apply a shape on image, we use its base64 string as source on the
`<image/>` of the shape svg file. Then, the svg is used as source on the
targeted DOM element (`<img/>` on snippet).

When the targeted image is an animated GIF, the behaviour is different:

CHROME:
- The animation works correctly.

SAFARI & FF:
- The GIF animation is lost (only on non-animated shapes). The animation
works correctly on the svg file but once it's used as src of `<img/>` tag,
the animation is lost.

The goal of this commit is to fix this behaviour by forcing the
animation on svg content.

task-2679905
