### PR TITLE
[FIX] i18n Support export of translatable terms to pot file

### DIFF
--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -99,6 +99,9 @@ def export_translation():
         config["translate_out"])
 
     fileformat = os.path.splitext(config["translate_out"])[-1][1:].lower()
+    # .pot is the same fileformat as .po
+    if fileformat == "pot":
+        fileformat = "po"
 
     with open(config["translate_out"], "wb") as buf:
         registry = odoo.modules.registry.Registry.new(dbname)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Not possible to create a pot file while exporting translatable terms.

Current behavior before PR:

Trying to create pot file results in crash:

$ bin/start_odoo -d odocaldem15 --i18n-export=parts/projectname/portal_invoice/i18n/portal_invoice.pot --modules=portal_invoice
...
Traceback (most recent call last):
  File "./parts/odoo/odoo-bin", line 8, in <module>
    odoo.cli.main()
  File "/home/openeyedev/var/projects/projectname_15001/odoo/parts/odoo/odoo/cli/command.py", line 61, in main
    o.run(args)
  File "/home/openeyedev/var/projects/projectname_15001/odoo/parts/odoo/odoo/cli/server.py", line 176, in run
    main(args)
  File "/home/openeyedev/var/projects/projectname_15001/odoo/parts/odoo/odoo/cli/server.py", line 155, in main
    export_translation()
  File "/home/openeyedev/var/projects/projectname_15001/odoo/parts/odoo/odoo/cli/server.py", line 107, in export_translation
    config["translate_modules"] or ["all"], buf, fileformat, cr)
  File "/home/openeyedev/var/projects/projectname_15001/odoo/parts/odoo/odoo/tools/translate.py", line 829, in trans_export
    writer = TranslationFileWriter(buffer, fileformat=format, lang=lang)
  File "/home/openeyedev/var/projects/projectname_15001/odoo/parts/odoo/odoo/tools/translate.py", line 703, in TranslationFileWriter
    '.csv, .po, or .tgz (received .%s).') % fileformat)
Exception: Unrecognized extension: must be one of .csv, .po, or .tgz (received .pot).

Desired behavior after PR is merged:

Creating pot file ends without problems



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
