### PR TITLE
[FIX] fleet: fix search method for contract_renewal*

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -179,7 +179,7 @@ class FleetVehicle(models.Model):
             ('expiration_date', '>', today),
             ('expiration_date', '<', limit_date),
             ('state', 'in', ['open', 'expired'])
-        ]).mapped('id')
+        ]).mapped('vehicle_id').ids
         res.append(('id', search_operator, res_ids))
         return res
 
@@ -195,7 +195,7 @@ class FleetVehicle(models.Model):
             ('expiration_date', '!=', False),
             ('expiration_date', '<', today),
             ('state', 'in', ['open', 'expired'])
-        ]).mapped('id')
+        ]).mapped('vehicle_id').ids
         res.append(('id', search_operator, res_ids))
         return res
 

--- a/addons/fleet/tests/__init__.py
+++ b/addons/fleet/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_access_rights
+from . import test_overdue

--- a/addons/fleet/tests/test_overdue.py
+++ b/addons/fleet/tests/test_overdue.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests import common, new_test_user
+from odoo import fields
+
+
+class TestFleet(common.SavepointCase):
+
+    def test_search_renewal(self):
+        """
+            Should find the car with overdue contract or renewal due soon
+        """
+        user = new_test_user(self.env, "test base user", groups="base.group_user")
+        brand = self.env["fleet.vehicle.model.brand"].create({
+            "name": "Audi",
+        })
+        model = self.env["fleet.vehicle.model"].create({
+            "brand_id": brand.id,
+            "name": "A3",
+        })
+        car_1 = self.env["fleet.vehicle"].create({
+            "model_id": model.id,
+            "driver_id": user.partner_id.id,
+            "plan_to_change_car": False
+        })
+
+        car_2 = self.env["fleet.vehicle"].create({
+            "model_id": model.id,
+            "driver_id": user.partner_id.id,
+            "plan_to_change_car": False
+        })
+        Log = self.env['fleet.vehicle.log.contract']
+        log = Log.create({
+            'vehicle_id': car_2.id,
+            'expiration_date': fields.Date.add(fields.Date.today(), days=10)
+        })
+        res = self.env["fleet.vehicle"].search([('contract_renewal_due_soon', '=', True), ('id', '=', car_2.id)])
+        self.assertEqual(res, car_2)
+
+        log = Log.create({
+            'vehicle_id': car_1.id,
+            'expiration_date': fields.Date.add(fields.Date.today(), days=-10)
+        })
+        res = self.env["fleet.vehicle"].search([('contract_renewal_overdue', '=', True), ('id', '=', car_1.id)])
+        self.assertEqual(res, car_1)


### PR DESCRIPTION
the search method of contract_renewal_due_soon and
contract_renewal_overdue return a domain
id in res_ids where res_ids are id of contract
not vehicle

So it return random result

Solution
--------
Get the vehicle_id from the contract record set


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
