### PR TITLE
[FIX] stock: compute replenishment info

### DIFF
--- a/addons/stock/wizard/stock_replenishment_info.py
+++ b/addons/stock/wizard/stock_replenishment_info.py
@@ -49,7 +49,7 @@ class StockReplenishmentInfo(models.TransientModel):
         for replenishment_report in self:
             replenishment_history = []
             today = fields.Datetime.now()
-            first_month = subtract(today, month=2)
+            first_month = subtract(today, months=2)
             date_from, dummy = get_month(first_month)
             dummy, date_to = get_month(today)
             domain = [


### PR DESCRIPTION
The history of the replenishment info may be empty while it should not

To reproduce the issue:
(Set your device on January)
1. Process a delivery for product P
2. (Inventory > Operations > Replenishment, create a new one for P)
3. Click on the information icon (I) of P's line

Error: The sales history does contain anything

When calling `relativedelta`, `month` is considered as an absolute value
and will replace the corresponding value while `months` is a relative
value and will be added/subtracted to the corresponding value.

OPW-2740123