### PR TITLE
[FIX] event: improve attendee view by removing the default group by week

### DIFF
--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -198,8 +198,7 @@
                         <div class="oe_button_box" name="button_box" groups="base.group_user">
                             <button name="%(event.act_event_registration_from_event)d"
                                     type="action"
-                                    context="{'search_default_expected': True,
-                                     'search_default_group_by_create_date_week': True}"
+                                    context="{'search_default_expected': True}"
                                     class="oe_stat_button"
                                     icon="fa-users"
                                     help="Total Registrations for this Event">
@@ -384,8 +383,7 @@
                                         <h5 class="o_event_fontsize_11 p-0">
                                             <a name="%(act_event_registration_from_event)d"
                                                type="action"
-                                               context="{'search_default_expected': True,
-                                                'search_default_group_by_create_date_week': True}">
+                                               context="{'search_default_expected': True}">
                                                 <t t-esc="record.seats_expected.raw_value"/> Expected attendees
                                             </a>
                                             <t t-set="total_seats" t-value="record.seats_reserved.raw_value + record.seats_used.raw_value"/>


### PR DESCRIPTION
The default group by registration week has been removed in the attendee view  because:
- it makes the view impossible to use on mobile (too many columns)
- it makes the navigation on desktop a bit tricky

Task 2761011

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
