### PR TITLE
[FIX] website: not hide header partially when scrolling to snippet

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -80,7 +80,9 @@ const BaseAnimatedHeader = animations.Animation.extend({
      */
     _adaptToHeaderChange: function () {
         this._updateMainPaddingTop();
-        this.el.classList.toggle('o_top_fixed_element', this.fixedHeader && this._isShown());
+        // Take menu into account when `dom.scrollTo()` is used whenever it is
+        // visible - be it floating, fully displayed or partially hidden.
+        this.el.classList.toggle('o_top_fixed_element', this._isShown());
 
         for (const callback of extraMenuUpdateCallbacks) {
             callback();


### PR DESCRIPTION
Since [1] only floating fixed headers were included in the calculation
of the `dom.scrollTo()`'s offset.
Because of this when a snippet was dropped on the top of a page, the
header being shown but non-floating was not used in the offset
calculation, which made the automatic scroll operation hide the header
partially for headers taller than the requested 50px offset from the top
of the display.

After this commit, any shown header is included in that calculation -
even non floating ones.

Steps to reproduce:
- drop snippets into the page until it has to scroll
- drop a snippet right below the header
=> header was partially hidden upon drop by the automatic scolling

[1]: https://github.com/odoo/odoo/commit/ee47bd9ce0da526ea5b3387a354ab8fbd06cc55f

task-2765820

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
