### PR TITLE
[IMP] mail, *: make mail module's beforeEach functions async

### DIFF
--- a/addons/calendar/static/tests/systray_activity_menu_tests.js
+++ b/addons/calendar/static/tests/systray_activity_menu_tests.js
@@ -7,8 +7,8 @@ import testUtils from 'web.test_utils';
 
 QUnit.module('calendar', {}, function () {
 QUnit.module('ActivityMenu', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         Object.assign(this.data, {
             'calendar.event': {

--- a/addons/hr/static/tests/m2x_avatar_employee_tests.js
+++ b/addons/hr/static/tests/m2x_avatar_employee_tests.js
@@ -15,8 +15,8 @@ import { dom, mock } from 'web.test_utils';
 
 QUnit.module('hr', {}, function () {
     QUnit.module('M2XAvatarEmployee', {
-        beforeEach() {
-            beforeEach(this);
+        async beforeEach() {
+            await beforeEach(this);
 
             // reset the cache before each test
             Many2OneAvatarEmployee.prototype.partnerIds = {};

--- a/addons/hr_holidays/static/src/components/partner_im_status_icon/tests/partner_im_status_icon_tests.js
+++ b/addons/hr_holidays/static/src/components/partner_im_status_icon/tests/partner_im_status_icon_tests.js
@@ -11,8 +11,8 @@ QUnit.module('hr_holidays', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('partner_im_status_icon', {}, function () {
 QUnit.module('partner_im_status_icon_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.createPartnerImStatusIcon = async partner => {
             await createRootMessagingComponent(this, "PartnerImStatusIcon", {

--- a/addons/hr_holidays/static/src/components/thread_icon/tests/thread_icon_tests.js
+++ b/addons/hr_holidays/static/src/components/thread_icon/tests/thread_icon_tests.js
@@ -11,8 +11,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('thread_icon', {}, function () {
 QUnit.module('thread_icon_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.createThreadIcon = async thread => {
             await createRootMessagingComponent(this, "ThreadIcon", {

--- a/addons/hr_holidays/static/src/components/thread_view/tests/thread_view_tests.js
+++ b/addons/hr_holidays/static/src/components/thread_view/tests/thread_view_tests.js
@@ -11,8 +11,8 @@ QUnit.module('hr_holidays', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('thread_view', {}, function () {
 QUnit.module('thread_view_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });

--- a/addons/im_livechat/static/src/components/chat_window_manager/tests/chat_window_manager_tests.js
+++ b/addons/im_livechat/static/src/components/chat_window_manager/tests/chat_window_manager_tests.js
@@ -11,8 +11,8 @@ QUnit.module('im_livechat', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('chat_window_manager', {}, function () {
 QUnit.module('chat_window_manager_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start(Object.assign(

--- a/addons/im_livechat/static/src/components/composer/tests/composer_tests.js
+++ b/addons/im_livechat/static/src/components/composer/tests/composer_tests.js
@@ -6,8 +6,8 @@ QUnit.module('im_livechat', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('composer', {}, function () {
 QUnit.module('composer_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });

--- a/addons/im_livechat/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/im_livechat/static/src/components/discuss/tests/discuss_tests.js
@@ -14,8 +14,8 @@ QUnit.module('im_livechat', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('discuss', {}, function () {
 QUnit.module('discuss_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {

--- a/addons/im_livechat/static/src/components/discuss_sidebar_category/tests/discuss_sidebar_category_tests.js
+++ b/addons/im_livechat/static/src/components/discuss_sidebar_category/tests/discuss_sidebar_category_tests.js
@@ -11,8 +11,8 @@ QUnit.module('im_livechat', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('discuss_sidebar_category', {}, function () {
 QUnit.module('discuss_sidebar_category_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {

--- a/addons/im_livechat/static/src/components/discuss_sidebar_category_item/tests/discuss_sidebar_category_item_tests.js
+++ b/addons/im_livechat/static/src/components/discuss_sidebar_category_item/tests/discuss_sidebar_category_item_tests.js
@@ -10,8 +10,8 @@ QUnit.module('im_livechat', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('discuss_sidebar_category_item', {}, function () {
 QUnit.module('discuss_sidebar_category_item_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {

--- a/addons/im_livechat/static/src/components/messaging_menu/tests/messaging_menu_tests.js
+++ b/addons/im_livechat/static/src/components/messaging_menu/tests/messaging_menu_tests.js
@@ -11,8 +11,8 @@ QUnit.module('im_livechat', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('messaging_menu', {}, function () {
 QUnit.module('messaging_menu_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start(Object.assign({}, params, {

--- a/addons/im_livechat/static/src/components/thread_icon/tests/thread_icon_tests.js
+++ b/addons/im_livechat/static/src/components/thread_icon/tests/thread_icon_tests.js
@@ -12,8 +12,8 @@ QUnit.module('im_livechat', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('thread_icon', {}, function () {
 QUnit.module('thread_icon_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.createThreadIcon = async thread => {
             await createRootMessagingComponent(this, "ThreadIcon", {

--- a/addons/im_livechat/static/src/components/thread_textual_typing_status/tests/thread_textual_typing_status_tests.js
+++ b/addons/im_livechat/static/src/components/thread_textual_typing_status/tests/thread_textual_typing_status_tests.js
@@ -12,8 +12,8 @@ QUnit.module('im_livechat', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('thread_textual_typing_status', {}, function () {
 QUnit.module('thread_textual_typing_status_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.createThreadTextualTypingStatusComponent = async thread => {
             await createRootMessagingComponent(this, "ThreadTextualTypingStatus", {

--- a/addons/mail/static/src/components/activity/tests/activity_tests.js
+++ b/addons/mail/static/src/components/activity/tests/activity_tests.js
@@ -9,8 +9,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('activity', {}, function () {
 QUnit.module('activity_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });

--- a/addons/mail/static/src/components/activity_mark_done_popover/tests/activity_mark_done_popover_tests.js
+++ b/addons/mail/static/src/components/activity_mark_done_popover/tests/activity_mark_done_popover_tests.js
@@ -8,8 +8,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('activity_mark_done_popover', {}, function () {
 QUnit.module('activity_mark_done_popover_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });

--- a/addons/mail/static/src/components/attachment_box/tests/attachment_box_tests.js
+++ b/addons/mail/static/src/components/attachment_box/tests/attachment_box_tests.js
@@ -17,8 +17,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('attachment_box', {}, function () {
 QUnit.module('attachment_box_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/components/attachment_image/tests/attachment_image_tests.js
+++ b/addons/mail/static/src/components/attachment_image/tests/attachment_image_tests.js
@@ -11,8 +11,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('attachment_image', {}, function () {
 QUnit.module('attachment_image_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });

--- a/addons/mail/static/src/components/attachment_list/tests/attachment_list_tests.js
+++ b/addons/mail/static/src/components/attachment_list/tests/attachment_list_tests.js
@@ -13,8 +13,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('attachment_list', {}, function () {
 QUnit.module('attachment_list_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });

--- a/addons/mail/static/src/components/channel_invitation_form/tests/channel_invitation_form_tests.js
+++ b/addons/mail/static/src/components/channel_invitation_form/tests/channel_invitation_form_tests.js
@@ -11,8 +11,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('channel_invitation_form', {}, function () {
 QUnit.module('channel_invitation_form_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/components/chat_window_manager/tests/chat_window_manager_tests.js
+++ b/addons/mail/static/src/components/chat_window_manager/tests/chat_window_manager_tests.js
@@ -17,8 +17,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('chat_window_manager', {}, function () {
 QUnit.module('chat_window_manager_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start(Object.assign(

--- a/addons/mail/static/src/components/chatter/tests/chatter_suggested_recipient_tests.js
+++ b/addons/mail/static/src/components/chatter/tests/chatter_suggested_recipient_tests.js
@@ -6,8 +6,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('chatter', {}, function () {
 QUnit.module('chatter_suggested_recipients_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/components/chatter/tests/chatter_tests.js
+++ b/addons/mail/static/src/components/chatter/tests/chatter_tests.js
@@ -6,8 +6,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('chatter', {}, function () {
 QUnit.module('chatter_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });

--- a/addons/mail/static/src/components/chatter_topbar/tests/chatter_topbar_tests.js
+++ b/addons/mail/static/src/components/chatter_topbar/tests/chatter_topbar_tests.js
@@ -8,8 +8,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('chatter_topbar', {}, function () {
 QUnit.module('chatter_topbar_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/components/composer/tests/composer_tests.js
+++ b/addons/mail/static/src/components/composer/tests/composer_tests.js
@@ -23,8 +23,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('composer', {}, function () {
 QUnit.module('composer_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });

--- a/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_canned_response_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_canned_response_tests.js
@@ -6,8 +6,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('composer_suggestion', {}, function () {
 QUnit.module('composer_suggestion_canned_response_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });

--- a/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_channel_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_channel_tests.js
@@ -6,8 +6,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('composer_suggestion', {}, function () {
 QUnit.module('composer_suggestion_channel_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });

--- a/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_command_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_command_tests.js
@@ -6,8 +6,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('composer_suggestion', {}, function () {
 QUnit.module('composer_suggestion_command_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });

--- a/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_partner_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_partner_tests.js
@@ -6,8 +6,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('composer_suggestion', {}, function () {
 QUnit.module('composer_suggestion_partner_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });

--- a/addons/mail/static/src/components/dialog_manager/tests/dialog_manager_tests.js
+++ b/addons/mail/static/src/components/dialog_manager/tests/dialog_manager_tests.js
@@ -12,8 +12,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('dialog_manager', {}, function () {
 QUnit.module('dialog_manager_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign(

--- a/addons/mail/static/src/components/discuss/tests/discuss_inbox_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_inbox_tests.js
@@ -14,8 +14,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('discuss', {}, function () {
 QUnit.module('discuss_inbox_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/components/discuss/tests/discuss_message_edit_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_message_edit_tests.js
@@ -6,8 +6,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('discuss', {}, function () {
 QUnit.module('discuss_message_edit_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/components/discuss/tests/discuss_pinned_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_pinned_tests.js
@@ -11,8 +11,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('discuss', {}, function () {
 QUnit.module('discuss_pinned_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/components/discuss/tests/discuss_sidebar_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_sidebar_tests.js
@@ -13,8 +13,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('discuss', {}, function () {
 QUnit.module('discuss_sidebar_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_tests.js
@@ -19,8 +19,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('discuss', {}, function () {
 QUnit.module('discuss_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/components/discuss_mobile_mailbox_selection/mobile_tests/discuss_mobile_mailbox_selection_tests.js
+++ b/addons/mail/static/src/components/discuss_mobile_mailbox_selection/mobile_tests/discuss_mobile_mailbox_selection_tests.js
@@ -11,8 +11,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('discuss_mobile_mailbox_selection', {}, function () {
 QUnit.module('discuss_mobile_mailbox_selection_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign(

--- a/addons/mail/static/src/components/discuss_sidebar_category/tests/discuss_sidebar_category_tests.js
+++ b/addons/mail/static/src/components/discuss_sidebar_category/tests/discuss_sidebar_category_tests.js
@@ -11,8 +11,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('discuss_sidebar_category', {}, function () {
 QUnit.module('discuss_sidebar_category_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/components/discuss_sidebar_category_item/tests/discuss_sidebar_category_item_tests.js
+++ b/addons/mail/static/src/components/discuss_sidebar_category_item/tests/discuss_sidebar_category_item_tests.js
@@ -13,8 +13,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('discuss_sidebar_category_item', {}, function () {
 QUnit.module('discuss_sidebar_category_item_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/components/file_uploader/tests/file_uploader_tests.js
+++ b/addons/mail/static/src/components/file_uploader/tests/file_uploader_tests.js
@@ -9,8 +9,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('file_uploader', {}, function () {
 QUnit.module('file_uploader_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
         this.apps = [];
 
         this.start = async params => {

--- a/addons/mail/static/src/components/follow_button/tests/follow_button_tests.js
+++ b/addons/mail/static/src/components/follow_button/tests/follow_button_tests.js
@@ -12,8 +12,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('follow_button', {}, function () {
 QUnit.module('follow_button_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.createFollowButtonComponent = async (thread, otherProps = {}) => {
             const props = Object.assign({ threadLocalId: thread.localId }, otherProps);

--- a/addons/mail/static/src/components/follower/tests/follower_tests.js
+++ b/addons/mail/static/src/components/follower/tests/follower_tests.js
@@ -16,8 +16,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('follower', {}, function () {
 QUnit.module('follower_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.createFollowerComponent = async (follower) => {
             await createRootMessagingComponent(this, "Follower", {

--- a/addons/mail/static/src/components/follower_list_menu/tests/follower_list_menu_tests.js
+++ b/addons/mail/static/src/components/follower_list_menu/tests/follower_list_menu_tests.js
@@ -15,8 +15,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('follower_list_menu', {}, function () {
 QUnit.module('follower_list_menu_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.createFollowerListMenuComponent = async (thread, otherProps = {}) => {
             const props = Object.assign({ threadLocalId: thread.localId }, otherProps);

--- a/addons/mail/static/src/components/follower_subtype/tests/follower_subtype_tests.js
+++ b/addons/mail/static/src/components/follower_subtype/tests/follower_subtype_tests.js
@@ -13,8 +13,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('follower_subtype', {}, function () {
 QUnit.module('follower_subtype_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.createFollowerSubtypeComponent = async ({ follower, followerSubtype }) => {
             const props = {

--- a/addons/mail/static/src/components/message/tests/message_tests.js
+++ b/addons/mail/static/src/components/message/tests/message_tests.js
@@ -17,8 +17,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('message', {}, function () {
 QUnit.module('message_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });

--- a/addons/mail/static/src/components/message_seen_indicator/tests/message_seen_indicator_tests.js
+++ b/addons/mail/static/src/components/message_seen_indicator/tests/message_seen_indicator_tests.js
@@ -12,8 +12,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('message_seen_indicator', {}, function () {
 QUnit.module('message_seen_indicator_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.createMessageSeenIndicatorComponent = async ({ message, thread }, otherProps) => {
             const props = Object.assign(

--- a/addons/mail/static/src/components/messaging_menu/tests/messaging_menu_tests.js
+++ b/addons/mail/static/src/components/messaging_menu/tests/messaging_menu_tests.js
@@ -14,8 +14,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('messaging_menu', {}, function () {
 QUnit.module('messaging_menu_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/components/notification_list/tests/notification_list_notification_group_tests.js
+++ b/addons/mail/static/src/components/notification_list/tests/notification_list_notification_group_tests.js
@@ -8,8 +8,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('notification_list', {}, function () {
 QUnit.module('notification_list_notification_group_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/components/notification_list/tests/notification_list_tests.js
+++ b/addons/mail/static/src/components/notification_list/tests/notification_list_tests.js
@@ -6,8 +6,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('notification_list', {}, function () {
 QUnit.module('notification_list_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/components/partner_im_status_icon/tests/partner_im_status_icon_tests.js
+++ b/addons/mail/static/src/components/partner_im_status_icon/tests/partner_im_status_icon_tests.js
@@ -12,8 +12,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('partner_im_status_icon', {}, function () {
 QUnit.module('partner_im_status_icon_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.createPartnerImStatusIcon = async partner => {
             await createRootMessagingComponent(this, "PartnerImStatusIcon", {

--- a/addons/mail/static/src/components/thread_icon/tests/thread_icon_tests.js
+++ b/addons/mail/static/src/components/thread_icon/tests/thread_icon_tests.js
@@ -12,8 +12,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('thread_icon', {}, function () {
 QUnit.module('thread_icon_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.createThreadIcon = async thread => {
             await createRootMessagingComponent(this, "ThreadIcon", {

--- a/addons/mail/static/src/components/thread_needaction_preview/tests/thread_needaction_preview_tests.js
+++ b/addons/mail/static/src/components/thread_needaction_preview/tests/thread_needaction_preview_tests.js
@@ -8,8 +8,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('thread_needaction_preview', {}, function () {
 QUnit.module('thread_needaction_preview_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/components/thread_preview/tests/thread_preview_tests.js
+++ b/addons/mail/static/src/components/thread_preview/tests/thread_preview_tests.js
@@ -6,8 +6,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('thread_preview', {}, function () {
 QUnit.module('thread_preview_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/components/thread_textual_typing_status/tests/thread_textual_typing_status_tests.js
+++ b/addons/mail/static/src/components/thread_textual_typing_status/tests/thread_textual_typing_status_tests.js
@@ -13,8 +13,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('thread_textual_typing_status', {}, function () {
 QUnit.module('thread_textual_typing_status_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.createThreadTextualTypingStatusComponent = async thread => {
             await createRootMessagingComponent(this, "ThreadTextualTypingStatus", {

--- a/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
+++ b/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
@@ -13,8 +13,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('thread_view', {}, function () {
 QUnit.module('thread_view_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });

--- a/addons/mail/static/src/model/tests/model_field_command/clear_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/clear_tests.js
@@ -11,8 +11,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('model', {}, function () {
 QUnit.module('model_field_command', {}, function () {
 QUnit.module('clear_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {
                 data: this.data,

--- a/addons/mail/static/src/model/tests/model_field_command/insert_and_replace_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/insert_and_replace_tests.js
@@ -11,8 +11,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('model', {}, function () {
 QUnit.module('model_field_command', {}, function () {
 QUnit.module('insert_and_replace_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {
                 data: this.data,

--- a/addons/mail/static/src/model/tests/model_field_command/insert_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/insert_tests.js
@@ -11,8 +11,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('model', {}, function () {
 QUnit.module('model_field_command', {}, function () {
 QUnit.module('insert_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {
                 data: this.data,

--- a/addons/mail/static/src/model/tests/model_field_command/link_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/link_tests.js
@@ -11,8 +11,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('model', {}, function () {
 QUnit.module('model_field_command', {}, function () {
 QUnit.module('field_command_link_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {
                 data: this.data,

--- a/addons/mail/static/src/model/tests/model_field_command/replace_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/replace_tests.js
@@ -11,8 +11,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('model', {}, function () {
 QUnit.module('model_field_command', {}, function () {
 QUnit.module('replace_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {
                 data: this.data,

--- a/addons/mail/static/src/model/tests/model_field_command/set_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/set_tests.js
@@ -15,8 +15,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('model', {}, function () {
 QUnit.module('model_field_command', {}, function () {
 QUnit.module('set_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {
                 data: this.data,

--- a/addons/mail/static/src/model/tests/model_field_command/unlink_all_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/unlink_all_tests.js
@@ -11,8 +11,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('model', {}, function () {
 QUnit.module('model_field_command', {}, function () {
 QUnit.module('unlink_all_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {
                 data: this.data,

--- a/addons/mail/static/src/model/tests/model_field_command/unlink_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/unlink_tests.js
@@ -11,8 +11,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('model', {}, function () {
 QUnit.module('model_field_command', {}, function () {
 QUnit.module('unlink_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {
                 data: this.data,

--- a/addons/mail/static/src/models/attachment/tests/attachment_tests.js
+++ b/addons/mail/static/src/models/attachment/tests/attachment_tests.js
@@ -6,8 +6,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('models', {}, function () {
 QUnit.module('attachment', {}, function () {
 QUnit.module('attachment_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/models/message/tests/message_tests.js
+++ b/addons/mail/static/src/models/message/tests/message_tests.js
@@ -9,8 +9,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('models', {}, function () {
 QUnit.module('message', {}, function () {
 QUnit.module('message_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/models/messaging/tests/messaging_tests.js
+++ b/addons/mail/static/src/models/messaging/tests/messaging_tests.js
@@ -6,8 +6,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('models', {}, function () {
 QUnit.module('messaging', {}, function () {
 QUnit.module('messaging_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/models/messaging_menu/tests/messaging_menu_tests.js
+++ b/addons/mail/static/src/models/messaging_menu/tests/messaging_menu_tests.js
@@ -6,8 +6,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('models', {}, function () {
 QUnit.module('messaging_menu', {}, function () {
 QUnit.module('messaging_menu_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env } = await start({ data: this.data, ...params });

--- a/addons/mail/static/src/models/thread/tests/thread_tests.js
+++ b/addons/mail/static/src/models/thread/tests/thread_tests.js
@@ -7,8 +7,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('models', {}, function () {
 QUnit.module('thread', {}, function () {
 QUnit.module('thread_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {

--- a/addons/mail/static/src/utils/throttle/tests/throttle_tests.js
+++ b/addons/mail/static/src/utils/throttle/tests/throttle_tests.js
@@ -10,8 +10,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('utils', {}, function () {
 QUnit.module('throttle', {}, function () {
 QUnit.module('throttle_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
         this.throttles = [];
 
         this.start = async params => {

--- a/addons/mail/static/src/utils/timer/tests/timer_tests.js
+++ b/addons/mail/static/src/utils/timer/tests/timer_tests.js
@@ -9,8 +9,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('utils', {}, function () {
 QUnit.module('timer', {}, function () {
 QUnit.module('timer_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
         this.timers = [];
 
         this.start = async (params) => {

--- a/addons/mail/static/src/widgets/form_renderer/tests/form_renderer_tests.js
+++ b/addons/mail/static/src/widgets/form_renderer/tests/form_renderer_tests.js
@@ -21,8 +21,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('widgets', {}, function () {
 QUnit.module('form_renderer', {}, function () {
 QUnit.module('form_renderer_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         // FIXME archs could be removed once task-2248306 is done
         // The mockServer will try to get the list view

--- a/addons/mail/static/src/widgets/notification_alert/tests/notification_alert_tests.js
+++ b/addons/mail/static/src/widgets/notification_alert/tests/notification_alert_tests.js
@@ -8,8 +8,8 @@ QUnit.module('mail', {}, function () {
 QUnit.module('widgets', {}, function () {
 QUnit.module('notification_alert', {}, function () {
 QUnit.module('notification_alert_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             let { widget } = await start(Object.assign({

--- a/addons/mail/static/tests/chatter_tests.js
+++ b/addons/mail/static/tests/chatter_tests.js
@@ -8,8 +8,8 @@ import testUtils from 'web.test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('Chatter', {
-    beforeEach: function () {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.data['res.partner'].records.push({ id: 11, im_status: 'online' });
         this.data['mail.activity.type'].records.push(
@@ -372,8 +372,8 @@ QUnit.test('list activity exception widget with activity', async function (asser
 });
 
 QUnit.module('FieldMany2ManyTagsEmail', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         Object.assign(this.data['res.users'].fields, {
             timmy: { string: "pokemon", type: "many2many", relation: 'partner_type' },

--- a/addons/mail/static/tests/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/m2x_avatar_user_tests.js
@@ -18,8 +18,8 @@ let target;
 
 QUnit.module('mail', {}, function () {
     QUnit.module('M2XAvatarUser', {
-        beforeEach() {
-            beforeEach(this);
+        async beforeEach() {
+            await beforeEach(this);
 
             // reset the cache before each test
             Many2OneAvatarUser.prototype.partnerIds = {};

--- a/addons/mail/static/tests/systray/systray_activity_menu_tests.js
+++ b/addons/mail/static/tests/systray/systray_activity_menu_tests.js
@@ -12,8 +12,8 @@ import testUtils from 'web.test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('ActivityMenu', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         Object.assign(this.data, {
             'mail.activity.menu': {

--- a/addons/mail/static/tests/webclient/commands/mail_providers_tests.js
+++ b/addons/mail/static/tests/webclient/commands/mail_providers_tests.js
@@ -11,9 +11,9 @@ const serviceRegistry = registry.category("services");
 
 QUnit.module('mail', {}, function () {
     QUnit.module('Command Palette', {
-        beforeEach() {
+        async beforeEach() {
             serviceRegistry.add("command", commandService);
-            beforeEach(this);
+            await beforeEach(this);
             patchWithCleanup(browser, {
                 clearTimeout() {},
                 setTimeout(later, wait) {

--- a/addons/note/static/tests/systray_activity_menu_tests.js
+++ b/addons/note/static/tests/systray_activity_menu_tests.js
@@ -7,8 +7,8 @@ import testUtils from 'web.test_utils';
 
 QUnit.module('note', {}, function () {
 QUnit.module("ActivityMenu", {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         Object.assign(this.data, {
             'mail.activity.menu': {

--- a/addons/sms/static/src/components/message/tests/message_tests.js
+++ b/addons/sms/static/src/components/message/tests/message_tests.js
@@ -15,8 +15,8 @@ QUnit.module('sms', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('message', {}, function () {
 QUnit.module('message_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });

--- a/addons/sms/static/src/components/notification_list/tests/notification_list_notification_group_tests.js
+++ b/addons/sms/static/src/components/notification_list/tests/notification_list_notification_group_tests.js
@@ -8,8 +8,8 @@ QUnit.module('sms', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('notification_list', {}, function () {
 QUnit.module('notification_list_notification_group_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start(Object.assign({}, params, {

--- a/addons/snailmail/static/src/components/message/tests/message_tests.js
+++ b/addons/snailmail/static/src/components/message/tests/message_tests.js
@@ -14,8 +14,8 @@ QUnit.module('snailmail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('message', {}, function () {
 QUnit.module('message_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });

--- a/addons/snailmail/static/src/components/notification_list/tests/notification_list_notification_group_tests.js
+++ b/addons/snailmail/static/src/components/notification_list/tests/notification_list_notification_group_tests.js
@@ -8,8 +8,8 @@ QUnit.module('snailmail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('notification_list', {}, function () {
 QUnit.module('notification_list_notification_group_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const res = await start(Object.assign({}, params, {

--- a/addons/website_livechat/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/website_livechat/static/src/components/discuss/tests/discuss_tests.js
@@ -10,8 +10,8 @@ QUnit.module('website_livechat', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('discuss', {}, function () {
 QUnit.module('discuss_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, params, {

--- a/addons/website_livechat/static/src/models/messaging_notification_handler/tests/messaging_notification_handler_tests.js
+++ b/addons/website_livechat/static/src/models/messaging_notification_handler/tests/messaging_notification_handler_tests.js
@@ -14,8 +14,8 @@ QUnit.module('website_livechat', {}, function () {
 QUnit.module('models', {}, function () {
 QUnit.module('messaging_notification_handler', {}, function () {
 QUnit.module('messaging_notification_handler_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
 
         this.start = async params => {
             const { env, widget } = await start(Object.assign({}, {

--- a/addons/website_slides/static/src/components/activity/tests/activity_tests.js
+++ b/addons/website_slides/static/src/components/activity/tests/activity_tests.js
@@ -6,8 +6,8 @@ QUnit.module('website_slides', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('activity', {}, function () {
 QUnit.module('activity_tests.js', {
-    beforeEach() {
-        beforeEach(this);
+    async beforeEach() {
+        await beforeEach(this);
         this.start = async params => {
             const res = await start({ ...params, data: this.data });
             const { apps, env, widget } = res;


### PR DESCRIPTION
This PR prepares the ground for the python model definitions PR. Mail module's beforeEach functions are made async now in order to reduce the noise in the main PR.

enterprise: https://github.com/odoo/enterprise/pull/24489
task-2767820