### PR TITLE
[FIX] l10n_ar: demo data credit note, also fix share sequence document numbers

### DIFF
--- a/addons/l10n_ar/demo/account_customer_refund_demo.xml
+++ b/addons/l10n_ar/demo/account_customer_refund_demo.xml
@@ -6,7 +6,7 @@
         <field name="reason">Mercadería defectuosa</field>
         <field name="refund_method">refund</field>
         <field name="move_ids" eval="[(4, ref('demo_invoice_3'), 0)]"/>
-        <field name="journal_id" search="[('company_id', '=', ref('l10n_ar.company_ri')), ('type', '=', 'sale')]"/>
+        <field name="journal_id" model="account.move.reversal" eval="obj().env.ref('l10n_ar.demo_invoice_3').journal_id"/>
         <field name="date" eval="time.strftime('%Y-%m')+'-01'"/>
     </record>
 
@@ -17,7 +17,7 @@
         <field name="reason">Venta cancelada</field>
         <field name="refund_method">cancel</field>
         <field name="move_ids" eval="[(4, ref('demo_invoice_4'), 0)]"/>
-        <field name="journal_id" search="[('company_id', '=', ref('l10n_ar.company_ri')), ('type', '=', 'sale')]"/>
+        <field name="journal_id" model="account.move.reversal" eval="obj().env.ref('l10n_ar.demo_invoice_4').journal_id"/>
         <field name="date" eval="time.strftime('%Y-%m')+'-01'"/>
     </record>
 
@@ -28,7 +28,7 @@
         <field name="reason">Venta cancelada</field>
         <field name="refund_method">cancel</field>
         <field name="move_ids" eval="[(4, ref('demo_invoice_16'), 0)]"/>
-        <field name="journal_id" search="[('company_id', '=', ref('l10n_ar.company_ri')), ('type', '=', 'sale')]"/>
+        <field name="journal_id" model="account.move.reversal" eval="obj().env.ref('l10n_ar.demo_invoice_16').journal_id"/>
         <field name="date" eval="time.strftime('%Y-%m')+'-01'"/>
     </record>
 

--- a/addons/l10n_ar/demo/exento_demo.xml
+++ b/addons/l10n_ar/demo/exento_demo.xml
@@ -45,7 +45,8 @@
             <field name='l10n_latam_use_documents' eval="True"/>
             <field name='l10n_ar_afip_pos_number'>2</field>
             <field name='l10n_ar_afip_pos_partner_id' ref="l10n_ar.partner_exento"/>
-            <field name='l10n_ar_afip_pos_system'>FEERCEL</field>
+            <field name='l10n_ar_afip_pos_system'>II_IM</field>
+            <field name='l10n_ar_share_sequences' eval="True"/>
         </record>
 
     </data>

--- a/addons/l10n_ar/demo/mono_demo.xml
+++ b/addons/l10n_ar/demo/mono_demo.xml
@@ -45,7 +45,8 @@
             <field name='l10n_latam_use_documents' eval="True"/>
             <field name='l10n_ar_afip_pos_number'>2</field>
             <field name='l10n_ar_afip_pos_partner_id' ref="l10n_ar.partner_mono"/>
-            <field name='l10n_ar_afip_pos_system'>FEERCEL</field>
+            <field name='l10n_ar_afip_pos_system'>II_IM</field>
+            <field name='l10n_ar_share_sequences' eval="True"/>
         </record>
 
     </data>

--- a/addons/l10n_ar/demo/respinsc_demo.xml
+++ b/addons/l10n_ar/demo/respinsc_demo.xml
@@ -52,8 +52,9 @@
             <field name='l10n_latam_use_documents' eval="True"/>
             <field name='l10n_ar_afip_pos_number'>2</field>
             <field name='l10n_ar_afip_pos_partner_id' ref="l10n_ar.partner_ri"/>
-            <field name='l10n_ar_afip_pos_system'>FEERCEL</field>
+            <field name='l10n_ar_afip_pos_system'>II_IM</field>
             <field name='refund_sequence' eval="False"/>
+            <field name='l10n_ar_share_sequences' eval="True"/>
         </record>
 
     </data>

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -228,6 +228,14 @@ class AccountMove(models.Model):
                 return self._get_formatted_sequence()
         return super()._get_starting_sequence()
 
+    def _get_last_sequence(self, relaxed=False, with_prefix=None):
+        """ If use share sequences we need to recompute the sequence to add the proper document code prefix """
+        res = super()._get_last_sequence(relaxed=relaxed, with_prefix=with_prefix)
+        if res and self.journal_id.l10n_ar_share_sequences and self.l10n_latam_document_type_id.doc_code_prefix not in res:
+            res = self._get_formatted_sequence(number=self._l10n_ar_get_document_number_parts(
+                res.split()[-1], self.l10n_latam_document_type_id.code)['invoice_number'])
+        return res
+
     def _get_last_sequence_domain(self, relaxed=False):
         where_string, param = super(AccountMove, self)._get_last_sequence_domain(relaxed)
         if self.company_id.account_fiscal_country_id.code == "AR" and self.l10n_latam_use_documents:


### PR DESCRIPTION
This is to avoid the error we have exporting the sales vat book txt file and also a bug found in share sequences.

### Description of the issue/feature this PR addresses:

Before this change, we have the errors:
1. receive an error when trying to export the sales vat book
2. the demo credit notes of pre-printed unified book sales journals name were wrongly set using the wrong doc prefix code

### Current behavior before PR:

1. When exporting the sales vat book txt file (on enterprise) we get the next traceback error
![image](https://user-images.githubusercontent.com/7593953/154755822-e82be7eb-919b-4f32-bc21-6a3be0630932.png)

2. Credit notes generated on pre-printed journals have a wrong doc prefix, They have `FA-` and should be `NC-`
![image](https://user-images.githubusercontent.com/7593953/154771075-12f10c4a-19a3-4d5b-a520-60e51081521a.png)

### Desired behavior after PR is merged:

1. Demo data fixed and we are able to print the sales vat book without error
2. The pre-printed unified book invoices and refunds are generated with the proper name.

![image](https://user-images.githubusercontent.com/7593953/154771629-03785bd8-43b6-4e14-b973-d0c975cf3a70.png)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
