### PR TITLE
[FIX] core: Update the default value for boolean column

### DIFF
--- a/doc/cla/individual/mo7amed-3bdalla7.md
+++ b/doc/cla/individual/mo7amed-3bdalla7.md
@@ -1,0 +1,11 @@
+Egypt, 2022-02-21
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mohamed Abdallah mo7amed.3bdalla7@gmail.com https://github.com/mo7amed-3bdalla7

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -89,7 +89,7 @@ def column_exists(cr, tablename, columnname):
 
 def create_column(cr, tablename, columnname, columntype, comment=None):
     """ Create a column with the given type. """
-    coldefault = (columntype.upper()=='BOOLEAN') and 'DEFAULT false' or ''
+    coldefault = (columntype.upper() in ('BOOL','BOOLEAN')) and 'DEFAULT false' or ''
     cr.execute('ALTER TABLE "{}" ADD COLUMN "{}" {} {}'.format(tablename, columnname, columntype, coldefault))
     if comment:
         cr.execute('COMMENT ON COLUMN "{}"."{}" IS %s'.format(tablename, columnname), (comment,))


### PR DESCRIPTION

Description of the issue/feature this PR addresses: The default value for the boolean column is checked against boolean and the column type comes as a bool.

Current behavior before PR: The default value for the boolean column on the database level is Null.

Desired behavior after PR is merged: Store default value as false in database level for boolean columns.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
