### PR TITLE
[FIX] web_editor, website, web_tour: not show link tools when link contains a media

### DIFF
--- a/addons/test_website/static/tests/tours/image_link.js
+++ b/addons/test_website/static/tests/tours/image_link.js
@@ -1,0 +1,84 @@
+/** @odoo-module **/
+
+import tour from 'web_tour.tour';
+
+/**
+ * The purpose of this tour is to check the link on image flow.
+ */
+
+tour.register('test_image_link', {
+    url: '/',
+    test: true
+}, [
+    {
+        content: "enter edit mode",
+        trigger: "a[data-action=edit]"
+    }, {
+        content: "drop Text-Image snippet",
+        trigger: "#oe_snippets .oe_snippet[name='Text - Image'] .oe_snippet_thumbnail:not(.o_we_already_dragging)",
+        extra_trigger: "body.editor_enable.editor_has_snippets",
+        moveTrigger: ".oe_drop_zone",
+        run: "drag_and_drop #wrap",
+    }, {
+        content: "select image",
+        trigger: "#wrapwrap .s_text_image img",
+    }, {
+        content: "enable link",
+        trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-customizeblock-option:has(we-title:contains(Media)) we-button.fa-link",
+    }, {
+        content: "enter site URL",
+        trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-input:contains(Your URL) input",
+        run: "text odoo.com",
+    }, {
+        content: "select image",
+        trigger: "#wrapwrap .s_text_image img",
+    }, {
+        content: "check popover content has site URL",
+        trigger: ".o_edit_menu_popover a.o_we_url_link[href='http://odoo.com/']:contains(http://odoo.com/)",
+        run: () => {}, // check
+    }, {
+        content: "remove URL",
+        trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-input:contains(Your URL) input",
+        run: "remove_text",
+    }, {
+        content: "select image",
+        trigger: "#wrapwrap .s_text_image img",
+    }, {
+        content: "check popover content has no URL",
+        trigger: ".o_edit_menu_popover a.o_we_url_link:not([href]):contains(No URL specified)",
+        run: () => {}, // check
+    }, {
+        content: "enter email URL",
+        trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-input:contains(Your URL) input",
+        run: "text mailto:test@test.com",
+    }, {
+        content: "select image",
+        trigger: "#wrapwrap .s_text_image img",
+    }, {
+        content: "check popover content has mail URL",
+        trigger: ".o_edit_menu_popover:has(.fa-envelope-o) a.o_we_url_link[href='mailto:test@test.com']:contains(mailto:test@test.com)",
+        run: () => {}, // check
+    }, {
+        content: "enter phone URL",
+        trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-input:contains(Your URL) input",
+        run: "text tel:555-2368",
+    }, {
+        content: "select image",
+        trigger: "#wrapwrap .s_text_image img",
+    }, {
+        content: "check popover content has phone URL",
+        trigger: ".o_edit_menu_popover:has(.fa-phone) a.o_we_url_link[href='tel:555-2368']:contains(tel:555-2368)",
+        run: () => {}, // check
+    }, {
+        content: "remove URL",
+        trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-input:contains(Your URL) input",
+        run: "remove_text",
+    }, {
+        content: "select image",
+        trigger: "#wrapwrap .s_text_image img",
+    }, {
+        content: "check popover content has no URL",
+        trigger: ".o_edit_menu_popover a.o_we_url_link:not([href]):contains(No URL specified)",
+        run: () => {}, // check
+    },
+]);

--- a/addons/test_website/tests/test_media.py
+++ b/addons/test_website/tests/test_media.py
@@ -18,3 +18,6 @@ class TestMedia(odoo.tests.HttpCase):
             'datas': GIF,
         })
         self.start_tour("/", 'test_replace_media', login="admin")
+
+    def test_02_image_link(self):
+        self.start_tour("/", 'test_image_link', login="admin")

--- a/addons/web_editor/i18n/web_editor.pot
+++ b/addons/web_editor/i18n/web_editor.pot
@@ -1616,6 +1616,13 @@ msgstr ""
 
 #. module: web_editor
 #. openerp-web
+#: code:addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js:0
+#, python-format
+msgid "No URL specified"
+msgstr ""
+
+#. module: web_editor
+#. openerp-web
 #: code:addons/web_editor/static/src/xml/wysiwyg.xml:0
 #, python-format
 msgid "No documents found."

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4725,6 +4725,7 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
      */
     onFocus() {
         core.bus.on('activate_image_link_tool', this, this._activateLinkTool);
+        core.bus.on('deactivate_image_link_tool', this, this._deactivateLinkTool);
         // When we start editing an image, rerender the UI to ensure the
         // we-select that suggests the anchors is in a consistent state.
         this.rerender = true;
@@ -4734,6 +4735,7 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
      */
     onBlur() {
         core.bus.off('activate_image_link_tool', this, this._activateLinkTool);
+        core.bus.off('deactivate_image_link_tool', this, this._deactivateLinkTool);
     },
 
     //--------------------------------------------------------------------------
@@ -4801,6 +4803,7 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
         }
         linkEl.setAttribute('href', url);
         this.rerender = true;
+        this.$target.trigger('href_changed');
     },
     /**
      * @override
@@ -4825,6 +4828,15 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
         if (this.$target[0].parentElement.tagName === 'A') {
             this._requestUserValueWidgets('media_url_opt')[0].focus();
         } else {
+            this._requestUserValueWidgets('media_link_opt')[0].enable();
+        }
+    },
+    /**
+     * @private
+     */
+    _deactivateLinkTool() {
+        const parentEl = this.$target[0].parentNode;
+        if (parentEl.tagName === 'A') {
             this._requestUserValueWidgets('media_link_opt')[0].enable();
         }
     },

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4793,6 +4793,7 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
         if (!url) {
             // As long as there is no URL, the image is not considered a link.
             linkEl.removeAttribute('href');
+            this.$target.trigger('href_changed');
             return;
         }
         if (!url.startsWith('/') && !url.startsWith('#')

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -105,6 +105,12 @@ const LinkPopoverWidget = Widget.extend({
                 this.$target.popover('show');
             }
         });
+        this.$target.on('href_changed.link_popover', (e) => {
+            // Do not change shown/hidden state.
+            if (popoverShown) {
+                this._loadAsyncLinkPreview();
+            }
+        });
         const onClickDocument = (e) => {
             if (popoverShown) {
                 const hierarchy = [e.target, ...ancestors(e.target)];
@@ -254,7 +260,7 @@ const LinkPopoverWidget = Widget.extend({
      */
     _onRemoveLinkClick(ev) {
         ev.preventDefault();
-        this.options.wysiwyg.odooEditor.execCommand('unlink');
+        this.options.wysiwyg.removeLink();
         ev.stopImmediatePropagation();
     },
 });

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -166,6 +166,11 @@ const LinkPopoverWidget = Widget.extend({
      */
     async _loadAsyncLinkPreview() {
         let url;
+        if (this.target.href === '') {
+            this._resetPreview('');
+            this.$previewFaviconFa.removeClass('fa-globe').addClass('fa-question-circle-o');
+            return;
+        }
         try {
             url = new URL(this.target.href); // relative to absolute
         } catch (e) {
@@ -227,8 +232,8 @@ const LinkPopoverWidget = Widget.extend({
      */
     _resetPreview(url) {
         this.$previewFaviconImg.addClass('d-none');
-        this.$previewFaviconFa.removeClass('d-none').addClass('fa-globe');
-        this.$urlLink.text(url).attr('href', url);
+        this.$previewFaviconFa.removeClass('d-none fa-question-circle-o fa-envelope-o fa-phone').addClass('fa-globe');
+        this.$urlLink.text(url || _t('No URL specified')).attr('href', url || null);
         this.$fullUrl.text(url).addClass('d-none').removeClass('o_we_webkit_box');
     },
 

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1091,6 +1091,16 @@ const Wysiwyg = Widget.extend({
             return;
         }
         if (this.snippetsMenu && !options.forceDialog) {
+            if (options.link && options.link.querySelector(mediaSelector) &&
+                    !options.link.textContent.trim() && wysiwygUtils.isImg(this.lastElement)) {
+                // If the link contains a media without text, the link is
+                // editable in the media options instead.
+                this.snippetsMenu._mutex.exec(() => {
+                    // Wait for the editor panel to be fully updated.
+                    core.bus.trigger('activate_image_link_tool');
+                });
+                return;
+            }
             if (options.forceOpen || !this.linkTools) {
                 const $btn = this.toolbar.$el.find('#create-link');
                 if (!this.linkTools || ![options.link, ...wysiwygUtils.ancestors(options.link)].includes(this.linkTools.$link[0])) {
@@ -1171,6 +1181,19 @@ const Wysiwyg = Widget.extend({
                     restoreSelection();
                 }
             });
+        }
+    },
+    /**
+     * Removes the current Link.
+     */
+    removeLink() {
+        if (this.snippetsMenu && wysiwygUtils.isImg(this.lastElement)) {
+            this.snippetsMenu._mutex.exec(() => {
+                // Wait for the editor panel to be fully updated.
+                core.bus.trigger('deactivate_image_link_tool');
+            });
+        } else {
+            this.odooEditor.execCommand('unlink');
         }
     },
     /**

--- a/addons/web_tour/static/src/js/running_tour_action_helper.js
+++ b/addons/web_tour/static/src/js/running_tour_action_helper.js
@@ -28,6 +28,9 @@ var RunningTourActionHelper = core.Class.extend({
     text: function (text, element) {
         this._text(this._get_action_values(element), text);
     },
+    remove_text(text, element) {
+        this._text(this._get_action_values(element), '\n');
+    },
     text_blur: function (text, element) {
         this._text_blur(this._get_action_values(element), text);
     },

--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -77,5 +77,44 @@ tour.register('link_tools', {
         content: "The link should have the secondary button style.",
         trigger: '.s_text_image a.btn.btn-secondary[href="http://odoo.be"]:contains("odoo website")',
         run: () => {}, // It's a check.
-    }
+    },
+    // 4. Add link on image.
+    wTourUtils.clickOnEdit(),
+    {
+        content: "Click on image.",
+        trigger: '.s_text_image img',
+        extra_trigger: '#oe_snippets.o_loaded',
+    },
+    {
+        content: "Activate link.",
+        trigger: '.o_we_customize_panel we-row:contains("Media") we-button.fa-link',
+    },
+    {
+        content: "Set URL.",
+        trigger: '.o_we_customize_panel we-input:contains("Your URL") input',
+        run: 'text odoo.com',
+    },
+    {
+        content: "Deselect image.",
+        trigger: '.s_text_image p',
+    },
+    {
+        content: "Re-select image.",
+        trigger: '.s_text_image img',
+    },
+    {
+        content: "Check that link tools appear.",
+        trigger: '.popover div a:contains("http://odoo.com")',
+        run: () => {}, // It's a check.
+    },
+    // 5. Remove link from image.
+    {
+        content: "Remove link.",
+        trigger: '.popover:contains("http://odoo.com") a .fa-chain-broken',
+    },
+    {
+        content: "Check that image is not within a link anymore.",
+        trigger: '.s_text_image div > img',
+        run: () => {}, // It's a check.
+    },
 ]);


### PR DESCRIPTION
Since [1] the link tools got created when the destroyed sub-elements of the
link were clicked on. This causes a problem when the element is a media
because upon detroy the tools reset the link to an incorrect state.

After this commit the link tools is not touched anymore if the element
that was clicked on is a media.
Also, it reflects the changes done in the popup into the media link
options, and the ones done in the option into the popup.

Steps to reproduce:
- Add an image-text snippet in the page
- Click on the image
- Set up a link
- DO NOT click on the image again
- Click on the left of the image (to click on the snippet itself)
- Click on the image again
=> The image was removed instead and a text link remained

This PR also fixes the fact that when emptying the URL the previously shown URL remained displayed in the popover.

[1]: https://github.com/odoo/odoo/commit/d69d26a2dd8830aca8c5922d3548e5ff59c688fc

task-2765857

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
