### PR TITLE
[FIX] stock: prevent useless SML creation in inventory mode

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -241,10 +241,6 @@ class StockQuant(models.Model):
             if any(field for field in vals.keys() if field not in allowed_fields):
                 raise UserError(_("Quant's editing is restricted, you can't do this operation."))
             self = self.sudo()
-            res = super(StockQuant, self).write(vals)
-            if res and self.env.context.get('inventory_report_mode'):
-                self.action_apply_inventory()
-            return res
         return super(StockQuant, self).write(vals)
 
     def action_view_stock_moves(self):

--- a/addons/stock/tests/test_quant_inventory_mode.py
+++ b/addons/stock/tests/test_quant_inventory_mode.py
@@ -239,6 +239,14 @@ class TestEditableQuant(TransactionCase):
         self.assertEqual(self.product.qty_available, 100)
         quant.with_context(inventory_report_mode=True).inventory_quantity_auto_apply = 75
         self.assertEqual(self.product.qty_available, 75)
+        quant.with_context(inventory_report_mode=True).inventory_quantity_auto_apply = 75
+        self.assertEqual(self.product.qty_available, 75)
+        smls = self.env['stock.move.line'].search([('product_id', '=', self.product.id)])
+        self.assertRecordValues(smls, [
+            {'qty_done': 100},
+            {'qty_done': 25},
+            {'qty_done': 0},
+        ])
 
     def test_sn_warning(self):
         """ Checks that a warning is given when reusing an existing SN


### PR DESCRIPTION
Some useless SMLs are generated when editing the on hand quantity in
inventory mode

To reproduce the issue:
1. Create a storable product P
2. Update its on hand quantity to 100
3. Inventory > Reporting > Inventory Report
4. On the line for P, update to quantity to 75
5. Inventory > Reporting > Product Moves, search for P

Error: There are two SMLs with a quantity equal to zero

When calling `action_apply_inventory`, it leads to `_apply_inventory`.
In this method, if there are not any difference in quantities to apply,
there will still be some new adjustment SMLs.

OPW-2739833