### PR TITLE
[FIX] stock: compute the source location of package level

### DIFF
--- a/addons/stock/models/stock_package_level.py
+++ b/addons/stock/models/stock_package_level.py
@@ -188,7 +188,7 @@ class StockPackageLevel(models.Model):
         for pl in self:
             if pl.state == 'new' or pl.is_fresh_package:
                 pl.location_id = False
-            elif pl.package_id:
+            elif pl.state != 'done' and pl.package_id:
                 pl.location_id = pl.package_id.location_id
             elif pl.state == 'confirmed' and pl.move_ids:
                 pl.location_id = pl.move_ids[0].location_id


### PR DESCRIPTION
When performing a picking with a package, the source location of the
package level may become incorrect

To reproduce the issue:
(Use demo data)
1. In Settings, enable:
    - Packages
    - Storage Locations
2. In Operations Types, edit "Internal Transfers":
    - Enable "Move Entire Packages"
3. Create a storable product P
4. Create a receipt R with for P
5. Put 10 P in pack and validate R
    - Let be PK the package generated/used
6. Process an internal transfer with PK
    - The destination location of the package level is WH/Stock/Shelf 1

Error: Once the picking is validated, the source location of the package
level is "WH/Stock/Shelf 1". This is not true, it should still be
"WH/Stock"

The compute method is incorrect. It uses the package location to define
the source location of the package level. However, once the picking is
processed, this package has moved so using its location to define the
source location doesn't make sense anymore.

OPW-2754179