### PR TITLE
[FIX] hr_holidays: correctly show employee's Dashboard

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -231,16 +231,12 @@ class HrEmployee(models.Model):
         return super()._get_user_m2o_to_empty_on_archived_employees() + ['leave_manager_id']
 
     def action_time_off_dashboard(self):
-        domain = []
-        if self.env.context.get('active_ids'):
-            domain = [('employee_id', 'in', self.env.context.get('active_ids', []))]
-
         return {
             'name': _('Time Off Dashboard'),
             'type': 'ir.actions.act_window',
             'res_model': 'hr.leave',
             'views': [[self.env.ref('hr_holidays.hr_leave_employee_view_dashboard').id, 'calendar']],
-            'domain': domain,
+            'domain': [('employee_id', 'in', self.ids)],
             'context': {
                 'employee_id': self.ids,
             },

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -203,8 +203,8 @@ class HolidaysRequest(models.Model):
     # To display in form view
     supported_attachment_ids = fields.Many2many(
         'ir.attachment', string="Attach File", compute='_compute_supported_attachment_ids',
-        inverse='_inverse_supported_attachment_ids', compute_sudo=True)
-    supported_attachment_ids_count = fields.Integer(compute='_compute_supported_attachment_ids', compute_sudo=True)
+        inverse='_inverse_supported_attachment_ids')
+    supported_attachment_ids_count = fields.Integer(compute='_compute_supported_attachment_ids')
     # UX fields
     leave_type_request_unit = fields.Selection(related='holiday_status_id.request_unit', readonly=True)
     leave_type_support_document = fields.Boolean(related="holiday_status_id.support_document")
@@ -630,7 +630,9 @@ class HolidaysRequest(models.Model):
 
     def _inverse_supported_attachment_ids(self):
         for holiday in self:
-            holiday.sudo().attachment_ids = holiday.supported_attachment_ids
+            holiday.supported_attachment_ids.write({
+                'res_id': holiday.id,
+            })
 
     @api.constrains('date_from', 'date_to', 'employee_id')
     def _check_date(self):
@@ -886,8 +888,7 @@ class HolidaysRequest(models.Model):
 
     def write(self, values):
         is_officer = self.env.user.has_group('hr_holidays.group_hr_holidays_user') or self.env.is_superuser()
-
-        if not is_officer:
+        if not is_officer and values.keys() - {'supported_attachment_ids', 'message_main_attachment_id'}:
             if any(hol.date_from.date() < fields.Date.today() and hol.employee_id.leave_manager_id != self.env.user for hol in self):
                 raise UserError(_('You must have manager rights to modify/validate a time off that already begun'))
 


### PR DESCRIPTION
Only show the leaves taken by the current employee when using the Leaves
stat button on an employee's form.

TaskID: 2764912

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
