### PR TITLE
[FIX] web: don't show empty burger menu on mobile

### DIFF
--- a/addons/web/static/src/webclient/burger_menu/burger_menu.js
+++ b/addons/web/static/src/webclient/burger_menu/burger_menu.js
@@ -45,6 +45,12 @@ export class BurgerMenu extends Component {
             (this.currentApp && this.menuRepo.getMenuAsTree(this.currentApp.id).childrenTree) || []
         );
     }
+    get isUserMenuUnfolded() {
+        return !this.isUserMenuTogglable || this.state.isUserMenuOpened;
+    }
+    get isUserMenuTogglable() {
+        return this.currentApp && this.currentAppSections.length > 0;
+    }
     _closeBurger() {
         this.state.isUserMenuOpened = false;
         this.state.isBurgerOpened = false;

--- a/addons/web/static/src/webclient/burger_menu/burger_menu.xml
+++ b/addons/web/static/src/webclient/burger_menu/burger_menu.xml
@@ -15,22 +15,22 @@
         <div class="o_burger_menu d-flex flex-column flex-nowrap position-fixed" t-att-class="transition.className" t-on-touchstart.stop="_onSwipeStart" t-on-touchend.stop="_onSwipeEnd">
           <div class="o_burger_menu_topbar d-flex align-items-center justify-content-between"
               t-on-click.stop='_toggleUserMenu'>
-              <span class="dropdown-toggle small d-flex align-items-center justify-content-between o-no-caret" t-att-class="{active: state.isUserMenuOpened}">
+              <span class="dropdown-toggle small d-flex align-items-center justify-content-between o-no-caret" t-att-class="{active: isUserMenuUnfolded}">
                   <img class="o_burger_menu_avatar o_image_24_cover rounded-circle" t-att-src="'/web/image?model=res.users&amp;field=avatar_128&amp;id=' + user.userId" alt="Menu"/>
                   <span class="o_burger_menu_username px-2"><t t-esc="user.name"/></span>
-                  <i t-if="currentApp" class="oi" t-att-class="state.isUserMenuOpened ? 'oi-caret--down' : 'oi-caret--left'"/>
+                  <i t-if="isUserMenuTogglable" class="oi" t-att-class="state.isUserMenuOpened ? 'oi-caret--down' : 'oi-caret--left'"/>
               </span>
               <span type="button" class="o_burger_menu_close oi oi-close" aria-label="Close menu" title="Close menu" t-on-click.stop="_closeBurger"/>
           </div>
           <div class="o_burger_menu_content flex-grow-1 flex-shrink-1 overflow-auto"
-              t-att-class="{o_burger_menu_dark: !state.isUserMenuOpened and currentApp}">
-              <div t-if="!currentApp or state.isUserMenuOpened" class="o_burger_menu_user">
+              t-att-class="{o_burger_menu_dark: !isUserMenuUnfolded}">
+              <div t-if="isUserMenuUnfolded" class="o_burger_menu_user">
                   <MobileSwitchCompanyMenu t-if="Object.values(company.availableCompanies).length > 1" />
                   <BurgerUserMenu/>
               </div>
 
               <!-- Current App Sections -->
-              <div class="o_burger_menu_app" t-if="!state.isUserMenuOpened and currentApp">
+              <div class="o_burger_menu_app" t-if="!isUserMenuUnfolded">
                   <div class="o_menu_sections">
                       <t t-foreach="currentAppSections" t-as="subMenu" t-key="subMenu_index">
                           <t t-call="web.BurgerSection">

--- a/addons/web/static/tests/mobile/burger_menu_tests.js
+++ b/addons/web/static/tests/mobile/burger_menu_tests.js
@@ -89,6 +89,26 @@ QUnit.test("Burger Menu on an App", async (assert) => {
     assert.hasClass(document.body.querySelector(".o_burger_menu_content"), "o_burger_menu_dark");
 });
 
+QUnit.test("Burger Menu on an App without SubMenu", async (assert) => {
+    assert.expect(6);
+
+    await createWebClient({ serverData });
+    await click(document.body, ".o_navbar_apps_menu .dropdown-toggle");
+    await legacyExtraNextTick();
+    await click(document.body, ".o_app:nth-of-type(2)");
+    await legacyExtraNextTick();
+
+    assert.containsNone(document.body, ".o_burger_menu");
+
+    await click(document.body, ".o_mobile_menu_toggle");
+    assert.containsOnce(document.body, ".o_burger_menu");
+    assert.containsOnce(document.body, ".o_user_menu_mobile");
+    assert.containsOnce(document.body, ".o_burger_menu_user");
+    assert.containsNone(document.body, ".o_burger_menu_app");
+    await click(document.body, ".o_burger_menu_close");
+    assert.containsNone(document.body, ".o_burger_menu");
+});
+
 QUnit.test("Burger menu closes when an action is requested", async (assert) => {
     assert.expect(3);
 


### PR DESCRIPTION
When the current app doesn't provides menu-items (or the user doesn't
have the rights to access them), the mobile burger menu should fallback
to the user menu instead of an empty one (like on the App Switcher).

Steps to reproduce (on mobile):
- on a newly database, install only "notes" app
- connect as 'demo' user
- open the notes app
- open the burger menu
=> as there is no submenus, burger menu is empty.

task-2345001

Forward-Port-Of: odoo/enterprise#21013