### PR TITLE
[FIX] pos_six: use same web socket 

### DIFF
--- a/addons/pos_six/static/src/js/payment_six.js
+++ b/addons/pos_six/static/src/js/payment_six.js
@@ -28,6 +28,19 @@ var PaymentSix = PaymentInterface.extend({
         this._super.apply(this, arguments);
         this.enable_reversals();
 
+        var terminal_ip = this.payment_method.six_terminal_ip;
+        var instanced_payment_method = _.find(this.pos.payment_methods, function(payment_method) {
+            return payment_method.use_payment_terminal === "six"
+                && payment_method.six_terminal_ip === terminal_ip
+                && payment_method.payment_terminal
+        })
+        if (instanced_payment_method !== undefined) {
+            var payment_terminal = instanced_payment_method.payment_terminal;
+            this.terminal = payment_terminal.terminal;
+            this.terminalListener = payment_terminal.terminalListener;
+            return;
+        }
+
         var settings = new timapi.TerminalSettings();
         settings.connectionMode = timapi.constants.ConnectionMode.onFixIp;
         settings.connectionIPString = this.payment_method.six_terminal_ip;


### PR DESCRIPTION
When a user cancels a six payment method, he won't be able to select
another six payment method

To reproduce the issue:
(Use demo data. Install l10n_be so your company is in EUR)
1. Create two Payment Methods PM01, PM02 that use the same payment
terminal (a Six one)
2. Add the methods to the POS
3. Start a POS session
4. Select a product and go to payment page
5. Select PM01, send it then remove the line
6. Select PM02, send

Error: Nothing happens (the terminal doesn't receive the instructions).
After several seconds, an error message is displayed "Transaction was
not processed correctly: apiConnectionLostTerminal"

When starting the POS, because there are two payments methods, both are
instanced, each one with its own instance of `PaymentSix`. However, in
the above case, both payment methods use the same terminal. Therefore,
when sending the transaction with the second method (step 6), the API
creates a second WebSocket (for the second instance of `PaymentSix`)
between the POS and the terminal while such a `WebSocket` already exists
(first instance of `PaymentSix`)

OPW-2679181