### PR TITLE
[FIX] web: action service: button action with html help

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1184,6 +1184,9 @@ function makeActionManager(env) {
                 action && typeof action === "object"
                     ? action
                     : { type: "ir.actions.act_window_close" };
+            if (action.help) {
+                action.help = markup(action.help);
+            }
         } else if (params.type === "action") {
             // execute a given action, so load it first
             context.active_id = params.resId || null;

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -983,6 +983,34 @@ QUnit.module("ActionManager", (hooks) => {
         }
     );
 
+    QUnit.test("action with html help returned by a call_button", async function (assert) {
+        assert.expect(1);
+        const mockRPC = async (route, args) => {
+            if (route === "/web/dataset/call_button") {
+                return Promise.resolve({
+                    res_model: "partner",
+                    type: "ir.actions.act_window",
+                    views: [[false, "list"]],
+                    help: "<p>I am not a helper</p>",
+                    domain: [[0, "=", 1]],
+                });
+            }
+        };
+        const webClient = await createWebClient({ serverData, mockRPC });
+        await doAction(webClient, 3);
+
+        // open a record in form view
+        await click(target.querySelector(".o_list_view .o_data_row"));
+        await legacyExtraNextTick();
+
+        await click(target.querySelector(".o_statusbar_buttons button"));
+        await legacyExtraNextTick();
+        assert.strictEqual(
+            target.querySelector(".o_list_view .o_nocontent_help p").innerText,
+            "I am not a helper"
+        );
+    });
+
     QUnit.test("can open different records from a multi record view", async function (assert) {
         assert.expect(12);
         const mockRPC = async (route, args) => {


### PR DESCRIPTION
The method call_button sometimes returns an action with a help key.
That help was not marked up, leading to an incorrect display of that help.