### PR TITLE
[IMP] website_sale: disable archived variants

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -738,6 +738,7 @@ class ProductTemplate(models.Model):
 
         :return: dict of exclusions
             - exclusions: from this product itself
+            - archived_combinations: list of archived combinations
             - parent_combination: ids of the given parent_combination
             - parent_exclusions: from the parent_combination
            - parent_product_name: the name of the parent product if any, used in the interface
@@ -749,8 +750,10 @@ class ProductTemplate(models.Model):
         """
         self.ensure_one()
         parent_combination = parent_combination or self.env['product.template.attribute.value']
+        archived_products = self.with_context(active_test=False).product_variant_ids.filtered(lambda l: not l.active)
         return {
             'exclusions': self._complete_inverse_exclusions(self._get_own_attribute_exclusions()),
+            'archived_combinations': [product.product_template_attribute_value_ids.ids for product in archived_products],
             'parent_exclusions': self._get_parent_attribute_exclusions(parent_combination),
             'parent_combination': parent_combination.ids,
             'parent_product_name': parent_name,

--- a/addons/sale/static/src/js/variant_mixin.js
+++ b/addons/sale/static/src/js/variant_mixin.js
@@ -382,6 +382,44 @@ var VariantMixin = {
                 }
             });
         }
+        // combination exclusions: array of array of ptav
+        // for example a product with 3 variation and one specific variation is disabled (archived)
+        //  requires the first 2 to be selected for the third to be disabled
+        if (combinationData.archived_combinations) {
+            combinationData.archived_combinations.forEach((excludedCombination) => {
+                const ptavCommon = excludedCombination.filter((ptav) => combination.includes(ptav));
+                if (ptavCommon.length === combination.length) {
+                    // Selected combination is archived, all attributes must be disabled from each other
+                    combination.forEach((ptav) => {
+                        combination.forEach((ptavOther) => {
+                            if (ptav === ptavOther) {
+                                return;
+                            }
+                            self._disableInput(
+                                $parent,
+                                ptav,
+                                ptavOther,
+                                combinationData.mapped_attribute_names,
+                            );
+                        })
+                    })
+                } else if (ptavCommon.length === (combination.length - 1)) {
+                    // In this case we only need to disable the remaining ptav
+                    const disabledPtav = excludedCombination.find((ptav) => !combination.includes(ptav));
+                    excludedCombination.forEach((ptav) => {
+                        if (ptav === disabledPtav) {
+                            return;
+                        }
+                        self._disableInput(
+                            $parent,
+                            disabledPtav,
+                            ptav,
+                            combinationData.mapped_attribute_names,
+                        )
+                    });
+                }
+            });
+        }
 
         // parent exclusions (tell which attributes are excluded from parent)
         _.each(combinationData.parent_exclusions, function (exclusions, excluded_by){

--- a/addons/website_sale/static/tests/tours/website_sale_shop_archived_variant_multi.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_archived_variant_multi.js
@@ -1,0 +1,44 @@
+/** @odoo-module **/
+
+import tour from 'web_tour.tour';
+
+tour.register('tour_shop_archived_variant_multi', {
+    test: true,
+    url: '/shop?search=Test Product 2',
+},
+[
+    {
+        content: "select Test Product",
+        trigger: '.oe_product_cart a:containsExact("Test Product 2")',
+    },
+    {
+        content: 'click on the first variant',
+        trigger: 'input[data-attribute_name="Size"][data-value_name="Small"]',
+    },
+    {
+        content: "click on the second variant",
+        trigger: 'input[data-attribute_name="Color"][data-value_name="Black"]',
+    },
+    {
+        content: "Check that brand b is not available and select it",
+        trigger: '.css_not_available input[data-attribute_name="Brand"][data-value_name="Brand B"]',
+    },
+    {
+        content: "check combination is not possible",
+        trigger: '.js_main_product.css_not_available .css_not_available_msg:contains("This combination does not exist.")'
+    },
+    {
+        content: "check add to cart not possible",
+        trigger: '#add_to_cart.disabled',
+        run: function () {},
+    },
+    {
+        content: "change second variant to remove warning",
+        trigger: 'input[data-attribute_name="Color"][data-value_name="White"]',
+    },
+    {
+        content: "Check that second variant is disabled",
+        trigger: '.css_not_available input[data-attribute_name="Color"][data-value_name="Black"]',
+        run: function () {},
+    },
+]);

--- a/addons/website_sale/tests/test_customize.py
+++ b/addons/website_sale/tests/test_customize.py
@@ -314,3 +314,85 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
 
     def test_07_editor_shop(self):
         self.start_tour("/", 'shop_editor', login="admin")
+
+    def test_08_portal_tour_archived_variant_multiple_attributes(self):
+        """The goal of this test is to make sure that an archived variant with multiple
+        attributes only disabled other options if only one is missing or all are selected.
+
+        Using "portal" to have various users in the tests.
+        """
+
+        attribute_1, attribute_2, attribute_3 = self.env['product.attribute'].create([
+            {
+                'name': 'Size',
+                'create_variant': 'always',
+            },
+            {
+                'name': 'Color',
+                'create_variant': 'always',
+            },
+            {
+                'name': 'Brand',
+                'create_variant': 'always',
+            },
+        ])
+
+        attribute_values = self.env['product.attribute.value'].create([
+            {
+                'name': 'Large',
+                'attribute_id': attribute_1.id,
+                'sequence': 1,
+            },
+            {
+                'name': 'Small',
+                'attribute_id': attribute_1.id,
+                'sequence': 2,
+            },
+            {
+                'name': 'White',
+                'attribute_id': attribute_2.id,
+                'sequence': 1,
+            },
+            {
+                'name': 'Black',
+                'attribute_id': attribute_2.id,
+                'sequence': 2,
+            },
+            {
+                'name': 'Brand A',
+                'attribute_id': attribute_3.id,
+                'sequence': 1,
+            },
+            {
+                'name': 'Brand B',
+                'attribute_id': attribute_3.id,
+                'sequence': 2,
+            },
+        ])
+
+        product_template = self.env['product.template'].create({
+            'name': 'Test Product 2',
+            'is_published': True,
+        })
+
+        self.env['product.template.attribute.line'].create([
+            {
+                'attribute_id': attribute_1.id,
+                'product_tmpl_id': product_template.id,
+                'value_ids': [(6, 0, attribute_values.filtered(lambda v: v.attribute_id == attribute_1).ids)],
+            },
+            {
+                'attribute_id': attribute_2.id,
+                'product_tmpl_id': product_template.id,
+                'value_ids': [(6, 0, attribute_values.filtered(lambda v: v.attribute_id == attribute_2).ids)],
+            },
+            {
+                'attribute_id': attribute_3.id,
+                'product_tmpl_id': product_template.id,
+                'value_ids': [(6, 0, attribute_values.filtered(lambda v: v.attribute_id == attribute_3).ids)],
+            },
+        ])
+
+        product_template.product_variant_ids[-1].active = False
+
+        self.start_tour("/", 'tour_shop_archived_variant_multi', login="portal")


### PR DESCRIPTION
Prior to this commit archived variants would not appear as disabled
 in the shop, the different options will now be greyd out if selecting
 them would result in an archived variant.

TaskId-2762122
