### PR TITLE
[FIX] mass_mailing: properly convert base64 images

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1140,6 +1140,6 @@ class MassMailing(models.Model):
                 modified = True
 
         if modified:
-            return lxml.html.tostring(root)
+            return lxml.html.tostring(root, encoding='unicode')
 
         return body_html


### PR DESCRIPTION
The function that converts inline images to urls returned the modified html as a byte string. As a result, the Mail Debug tab showed a hexadecimal string rather than rendered html. This makes sure the string is encoded in unicode instead, so the format of the string coming out of the function is the same as it was coming in.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
