### PR TITLE
[FIX] web_editor: block options panel until its changes are applied

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2670,7 +2670,13 @@ var SnippetsMenu = Widget.extend({
      * @param {function} ev.data.exec
      */
     _onSnippetEditionRequest: function (ev) {
-        this._execWithLoadingEffect(ev.data.exec, true);
+        if (ev.data.optionsLoader) {
+            this._execWithLoadingEffect(() => {
+                this._execWithLoadingEffect(ev.data.exec, true);
+            }, false);
+        } else {
+            this._execWithLoadingEffect(ev.data.exec, true);
+        }
     },
     /**
      * @private

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2820,6 +2820,10 @@ const SnippetOptionWidget = Widget.extend({
 
         // Ask a mutexed snippet update according to the widget value change
         const shouldRecordUndo = (!previewMode && !ev.data.isSimulatedEvent);
+        const isOptionsTab = widget.$el.closest([
+            'we-customizeblock-option.snippet-option-OptionsTab',
+            'we-customizeblock-option.snippet-option-ThemeColors',
+        ].join(',')).length;
         this.trigger_up('snippet_edition_request', {exec: async () => {
             // If some previous snippet edition in the mutex removed the target from
             // the DOM, the widget can be destroyed, in that case the edition request
@@ -2875,7 +2879,7 @@ const SnippetOptionWidget = Widget.extend({
             // Set timeout needed so that the user event which triggered the
             // option can bubble first.
             }));
-        }});
+        }, optionsLoader: isOptionsTab});
 
         if (ev.data.isSimulatedEvent) {
             // If the user value update was simulated through a trigger, we


### PR DESCRIPTION
Before this commit, modifying an option in the options tab did only put
a blocking loader overlay on the page, but not on the options tab.
This made it possible to modify several options while a single change
was being applied.

After this commit when a change is done in the options tab an additional
blocking loader overlay is put on top of the options tab until de change
is fully applied.

task-2633169

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
