### PR TITLE
[FIX] hr_attendance: fix attendance report

### DIFF
--- a/addons/hr_attendance/report/hr_attendance_report.py
+++ b/addons/hr_attendance/report/hr_attendance_report.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import fields, models, tools
 
 
 class HRAttendanceReport(models.Model):
@@ -11,11 +11,14 @@ class HRAttendanceReport(models.Model):
 
     department_id = fields.Many2one('hr.department', string="Department", readonly=True)
     employee_id = fields.Many2one('hr.employee', string="Employee", readonly=True)
+    company_id = fields.Many2one('res.company', string="Company", readonly=True)
     check_in = fields.Date("Check In", readonly=True)
     worked_hours = fields.Float("Hours Worked", readonly=True)
     overtime_hours = fields.Float("Extra Hours", readonly=True)
 
     def init(self):
+        tools.drop_view_if_exists(self.env.cr, self._table)
+
         self.env.cr.execute("""
             CREATE OR REPLACE VIEW %s AS (
                 (
@@ -23,6 +26,7 @@ class HRAttendanceReport(models.Model):
                         hra.id,
                         hr_employee.department_id,
                         hra.employee_id,
+                        hr_employee.company_id,
                         hra.check_in,
                         hra.worked_hours,
                         coalesce(ot.duration, 0) as overtime_hours

--- a/addons/hr_attendance/security/hr_attendance_security.xml
+++ b/addons/hr_attendance/security/hr_attendance_security.xml
@@ -108,5 +108,12 @@
             <field name="perm_unlink" eval="0"/>
             <field name="groups" eval="[(4,ref('base.group_user'))]"/>
         </record>
+
+        <!-- Report -->
+        <record id="hr_attendance_report_rule_multi_company" model="ir.rule">
+            <field name="name">Attendance report multi company rule</field>
+            <field name="model_id" ref="model_hr_attendance_report"/>
+            <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
This commit contains two fixes.
The first fixes the absence of a multi company rule for the attendance
report model.
The second fixes the wrong widget being used in the pivot view of the
attendance report.

TaskId-2765671