### PR TITLE
[FIX] account_*: payment method journal filter

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -279,7 +279,7 @@ class AccountJournal(models.Model):
             else:
                 journal.default_account_type = False
 
-    @api.depends('type')
+    @api.depends('type', 'currency_id')
     def _compute_inbound_payment_method_line_ids(self):
         for journal in self:
             pay_method_line_ids_commands = [Command.clear()]
@@ -291,7 +291,7 @@ class AccountJournal(models.Model):
                 }) for pay_method in default_methods]
             journal.inbound_payment_method_line_ids = pay_method_line_ids_commands
 
-    @api.depends('type')
+    @api.depends('type', 'currency_id')
     def _compute_outbound_payment_method_line_ids(self):
         for journal in self:
             pay_method_line_ids_commands = [Command.clear()]
@@ -929,3 +929,23 @@ class AccountJournal(models.Model):
             return self.inbound_payment_method_line_ids
         else:
             return self.outbound_payment_method_line_ids
+
+    def _is_payment_method_available(self, payment_method_code):
+        """ Check if the payment method is available on this journal. """
+        self.ensure_one()
+        pm_info = self.env['account.payment.method']._get_payment_method_information().get(payment_method_code)
+        if not pm_info:
+            return False
+        currency_ids = pm_info.get('currency_ids')
+        country_id = pm_info.get('country_id')
+        domain = pm_info.get('domain', [('type', 'in', ('bank', 'cash'))])
+        journal_types = next(right for left, operator, right in domain if left == 'type' and operator in ('in', '='))
+
+        journal_currency_id = self.currency_id.id or self.company_id.currency_id.id
+        if currency_ids and journal_currency_id not in currency_ids:
+            return False
+        if country_id and self.company_id.account_fiscal_country_id.id != country_id:
+            return False
+        if self.type not in journal_types:
+            return False
+        return True

--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -44,15 +44,15 @@ class AccountPaymentMethod(models.Model):
         self.ensure_one()
         information = self._get_payment_method_information().get(self.code)
 
-        currency_id = information.get('currency_id')
+        currency_ids = information.get('currency_ids')
         country_id = information.get('country_id')
         default_domain = [('type', 'in', ('bank', 'cash'))]
         domains = [information.get('domain', default_domain)]
 
-        if currency_id:
+        if currency_ids:
             domains += [expression.OR([
-                [('currency_id', '=', False), ('company_id.currency_id', '=', currency_id)],
-                [('currency_id', '=', currency_id)]],
+                [('currency_id', '=', False), ('company_id.currency_id', 'in', currency_ids)],
+                [('currency_id', 'in', currency_ids)]],
             )]
 
         if country_id:

--- a/addons/account_check_printing/models/account_journal.py
+++ b/addons/account_check_printing/models/account_journal.py
@@ -11,7 +11,7 @@ class AccountJournal(models.Model):
 
     def _default_outbound_payment_methods(self):
         res = super()._default_outbound_payment_methods()
-        if self.type == 'bank':
+        if self._is_payment_method_available('check_printing'):
             res |= self.env.ref('account_check_printing.account_payment_method_check')
         return res
 


### PR DESCRIPTION
Fix two issues linked to payment methods and their journal link.

SEPA Credit Transfer was marked as only available on EUR journals, but
from what we have been told, and we have seen, it should also be made
available for other currencies (CHF/SEK).
So we are changing the rule used to determine if SEPA Credit Transfer
is available on a journal to allow to use it on journals using CHF or
SEK as a currency.

There is another issue, where the filtering is done differently at the
journal creation and when the user add the payment method manually in
the lists.
The filter rules were not respected at the journal creation, which
would lead to incorrect default inbound and outbound payment method list.
For example, a new journal would have the company currency (let's say,
USD) but still have SEPA Credit Transfer (EUR,CHF,SEK) added on it by
default while it should not be available there.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
