### PR TITLE
[FIX] mail: z-index inside the messaging menu on mobile

### DIFF
--- a/addons/mail/static/src/components/messaging_menu/messaging_menu.scss
+++ b/addons/mail/static/src/components/messaging_menu/messaging_menu.scss
@@ -20,6 +20,8 @@
      */
     margin-top: map-get($spacers, 0);
 
+    z-index: 1100; // on top of chat windows and leafset internal z-index
+
     &.o-messaging-not-initialized {
         align-items: center;
         justify-content: center;
@@ -30,7 +32,6 @@
         width: 350px;
         min-height: 50px;
         max-height: 400px;
-        z-index: 1100; // on top of chat windows
     }
 
     &.o-mobile {


### PR DESCRIPTION
1. On mobile device go to "Field Service" app
2. Open the "map" view
3. Click on "messaging menu" icon
   Some part of leafset is still visible on the screen
   => bug