### PR TITLE
[13.0][FIX] resource: Exclude incorrect days according to re-define start previoysly with weeks=-1

### DIFF
--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -398,6 +398,9 @@ class ResourceCalendar(models.Model):
                     days = rrule(DAILY, start, until=until, byweekday=weekday)
 
                 for day in days:
+                    # We need to exclude incorrect days according to re-define start previoysly with weeks=-1
+                    if (self.two_weeks_calendar and attendance.date_from and attendance.date_from > day.date()):
+                        continue
                     # attendance hours are interpreted in the resource's timezone
                     hour_from = attendance.hour_from
                     if (tz, day, hour_from) in cache_deltas:

--- a/addons/resource/tests/test_resource.py
+++ b/addons/resource/tests/test_resource.py
@@ -279,6 +279,117 @@ class TestCalendar(TestResourceCommon):
 
         leave.unlink()
 
+        # 2 weeks calendar with date_from and date_to to check work_hours
+        self.calendar_jules.attendance_ids.unlink()
+        self.calendar_jules.write({
+            "attendance_ids": [
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Monday (morning)",
+                        "day_period": "morning",
+                        "dayofweek": "0",
+                        "week_type": "0",
+                        "hour_from": 8.0,
+                        "hour_to": 12.0,
+                        "date_from": "2022-01-01",
+                        "date_to": "2022-01-16"
+                    },
+                ),
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Monday (morning)",
+                        "day_period": "morning",
+                        "dayofweek": "0",
+                        "week_type": "0",
+                        "hour_from": 8.0,
+                        "hour_to": 12.0,
+                        "date_from": "2022-01-17",
+                    },
+                ),
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Monday (afternoon)",
+                        "day_period": "afternoon",
+                        "dayofweek": "0",
+                        "week_type": "0",
+                        "hour_from": 16.0,
+                        "hour_to": 20.0,
+                        "date_from": "2022-01-17",
+                    },
+                ),
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Monday (morning)",
+                        "day_period": "morning",
+                        "dayofweek": "0",
+                        "week_type": "1",
+                        "hour_from": 8.0,
+                        "hour_to": 12.0,
+                        "date_from": "2022-01-01",
+                        "date_to": "2022-01-16"
+                    },
+                ),
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Monday (afternoon)",
+                        "day_period": "afternoon",
+                        "dayofweek": "0",
+                        "week_type": "1",
+                        "hour_from": 16.0,
+                        "hour_to": 20.0,
+                        "date_from": "2022-01-01",
+                        "date_to": "2022-01-16"
+                    },
+                ),
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Monday (morning)",
+                        "day_period": "morning",
+                        "dayofweek": "0",
+                        "week_type": "1",
+                        "hour_from": 8.0,
+                        "hour_to": 12.0,
+                        "date_from": "2022-01-17",
+                    },
+                ),
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Monday (afternoon)",
+                        "day_period": "afternoon",
+                        "dayofweek": "0",
+                        "week_type": "1",
+                        "hour_from": 16.0,
+                        "hour_to": 20.0,
+                        "date_from": "2022-01-17",
+                    },
+                ),
+            ],
+        })
+        hours = self.calendar_jules.get_work_hours_count(
+            datetime_tz(2022, 1, 10, 0, 0, 0, tzinfo=self.jules.tz),
+            datetime_tz(2022, 1, 10, 23, 59, 59, tzinfo=self.jules.tz),
+        )
+        self.assertEqual(hours, 4)
+        hours = self.calendar_jules.get_work_hours_count(
+            datetime_tz(2022, 1, 17, 0, 0, 0, tzinfo=self.jules.tz),
+            datetime_tz(2022, 1, 17, 23, 59, 59, tzinfo=self.jules.tz),
+        )
+        self.assertEqual(hours, 8)
+
     def test_calendar_working_hours_count(self):
         calendar = self.env.ref('resource.resource_calendar_std_35h')
         calendar.tz = 'UTC'


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**:
Exclude incorrect days according to re-define start previoysly with weeks=-1

**Initial configuration to reproduce the error:**
- Go to Employees and edit Abigail Peterson (in debug mode).
- Set in "Work information" tab a new work schedule with the following lines:
![ejemplo](https://user-images.githubusercontent.com/4117568/178269205-78fab4a6-bf3a-492c-9bbf-36d29284c224.png)

**Current behavior before the PR:**
- Go to Time Off > Managers > Time Off and create a new record for Abigail with the following information:
- Type: Compensatory Days, From: 2022-01-10, To: 2022-01-10 > Duration: 8 hours.
- We create a new record with the following information:
- Type: Compensatory Days, From: 2022-01-17, To: 2022-01-17 > Duration: 8 hours.

**Current behavior after PR:**
- Go to Time Off > Managers > Time Off and create a new record for Abigail with the following information:
- Type: Compensatory Days, From: 2022-01-10, To: 2022-01-10 > Duration: 4 hours.
- We create a new record with the following information:
- Type: Compensatory Days, From: 2022-01-17, To: 2022-01-17 > Duration: 8 hours.


Part of master refractor https://github.com/odoo/odoo/commit/df984fff4e67e56fea5df338e74a1d35f3074cbd

**Impacted versions**:
- 13.0
- 14.0
- 15.0

cc @Tecnativa TT34416

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr