### PR TITLE
[FIX] sale: Impossible to unset `invoice_mail_template_id`

### DIFF
--- a/addons/sale/data/sale_data.xml
+++ b/addons/sale/data/sale_data.xml
@@ -7,6 +7,11 @@
         <field name="value" ref="sale.mail_template_sale_confirmation"/>
     </record>
 
+    <record id="default_invoice_email_template" model="ir.config_parameter">
+        <field name="key">sale.default_invoice_email_template</field>
+        <field name="value" ref="account.email_template_edi_invoice"/>
+    </record>
+
     <record id="send_invoice_cron" model="ir.cron">
         <field name="name">automatic invoicing: send ready invoice</field>
         <field name="model_id" ref="payment.model_payment_transaction" />

--- a/addons/sale/models/res_config_settings.py
+++ b/addons/sale/models/res_config_settings.py
@@ -55,7 +55,7 @@ class ResConfigSettings(models.TransientModel):
         string='Invoice Email Template',
         domain="[('model', '=', 'account.move')]",
         config_parameter='sale.default_invoice_email_template',
-        default=lambda self: self.env.ref('account.email_template_edi_invoice', False)
+        help="Email sent to the customer once the invoice is available.",
     )
     confirmation_mail_template_id = fields.Many2one(
         comodel_name='mail.template',


### PR DESCRIPTION
**Steps to reproduce:**

1. Go to Configuration > Website
2. Enable Automatic Invoice and Save
3. Remove the value from Invoice Email Template and Save

![image](https://user-images.githubusercontent.com/1914185/154695232-d085d164-a773-4996-a792-c9db463bd0c4.png)


**Result:**

* The field shows as set by the default value.
* The ir.config_parameter doesn't exist.

**Excepted:**

* The field should be shown as unset.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
