### PR TITLE
[FIX] link_tracker: get redirected page title instead of URL


### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -97,7 +97,7 @@ class LinkTracker(models.Model):
     @api.depends('url')
     def _get_title_from_url(self, url):
         try:
-            head = requests.head(url, timeout=5)
+            head = requests.head(url, allow_redirects=True, timeout=5)
             if (
                     int(head.headers.get('Content-Length', 0)) > URL_MAX_SIZE
                     or


### PR DESCRIPTION

In 2e3075693b06d71222b446bd8a805dacb639d0e4 we used a head request to
determine type of page before trying to get a title out of it.

But requests.head does not allow redirect by default:

https://docs.python-requests.org/en/v2.9.1/user/quickstart/#redirection-and-history

so if an URL was a redirect, we would not longer get the page title.

opw-2457640
