### PR TITLE
[FIX] event_sale: users without access to event

### DIFF
--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -93,10 +93,10 @@ class SaleOrderLine(models.Model):
         super(SaleOrderLine, self).unlink()
 
     def _cancel_associated_registrations(self):
-        self.env['event.registration'].search([('sale_order_line_id', 'in', self.ids)]).button_reg_cancel()
+        self.env['event.registration'].sudo().search([('sale_order_line_id', 'in', self.ids)]).button_reg_cancel()
 
     def _unlink_associated_registrations(self):
-        self.env['event.registration'].search([('sale_order_line_id', 'in', self.ids)]).unlink()
+        self.env['event.registration'].sudo().search([('sale_order_line_id', 'in', self.ids)]).unlink()
 
     def get_sale_order_line_multiline_description_sale(self, product):
         """ We override this method because we decided that:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Allow users without access to event edit a sale order

Current behavior before PR:
When any user without access to event want to edit a sale order can not save changes.
This problem was added with the following pull request: https://github.com/odoo/odoo/commit/5ac733ee31db515044113bac848d4e7ebf69234c

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
