### PR TITLE
[FIX] account: customer_rank/supplier_rank no copy

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -483,8 +483,8 @@ class ResPartner(models.Model):
     invoice_warn_msg = fields.Text('Message for Invoice')
     # Computed fields to order the partners as suppliers/customers according to the
     # amount of their generated incoming/outgoing account moves
-    supplier_rank = fields.Integer(default=0)
-    customer_rank = fields.Integer(default=0)
+    supplier_rank = fields.Integer(default=0, copy=False)
+    customer_rank = fields.Integer(default=0, copy=False)
 
     def _get_name_search_order_by_fields(self):
         res = super()._get_name_search_order_by_fields()


### PR DESCRIPTION
If partner is copied, it will copy customer_rank/supplier_rank and it
will be treated as such even though such partner has no references to
invoices for example.

Description of the issue/feature this PR addresses:
Do not make partner customer/supplier when copying if it has no references to ranks.

Current behavior before PR:
partner will keep customer/supplier ranks even though it has no references to documents that generated these ranks.

Desired behavior after PR is merged:
new partner will have ranks set to 0, to reflect the fact that it has no references.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
