### PR TITLE
[FIX] web: many2many tag always shows delete icon

### DIFF
--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -1075,11 +1075,11 @@
             </t>
             <t t-if="hasDropdown">
                 <a role="button" href="#" class="dropdown-toggle o-no-caret" data-toggle="dropdown" aria-expanded="false">
-                    <span t-out="_badge_text"/>
+                    <t t-out="_badge_text"/>
                 </a>
             </t>
             <t t-else="">
-                <span t-out="_badge_text"/>
+                <t t-out="_badge_text"/>
             </t>
             <a t-if="!readonly" href="#" class="fa fa-times o_delete" title="Delete" aria-label="Delete"/>
         </div>


### PR DESCRIPTION
The delete icon of many2many tags disappears when the text is too long
for the column

Steps to reproduce:
1. Install Invoicing
2. Open Invoicing and create a new invoice
3. Add any product (a tax should be added for that product) and reduce
the size of the 'Taxes' column until the tag is too long for the column
4. The tag's content overflows and the delete icon is not accessible
anymore

Solution:
Change \<span> element back to \<t>

Problem:
This commit https://github.com/odoo/odoo/commit/0915ac5a0e95ef9511559fded7cf1e149b19ce67
changed the element of `_badge_text` to \<span> which broke the
adaptability of the many2many tags

opw-2755293