### PR TITLE
[FIX] mail: Onchange error after done & schedule next activity

### DIFF
--- a/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover.js
+++ b/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover.js
@@ -93,10 +93,11 @@ class ActivityMarkDonePopover extends Component {
     /**
      * @private
      */
-    _onClickDoneAndScheduleNext() {
-        this.activity.markAsDoneAndScheduleNext({
+    async _onClickDoneAndScheduleNext() {
+        await this.activity.markAsDoneAndScheduleNext({
             feedback: this._feedbackTextareaRef.el.value,
         });
+        this.trigger('reload', { keepChanges: true });
     }
 
     /**


### PR DESCRIPTION
Current behavior:
In any chatter, if you schedule an activity then use the "Done & schedule next" options you had an error if you try to modify some fields of the record linked to the chatter.
For example in CRM you couldn't modify the probability after using "Done & Schedule next"

Steps to reproduce:
-Go in CRM
-Go on a lead page
-In the chatter schedule an activity
-Click on mark done and then on Done & Schedule next
-Try to edit the probabilty field of the lead
-You get an error : `Record does not exist or has been deleted. (Record: mail.activity(x,), User: xx)`

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
