### PR TITLE
[IMP] payment: improve `send_payment_request` test

### DIFF
--- a/addons/payment/tests/common.py
+++ b/addons/payment/tests/common.py
@@ -193,3 +193,28 @@ class PaymentCommon(PaymentTestUtils):
         return self.env['payment.transaction'].sudo().search([
             ('reference', '=', reference),
         ])
+
+    def _prepare_transaction_values(self, payment_option_id, flow):
+        """ Prepare the basic payment/transaction route values.
+
+        :param int payment_option_id: The payment option handling the transaction, as a
+                                      `payment.acquirer` id or a `payment.token` id
+        :param str flow: The payment flow
+        :return: The route values
+        :rtype: dict
+        """
+        return {
+            'amount': self.amount,
+            'currency_id': self.currency.id,
+            'partner_id': self.partner.id,
+            'access_token': self._generate_test_access_token(
+                self.partner.id, self.amount, self.currency.id
+            ),
+            'payment_option_id': payment_option_id,
+            'reference_prefix': 'test',
+            'tokenization_requested': True,
+            'landing_route': 'Test',
+            'is_validation': False,
+            'invoice_id': self.invoice.id,
+            'flow': flow,
+        }

--- a/addons/payment/tests/http_common.py
+++ b/addons/payment/tests/http_common.py
@@ -167,8 +167,10 @@ class PaymentHttpCommon(PaymentTestUtils, HttpCase):
         """
         uri = '/payment/transaction'
         url = self._build_url(uri)
+        response = self._make_json_request(url, route_kwargs)
+        self.assertEqual(response.status_code, 200)  # Check the request went through.
 
-        return self._make_json_request(url, route_kwargs)
+        return response
 
     def get_processing_values(self, **route_kwargs):
         response = self.portal_transaction(**route_kwargs)

--- a/addons/payment/tests/test_payments.py
+++ b/addons/payment/tests/test_payments.py
@@ -1,7 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import tagged
 from unittest.mock import patch
+
+from odoo.tests import tagged
 
 from odoo.addons.payment.tests.common import PaymentCommon
 
@@ -117,7 +118,7 @@ class TestPayments(PaymentCommon):
             msg="The refunds count should only consider transactions with operation 'refund'."
         )
 
-    def test_action_post_call_send_payment_request_only_once(self):
+    def test_action_post_calls_send_payment_request_only_once(self):
         payment_token = self.create_token()
         payment_without_token = self.env['account.payment'].create({
             'payment_type': 'inbound',


### PR DESCRIPTION
We split the test in three to allow easier debugging at no cost in line of codes and by extracting a part that could be used for future tests.

task-2659750

Follow up of:
- https://github.com/odoo/odoo/pull/80590