### PR TITLE
[FIX] account: remove default journal in cut-off

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5123,6 +5123,7 @@ class AccountMoveLine(models.Model):
         # Force the values of the move line in the context to avoid issues
         ctx = dict(self.env.context)
         ctx.pop('active_id', None)
+        ctx.pop('default_journal_id', None)
         ctx['active_ids'] = self.ids
         ctx['active_model'] = 'account.move.line'
         action['context'] = ctx


### PR DESCRIPTION
The journal in a cut-off has to be of type general. But there is an
issue at the moment where a default_journal_id would be provided in
the context (coming from the dashboard for example) and thus, fill
the journal in the cut-off wizard with a wrong value (vendor bill for
example).

This change makes sure no default values are provided to the wizard.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
