### PR TITLE
[IMP] base, mail, survey: improves slightly the UX

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -19,7 +19,7 @@
                             <field name="res_model" groups="base.group_no_one"/>
                             <field name="res_model_change" invisible="1"/>
                             <field name="initial_res_model" invisible="1"/>
-                            <field name="summary"/>
+                            <field name="summary" placeholder="e.g. &quot;Discuss proposal&quot;"/>
                             <field name="icon" groups="base.group_no_one"/>
                             <field name="decoration_type" groups="base.group_no_one"/>
                         </group>
@@ -44,9 +44,8 @@
                             </div>
                         </group>
                     </group>
-                    <group>
-                        <field name="default_note"/>
-                    </group>
+                    <label for="default_note" class="font-weight-bold"/>
+                    <field nolabel="1" name="default_note" placeholder="e.g. &quot;Go over the offer and discuss details&quot;" class="oe-bordered-editor"/>
                     <p class="alert alert-info" role="alert" attrs="{'invisible': [('res_model_change', '=', False)]}">Modifying the model can have an impact on existing activities using this activity type, be careful.</p>
                 </sheet>
             </form>

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -43,7 +43,7 @@
                     <notebook attrs="{'invisible': [('composition_mode', '!=', 'mass_mail')]}">
                         <page string="Content">
                             <div>
-                                <field name="body" placeholder="Write your message here..." options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
+                                <field name="body" class="oe-bordered-editor" placeholder="Write your message here..." options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
                                 <group col="4">
                                     <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1" colspan="2"/>
                                     <field name="template_id" string="Load template" options="{'no_create': True}"

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -162,7 +162,8 @@
                             </group>
                         </page>
                         <page string="Description" name="survey_description">
-                            <field name="description" widget="html"/>
+                            <field name="description" widget="html"
+                                   placeholder="e.g. Guidelines, instructions, picture, ... to help attendees answer"/>
                         </page>
                         <page string="Options" name="options" attrs="{'invisible': [('is_page', '=', True)]}">
                             <group>

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -182,7 +182,7 @@
                                 </group>
                             </group>
                             <group name="help" string="Help">
-                                <field colspan="2" name="help" nolabel="1"/>
+                                <field colspan="2" name="help" nolabel="1" class="oe-bordered-editor"/>
                             </group>
                             <group name="views_tree" string="Views">
                                 <field colspan="2" name="view_ids" nolabel="1">


### PR DESCRIPTION
Improves UX by adding placeholders to clarify the purpose of some inputs and
changing some field layout to ease the edition (with the use of multi-lined
editor).

Details:
Some placeholders have been added:
- description field of survey.question
- default_note field of mail.activity.type
- summary of mail_activity_type_view_form

Some field layouts have been turned into multi-lined editor:
- default_note field of mail.activity.type
- write a message in mass mail mode (email_compose_message_wizard_form)

Added border for field help of edit action (class oe-bordered-editor)

Task-2766291

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
