### PR TITLE
[FIX] payment: improve heuristic for detecting empty HTML fields

### DIFF
--- a/addons/payment/views/payment_templates.xml
+++ b/addons/payment/views/payment_templates.xml
@@ -78,7 +78,7 @@
                         <!-- === Payment icon list === -->
                         <t t-call="payment.icon_list"/>
                         <!-- === Help message === -->
-                        <div t-if="acquirer.pre_msg != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'"
+                        <div t-if="not is_html_empty(acquirer.pre_msg)"
                              t-out="acquirer.pre_msg"
                              class="text-muted ml-3"/>
                     </div>
@@ -201,7 +201,7 @@
                         <!-- === Payment icon list === -->
                         <t t-call="payment.icon_list"/>
                         <!-- === Help message === -->
-                        <div t-if="acquirer.pre_msg != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'"
+                        <div t-if="not is_html_empty(acquirer.pre_msg)"
                              t-out="acquirer.pre_msg"
                              class="text-muted ml-3"/>
                     </div>
@@ -335,22 +335,22 @@
         <!-- Variables description:
             - 'tx' - The transaction whose status must be displayed
         -->
-        <div t-if="tx.state == 'pending' and tx.acquirer_id.sudo().pending_msg != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'"
+        <div t-if="tx.state == 'pending' and not is_html_empty(tx.acquirer_id.sudo().pending_msg)"
              class="alert alert-warning alert-dismissible">
             <span t-out="tx.acquirer_id.sudo().pending_msg"/>
             <button class="close" data-dismiss="alert" title="Dismiss">×</button>
         </div>
-        <div t-elif="tx.state == 'authorized' and tx.acquirer_id.sudo().auth_msg != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'"
+        <div t-elif="tx.state == 'authorized' and not is_html_empty(tx.acquirer_id.sudo().auth_msg)"
              class="alert alert-success alert-dismissible">
             <span t-out="tx.acquirer_id.sudo().auth_msg"/>
             <button class="close" data-dismiss="alert" title="Dismiss">×</button>
         </div>
-        <div t-elif="tx.state == 'done' and tx.acquirer_id.sudo().done_msg != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'"
+        <div t-elif="tx.state == 'done' and not is_html_empty(tx.acquirer_id.sudo().done_msg)"
              class="alert alert-success alert-dismissible">
             <span t-out="tx.acquirer_id.sudo().done_msg"/>
             <button class="close" data-dismiss="alert" title="Dismiss">×</button>
         </div>
-        <div t-elif="tx.state == 'cancel' and tx.acquirer_id.sudo().cancel_msg != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'"
+        <div t-elif="tx.state == 'cancel' and not is_html_empty(tx.acquirer_id.sudo().cancel_msg)"
              class="alert alert-danger alert-dismissible">
             <span t-out="tx.acquirer_id.sudo().cancel_msg"/>
             <button class="close" data-dismiss="alert" title="Dismiss">×</button>


### PR DESCRIPTION
This commit uses the `is_html_empty` util method to detect empty HTML
fields in cleaner and more resilient fashion than what was done in
808cc53bb02b0f1851a2a229bd5235a5fb944408.
