### PR TITLE
[FIX] mobile: calculation of invoice lines and journal items on update

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -820,6 +820,8 @@
                                         <field name="account_internal_type" invisible="1"/>
                                         <field name="always_set_currency_id" invisible="1"/>
                                     </kanban>
+
+                                    <!-- Form view to cover mobile use -->
                                     <form>
                                         <sheet>
                                             <field name="display_type" invisible="1"/>
@@ -827,6 +829,8 @@
                                             <group>
                                                 <field name="partner_id" invisible="1"/>
                                                 <field name="company_id" invisible="1"/>
+                                                <field name="debit" invisible="1"/>
+                                                <field name="credit" invisible="1"/>
                                                 <field name="product_id" widget="many2one_barcode"/>
                                                 <field name="quantity"/>
                                                 <field name="product_uom_id" groups="uom.group_uom"/>
@@ -844,6 +848,10 @@
                                             <label for="name" string="Section" attrs="{'invisible': [('display_type', '!=', 'line_section')]}"/>
                                             <label for="name" string="Note" attrs="{'invisible': [('display_type', '!=', 'line_note')]}"/>
                                             <field name="name" widget="text"/>
+                                            <group>
+                                                <field name="price_subtotal" string="Subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
+                                                <field name="price_total" string="Total" groups="account.group_show_line_subtotals_tax_included"/>
+                                            </group>
                                         </sheet>
                                     </form>
                                 </field>


### PR DESCRIPTION
[FIX] mobile: calculation of invoice lines and journal items on update

Problem :
- updating an invoice line on mobile would result in an incorrect untaxed amount, tax amount and total amount on the invoice and an incorrect entries in the journal items
- subtotal of invoice line was not showing in mobile view

Solution :
- the problem was that debit and credit fields were missing from the view so onchange were not trigger

Task: task-2766245

--

I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)
