### PR TITLE
[FIX] hr_holidays: Only show time off of current company's employee

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar.js
@@ -2,6 +2,7 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
     'use strict';
 
     var core = require('web.core');
+    var CalendarModel = require('web.CalendarModel');
     var CalendarPopover = require('web.CalendarPopover');
     var CalendarController = require("web.CalendarController");
     var CalendarRenderer = require("web.CalendarRenderer");
@@ -10,6 +11,15 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
 
     var _t = core._t;
     var QWeb = core.qweb;
+
+    var TimeOffCalendarModel = CalendarModel.extend({
+
+        _getFilterDomain: function() {
+            const company_domain = [['user_id.company_id', 'in', this.data.context.allowed_company_ids]];
+            return this._super().concat(company_domain);
+        },
+
+    });
 
     var TimeOffCalendarPopover = CalendarPopover.extend({
         template: 'hr_holidays.calendar.popover',
@@ -165,6 +175,7 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
         config: _.extend({}, CalendarView.prototype.config, {
             Controller: TimeOffCalendarController,
             Renderer: TimeOffCalendarRenderer,
+            Model: TimeOffCalendarModel,
         }),
     });
 


### PR DESCRIPTION
Step to reproduce (Traceback):
- Be in multi-company
- Create a time off type with duration in hour and no company_id
- Create an instance of this type on company A with a user linked
 to company A (need access to both)
- Switch to company B

Current Behaviour:
- Traceback
- Cannot fetch user's calendar if content of company A is not checked
 for convertion from Days to Hour

Behaviour after PR:
- We only fetch if the user related to the leave is in allowed_companies
 -> only fetch if the user data is available
- This is also true if duration is in Days/Half-Days (GMF Approved)

opw-2749258


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
