### PR TITLE
[FIX] server, bus: filedescriptor out of range in select

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -8,7 +8,7 @@ import os
 import os.path
 import platform
 import random
-import select
+import selectors
 import signal
 import socket
 import subprocess
@@ -61,6 +61,8 @@ from odoo.tools import stripped_sys_argv, dumpstacks, log_ormcache_stats
 from ..tests import loader, runner
 
 _logger = logging.getLogger(__name__)
+
+select = selectors.DefaultSelector
 
 SLEEP_INTERVAL = 60     # 1 min
 
@@ -428,13 +430,13 @@ class ThreadedServer(CommonServer):
 
         from odoo.addons.base.models.ir_cron import ir_cron
         conn = odoo.sql_db.db_connect('postgres')
-        with conn.cursor() as cr:
+        with conn.cursor() as cr, select() as sel:
             pg_conn = cr._cnx
             cr.execute("LISTEN cron_trigger")
             cr.commit()
-
+            sel.register(pg_conn, selectors.EVENT_READ)
             while True:
-                select.select([pg_conn], [], [], SLEEP_INTERVAL + number)
+                sel.select(timeout=SLEEP_INTERVAL + number)
                 time.sleep(number / 100)
                 pg_conn.poll()
 
@@ -833,17 +835,19 @@ class PreforkServer(CommonServer):
         try:
             # map of fd -> worker
             fds = {w.watchdog_pipe[0]: w for w in self.workers.values()}
-            fd_in = list(fds) + [self.pipe[0]]
             # check for ping or internal wakeups
-            ready = select.select(fd_in, [], [], self.beat)
-            # update worker watchdogs
-            for fd in ready[0]:
-                if fd in fds:
-                    fds[fd].watchdog_time = time.time()
-                empty_pipe(fd)
-        except select.error as e:
-            if e.args[0] not in [errno.EINTR]:
-                raise
+            with select() as sel:
+                for fd in fds:
+                    sel.register(fd, selectors.EVENT_READ)
+                sel.register(self.pipe[0], selectors.EVENT_READ)
+                events = sel.select(timeout=self.beat)
+                for key, _mask in events:
+                    # update worker watchdogs
+                    if key.fd in fds:
+                        fds[key.fd].watchdog_time = time.time()
+                    empty_pipe(key.fd)
+        except InterruptedError:
+            pass
 
     def start(self):
         # wakeup pipe, python doesn't throw EINTR when a syscall is interrupted
@@ -963,12 +967,15 @@ class Worker(object):
 
     def sleep(self):
         try:
-            select.select([self.multi.socket, self.wakeup_fd_r], [], [], self.multi.beat)
-            # clear wakeup pipe if we were interrupted
-            empty_pipe(self.wakeup_fd_r)
-        except select.error as e:
-            if e.args[0] not in [errno.EINTR]:
-                raise
+            with select() as sel:
+                sel.register(self.multi.socket, selectors.EVENT_READ)
+                sel.register(self.wakeup_fd_r, selectors.EVENT_READ)
+                sel.select(timeout=self.multi.beat)
+
+                # clear wakeup pipe if we were interrupted
+                empty_pipe(self.wakeup_fd_r)
+        except InterruptedError:
+            pass
 
     def check_limits(self):
         # If our parent changed suicide
@@ -1117,14 +1124,16 @@ class WorkerCron(Worker):
 
             # simulate interruptible sleep with select(wakeup_fd, timeout)
             try:
-                select.select([self.wakeup_fd_r, self.dbcursor._cnx], [], [], interval)
-                # clear pg_conn/wakeup pipe if we were interrupted
-                time.sleep(self.pid / 100 % .1)
-                self.dbcursor._cnx.poll()
-                empty_pipe(self.wakeup_fd_r)
-            except select.error as e:
-                if e.args[0] != errno.EINTR:
-                    raise
+                with select() as sel:
+                    sel.register(self.wakeup_fd_r, selectors.EVENT_READ)
+                    sel.register(self.dbcursor._cnx, selectors.EVENT_READ)
+                    sel.select(timeout=interval)
+                    # clear pg_conn/wakeup pipe if we were interrupted
+                    time.sleep(self.pid / 100 % .1)
+                    self.dbcursor._cnx.poll()
+                    empty_pipe(self.wakeup_fd_r)
+            except InterruptedError:
+                pass
 
     def _db_list(self):
         if config['db_name']:


### PR DESCRIPTION
Use the most efficient Selector implementation available on the current platform

Odoo supports only SelectSelector but it is a little obsolete

python >= 3.4 supports a new high-level library Selectors:
 - https://docs.python.org/es/3/library/selectors.html

It could to auto-choose the following ones:
 - SelectSelector
 - PollSelector
 - EpollSelector
 - DevpollSelector
 - KqueueSelector

Using the DefaultSelector class the most efficient implementation available on the current platform will be use:
 - https://docs.python.org/3/library/selectors.html#selectors.DefaultSelector

It helps to support better the resources of the system

Using SelectSelector you are not able to run workers >=255

If you set `ulimit -n 10240` and run `odoo-bin --workers=255`
the following error is raised:

    Traceback (most recent call last):
    File "odoo/service/server.py", line 926, in run
        self.sleep()
    File "odoo/service/server.py", line 852, in sleep
        sel.select(self.beat)
    File "python3.8/lib/python3.8/selectors.py", line 323, in select
        r, w, _ = self._select(self._readers, self._writers, [], timeout)
    ValueError: filedescriptor out of range in select()

But using PollSelector it is not reproduced even using more workers

Most of platform supports PollSelector but using DefaultSelector we can be sure
that even too old system are supported too

And using this High-level library will allow to use the future new improvements

e.g. Epoll has better performance improvements

More info about:
 - https://devarea.com/linux-io-multiplexing-select-vs-poll-vs-epoll
 - https://github.com/redis/redis-py/issues/486

Forcing the current SelectSelector:
 - ![Screen Shot 2022-02-15 at 14 28 00](https://user-images.githubusercontent.com/6644187/154143826-ad99ba18-978d-4435-9735-ed1425ef055d.png)

Using the DefaultSelector:
 - ![Screen Shot 2022-02-15 at 14 32 47](https://user-images.githubusercontent.com/6644187/154144432-bf67e24a-2732-46cb-85ee-f277a1a53f12.png)

Even if you don't need too many workers because of horizontal autoscaling it will have better performance and auto-evolution in the future python versions or systems

If you like this PR for v14.0 you can check the following PR:
 - https://github.com/Vauxoo/odoo/pull/477
