### PR TITLE
[IMP] sale: Move automatic_invoice and mail template settings to `res.company` 🏢 (Multi-company)

### DIFF
--- a/addons/sale/__init__.py
+++ b/addons/sale/__init__.py
@@ -6,13 +6,3 @@ from . import controllers
 from . import report
 from . import wizard
 from . import populate
-
-from odoo.api import Environment, SUPERUSER_ID
-
-
-def _synchronize_cron(cr, registry):
-    env = Environment(cr, SUPERUSER_ID, {'active_test': False})
-    send_invoice_cron = env.ref('sale.send_invoice_cron', raise_if_not_found=False)
-    if send_invoice_cron:
-        config = env['ir.config_parameter'].get_param('sale.automatic_invoice', False)
-        send_invoice_cron.active = bool(config)

--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -83,6 +83,5 @@ This module contains all the common features of Sales Management and eCommerce.
             'sale/static/src/scss/sale_report.scss',
         ],
     },
-    'post_init_hook': '_synchronize_cron',
     'license': 'LGPL-3',
 }

--- a/addons/sale/data/sale_data.xml
+++ b/addons/sale/data/sale_data.xml
@@ -1,19 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
 
-    <!-- TODO remove as it is already the fallback in _find_mail_template -->
-    <record id="default_confirmation_template" model="ir.config_parameter">
-        <field name="key">sale.default_confirmation_template</field>
-        <field name="value" ref="sale.mail_template_sale_confirmation"/>
-    </record>
-
-    <record id="default_invoice_email_template" model="ir.config_parameter">
-        <field name="key">sale.default_invoice_email_template</field>
-        <field name="value" ref="account.email_template_edi_invoice"/>
-    </record>
-
     <record id="send_invoice_cron" model="ir.cron">
-        <field name="name">automatic invoicing: send ready invoice</field>
+        <field name="name">Automatic invoicing: send ready invoice</field>
+        <field name="active" eval="False" />
         <field name="model_id" ref="payment.model_payment_transaction" />
         <field name="state">code</field>
         <field name="code">model._cron_send_invoice()</field>

--- a/addons/sale/models/res_config_settings.py
+++ b/addons/sale/models/res_config_settings.py
@@ -41,38 +41,14 @@ class ResConfigSettings(models.TransientModel):
     module_sale_coupon = fields.Boolean("Coupons & Promotions")
     module_sale_amazon = fields.Boolean("Amazon Sync")
 
-    automatic_invoice = fields.Boolean(
-        string="Automatic Invoice",
-        help="The invoice is generated automatically and available in the customer portal when the "
-             "transaction is confirmed by the payment acquirer.\nThe invoice is marked as paid and "
-             "the payment is registered in the payment journal defined in the configuration of the "
-             "payment acquirer.\nThis mode is advised if you issue the final invoice at the order "
-             "and not after the delivery.",
-        config_parameter='sale.automatic_invoice',
-    )
-    invoice_mail_template_id = fields.Many2one(
-        comodel_name='mail.template',
-        string='Invoice Email Template',
-        domain="[('model', '=', 'account.move')]",
-        config_parameter='sale.default_invoice_email_template',
-        help="Email sent to the customer once the invoice is available.",
-    )
-    confirmation_mail_template_id = fields.Many2one(
-        comodel_name='mail.template',
-        string='Confirmation Email Template',
-        domain="[('model', '=', 'sale.order')]",
-        config_parameter='sale.default_confirmation_template',
-        help="Email sent to the customer once the order is paid."
-    )
+    automatic_invoice = fields.Boolean(related="company_id.automatic_invoice", readonly=False)
+    invoice_mail_template_id = fields.Many2one(related="company_id.invoice_mail_template_id", readonly=False)
+    confirmation_mail_template_id = fields.Many2one(related="company_id.confirmation_mail_template_id", readonly=False)
 
     def set_values(self):
         super().set_values()
-        if self.default_invoice_policy != 'order':
-            self.env['ir.config_parameter'].set_param('sale.automatic_invoice', False)
-
-        send_invoice_cron = self.env.ref('sale.send_invoice_cron', raise_if_not_found=False)
-        if send_invoice_cron and send_invoice_cron.active != self.automatic_invoice:
-            send_invoice_cron.active = self.automatic_invoice
+        if self.default_invoice_policy != "order":
+            self.automatic_invoice = False
 
     @api.onchange('use_quotation_validity_days')
     def _onchange_use_quotation_validity_days(self):

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -924,8 +924,7 @@ class SaleOrder(models.Model):
         template_id = False
 
         if force_confirmation_template or (self.state == 'sale' and not self.env.context.get('proforma', False)):
-            template_id = int(self.env['ir.config_parameter'].sudo().get_param('sale.default_confirmation_template'))
-            template_id = self.env['mail.template'].search([('id', '=', template_id)]).id
+            template_id = self.company_id.confirmation_mail_template_id.id
             if not template_id:
                 template_id = self.env['ir.model.data']._xmlid_to_res_id('sale.mail_template_sale_confirmation', raise_if_not_found=False)
         if not template_id:

--- a/addons/sale/tests/test_payment_flow.py
+++ b/addons/sale/tests/test_payment_flow.py
@@ -162,7 +162,7 @@ class TestSalePayment(PaymentCommon, PaymentHttpCommon):
         """Test that with automatic invoice and invoicing policy based on delivered quantity, a transaction for the partial
         amount does not validate the SO."""
         # set automatic invoice
-        self.env['ir.config_parameter'].sudo().set_param('sale.automatic_invoice', 'True')
+        self.company.automatic_invoice = True
         # invoicing policy is based on delivered quantity
         self.sale_product.invoice_policy = 'delivery'
 

--- a/addons/sale/views/res_config_settings_views.xml
+++ b/addons/sale/views/res_config_settings_views.xml
@@ -198,6 +198,7 @@
                         <div class="col-12 col-lg-6 o_setting_box" id="confirmation_email_setting" attrs="{'invisible': [('portal_confirmation_pay', '=', False) , ('portal_confirmation_sign', '=', False)]}" groups="base.group_no_one">
                             <div class="o_setting_right_pane">
                                 <span class="o_form_label">Confirmation Email</span>
+                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
                                 <div class="text-muted">
                                     Automatic email sent after the customer has signed or paid online
                                 </div>
@@ -382,6 +383,7 @@
                             </div>
                             <div class="o_setting_right_pane">
                                 <label for="automatic_invoice"/>
+                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
                                 <div class="text-muted">
                                     Generate the invoice automatically when the online payment is confirmed
                                 </div>

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -334,6 +334,7 @@
                             </div>
                             <div class="o_setting_right_pane">
                                 <label for="automatic_invoice"/>
+                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
                                 <div class="text-muted">
                                     Generate the invoice automatically when the online payment is confirmed
                                 </div>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Before they were stored as `ir.config_parameters`, but that doesn't play nice in multi-company environments, where different companies may require different settings.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
