### PR TITLE
[FIX] web_editor: properly convert fonts to images

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -57,6 +57,7 @@ class Web_Editor(http.Controller):
 
             :returns PNG image converted from given font
         """
+        size = max(width, height, 1) if width else size
         width = width or size
         height = height or size
         # Make sure we have at least size=1
@@ -75,7 +76,7 @@ class Web_Editor(http.Controller):
             bg = ','.join(bg.split(',')[:-1])+')'
 
         # Determine the dimensions of the icon
-        image = Image.new("RGBA", (width, height), color=(0, 0, 0, 0))
+        image = Image.new("RGBA", (width, height), color)
         draw = ImageDraw.Draw(image)
 
         boxw, boxh = draw.textsize(icon, font=font_obj)


### PR DESCRIPTION
export_icon_to_png sometimes failed because PIL's getbbox returned None.
This fixes it by not using a default color of (0, 0, 0, 0) when creating the image but using the actual color of the image instead.
Also, the size of the image was wrong because of using the default size when width and height are defined.

task-2761098


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
