### PR TITLE
[FIX]project: traceback on project update notif

### DIFF
--- a/addons/project/static/src/js/right_panel/project_right_panel.js
+++ b/addons/project/static/src/js/right_panel/project_right_panel.js
@@ -35,6 +35,9 @@ export default class ProjectRightPanel extends owl.Component {
     }
 
     async _loadQwebContext() {
+        if (!this.project_id){ // If this is called from notif, multiples updates but no specific project
+            return {};
+        }
         const data = await this.rpc({
             model: 'project.project',
             method: 'get_panel_data',

--- a/addons/project/static/src/xml/project_templates.xml
+++ b/addons/project/static/src/xml/project_templates.xml
@@ -27,10 +27,12 @@
     </div>
 
     <t t-name="project.ProjectRightPanel" owl="1">
-        <div class="o_rightpanel">
+        <div t-if="project_id" class="o_rightpanel">
             <t t-call="project.StatButtonsSection"/>
             <t t-call="project.MilestoneSection"/>
         </div>
+        <!-- If this is called from notif, multiples updates but no specific project -->
+        <div t-else=""/>
     </t>
 
     <t t-name="project.StatButtonsSection" owl="1">


### PR DESCRIPTION
Step to reproduce:
- Schedule activity on a project update
- Access the activity

Current Behaviour:
- On Project.update, we try to compute the info related to the project_update's project
due to the project update view showing information about the project.
In case of notification, we can show multiple project and thus no project_id can be
provided.
- Traceback

Behaviour after the PR:
- If there is no set project_id when opening the project update kanban view
We do not show the RightPanel related to the project and do not compute

related PR in enterprise odoo/enterprise#24427

opw-2755473

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
