### PR TITLE
[FIX] hr_expense, hr_timesheet, l10n_sa_invoice: Adapting barcode API callers to the new API

### DIFF
--- a/addons/hr_expense/static/src/js/expense_qr_code_action.js
+++ b/addons/hr_expense/static/src/js/expense_qr_code_action.js
@@ -11,7 +11,7 @@ const QRModalAction = AbstractAction.extend({
 
     init: function(parent, action){
         this._super.apply(this, arguments);
-        this.url = _.str.sprintf("/report/barcode/?type=QR&value=%s&width=256&height=256&humanreadable=1", action.params.url);
+        this.url = _.str.sprintf("/report/barcode/?barcode_type=QR&value=%s&width=256&height=256&humanreadable=1", action.params.url);
     },
 });
 

--- a/addons/hr_timesheet/static/src/js/qr_code_action.js
+++ b/addons/hr_timesheet/static/src/js/qr_code_action.js
@@ -11,7 +11,7 @@ const QRModalAction = AbstractAction.extend({
 
     init: function(parent, action){
         this._super.apply(this, arguments);
-        this.url = _.str.sprintf("/report/barcode/?type=QR&value=%s&width=256&height=256&humanreadable=1", action.params.url);
+        this.url = _.str.sprintf("/report/barcode/?barcode_type=QR&value=%s&width=256&height=256&humanreadable=1", action.params.url);
     },
 });
 

--- a/addons/hr_timesheet/static/src/js/timesheet_config_form_view.js
+++ b/addons/hr_timesheet/static/src/js/timesheet_config_form_view.js
@@ -15,7 +15,7 @@ odoo.define('hr_timesheet.res.config.form', function (require) {
          * @override
          */
         init: function (parent, url) {
-            this.url = _.str.sprintf("/report/barcode/?type=QR&value=%s&width=256&height=256&humanreadable=1", url);
+            this.url = _.str.sprintf("/report/barcode/?barcode_type=QR&value=%s&width=256&height=256&humanreadable=1", url);
             this._super(parent, {
                 title: _t('Download our App'),
                 buttons: [{

--- a/addons/l10n_sa_invoice/views/report_invoice.xml
+++ b/addons/l10n_sa_invoice/views/report_invoice.xml
@@ -24,7 +24,7 @@
         <xpath expr="//div[@name='qr_code']" position="inside">
             <img t-if="o.l10n_sa_qr_code_str"
                  style="display:block;margin:10% auto 0 auto;"
-                 t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', o.l10n_sa_qr_code_str, 150, 150)"/>
+                 t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', o.l10n_sa_qr_code_str, 150, 150)"/>
         </xpath>
     </template>
 


### PR DESCRIPTION
The change in the `barcode` API has broken many callers.
This PR and the enterprise one will change 'type' -> 'barcode_type'

See: https://github.com/odoo/odoo/commit/ee324e8374536cebca4d7302210b07e8f33d3852#diff-8f0bbb50491623995fba965c3d64585c6cbfdbbe519ec95473e472826d253826R1977-R1979

Enterprise PR: https://github.com/odoo/enterprise/pull/24430