### PR TITLE
[FIX] stock_picking_batch: new stock.move added to wave picking

### DIFF
--- a/addons/stock_picking_batch/models/__init__.py
+++ b/addons/stock_picking_batch/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import stock_move
 from . import stock_move_line
 from . import stock_picking
 from . import stock_picking_batch

--- a/addons/stock_picking_batch/models/stock_move.py
+++ b/addons/stock_picking_batch/models/stock_move.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+from odoo.osv import expression
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _search_picking_for_assignation_domain(self):
+        domain = super()._search_picking_for_assignation_domain()
+        domain = expression.AND([domain, ['|', ('batch_id', '=', False), ('batch_id.is_wave', '=', False)]])
+        return domain


### PR DESCRIPTION
Usecase to reproduce:
- Create a batch picking from a new location to customer
- Put some `stock.move.line` in a wave
- Validate the remaining of the initial `stock.picking`
- Create a new `stock.move` with the same data and without `picking_id`

Current behavior
The stock.move is added to the existing wave. However the
stock.move.line created could not match the current wave specification

Expected behavior
A new picking is created and it could be merge in the wave picking if
wanted

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
