### PR TITLE
[FIX] web_editor,website_sale: fix click on pricelist while editing

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -74,7 +74,11 @@ const Wysiwyg = Widget.extend({
         this.colorpickers = {};
         this._onDocumentMousedown = this._onDocumentMousedown.bind(this);
         this._onBlur = this._onBlur.bind(this);
-        this.customizableLinksSelector = 'a:not([data-toggle="tab"]):not([data-toggle="collapse"])';
+        this.customizableLinksSelector = 'a'
+            + ':not([data-toggle="tab"])'
+            + ':not([data-toggle="collapse"])'
+            + ':not([data-toggle="dropdown"])'
+            + ':not(.dropdown-item)';
         // navigator.onLine is sometimes a false positive, this._isOnline use
         // more heuristics to bypass the limitation.
         this._isOnline = true;
@@ -279,7 +283,8 @@ const Wysiwyg = Widget.extend({
                     && $target[0].isContentEditable
                     && !$target.attr('data-oe-model')
                     && !$target.find('> [data-oe-model]').length
-                    && !$target[0].closest('.o_extra_menu_items')) {
+                    && !$target[0].closest('.o_extra_menu_items')
+                    && $target[0].isContentEditable) {
                 this.linkPopover = $target.data('popover-widget-initialized');
                 if (!this.linkPopover) {
                     // TODO this code is ugly maybe the mutex should be in the
@@ -1015,7 +1020,7 @@ const Wysiwyg = Widget.extend({
      */
     toggleLinkTools(options = {}) {
         const linkEl = getInSelection(this.odooEditor.document, 'a');
-        if (linkEl && !linkEl.matches(this.customizableLinksSelector)) {
+        if (linkEl && (!linkEl.matches(this.customizableLinksSelector) || !linkEl.isContentEditable)) {
             return;
         }
         if (this.snippetsMenu && !options.forceDialog) {
@@ -1577,7 +1582,7 @@ const Wysiwyg = Widget.extend({
             this._updateFaResizeButtons();
         }
         const link = getInSelection(this.odooEditor.document, this.customizableLinksSelector);
-        if (isInMedia || link) {
+        if (isInMedia || (link && link.isContentEditable)) {
             // Handle the media/link's tooltip.
             this.showTooltip = true;
             setTimeout(() => {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
@@ -1,0 +1,19 @@
+/** @odoo-module **/
+
+import tour from 'web_tour.tour';
+
+tour.register('shop_editor', {
+    test: true,
+    url: '/shop?enable_editor=1',
+}, [{
+    content: "Click on pricelist dropdown",
+    trigger: "div.o_pricelist_dropdown a[data-toggle=dropdown]",
+}, {
+    trigger: "input[name=search]",
+    extra_trigger: "div.o_pricelist_dropdown a[data-toggle=dropdown][aria-expanded=true]",
+    content: "Click somewhere else in the shop.",
+}, {
+    trigger: "div.o_pricelist_dropdown a[data-toggle=dropdown]",
+    extra_trigger: "div.o_pricelist_dropdown a[data-toggle=dropdown][aria-expanded=false]",
+    content: "Click on the pricelist again.",
+}]);

--- a/addons/website_sale/tests/test_customize.py
+++ b/addons/website_sale/tests/test_customize.py
@@ -312,3 +312,6 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
         config.execute()
 
         self.start_tour("/", 'shop_list_view_b2c', login="admin")
+
+    def test_07_editor_shop(self):
+        self.start_tour("/", 'shop_editor', login="admin")


### PR DESCRIPTION
Prior to this commit, when a user edits the Shop page, clicks on the
pricelist dropdown and finally clicks elsewhere, a traceback occurs:
`Uncaught TypeError: Cannot read properties of undefined (reading
'getColorNames')`

This commit ensures the link tools is not toggles on dropdown links,
i.e. the customizable links selector does not contain the dropdown
anymore.

task-2695091

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
