### PR TITLE
[IMP] hr_holidays: improve extendability

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -791,11 +791,10 @@ class HolidaysRequest(models.Model):
     # Business methods
     ####################################################
 
-    def _create_resource_leave(self):
-        """ This method will create entry in resource calendar time off object at the time of holidays validated
-        :returns: created `resource.calendar.leaves`
+    def _prepare_resource_leave_vals_list(self):
+        """Hook method for others to inject data
         """
-        vals_list = [{
+        return [{
             'name': leave.name,
             'date_from': leave.date_from,
             'holiday_id': leave.id,
@@ -803,7 +802,13 @@ class HolidaysRequest(models.Model):
             'resource_id': leave.employee_id.resource_id.id,
             'calendar_id': leave.employee_id.resource_calendar_id.id,
             'time_type': leave.holiday_status_id.time_type,
-        } for leave in self]
+            } for leave in self]
+
+    def _create_resource_leave(self):
+        """ This method will create entry in resource calendar time off object at the time of holidays validated
+        :returns: created `resource.calendar.leaves`
+        """
+        vals_list = self._prepare_resource_leave_vals_list()
         return self.env['resource.calendar.leaves'].sudo().create(vals_list)
 
     def _remove_resource_leave(self):


### PR DESCRIPTION
Split the method `_create_resource_leave()` that does value preparation and record creation at the same time into 2 methods:

- [x] `_prepare_resource_leave_vals_list()` that will prepare list of value for creation later in `_create_resource_leave()`
- [x] `_create_resource_leave()` now calls the `_prepare_resource_leave_vals_list()` instead of having done the job itself

This structure give convenient for others to extend Odoo functionality without harming performance and less attempt




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
