### PR TITLE
[ADD] account_edi_proxy_client, l10n_it_edi_sdicoop: user settings for demo mode

### DIFF
--- a/addons/account_edi_proxy_client/data/config_demo.xml
+++ b/addons/account_edi_proxy_client/data/config_demo.xml
@@ -3,7 +3,7 @@
 
     <record id="account_edi_proxy_client_demo" model="ir.config_parameter">
         <field name="key">account_edi_proxy_client.demo</field>
-        <field name="value">True</field>
+        <field name="value">demo</field>
     </record>
 
 </odoo>

--- a/addons/l10n_it_edi/views/l10n_it_view.xml
+++ b/addons/l10n_it_edi/views/l10n_it_view.xml
@@ -76,13 +76,11 @@
                         </div>
                         <group>
                             <field name="l10n_it_has_eco_index" string="Company listed on the register of companies"/>
-                        </group>
-                        <group attrs="{'invisible': [('l10n_it_has_eco_index', '=', False)]}">
-                            <field name="l10n_it_eco_index_office"/>
-                            <field name="l10n_it_eco_index_number"/>
-                            <field name="l10n_it_eco_index_share_capital"/>
-                            <field name="l10n_it_eco_index_sole_shareholder"/>
-                            <field name="l10n_it_eco_index_liquidation_state"/>
+                            <field name="l10n_it_eco_index_office" attrs="{'invisible': [('l10n_it_has_eco_index', '=', False)]}"/>
+                            <field name="l10n_it_eco_index_number" attrs="{'invisible': [('l10n_it_has_eco_index', '=', False)]}"/>
+                            <field name="l10n_it_eco_index_share_capital" attrs="{'invisible': [('l10n_it_has_eco_index', '=', False)]}"/>
+                            <field name="l10n_it_eco_index_sole_shareholder" attrs="{'invisible': [('l10n_it_has_eco_index', '=', False)]}"/>
+                            <field name="l10n_it_eco_index_liquidation_state" attrs="{'invisible': [('l10n_it_has_eco_index', '=', False)]}"/>
                         </group>
                     </group>
                     <group>
@@ -93,9 +91,7 @@
                         </div>
                         <group>
                             <field name="l10n_it_has_tax_representative" string="Company have a tax representative"/>
-                        </group>
-                        <group attrs="{'invisible': [('l10n_it_has_tax_representative', '=', False)]}">
-                            <field name="l10n_it_tax_representative_partner_id"/>
+                            <field name="l10n_it_tax_representative_partner_id" attrs="{'invisible': [('l10n_it_has_tax_representative', '=', False)]}"/>
                         </group>
                     </group>
                 </page>

--- a/addons/l10n_it_edi_sdicoop/models/res_config_settings.py
+++ b/addons/l10n_it_edi_sdicoop/models/res_config_settings.py
@@ -7,6 +7,22 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     is_edi_proxy_active = fields.Boolean(compute='_compute_is_edi_proxy_active')
+    l10n_it_edi_sdicoop_demo_mode = fields.Selection(
+        [('demo', 'Demo'),
+         ('test', 'Test (experimental)'),
+         ('prod', 'Official')],
+        compute='_compute_l10n_it_edi_sdicoop_demo_mode',
+        inverse='_set_l10n_it_edi_sdicoop_demo_mode',
+        readonly=False)
+
+    @api.depends("is_edi_proxy_active")
+    def _compute_l10n_it_edi_sdicoop_demo_mode(self):
+        for config in self:
+            config.l10n_it_edi_sdicoop_demo_mode = self.env['account_edi_proxy_client.user']._get_demo_state()
+
+    def _set_l10n_it_edi_sdicoop_demo_mode(self):
+        for config in self:
+            self.env['ir.config_parameter'].set_param('account_edi_proxy_client.demo', config.l10n_it_edi_sdicoop_demo_mode)
 
     @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
     def _compute_is_edi_proxy_active(self):

--- a/addons/l10n_it_edi_sdicoop/views/res_config_settings_views.xml
+++ b/addons/l10n_it_edi_sdicoop/views/res_config_settings_views.xml
@@ -36,6 +36,22 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_right_pane">
+                                <div class="content-group">
+                                    <span class="o_form_label">
+                                        Fattura Elettronica mode
+                                    </span>
+                                    <div class="text-muted">
+                                        In demo mode Odoo will just simulate the sending of invoices to the government.<br/>
+                                        In test mode (experimental) Odoo will send the invoices to a non-production service.
+                                    </div>
+                                    <field name="l10n_it_edi_sdicoop_demo_mode"
+                                           widget="radio"
+                                           options="{'horizontal': true}"/>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </xpath>


### PR DESCRIPTION
 - A new flag is added to the Setting (l10n_it_edi_sdicoop_demo_mode) that is computed from the `ir.config_parameter` `account_edi_proxy_client.demo`
 
   If the flag is `demo`, Odoo will not send invoices through the EDI,
   if the flag is `test`, Odoo will send invoices to an IAP test server instance that operates with a test SDICoop service
   if the flag is `prod`, Odoo will send invoices to production IAP, that routes them to the official SDICoop service
    
- Some minor UI rework for the EDI parameters on res.company
  The EDI settings in the res_company form, under the 'Electronic Invoicing' tab, must stay on the left