### PR TITLE
[FIX] hr_expense: Fix traceback caused by an empty currency_id

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -127,8 +127,9 @@ class HrExpense(models.Model):
     def _compute_currency_rate(self):
         date_today = fields.Date.context_today(self.env.user)
         for expense in self:
+            target_currency = expense.currency_id or self.env.company.currency_id
             expense.currency_rate = self.env['res.currency']._get_conversion_rate(
-                from_currency=expense.currency_id,
+                from_currency=target_currency,
                 to_currency=expense.company_currency_id,
                 company=expense.company_id,
                 date=expense.date or date_today,


### PR DESCRIPTION
When we are setting currency_id, if we delete it altogether,
we get a traceback.

Task - 2704297
