### PR TITLE
[IMP] crm_livechat: Test channel should specify the 'channel_type' field

### DIFF
--- a/addons/crm_livechat/tests/test_crm_lead.py
+++ b/addons/crm_livechat/tests/test_crm_lead.py
@@ -33,7 +33,9 @@ class TestLivechatLead(TestCrmCommon):
         # public: should not be set as customer
         channel = self.env['mail.channel'].create({
             'name': 'Chat with Visitor',
-            'channel_partner_ids': [(4, self.user_anonymous.partner_id.id)]
+            'channel_type': 'livechat',
+            'channel_partner_ids': [(4, self.user_anonymous.partner_id.id)],
+            'livechat_operator_id': self.env.user.partner_id.id
         })
         lead = channel._convert_visitor_to_lead(self.env.user.partner_id, '/lead TestLead command')
 
@@ -50,7 +52,9 @@ class TestLivechatLead(TestCrmCommon):
 
         channel = self.env['mail.channel'].create({
             'name': 'Chat with Visitor',
-            'channel_partner_ids': [(4, self.env.ref('base.public_partner').id)]
+            'channel_type': 'livechat',
+            'channel_partner_ids': [(4, self.env.ref('base.public_partner').id)],
+            'livechat_operator_id': self.env.user.partner_id.id
         })
         lead = channel._convert_visitor_to_lead(self.env.user.partner_id, '/lead TestLead command')
 
@@ -71,7 +75,9 @@ class TestLivechatLead(TestCrmCommon):
         # portal: should be set as customer
         channel = self.env['mail.channel'].create({
             'name': 'Chat with Visitor',
-            'channel_partner_ids': [(4, self.user_portal.partner_id.id)]
+            'channel_type': 'livechat',
+            'channel_partner_ids': [(4, self.user_portal.partner_id.id)],
+            'livechat_operator_id': self.env.user.partner_id.id
         })
         lead = channel._convert_visitor_to_lead(self.env.user.partner_id, '/lead TestLead command')
 


### PR DESCRIPTION
The 'channel_type' field should be specified in the test TestLivechatLead.
For simulating the chat with the customer, the channel_type should be set manually rather than the default value, which is currently 'channel'.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
