### PR TITLE
[FIX] mrp: list all kit components in delivery slip

### DIFF
--- a/addons/mrp/report/report_deliveryslip.xml
+++ b/addons/mrp/report/report_deliveryslip.xml
@@ -28,6 +28,8 @@
     </template>
 
     <template id="stock_report_delivery_kit_sections">
+        <!-- get all kits-related SML, including subkits and excluding the packaged SML -->
+        <t t-set="all_kits_move_lines" t-value="o.move_line_ids.filtered(lambda l: l.move_id.bom_line_id.bom_id.type == 'phantom' and not l.result_package_id)"/>
         <!-- do another map to get unique top level kits -->
         <t t-set="boms" t-value="has_kits.mapped('move_id.bom_line_id.bom_id')"/>
         <t t-foreach="boms" t-as="bom">
@@ -43,10 +45,10 @@
                     <span t-esc="kit.display_name"/>
                 </td>
             </tr>
-            <t t-set="kit_move_lines" t-value="has_kits.filtered(lambda l: l.move_id.name == kit.display_name)"/>
+            <t t-set="kit_move_lines" t-value="all_kits_move_lines.filtered(lambda l: l.move_id.name == kit.display_name)"/>
             <t t-if="has_serial_number">
                 <tr t-foreach="kit_move_lines" t-as="move_line">
-                    <t t-set="description" t-as="move_line.move_id.description_picking"/>
+                    <t t-set="description" t-value="move_line.move_id.description_picking"/>
                     <t t-if="description == kit.display_name">
                         <t t-set="description" t-value=""/>
                     </t>


### PR DESCRIPTION
When printing a delivery slip, if the delivered product is a kit
composed with a subkit, the products of this subkit won't be listed

To reproduced the issue:
1. Create 5 consumable products: 'Compo 01', 'Compo 02', 'Compo 03',
'Sub Kit', 'Super Kit'
2. Create two phantom-type boms:
    - Sub kit:
        - 1 x Compo 02
        - 1 x Compo 03
    - Super Kit:
        - 1 x Compo 01
        - 1 x Sub Kit
3. Process a delivery with 1 x Super Kit (the picking must be done)
4. Print the delivery slip

Error: The report only contains two lines, i.e. the name of the kit
('Super Kit') and the name of the 'direct' component ('Compo 01)

The issue comes from the SML used to define `kit_move_lines` (XML side).
It uses `has_kits` which only contains the top level kits' SML:
https://github.com/odoo/odoo/blob/1b1067b0cf2a3de2773915ff8205084492b1bbe3/addons/mrp/report/report_deliveryslip.xml#L6-L9
This is the reason why the SML for Compo 02 and Compo 03 are not listed

OPW-2740247