### PR TITLE
Fix partner grade and partner activation seqence

### DIFF
--- a/addons/website_crm_partner_assign/data/res_partner_activation_data.xml
+++ b/addons/website_crm_partner_assign/data/res_partner_activation_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="res_partner_activation_data_fully_operational" model="res.partner.activation">
         <field name="name">Fully Operational</field>
-        <field name="sequence">3</field>
+        <field name="sequence">1</field>
     </record>
     <record id="res_partner_activation_data_ramp_up" model="res.partner.activation">
         <field name="name">Ramp-up</field>
@@ -10,6 +10,6 @@
     </record>
     <record id="res_partner_activation_data_first_contact" model="res.partner.activation">
         <field name="name">First Contact</field>
-        <field name="sequence">1</field>
+        <field name="sequence">3</field>
     </record>
 </odoo>

--- a/addons/website_crm_partner_assign/data/res_partner_grade_data.xml
+++ b/addons/website_crm_partner_assign/data/res_partner_grade_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="res_partner_grade_data_gold" model="res.partner.grade">
         <field name="name">Gold</field>
-        <field name="sequence">3</field>
+        <field name="sequence">1</field>
     </record>
     <record id="res_partner_grade_data_silver" model="res.partner.grade">
         <field name="name">Silver</field>
@@ -10,6 +10,6 @@
     </record>
     <record id="res_partner_grade_data_bronze" model="res.partner.grade">
         <field name="name">Bronze</field>
-        <field name="sequence">1</field>
+        <field name="sequence">3</field>
     </record>
 </odoo>

--- a/addons/website_crm_partner_assign/models/res_partner.py
+++ b/addons/website_crm_partner_assign/models/res_partner.py
@@ -8,7 +8,7 @@ from odoo.addons.http_routing.models.ir_http import slug
 
 class ResPartnerGrade(models.Model):
     _name = 'res.partner.grade'
-    _order = 'sequence desc'
+    _order = 'sequence'
     _inherit = ['website.published.mixin']
     _description = 'Partner Grade'
 
@@ -29,7 +29,7 @@ class ResPartnerGrade(models.Model):
 
 class ResPartnerActivation(models.Model):
     _name = 'res.partner.activation'
-    _order = 'sequence desc'
+    _order = 'sequence'
     _description = 'Partner Activation'
 
     sequence = fields.Integer('Sequence')


### PR DESCRIPTION
Recently with commit https://github.com/odoo/odoo/commit/b28aae2, we changed the sequence for partner
grades and partner activations at db level (from asc to desc) to see the
records created with data files in our chosen order (for example Gold, Silver,
Bronze instead of Bronze, Silver and Gold).

However, there are several drawbacks with this approach. For example
during db upgrade, all the existing records needs to be adapted to
keep up the order of records created by data files.

This commit reverts change of order at db level, and instead adapts the
sequence of the records being created with the data files in a way that
they are still in the same order we wanted. And it will also maintain the
order of the records manually created by users after db upgradation.

taskID-2765577
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
