### PR TITLE
[FIX] base_import: read error message clearer for import

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -352,6 +352,8 @@ class Import(models.TransientModel):
         if handler:
             try:
                 return getattr(self, '_read_' + file_extension)(options)
+            except ValueError as e:
+                raise e
             except Exception:
                 _logger.warning("Failed to read file '%s' (transient id %d) using guessed mimetype %s", self.file_name or '<unknown>', self.id, mimetype)
 
@@ -360,6 +362,8 @@ class Import(models.TransientModel):
         if handler:
             try:
                 return getattr(self, '_read_' + file_extension)(options)
+            except ValueError as e:
+                raise e
             except Exception:
                 _logger.warning("Failed to read file '%s' (transient id %d) using user-provided mimetype %s", self.file_name or '<unknown>', self.id, self.file_type)
 
@@ -371,6 +375,8 @@ class Import(models.TransientModel):
             if ext in EXTENSIONS:
                 try:
                     return getattr(self, '_read_' + ext[1:])(options)
+                except ValueError as e:
+                    raise e
                 except Exception:
                     _logger.warning("Failed to read file '%s' (transient id %s) using file extension", self.file_name, self.id)
 


### PR DESCRIPTION
How to reproduce the bug ?

- install the inventory app
- open the app and try to import a file where at least one cell has a
wrong value

What is the bug ?

When you try to import a file in the inventory app where at least one
cell has a wrong value, the file won't be imported. In addition to that,
you will get an error saying that one python module is missing while
this might not be the case.

opw-2715625

Signed-off-by: Adrien Minet <admi@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
