### PR TITLE
[FIX] hr_attendance: report time not in decimal

### DIFF
--- a/addons/hr_attendance/report/hr_attendance_report_views.xml
+++ b/addons/hr_attendance/report/hr_attendance_report_views.xml
@@ -23,8 +23,8 @@
             <pivot string="Attendance" disable_linking="1">
                 <field name="employee_id" type="row"/>
                 <field name="check_in" type="col"/>
-                <field name="worked_hours" type="measure"/>
-                <field name="overtime_hours" type="measure"/>
+                <field name="worked_hours" type="measure" widget="float_time"/>
+                <field name="overtime_hours" type="measure" widget="float_time"/>
             </pivot>
         </field>
     </record>


### PR DESCRIPTION
Current behaviour:
- Time in pivot view of report in attendance is in decimal hours
(e.g. 90 minutes is noted as 1.5 instead of 1:30)

Behaviour after PR:
- Time is noted in proper time manner

opw-2752651

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
