### PR TITLE
[FIX] web: add basic search for binary field

### DIFF
--- a/addons/web/static/src/js/control_panel/search_utils.js
+++ b/addons/web/static/src/js/control_panel/search_utils.js
@@ -11,6 +11,10 @@ odoo.define('web.searchUtils', function (require) {
 
     // Filter menu parameters
     const FIELD_OPERATORS = {
+        binary: [
+            { symbol: "!=", description: _lt("is set"), value: false },
+            { symbol: "=", description: _lt("is not set"), value: false },
+        ],
         boolean: [
             { symbol: "=", description: _lt("is true"), value: true },
             { symbol: "!=", description: _lt("is false"), value: true },
@@ -68,6 +72,7 @@ odoo.define('web.searchUtils', function (require) {
         ],
     };
     const FIELD_TYPES = {
+        binary: 'binary',
         boolean: 'boolean',
         char: 'char',
         date: 'date',

--- a/addons/web/static/tests/control_panel/custom_filter_item_tests.js
+++ b/addons/web/static/tests/control_panel/custom_filter_item_tests.js
@@ -16,6 +16,7 @@ odoo.define('web.filter_menu_generator_tests', function (require) {
                 date_field: { name: 'date_field', string: "A date", type: 'date', searchable: true },
                 date_time_field: { name: 'date_time_field', string: "DateTime", type: 'datetime', searchable: true },
                 boolean_field: { name: 'boolean_field', string: "Boolean Field", type: 'boolean', default: true, searchable: true },
+                binary_field: { name: 'binary_field', string: "Binary Field", type: 'binary', searchable: true },
                 char_field: { name: 'char_field', string: "Char Field", type: 'char', default: "foo", trim: true, searchable: true },
                 float_field: { name: 'float_field', string: "Floaty McFloatface", type: 'float', searchable: true },
                 color: { name: 'color', string: "Color", type: 'selection', selection: [['black', "Black"], ['white', "White"]], searchable: true },
@@ -66,6 +67,49 @@ odoo.define('web.filter_menu_generator_tests', function (require) {
             assert.containsN(cfi, 'div.o_filter_condition', 2);
             assert.containsOnce(cfi, 'div.o_filter_condition .o_or_filter');
             assert.containsN(cfi, 'div.o_filter_condition .o_generator_menu_delete', 2);
+
+            cfi.destroy();
+        });
+
+        QUnit.test('binary field: basic search', async function (assert) {
+            assert.expect(4);
+
+            let expectedFilters;
+            class MockedSearchModel extends ActionModel {
+                dispatch(method, ...args) {
+                    assert.strictEqual(method, 'createNewFilters');
+                    const preFilters = args[0];
+                    assert.deepEqual(preFilters, expectedFilters);
+                }
+            }
+            const searchModel = new MockedSearchModel();
+            const cfi = await createComponent(CustomFilterItem, {
+                props: {
+                    fields: this.fields,
+                },
+                env: { searchModel },
+            });
+
+            // Default value
+            expectedFilters = [{
+                description: 'Binary Field is set',
+                domain: '[["binary_field","!=",False]]',
+                type: 'filter',
+            }];
+            await cpHelpers.toggleAddCustomFilter(cfi);
+            await testUtils.fields.editSelect(cfi.el.querySelector('.o_generator_menu_field'), 'binary_field');
+            await cpHelpers.applyFilter(cfi);
+
+            // Updated value
+            expectedFilters = [{
+                description: 'Binary Field is not set',
+                domain: '[["binary_field","=",False]]',
+                type: 'filter',
+            }];
+            await cpHelpers.toggleAddCustomFilter(cfi);
+            await testUtils.fields.editSelect(cfi.el.querySelector('.o_generator_menu_field'), 'binary_field');
+            await testUtils.fields.editSelect(cfi.el.querySelector('.o_generator_menu_operator'), '=');
+            await cpHelpers.applyFilter(cfi);
 
             cfi.destroy();
         });
@@ -137,6 +181,7 @@ odoo.define('web.filter_menu_generator_tests', function (require) {
             });
 
             await cpHelpers.toggleAddCustomFilter(cfi);
+            await testUtils.fields.editSelect(cfi.el.querySelector('.o_generator_menu_field'), 'boolean_field');
             await cpHelpers.applyFilter(cfi);
 
             // The only thing visible should be the button 'Add Custome Filter';


### PR DESCRIPTION
With this commit: we are adding basic search feature for binary fields,
custom filter will have binary fields and selecting binary field will
display 'is set', 'is not set' operators.

with this user can at least filter records based on whether binary field
is set or not set.

task-2512226

closes odoo/odoo#70149

Backport of 28fa5bc806f2f0d0db1b7737f9b2c4f32793b032

This feature was working in 13.0 but it has been lost during the control panel
refactoring.

opw:2753199