### PR TITLE
[IMP] l10n_it_edi_sdicoop: Improving behaviour after MancataConsegna

### DIFF
--- a/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
+++ b/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
@@ -3,7 +3,7 @@
 
 from odoo import models, _, _lt
 from odoo.exceptions import UserError
-from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError, DEFAULT_SERVER_URL, DEFAULT_TEST_SERVER_URL
+from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
 
 from lxml import etree
 import base64
@@ -231,13 +231,25 @@ class AccountEdiFormat(models.Model):
                 to_return[invoice] = {'error': self._format_error_message(_('The invoice has been refused by the Exchange System'), errors), 'blocking_level': 'error'}
                 invoice.l10n_it_edi_transaction = False
             elif state == 'notificaMancataConsegna':
-                to_return[invoice] = {
-                    'error': _('The E-invoice is not delivered to the addressee. The Exchange System is\
-                    unable to deliver the file to the Public Administration. The Exchange System will\
-                    contact the PA to report the problem and request that they provide a solution. \
-                    During the following 15 days, the Exchange System will try to forward the FatturaPA\
-                    file to the Administration in question again.'),
-                }
+                if invoice._is_commercial_partner_pa():
+                    to_return[invoice] = {'error': _(
+                        'The invoice has been issued, but the delivery to the Public Administration'
+                        ' has failed. The Exchange System will contact them to report the problem'
+                        ' and request that they provide a solution.'
+                        ' During the following 10 days, the Exchange System will try to forward the'
+                        ' FatturaPA file to the Public Administration in question again.'
+                        ' Should this also fail, the System will notify Odoo of the failed delivery,'
+                        ' and you will be required to send the invoice to the Administration'
+                        ' through another channel, outside of the Exchange System.')}
+                else:
+                    to_return[invoice] = {'success': True, 'attachment': invoice.l10n_it_edi_attachment_id}
+                    invoice._message_log(body=_(
+                        'The invoice has been issued, but the delivery to the Addressee has'
+                        ' failed. You will be required to send a courtesy copy of the invoice'
+                        ' to your customer through another channel, outside of the Exchange'
+                        ' System, and promptly notify him that the original is deposited'
+                        ' in his personal area on the portal "Invoices and Fees" of the'
+                        ' Revenue Agency.'))
             elif state == 'notificaEsito':
                 outcome = response_tree.find('Esito').text
                 if outcome == 'EC01':


### PR DESCRIPTION
- In the B2B case, after a MancataConsegna, the invoice is considered issued, but the delivery is failed.
- In the B2G case, the Exchange System will retry to send it for 10 days and inform the Public Administration. After 10 days, it will be considered issued but not delivered.

In both cases of failure, the user is required to send the invoice through other means than the Exchange System.

Ref (IT): https://www.datalog.it/fattura-elettronica-cosa-fare-in-caso-di-mancata-consegna