### PR TITLE
[FIX] sale: prevent invoice loop with unaligned precisions

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -4,7 +4,6 @@
 from datetime import datetime, timedelta
 from itertools import groupby
 import json
-import math
 
 from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.exceptions import AccessError, UserError, ValidationError
@@ -691,10 +690,9 @@ class SaleOrder(models.Model):
         down_payment_line_ids = []
         invoiceable_line_ids = []
         pending_section = None
-        global_precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
+        precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
 
         for line in self.order_line:
-            precision = min(math.ceil(abs(math.log10(line.product_uom.rounding or 1))), global_precision)
             if line.display_type == 'line_section':
                 # Only invoice the section if one of its lines is invoiceable
                 pending_section = line

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -4,6 +4,7 @@
 from datetime import datetime, timedelta
 from itertools import groupby
 import json
+import math
 
 from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.exceptions import AccessError, UserError, ValidationError
@@ -690,9 +691,10 @@ class SaleOrder(models.Model):
         down_payment_line_ids = []
         invoiceable_line_ids = []
         pending_section = None
-        precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
+        global_precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
 
         for line in self.order_line:
+            precision = min(math.ceil(abs(math.log10(line.product_uom.rounding or 1))), global_precision)
             if line.display_type == 'line_section':
                 # Only invoice the section if one of its lines is invoiceable
                 pending_section = line

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import timedelta
+import math
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
@@ -31,8 +32,9 @@ class SaleOrderLine(models.Model):
           is removed from the list.
         - invoiced: the quantity invoiced is larger or equal to the quantity ordered.
         """
-        precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
+        global_precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
         for line in self:
+            precision = min(math.ceil(abs(math.log10(line.product_uom.rounding or 1))), global_precision)
             if line.state not in ('sale', 'done'):
                 line.invoice_status = 'no'
             elif line.is_downpayment and line.untaxed_amount_to_invoice == 0:

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -389,6 +389,14 @@ class TestSaleToInvoice(TestSaleCommon):
         sol_prod_deliver.env.add_to_compute(qty_invoiced_field, sol_prod_deliver)
         self.assertEqual(sol_prod_deliver.qty_invoiced, expected_qty)
 
+        # Now record a quantity with a higher precision
+        sol_prod_deliver.product_uom_qty = 5.47
+        sol_prod_deliver.qty_delivered = 5.47
+        # Without proper rounding, we would get in an invoice/refund loop
+        self.assertEqual(sol_prod_deliver.invoice_status, 'to invoice')
+        invoicing_wizard.create_invoices()
+        self.assertEqual(sol_prod_deliver.invoice_status, 'invoiced')
+
     def test_invoice_analytic_account_default(self):
         """ Tests whether, when an analytic account rule is set and the so has no analytic account,
         the default analytic acount is correctly computed in the invoice.


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
=======================================
Having a Product Unit of Measure precision higher than the actual product uom precision of the sale order line can cause an invoicing/refund loop. This change ensures that the base amount for the invoicing is rounded in the same way that invoiced amounts are rounded.

Current behavior before PR:
======================
The order remains invoiceable, allowing the user (or an automated invoicing job) to create new invoices and refunds for the difference between the rounded and the unrounded quantity.

Desired behavior after PR is merged:
============================
The order line goes into state 'invoiced' once the line is invoiced for the full quantity.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
