### PR TITLE
[FIX] web_editor: prevent traceback on apply style to empty lines

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -263,12 +263,14 @@ export function applyInlineStyle(editor, applyStyle) {
         }
         applyStyle(textNode.parentElement);
     }
-    const firstNode = selectedTextNodes[0];
-    const lastNode = selectedTextNodes[selectedTextNodes.length - 1];
-    if (direction === DIRECTIONS.RIGHT) {
-        setSelection(firstNode, 0, lastNode, lastNode.length);
-    } else {
-        setSelection(lastNode, lastNode.length, firstNode, 0);
+    if (selectedTextNodes.length) {
+        const firstNode = selectedTextNodes[0];
+        const lastNode = selectedTextNodes[selectedTextNodes.length - 1];
+        if (direction === DIRECTIONS.RIGHT) {
+            setSelection(firstNode, 0, lastNode, lastNode.length);
+        } else {
+            setSelection(lastNode, lastNode.length, firstNode, 0);
+        }
     }
 }
 function addColumn(editor, beforeOrAfter) {


### PR DESCRIPTION
When the selection only contains empty lines, no text nodes are selected. `applyInlineStyle` however counted on text nodes being selected, resulting in a traceback.

task-2740204

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
