### PR TITLE
[FIX] account,l10n_*: always auto_install l10n_*_edi

### DIFF
--- a/addons/account/__init__.py
+++ b/addons/account/__init__.py
@@ -48,19 +48,11 @@ def _auto_install_l10n(env):
                 module_list.append('l10n_' + country_code.lower())
             else:
                 module_list.append('l10n_generic_coa')
-        if country_code in ['US', 'CA']:
-            module_list.append('account_check_printing')
         if country_code in SYSCOHADA_LIST + [
             'AT', 'BE', 'CA', 'CO', 'DE', 'EC', 'ES', 'ET', 'FR', 'GR', 'IT', 'LU', 'MX', 'NL', 'NO',
             'PL', 'PT', 'RO', 'SI', 'TR', 'GB', 'VE', 'VN'
             ]:
             module_list.append('base_vat')
-        if country_code == 'MX':
-            module_list.append('l10n_mx_edi')
-        if country_code == 'IT':
-            module_list.append('l10n_it_edi_sdicoop')
-        if country_code == 'SA':
-            module_list.append('l10n_sa_invoice')
 
         module_ids = env['ir.module.module'].search([('name', 'in', module_list), ('state', '=', 'uninstalled')])
         module_ids.sudo().button_install()

--- a/addons/l10n_be_edi/__manifest__.py
+++ b/addons/l10n_be_edi/__manifest__.py
@@ -12,12 +12,16 @@ invoices. The UBL standard became the `ISO/IEC 19845
 (cf the `official announce <http://www.prweb.com/releases/2016/01/prweb13186919.htm>`_).
 Belgian e-invoicing uses the UBL 2.0 using the e-fff protocol.
     """,
-    'depends': ['l10n_be', 'account_edi_ubl'],
+    'depends': [
+        'l10n_be',
+        'account_edi',
+        'account_edi_ubl',
+    ],
     'data': [
         'data/account_edi_data.xml',
         'data/ubl_templates.xml',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': ['l10n_be', 'account_edi'],
     'license': 'LGPL-3',
 }

--- a/addons/l10n_it_edi/__manifest__.py
+++ b/addons/l10n_it_edi/__manifest__.py
@@ -10,6 +10,7 @@
         'fetchmail',
         'account_edi'
     ],
+    'auto_install': ['l10n_it', 'account_edi'],
     'author': 'Odoo',
     'description': """
 E-invoice implementation

--- a/addons/l10n_it_edi_sdicoop/__manifest__.py
+++ b/addons/l10n_it_edi_sdicoop/__manifest__.py
@@ -9,6 +9,7 @@
         'account_edi',
         'account_edi_proxy_client',
     ],
+    'auto_install': ['l10n_it_edi'],
     'author': 'Odoo',
     'description': """
 E-invoice implementation for Italy with the web-service. Ability to send and receive document from SdiCoop. Files sent by SdiCoop are first stored on the proxy

--- a/addons/l10n_nl_edi/__manifest__.py
+++ b/addons/l10n_nl_edi/__manifest__.py
@@ -8,12 +8,16 @@
     'description': """
 NLCIUS is the Dutch implementation of EN 16931 norm. Both for UBL and UN / CEFACT XML CII.
     """,
-    'depends': ['l10n_nl', 'account_edi_ubl_bis3'],
+    'depends': [
+        'l10n_nl',
+        'account_edi',
+        'account_edi_ubl_bis3',
+    ],
     'data': [
         'data/account_edi_data.xml',
         'data/nlcius_template.xml',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': ['l10n_nl', 'account_edi'],
     'license': 'LGPL-3',
 }

--- a/addons/l10n_no_edi/__manifest__.py
+++ b/addons/l10n_no_edi/__manifest__.py
@@ -8,12 +8,16 @@
     'description': """
 EHF 3 is the Norwegian implementation of EN 16931 norm.
     """,
-    'depends': ['l10n_no', 'account_edi_ubl_bis3'],
+    'depends': [
+        'l10n_no',
+        'account_edi',
+        'account_edi_ubl_bis3',
+    ],
     'data': [
         'data/account_edi_data.xml',
         'data/ehf_3_template.xml',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': ['l10n_no', 'account_edi'],
     'license': 'LGPL-3',
 }

--- a/addons/l10n_sa_invoice/__manifest__.py
+++ b/addons/l10n_sa_invoice/__manifest__.py
@@ -10,6 +10,7 @@
     Invoices for the Kingdom of Saudi Arabia
 """,
     'depends': ['l10n_sa', 'l10n_gcc_invoice'],
+    'auto_install': ['l10n_sa'],
     'data': [
         'views/view_move_form.xml',
         'views/report_invoice.xml',


### PR DESCRIPTION
The logic should not be made in the post init hook of account otherwise
modules will only get installed like expected during the database
initialization, based on the country set on the main company before the
installation of `account`.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
