### PR TITLE
[FIX] note: display the proper long title

### DIFF
--- a/addons/note/views/note_views.xml
+++ b/addons/note/views/note_views.xml
@@ -117,7 +117,7 @@
                       </a>
                     </span>
 
-                    <span t-attf-class="oe_kanban_content flex-grow-1 #{record.open.raw_value ? '' : 'note_text_line_through'}">
+                    <span t-attf-class="oe_kanban_content flex-grow-1 text-break #{record.open.raw_value ? '' : 'note_text_line_through'}">
                       <!-- title -->
                       <field name="name"/>
                     </span>


### PR DESCRIPTION
Right now, in kanban view, if a note content that cannot be easily divided into
multiple lines, taking the content out of a card.

In this PR, a bootstrap class is added to force the line break
so the content won't escape the card.

taskID-2754915