### PR TITLE
[FIX] website: multiwebsite published link redirect to correct website

### DIFF
--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -4,6 +4,8 @@
 import logging
 import re
 
+from werkzeug.urls import url_join
+
 from odoo import api, fields, models, _
 from odoo.addons.website.tools import text_from_html
 from odoo.http import request
@@ -279,6 +281,13 @@ class WebsitePublishedMultiMixin(WebsitePublishedMixin):
             return (['!'] if value is False else []) + expression.AND([is_published, on_current_website])
         else:  # should be in the backend, return things that are published anywhere
             return is_published
+
+    def open_website_url(self):
+        return {
+            'type': 'ir.actions.act_url',
+            'url': url_join(self.website_id._get_http_domain(), self.website_url) if self.website_id else self.website_url,
+            'target': 'self',
+        }
 
 
 class WebsiteSearchableMixin(models.AbstractModel):


### PR DESCRIPTION
[RDE Detailed summary [here](https://github.com/odoo/odoo/pull/84559#issuecomment-1039365520) and [here](https://github.com/odoo/odoo/pull/84559#issuecomment-1042747020)]

Step to reproduce:
- Have 2 websites
- Switch to Website B on the Website module
- Create a recruitment offer linked to website A
- Click 'Go to Website'

Current Behaviour:
- 404 Error, there is no such recruitment on website B

Behaviour after PR:
- If the recruitment offer is related to a website, go to that website

NB: This is also valid for other model inherinting from `website.published.multi.mixin`

opw-2731186

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
