### PR TITLE
[IMP] mass_mailing: allow more image options for emails

### DIFF
--- a/addons/mass_mailing/data/mass_mailing_data.xml
+++ b/addons/mass_mailing/data/mass_mailing_data.xml
@@ -36,6 +36,12 @@
             <field name="list_ids" eval="[(6,0,[ref('mass_mailing.mailing_list_data')])]"/>
         </record>
         <!-- Snippets' Default Images -->
+        <record id="mass_mailing.s_cover_default_image" model="ir.attachment">
+            <field name="public" eval="True"/>
+            <field name="name">s_cover_default_image.jpg</field>
+            <field name="type">url</field>
+            <field name="url">/mass_mailing/static/src/img/theme_default/s_default_image_block_banner.jpg</field>
+        </record>
         <record id="mass_mailing.s_media_list_default_image_1" model="ir.attachment">
             <field name="public" eval="True"/>
             <field name="name">s_media_list_default_image_1.jpg</field>
@@ -162,6 +168,18 @@
             <field name="type">url</field>
             <field name="url">/mass_mailing/static/src/img/snippets_demo/s_blockquote_cover.jpg</field>
         </record>
+        <record id="mass_mailing.s_image_text_default_image" model="ir.attachment">
+            <field name="public" eval="True"/>
+            <field name="name">s_image_text_default_image.jpg</field>
+            <field name="type">url</field>
+            <field name="url">/mass_mailing/static/src/img/theme_default/s_default_image_block_image_text.jpg</field>
+        </record>
+        <record id="mass_mailing.s_mail_block_event_default_image" model="ir.attachment">
+            <field name="public" eval="True"/>
+            <field name="name">s_mail_block_event_default_image.jpg</field>
+            <field name="type">url</field>
+            <field name="url">/mass_mailing/static/src/img/theme_default/s_default_image_block_event.jpg</field>
+        </record>
         <record id="mass_mailing.s_masonry_block_default_image_1" model="ir.attachment">
             <field name="public" eval="True"/>
             <field name="name">s_masonry_block_default_image_1.jpg</field>
@@ -173,6 +191,36 @@
             <field name="name">s_masonry_block_default_image_2.jpg</field>
             <field name="type">url</field>
             <field name="url">/mass_mailing/static/src/img/snippets_demo/s_cover.jpg</field>
+        </record>
+        <record id="mass_mailing.s_picture_default_image" model="ir.attachment">
+            <field name="public" eval="True"/>
+            <field name="name">s_picture_default_image.jpg</field>
+            <field name="type">url</field>
+            <field name="url">/mass_mailing/static/src/img/theme_default/s_default_image_block_image.jpg</field>
+        </record>
+        <record id="mass_mailing.s_text_image_default_image" model="ir.attachment">
+            <field name="public" eval="True"/>
+            <field name="name">s_text_image_default_image.jpg</field>
+            <field name="type">url</field>
+            <field name="url">/mass_mailing/static/src/img/theme_default/s_default_image_block_text_image.jpg</field>
+        </record>
+        <record id="mass_mailing.s_three_columns_default_image_1" model="ir.attachment">
+            <field name="public" eval="True"/>
+            <field name="name">s_three_columns_default_image_1.jpg</field>
+            <field name="type">url</field>
+            <field name="url">/mass_mailing/static/src/img/theme_default/s_default_image_block_three_cols_1.jpg</field>
+        </record>
+        <record id="mass_mailing.s_three_columns_default_image_2" model="ir.attachment">
+            <field name="public" eval="True"/>
+            <field name="name">s_three_columns_default_image_2.jpg</field>
+            <field name="type">url</field>
+            <field name="url">/mass_mailing/static/src/img/theme_default/s_default_image_block_three_cols_2.jpg</field>
+        </record>
+        <record id="mass_mailing.s_three_columns_default_image_3" model="ir.attachment">
+            <field name="public" eval="True"/>
+            <field name="name">s_three_columns_default_image_3.jpg</field>
+            <field name="type">url</field>
+            <field name="url">/mass_mailing/static/src/img/theme_default/s_default_image_block_three_cols_3.jpg</field>
         </record>
     </data>
 </odoo>

--- a/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
@@ -5,7 +5,6 @@ const options = require('web_editor.snippets.options');
 const {ColorpickerWidget} = require('web.Colorpicker');
 const SelectUserValueWidget = options.userValueWidgetsRegistry['we-select'];
 const weUtils = require('web_editor.utils');
-const {_t} = require('web.core');
 
 //--------------------------------------------------------------------------
 // Constants
@@ -199,26 +198,6 @@ options.registry.BackgroundImage = options.registry.BackgroundImage.extend({
 options.registry.ImageTools.include({
 
     //--------------------------------------------------------------------------
-    // Public
-    //--------------------------------------------------------------------------
-
-    /**
-     * @override
-     */
-    async updateUIVisibility() {
-        await this._super(...arguments);
-
-        // The image shape option should work correctly with this update of the
-        // ImageTools option but unfortunately, SVG support in mail clients
-        // prevents the final rendering of the image. For now, we disable the
-        // feature.
-        const imgShapeContainerEl = this.el.querySelector('.o_we_image_shape');
-        if (imgShapeContainerEl) {
-            imgShapeContainerEl.classList.toggle('d-none', !odoo.debug);
-        }
-    },
-
-    //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
 
@@ -235,20 +214,6 @@ options.registry.ImageTools.include({
             return ColorpickerWidget.normalizeCSSColor(colorValue).replace(/"/g, "'");
         }
         return this._super(...arguments);
-    },
-    /**
-     * @override
-     */
-    async _renderCustomWidgets(uiFragment) {
-        await this._super(...arguments);
-
-        const imgShapeTitleEl = uiFragment.querySelector('.o_we_image_shape we-title');
-        if (imgShapeTitleEl) {
-            const warningEl = document.createElement('i');
-            warningEl.classList.add('fa', 'fa-exclamation-triangle', 'ml-1');
-            warningEl.title = _t("Be aware that this option may not work on many mail clients");
-            imgShapeTitleEl.appendChild(warningEl);
-        }
     },
 });
 

--- a/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
@@ -205,6 +205,9 @@ options.registry.ImageTools.include({
      * @override
      */
     _getCSSColorValue(color) {
+        if (!color || ColorpickerWidget.isCSSColor(color)) {
+            return color;
+        }
         const doc = this.options.document;
         if (doc && doc.querySelector('.o_mass_mailing_iframe') && !ColorpickerWidget.isCSSColor(color)) {
             const tempEl = doc.body.appendChild(doc.createElement('div'));

--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -63,13 +63,13 @@ var MassMailingFieldHtml = FieldHtml.extend({
         if (this.wysiwyg.snippetsMenu) {
             await this.wysiwyg.snippetsMenu.cleanForSave();
         }
-        return this.wysiwyg.saveModifiedImages(this.$content).then(function () {
+        return this.wysiwyg.saveModifiedImages(this.$content).then(async function () {
             self._isDirty = self.wysiwyg.isDirty();
             self._doAction();
 
             const $editorEnable = $editable.closest('.editor_enable');
             $editorEnable.removeClass('editor_enable');
-            convertInline.toInline($editable, self.cssRules, self.wysiwyg.$iframe);
+            await convertInline.toInline($editable, self.cssRules, self.wysiwyg.$iframe);
             $editorEnable.addClass('editor_enable');
 
             self.trigger_up('field_changed', {

--- a/addons/mass_mailing/views/snippets/s_cover.xml
+++ b/addons/mass_mailing/views/snippets/s_cover.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template id="s_cover" name="Cover">
         <div class="s_cover o_mail_snippet_general" data-snippet="s_cover">
-            <img src="/mass_mailing/static/src/img/theme_default/s_default_image_block_banner.jpg" alt="Cover image" class="img-fluid w-100 mx-auto"/>
+            <img src="/web/image/mass_mailing.s_cover_default_image" alt="Cover image" class="img-fluid w-100 mx-auto"/>
         </div>
     </template>
 </odoo>

--- a/addons/mass_mailing/views/snippets/s_image_text.xml
+++ b/addons/mass_mailing/views/snippets/s_image_text.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-lg-6 px-0">
-                    <img src="/mass_mailing/static/src/img/theme_default/s_default_image_block_image_text.jpg" class="img w-100" />
+                    <img src="/web/image/mass_mailing.s_image_text_default_image" class="img w-100" />
                 </div>
                 <div class="col-lg-6 pt16 pb16">
                     <h3>Omnichannel sales</h3>

--- a/addons/mass_mailing/views/snippets/s_picture.xml
+++ b/addons/mass_mailing/views/snippets/s_picture.xml
@@ -7,7 +7,7 @@
             <font style="font-size: 48px;" class="o_default_snippet_text">A punchy Headline</font>
         </h2>
         <p class="text-center">With strong technical foundations, Odoo's framework is unique. It provides <strong>top notch usability that scales across all apps</strong>.</p>
-        <img src="/mass_mailing/static/src/img/theme_default/s_default_image_block_image.jpg" class="img-thumbnail padding-large mx-auto d-block" width="500" alt=""/>
+        <img src="/web/image/mass_mailing.s_picture_default_image" class="img-thumbnail padding-large mx-auto d-block" width="500" alt=""/>
         <p class="figure-caption text-center py-3">Add a caption to enhance the meaning of this image.</p>
     </div>
 </template>

--- a/addons/mass_mailing/views/snippets/s_text_image.xml
+++ b/addons/mass_mailing/views/snippets/s_text_image.xml
@@ -13,7 +13,7 @@
                     </div>
                 </div>
                 <div class="col-lg-6 px-0">
-                    <img src="/mass_mailing/static/src/img/theme_default/s_default_image_block_text_image.jpg" class="img w-100"/>
+                    <img src="/web/image/mass_mailing.s_text_image_default_image" class="img w-100"/>
                 </div>
             </div>
         </div>

--- a/addons/mass_mailing/views/snippets/s_three_columns.xml
+++ b/addons/mass_mailing/views/snippets/s_three_columns.xml
@@ -7,7 +7,7 @@
             <div class="row d-flex align-items-stretch">
                 <div class="col-lg-4 s_col_no_bgcolor pt16 pb16">
                     <div class="card bg-white h-100">
-                        <img class="card-img-top" src="/mass_mailing/static/src/img/theme_default/s_default_image_block_three_cols_1.jpg" alt=""/>
+                        <img class="card-img-top" src="/web/image/mass_mailing.s_three_columns_default_image_1" alt=""/>
                         <div class="card-body">
                             <h3 class="card-title">Feature One</h3>
                             <p class="card-text">Adapt these three columns to fit your design need. To duplicate, delete or move columns, select the column and use the top icons to perform your action.</p>
@@ -16,7 +16,7 @@
                 </div>
                 <div class="col-lg-4 s_col_no_bgcolor pt16 pb16">
                     <div class="card bg-white h-100">
-                        <img class="card-img-top" src="/mass_mailing/static/src/img/theme_default/s_default_image_block_three_cols_2.jpg" alt=""/>
+                        <img class="card-img-top" src="/web/image/mass_mailing.s_three_columns_default_image_2" alt=""/>
                         <div class="card-body">
                             <h3 class="card-title">Feature Two</h3>
                             <p class="card-text">To add a fourth column, reduce the size of these three columns using the right icon of each block. Then, duplicate one of the columns to create a new one as a copy.</p>
@@ -25,7 +25,7 @@
                 </div>
                 <div class="col-lg-4 s_col_no_bgcolor pt16 pb16">
                     <div class="card bg-white h-100">
-                        <img class="card-img-top" src="/mass_mailing/static/src/img/theme_default/s_default_image_block_three_cols_3.jpg" alt=""/>
+                        <img class="card-img-top" src="/web/image/mass_mailing.s_three_columns_default_image_3" alt=""/>
                         <div class="card-body">
                             <h3 class="card-title">Feature Three</h3>
                             <p class="card-text">Delete the above image or replace it with a picture that illustrates your message. Click on the picture to change its <em>rounded corner</em> style.</p>

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -227,7 +227,7 @@
                     <p class="o_mail_no_margin">ALL DAY</p>
                 </div>
                 <div class="col-lg-2 px-0">
-                    <img src="/mass_mailing/static/src/img/theme_default/s_default_image_block_event.jpg" class="img w-100"/>
+                    <img src="/web/image/mass_mailing.s_mail_block_event_default_image" class="img w-100"/>
                 </div>
                 <div class="col-lg-7">
                     <h4>Cybersecurity</h4>

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -349,6 +349,7 @@
 
 <!-- Snippet themes Options -->
 <template id="snippet_options">
+    <t t-set="no_animations" t-value="True"/>
     <t t-call="web_editor.snippet_options"/>
     <t t-out="0"/>
 

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -444,7 +444,7 @@
         <div class="o_we_image_shape">
             <we-row string="Shape" class="o_we_full_row">
                 <we-select-pager data-name="shape_img_opt" class="o_we_select_grid o_we_fake_transparent_background">
-                    <we-select-page string="Basics">
+                    <we-select-page string="Basics" t-if="not no_animations">
                         <we-button data-set-img-shape="web_editor/basic/bsc_square_1" data-select-label="Square 1" data-animated="true"/>
                         <we-button data-set-img-shape="web_editor/basic/bsc_square_2" data-select-label="Square 2" data-animated="true"/>
                         <we-button data-set-img-shape="web_editor/basic/bsc_square_3" data-select-label="Square 3" data-animated="true"/>
@@ -462,37 +462,37 @@
                         <we-button data-set-img-shape="web_editor/solid/blob_2_solid_str" data-select-label="Blob Solid 2" />
                         <we-button data-set-img-shape="web_editor/solid/blob_3_solid_rd" data-select-label="Blob Solid 3" />
                         <we-button data-set-img-shape="web_editor/solid/oval_1_solid_rd" data-select-label="Oval Solid"/>
-                        <we-button data-set-img-shape="web_editor/solid/sld_blob_4" data-select-label="Blob Solid 4" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/solid/sld_blob_shadow_1" data-select-label="Blob Shadow 1" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/solid/sld_blob_shadow_2" data-select-label="Blob Shadow 2" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/solid/sld_square_1" data-select-label="Square 1" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/solid/sld_square_2" data-select-label="Square 2" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/solid/sld_square_organic_1" data-select-label="Square - Organic" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/solid/sld_blob_4" data-select-label="Blob Solid 4" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/solid/sld_blob_shadow_1" data-select-label="Blob Shadow 1" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/solid/sld_blob_shadow_2" data-select-label="Blob Shadow 2" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/solid/sld_square_1" data-select-label="Square 1" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/solid/sld_square_2" data-select-label="Square 2" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/solid/sld_square_organic_1" data-select-label="Square - Organic" data-animated="true"/>
                     </we-select-page>
                     <we-select-page string="Patterns">
-                        <we-button data-set-img-shape="web_editor/pattern/organic_2_pattern_dot" data-select-label="Organic Dot" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/pattern/organic_2_pattern_dot" data-select-label="Organic Dot" data-animated="true"/>
                         <we-button data-set-img-shape="web_editor/pattern/organic_3_pattern_cross" data-select-label="Organic Cross" />
                         <we-button data-set-img-shape="web_editor/pattern/organic_4_pattern_caps" data-select-label="Organic Caps" />
-                        <we-button data-set-img-shape="web_editor/pattern/pattern_labyrinth" data-select-label="Labyrinth" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/pattern/pattern_points_1" data-select-label="Points" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/pattern/pattern_waves_1" data-select-label="Waves 1" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/pattern/pattern_waves_2" data-select-label="Waves 2" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/pattern/pattern_waves_3" data-select-label="Waves 3" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/pattern/pattern_waves_4" data-select-label="Waves 4" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/pattern/pattern_labyrinth" data-select-label="Labyrinth" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/pattern/pattern_points_1" data-select-label="Points" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/pattern/pattern_waves_1" data-select-label="Waves 1" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/pattern/pattern_waves_2" data-select-label="Waves 2" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/pattern/pattern_waves_3" data-select-label="Waves 3" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/pattern/pattern_waves_4" data-select-label="Waves 4" data-animated="true"/>
                     </we-select-page>
                     <we-select-page string="Lines">
                         <we-button data-set-img-shape="web_editor/line/oval_3_pattern_line" data-select-label="Oval Line" />
                         <we-button data-set-img-shape="web_editor/line/organic_1_line" data-select-label="Organic Line" />
                         <we-button data-set-img-shape="web_editor/line/oval_2_line" data-select-label="Oval Line 2" />
-                        <we-button data-set-img-shape="web_editor/line/little_lines_1" data-select-label="Little lines 1" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/line/little_lines_2" data-select-label="Little lines 2" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/line/little_lines_3" data-select-label="Little lines 2" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/line/line_square_1" data-select-label="Square" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/line/line_triangle" data-select-label="Triangles" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/line/line_star" data-select-label="Star" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/line/line_sun" data-select-label="Sun" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/line/little_lines_1" data-select-label="Little lines 1" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/line/little_lines_2" data-select-label="Little lines 2" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/line/little_lines_3" data-select-label="Little lines 2" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/line/line_square_1" data-select-label="Square" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/line/line_triangle" data-select-label="Triangles" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/line/line_star" data-select-label="Star" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/line/line_sun" data-select-label="Sun" data-animated="true"/>
                     </we-select-page>
-                    <we-select-page string="Floats">
+                    <we-select-page string="Floats" t-if="not no_animations">
                         <we-button data-set-img-shape="web_editor/float/flt_primary_1" data-select-label="Primary shapes 1" data-animated="true"/>
                         <we-button data-set-img-shape="web_editor/float/flt_primary_2" data-select-label="Primary shapes 2" data-animated="true"/>
                         <we-button data-set-img-shape="web_editor/float/flt_primary_3" data-select-label="Primary shapes 3" data-animated="true"/>
@@ -503,7 +503,7 @@
                         <we-button data-set-img-shape="web_editor/float/flt_square_3" data-select-label="Square 3" data-animated="true"/>
                         <we-button data-set-img-shape="web_editor/float/flt_square_4" data-select-label="Square 4" data-animated="true"/>
                     </we-select-page>
-                    <we-select-page string="Specials">
+                    <we-select-page string="Specials" t-if="not no_animations">
                         <we-button data-set-img-shape="web_editor/special/spl_speed_1" data-select-label="Speed" data-animated="true"/>
                         <we-button data-set-img-shape="web_editor/special/spl_rain_1" data-select-label="Rain" data-animated="true"/>
                         <we-button data-set-img-shape="web_editor/special/spl_snow_1" data-select-label="Snow" data-animated="true"/>


### PR DESCRIPTION
Handle the image shape option in mass mailing.

- This allows users to use the shape feature on images in mass_mailing. Since email clients do not support the svg file type, it converts these svg images into png images on save.
- Email clients do not support svg images so we can't support animated shapes in mass_mailing. This removes them from the options.
- The shape feature only applies to attachments. This moves images from mass_mailing snippets into attachments so they can be shaped in the editor.
- mass_mailing has an override of _getCSSColorValue which was basically never used since the option it's linked to was mostly inactive. Now it's active it became obvious there is a mistake in it that causes a traceback to occur when no color is passed to it. This adds the same check as in the original method and thereby prevents the traceback.

task-2760157

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
