### PR TITLE
[mail] Open document links in new tabs

### DIFF
--- a/addons/web/static/lib/pdfjs/web/viewer.js
+++ b/addons/web/static/lib/pdfjs/web/viewer.js
@@ -13913,9 +13913,9 @@ function getDefaultPreferences() {
       "disablePageLabels": false,
       "enablePrintAutoRotate": false,
       "enableWebGL": false,
-      // Odoo: This change is needed here as we can't change this parameter in an iframe.
+      // Odoo: Below two preference changes are needed here as we can't change them as parameters in an iframe.
       "eventBusDispatchToDOM": true, 
-      "externalLinkTarget": 0,
+      "externalLinkTarget": 2,
       "historyUpdateUrl": false,
       "pdfBugEnabled": false,
       "renderer": "canvas",


### PR DESCRIPTION
PURPOSE:

To open document links in new tab so that the Odoo document is not lost.

Specification:
Current:
Links are openinf in same tab
To be:
To open document link in new tab

TASKID: 2752002

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
