### PR TITLE
[FIX] web: Add support for () in domain editor for studio

### DIFF
--- a/addons/web/static/src/legacy/js/core/domain.js
+++ b/addons/web/static/src/legacy/js/core/domain.js
@@ -391,6 +391,7 @@ var Domain = collections.Tree.extend({
                 case '(string)': return node.value;
                 case '(number)': return node.value;
                 case '(constant)': return node.value === 'None' ? null : node.value === 'True' ? true : false;
+                case '(':
                 case '[': return _.map(node.first, function (node) {return astToStackValue(node);});
             }
         }

--- a/addons/web/static/tests/legacy/core/domain_tests.js
+++ b/addons/web/static/tests/legacy/core/domain_tests.js
@@ -81,7 +81,7 @@ QUnit.module('core', {}, function () {
     });
 
     QUnit.test("domain <=> condition", function (assert) {
-        assert.expect(3);
+        assert.expect(4);
 
         var domain = [
             '|',
@@ -99,6 +99,9 @@ QUnit.module('core', {}, function () {
         assert.deepEqual(Domain.prototype.conditionToDomain(
             'doc and toto is None or not tata'),
             ['|', '&', ['doc', '!=', false], ['toto', '=', null], ['tata', '=', false]]);
+        assert.deepEqual(Domain.prototype.conditionToDomain(
+            `field in ("foo", "bar") and display_name in ['boo','far']`),
+            ['&', ['field', 'in', ['foo', 'bar']], ['display_name', 'in', ['boo', 'far']]]);
     });
 
     QUnit.test("condition 'a field is set' does not convert to a domain", function (assert) {


### PR DESCRIPTION
If a report contains a t-if with something like `field in ('a', 'b')`
as a condition, a crash occurs if you try to modify the 'Visible if'
field in the report editor because the domain editor doesn't support parenthesis.

This commit adds this compatibility based on the case of `[]` which is essentially the same thing


enterprise: https://github.com/odoo/enterprise/pull/24468

opw-2738343