### PR TITLE
[FIX] mail: prevent empty popover in the rtc controller

### DIFF
--- a/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
+++ b/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
@@ -76,7 +76,7 @@
                                     <i class="oi oi-overflow-menu--horizontal" t-att-class="{ 'oi-2x': !rtcController.isSmall }"/>
                                 </div>
                             </button>
-                            <t t-set="opened">
+                            <t t-set-slot="opened">
                                 <RtcOptionList localId="rtcController.rtcOptionList.localId"/>
                             </t>
                         </Popover>


### PR DESCRIPTION
Before this commit, the popover containing the options of the rtc
controller was rendered empty. This was because the `t-set` was used
instead of `t-set-slot`. This commit fixes this issue.

