### PR TITLE
[FIX] pos_sale : PoS hardcoded terms

### DIFF
--- a/addons/pos_sale/i18n/pos_sale.pot
+++ b/addons/pos_sale/i18n/pos_sale.pot
@@ -39,6 +39,13 @@ msgstr ""
 
 #. module: pos_sale
 #. openerp-web
+#: code:addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js:0
+#, python-format
+msgid "Apply a down payment"
+msgstr ""
+
+#. module: pos_sale
+#. openerp-web
 #: code:addons/pos_sale/static/src/xml/OrderManagementScreen/SaleOrderManagementControlPanel.xml:0
 #, python-format
 msgid "Back"
@@ -415,6 +422,13 @@ msgstr ""
 #. module: pos_sale
 #: model:ir.model.fields,field_description:pos_sale.field_pos_order_line__sale_order_line_id
 msgid "Source Sale Order Line"
+msgstr ""
+
+#. module: pos_sale
+#. openerp-web
+#: code:addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js:0
+#, python-format
+msgid "Settle the order"
 msgstr ""
 
 #. module: pos_sale

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
@@ -77,7 +77,7 @@ odoo.define('pos_sale.SaleOrderManagementScreen', function (require) {
             const { confirmed, payload: selectedOption } = await this.showPopup('SelectionPopup',
                 {
                     title: this.env._t('What do you want to do?'),
-                    list: [{id:"0", label: "Apply a down payment", item: false}, {id:"1", label: "Settle the order", item: true}],
+                    list: [{id:"0", label: this.env._t("Apply a down payment"), item: false}, {id:"1", label: this.env._t("Settle the order"), item: true}],
                 });
 
             if(confirmed){


### PR DESCRIPTION
Current behavior:
In the PoS when you add an order the 2 terms "Settle the order" and "Apply down payment" were hardcoded in the code.

Steps to reproduce:
- Have PoS and Sale module installed
- Go in PoS
- Try to add an order sale
- The 2 terms are hardcoded and cannot be translated

opw-2754052
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
