### PR TITLE
Deterministic mock server sorting

### DIFF
--- a/addons/crm/static/tests/forecast_view_tests.js
+++ b/addons/crm/static/tests/forecast_view_tests.js
@@ -52,6 +52,7 @@ QUnit.module("Views", (hooks) => {
                     },
                     records: [],
                 },
+                partner: {},
             },
             views: {
                 "foo,false,legacy_toy": `<legacy_toy/>`,

--- a/addons/web/static/tests/legacy/mockserver_tests.js
+++ b/addons/web/static/tests/legacy/mockserver_tests.js
@@ -3,7 +3,7 @@ odoo.define('web.mockserver_tests', function (require) {
 
 const MockServer = require("web.MockServer");
 
-QUnit.module("MockServer", {
+QUnit.module("Legacy MockServer", {
     beforeEach() {
         this.data = {
             "res.partner": {

--- a/addons/web/static/tests/search/search_panel_tests.js
+++ b/addons/web/static/tests/search/search_panel_tests.js
@@ -1964,10 +1964,10 @@ QUnit.module("Search", (hooks) => {
 
         assert.deepEqual(getCategoriesContent(comp), [
             "All",
+            "lowID",
             "asustek: 2",
             "agrolait: 2",
             "highID",
-            "lowID",
         ]);
     });
 

--- a/addons/web/static/tests/views/graph_view_tests.js
+++ b/addons/web/static/tests/views/graph_view_tests.js
@@ -162,21 +162,27 @@ QUnit.module("Views", (hooks) => {
                 foo: {
                     fields: {
                         id: { string: "Id", type: "integer" },
-                        foo: { string: "Foo", type: "integer", store: true, group_operator: "sum", sortable: true },
+                        foo: {
+                            string: "Foo",
+                            type: "integer",
+                            store: true,
+                            group_operator: "sum",
+                            sortable: true,
+                        },
                         bar: { string: "bar", type: "boolean", store: true, sortable: true },
                         product_id: {
                             string: "Product",
                             type: "many2one",
                             relation: "product",
                             store: true,
-                            sortable: true
+                            sortable: true,
                         },
                         color_id: {
                             string: "Color",
                             type: "many2one",
                             relation: "color",
                             store: true,
-                            sortable: true
+                            sortable: true,
                         },
                         date: { string: "Date", type: "date", store: true, sortable: true },
                         revenue: {
@@ -184,7 +190,7 @@ QUnit.module("Views", (hooks) => {
                             type: "float",
                             store: true,
                             group_operator: "sum",
-                            sortable: true
+                            sortable: true,
                         },
                     },
                     records: [
@@ -338,16 +344,16 @@ QUnit.module("Views", (hooks) => {
             arch: `<graph><field name="bar"/></graph>`,
         });
         assert.containsOnce(graph.el, "div.o_graph_canvas_container canvas");
-        checkLabels(assert, graph, ["true", "false"]);
+        checkLabels(assert, graph, ["false", "true"]);
         checkDatasets(assert, graph, ["backgroundColor", "borderColor", "data", "label"], {
             backgroundColor: "#1f77b4",
             borderColor: undefined,
-            data: [3, 5],
+            data: [5, 3],
             label: "Count",
         });
         checkLegend(assert, graph, "Count");
-        checkTooltip(assert, graph, { lines: [{ label: "true", value: "3" }] }, 0);
-        checkTooltip(assert, graph, { lines: [{ label: "false", value: "5" }] }, 1);
+        checkTooltip(assert, graph, { lines: [{ label: "false", value: "5" }] }, 0);
+        checkTooltip(assert, graph, { lines: [{ label: "true", value: "3" }] }, 1);
     });
 
     QUnit.test("simple bar chart rendering (two groupBy)", async function (assert) {
@@ -364,7 +370,7 @@ QUnit.module("Views", (hooks) => {
             `,
         });
         assert.containsOnce(graph.el, "div.o_graph_canvas_container canvas");
-        checkLabels(assert, graph, ["true", "false"]);
+        checkLabels(assert, graph, ["false", "true"]);
         checkDatasets(
             assert,
             graph,
@@ -373,22 +379,22 @@ QUnit.module("Views", (hooks) => {
                 {
                     backgroundColor: "#1f77b4",
                     borderColor: undefined,
-                    data: [3, 1],
+                    data: [1, 3],
                     label: "xphone",
                 },
                 {
                     backgroundColor: "#ff7f0e",
                     borderColor: undefined,
-                    data: [0, 4],
+                    data: [4, 0],
                     label: "xpad",
                 },
             ]
         );
         checkLegend(assert, graph, ["xphone", "xpad"]);
-        checkTooltip(assert, graph, { lines: [{ label: "true / xphone", value: "3" }] }, 0, 0);
-        checkTooltip(assert, graph, { lines: [{ label: "false / xphone", value: "1" }] }, 1, 0);
-        checkTooltip(assert, graph, { lines: [{ label: "true / xpad", value: "0" }] }, 0, 1);
-        checkTooltip(assert, graph, { lines: [{ label: "false / xpad", value: "4" }] }, 1, 1);
+        checkTooltip(assert, graph, { lines: [{ label: "false / xphone", value: "1" }] }, 0, 0);
+        checkTooltip(assert, graph, { lines: [{ label: "true / xphone", value: "3" }] }, 1, 0);
+        checkTooltip(assert, graph, { lines: [{ label: "false / xpad", value: "4" }] }, 0, 1);
+        checkTooltip(assert, graph, { lines: [{ label: "true / xpad", value: "0" }] }, 1, 1);
     });
 
     QUnit.test("bar chart rendering (no groupBy, several domains)", async function (assert) {
@@ -665,11 +671,11 @@ QUnit.module("Views", (hooks) => {
         async function (assert) {
             assert.expect(15);
             serverData.models.foo.records = [
-                { date: "2021-01-04", bar: true, revenue: 12 },
-                { date: "2021-01-12", bar: false, revenue: 5 },
-                { date: "2021-02-04", bar: true, revenue: 14 },
-                { date: "2021-02-17", bar: false, revenue: false },
-                { date: false, bar: true, revenue: 0 },
+                { date: "2021-01-04", bar: false, revenue: 12 },
+                { date: "2021-01-12", bar: true, revenue: 5 },
+                { date: "2021-02-04", bar: false, revenue: 14 },
+                { date: "2021-02-17", bar: true, revenue: false },
+                { date: false, bar: false, revenue: 0 },
             ];
             const graph = await makeView({
                 serverData,
@@ -702,7 +708,7 @@ QUnit.module("Views", (hooks) => {
                     fieldName: "date",
                 },
             });
-            checkLabels(assert, graph, ["true", "false"]);
+            checkLabels(assert, graph, ["false", "true"]);
             checkDatasets(
                 assert,
                 graph,
@@ -745,7 +751,7 @@ QUnit.module("Views", (hooks) => {
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "true / February 2021 / W05 2021", value: "14" }],
+                    lines: [{ label: "false / February 2021 / W05 2021", value: "14" }],
                 },
                 0,
                 0
@@ -755,7 +761,7 @@ QUnit.module("Views", (hooks) => {
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "true / January 2021 / W01 2021", value: "12" }],
+                    lines: [{ label: "false / January 2021 / W01 2021", value: "12" }],
                 },
                 0,
                 2
@@ -765,7 +771,7 @@ QUnit.module("Views", (hooks) => {
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "false / January 2021 / W02 2021", value: "5" }],
+                    lines: [{ label: "true / January 2021 / W02 2021", value: "5" }],
                 },
                 1,
                 3
@@ -809,16 +815,16 @@ QUnit.module("Views", (hooks) => {
             `,
         });
         assert.containsOnce(graph.el, "div.o_graph_canvas_container canvas");
-        checkLabels(assert, graph, ["true", "false"]);
+        checkLabels(assert, graph, ["false", "true"]);
         checkDatasets(assert, graph, ["backgroundColor", "borderColor", "data", "label"], {
             backgroundColor: "rgba(31,119,180,0.4)",
             borderColor: "#1f77b4",
-            data: [3, 5],
+            data: [5, 3],
             label: "Count",
         });
         checkLegend(assert, graph, "Count");
-        checkTooltip(assert, graph, { lines: [{ label: "true", value: "3" }] }, 0);
-        checkTooltip(assert, graph, { lines: [{ label: "false", value: "5" }] }, 1);
+        checkTooltip(assert, graph, { lines: [{ label: "false", value: "5" }] }, 0);
+        checkTooltip(assert, graph, { lines: [{ label: "true", value: "3" }] }, 1);
     });
 
     QUnit.test("line chart rendering (two groupBy)", async function (assert) {
@@ -835,7 +841,7 @@ QUnit.module("Views", (hooks) => {
             `,
         });
         assert.containsOnce(graph.el, "div.o_graph_canvas_container canvas");
-        checkLabels(assert, graph, ["true", "false"]);
+        checkLabels(assert, graph, ["false", "true"]);
         checkDatasets(
             assert,
             graph,
@@ -844,13 +850,13 @@ QUnit.module("Views", (hooks) => {
                 {
                     backgroundColor: undefined,
                     borderColor: "#1f77b4",
-                    data: [3, 1],
+                    data: [1, 3],
                     label: "xphone",
                 },
                 {
                     backgroundColor: undefined,
                     borderColor: "#ff7f0e",
-                    data: [0, 4],
+                    data: [4, 0],
                     label: "xpad",
                 },
             ]
@@ -861,8 +867,8 @@ QUnit.module("Views", (hooks) => {
             graph,
             {
                 lines: [
-                    { label: "true / xphone", value: "3" },
-                    { label: "true / xpad", value: "0" },
+                    { label: "false / xpad", value: "4" },
+                    { label: "false / xphone", value: "1" },
                 ],
             },
             0
@@ -872,8 +878,8 @@ QUnit.module("Views", (hooks) => {
             graph,
             {
                 lines: [
-                    { label: "false / xpad", value: "4" },
-                    { label: "false / xphone", value: "1" },
+                    { label: "true / xphone", value: "3" },
+                    { label: "true / xpad", value: "0" },
                 ],
             },
             1
@@ -1145,11 +1151,11 @@ QUnit.module("Views", (hooks) => {
         async function (assert) {
             assert.expect(11);
             serverData.models.foo.records = [
-                { date: "2021-01-04", bar: true, revenue: 12 },
-                { date: "2021-01-12", bar: false, revenue: 5 },
-                { date: "2021-02-04", bar: true, revenue: 14 },
-                { date: "2021-02-17", bar: false, revenue: false },
-                { date: false, bar: true, revenue: 0 },
+                { date: "2021-01-04", bar: false, revenue: 12 },
+                { date: "2021-01-12", bar: true, revenue: 5 },
+                { date: "2021-02-04", bar: false, revenue: 14 },
+                { date: "2021-02-17", bar: true, revenue: false },
+                { date: false, bar: false, revenue: 0 },
             ];
             const graph = await makeView({
                 serverData,
@@ -1182,7 +1188,7 @@ QUnit.module("Views", (hooks) => {
                     fieldName: "date",
                 },
             });
-            checkLabels(assert, graph, ["true", "false"]);
+            checkLabels(assert, graph, ["false", "true"]);
             checkDatasets(
                 assert,
                 graph,
@@ -1226,10 +1232,10 @@ QUnit.module("Views", (hooks) => {
                 {
                     title: "Revenue",
                     lines: [
-                        { label: "true / February 2021 / W05 2021", value: "14" },
-                        { label: "true / January 2021 / W01 2021", value: "12" },
-                        { label: "true / February 2021 / W07 2021", value: "0" },
-                        { label: "true / January 2021 / W02 2021", value: "0" },
+                        { label: "false / February 2021 / W05 2021", value: "14" },
+                        { label: "false / January 2021 / W01 2021", value: "12" },
+                        { label: "false / February 2021 / W07 2021", value: "0" },
+                        { label: "false / January 2021 / W02 2021", value: "0" },
                     ],
                 },
                 0
@@ -1240,10 +1246,10 @@ QUnit.module("Views", (hooks) => {
                 {
                     title: "Revenue",
                     lines: [
-                        { label: "false / January 2021 / W02 2021", value: "5" },
-                        { label: "false / February 2021 / W05 2021", value: "0" },
-                        { label: "false / February 2021 / W07 2021", value: "0" },
-                        { label: "false / January 2021 / W01 2021", value: "0" },
+                        { label: "true / January 2021 / W02 2021", value: "5" },
+                        { label: "true / February 2021 / W05 2021", value: "0" },
+                        { label: "true / February 2021 / W07 2021", value: "0" },
+                        { label: "true / January 2021 / W01 2021", value: "0" },
                     ],
                 },
                 1
@@ -1301,15 +1307,15 @@ QUnit.module("Views", (hooks) => {
             `,
         });
         assert.containsOnce(graph.el, "div.o_graph_canvas_container canvas");
-        checkLabels(assert, graph, ["true", "false"]);
+        checkLabels(assert, graph, ["false", "true"]);
         checkDatasets(assert, graph, ["backgroundColor", "borderColor", "data"], {
             backgroundColor: ["#1f77b4", "#ff7f0e"],
             borderColor: BORDER_WHITE,
-            data: [3, 5],
+            data: [5, 3],
         });
-        checkLegend(assert, graph, ["true", "false"]);
-        checkTooltip(assert, graph, { lines: [{ label: "true", value: "3 (37.50%)" }] }, 0);
-        checkTooltip(assert, graph, { lines: [{ label: "false", value: "5 (62.50%)" }] }, 1);
+        checkLegend(assert, graph, ["false", "true"]);
+        checkTooltip(assert, graph, { lines: [{ label: "false", value: "5 (62.50%)" }] }, 0);
+        checkTooltip(assert, graph, { lines: [{ label: "true", value: "3 (37.50%)" }] }, 1);
     });
 
     QUnit.test("pie chart rendering (two groupBy)", async function (assert) {
@@ -1326,27 +1332,27 @@ QUnit.module("Views", (hooks) => {
             `,
         });
         assert.containsOnce(graph.el, "div.o_graph_canvas_container canvas");
-        checkLabels(assert, graph, ["true / xphone", "false / xphone", "false / xpad"]);
+        checkLabels(assert, graph, ["false / xphone", "false / xpad", "true / xphone"]);
         checkDatasets(assert, graph, ["backgroundColor", "borderColor", "data", "label"], {
             backgroundColor: ["#1f77b4", "#ff7f0e", "#aec7e8"],
             borderColor: BORDER_WHITE,
-            data: [3, 1, 4],
+            data: [1, 4, 3],
             label: "",
         });
-        checkLegend(assert, graph, ["true / xphone", "false / xphone", "false / xpad"]);
-        checkTooltip(
-            assert,
-            graph,
-            { lines: [{ label: "true / xphone", value: "3 (37.50%)" }] },
-            0
-        );
+        checkLegend(assert, graph, ["false / xphone", "false / xpad", "true / xphone"]);
         checkTooltip(
             assert,
             graph,
             { lines: [{ label: "false / xphone", value: "1 (12.50%)" }] },
-            1
+            0
         );
-        checkTooltip(assert, graph, { lines: [{ label: "false / xpad", value: "4 (50.00%)" }] }, 2);
+        checkTooltip(assert, graph, { lines: [{ label: "false / xpad", value: "4 (50.00%)" }] }, 1);
+        checkTooltip(
+            assert,
+            graph,
+            { lines: [{ label: "true / xphone", value: "3 (37.50%)" }] },
+            2
+        );
     });
 
     QUnit.test("pie chart rendering (no groupBy, several domains)", async function (assert) {
@@ -1635,11 +1641,11 @@ QUnit.module("Views", (hooks) => {
         async function (assert) {
             assert.expect(15);
             serverData.models.foo.records = [
-                { date: "2021-01-04", bar: true, revenue: 12 },
-                { date: "2021-01-12", bar: false, revenue: 5 },
-                { date: "2021-02-04", bar: true, revenue: 14 },
-                { date: "2021-02-17", bar: false, revenue: false },
-                { date: false, bar: true, revenue: 0 },
+                { date: "2021-01-04", bar: false, revenue: 12 },
+                { date: "2021-01-12", bar: true, revenue: 5 },
+                { date: "2021-02-04", bar: false, revenue: 14 },
+                { date: "2021-02-17", bar: true, revenue: false },
+                { date: false, bar: false, revenue: 0 },
             ];
             const graph = await makeView({
                 serverData,
@@ -1672,7 +1678,7 @@ QUnit.module("Views", (hooks) => {
                     fieldName: "date",
                 },
             });
-            checkLabels(assert, graph, ["true / W05 2021", "true / W01 2021", "false / W02 2021"]);
+            checkLabels(assert, graph, ["false / W05 2021", "false / W01 2021", "true / W02 2021"]);
             checkDatasets(
                 assert,
                 graph,
@@ -1692,13 +1698,13 @@ QUnit.module("Views", (hooks) => {
                     },
                 ]
             );
-            checkLegend(assert, graph, ["true / W05 2021", "true / W01 2021", "false / W02 2021"]);
+            checkLegend(assert, graph, ["false / W05 2021", "false / W01 2021", "true / W02 2021"]);
             checkTooltip(
                 assert,
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "February 2021 / true / W05 2021", value: "14 (100.00%)" }],
+                    lines: [{ label: "February 2021 / false / W05 2021", value: "14 (100.00%)" }],
                 },
                 0,
                 0
@@ -1708,7 +1714,7 @@ QUnit.module("Views", (hooks) => {
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "January 2021 / true / W01 2021", value: "12 (70.59%)" }],
+                    lines: [{ label: "January 2021 / false / W01 2021", value: "12 (70.59%)" }],
                 },
                 1,
                 1
@@ -1718,7 +1724,7 @@ QUnit.module("Views", (hooks) => {
                 graph,
                 {
                     title: "Revenue",
-                    lines: [{ label: "January 2021 / false / W02 2021", value: "5 (29.41%)" }],
+                    lines: [{ label: "January 2021 / true / W02 2021", value: "5 (29.41%)" }],
                 },
                 2,
                 1
@@ -2015,25 +2021,25 @@ QUnit.module("Views", (hooks) => {
         });
 
         checkLabels(assert, graph, ["xphone", "xpad"]);
-        checkLegend(assert, graph, ["true / Undefined", "true / red", "false / Undefined"]);
+        checkLegend(assert, graph, ["false / Undefined", "true / Undefined", "true / red"]);
 
         await selectMode(graph.el, "line");
 
         checkLabels(assert, graph, ["xphone", "xpad"]);
-        checkLegend(assert, graph, ["true / Undefined", "true / red", "false / Undefined"]);
+        checkLegend(assert, graph, ["false / Undefined", "true / Undefined", "true / red"]);
 
         await selectMode(graph.el, "pie");
 
         checkLabels(assert, graph, [
+            "xphone / false / Undefined",
             "xphone / true / Undefined",
             "xphone / true / red",
-            "xphone / false / Undefined",
             "xpad / false / Undefined",
         ]);
         checkLegend(assert, graph, [
+            "xphone / false / Undefined",
             "xphone / true / Undefined",
             "xphone / true / red",
-            "xphone / false / Undefined",
             "xpad / false / Undefined",
         ]);
     });
@@ -2268,8 +2274,8 @@ QUnit.module("Views", (hooks) => {
         async function (assert) {
             assert.expect(10);
             serverData.models.foo.records = [
-                { id: 1, bar: true, revenue: 1.5 },
-                { id: 2, bar: false, revenue: 2 },
+                { id: 1, bar: false, revenue: 1.5 },
+                { id: 2, bar: true, revenue: 2 },
             ];
             const graph = await makeView({
                 serverData,
@@ -2283,17 +2289,17 @@ QUnit.module("Views", (hooks) => {
                 `,
             });
             checkDatasets(assert, graph, "data", { data: [1.5, 2] });
-            checkLabels(assert, graph, ["true", "false"]);
+            checkLabels(assert, graph, ["false", "true"]);
             checkTooltip(
                 assert,
                 graph,
-                { title: "Revenue", lines: [{ label: "true", value: "1.50" }] },
+                { title: "Revenue", lines: [{ label: "false", value: "1.50" }] },
                 0
             );
             checkTooltip(
                 assert,
                 graph,
-                { title: "Revenue", lines: [{ label: "false", value: "2.00" }] },
+                { title: "Revenue", lines: [{ label: "true", value: "2.00" }] },
                 1
             );
         }
@@ -2453,9 +2459,9 @@ QUnit.module("Views", (hooks) => {
               </graph>
             `,
         });
-        checkLabels(assert, graph, ["true", "false"]);
+        checkLabels(assert, graph, ["false", "true"]);
         checkLegend(assert, graph, "Product");
-        checkDatasets(assert, graph, "data", { data: [1, 2] });
+        checkDatasets(assert, graph, "data", { data: [2, 1] });
     });
 
     QUnit.test("use a many2one as a measure and as a groupby should work", async function (assert) {
@@ -2492,7 +2498,7 @@ QUnit.module("Views", (hooks) => {
                 </graph>
             `,
         });
-        checkLabels(assert, graph, ["xphone", "xpad", "xphone (2)"]);
+        checkLabels(assert, graph, ["xphone", "xphone (2)", "xpad"]);
     });
 
     QUnit.test("not use a many2one as a measure by default", async function (assert) {
@@ -2785,7 +2791,7 @@ QUnit.module("Views", (hooks) => {
                                     tz: "taht",
                                     uid: 7,
                                 },
-                                domain: [["bar", "=", true]],
+                                domain: [["bar", "=", false]],
                                 name: "Foo Analysis",
                                 res_model: "foo",
                                 target: "current",
@@ -2814,7 +2820,7 @@ QUnit.module("Views", (hooks) => {
         });
         checkModeIs(assert, graph, "bar");
         checkDatasets(assert, graph, ["domains"], {
-            domains: [[["bar", "=", true]], [["bar", "=", false]]],
+            domains: [[["bar", "=", false]], [["bar", "=", true]]],
         });
         await clickOnDataset(graph);
     });
@@ -2836,7 +2842,7 @@ QUnit.module("Views", (hooks) => {
                                         tz: "taht",
                                         uid: 7,
                                     },
-                                    domain: [["bar", "=", true]],
+                                    domain: [["bar", "=", false]],
                                     name: "Foo Analysis",
                                     res_model: "foo",
                                     target: "current",
@@ -2891,7 +2897,7 @@ QUnit.module("Views", (hooks) => {
                                         tz: "taht",
                                         uid: 7,
                                     },
-                                    domain: [["bar", "=", true]],
+                                    domain: [["bar", "=", false]],
                                     name: "Foo Analysis",
                                     res_model: "foo",
                                     target: "current",
@@ -2927,7 +2933,7 @@ QUnit.module("Views", (hooks) => {
             });
             checkModeIs(assert, graph, "pie");
             checkDatasets(assert, graph, ["domains"], {
-                domains: [[["bar", "=", true]], [["bar", "=", false]]],
+                domains: [[["bar", "=", false]], [["bar", "=", true]]],
             });
             await clickOnDataset(graph);
         }
@@ -2963,7 +2969,7 @@ QUnit.module("Views", (hooks) => {
         });
         checkModeIs(assert, graph, "bar");
         checkDatasets(assert, graph, ["domains"], {
-            domains: [[["bar", "=", true]], [["bar", "=", false]]],
+            domains: [[["bar", "=", false]], [["bar", "=", true]]],
         });
         await clickOnDataset(graph);
     });
@@ -3062,7 +3068,7 @@ QUnit.module("Views", (hooks) => {
             "active",
             "descending order button should not be active"
         );
-        checkDatasets(assert, graph, "data", { data: [4, 3, 1] });
+        checkDatasets(assert, graph, "data", { data: [4, 1, 3] });
 
         // set line mode
         await selectMode(graph.el, "line");
@@ -3075,7 +3081,7 @@ QUnit.module("Views", (hooks) => {
             "active",
             "descending order should be applied"
         );
-        checkDatasets(assert, graph, "data", { data: [4, 3, 1] });
+        checkDatasets(assert, graph, "data", { data: [4, 1, 3] });
 
         await click(graph.el, "button.oi-sort--ascending");
         assert.hasClass(
@@ -3113,8 +3119,8 @@ QUnit.module("Views", (hooks) => {
             `,
         });
 
-        checkLegend(assert, graph, ["true", "false"], "measure should be by count");
-        checkDatasets(assert, graph, "data", [{ data: [3, 0, 0] }, { data: [1, 3, 1] }]);
+        checkLegend(assert, graph, ["false", "true"], "measure should be by count");
+        checkDatasets(assert, graph, "data", [{ data: [1, 1, 3] }, { data: [3, 0, 0] }]);
 
         await click(graph.el, "button.oi-sort--ascending");
         assert.hasClass(
@@ -3130,7 +3136,7 @@ QUnit.module("Views", (hooks) => {
             "active",
             "ascending order button should be active"
         );
-        checkDatasets(assert, graph, "data", [{ data: [3, 0, 0] }, { data: [1, 3, 1] }]);
+        checkDatasets(assert, graph, "data", [{ data: [1, 3, 1] }, { data: [3, 0, 0] }]);
 
         // again click on descending button to deactivate order button
         await click(graph.el, "button.oi-sort--descending");
@@ -3139,7 +3145,7 @@ QUnit.module("Views", (hooks) => {
             "active",
             "descending order button should not be active"
         );
-        checkDatasets(assert, graph, "data", [{ data: [3, 0, 0] }, { data: [1, 3, 1] }]);
+        checkDatasets(assert, graph, "data", [{ data: [1, 1, 3] }, { data: [3, 0, 0] }]);
     });
 
     QUnit.test("graph view sort by measure for multiple grouped data", async function (assert) {
@@ -3169,11 +3175,11 @@ QUnit.module("Views", (hooks) => {
             `,
         });
 
-        checkLegend(assert, graph, ["xpad", "xphone", "zphone"], "measure should be by count");
+        checkLegend(assert, graph, ["xphone", "xpad", "zphone"], "measure should be by count");
         checkDatasets(assert, graph, "data", [
-            { data: [2, 1, 1, 2] },
-            { data: [0, 1, 0, 0] },
             { data: [1, 0, 0, 0] },
+            { data: [1, 2, 1, 2] },
+            { data: [0, 1, 0, 0] },
         ]);
 
         await click(graph.el, "button.oi-sort--ascending");
@@ -3195,8 +3201,8 @@ QUnit.module("Views", (hooks) => {
             "descending order button should be active"
         );
         checkDatasets(assert, graph, "data", [
-            { data: [2, 1, 2, 1] },
             { data: [1, 0, 0, 0] },
+            { data: [2, 1, 2, 1] },
             { data: [0, 1, 0, 0] },
         ]);
 
@@ -3208,9 +3214,9 @@ QUnit.module("Views", (hooks) => {
             "descending order button should not be active"
         );
         checkDatasets(assert, graph, "data", [
-            { data: [2, 1, 1, 2] },
-            { data: [0, 1, 0, 0] },
             { data: [1, 0, 0, 0] },
+            { data: [1, 2, 1, 2] },
+            { data: [0, 1, 0, 0] },
         ]);
     });
 
@@ -3331,7 +3337,7 @@ QUnit.module("Views", (hooks) => {
                     search_default_group_by_foo: 1,
                 },
             });
-            checkLabels(assert, graph, ["3", "53", "2", "24", "4", "63", "42", "48"]);
+            checkLabels(assert, graph, ["2", "3", "4", "24", "42", "48", "53", "63"]);
             await toggleGroupByMenu(graph);
             await toggleMenuItem(graph, "Foo");
             checkLabels(assert, graph, ["xphone", "xpad"]);
@@ -3670,5 +3676,5 @@ QUnit.module("Views", (hooks) => {
             },
         });
         checkLabels(assert, graph, ["January 2016", "March 2016", "May 2016", "April 2016"]);
-    })
+    });
 });

--- a/addons/web/static/tests/views/pivot_view_tests.js
+++ b/addons/web/static/tests/views/pivot_view_tests.js
@@ -986,7 +986,7 @@ QUnit.module("Views", (hooks) => {
         await click(pivot.el.querySelector("thead .o_pivot_header_cell_closed:last-child"));
         await click(pivot.el.querySelector(".dropdown-menu span:nth-child(1)"));
         assert.containsN(pivot, "thead tr", 4);
-        values = ["12", "3", "17", "32"];
+        values = ["12", "17", "3", "32"];
         assert.strictEqual(getCurrentValues(pivot.el), values.join(","));
     });
 
@@ -1750,9 +1750,9 @@ QUnit.module("Views", (hooks) => {
             "should have 7 rows (total + 3 for December and 2 for October and April)"
         );
 
-        // collapse the last two rows
-        await click(pivot.el.querySelectorAll("tbody .o_pivot_header_cell_opened")[3]);
+        // collapse the first two rows
         await click(pivot.el.querySelectorAll("tbody .o_pivot_header_cell_opened")[2]);
+        await click(pivot.el.querySelectorAll("tbody .o_pivot_header_cell_opened")[1]);
 
         assert.containsN(pivot, "tbody tr", 6, "should have 6 rows now");
 
@@ -1801,9 +1801,9 @@ QUnit.module("Views", (hooks) => {
             "should have 7 rows (total + 3 for December and 2 for October and April)"
         );
 
-        // collapse the last two rows
-        await click(pivot.el.querySelectorAll("tbody .o_pivot_header_cell_opened")[3]);
+        // collapse the first two rows
         await click(pivot.el.querySelectorAll("tbody .o_pivot_header_cell_opened")[2]);
+        await click(pivot.el.querySelectorAll("tbody .o_pivot_header_cell_opened")[1]);
 
         assert.containsN(pivot, "tbody tr", 6, "should have 6 rows now");
 
@@ -2149,7 +2149,7 @@ QUnit.module("Views", (hooks) => {
 
         assert.strictEqual(
             target.querySelector("tbody .o_pivot_header_cell_closed").textContent,
-            "December 2016"
+            "April 2016"
         );
 
         // Apply BAR groupbys
@@ -2157,14 +2157,14 @@ QUnit.module("Views", (hooks) => {
         await toggleMenuItem(target, "Bar");
         assert.strictEqual(
             target.querySelector("tbody .o_pivot_header_cell_closed").textContent,
-            "Yes"
+            "No"
         );
 
         // remove groupBy
         await toggleMenuItem(target, "Bar");
         assert.strictEqual(
             target.querySelector("tbody .o_pivot_header_cell_closed").textContent,
-            "December 2016"
+            "April 2016"
         );
 
         // remove all facets
@@ -2172,7 +2172,7 @@ QUnit.module("Views", (hooks) => {
 
         assert.strictEqual(
             target.querySelector("tbody .o_pivot_header_cell_closed").textContent,
-            "December 2016"
+            "April 2016"
         );
     });
 
@@ -2268,7 +2268,7 @@ QUnit.module("Views", (hooks) => {
 
             assert.strictEqual(
                 target.querySelector("thead .o_pivot_header_cell_closed").textContent,
-                "December 2016"
+                "April 2016"
             );
 
             // activate the unique existing favorite
@@ -2282,7 +2282,7 @@ QUnit.module("Views", (hooks) => {
 
             assert.strictEqual(
                 target.querySelector("thead .o_pivot_header_cell_closed").textContent,
-                "Yes"
+                "No"
             );
 
             // desactivate the unique existing favorite
@@ -2295,7 +2295,7 @@ QUnit.module("Views", (hooks) => {
 
             assert.strictEqual(
                 target.querySelector("thead .o_pivot_header_cell_closed").textContent,
-                "Yes"
+                "No"
             );
 
             // Let's get rid of the rows and columns groupBy
@@ -2323,7 +2323,7 @@ QUnit.module("Views", (hooks) => {
 
             assert.strictEqual(
                 target.querySelector("thead .o_pivot_header_cell_closed").textContent,
-                "Yes"
+                "No"
             );
         }
     );
@@ -2570,14 +2570,14 @@ QUnit.module("Views", (hooks) => {
         await click(pivot.el.querySelectorAll("thead .o_pivot_header_cell_closed")[1]);
         await click(pivot.el.querySelectorAll("thead .dropdown-menu .dropdown-item")[1]);
 
-        values = ["29", "1", "2", "32", "12", "12", "17", "1", "2", "20"];
+        values = ["29", "2", "1", "32", "12", "12", "17", "2", "1", "20"];
         assert.strictEqual(getCurrentValues(pivot.el), values.join(","));
 
         // expand a row group
         await click(pivot.el.querySelectorAll("tbody .o_pivot_header_cell_closed")[1]);
         await click(pivot.el.querySelectorAll("tbody .dropdown-menu .dropdown-item")[3]);
 
-        values = ["29", "1", "2", "32", "12", "12", "17", "1", "2", "20", "17", "1", "2", "20"];
+        values = ["29", "2", "1", "32", "12", "12", "17", "2", "1", "20", "17", "2", "1", "20"];
         assert.strictEqual(getCurrentValues(pivot.el), values.join(","));
 
         // reload (should keep folded groups folded as col/row groupbys didn't change)
@@ -2593,20 +2593,20 @@ QUnit.module("Views", (hooks) => {
         values = [
             "12",
             "17",
-            "1",
             "2",
+            "1",
             "32",
             "12",
             "12",
             "12",
             "12",
             "17",
-            "1",
             "2",
+            "1",
             "20",
             "17",
-            "1",
             "2",
+            "1",
             "20",
         ];
         assert.strictEqual(getCurrentValues(pivot.el), values.join(","));
@@ -3177,7 +3177,7 @@ QUnit.module("Views", (hooks) => {
 
         assert.strictEqual(
             pivot.el.querySelector("table tbody tr").innerText.replace(/\s/g, ""),
-            "Total2112",
+            "Total1122",
             "should display product_id count as measure"
         );
     });
@@ -3203,7 +3203,7 @@ QUnit.module("Views", (hooks) => {
 
         assert.strictEqual(
             [...pivot.el.querySelectorAll(".o_pivot_cell_value")].map((c) => c.innerText).join(""),
-            "2211",
+            "2112",
             "should have loaded the proper data"
         );
     });
@@ -3836,16 +3836,16 @@ QUnit.module("Views", (hooks) => {
                 "19",
                 "13",
                 "-31.58%",
-                "17",
-                "0",
-                "-100%",
-                "17",
-                "0",
-                "-100%",
                 "2",
                 "0",
                 "-100%",
                 "2",
+                "0",
+                "-100%",
+                "17",
+                "0",
+                "-100%",
+                "17",
                 "0",
                 "-100%",
                 "0",
@@ -3992,16 +3992,16 @@ QUnit.module("Views", (hooks) => {
                 "19",
                 "13",
                 "-31.58%",
-                "17",
-                "0",
-                "-100%",
-                "17",
-                "0",
-                "-100%",
                 "2",
                 "0",
                 "-100%",
                 "2",
+                "0",
+                "-100%",
+                "17",
+                "0",
+                "-100%",
+                "17",
                 "0",
                 "-100%",
                 "0",
@@ -4031,16 +4031,16 @@ QUnit.module("Views", (hooks) => {
                 "19",
                 "13",
                 "-31.58%",
-                "17",
-                "0",
-                "-100%",
-                "17",
-                "0",
-                "-100%",
                 "2",
                 "0",
                 "-100%",
                 "2",
+                "0",
+                "-100%",
+                "17",
+                "0",
+                "-100%",
+                "17",
                 "0",
                 "-100%",
                 "0",
@@ -4212,16 +4212,16 @@ QUnit.module("Views", (hooks) => {
                 "19",
                 "13",
                 "-31.58%",
-                "17",
-                "0",
-                "-100%",
-                "17",
-                "0",
-                "-100%",
                 "2",
                 "0",
                 "-100%",
                 "2",
+                "0",
+                "-100%",
+                "17",
+                "0",
+                "-100%",
+                "17",
                 "0",
                 "-100%",
                 "0",
@@ -4243,10 +4243,10 @@ QUnit.module("Views", (hooks) => {
             await click(pivot.el.querySelector(".o_pivot_flip_button"));
 
             values = [
-                "17",
+                "2",
                 "0",
                 "-100%",
-                "2",
+                "17",
                 "0",
                 "-100%",
                 "0",
@@ -4314,7 +4314,7 @@ QUnit.module("Views", (hooks) => {
         );
         assert.deepEqual(
             [...pivot.el.querySelectorAll("tbody th")].map((th) => th.innerText),
-            ["Total", "2016-12-15", "2016-12-17", "2016-11-22", "2016-11-03"],
+            ["Total", "2016-11-03", "2016-11-22", "2016-12-15", "2016-12-17"],
             "The row headers should be as expected"
         );
 
@@ -4327,10 +4327,10 @@ QUnit.module("Views", (hooks) => {
                 "",
                 "Total",
                 "",
+                "2016-11-03",
+                "2016-11-22",
                 "2016-12-15",
                 "2016-12-17",
-                "2016-11-22",
-                "2016-11-03",
                 "Foo",
                 "Foo",
                 "Foo",
@@ -4360,8 +4360,8 @@ QUnit.module("Views", (hooks) => {
                 "",
                 "Total",
                 "",
-                "2016-11-22",
                 "2016-11-03",
+                "2016-11-22",
                 "2016-12-15",
                 "2016-12-17",
                 "Foo",
@@ -4460,7 +4460,7 @@ QUnit.module("Views", (hooks) => {
             );
             assert.deepEqual(
                 [...pivot.el.querySelectorAll("tbody th")].map((th) => th.innerText),
-                ["Total", "Dog", "false", "None", "None"],
+                ["Total", "Dog", "None", "false", "None"],
                 "The row headers should be as expected"
             );
         }
@@ -4537,7 +4537,7 @@ QUnit.module("Views", (hooks) => {
             );
             assert.deepEqual(
                 [...pivot.el.querySelectorAll("tbody th")].map((th) => th.innerText),
-                ["Total", "Company", "Yes", "individual", "Yes", "No"],
+                ["Total", "Company", "Yes", "individual", "No", "Yes"],
                 "The row headers should be as expected"
             );
         }
@@ -5010,7 +5010,7 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        const values = ["29", "1", "2", "32", "12", "12", "17", "1", "2", "20"];
+        const values = ["2", "1", "29", "32", "12", "12", "2", "1", "17", "20"];
         assert.strictEqual(getCurrentValues(pivot.el), values.join(","));
 
         // Set a domain (this reload is delayed)
@@ -5026,7 +5026,7 @@ QUnit.module("Views", (hooks) => {
         def.resolve();
         await nextTick();
 
-        assert.strictEqual(getCurrentValues(pivot.el), ["20", "1", "17", "2"].join(","));
+        assert.strictEqual(getCurrentValues(pivot.el), ["20", "2", "1", "17"].join(","));
     });
 
     QUnit.test("sort rows while loading a filter", async function (assert) {


### PR DESCRIPTION
This PR orders the records coming from the mock server the same
way they are ordered by the ORM, while also allowing it to support
multiple levels of orderby.

This has been done to increase consistency in the test suite and provide
a more accurate representation of how records would be returned by the
actual server.

Some tests performed their assertions based on this previous
undeterministic system and have been adapted, either by altering
the base setup or the assertions themselves.

Enterprise: https://github.com/odoo/enterprise/pull/24509