### PR TITLE
[IMP] account: detect holes in sequences

### DIFF
--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -24,6 +24,10 @@
                                     <t t-if="(journal_type == 'bank' || journal_type == 'cash')" t-call="JournalBodyBankCash"/>
                                     <t t-if="journal_type == 'sale' || journal_type == 'purchase'" t-call="JournalBodySalePurchase"/>
                                     <t t-if="journal_type == 'general'" t-call="JournalMiscelaneous"/>
+                                    <div class="col-12 col-sm-5 mb-3 mb-sm-0 o_kanban_primary_left"/>
+                                    <div class="col-12 col-sm-7 o_kanban_primary_right">
+                                        <t t-call="HasSequenceHoles"/>
+                                    </div>
                                 </div>
                                 <t t-if="journal_type == 'bank' || journal_type == 'cash' || journal_type == 'sale' || journal_type == 'purchase'" t-call="JournalBodyGraph"/>
                             </div><div class="container o_kanban_card_manage_pane dropdown-menu" role="menu">
@@ -49,6 +53,14 @@
                                 <a class="o_kanban_manage_toggle_button" href="#"><i class="fa fa-ellipsis-v" aria-label="Selection" role="img" title="Selection"/></a>
                             </div>
                         </div>
+                    </t>
+
+                    <t t-name="HasSequenceHoles">
+                        <field name="has_sequence_holes" invisible="1"/>
+                        <a t-if="record.has_sequence_holes.raw_value" name="show_sequence_holes" type="object" class="text-warning">
+                            <i class="fa fa-exclamation-triangle"/>
+                            Holes in the sequence
+                        </a>
                     </t>
 
                     <t t-name="JournalManage">

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -400,9 +400,10 @@
             <field name="name">account.move.tree</field>
             <field name="model">account.move</field>
             <field name="arch" type="xml">
-                <tree string="Journal Entries" sample="1" decoration-info="state == 'draft'">
+                <tree string="Journal Entries" sample="1" decoration-info="state == 'draft'" expand="context.get('expand', False)">
+                    <field name="made_sequence_hole" invisible="1"/>
                     <field name="date"/>
-                    <field name="name"/>
+                    <field name="name" decoration-danger="made_sequence_hole"/>
                     <field name="partner_id" optional="show"/>
                     <field name="ref" optional="show"/>
                     <field name="journal_id"/>
@@ -422,13 +423,15 @@
                 <tree string="Invoices"
                       js_class="account_tree"
                       decoration-info="state == 'draft'"
+                      expand="context.get('expand', False)"
                       sample="1">
                     <header>
                         <button name="action_register_payment" type="object" string="Register Payment"
                             groups="account.group_account_user"
                             invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt', 'in_invoice', 'in_refund','in_receipt')"/>
                     </header>
-                    <field name="name" decoration-bf="1"/>
+                    <field name="made_sequence_hole" invisible="1"/>
+                    <field name="name" decoration-bf="1" decoration-danger="made_sequence_hole"/>
                     <field name="partner_id" invisible="1"/>
                     <field name="invoice_source_email" invisible="1"/>
                     <field name="invoice_partner_display_name" invisible="context.get('default_move_type') not in ('in_invoice', 'in_refund','in_receipt')" groups="base.group_user" string="Vendor" />
@@ -1363,6 +1366,7 @@
                         <separator/>
                         <filter string="Invoice Date" name="invoicedate" context="{'group_by': 'invoice_date'}"/>
                         <filter string="Due Date" name="duedate" context="{'group_by': 'invoice_date_due'}"/>
+                        <filter string="Sequence Prefix" name="group_by_sequence_prefix" context="{'group_by': 'sequence_prefix'}" invisible="1"/>
                     </group>
                </search>
             </field>


### PR DESCRIPTION
The resequence feature and the possibility to edit the invoice number in
draft are powerful flexibility tools. Though, misusing them can lead to
holes in a sequence that can be hard to detect.

This task aims at providing alerts on the dashboard (on Sales and
Purchases journals' cards) highlighting the holes in the sections

_____________

Suppose the following sequence on a journal

BILL/2022/01/0001
BILL/2022/01/0002
BILL/2022/01/0004

> BILL/2022/01/0003 is missing.

Then show a link on this journal's card in the kanban view of journals
(accounting dashboard) mentioning.

> Check the sequence

Pressing the button opens the list view of bills on this specific
journal.

BILL/2022/01/0004 appears in red ; since it is after a hole

[task-2767272](https://www.odoo.com/web#id=2767272&model=project.task)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
