### PR TITLE
[FIX] payment: stop showing the content of HTML fields if they are empty

### DIFF
--- a/addons/payment/views/payment_templates.xml
+++ b/addons/payment/views/payment_templates.xml
@@ -78,7 +78,7 @@
                         <!-- === Payment icon list === -->
                         <t t-call="payment.icon_list"/>
                         <!-- === Help message === -->
-                        <div t-if="acquirer.pre_msg"
+                        <div t-if="acquirer.pre_msg != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'"
                              t-out="acquirer.pre_msg"
                              class="text-muted ml-3"/>
                     </div>
@@ -201,7 +201,7 @@
                         <!-- === Payment icon list === -->
                         <t t-call="payment.icon_list"/>
                         <!-- === Help message === -->
-                        <div t-if="acquirer.pre_msg"
+                        <div t-if="acquirer.pre_msg != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'"
                              t-out="acquirer.pre_msg"
                              class="text-muted ml-3"/>
                     </div>
@@ -335,21 +335,24 @@
         <!-- Variables description:
             - 'tx' - The transaction whose status must be displayed
         -->
-        <div t-if="tx.state == 'pending'" class="alert alert-warning alert-dismissible">
-            <span t-if='tx.acquirer_id.sudo().pending_msg'
-                  t-out="tx.acquirer_id.sudo().pending_msg"/>
+        <div t-if="tx.state == 'pending' and tx.acquirer_id.sudo().pending_msg != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'"
+             class="alert alert-warning alert-dismissible">
+            <span t-out="tx.acquirer_id.sudo().pending_msg"/>
             <button class="close" data-dismiss="alert" title="Dismiss">×</button>
         </div>
-        <div t-elif="tx.state == 'authorized'" class="alert alert-success alert-dismissible">
-            <span t-if='tx.acquirer_id.sudo().auth_msg' t-out="tx.acquirer_id.sudo().auth_msg"/>
+        <div t-elif="tx.state == 'authorized' and tx.acquirer_id.sudo().auth_msg != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'"
+             class="alert alert-success alert-dismissible">
+            <span t-out="tx.acquirer_id.sudo().auth_msg"/>
             <button class="close" data-dismiss="alert" title="Dismiss">×</button>
         </div>
-        <div t-elif="tx.state == 'done'" class="alert alert-success alert-dismissible">
-            <span t-if='tx.acquirer_id.sudo().done_msg' t-out="tx.acquirer_id.sudo().done_msg"/>
+        <div t-elif="tx.state == 'done' and tx.acquirer_id.sudo().done_msg != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'"
+             class="alert alert-success alert-dismissible">
+            <span t-out="tx.acquirer_id.sudo().done_msg"/>
             <button class="close" data-dismiss="alert" title="Dismiss">×</button>
         </div>
-        <div t-elif="tx.state == 'cancel'" class="alert alert-danger alert-dismissible">
-            <span t-if='tx.acquirer_id.sudo().cancel_msg' t-out="tx.acquirer_id.sudo().cancel_msg"/>
+        <div t-elif="tx.state == 'cancel' and tx.acquirer_id.sudo().cancel_msg != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'"
+             class="alert alert-danger alert-dismissible">
+            <span t-out="tx.acquirer_id.sudo().cancel_msg"/>
             <button class="close" data-dismiss="alert" title="Dismiss">×</button>
         </div>
         <span t-if="tx.state_message" t-esc="tx.state_message"/>


### PR DESCRIPTION
Before this commit, an empty line would be shown in the payment forms on
the card of each payment acquirer whose `pre_msg` field was not empty.
This is because displaying this HTML field in a form view and saving it
causes the value `<p><br></p>` to be written on the field, even if it
was left empty. The same issue occurred with the `pending_msg`,
`auth_msg`, `done_msg`, and `cancel_msg` fields that are shown on the
portal of some apps (Sales, Accounting...).

With this commit, the value of these fields is tested before displaying
them. If the value is `<p><br></p>`, the field is not displayed, hence
avoiding displaying a blank line.

Note: This fix is only temporary. A more resilient solution will come in master with task-2692125.