### PR TITLE
[FIX] web: Star a product via sales form

### DIFF
--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -2466,7 +2466,7 @@ var PriorityWidget = AbstractField.extend({
     events: {
         'mouseover > a': '_onMouseOver',
         'mouseout > a': '_onMouseOut',
-        'click > a': '_onClick',
+        'click > a': '_onPriorityClick',
         'keydown > a': '_onKeydown',
     },
     supportedFieldTypes: ['selection'],
@@ -2589,7 +2589,7 @@ var PriorityWidget = AbstractField.extend({
      * @param {MouseEvent} event
      * @private
      */
-    _onClick: function (event) {
+    _onPriorityClick: function (event) {
         event.preventDefault();
         event.stopPropagation();
         var index = $(event.currentTarget).data('index');

--- a/addons/web/static/tests/legacy/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/basic_fields_tests.js
@@ -6590,21 +6590,29 @@ QUnit.module('basic_fields', {
     });
 
     QUnit.test('priority widget with readonly attribute', async function (assert) {
-        assert.expect(1);
+        assert.expect(2);
 
         const form = await createView({
             View: FormView,
             model: 'partner',
             data: this.data,
-            arch: `
-                <form>
-                    <field name="selection" widget="priority" readonly="1"/>
-                </form>`,
+            arch: '<form><field name="selection" widget="priority" readonly="1"/></form>',
             res_id: 2,
+            mockRPC(route, args) {
+                if (args.method === "write") {
+                    throw new Error("should not save");
+                }
+                return this._super.apply(this, arguments);
+            },
         });
 
-        assert.containsN(form, '.o_field_widget.o_priority span', 2,
-            "stars of priority widget should rendered with span tag if readonly");
+        assert.strictEqual(form.$('span.o_priority_star.fa.fa-star-o').length, 2,
+        "stars of priority widget should rendered with span tag if readonly");
+
+        await testUtils.dom.click(form.$('.o_priority_star.fa-star-o').last());
+
+        assert.strictEqual(form.$('.o_priority_star.fa.fa-star-o').length, 2,
+        "should still have two stars");
 
         form.destroy();
     });


### PR DESCRIPTION
For the moment we cannot star a product from the form of sales view

Steps:
    -Sales/Quotation
    - Create new quotation
    - Add a new product in the order lines
    - Open product form from External link
    - Try to star product

A function tries to retrieve the data-index via `ev.currentTarget`
but in this case the currentTarget returns the wrong element
This fix fallback on the use of ev.target in case currentTarget
does not return the right element

opw-2759063