### PR TITLE
[FIX] hr_holidays: fix invalid first level next call date

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -409,6 +409,9 @@ class HolidaysAllocation(models.Model):
                     continue
                 allocation.lastcall = max(allocation.lastcall, first_level_start_date)
                 allocation.nextcall = first_level._get_next_date(allocation.lastcall)
+                if len(level_ids) > 1:
+                    second_level_start_date = allocation.date_from + get_timedelta(level_ids[1].start_count, level_ids[1].start_type)
+                    allocation.nextcall = min(second_level_start_date - relativedelta(days=1), allocation.nextcall)
                 allocation._message_log(body=first_allocation)
             days_added_per_level = defaultdict(lambda: 0)
             while allocation.nextcall <= today:


### PR DESCRIPTION
Prior to this commit the next call date for the first level would not
take the second level into account, as such it could be that the first
level would be completely skipped instead of being prorated properly.

TaskId-2768435
