### PR TITLE
[IMP] mail, hr: constraints when channel_type is not 'channel'

### DIFF
--- a/addons/hr/models/mail_channel.py
+++ b/addons/hr/models/mail_channel.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class Channel(models.Model):
@@ -10,6 +11,12 @@ class Channel(models.Model):
     subscription_department_ids = fields.Many2many(
         'hr.department', string='HR Departments',
         help='Automatically subscribe members of those departments to the channel.')
+
+    @api.constrains('subscription_department_ids')
+    def _constraint_subscription_department_ids_channel(self):
+        failing_channels = self.sudo().filtered(lambda channel: channel.channel_type != 'channel' and channel.subscription_department_ids)
+        if failing_channels:
+            raise ValidationError(_("For %(channels)s, channel_type should be 'channel' to have the department auto-subscription.", channels=', '.join([ch.name for ch in failing_channels])))
 
     def _subscribe_users_automatically_get_members(self):
         """ Auto-subscribe members of a department to a channel """

--- a/addons/hr/views/mail_channel_views.xml
+++ b/addons/hr/views/mail_channel_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='group_ids']" position="after">
                 <field name="subscription_department_ids" widget="many2many_tags"
+                    attrs="{'invisible': [('channel_type', '!=', 'channel')]}"
                     string="Auto Subscribe Departments"/>
             </xpath>
         </field>

--- a/addons/mail/tests/test_mail_channel.py
+++ b/addons/mail/tests/test_mail_channel.py
@@ -237,20 +237,18 @@ class TestChannelInternals(MailCommon):
         self.assertEqual(new_msg.partner_ids, self.env['res.partner'])
         self.assertEqual(new_msg.notified_partner_ids, self.env['res.partner'])
 
+    @users('employee')
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     def test_channel_recipients_chat(self):
         """ Posting a message on a chat should not send emails """
-        self.test_channel.write({
-            'channel_type': 'chat',
-        })
-        self.test_channel.add_members((self.partner_employee | self.partner_admin | self.test_partner).ids)
+        channel_info = self.env['mail.channel'].with_user(self.user_admin).channel_get((self.partner_employee | self.user_admin.partner_id).ids)
+        chat = self.env['mail.channel'].with_user(self.user_admin).browse(channel_info['id'])
         with self.mock_mail_gateway():
             with self.with_user('employee'):
-                channel = self.env['mail.channel'].browse(self.test_channel.ids)
-                new_msg = channel.message_post(body="Test", message_type='comment', subtype_xmlid='mail.mt_comment')
+                new_msg = chat.message_post(body="Test", message_type='comment', subtype_xmlid='mail.mt_comment')
         self.assertNotSentEmail()
-        self.assertEqual(new_msg.model, self.test_channel._name)
-        self.assertEqual(new_msg.res_id, self.test_channel.id)
+        self.assertEqual(new_msg.model, chat._name)
+        self.assertEqual(new_msg.res_id, chat.id)
         self.assertEqual(new_msg.partner_ids, self.env['res.partner'])
         self.assertEqual(new_msg.notified_partner_ids, self.env['res.partner'])
 

--- a/addons/mail/views/mail_channel_views.xml
+++ b/addons/mail/views/mail_channel_views.xml
@@ -73,9 +73,10 @@
                                 <group class="o_label_nowrap">
                                     <field name="public" widget="radio" string="Who can follow the group's activities?"/>
                                     <field name="group_public_id"
-                                        attrs="{'invisible': [('public','!=','groups')], 'required': [('public','=','groups')]}"
+                                        attrs="{'invisible': ['|', ('channel_type', '!=', 'channel'), ('public','!=','groups')], 'required': [('public','=','groups')]}"
                                         />
                                     <field name="group_ids" widget="many2many_tags"
+                                        attrs="{'invisible': [('channel_type', '!=', 'channel')]}"
                                         string="Auto Subscribe Groups"/>
                                 </group>
                             </page>


### PR DESCRIPTION
The group_public_id and group_id and subscription_department_ids
should only be used when the channel_type is 'channel'.


task-2766712

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
