### PR TITLE
[FIX] website_sale: add product snippet filter on all websites

### DIFF
--- a/addons/website_sale/__init__.py
+++ b/addons/website_sale/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import api, SUPERUSER_ID
+from odoo import api, SUPERUSER_ID, _
 from . import controllers
 from . import models
 from . import wizard
@@ -8,12 +8,22 @@ from . import report
 
 
 def uninstall_hook(cr, registry):
-    ''' Need to reenable the `product` pricelist multi-company rule that were
+    """ Need to reenable the `product` pricelist multi-company rule that were
         disabled to be 'overridden' for multi-website purpose
-    '''
+    """
     env = api.Environment(cr, SUPERUSER_ID, {})
     pl_rule = env.ref('product.product_pricelist_comp_rule', raise_if_not_found=False)
     pl_item_rule = env.ref('product.product_pricelist_item_comp_rule', raise_if_not_found=False)
     multi_company_rules = pl_rule or env['ir.rule']
     multi_company_rules += pl_item_rule or env['ir.rule']
     multi_company_rules.write({'active': True})
+
+
+def post_init_hook(cr, registry):
+    """ Need to add product filters to previously created website """
+    # Do the same as in _bootstrap_snippet_filters()
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    filter = env.ref('website_sale.dynamic_filter_demo_products', raise_if_not_found=False)
+    if filter:
+        for website in env['website'].search([('id', '!=', filter.website_id.id)]):
+            filter.copy({'website_id': website.id})

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -33,6 +33,7 @@
     'qweb': ['static/src/xml/*.xml'],
     'installable': True,
     'application': True,
+    'post_init_hook': 'post_init_hook',
     'uninstall_hook': 'uninstall_hook',
     'license': 'LGPL-3',
 }

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -389,6 +389,7 @@ class Website(models.Model):
 
     def _bootstrap_snippet_filters(self):
         super(Website, self)._bootstrap_snippet_filters()
+        # The same behavior is done in the post_init hook
         action = self.env.ref('website_sale.dynamic_snippet_products_action', raise_if_not_found=False)
         if action:
             self.env['website.snippet.filter'].create({


### PR DESCRIPTION
If applied, this commit will fix the following bug by changing
the implementation of adding the product filter to websites
to include the rest of the websites not only the default one

Steps to reproduce:

1- install website module
2- create more than 1 website
3- install website_sale module
4- the dynamic product snippet only works on the default website

Bug:

the ```website.snippet.filter``` for products is added to the default
website only

Fix:

convert to post_init_hook and include all websites

related to: https://github.com/odoo/odoo/commit/01fafecf98aba5886c5fe836e2a81f2551155f35

DON'T forward port to v15 onwards, the website_id field is not required
 anymore for website.snippet.filter which makes them global by default

OPW-2754340