### PR TITLE
[FIX] account_check_printing: manual payment method on payment widget

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -20,7 +20,7 @@ class AccountPaymentRegister(models.TransientModel):
                 lambda l: l.payment_method_id == preferred
             )
             if record.payment_type == 'outbound' and method_line:
-                record.payment_method_line_id = method_line
+                record.payment_method_line_id = method_line[0]
 
 
 class AccountPayment(models.Model):
@@ -113,7 +113,7 @@ class AccountPayment(models.Model):
             method_line = record.journal_id.outbound_payment_method_line_ids\
                 .filtered(lambda l: l.payment_method_id == preferred)
             if record.payment_type == 'outbound' and method_line:
-                record.payment_method_line_id = method_line
+                record.payment_method_line_id = method_line[0]
 
     def action_post(self):
         res = super(AccountPayment, self).action_post()


### PR DESCRIPTION
Steps to reproduce:

- On bank journal, set at least two manual
  outbound_payment_method_line_ids
- Set a vendor X with manual property_payment_method_id
- Create a Vendor Bill with vendor X, confirm it, and register payment

Issue:

Got a traceback

The reason is we expected one value instead of several.

With this commit, we take the manual payment method with the
highest priority based on its sequence number.

opw-2743110

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
