### PR TITLE
[FIX] partner_autocomplete: VAT not showing in edit mode

### DIFF
--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
@@ -58,19 +58,6 @@ var PartnerField = FieldMany2One.extend(AutocompleteMixin, {
     },
 
     /**
-     * Returns the display_name from a string which contains it but was altered
-     * as a result of the show_vat option.
-     * Note that the split is done on a 'figuredash', not a standard dash.
-     *
-     * @private
-     * @param {string} value
-     * @returns {string} display_name without TaxID
-     */
-    _getDisplayNameWithoutVAT: function (value) {
-        return value.split(' ‒ ')[0];
-    },
-
-    /**
      * Modify autocomplete results rendering
      * Add logo in the autocomplete results if logo is provided
      *
@@ -104,7 +91,6 @@ var PartnerField = FieldMany2One.extend(AutocompleteMixin, {
      * @private
      */
     _renderEdit: function (){
-        this.m2o_value = this._getDisplayNameWithoutVAT(this.m2o_value);
         this._super.apply(this, arguments);
         this._modifyAutompleteRendering();
     },


### PR DESCRIPTION
When using the widget res_partner_many2one (e.g. in the customer invoice
form view), the VAT number disappears when being in 'edit' mode.

task-2749331