### PR TITLE
[FIX] mrp: allow adding byproducts to confirmed MO

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -711,8 +711,6 @@ class MrpProduction(models.Model):
     @api.constrains('move_byproduct_ids')
     def _check_byproducts(self):
         for order in self:
-            if any(float_compare(move.product_qty, 0.0, precision_rounding=move.product_uom.rounding or move.product_id.uom_id.rounding) <= 0 for move in order.move_byproduct_ids):
-                raise ValidationError(_("The quantity produced of by-products must be positive."))
             if any(move.cost_share < 0 for move in order.move_byproduct_ids):
                 raise ValidationError(_("By-products cost shares must be positive."))
             if sum(order.move_byproduct_ids.mapped('cost_share')) > 100:

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -409,11 +409,6 @@ class StockMove(models.Model):
     def _prepare_merge_negative_moves_excluded_distinct_fields(self):
         return super()._prepare_merge_negative_moves_excluded_distinct_fields() + ['created_production_id']
 
-    def _merge_moves_fields(self):
-        res = super()._merge_moves_fields()
-        res['cost_share'] = sum(self.mapped('cost_share'))
-        return res
-
     def _compute_kit_quantities(self, product_id, kit_qty, kit_bom, filters):
         """ Computes the quantity delivered or received when a kit is sold or purchased.
         A ratio 'qty_processed/qty_needed' is computed for each component, and the lowest one is kept

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -373,7 +373,7 @@
                                     <field name="move_lines_count" invisible="1"/>
                                     <field name="location_dest_id" domain="[('id', 'child_of', parent.location_dest_id)]" invisible="1"/>
                                     <field name="state" invisible="1" force_save="1"/>
-                                    <field name="product_uom_qty" string="To Produce" attrs="{'readonly': ['&amp;', ('parent.state', '!=', 'draft'), '|', '&amp;', ('parent.state', 'not in', ('confirmed', 'progress', 'to_close')), ('parent.is_planned', '!=', True), ('parent.is_locked', '=', True)]}"/>
+                                    <field name="product_uom_qty" string="To Produce" force_save="1" attrs="{'readonly': ['&amp;', ('parent.state', '!=', 'draft'), '|', '&amp;', ('parent.state', 'not in', ('confirmed', 'progress', 'to_close')), ('parent.is_planned', '!=', True), ('parent.is_locked', '=', True)]}"/>
                                     <field name="is_quantity_done_editable" invisible="1"/>
                                     <field name="quantity_done" string="Produced" attrs="{'column_invisible': [('parent.state', '=', 'draft')], 'readonly': [('is_quantity_done_editable', '=', False)]}"/>
                                     <field name="product_uom" groups="uom.group_uom"/>


### PR DESCRIPTION
Steps to reproduce:
- Create + confirm a MO
- Add a byproduct with a Produced (qty) > 1
- Change the `qty_producing` to a non-zero qty

Expected result:
  Byproduct's "Produced" qty stays unchanged and its "To Produce" is 0
Actual result:
  Byproduct's "To Produce" defaults to 1 and its "Produced" qty is
  updated to scale to the according to the amount `qty_producing` (i.e.
  if `product_qty` = 2 and `qty_producing` = 1, then by-product's
  "Produced" = .5

Additionally, a Missing Record error pops up because of missing
stock.move.line

Solution, don't allow byproducts added after MO is confirmed to default
to 0. Additionally allow byproducts to have 0 "To Produce" quantity and
don't sum the cost share of merged byproduct moves since when Produced
> To Produce then an extra move is created and the cost share ends up
being doubled during the merge.

Task: 2716164

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
