### PR TITLE
[FIX] website: gives acces to ir.asset to the website admin

### DIFF
--- a/addons/website/security/ir.model.access.csv
+++ b/addons/website/security/ir.model.access.csv
@@ -9,6 +9,7 @@ access_website_page,access_website_page,model_website_page,,0,0,0,0
 access_website_page_designer,Web Page Manager,model_website_page,group_website_designer,1,1,1,1
 access_website_ir_ui_view_publisher,access_website_ir_ui_view_publisher,model_ir_ui_view,group_website_publisher,1,0,0,0
 access_website_ir_ui_view_designer,access_website_ir_ui_view_designer,model_ir_ui_view,group_website_designer,1,1,1,1
+access_website_ir_asset_designer,access_website_ir_asset_designer,model_ir_asset,group_website_designer,1,1,1,0
 access_seo_public,access_seo_public,model_website_seo_metadata,,1,0,0,0
 access_seo_designer,access_seo_designer,model_website_seo_metadata,group_website_designer,1,1,1,1
 access_website_visitor_designer,access_website_visitor_designer,model_website_visitor,website.group_website_designer,1,1,0,1


### PR DESCRIPTION
Before this commit, the users with the "editor and designer" role no
longer had access to the theme tab options (and also other flows like
assets regeneration in debug mode, etc). This is because when the
website assets have been changed to be handled by ir.asset records, in
this commit [1], the "editor and designer" rights were not updated to
have an access to ir.asset.

After this commit, the users with the "editor and designer" role have
the rights to access ir.asset (read, write, create, but not unlink
because the admin does not need it).

This mimick what is done with ir.ui.view, which is way more critical
than ir.asset, so it should be relatively safe to add this right to the
website admin for assets, as it is already the case for views.

We could have added sudo() everywhere (as no need of a -u, and which is
less risky that adding rights directly through csv but the ir.asset
rights covers too many different flows to do so.

[1]: https://github.com/odoo/odoo/commit/8cc066173dfb61bd95b8e1f0716f71f4e251810a

task-2748004

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
