### PR TITLE
[FIX] Unreserve script: prevent crash if only one stock_move_line

### DIFF
--- a/addons/stock/data/stock_data.xml
+++ b/addons/stock/data/stock_data.xml
@@ -104,11 +104,10 @@ for move_line in move_lines:
         move_lines_to_unreserve.append(move_line.id)
         move_line_to_recompute_ids.append(move_line.id)
 
-if len(move_lines_to_unreserve) &gt; 0:
-    env.cr.execute("""
-            UPDATE stock_move_line SET product_uom_qty = 0, product_qty = 0 WHERE id in %s ;
-        """
-                   % (tuple(move_lines_to_unreserve), ))
+if len(move_lines_to_unreserve) > 1:
+    env.cr.execute(""" UPDATE stock_move_line SET product_uom_qty = 0, product_qty = 0 WHERE id in %s ;""" % (tuple(move_lines_to_unreserve), ))
+elif len(move_lines_to_unreserve) == 1:
+    env.cr.execute(""" UPDATE stock_move_line SET product_uom_qty = 0, product_qty = 0 WHERE id = %s ;""" % (move_lines_to_unreserve[0]))
 
 if logging:
     env['ir.logging'].sudo().create({


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- If there is only one stock_move_line returned after the search, the script will crash

Current behavior before PR:

- Crash with error like: 
ValueError: <class 'psycopg2.ProgrammingError'>: "syntax error at or near ")"
LINE 2: ...product_uom_qty = 0, product_qty = 0 WHERE id in (121903,) ;

Desired behavior after PR is merged:

- Run the fix without error


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
