### PR TITLE
[FIX] [13.0] web_tour: fix event triggering

### DIFF
--- a/addons/web_tour/static/src/js/running_tour_action_helper.js
+++ b/addons/web_tour/static/src/js/running_tour_action_helper.js
@@ -56,7 +56,7 @@ var RunningTourActionHelper = core.Class.extend({
     },
     _click: function (values, nb, leave) {
 //        values.$element.trigger("mouseenter");
-        trigger_mouse_event(values.$element, "mouseenter");
+        trigger_mouse_event(values.$element, "mouseenter", 0, true);
         trigger_mouse_event(values.$element, "mouseover");
         for (var i = 1 ; i <= (nb || 1) ; i++) {
             trigger_mouse_event(values.$element, "mousedown");
@@ -68,13 +68,13 @@ var RunningTourActionHelper = core.Class.extend({
         }
         if (leave !== false) {
             trigger_mouse_event(values.$element, "mouseout");
-            values.$element.trigger("mouseleave");
-//            trigger_mouse_event(values.$element, "mouseleave");
+//            values.$element.trigger("mouseleave");
+            trigger_mouse_event(values.$element, "mouseleave", 0, true);
         }
 
-        function trigger_mouse_event($element, type, count) {
+        function trigger_mouse_event($element, type, count, no_bubble) {
             var e = document.createEvent("MouseEvents");
-            e.initMouseEvent(type, true, true, window, count || 0, 0, 0, 0, 0, false, false, false, false, 0, $element[0]);
+            e.initMouseEvent(type, !no_bubble, true, window, count || 0, 0, 0, 0, 0, false, false, false, false, 0, $element[0]);
             $element[0].dispatchEvent(e);
         }
     },

--- a/addons/web_tour/static/src/js/running_tour_action_helper.js
+++ b/addons/web_tour/static/src/js/running_tour_action_helper.js
@@ -56,7 +56,11 @@ var RunningTourActionHelper = core.Class.extend({
     },
     _click: function (values, nb, leave) {
 //        values.$element.trigger("mouseenter");
-        trigger_mouse_event(values.$element, "mouseenter", 0, true);
+        let element = values.$element;
+        while (element.prop("tagName").toLowerCase() != 'body') {
+            element.trigger("mouseenter");
+            element = element.parent();
+        }
         trigger_mouse_event(values.$element, "mouseover");
         for (var i = 1 ; i <= (nb || 1) ; i++) {
             trigger_mouse_event(values.$element, "mousedown");
@@ -69,7 +73,11 @@ var RunningTourActionHelper = core.Class.extend({
         if (leave !== false) {
             trigger_mouse_event(values.$element, "mouseout");
 //            values.$element.trigger("mouseleave");
-            trigger_mouse_event(values.$element, "mouseleave", 0, true);
+            let element = values.$element;
+            while (element.prop("tagName").toLowerCase() != 'body') {
+                element.trigger("mouseleave");
+                element = element.parent();
+            }
         }
 
         function trigger_mouse_event($element, type, count, no_bubble) {

--- a/addons/web_tour/static/src/js/running_tour_action_helper.js
+++ b/addons/web_tour/static/src/js/running_tour_action_helper.js
@@ -55,7 +55,8 @@ var RunningTourActionHelper = core.Class.extend({
         };
     },
     _click: function (values, nb, leave) {
-        trigger_mouse_event(values.$element, "mouseenter");
+       values.$element.trigger("mouseenter");
+//        trigger_mouse_event(values.$element, "mouseenter");
         trigger_mouse_event(values.$element, "mouseover");
         for (var i = 1 ; i <= (nb || 1) ; i++) {
             trigger_mouse_event(values.$element, "mousedown");
@@ -67,7 +68,8 @@ var RunningTourActionHelper = core.Class.extend({
         }
         if (leave !== false) {
             trigger_mouse_event(values.$element, "mouseout");
-            trigger_mouse_event(values.$element, "mouseleave");
+            values.$element.trigger("mouseleave");
+//            trigger_mouse_event(values.$element, "mouseleave");
         }
 
         function trigger_mouse_event($element, type, count) {
@@ -98,8 +100,8 @@ var RunningTourActionHelper = core.Class.extend({
             values.$element.focusInEnd();
             values.$element.trigger($.Event( "keyup", {key: '_', keyCode: 95}));
         }
-//        values.$element[0].dispatchEvent(new Event("change"));
-        values.$element.trigger("change");
+        values.$element[0].dispatchEvent(new Event("change"));
+//        values.$element.trigger("change");
     },
     _drag_and_drop: function (values, to) {
         var $to;

--- a/addons/web_tour/static/src/js/running_tour_action_helper.js
+++ b/addons/web_tour/static/src/js/running_tour_action_helper.js
@@ -57,7 +57,7 @@ var RunningTourActionHelper = core.Class.extend({
     _click: function (values, nb, leave) {
 //        values.$element.trigger("mouseenter");
         let element = values.$element;
-        while (element && element.prop("tagName").toLowerCase() != 'body') {
+        while (element && element.prop("tagName")) {
             element.trigger("mouseenter");
             element = element.parent();
         }
@@ -74,7 +74,7 @@ var RunningTourActionHelper = core.Class.extend({
             trigger_mouse_event(values.$element, "mouseout");
 //            values.$element.trigger("mouseleave");
             let element = values.$element;
-            while (element && element.prop("tagName").toLowerCase() != 'body') {
+            while (element && element.prop("tagName")) {
                 element.trigger("mouseleave");
                 element = element.parent();
             }

--- a/addons/web_tour/static/src/js/running_tour_action_helper.js
+++ b/addons/web_tour/static/src/js/running_tour_action_helper.js
@@ -55,8 +55,8 @@ var RunningTourActionHelper = core.Class.extend({
         };
     },
     _click: function (values, nb, leave) {
-        values.$element.trigger("mouseenter");
-//        trigger_mouse_event(values.$element, "mouseenter");
+//        values.$element.trigger("mouseenter");
+        trigger_mouse_event(values.$element, "mouseenter");
         trigger_mouse_event(values.$element, "mouseover");
         for (var i = 1 ; i <= (nb || 1) ; i++) {
             trigger_mouse_event(values.$element, "mousedown");
@@ -101,7 +101,6 @@ var RunningTourActionHelper = core.Class.extend({
             values.$element.trigger($.Event( "keyup", {key: '_', keyCode: 95}));
         }
         values.$element[0].dispatchEvent(new Event("change", { bubbles: true }));
-//        values.$element.trigger("change");
     },
     _drag_and_drop: function (values, to) {
         var $to;

--- a/addons/web_tour/static/src/js/running_tour_action_helper.js
+++ b/addons/web_tour/static/src/js/running_tour_action_helper.js
@@ -98,7 +98,8 @@ var RunningTourActionHelper = core.Class.extend({
             values.$element.focusInEnd();
             values.$element.trigger($.Event( "keyup", {key: '_', keyCode: 95}));
         }
-        values.$element[0].dispatchEvent(new Event("change"));
+//        values.$element[0].dispatchEvent(new Event("change"));
+        values.$element.trigger("change");
     },
     _drag_and_drop: function (values, to) {
         var $to;

--- a/addons/web_tour/static/src/js/running_tour_action_helper.js
+++ b/addons/web_tour/static/src/js/running_tour_action_helper.js
@@ -58,7 +58,7 @@ var RunningTourActionHelper = core.Class.extend({
 //        values.$element.trigger("mouseenter");
         let element = values.$element;
         while (element && element.prop("tagName")) {
-            element.trigger("mouseenter");
+            trigger_mouse_event(element, "mouseenter");
             element = element.parent();
         }
         trigger_mouse_event(values.$element, "mouseover");
@@ -75,7 +75,7 @@ var RunningTourActionHelper = core.Class.extend({
 //            values.$element.trigger("mouseleave");
             let element = values.$element;
             while (element && element.prop("tagName")) {
-                element.trigger("mouseleave");
+                trigger_mouse_event(element, "mouseleave");
                 element = element.parent();
             }
         }

--- a/addons/web_tour/static/src/js/running_tour_action_helper.js
+++ b/addons/web_tour/static/src/js/running_tour_action_helper.js
@@ -55,8 +55,8 @@ var RunningTourActionHelper = core.Class.extend({
         };
     },
     _click: function (values, nb, leave) {
-        trigger_mouse_event(values.$element, "mouseover");
         trigger_mouse_event(values.$element, "mouseenter");
+        trigger_mouse_event(values.$element, "mouseover");
         for (var i = 1 ; i <= (nb || 1) ; i++) {
             trigger_mouse_event(values.$element, "mousedown");
             trigger_mouse_event(values.$element, "mouseup");
@@ -98,9 +98,7 @@ var RunningTourActionHelper = core.Class.extend({
             values.$element.focusInEnd();
             values.$element.trigger($.Event( "keyup", {key: '_', keyCode: 95}));
         }
-        values.$element[0].dispatchEvent(new Event('change', {
-            bubbles: true,
-        }));
+        values.$element[0].dispatchEvent(new Event("change"));
     },
     _drag_and_drop: function (values, to) {
         var $to;

--- a/addons/web_tour/static/src/js/running_tour_action_helper.js
+++ b/addons/web_tour/static/src/js/running_tour_action_helper.js
@@ -56,7 +56,7 @@ var RunningTourActionHelper = core.Class.extend({
     },
     _click: function (values, nb, leave) {
         trigger_mouse_event(values.$element, "mouseover");
-        values.$element.trigger("mouseenter");
+        trigger_mouse_event(values.$element, "mouseenter");
         for (var i = 1 ; i <= (nb || 1) ; i++) {
             trigger_mouse_event(values.$element, "mousedown");
             trigger_mouse_event(values.$element, "mouseup");
@@ -67,7 +67,7 @@ var RunningTourActionHelper = core.Class.extend({
         }
         if (leave !== false) {
             trigger_mouse_event(values.$element, "mouseout");
-            values.$element.trigger("mouseleave");
+            trigger_mouse_event(values.$element, "mouseleave");
         }
 
         function trigger_mouse_event($element, type, count) {
@@ -98,7 +98,9 @@ var RunningTourActionHelper = core.Class.extend({
             values.$element.focusInEnd();
             values.$element.trigger($.Event( "keyup", {key: '_', keyCode: 95}));
         }
-        values.$element.trigger("change");
+        values.$element[0].dispatchEvent(new Event('change', {
+            bubbles: true,
+        }));
     },
     _drag_and_drop: function (values, to) {
         var $to;

--- a/addons/web_tour/static/src/js/running_tour_action_helper.js
+++ b/addons/web_tour/static/src/js/running_tour_action_helper.js
@@ -55,7 +55,7 @@ var RunningTourActionHelper = core.Class.extend({
         };
     },
     _click: function (values, nb, leave) {
-       values.$element.trigger("mouseenter");
+        values.$element.trigger("mouseenter");
 //        trigger_mouse_event(values.$element, "mouseenter");
         trigger_mouse_event(values.$element, "mouseover");
         for (var i = 1 ; i <= (nb || 1) ; i++) {
@@ -100,7 +100,7 @@ var RunningTourActionHelper = core.Class.extend({
             values.$element.focusInEnd();
             values.$element.trigger($.Event( "keyup", {key: '_', keyCode: 95}));
         }
-        values.$element[0].dispatchEvent(new Event("change"));
+        values.$element[0].dispatchEvent(new Event("change", { bubbles: true }));
 //        values.$element.trigger("change");
     },
     _drag_and_drop: function (values, to) {

--- a/addons/web_tour/static/src/js/running_tour_action_helper.js
+++ b/addons/web_tour/static/src/js/running_tour_action_helper.js
@@ -57,7 +57,7 @@ var RunningTourActionHelper = core.Class.extend({
     _click: function (values, nb, leave) {
 //        values.$element.trigger("mouseenter");
         let element = values.$element;
-        while (element.prop("tagName").toLowerCase() != 'body') {
+        while (element && element.prop("tagName").toLowerCase() != 'body') {
             element.trigger("mouseenter");
             element = element.parent();
         }
@@ -74,7 +74,7 @@ var RunningTourActionHelper = core.Class.extend({
             trigger_mouse_event(values.$element, "mouseout");
 //            values.$element.trigger("mouseleave");
             let element = values.$element;
-            while (element.prop("tagName").toLowerCase() != 'body') {
+            while (element && element.prop("tagName").toLowerCase() != 'body') {
                 element.trigger("mouseleave");
                 element = element.parent();
             }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

web_tour tests don't work in some cases:
1. `run: 'click'` code fires a lot of events. But 'mouseenter' and 'mouseleave' used different way to trigger.
It seems that this way doesn't work. So in tour tests was no ablility to open subdropdown because it opens on 'mouseenter'.
2. 'change' event for select element won't fire. So in tour tests was no ability to select option from HTML select element. I've found only one variant to choose option from HTML select: `run: 'text OptionName'`. But this variant doesn't fire 'change' event properly so form don't adapt to selected option. 


Desired behavior after PR is merged:
There is ability to open subdropdown from web_tour test
There is ability to enter text in select to choose some option and 'change' event will fired properly.


Sample web_tour that doesn't work without this PR and works with it:

```javascript
const tour = require('web_tour.tour');
tour.register('test_filters', {
    test: true,
    url: '/web#action=base.open_module_tree',
}, [
    {
        trigger: '.o_filter_menu button',
        content: 'Click on Filters menu',
    },
    {
        trigger: '.o_add_custom_filter_menu button',
        content: 'Open submenu to add custom filter',
    },
    {
        trigger: '.o_generator_menu_field',
        run: 'text Application',
        content: 'Choose application field to filter',
    },
    {
        trigger: '.o_generator_menu_operator',
        run: 'text is false',
        content: 'Add conflicting condition to force empty result',
    },
    {
        trigger: '.o_apply_filter',
        content: 'Apply button',
    },
    {
        trigger: '.o_nocontent_help:contains("No module found!")',
        content: 'Two conflicting filters must result as empty list',
    },
]);
```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
