### PR TITLE
[FIX] payment_adyen: unblock the UI when additional details are required

### DIFF
--- a/addons/payment_adyen/static/src/js/payment_form.js
+++ b/addons/payment_adyen/static/src/js/payment_form.js
@@ -23,7 +23,6 @@ odoo.define('payment_adyen.payment_form', require => {
          * @return {Promise}
          */
         _dropinOnAdditionalDetails: function (state, dropin) {
-            this._hideInputs(); // Only the inputs of the inline form should be used
             return this._rpc({
                 route: '/payment/adyen/payment_details',
                 params: {
@@ -92,6 +91,8 @@ odoo.define('payment_adyen.payment_form', require => {
                 });
             }).then(paymentResponse => {
                 if (paymentResponse.action) { // Additional action required from the shopper
+                    this._hideInputs(); // Only the inputs of the inline form should be used
+                    $('body').unblock(); // The page is blocked at this point, unblock it
                     dropin.handleAction(paymentResponse.action);
                 } else { // The payment reached a final state, redirect to the status page
                     window.location = '/payment/status';


### PR DESCRIPTION
Commit b6ae8a0a introduced the generic behavior of blocking the UI as
soon as a submit button is pressed in a payment form. The 3DS2 flow of
Adyen was not taken into account, resulting in the impossibility to
enter the additional details required by Adyen.

With this commit, the UI is unblocked at the right time to allow the
user to submit the additional details. Moreover, the submit button is
now hidden as soon as we don't want to show it anymore, rather than
after having submitted the additional payment details.