### PR TITLE
[IMP] web: tests: show dialogs when debugging a test

### DIFF
--- a/addons/web/static/tests/qunit.js
+++ b/addons/web/static/tests/qunit.js
@@ -309,6 +309,7 @@
     });
 
     QUnit.debug = (name, cb) => {
+        document.body.classList.add("debug");
         QUnit.config.debug = true;
         QUnit.only(name, cb);
     };


### PR DESCRIPTION
By default, dialogs are hidden in tests, s.t. we don't see them
flicker when running the test suite. There is a css rule to hide
them, only if there's no "debug" classname on the body.

This commit toggles this classname when a test is run with
QUnit.debug.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
