### PR TITLE
[FIX] base: negative duration correct html render

### DIFF
--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -536,6 +536,10 @@ class DurationConverter(models.AbstractModel):
         r = round((value * factor) / round_to) * round_to
 
         sections = []
+        sign = ''
+        if value < 0:
+            r = -r
+            sign = '-'
 
         if options.get('digital'):
             for unit, secs_per_unit in TIMEDELTA_UNITS:
@@ -544,14 +548,9 @@ class DurationConverter(models.AbstractModel):
                 v, r = divmod(r, secs_per_unit)
                 if not v and (secs_per_unit > factor or secs_per_unit < round_to):
                     continue
-                if len(sections):
-                    sections.append(u':')
                 sections.append(u"%02.0f" % int(round(v)))
-            return u''.join(sections)
+            return sign + u':'.join(sections)
 
-        if value < 0:
-            r = -r
-            sections.append(u'-')
         for unit, secs_per_unit in TIMEDELTA_UNITS:
             v, r = divmod(r, secs_per_unit)
             if not v:
@@ -560,7 +559,8 @@ class DurationConverter(models.AbstractModel):
                 v*secs_per_unit, threshold=1, locale=locale)
             if section:
                 sections.append(section)
-
+        if sign:
+            sections.insert(0, sign)
         return u' '.join(sections)
 
 

--- a/odoo/addons/test_converter/tests/test_html.py
+++ b/odoo/addons/test_converter/tests/test_html.py
@@ -324,6 +324,11 @@ class TestDurationExport(TestBasicExport):
         result = converter(72, {'unit': 'second'}, {'lang': 'fr_FR'})
         self.assertEqual(result, u"1 minute 12 secondes")
 
+    def test_negative_digital(self):
+        converter = self.get_converter('float', 'duration')
+        result = converter(-90, {'unit': 'minute', 'round': 'minute', 'digital': True}, {'lang': 'fr_FR'})
+        self.assertEqual(result, u'-01:30')
+
 
 class TestRelativeDatetime(TestBasicExport):
     # not sure how a test based on "current time" should be tested. Even less


### PR DESCRIPTION
Step to reproduce:
- Render negative duration with the duration widget

Example V15:
- Create timesheet entry with negative duration (e.g. -00:30)
- Print the timesheet entry

Current Behaviour:
- Time is rendered as Time-1h (in e.g. -01:30)

Behaviour after PR:
- Time is correctly rendered (in e.g. -00:30)

opw-2731186

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
