### PR TITLE
[FIX] pos_coupon: allow use coupon for pos users

### DIFF
--- a/addons/pos_coupon/models/pos_config.py
+++ b/addons/pos_coupon/models/pos_config.py
@@ -94,7 +94,7 @@ class PosConfig(models.Model):
                 "payload": {"error_message": error_message},
             }
 
-        coupon_to_check.write({"state": "used"})
+        coupon_to_check.sudo().write({"state": "used"})
         return {
             "successful": True,
             "payload": {


### PR DESCRIPTION
When a user only has pos users access rights, he cannot write on coupon
and get an error when he tries to use a coupon in POS.

To avoid this issue, we write the coupon with sudo after having checked
it is valid.

TASK-ID: 2742528

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
