### PR TITLE
[FIX] hr: default buttons still visible on my profile

### DIFF
--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -12,9 +12,9 @@
             <field name="inherit_id" ref="base.view_users_form_simple_modif"/>
             <field name="mode">primary</field>
             <field name="arch" type="xml">
-                <footer position="attributes">
+                <xpath expr="//footer[not(ancestor::field)]" position="attributes">
                     <attribute name="invisible">1</attribute>
-                </footer>
+                </xpath>
                 <h1 position="replace"/>
                 <xpath expr="//field[@name='image_1920']" position="replace"/>
                 <xpath expr="//field[@name='company_id']" position="attributes">


### PR DESCRIPTION
How to reproduce the bug ?

- install the hr app
- go to 'My Profile'

What is the bug ?

If you have install the hr module such that the 'My Profile' page is
available, you will see that the 'Save'/'Cancel' buttons that were
displayed on the basic profile page are still visible.

opw-2744380

Signed-off-by: Adrien Minet <admi@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
