### PR TITLE
[FIX] iap_mail: Remove messageIsHtml from IAP failure notification

### DIFF
--- a/addons/iap_mail/static/src/js/services/iap_notification_service.js
+++ b/addons/iap_mail/static/src/js/services/iap_notification_service.js
@@ -39,7 +39,6 @@ export const iapNotificationService = {
             const message = Markup`<a class='btn btn-link' href='${notif.url}' target='_blank' ><i class='fa fa-arrow-right'></i> ${env._t("Buy more credits")}</a>`;
             notification.add(message, {
                 type: notif.error_type,
-                messageIsHtml: true,
                 title: notif.title
             });
         }


### PR DESCRIPTION
Before the fix:
When we don't have enough credits for Bill Digitalization,
try to scan expense from expense app (or upload bill from billing).
Instead of getting 'Not enough credits for Bill Digitalization',
we are getting 'Odoo Client Error'.

That is because messageIsHtml is no more prop to component 'Notification'.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
