### PR TITLE
[FIX] base: Only comment out code for inactive cron jobs

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -655,19 +655,6 @@ class IrActionsServer(models.Model):
                 )
         return res or False
 
-    def _neutralize(self):
-        # In some cases, cron neutralization is not enough as modifying records
-        # like `fetchmail.server`, `calendar.alarm` and `base.automation` will
-        # re-enable their cron jobs as a side-effect.
-        super()._neutralize()
-        self.flush()
-        self.invalidate_cache()
-        self.env.cr.execute("""
-            UPDATE ir_act_server
-            SET code = '#' || REPLACE(code, E'\n', E'\n#')
-            WHERE usage = 'ir_cron' AND state = 'code'
-        """)
-
 
 class IrServerObjectLines(models.Model):
     _name = 'ir.server.object.lines'

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -478,6 +478,22 @@ class ir_cron(models.Model):
             )
         """)
 
+        # Modifying records like `fetchmail.server`, `calendar.alarm` and
+        # `base.automation` will re-enable their cron jobs as a side-effect. To
+        # prevent this from causing cron jobs to execute unexpectedly on neutralized
+        # duplicates, comment out the code of the cron jobs. This means that if you
+        # really want to execute a cron job on a duplicate, you'll need to uncomment
+        # the code of its server action in addition to re-activating it."
+        self.env.cr.execute("""
+            UPDATE ir_act_server
+            SET code = '#' || REPLACE(code, E'\n', E'\n#')
+            FROM ir_cron
+            WHERE ir_act_server.usage = 'ir_cron'
+                AND ir_act_server.state = 'code'
+                AND ir_cron.active = FALSE
+                AND ir_cron.ir_actions_server_id = ir_act_server.id
+        """)
+
 
 class ir_cron_trigger(models.Model):
     _name = 'ir.cron.trigger'


### PR DESCRIPTION
The original neutralize code in `ir_actions` was ported from
`oe-support`, which sets `active` to `False` for all `ir_cron` records.

On platforms like SaaS and Odoo.sh, some cron jobs are deliberately
kept active (like the auto-vacuum). So the code for these should not
be commented out.

The current neutralize code for `ir_cron` deactivates everything except
the auto-vacuum. The current neutralize code for `ir_actions` doesn't
take into account whether a cron job is active or not, so it comments
everything.

If the `ir_actions` implementation is updated to take into account
the `active` flag, this still means that depending on whether the
neutralize code for `ir_actions` or `ir_cron` executes first, you get
different results.

To remove that execution order dependency, the code for commenting out
the server actions related to deactivated crons is moved to `ir_cron`,
since it's strongly coupled to that in any case.