### PR TITLE
[FIX]: l10n_se: Hide Swedish OCR for non-SE

### DIFF
--- a/addons/l10n_se/models/res_partner.py
+++ b/addons/l10n_se/models/res_partner.py
@@ -10,6 +10,7 @@ class ResPartner(models.Model):
 
     l10n_se_check_vendor_ocr = fields.Boolean(string='Check Vendor OCR', help='This Vendor uses OCR Number on their Vendor Bills.')
     l10n_se_default_vendor_payment_ref = fields.Char(string='Default Vendor Payment Ref', help='If set, the vendor uses the same Default Payment Reference or OCR Number on all their Vendor Bills.')
+    user_country_code = fields.Char(string="User current company country code", compute="_compute_user_country_code")
 
     @api.onchange('l10n_se_default_vendor_payment_ref')
     def onchange_l10n_se_default_vendor_payment_ref(self):
@@ -19,3 +20,8 @@ class ResPartner(models.Model):
                 luhn.validate(reference)
             except: 
                 return {'warning': {'title': _('Warning'), 'message': _('Default vendor OCR number isn\'t a valid OCR number.')}}
+
+    @api.depends_context("allowed_company_ids")
+    def _compute_user_country_code(self):
+        cid = self._context.get("allowed_company_ids", [None])[0]
+        self.user_country_code = self.env["res.company"].browse(cid).country_code if cid else "SE"

--- a/addons/l10n_se/views/partner_view.xml
+++ b/addons/l10n_se/views/partner_view.xml
@@ -7,7 +7,8 @@
             <field name="inherit_id" ref="account.view_partner_property_form"/>
             <field name="arch" type="xml">
                 <group name="accounting_entries" position="after">
-                    <group string="Payment Options Sweden" name="payment_options">
+                    <field name="user_country_code" invisible='True'/>
+                    <group string="Payment Options Sweden" name="payment_options" attrs="{'invisible': [('user_country_code', '!=', 'SE')]}">
                         <field name="l10n_se_check_vendor_ocr"/>
                         <field name="l10n_se_default_vendor_payment_ref"/>
                     </group>


### PR DESCRIPTION
### [FIX]: l10n_se: Hide Swedish OCR for non-SE
Swedish OCR options are currently available  everywhere when the
localisation is implemented.

This hides the options when the current user active company is not
Swedish

**Task:** task-2732385
Signed-off-by: Julien Alardot (jual) <jual@odoo.com>

**Description of the issue/feature this PR addresses:** Swedish OCR settings are available all the time

**Current behavior before PR:** Swedish OCR settings are currently available on every partner all the time when the
localisation is implemented. Even when the company the user uses is not localized in Sweden

**Desired behavior after PR is merged:** Swedish OCR settings are only displayed when the company the user uses is localized in Sweden (the one that is displayed on top if several are selected)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
