### PR TITLE
[REF] web, *: remove useless code in main web controller

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -15,6 +15,7 @@ import re
 import sys
 import tempfile
 import unicodedata
+import warnings
 from collections import OrderedDict, defaultdict
 
 import babel.messages.pofile
@@ -1267,37 +1268,16 @@ class DataSet(http.Controller):
 
     @http.route('/web/dataset/search_read', type='json', auth="user")
     def search_read(self, model, fields=False, offset=0, limit=False, domain=None, sort=None):
-        return self.do_search_read(model, fields, offset, limit, domain, sort)
-
-    def do_search_read(self, model, fields=False, offset=0, limit=False, domain=None, sort=None):
-        """ Performs a search() followed by a read() (if needed) using the
-        provided search criteria
-
-        :param str model: the name of the model to search on
-        :param fields: a list of the fields to return in the result records
-        :type fields: [str]
-        :param int offset: from which index should the results start being returned
-        :param int limit: the maximum number of records to return
-        :param list domain: the search domain for the query
-        :param list sort: sorting directives
-        :returns: A structure (dict) with two keys: ids (all the ids matching
-                  the (domain, context) pair) and records (paginated records
-                  matching fields selection set)
-        :rtype: list
-        """
-        Model = request.env[model]
-        return Model.web_search_read(domain, fields, offset=offset, limit=limit, order=sort)
+        return request.env[model].web_search_read(domain, fields, offset=offset, limit=limit, order=sort)
 
     @http.route('/web/dataset/load', type='json', auth="user")
     def load(self, model, id, fields):
+        warnings.warn("the route /web/dataset/load is deprecated and will be removed in Odoo 17. Use /web/dataset/call_kw with method 'read' and a list containing the id as args instead", DeprecationWarning)
         value = {}
         r = request.env[model].browse([id]).read()
         if r:
             value = r[0]
         return {'value': value}
-
-    def call_common(self, model, method, args, domain_id=None, context_id=None):
-        return self._call_kw(model, method, args, {})
 
     def _call_kw(self, model, method, args, kwargs):
         check_method_name(method)
@@ -1305,6 +1285,7 @@ class DataSet(http.Controller):
 
     @http.route('/web/dataset/call', type='json', auth="user")
     def call(self, model, method, args, domain_id=None, context_id=None):
+        warnings.warn("the route /web/dataset/call is deprecated and will be removed in Odoo 17. Use /web/dataset/call_kw with empty kwargs instead", DeprecationWarning)
         return self._call_kw(model, method, args, {})
 
     @http.route(['/web/dataset/call_kw', '/web/dataset/call_kw/<path:path>'], type='json', auth="user")

--- a/addons/website_sale_coupon/static/tests/tours/website_sale_coupon.js
+++ b/addons/website_sale_coupon/static/tests/tours/website_sale_coupon.js
@@ -80,15 +80,16 @@ tour.register('shop_sale_coupon', {
             content: "go to shop",
             trigger: '.td-product_name:contains("10.0% discount on total amount")',
             run: function () {
-                ajax.jsonRpc('/web/dataset/call', 'call', {
+                ajax.jsonRpc('/web/dataset/call_kw', 'call', {
                     model: 'account.tax',
                     method: 'create',
                     args: [{
                       'name':'15% tax incl ' + _.now(),
                       'amount': 15,
                     }],
+                    kwargs: {},
                 }).then(function (tax_id) {
-                    ajax.jsonRpc('/web/dataset/call', 'call', {
+                    ajax.jsonRpc('/web/dataset/call_kw', 'call', {
                         model: 'product.template',
                         method: 'create',
                         args: [{
@@ -97,6 +98,7 @@ tour.register('shop_sale_coupon', {
                           'list_price': 100,
                           'website_published': true,
                         }],
+                        kwargs: {},
                     }).then(function (data) {
                         location.href = '/shop';
                     });

--- a/odoo/addons/test_apikeys/static/tests/apikey_flow.js
+++ b/odoo/addons/test_apikeys/static/tests/apikey_flow.js
@@ -49,9 +49,10 @@ tour.register('apikeys_tour_setup', {
     trigger: 'p:contains("Here is your new API key")',
     run: async () => {
         const key = $('code span[name=key]').text();
-        await ajax.jsonRpc('/web/dataset/call', 'call', {
+        await ajax.jsonRpc('/web/dataset/call_kw', 'call', {
             model: 'ir.logging', method: 'send_key',
             args: [key],
+            kwargs: {},
         });
         $('button:contains("Done")').click();
     }


### PR DESCRIPTION
*: website_sale_coupon, test_apikeys

The do_search_read method was only used in a single place: the
search_read controller, whose entire function body was just a function
call. The content of the do_search_read method has been moved to the
search_read controller.

The search_read controller is still pretty useless: it's basically
equivalent to making an RPC on a model and calling the method
web_search_read. As such, this controller should be removed, but lots of
code depends on it and adapting all the code that uses it is out of
scope for this PR. It will hopefully be removed alongside the legacy
views in the webclient (which are its main users).

The call_common method is completely unused.

The /web/dataset/call controller is used in only two places and can
trivially be replaced with a call to /web/dataset/call_kw