### PR TITLE
[FIX] crm: use default_lang in contact creation only for active lang

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1792,12 +1792,14 @@ class Lead(models.Model):
         recipients = super(Lead, self)._message_get_suggested_recipients()
         try:
             for lead in self:
+                # check if that language is correctly installed (and active) before using it
+                lang_code = lead.lang_code if lead.lang_code and self.env['res.lang']._lang_get(lead.lang_code) else None
                 if lead.partner_id:
                     lead._message_add_suggested_recipient(
-                        recipients, partner=lead.partner_id, lang=lead.lang_code, reason=_('Customer'))
+                        recipients, partner=lead.partner_id, lang=lang_code, reason=_('Customer'))
                 elif lead.email_from:
                     lead._message_add_suggested_recipient(
-                        recipients, email=lead.email_from, lang=lead.lang_code, reason=_('Customer Email'))
+                        recipients, email=lead.email_from, lang=lang_code, reason=_('Customer Email'))
         except AccessError:  # no read access rights -> just ignore suggested recipients because this imply modifying followers
             pass
         return recipients

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -536,6 +536,42 @@ class TestCRMLead(TestCrmCommon):
         self.assertEqual(new_lead.partner_id.team_id, self.sales_team_1)
 
     @users('user_sales_manager')
+    def test_message_get_suggested_recipients(self):
+        """This test checks that creating a contact from a lead with an inactive language will ignore the language
+            while creating a contact from a lead with an active language will take it into account """
+        ResLang = self.env['res.lang'].sudo().with_context(active_test=False)
+
+        """Create a lead with an inactive language -> should ignore the preset language"""
+        lang_fr = ResLang.search([('code', '=', 'fr_FR')])
+        if not lang_fr:
+            lang_fr = ResLang._create_lang('fr_FR')
+        # set French language as inactive then try to call "_message_get_suggested_recipients"
+        # -> lang code should be ignored
+        lang_fr.active = False
+        lead1 = self.env['crm.lead'].create({
+            'name': 'TestLead',
+            'email_from': self.test_email,
+            'lang_id': lang_fr.id,
+        })
+        data = lead1._message_get_suggested_recipients()[lead1.id]
+        self.assertEqual(data, [(False, self.test_email, None, 'Customer Email')])
+
+        """Create a lead with an active language -> should keep the preset language for recipients"""
+        lang_en = ResLang.search([('code', '=', 'en_US')])
+        if not lang_en:
+            lang_en = ResLang._create_lang('en_US')
+        # set American English language as active then try to call "_message_get_suggested_recipients"
+        # -> lang code should be kept
+        lang_en.active = True
+        lead2 = self.env['crm.lead'].create({
+            'name': 'TestLead',
+            'email_from': self.test_email,
+            'lang_id': lang_en.id,
+        })
+        data = lead2._message_get_suggested_recipients()[lead2.id]
+        self.assertEqual(data, [(False, self.test_email, "en_US", 'Customer Email')])
+
+    @users('user_sales_manager')
     def test_phone_mobile_search(self):
         lead_1 = self.env['crm.lead'].create({
             'name': 'Lead 1',


### PR DESCRIPTION
### Expected Behaviour
When creating a contact from a lead with an unactive language, Odoo should replace this language with the parent's language or the DB language.

### Observed Behaviour
Since saas-15.1, when you create a contact from a lead email adress, the contact is created with the lead's language, even if it's not active, which give an error.

### Reproducibility
This bug can be reproduced following these steps:
1. Set an uninstalled language on a lead (two choices):
   1. Select an uninstalled language on a lead (this is what happens with the trial creation, and how to reproduce it via the interface)
      - install 8 languages in order to activate the "Search More..." link in the Language select field of a lead
      - on a lead which doesn't have a Customer yet, in the Language, "Search More...", filter with Active = False, and select an uninstalled language
   2. Install a language, select it on a lead with no Customer, and uninstall the language
2. On the lead, in its chatter, open the Send Message and check the checkbox next to its email => it should open a popup
3. Validate the popup => there is an exception in saas-15.X, and not in 15.0.

### Related Issues/PR
- [opw-2745841](https://www.odoo.com/web#id=2745841&model=project.task)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
