### PR TITLE
[FIX] *_mail_plugin: hide modules if the user doesn't have access

### DIFF
--- a/addons/crm_mail_plugin/controllers/mail_plugin.py
+++ b/addons/crm_mail_plugin/controllers/mail_plugin.py
@@ -52,7 +52,16 @@ class MailPluginController(mail_plugin.MailPluginController):
         return leads
 
     def _get_contact_data(self, partner):
+        """
+        Return the leads key only if the current user can create leads. So, if he can not
+        create leads, the section won't be visible on the addin side (like if the CRM
+        module was not installed on the database).
+        """
         contact_values = super(MailPluginController, self)._get_contact_data(partner)
+
+        if not request.env['crm.lead'].check_access_rights('create', raise_exception=False):
+            return contact_values
+
         if not partner:
             contact_values['leads'] = []
         else:
@@ -60,7 +69,13 @@ class MailPluginController(mail_plugin.MailPluginController):
         return contact_values
 
     def _mail_content_logging_models_whitelist(self):
-        return super(MailPluginController, self)._mail_content_logging_models_whitelist() + ['crm.lead']
+        models_whitelist = super(MailPluginController, self)._mail_content_logging_models_whitelist()
+        if not request.env['crm.lead'].check_access_rights('create', raise_exception=False):
+            return models_whitelist
+        return models_whitelist + ['crm.lead']
 
     def _translation_modules_whitelist(self):
-        return super(MailPluginController, self)._translation_modules_whitelist() + ['crm_mail_plugin']
+        modules_whitelist = super(MailPluginController, self)._translation_modules_whitelist()
+        if not request.env['crm.lead'].check_access_rights('create', raise_exception=False):
+            return modules_whitelist
+        return modules_whitelist + ['crm_mail_plugin']

--- a/addons/crm_mail_plugin/tests/__init__.py
+++ b/addons/crm_mail_plugin/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_crm_mail_plugin

--- a/addons/crm_mail_plugin/tests/test_crm_mail_plugin.py
+++ b/addons/crm_mail_plugin/tests/test_crm_mail_plugin.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+
+from odoo.addons.mail_plugin.tests.common import TestMailPluginControllerCommon, mock_auth_method_outlook
+
+
+class TestCrmMailPlugin(TestMailPluginControllerCommon):
+    @mock_auth_method_outlook('employee')
+    def test_get_contact_data(self):
+        """Check that the leads section is not visible if the user has not access to crm.lead."""
+        partner, partner_2 = self.env["res.partner"].create([
+            {"name": "Partner 1"},
+            {"name": "Partner 2"},
+        ])
+
+        data = {
+            "id": 0,
+            "jsonrpc": "2.0",
+            "method": "call",
+            "params": {"partner_id": partner.id},
+        }
+
+        result = self.url_open(
+            "/mail_plugin/partner/get",
+            data=json.dumps(data).encode(),
+            headers={"Content-Type": "application/json"},
+        ).json()["result"]
+
+        self.assertNotIn("leads", result,
+            msg="The user has no access to crm.lead, the leads section should not be visible")
+
+        self.user_test.groups_id |= self.env.ref("sales_team.group_sale_salesman_all_leads")
+
+        lead_1, lead_2 = self.env["crm.lead"].create([
+            {"name": "Lead Partner 1", "partner_id": partner.id},
+            {"name": "Lead Partner 2", "partner_id": partner_2.id},
+        ])
+
+        result = self.url_open(
+            "/mail_plugin/partner/get",
+            data=json.dumps(data).encode(),
+            headers={"Content-Type": "application/json"},
+        ).json()["result"]
+
+        self.assertIn(
+            "leads",
+            result,
+            msg="The user has access to crm.lead, the leads section should be visible",
+        )
+
+        self.assertTrue([lead for lead in result["leads"] if lead["lead_id"] == lead_1.id],
+            msg="The first lead belongs to the first partner, it should be returned")
+        self.assertFalse([lead for lead in result["leads"] if lead["lead_id"] == lead_2.id],
+            msg="The second lead does not belong to the first partner, it should not be returned")

--- a/addons/mail_plugin/tests/common.py
+++ b/addons/mail_plugin/tests/common.py
@@ -2,11 +2,30 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
+from contextlib import contextmanager
 from unittest.mock import patch
 
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.http import request
 from odoo.tests.common import HttpCase
+
+
+@contextmanager
+def mock_auth_method_outlook(login):
+    """Mock the Outlook auth method.
+
+    This must be used as a method decorator.
+
+    :param login: Login of the user used for the authentication
+    """
+    def patched_auth_method_outlook(*args, **kwargs):
+        request.uid = request.env['res.users'].search([('login', '=', login)], limit=1).id
+
+    with patch(
+            'odoo.addons.mail_plugin.models.ir_http.IrHttp'
+            '._auth_method_outlook',
+            new=patched_auth_method_outlook):
+        yield
 
 
 class TestMailPluginControllerCommon(HttpCase):
@@ -18,6 +37,7 @@ class TestMailPluginControllerCommon(HttpCase):
             groups="base.group_user,base.group_partner_manager",
         )
 
+    @mock_auth_method_outlook('employee')
     def mock_plugin_partner_get(self, name, email, patched_iap_enrich):
         """Simulate a HTTP call to /partner/get with the given email and name.
 
@@ -25,8 +45,6 @@ class TestMailPluginControllerCommon(HttpCase):
         The third argument "patched_iap_enrich" allow you to mock the IAP request and
         to return the response you want.
         """
-        def patched_auth_method_outlook(*args, **kwargs):
-            request.uid = self.user_test.id
 
         data = {
             "id": 0,
@@ -36,10 +54,6 @@ class TestMailPluginControllerCommon(HttpCase):
         }
 
         with patch(
-            "odoo.addons.mail_plugin.models.ir_http.IrHttp"
-            "._auth_method_outlook",
-            new=patched_auth_method_outlook,
-        ), patch(
             "odoo.addons.mail_plugin.controllers.mail_plugin.MailPluginController"
             "._iap_enrich",
             new=patched_iap_enrich,
@@ -55,15 +69,13 @@ class TestMailPluginControllerCommon(HttpCase):
 
         return result.json().get("result", {})
 
+    @mock_auth_method_outlook('employee')
     def mock_enrich_and_create_company(self, partner_id, patched_iap_enrich):
         """Simulate a HTTP call to /partner/enrich_and_create_company on the given partner.
 
         The third argument "patched_iap_enrich" allow you to mock the IAP request and
         to return the response you want.
         """
-        def patched_auth_method_outlook(*args, **kwargs):
-            request.uid = self.user_test.id
-
         data = {
             "id": 0,
             "jsonrpc": "2.0",
@@ -72,10 +84,6 @@ class TestMailPluginControllerCommon(HttpCase):
         }
 
         with patch(
-            "odoo.addons.mail_plugin.models.ir_http.IrHttp"
-            "._auth_method_outlook",
-            new=patched_auth_method_outlook,
-        ), patch(
             "odoo.addons.mail_plugin.controllers.mail_plugin.MailPluginController"
             "._iap_enrich",
             new=patched_iap_enrich,

--- a/addons/project_mail_plugin/controllers/mail_plugin.py
+++ b/addons/project_mail_plugin/controllers/mail_plugin.py
@@ -18,8 +18,16 @@ class MailPluginController(mail_plugin.MailPluginController):
         information dict loaded when opening an email on Outlook.
         This is structured this way to enable the "project" feature on the Outlook side only if the Odoo version
         supports it.
+
+        Return the tasks key only if the current user can create tasks. So, if he can not
+        create tasks, the section won't be visible on the addin side (like if the project
+        module was not installed on the database).
         """
         contact_values = super(MailPluginController, self)._get_contact_data(partner)
+
+        if not request.env['project.task'].check_access_rights('create', raise_exception=False):
+            return contact_values
+
         if not partner:
             contact_values['tasks'] = []
         else:
@@ -40,7 +48,13 @@ class MailPluginController(mail_plugin.MailPluginController):
         return contact_values
 
     def _mail_content_logging_models_whitelist(self):
-        return super(MailPluginController, self)._mail_content_logging_models_whitelist() + ['project.task']
+        models_whitelist = super(MailPluginController, self)._mail_content_logging_models_whitelist()
+        if not request.env['project.task'].check_access_rights('create', raise_exception=False):
+            return models_whitelist
+        return models_whitelist + ['project.task']
 
     def _translation_modules_whitelist(self):
-        return super(MailPluginController, self)._translation_modules_whitelist() + ['project_mail_plugin']
+        modules_whitelist = super(MailPluginController, self)._translation_modules_whitelist()
+        if not request.env['project.task'].check_access_rights('create', raise_exception=False):
+            return modules_whitelist
+        return modules_whitelist + ['project_mail_plugin']


### PR DESCRIPTION
Bug
===
If the user doesn't have access to the project / CRM module, those
menus were visible on the addin side.

Now, the sections are not visible if the user doesn't have access to.

Task-2765323