### PR TITLE
[FIX] web_editor: Show snippet name

### DIFF
--- a/addons/web_editor/models/ir_qweb.py
+++ b/addons/web_editor/models/ir_qweb.py
@@ -120,10 +120,13 @@ class IrQWeb(models.AbstractModel):
 
     def _directives_eval_order(self):
         directives = super()._directives_eval_order()
-        directives.insert(directives.index('att'), 'placeholder')
-        directives.insert(directives.index('call'), 'snippet')
-        directives.insert(directives.index('call'), 'snippet-call')
-        directives.insert(directives.index('call'), 'install')
+        # Insert before "att" as those may rely on static attributes like
+        # "string" and "att" clears all of those
+        index = directives.index('att') - 1
+        directives.insert(index, 'placeholder')
+        directives.insert(index, 'snippet')
+        directives.insert(index, 'snippet-call')
+        directives.insert(index, 'install')
         return directives
 
 


### PR DESCRIPTION
[FIX] web_editor: name instead of "Snippet" as label for t-install apps

Issue: Since the refactoring done on ir.qweb https://github.com/odoo/odoo/commit/e830953570d5f28aee9bdcdf97af18d3e3246030,
directions are more autonomous, so `t-att`, `t-options`... are no longer
evaluated by other directives. These directives are also ordered.
Therefore, when directives such as ``t-snippet``, ``t-install``... are
called, the attributes have already been consumed (``string`` attributes
is removed, because at the end of the compilation tags should no longer
have attributes, `t-att` remove all statics attributes).
There are then two solutions, the first is to change the order, the other
is to follow the generated code (using the generated values).

task-2762377