### PR TITLE
[FIX] website_sale: match product's internal note in search

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -371,6 +371,9 @@ class ProductTemplate(models.Model):
         if with_image:
             mapping['image_url'] = {'name': 'image_url', 'type': 'html'}
         if with_description:
+            # Internal note is not part of the rendering.
+            search_fields.append('description')
+            fetch_fields.append('description')
             search_fields.append('description_sale')
             fetch_fields.append('description_sale')
             mapping['description'] = {'name': 'description_sale', 'type': 'text', 'match': True}


### PR DESCRIPTION
Since [1] the product search from website did not match the content of
the product internal note anymore.

After this commit the product search from website also matches products
if the terms appear in the product's internal note.

[1]: https://github.com/odoo/odoo/commit/7559626c54e34b41e1549e28276a650accec6986

opw-2715647

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
