### PR TITLE
[IMP] hr_holidays: open corresponding record on Time Off Analysis

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report.py
+++ b/addons/hr_holidays/report/hr_leave_report.py
@@ -112,3 +112,13 @@ class LeaveReport(models.Model):
                 'search_default_active_employee': True,
             }
         }
+
+    def action_open_record(self):
+        self.ensure_one()
+
+        return {
+            'type': 'ir.actions.act_window',
+            'view_mode': 'form',
+            'res_id': self.leave_id.id if self.leave_id else self.allocation_id.id,
+            'res_model': 'hr.leave' if self.leave_id else 'hr.leave.allocation',
+        }

--- a/addons/hr_holidays/report/hr_leave_reports.xml
+++ b/addons/hr_holidays/report/hr_leave_reports.xml
@@ -40,6 +40,7 @@
         <field name="model">hr.leave.report</field>
         <field name="arch" type="xml">
             <tree create="0" edit="0" delete="0">
+                <button name="action_open_record" type="object" icon="fa-external-link" title="Open" />
                 <field name="employee_id" decoration-muted="not active_employee"/>
                 <field name="number_of_days" string="Number of Days" sum="Remaining Days"/>
                 <field name="leave_type"/>
@@ -106,7 +107,7 @@
         <field name="model_id" ref="hr_holidays.model_hr_leave_report"/>
         <field name="binding_model_id" ref="hr.model_hr_employee"/>
         <field name="state">code</field>
-        <field name="groups_id" eval="[(4, ref('base.group_user'))]"/>
+        <field name="groups_id" eval="[(4, ref('hr_holidays.group_hr_holidays_user'))]"/>
         <field name="code">
         action = model.action_time_off_analysis()
         </field>


### PR DESCRIPTION
Add a button to directly open the leave/allocation in the Time Off
Analysis view.

TaskID: 2762014

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
