### PR TITLE
[FIX] mail: take all messages into account on unlink

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -338,7 +338,7 @@ class MailThread(models.AbstractModel):
         cascaded, because link is done through (res_model, res_id). """
         if not self:
             return True
-        self.env['mail.message'].search([('model', '=', self._name), ('res_id', 'in', self.ids)]).sudo().unlink()
+        self.env['mail.message'].sudo().search([('model', '=', self._name), ('res_id', 'in', self.ids)]).unlink()
         res = super(MailThread, self).unlink()
         self.env['mail.followers'].sudo().search(
             [('res_model', '=', self._name), ('res_id', 'in', self.ids)]


### PR DESCRIPTION
### Current behavior
When you delete a record (for example project.task), all the messages related to this record aren't deleted. 
This, in case a user has his notifications managed in Odoo, may prevent him from accessing the History tab in the Discuss app because these messages are linked to a record that doesn't exist anymore and it will raise a Missing Record error

### Steps
*with demo data*
- Install Project
- Make Marc Demo notifications managed in Odoo
- Delete a task project to which Marc Demo is assigned
(*with Marc Demo*)
- Go to Discuss and try to access History tab

OPW-2764855