### PR TITLE
[IMP] account: faster account_move unlink

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -297,8 +297,14 @@ class AccountMove(models.Model):
         help='If this checkbox is ticked, this entry will be automatically posted at its date.')
 
     # ==== Reverse feature fields ====
-    reversed_entry_id = fields.Many2one('account.move', string="Reversal of", readonly=True, copy=False,
-        check_company=True)
+    reversed_entry_id = fields.Many2one(
+        comodel_name='account.move',
+        string="Reversal of",
+        index='btree_not_null',
+        readonly=True,
+        copy=False,
+        check_company=True
+    )
     reversal_move_id = fields.One2many('account.move', 'reversed_entry_id')
 
     # =========================================================


### PR DESCRIPTION
Solving performance issue raised in the following PR for master: 
- https://github.com/odoo/odoo/pull/83472
- https://github.com/odoo/odoo/pull/83469

Current behavior before PR:
On bigger DB, unlinking a draft account_move takes ages.

Desired behavior after PR is merged:
On bigger DB, unlinking a draft account_move goes smoothly.

