### PR TITLE
[FIX] ir_actions: home action restriction

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -66,6 +66,10 @@ class IrActions(models.Model):
         self.clear_caches()
         return res
 
+    @api.ondelete(at_uninstall=True)
+    def _unlink_check_home_action(self):
+        self.env['res.users'].with_context(active_test=False).search([('action_id', 'in', self.ids)]).sudo().write({'action_id': None})
+
     @api.model
     def _get_eval_context(self, action=None):
         """ evaluation context to pass to safe_eval """


### PR DESCRIPTION
Steps to reproduce:
- define a home action for the user
- delete the action in configuration > Window Action
- refresh to the home page
-> id not found

Solution:
- prevent the deletion of a window action if used as a home action

OPW-2728824
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
