### PR TITLE
[FIX] mail,web: fix typo for oi-large icons

### DIFF
--- a/addons/mail/static/src/components/rtc_activity_notice/rtc_activity_notice.xml
+++ b/addons/mail/static/src/components/rtc_activity_notice/rtc_activity_notice.xml
@@ -9,7 +9,7 @@
                     <t t-set="title">Open conference: <t t-esc="messaging.rtc.channel.displayName"/></t>
                     <a class="o_RtcActivityNotice_button px-3 user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="title" role="button" t-on-click="_onClick">
                         <div class="o_RtcActivityNotice_buttonContent d-flex align-items-center">
-                            <i class="o_RtcActivityNotice_outputIndicator oi oi-lg" t-att-class="{
+                            <i class="o_RtcActivityNotice_outputIndicator oi oi-large" t-att-class="{
                                 'oi-phone--voice': !messaging.rtc.sendDisplay and !messaging.rtc.sendUserVideo,
                                 'oi-video': messaging.rtc.sendUserVideo,
                                 'oi-screen': messaging.rtc.sendDisplay,

--- a/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
+++ b/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
@@ -15,7 +15,7 @@
                             t-on-click="rtcController.onClickMicrophone">
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
                                 <i class="oi" t-att-class="{
-                                    'oi-lg': !rtcController.isSmall,
+                                    'oi-large': !rtcController.isSmall,
                                     'oi-microphone--filled': !messaging.rtc.currentRtcSession.isMute,
                                     'oi-microphone--off--filled': messaging.rtc.currentRtcSession.isMute,
                                     'text-danger': messaging.rtc.currentRtcSession.isMute,
@@ -31,7 +31,7 @@
                             t-on-click="rtcController.onClickDeafen">
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
                                 <i class="oi" t-att-class="{
-                                    'oi-lg': !rtcController.isSmall,
+                                    'oi-large': !rtcController.isSmall,
                                     'oi-volume--up--filled': !messaging.rtc.currentRtcSession.isDeaf,
                                     'oi-volume--mute--filled': messaging.rtc.currentRtcSession.isDeaf,
                                     'text-danger': messaging.rtc.currentRtcSession.isDeaf,
@@ -49,7 +49,7 @@
                             t-att-title="cameraTitle"
                             t-on-click="rtcController.onClickCamera">
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
-                                <i class="oi oi-video--filled" t-att-class="{ 'oi-lg': !rtcController.isSmall }"/>
+                                <i class="oi oi-video--filled" t-att-class="{ 'oi-large': !rtcController.isSmall }"/>
                             </div>
                         </button>
                         <t t-if="messaging.rtc.sendDisplay"><t t-set="displayTitle">Stop screen sharing</t></t>
@@ -63,7 +63,7 @@
                             t-att-title="displayTitle"
                             t-on-click="rtcController.onClickScreen">
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
-                                <i class="oi oi-screen" t-att-class="{ 'oi-lg': !rtcController.isSmall }"/>
+                                <i class="oi oi-screen" t-att-class="{ 'oi-large': !rtcController.isSmall }"/>
                             </div>
                         </button>
                         <Popover position="'top'">
@@ -73,7 +73,7 @@
                                 t-att-class="{ 'o-isSmall': rtcController.isSmall }"
                             >
                                 <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
-                                    <i class="oi oi-overflow-menu--horizontal" t-att-class="{ 'oi-2x': !rtcController.isSmall }"/>
+                                    <i class="oi oi-overflow-menu--horizontal" t-att-class="{ 'oi-large': !rtcController.isSmall }"/>
                                 </div>
                             </button>
                             <t t-set-slot="opened">
@@ -89,7 +89,7 @@
                             t-att-disabled="rtcController.callViewer.threadView.thread.hasPendingRtcRequest"
                             t-on-click="rtcController.onClickToggleVideoCall">
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
-                                <i class="oi oi-video--filled" t-att-class="{ 'oi-lg': !rtcController.isSmall }"/>
+                                <i class="oi oi-video--filled" t-att-class="{ 'oi-large': !rtcController.isSmall }"/>
                             </div>
                         </button>
                     </t>
@@ -102,7 +102,7 @@
                                 t-att-disabled="rtcController.callViewer.threadView.thread.hasPendingRtcRequest"
                                 t-on-click="rtcController.onClickRejectCall">
                                 <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
-                                    <i class="oi oi-phone--filled" t-att-class="{ 'oi-lg': !rtcController.isSmall }"/>
+                                    <i class="oi oi-phone--filled" t-att-class="{ 'oi-large': !rtcController.isSmall }"/>
                                 </div>
                             </button>
                         </t>
@@ -115,7 +115,7 @@
                             t-att-title="phoneTitle"
                             t-on-click="rtcController.onClickToggleAudioCall">
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
-                                <i class="oi oi-phone--filled" t-att-class="{ 'oi-lg': !rtcController.isSmall }"/>
+                                <i class="oi oi-phone--filled" t-att-class="{ 'oi-large': !rtcController.isSmall }"/>
                             </div>
                         </button>
                     </t>

--- a/addons/web/static/src/webclient/burger_menu/burger_menu.xml
+++ b/addons/web/static/src/webclient/burger_menu/burger_menu.xml
@@ -8,7 +8,7 @@
         class="o_mobile_menu_toggle dropdown-toggle o-no-caret d-md-none"
         title="Toggle menu" aria-label="Toggle menu"
         t-on-click="_openBurger">
-        <i class="oi oi-lg oi-open-panel--filled--right"/>
+        <i class="oi oi-large oi-open-panel--filled--right"/>
     </a>
     <t t-portal="'body'">
       <Transition name="'burgerslide'" visible="state.isBurgerOpened" leaveDuration="200" t-slot-scope="transition">

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
@@ -4,7 +4,7 @@
 <t t-name="web.SwitchCompanyMenu" owl="1">
     <Dropdown class="'o_switch_company_menu d-none d-md-block'" position="'bottom-end'">
         <t t-set-slot="toggler">
-            <i class="oi oi-lg oi-connection--two-way d-lg-none"/>
+            <i class="oi oi-large oi-connection--two-way d-lg-none"/>
             <span class="oe_topbar_name d-none d-lg-block" t-esc="currentCompany.name"/>
         </t>
         <t t-foreach="Object.values(companyService.availableCompanies).sort((c1, c2) => c1.sequence - c2.sequence)" t-as="company" t-key="company.id">


### PR DESCRIPTION
Large icons should use `oi-large` instead of `oi-lg` or `oi-2x`.
