### PR TITLE
[FIX] web_editor: remove custom gradient button from colors inventory

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -248,7 +248,7 @@ const ColorPaletteWidget = Widget.extend({
         const compatibilityColorNames = ['primary', 'secondary', 'alpha', 'beta', 'gamma', 'delta', 'epsilon', 'success', 'info', 'warning', 'danger'];
         this.colorNames = [...compatibilityColorNames];
         this.colorToColorNames = {};
-        this.el.querySelectorAll('button[data-color]').forEach(elem => {
+        this.el.querySelectorAll('button[data-color]:not(.o_custom_gradient_btn)').forEach(elem => {
             const colorName = elem.dataset.color;
             if (weUtils.isColorGradient(colorName)) {
                 return;


### PR DESCRIPTION
Since [1] when resetting the background color of the header, the footer
or the copyright, the 'menu-custom' property is saved as the 'false'
string.
There is no visual effect of this problem, but in case that property is
used in an SCSS `color-yiq` function call, it will trigger an error.

This commit solves this by removing the root cause of this 'false'
string: during the initialisation of color palettes a list of named
colors is built by browsing the color buttons and associating their
data-color attribute to their background-color, except for buttons
containing a gradient color.
Unfortunately this inventory also looked at the "Custom" gradient
button: this button has no background color (and was thus not detected
as being a gradient and therefore not excluded from the inventory) and
it has data-color="false". It therefore introduced a mapping between ""
and "false" - thus making the reset operation's empty string mapped to
the "false" string. This commit removes that button from the named
colors inventory.

Steps to reproduce:
- select the header
- open the "Colors" palette
- click on the None button (the trashcan icon)
=> the customization properties attachment contained a line
```
'menu-custom': 'false',
```

[1]: https://github.com/odoo/odoo/commit/a48a30f954afcb6ff3a59c4f32b05fd0c2cfcd2b

task-2633169

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
