### PR TITLE
[FIX] l10n_de_sale: add missing incoterm on SO

### DIFF
--- a/addons/l10n_de_sale/i18n/l10n_de_sale.pot
+++ b/addons/l10n_de_sale/i18n/l10n_de_sale.pot
@@ -40,6 +40,12 @@ msgstr ""
 #. module: l10n_de_sale
 #: code:addons/l10n_de_sale/models/sale.py:0
 #, python-format
+msgid "Incoterm"
+msgstr ""
+
+#. module: l10n_de_sale
+#: code:addons/l10n_de_sale/models/sale.py:0
+#, python-format
 msgid "Invoicing Address:"
 msgstr ""
 

--- a/addons/l10n_de_sale/models/sale.py
+++ b/addons/l10n_de_sale/models/sale.py
@@ -28,6 +28,8 @@ class SaleOrder(models.Model):
                 data.append((_('Customer Reference'), record.client_order_ref))
             if record.user_id:
                 data.append((_("Salesperson"), record.user_id.name))
+            if 'incoterm' in record._fields and record.incoterm:
+                data.append((_("Incoterm"), record.incoterm.code))
 
     def _compute_l10n_de_document_title(self):
         for record in self:


### PR DESCRIPTION
### Current behavior
Incoterm isn't printed on quotation/order report with DIN5008 layout

### Steps
- Install Sales, Inventory and Germany - Sale
- In Settings :
   - Enable Incoterms under Sales section
   - Select DIN5008 Layout (external_layout_din5008) for documents
- Go to Sales and get a new one
- Select an incoterm in Other info tab

OPW-2759568