### PR TITLE
[FIX] mrp: assign backorders according to the reservation method

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1514,7 +1514,6 @@ class MrpProduction(models.Model):
             self.move_raw_ids.filtered(lambda m: not m.additional)._do_unreserve()
             self.move_raw_ids.filtered(lambda m: not m.additional)._action_assign()
         backorders.action_confirm()
-        backorders.action_assign()
 
         # Remove the serial move line without reserved quantity. Post inventory will assigned all the non done moves
         # So those move lines are duplicated.

--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import datetime, timedelta
 
 from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo.tests import Form
@@ -413,6 +414,81 @@ class TestMrpProductionBackorder(TestMrpCommon):
         backorder_ids = production.procurement_group_id.mrp_production_ids[1]
         self.assertEqual(production.name.split('-')[0], backorder_ids.name.split('-')[0])
         self.assertEqual(int(production.name.split('-')[1]) + 1, int(backorder_ids.name.split('-')[1]))
+
+    def test_reservation_method_w_mo(self):
+        """ Create a MO for 2 units, Produce 1 and create a backorder.
+        The MO and the backorder should be assigned according to the reservation method
+        defined in the default manufacturing operation type
+        """
+        def create_mo(date_planned_start=False):
+            mo_form = Form(self.env['mrp.production'])
+            mo_form.product_id = self.bom_1.product_id
+            mo_form.bom_id = self.bom_1
+            mo_form.product_qty = 2
+            if date_planned_start:
+                mo_form.date_planned_start = date_planned_start
+            mo = mo_form.save()
+            mo.action_confirm()
+            return mo
+
+        def produce_one(mo):
+            mo_form = Form(mo)
+            mo_form.qty_producing = 1
+            mo = mo_form.save()
+            action = mo.button_mark_done()
+            backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+            backorder.save().action_backorder()
+            return mo.procurement_group_id.mrp_production_ids[-1]
+
+        # Make some stock and reserve
+        for product in self.bom_1.bom_line_ids.product_id:
+            product.type = 'product'
+            self.env['stock.quant'].with_context(inventory_mode=True).create({
+                'product_id': product.id,
+                'inventory_quantity': 100,
+                'location_id': self.stock_location.id,
+            })._apply_inventory()
+
+        default_picking_type_id = self.env['mrp.production']._get_default_picking_type()
+        default_picking_type = self.env['stock.picking.type'].browse(default_picking_type_id)
+
+        # make sure generated MO will auto-assign
+        default_picking_type.reservation_method = 'at_confirm'
+        production = create_mo()
+        self.assertEqual(production.state, 'confirmed')
+        self.assertEqual(production.reserve_visible, False)
+        # check whether the backorder follows the same scenario as the original MO
+        backorder = produce_one(production)
+        self.assertEqual(backorder.state, 'confirmed')
+        self.assertEqual(backorder.reserve_visible, False)
+
+        # make sure generated MO will does not auto-assign
+        default_picking_type.reservation_method = 'manual'
+        production = create_mo()
+        self.assertEqual(production.state, 'confirmed')
+        self.assertEqual(production.reserve_visible, True)
+        backorder = produce_one(production)
+        self.assertEqual(backorder.state, 'confirmed')
+        self.assertEqual(backorder.reserve_visible, True)
+
+        # make sure generated MO auto-assigns according to scheduled date
+        default_picking_type.reservation_method = 'by_date'
+        default_picking_type.reservation_days_before = 2
+        # too early for scheduled date => don't auto-assign
+        production = create_mo(datetime.now() + timedelta(days=10))
+        self.assertEqual(production.state, 'confirmed')
+        self.assertEqual(production.reserve_visible, True)
+        backorder = produce_one(production)
+        self.assertEqual(backorder.state, 'confirmed')
+        self.assertEqual(backorder.reserve_visible, True)
+
+        # within scheduled date + reservation days before => auto-assign
+        production = create_mo()
+        self.assertEqual(production.state, 'confirmed')
+        self.assertEqual(production.reserve_visible, False)
+        backorder = produce_one(production)
+        self.assertEqual(backorder.state, 'confirmed')
+        self.assertEqual(backorder.reserve_visible, False)
 
 
 class TestMrpWorkorderBackorder(TransactionCase):


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to inventory > configuration > Operation types > Manufacturing
- Set "Reservation Method" to "Manually”
- Create a storable product “A”:
    - Update on-hand quantity to 10
- Create a storable product “B”:
    - Create a bill of materials and add the product B as component
- Create and confirm a MO with 2 * product B
- Product A is not reserved for this MO (works as expected)
- Validate the production of 1 unit and create a backorder

Problem:
product A is reserved for the backorder because there is no verification of the reservation method before assigning it.

Solution:
No need to assign here, because when an MO is confirmed, move_raw/move_finished are confirmed too: https://github.com/odoo/odoo/blob/89ddaa49b901787f58a3fa9efb4115d5f2038611/addons/mrp/models/mrp_production.py#L1172

And when a stock_move is confirmed, it is assigned or not by checking the reservation_method:
https://github.com/odoo/odoo/blob/dda9700d8236091626cbd78efc0ca4116e1e1acd/addons/stock/models/stock_move.py#L1239-L1245

opw-2744513




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
