### PR TITLE
[IMP] mail: add default explicitly in channel_create to be more clear

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -1073,6 +1073,7 @@ class Channel(models.Model):
         """
         # create the channel
         new_channel = self.create({
+            'channel_type': 'channel',
             'name': name,
             'public': privacy,
         })


### PR DESCRIPTION
Specify 'channel_type' explicitly in channel_create. This makes the
the method more clear and decoupling from the default value.
Once the default values change, the method can work as expected as well.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
