### PR TITLE
[FIX] sale_management+crm: wrong permissions for settings

### DIFF
--- a/addons/crm/views/res_config_settings_views.xml
+++ b/addons/crm/views/res_config_settings_views.xml
@@ -6,6 +6,7 @@
         <field name="model">res.config.settings</field>
         <field name="priority" eval="5"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
+        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'), 0)]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('settings')]" position="inside">
                 <div class="app_settings_block" data-string="CRM" string="CRM" data-key="crm" groups="sales_team.group_sale_manager">

--- a/addons/sale_management/views/res_config_settings_views.xml
+++ b/addons/sale_management/views/res_config_settings_views.xml
@@ -5,6 +5,7 @@
         <field name="name">res.config.settings.view.form.inherit.sale.management</field>
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="sale.res_config_settings_view_form"/>
+        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'), 0)]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@id='confirmation_email_setting']" position="after">
                 <div class="col-12 col-lg-6 o_setting_box">


### PR DESCRIPTION




Description of the issue/feature this PR addresses:
A user with settings permissions and without sales permissions cannot access settings.

Current behavior before PR:
Set these permissions:
![imagen](https://user-images.githubusercontent.com/973709/154015744-e9378276-0699-4876-beaf-1ed0d838028d.png)

Now, with that user, go to Project > Configuration > Settings. You get 2 errors:
![imagen](https://user-images.githubusercontent.com/973709/154015862-1e4a0bc6-55f2-42e8-891e-395ba9f08cbf.png)
![imagen](https://user-images.githubusercontent.com/973709/154016025-18d60e49-bc0d-4928-bc64-64ca75a8d16a.png)

Desired behavior after PR is merged: Works.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
  @moduon OPW-2755177