### PR TITLE
[IMP] models: small optimization in onchange

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6535,15 +6535,15 @@ Fields:
                     record._onchange_eval(name, field_onchange[name], result)
                 done.add(name)
 
+            if not env.context.get('recursive_onchanges', True):
+                break
+
             # determine which fields to process for the next pass
             todo = [
                 name
                 for name in nametree
                 if name not in done and snapshot0.has_changed(name)
             ]
-
-            if not env.context.get('recursive_onchanges', True):
-                todo = []
 
         # make the snapshot with the final values of record
         snapshot1 = Snapshot(record, nametree)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
a small optimization in onchange
Current behavior before PR:
The todo items are recalculated then discarded if `recursive_onchanges` is in the context
Desired behavior after PR is merged:
If `recursive_onchanges` is in context, todo items are not recalculated




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
