### PR TITLE
[FIX] website_sale: allow public user to print cart

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1078,7 +1078,7 @@ class WebsiteSale(http.Controller):
     def print_saleorder(self, **kwargs):
         sale_order_id = request.session.get('sale_last_order_id')
         if sale_order_id:
-            pdf, _ = request.env.ref('sale.action_report_saleorder').sudo()._render_qweb_pdf([sale_order_id])
+            pdf, _ = request.env.ref('sale.action_report_saleorder').with_user(SUPERUSER_ID)._render_qweb_pdf([sale_order_id])
             pdfhttpheaders = [('Content-Type', 'application/pdf'), ('Content-Length', u'%s' % len(pdf))]
             return request.make_response(pdf, headers=pdfhttpheaders)
         else:


### PR DESCRIPTION
### Current behavior
A public user couldn't print his cart because a 403 error is raised

### Steps
- Install eCommerce
- Go to the shop as a public user
- Process an order and payment
- Click on "Print" button on order confirmation page

### Note
Backport of 15.0 8ff6664c9dc98b7282c57b2859745bf1030aabc9

OPW-2753275