### PR TITLE
[FIX] account_edi_facturx: fix upload with inactive currency

### DIFF
--- a/addons/account_facturx/i18n/account_facturx.pot
+++ b/addons/account_facturx/i18n/account_facturx.pot
@@ -35,3 +35,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account_facturx.account_invoice_facturx_export
 msgid "urn:cen.eu:en16931:2017"
 msgstr ""
+
+#. module: account_facturx
+#: code:addons/account_facturx/models/account_move.py:0
+#, python-format
+msgid ""
+"The currency (%s) of the document you are uploading is not active in this database.\n"
+"Please activate it before trying again to import."
+msgstr ""

--- a/addons/account_facturx/models/account_move.py
+++ b/addons/account_facturx/models/account_move.py
@@ -179,6 +179,11 @@ class AccountMove(models.Model):
                 if elements[0].attrib.get('currencyID'):
                     currency_str = elements[0].attrib['currencyID']
                     currency = self.env.ref('base.%s' % currency_str.upper(), raise_if_not_found=False)
+                    if currency and not currency.active:
+                        raise UserError(
+                            _('The currency (%s) of the document you are uploading is not active in this database.\n'
+                              'Please activate it before trying again to import.') % currency.name
+                        )
                     if currency != self.env.company.currency_id and currency.active:
                         invoice_form.currency_id = currency
 


### PR DESCRIPTION
Retroactive fix for an issue in 15.0+
In 15.0+, importing an invoice with an inactive currency will raise
a traceback. Before this it was handled by not setting the correct
currency on the invoice if not active.

With this change, we'll activate the currency at the time of uploading
the document.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
