### PR TITLE
[FIX]hr_holidays: leave request traceback in arabic

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar.js
@@ -94,8 +94,8 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
                     res_model: "hr.leave",
                     view_id: ids,
                     context: {
-                        'default_date_from': moment().format('YYYY-MM-DD'),
-                        'default_date_to': moment().add(1, 'days').format('YYYY-MM-DD'),
+                        'default_date_from': moment().locale('en').format('YYYY-MM-DD'),
+                        'default_date_to': moment().add(1, 'days').locale('en').format('YYYY-MM-DD'),
                         'lang': self.context.lang,
                     },
                     title: _t("New time off"),


### PR DESCRIPTION
Step to reproduce:
- Switch language to arabic
- Go to Time off
- Click on 'New TIme Off'

Current behaviour:
- Traceback
Default date_from and date_to are given in arabic which cannot be parsed by the field

Behaviour after PR:
- Default date_from and date_to are given in english and then translated via the field

opw-2755258

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
