### PR TITLE
[FIX] l10n_fr_fec: fix translations

### DIFF
--- a/addons/l10n_fr_fec/i18n/fr.po
+++ b/addons/l10n_fr_fec/i18n/fr.po
@@ -167,12 +167,6 @@ msgid "FEC File Generation"
 msgstr "Génération du fichier FEC"
 
 #. module: l10n_fr_fec
-#: code:addons/l10n_fr_fec/wizard/account_fr_fec.py:0
-#, python-format
-msgid "FEC is for French companies only !"
-msgstr "FEC n'est que pour les sociétés françaises !"
-
-#. module: l10n_fr_fec
 #: model:ir.model,name:l10n_fr_fec.model_account_fr_fec
 msgid "Ficher Echange Informatise"
 msgstr ""
@@ -196,6 +190,12 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
 msgid "Idevise"
 msgstr ""
+
+#. module: l10n_fr_fec
+#: code:addons/l10n_fr_fec/wizard/account_fr_fec.py:0
+#, python-format
+msgid "Invalid VAT number for company %s"
+msgstr "Numéro de TVA invalide sur la société %s"
 
 #. module: l10n_fr_fec
 #: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
@@ -237,11 +237,6 @@ msgstr ""
 #: model:ir.model.fields.selection,name:l10n_fr_fec.selection__account_fr_fec__export_type__nonofficial
 msgid "Non-official FEC report (posted and unposted entries)"
 msgstr "Rapport FEC non-officiel (avec à la fois les entrées comptabilisées et non comptabilisées)"
-
-#: code:addons/l10n_fr_fec/wizard/fec.py:98
-#, python-format
-msgid "Invalid VAT number for company %s"
-msgstr "Numéro de TVA invalide sur la société %s"
 
 #. module: l10n_fr_fec
 #: model:ir.model.fields.selection,name:l10n_fr_fec.selection__account_fr_fec__export_type__official

--- a/addons/l10n_fr_fec/i18n/l10n_fr_fec.pot
+++ b/addons/l10n_fr_fec/i18n/l10n_fr_fec.pot
@@ -167,12 +167,6 @@ msgid "FEC File Generation"
 msgstr ""
 
 #. module: l10n_fr_fec
-#: code:addons/l10n_fr_fec/wizard/account_fr_fec.py:0
-#, python-format
-msgid "FEC is for French companies only !"
-msgstr ""
-
-#. module: l10n_fr_fec
 #: model:ir.model,name:l10n_fr_fec.model_account_fr_fec
 msgid "Ficher Echange Informatise"
 msgstr ""
@@ -195,6 +189,12 @@ msgstr ""
 #. module: l10n_fr_fec
 #: model_terms:ir.ui.view,arch_db:l10n_fr_fec.account_fr_fec_view
 msgid "Idevise"
+msgstr ""
+
+#. module: l10n_fr_fec
+#: code:addons/l10n_fr_fec/wizard/account_fr_fec.py:0
+#, python-format
+msgid "Invalid VAT number for company %s"
 msgstr ""
 
 #. module: l10n_fr_fec
@@ -226,12 +226,6 @@ msgstr ""
 #: code:addons/l10n_fr_fec/wizard/account_fr_fec.py:0
 #, python-format
 msgid "Missing VAT number for company %s"
-msgstr ""
-
-#. module: l10n_fr_fec
-#: code:addons/l10n_fr_fec/wizard/account_fr_fec.py:98
-#, python-format
-msgid "Invalid VAT number for company %s"
 msgstr ""
 
 #. module: l10n_fr_fec


### PR DESCRIPTION
Based on the po/pot files generated from odoo,
reorder the translations + remove the unused one.

Solve the issue raised in: https://github.com/odoo/odoo/commit/51e969c6e04d7a8d699e355dda951b44c53da9dd#r66715214