### PR TITLE
[FIX] board : drag task between personnal stages in dashboard

### DIFF
--- a/addons/board/static/src/legacy/js/board_view.js
+++ b/addons/board/static/src/legacy/js/board_view.js
@@ -269,7 +269,9 @@ var BoardRenderer = FormRenderer.extend({
                 return self.loadViews(action.res_model, context, [view])
                            .then(function (viewsInfo) {
                     var viewInfo = viewsInfo[viewType];
-                    var View = viewRegistry.get(viewType);
+                    var xml = new DOMParser().parseFromString(viewInfo.arch, "text/xml")
+                    var key = xml.documentElement.getAttribute("js_class");
+                    var View = viewRegistry.get(key || viewType);
 
                     const searchQuery = {
                         context: context,


### PR DESCRIPTION
Steps :
Install Project and Dashboard.
Project > My task > Favorites (search zone) > Add to Dashboard.
Notice you can drag task between stages.

Issue :
Dashboard > Notice you cannot.

Cause :
m2m groupby normally (in kanban_renderer.js) does not allow drag.
project_kanban overrides its _setState() method to allow it for parsonnal
stages, because they "become m2o" with a user.
Yet, in the dashboard, we pass through the default method, because the
wrong view is created.

Fix :
Take into account the js_class in the arch to create the view.

opw-2752072

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
