### PR TITLE
[IMP] account: share chatter between payment and the move behind it.

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -109,6 +109,7 @@ You could use this simplified accounting in case you work with an (external) acc
             'account/static/src/js/tours/account.js',
             'account/static/src/js/bills_upload.js',
             'account/static/src/js/account_selection.js',
+            'account/static/src/js/account_payment_form_view.js',
         ],
         'web.assets_frontend': [
             'account/static/src/js/account_portal_sidebar.js',

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -228,6 +228,7 @@ class AccountMove(models.Model):
     payment_id = fields.Many2one(
         index='btree_not_null',
         comodel_name='account.payment',
+        comodel_tracking=True,
         string="Payment", copy=False, check_company=True)
     statement_line_id = fields.Many2one(
         comodel_name='account.bank.statement.line',
@@ -3532,11 +3533,6 @@ class AccountMove(models.Model):
     def _track_subtype(self, init_values):
         # OVERRIDE to add custom subtype depending of the state.
         self.ensure_one()
-
-        if not self.is_invoice(include_receipts=True):
-            if self.payment_id and 'state' in init_values:
-                self.payment_id._message_track(['state'], {self.payment_id.id: init_values})
-            return super(AccountMove, self)._track_subtype(init_values)
 
         if 'payment_state' in init_values and self.payment_state == 'paid':
             return self.env.ref('account.mt_invoice_paid')

--- a/addons/account/static/src/js/account_payment_form_view.js
+++ b/addons/account/static/src/js/account_payment_form_view.js
@@ -1,0 +1,33 @@
+odoo.define("account_payment.FormView", function (require) {
+    "use strict";
+
+    const FormRenderer = require('web.FormRenderer');
+    const FormView = require("web.FormView");
+    const viewRegistry = require("web.view_registry");
+
+    const PaymentFormRenderer = FormRenderer.extend({
+        /**
+         * Share the chatter with the move that is behind the payment
+         */
+        _makeChatterContainerProps() {
+            const props = this._super(...arguments);
+            const move = this.state.data.move_id;
+            if (move) {
+                Object.assign(props, {
+                    threadId: move.res_id,
+                    threadModel: move.model,
+                });
+            }
+            return props;
+        },
+    });
+
+    const PaymentFormView = FormView.extend({
+        config: Object.assign({}, FormView.prototype.config, {
+            Renderer: PaymentFormRenderer,
+        }),
+    });
+
+    viewRegistry.add("account_payment_form", PaymentFormView);
+    return PaymentFormView;
+});

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -145,7 +145,7 @@
             <field name="name">account.payment.form</field>
             <field name="model">account.payment</field>
             <field name="arch" type="xml">
-                <form string="Register Payment">
+                <form js_class="account_payment_form"  string="Register Payment">
                     <header>
                         <button name="action_post" string="Confirm" type="object" class="oe_highlight"
                                 attrs="{'invisible': [('state', '!=', 'draft')]}" data-hotkey="v"/>
@@ -171,6 +171,7 @@
                     <sheet>
                         <!-- Invisible fields -->
                         <field name="id" invisible="1"/>
+                        <field name="move_id" invisible="1"/>
                         <field name="is_move_sent" invisible="1"/>
                         <field name="is_reconciled" invisible="1"/>
                         <field name="is_matched" invisible="1"/>


### PR DESCRIPTION
account.payment inherit mail.thread but inherits account.move.
Since account.move is also inheriting mail.thread, the payment is
working with 2 chatters.

This change aims to unify that by displaying the chatter from the account
move in the payment form view, while at the same time keep tracking
value changes from the payment as it was done at the moment.

Task id #2770147

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
