### PR TITLE
[WIP] *: render API without env mixup

### DIFF
--- a/addons/account/controllers/onboarding.py
+++ b/addons/account/controllers/onboarding.py
@@ -16,9 +16,10 @@ class OnboardingController(http.Controller):
             return {}
 
         return {
-            'html': request.env.ref('account.account_invoice_onboarding_panel')._render({
-                'company': company,
-                'state': company.get_and_update_account_invoice_onboarding_state()
+            'html': request.env['ir.ui.view']._render(
+                'account.account_invoice_onboarding_panel', {
+                    'company': company,
+                    'state': company.get_and_update_account_invoice_onboarding_state()
             })
         }
 
@@ -34,8 +35,9 @@ class OnboardingController(http.Controller):
             return {}
 
         return {
-            'html': request.env.ref('account.account_dashboard_onboarding_panel')._render({
-                'company': company,
-                'state': company.get_and_update_account_dashboard_onboarding_state()
+            'html': request.env['ir.ui.view']._render(
+                'account.account_dashboard_onboarding_panel', {
+                    'company': company,
+                    'state': company.get_and_update_account_dashboard_onboarding_state()
             })
         }

--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -420,7 +420,7 @@ class AccountBankStatement(models.Model):
 
             # Bank statement report.
             if statement.journal_id.type == 'bank':
-                content, content_type = self.env.ref('account.action_report_account_statement')._render(statement.id)
+                content, content_type = self.env['ir.ui.view']._render('account.action_report_account_statement', statement.id)
                 self.env['ir.attachment'].create({
                     'name': statement.name and _("Bank Statement %s.pdf", statement.name) or _("Bank Statement.pdf"),
                     'type': 'binary',

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -205,7 +205,8 @@ class ResCompany(models.Model):
             return
 
         for company in self.filtered(lambda company: is_html_empty(company.invoice_terms_html) and company.terms_type == 'html'):
-            company.invoice_terms_html = term_template._render({'company_name': company.name, 'company_country': company.country_id.name}, engine='ir.qweb')
+            company.invoice_terms_html = self.env['ir.ui.view']._render("account.account_default_terms_and_conditions",
+                {'company_name': company.name, 'company_country': company.country_id.name}, engine='ir.qweb')
 
     def get_and_update_account_invoice_onboarding_state(self):
         """ This method is called on the controller rendering method and ensures that the animations

--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -34,14 +34,15 @@ class IrActionsReport(models.Model):
                 attachment.register_as_main_attachment(force=False)
         return res
 
-    def _render_qweb_pdf(self, res_ids=None, data=None):
+    def _render_qweb_pdf(self, report_ref, res_ids=None, data=None):
         # Overridden so that the print > invoices actions raises an error
         # when trying to print a miscellaneous operation instead of an invoice.
-        if self.model == 'account.move' and res_ids:
+        report = self._get_report(report_ref)
+        if report.model == 'account.move' and res_ids:
             invoice_reports = (self.env.ref('account.account_invoices_without_payment'), self.env.ref('account.account_invoices'))
-            if self in invoice_reports:
+            if report in invoice_reports:
                 moves = self.env['account.move'].browse(res_ids)
                 if any(not move.is_invoice(include_receipts=True) for move in moves):
                     raise UserError(_("Only invoices could be printed."))
 
-        return super()._render_qweb_pdf(res_ids=res_ids, data=data)
+        return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)

--- a/addons/account/wizard/account_tour_upload_bill.py
+++ b/addons/account/wizard/account_tour_upload_bill.py
@@ -35,7 +35,7 @@ class AccountTourUploadBill(models.TransientModel):
             self.env.company.country_id.name,
         ] if x]
         ref = 'INV/%s/0001' % invoice_date.strftime('%Y/%m')
-        html = self.env.ref('account.bill_preview')._render({
+        html = self.env['ir.ui.view']._render('account.bill_preview', {
             'company_name': self.env.company.name,
             'company_street_address': addr,
             'invoice_name': 'Invoice ' + ref,

--- a/addons/account_edi_facturx/models/account_edi_format.py
+++ b/addons/account_edi_facturx/models/account_edi_format.py
@@ -44,10 +44,11 @@ class AccountEdiFormat(models.Model):
                 _logger.exception("Error while converting to PDF/A: %s", e)
             metadata_template = self.env.ref('account_edi_facturx.account_invoice_pdfa_3_facturx_metadata', raise_if_not_found=False)
             if metadata_template:
-                pdf_writer.add_file_metadata(metadata_template._render({
+                report = self.env['ir.ui.view']._render('account_edi_facturx.account_invoice_pdfa_3_facturx_metadata', {
                     'title': edi_document.move_id.name,
                     'date': fields.Date.context_today(self),
-                }).encode())
+                })
+                pdf_writer.add_file_metadata(report).encode()
 
     def _export_facturx(self, invoice):
 
@@ -71,7 +72,7 @@ class AccountEdiFormat(models.Model):
         }
 
         xml_content = markupsafe.Markup("<?xml version='1.0' encoding='UTF-8'?>")
-        xml_content += self.env.ref('account_edi_facturx.account_invoice_facturx_export')._render(template_values)
+        xml_content += self.env['ir.ui.view']._render('account_edi_facturx.account_invoice_facturx_export', template_values)
         return self.env['ir.attachment'].create({
             'name': 'factur-x.xml',
             'raw': xml_content.encode(),

--- a/addons/account_edi_ubl/models/account_edi_format.py
+++ b/addons/account_edi_ubl/models/account_edi_format.py
@@ -207,7 +207,7 @@ class AccountEdiFormat(models.Model):
         self.ensure_one()
         # Create file content.
         xml_content = markupsafe.Markup("<?xml version='1.0' encoding='UTF-8'?>")
-        xml_content += self.env.ref('account_edi_ubl.export_ubl_invoice')._render(self._get_ubl_values(invoice))
+        xml_content += self.env['ir.ui.view']._render('account_edi_ubl.export_ubl_invoice', self._get_ubl_values(invoice))
         xml_name = '%s_ubl_2_1.xml' % (invoice.name.replace('/', '_'))
         return self.env['ir.attachment'].create({
             'name': xml_name,

--- a/addons/calendar/controllers/main.py
+++ b/addons/calendar/controllers/main.py
@@ -75,7 +75,7 @@ class CalendarController(http.Controller):
         # - we need a template rendering which is not lazy, to render before cursor closing
         # - we need to display the template in the language of the user (not possible with
         #   request.render())
-        response_content = request.env['ir.ui.view'].with_context(lang=lang)._render_template(
+        response_content = request.env['ir.ui.view'].with_context(lang=lang)._render(
             'calendar.invitation_page_anonymous', {
                 'company': company,
                 'event': event,

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -634,7 +634,7 @@ class Team(models.Model):
             rcontext = {
                 'team': self,
             }
-            action['help'] = self.env['ir.ui.view']._render_template('crm.crm_action_helper', values=rcontext)
+            action['help'] = self.env['ir.ui.view']._render('crm.crm_action_helper', values=rcontext)
             return action
         return super(Team,self).action_primary_channel_button()
 

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -91,7 +91,7 @@ class EventEvent(models.Model):
         return self.env['event.stage'].search([], limit=1)
 
     def _default_description(self):
-        return self.env['ir.ui.view']._render_template('event.event_default_descripton')
+        return self.env['ir.ui.view']._render('event.event_default_descripton', {})
 
     def _default_event_mail_ids(self):
         return self.env['event.type']._default_event_mail_type_ids()

--- a/addons/hr/tests/test_multi_company.py
+++ b/addons/hr/tests/test_multi_company.py
@@ -28,14 +28,14 @@ class TestMultiCompany(TestHrCommon):
         cls.employees.invalidate_cache()
 
     def test_multi_company_report(self):
-        content, content_type = self.env.ref('hr.hr_employee_print_badge').with_user(self.res_users_hr_officer).with_context(
+        content, content_type = self.env['ir.actions.report'].with_user(self.res_users_hr_officer).with_context(
             allowed_company_ids=[self.company_1.id, self.company_2.id]
-        )._render_qweb_pdf(res_ids=self.employees.ids)
+        )._render_qweb_pdf('hr.hr_employee_print_badge', res_ids=self.employees.ids)
         self.assertIn(b'Bidule', content)
         self.assertIn(b'Machin', content)
 
     def test_single_company_report(self):
         with self.assertRaises(QWebException):  # CacheMiss followed by AccessError
-            content, content_type = self.env.ref('hr.hr_employee_print_badge').with_user(self.res_users_hr_officer).with_company(
+            content, content_type = self.env['ir.actions.report'].with_user(self.res_users_hr_officer).with_company(
                 self.company_1
-            )._render_qweb_pdf(res_ids=self.employees.ids)
+            )._render_qweb_pdf('hr.hr_employee_print_badge', res_ids=self.employees.ids)

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1381,6 +1381,19 @@ class HolidaysRequest(models.Model):
             'domain': domain
         }
 
+    def action_new_time_off(self):
+        today = fields.Date.today()
+        return {
+            'name': _("New time off"),
+            'type': 'ir.actions.act_window',
+            'res_model': 'hr.leave',
+            'view_mode': 'form',
+            'views': [[self.env.ref('hr_holidays.hr_leave_view_form_dashboard_new_time_off').id, 'form']],
+            'context': {
+                'default_date_from': fields.Date.to_string(today),
+                'default_date_to': fields.Date.to_string(today + timedelta(days=1)),
+            }
+        }
 
     def _check_approval_update(self, state):
         """ Check if target state is achievable. """

--- a/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_controller.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_controller.js
@@ -132,8 +132,8 @@ export const TimeOffCalendarController = CalendarController.extend({
      */
     async _onNewTimeOff() {
         const viewId = await this._rpc({
-            model: 'ir.ui.view',
-            method: 'get_view_id',
+            model: 'hr.leave',
+            method: 'action_new_time_off',
             args: ['hr_holidays.hr_leave_view_form_dashboard_new_time_off'],
         });
 

--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -589,7 +589,7 @@ class IrHttp(models.AbstractModel):
 
     @classmethod
     def _get_error_html(cls, env, code, values):
-        return code, env['ir.ui.view']._render_template('http_routing.%s' % code, values)
+        return code, env['ir.ui.view']._render('http_routing.%s' % code, values)
 
     @classmethod
     def _handle_exception(cls, exception):
@@ -646,7 +646,7 @@ class IrHttp(models.AbstractModel):
             try:
                 code, html = cls._get_error_html(env, code, values)
             except Exception:
-                code, html = 418, env['ir.ui.view']._render_template('http_routing.http_error', values)
+                code, html = 418, env['ir.ui.view']._render('http_routing.http_error', values)
 
         return werkzeug.wrappers.Response(html, status=code, content_type='text/html;charset=utf-8')
 

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -58,14 +58,14 @@ class ImLivechatChannel(models.Model):
             channel.are_you_inside = bool(self.env.uid in [u.id for u in channel.user_ids])
 
     def _compute_script_external(self):
-        view = self.env.ref('im_livechat.external_loader')
         values = {
             "dbname": self._cr.dbname,
         }
         for record in self:
             values["channel_id"] = record.id
             values["url"] = record.get_base_url()
-            record.script_external = view._render(values) if record.id else False
+            record.script_external = self.env['ir.ui.view']._render(
+                'im_livechat.external_loader', values) if record.id else False
 
     def _compute_web_page_link(self):
         for record in self:

--- a/addons/l10n_be_edi/models/account_edi_format.py
+++ b/addons/l10n_be_edi/models/account_edi_format.py
@@ -23,7 +23,7 @@ class AccountEdiFormat(models.Model):
         self.ensure_one()
         # Create file content.
         xml_content = markupsafe.Markup("<?xml version='1.0' encoding='UTF-8'?>")
-        xml_content += self.env.ref('l10n_be_edi.export_efff_invoice')._render(self._get_efff_values(invoice))
+        xml_content += self.env['ir.ui.view']._render('l10n_be_edi.export_efff_invoice', self._get_efff_values(invoice))
         xml_name = '%s.xml' % invoice._get_efff_name()
         return self.env['ir.attachment'].create({
             'name': xml_name,

--- a/addons/l10n_ch/models/mail_template.py
+++ b/addons/l10n_ch/models/mail_template.py
@@ -33,14 +33,14 @@ class MailTemplate(models.Model):
                 if record.l10n_ch_isr_valid:
                     # We add an attachment containing the ISR
                     isr_report_name = 'ISR-' + inv_print_name + '.pdf'
-                    isr_pdf = self.env.ref('l10n_ch.l10n_ch_isr_report')._render_qweb_pdf(record.ids)[0]
+                    isr_pdf = self.env['ir.actions.report']._render_qweb_pdf('l10n_ch.l10n_ch_isr_report', record.ids)[0]
                     isr_pdf = base64.b64encode(isr_pdf)
                     new_attachments.append((isr_report_name, isr_pdf))
 
                 if record.partner_bank_id._eligible_for_qr_code('ch_qr', record.partner_id, record.currency_id):
                     # We add an attachment containing the QR-bill
                     qr_report_name = 'QR-bill-' + inv_print_name + '.pdf'
-                    qr_pdf = self.env.ref('l10n_ch.l10n_ch_qr_report')._render_qweb_pdf(record.ids)[0]
+                    qr_pdf = self.env['ir.actions.report']._render_qweb_pdf('l10n_ch.l10n_ch_qr_report', record.ids)[0]
                     qr_pdf = base64.b64encode(qr_pdf)
                     new_attachments.append((qr_report_name, qr_pdf))
 

--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -153,7 +153,7 @@ class AccountMove(models.Model):
 
         # b64encode returns a bytestring, the template tries to turn it to string,
         # but only gets the repr(pdf) --> "b'<base64_data>'"
-        pdf = self.env.ref('account.account_invoices')._render_qweb_pdf(self.id)[0]
+        pdf = self.env['ir.actions.report']._render_qweb_pdf('account.account_invoices', self.ids)[0]
         pdf = base64.b64encode(pdf).decode()
         pdf_name = re.sub(r'\W+', '', self.name) + '.pdf'
 
@@ -191,7 +191,7 @@ class AccountMove(models.Model):
         :return: The XML content as str.
         '''
         template_values = self._prepare_fatturapa_export_values()
-        content = self.env.ref('l10n_it_edi.account_invoice_it_FatturaPA_export')._render(template_values)
+        content = self.env['ir.ui.view']._render('l10n_it_edi.account_invoice_it_FatturaPA_export', template_values)
         return content
 
     def _post(self, soft=True):

--- a/addons/l10n_nl_edi/models/account_edi_format.py
+++ b/addons/l10n_nl_edi/models/account_edi_format.py
@@ -67,7 +67,7 @@ class AccountEdiFormat(models.Model):
         self.ensure_one()
         # Create file content.
         xml_content = markupsafe.Markup("<?xml version='1.0' encoding='UTF-8'?>")
-        xml_content += self.env.ref('l10n_nl_edi.export_nlcius_invoice')._render(self._get_nlcius_values(invoice))
+        xml_content += self.env['ir.ui.view']._render('l10n_nl_edi.export_nlcius_invoice', self._get_nlcius_values(invoice))
         vat = invoice.company_id.partner_id.commercial_partner_id.vat
         xml_name = 'nlcius-%s%s%s.xml' % (vat or '', '-' if vat else '', invoice.name.replace('/', '_'))
         return self.env['ir.attachment'].create({

--- a/addons/l10n_no_edi/models/account_edi_format.py
+++ b/addons/l10n_no_edi/models/account_edi_format.py
@@ -52,7 +52,7 @@ class AccountEdiFormat(models.Model):
     def _export_ehf_3(self, invoice):
         self.ensure_one()
         # Create file content.
-        xml_content = self.env.ref('l10n_no_edi.export_ehf_3_invoice')._render(self._get_ehf_3_values(invoice))
+        xml_content = self.env['ir.ui.view']._render('l10n_no_edi.export_ehf_3_invoice', self._get_ehf_3_values(invoice))
         vat = invoice.company_id.partner_id.commercial_partner_id.vat
         xml_name = 'ehf-%s%s%s.xml' % (vat or '', '-' if vat else '', invoice.name.replace('/', '_'))
         return self.env['ir.attachment'].create({

--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -319,7 +319,7 @@ class MailRenderMixin(models.AbstractModel):
         if any(r is None for r in res_ids):
             raise ValueError(_('Template rendering should be called on a valid record IDs.'))
 
-        view = self.env.ref(template_src, raise_if_not_found=False) or self.env['ir.ui.view']
+        view = self.env.ref(template_src, raise_if_not_found=False)
         results = dict.fromkeys(res_ids, u"")
         if not view:
             return results
@@ -333,7 +333,7 @@ class MailRenderMixin(models.AbstractModel):
         for record in self.env[model].browse(res_ids):
             variables['object'] = record
             try:
-                render_result = view._render(variables, engine='ir.qweb', minimal_qcontext=True, options=options)
+                render_result = self.env['ir.ui.view']._render(template_src, variables, engine='ir.qweb', minimal_qcontext=True, options=options)
             except Exception as e:
                 _logger.info("Failed to render template : %s (%d)", template_src, view.id, exc_info=True)
                 raise UserError(_("Failed to render template : %(xml_id)s (%(view_id)d)",

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2833,8 +2833,6 @@ class MailThread(models.AbstractModel):
         if not self.env.registry.ready:  # Don't send notification during install
             return
 
-        view = self.env['ir.ui.view'].browse(self.env['ir.model.data']._xmlid_to_res_id(template))
-
         for record in self:
             model_description = self.env['ir.model']._get(record._name).display_name
             values = {
@@ -2842,7 +2840,7 @@ class MailThread(models.AbstractModel):
                 'model_description': model_description,
                 'access_link': record._notify_get_action_link('view'),
             }
-            assignation_msg = view._render(values, engine='ir.qweb', minimal_qcontext=True)
+            assignation_msg = self.env['ir.ui.view']._render(template, values, engine='ir.qweb', minimal_qcontext=True)
             assignation_msg = self.env['mail.render.mixin']._replace_local_links(assignation_msg)
             record.message_notify(
                 subject=_('You have been assigned to %s', record.display_name),

--- a/addons/mail_group/controllers/portal.py
+++ b/addons/mail_group/controllers/portal.py
@@ -201,7 +201,7 @@ class PortalMailGroup(http.Controller):
             'msg_more_count': message_count - self._replies_per_page,
             'replies_per_page': self._replies_per_page,
         }
-        return request.env.ref('mail_group.messages_short')._render(values, engine='ir.qweb')
+        return request.env['ir.ui.view']._render('mail_group.messages_short', values, engine='ir.qweb')
 
     # ------------------------------------------------------------
     # SUBSCRIPTION

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1855,7 +1855,7 @@ class MrpProduction(models.Model):
                 'impacted_pickings': False,
                 'cancel': cancel
             }
-            return self.env.ref('mrp.exception_on_mo')._render(values=values)
+            return self.env['ir.ui.view']._render('mrp.exception_on_mo', values=values)
 
         documents = self.env['stock.picking']._log_activity_get_documents(moves_modification, 'move_dest_ids', 'DOWN', _keys_in_groupby)
         documents = self.env['stock.picking']._less_quantities_than_expected_add_documents(moves_modification, documents)
@@ -1881,7 +1881,7 @@ class MrpProduction(models.Model):
                 'impacted_object': impacted_object,
                 'cancel': cancel
             }
-            return self.env.ref('mrp.exception_on_mo')._render(values=values)
+            return self.env['ir.ui.view']._render('mrp.exception_on_mo', values=values)
 
         self.env['stock.picking']._log_activity(_render_note_exception_quantity_mo, documents)
 

--- a/addons/mrp/tests/test_stock_report.py
+++ b/addons/mrp/tests/test_stock_report.py
@@ -241,8 +241,8 @@ class TestMrpStockReports(TestReportsCommon):
         move.move_line_ids.result_package_id = self.env['stock.quant.package'].create({'name': 'Package0001'})
         picking.button_validate()
 
-        report = self.env['ir.actions.report']._get_report_from_name('stock.report_deliveryslip')
-        html_report = report._render_qweb_html(picking.ids)[0].decode('utf-8').split('\n')
+        html_report = self.env['ir.actions.report']._render_qweb_html(
+            'stock.report_deliveryslip', picking.ids)[0].decode('utf-8').split('\n')
         keys = [
             "Package0001", "Compo 03",
             "Products with no package assigned", "Compo 01", "Compo 02",

--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -493,7 +493,7 @@ class PaymentTransaction(models.Model):
                     "%(ref)s:\n%(values)s",
                     {'ref': self.reference, 'values': pprint.pformat(rendering_values)},
                 )
-                redirect_form_html = redirect_form_view._render(rendering_values, engine='ir.qweb')
+                redirect_form_html = self.env['ir.ui.view']._render(redirect_form_view.id, rendering_values, engine='ir.qweb')
                 processing_values.update(redirect_form_html=redirect_form_html)
 
         return processing_values

--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -82,7 +82,8 @@ class PosController(http.Controller):
     @http.route('/pos/sale_details_report', type='http', auth='user')
     def print_sale_details(self, date_start=False, date_stop=False, **kw):
         r = request.env['report.point_of_sale.report_saledetails']
-        pdf, _ = request.env.ref('point_of_sale.sale_details_report').with_context(date_start=date_start, date_stop=date_stop)._render_qweb_pdf(r)
+        pdf, _ = request.env['ir.actions.report'].with_context(date_start=date_start, date_stop=date_stop)._render_qweb_pdf(
+            'point_of_sale.sale_details_report', r)
         pdfhttpheaders = [('Content-Type', 'application/pdf'), ('Content-Length', len(pdf))]
         return request.make_response(pdf, headers=pdfhttpheaders)
 

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -773,7 +773,7 @@ class PosOrder(models.Model):
         attachment = [(4, receipt.id)]
 
         if self.mapped('account_move'):
-            report = self.env.ref('account.account_invoices')._render_qweb_pdf(self.account_move.ids[0])
+            report = self.env['ir.actions.report']._render_qweb_pdf('account.account_invoices', [self.account_move.ids[0]])
             filename = name + '.pdf'
             invoice = self.env['ir.attachment'].create({
                 'name': filename,

--- a/addons/product/report/product_pricelist_report.py
+++ b/addons/product/report/product_pricelist_report.py
@@ -14,7 +14,7 @@ class ProductPricelistReport(models.AbstractModel):
     @api.model
     def get_html(self, data):
         render_values = self._get_report_data(data, 'html')
-        return self.env.ref('product.report_pricelist_page')._render(render_values)
+        return self.env['ir.ui.view']._render('product.report_pricelist_page', render_values)
 
     def _get_report_data(self, data, report_type='html'):
         quantities = data['quantities'] or [1]

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1853,7 +1853,7 @@ class Task(models.Model):
         template_id = self.env['ir.model.data']._xmlid_to_res_id('project.project_message_user_assigned', raise_if_not_found=False)
         if not template_id:
             return
-        view = self.env['ir.ui.view'].browse(template_id)
+
         task_model_description = self.env['ir.model']._get(self._name).display_name
         for task, users in users_per_task.items():
             if not users:
@@ -1865,7 +1865,7 @@ class Task(models.Model):
             }
             for user in users:
                 values.update(assignee_name=user.sudo().name)
-                assignation_msg = view._render(values, engine='ir.qweb', minimal_qcontext=True)
+                assignation_msg = self.env['ir.ui.view']._render(template_id, values, engine='ir.qweb', minimal_qcontext=True)
                 assignation_msg = self.env['mail.render.mixin']._replace_local_links(assignation_msg)
                 task.message_notify(
                     subject=_('You have been assigned to %s', task.display_name),

--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -167,7 +167,7 @@ class PurchaseOrder(models.Model):
                 'order_exceptions': order_exceptions.values(),
                 'impacted_pickings': impacted_pickings,
             }
-            return self.env.ref('purchase_stock.exception_on_po')._render(values=values)
+            return self.env['ir.ui.view']._render('purchase_stock.exception_on_po', values=values)
 
         documents = self.env['stock.picking']._log_activity_get_documents(purchase_order_lines_quantities, 'move_ids', 'DOWN', _keys_in_groupby)
         filtered_documents = {}

--- a/addons/rating/controllers/main.py
+++ b/addons/rating/controllers/main.py
@@ -45,7 +45,7 @@ class Rating(http.Controller):
         }
         rating.write({'rating': rate, 'consumed': True})
         lang = rating.partner_id.lang or get_lang(request.env).code
-        return request.env['ir.ui.view'].with_context(lang=lang)._render_template('rating.rating_external_page_submit', {
+        return request.env['ir.ui.view'].with_context(lang=lang)._render('rating.rating_external_page_submit', {
             'rating': rating, 'token': token,
             'rate_names': rate_names, 'rate': rate
         })
@@ -60,7 +60,7 @@ class Rating(http.Controller):
         record_sudo = request.env[rating.res_model].sudo().browse(rating.res_id)
         record_sudo.rating_apply(rate, token=token, feedback=kwargs.get('feedback'))
         lang = rating.partner_id.lang or get_lang(request.env).code
-        return request.env['ir.ui.view'].with_context(lang=lang)._render_template('rating.rating_external_page_view', {
+        return request.env['ir.ui.view'].with_context(lang=lang)._render('rating.rating_external_page_view', {
             'web_base_url': rating.get_base_url(),
             'rating': rating,
         })

--- a/addons/sale_management/controllers/portal.py
+++ b/addons/sale_management/controllers/portal.py
@@ -28,7 +28,7 @@ class CustomerPortal(portal.CustomerPortal):
                'order_line_price_subtotal': format_price(order_line.price_subtotal)
             })
             try:
-                results['order_totals_table'] = request.env['ir.ui.view']._render_template('sale.sale_order_portal_content_totals_table', {'sale_order': order_sudo})
+                results['order_totals_table'] = request.env['ir.ui.view']._render('sale.sale_order_portal_content_totals_table', {'sale_order': order_sudo})
             except ValueError:
                 pass
 
@@ -58,7 +58,7 @@ class CustomerPortal(portal.CustomerPortal):
             results = self._get_portal_order_details(order_sudo)
             results.update({
                 'unlink': True,
-                'sale_template': request.env['ir.ui.view']._render_template('sale.sale_order_portal_content', {
+                'sale_template': request.env['ir.ui.view']._render('sale.sale_order_portal_content', {
                     'sale_order': order_sudo,
                     'report_type': "html"
                 }),
@@ -84,7 +84,7 @@ class CustomerPortal(portal.CustomerPortal):
 
         option_sudo.add_option_to_order()
         results = self._get_portal_order_details(order_sudo)
-        results['sale_template'] = request.env['ir.ui.view']._render_template("sale.sale_order_portal_content", {
+        results['sale_template'] = request.env['ir.ui.view']._render("sale.sale_order_portal_content", {
             'sale_order': option_sudo.order_id,
             'report_type': "html"
         })

--- a/addons/sale_product_configurator/controllers/main.py
+++ b/addons/sale_product_configurator/controllers/main.py
@@ -21,7 +21,7 @@ class ProductConfiguratorController(http.Controller):
         if pricelist:
             product_template = product_template.with_context(pricelist=pricelist.id, partner=request.env.user.partner_id)
 
-        return request.env['ir.ui.view']._render_template("sale_product_configurator.configure", {
+        return request.env['ir.ui.view']._render("sale_product_configurator.configure", {
             'product': product_template,
             'pricelist': pricelist,
             'add_qty': add_qty,
@@ -48,7 +48,7 @@ class ProductConfiguratorController(http.Controller):
             # They are kept in the context since they are not linked to this product variant
             parent_combination |= product.env.context.get('no_variant_attribute_values')
 
-        return request.env['ir.ui.view']._render_template("sale_product_configurator.optional_product_items", {
+        return request.env['ir.ui.view']._render("sale_product_configurator.optional_product_items", {
             'product': product,
             'parent_name': product.name,
             'parent_combination': parent_combination,
@@ -67,7 +67,7 @@ class ProductConfiguratorController(http.Controller):
         if no_variant_attribute_values:
             product = product.with_context(no_variant_attribute_values=no_variant_attribute_values)
 
-        return request.env['ir.ui.view']._render_template("sale_product_configurator.optional_products_modal", {
+        return request.env['ir.ui.view']._render("sale_product_configurator.optional_products_modal", {
             'product': product,
             'combination': combination,
             'add_qty': add_qty,

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -236,7 +236,7 @@ class SaleOrder(models.Model):
                 'impacted_pickings': impacted_pickings,
                 'cancel': cancel
             }
-            return self.env.ref('sale_stock.exception_on_so')._render(values=values)
+            return self.env['ir.ui.view']._render('sale_stock.exception_on_so', values=values)
 
         self.env['stock.picking']._log_activity(_render_note_exception_quantity_so, documents)
 

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -144,7 +144,7 @@ class StockPicking(models.Model):
                 'origin_picking': origin_picking,
                 'moves_information': moves_information.values(),
             }
-            return self.env.ref('sale_stock.exception_on_picking')._render(values=values)
+            return self.env['ir.ui.view']._render('sale_stock.exception_on_picking', values=values)
 
         documents = self._log_activity_get_documents(moves, 'sale_line_id', 'DOWN', _keys_in_groupby)
         self._log_activity(_render_note_exception_quantity, documents)

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1300,7 +1300,7 @@ class Picking(models.Model):
                 'moves_information': rendering_context.values(),
                 'impacted_pickings': impacted_pickings,
             }
-            return self.env.ref('stock.exception_on_picking')._render(values=values)
+            return self.env['ir.ui.view']._render('stock.exception_on_picking', values=values)
 
         documents = self._log_activity_get_documents(moves, 'move_dest_ids', 'DOWN', _keys_in_groupby)
         documents = self._less_quantities_than_expected_add_documents(moves, documents)

--- a/addons/stock/report/stock_traceability.py
+++ b/addons/stock/report/stock_traceability.py
@@ -216,7 +216,7 @@ class MrpStockReport(models.TransientModel):
         if context.get('active_id') and context.get('active_model'):
             rcontext['reference'] = self.env[context.get('active_model')].browse(int(context.get('active_id'))).display_name
 
-        body = self.env['ir.ui.view'].with_context(context)._render_template(
+        body = self.env['ir.ui.view'].with_context(context)._render(
             "stock.report_stock_inventory_print",
             values=dict(rcontext, lines=lines, report=self, context=self),
         )
@@ -236,7 +236,7 @@ class MrpStockReport(models.TransientModel):
         rcontext = {}
         context = dict(self.env.context)
         rcontext['lines'] = self.with_context(context).get_lines()
-        result['html'] = self.env.ref('stock.report_stock_inventory')._render(rcontext)
+        result['html'] = self.env['ir.ui.view']._render('stock.report_stock_inventory', rcontext)
         return result
 
     @api.model

--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -342,9 +342,9 @@ class Survey(http.Controller):
         survey_data = self._prepare_survey_data(survey_sudo, answer_sudo, **post)
 
         if answer_sudo.state == 'done':
-            survey_content = request.env.ref('survey.survey_fill_form_done')._render(survey_data)
+            survey_content = request.env['ir.ui.view']._render('survey.survey_fill_form_done', survey_data)
         else:
-            survey_content = request.env.ref('survey.survey_fill_form_in_progress')._render(survey_data)
+            survey_content = request.env['ir.ui.view']._render('survey.survey_fill_form_in_progress', survey_data)
 
         survey_progress = False
         if answer_sudo.state == 'in_progress' and not survey_data.get('question', request.env['survey.question']).is_page:
@@ -372,7 +372,7 @@ class Survey(http.Controller):
         return {
             'survey_content': survey_content,
             'survey_progress': survey_progress,
-            'survey_navigation': request.env.ref('survey.survey_navigation')._render(survey_data),
+            'survey_navigation': request.env['ir.ui.view']._render('survey.survey_navigation', survey_data),
             'background_image_url': background_image_url
         }
 

--- a/addons/survey/controllers/survey_session_manage.py
+++ b/addons/survey/controllers/survey_session_manage.py
@@ -120,7 +120,7 @@ class UserInputSession(http.Controller):
 
             return {
                 'background_image_url': survey.session_question_id.background_image_url,
-                'question_html': request.env.ref('survey.user_input_session_manage_content')._render(template_values)
+                'question_html': request.env['ir.ui.view']._render('survey.user_input_session_manage_content', template_values)
             }
         else:
             return {}

--- a/addons/test_website/tests/test_reset_views.py
+++ b/addons/test_website/tests/test_reset_views.py
@@ -79,7 +79,7 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
     #     self.assertEqual(total_views + 1, self.View.search_count([('type', '=', 'qweb')]), "Missing COW view (1)")
     #     self.fix_it('/test_view')
 
-    # also mute ir.ui.view as `get_view_id()` will raise "Could not find view object with xml_id 'no_record.exist'""
+    # also mute ir.ui.view as `_get_view_id()` will raise "Could not find view object with xml_id 'no_record.exist'""
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.addons.website.models.ir_ui_view')
     def test_06_reset_specific_view_controller_inexisting_template(self):
         total_views = self.View.search_count([('type', '=', 'qweb')])

--- a/addons/web/models/base_document_layout.py
+++ b/addons/web/models/base_document_layout.py
@@ -120,7 +120,7 @@ class BaseDocumentLayout(models.TransientModel):
                     wizard_with_logo = wizard
                 preview_css = markupsafe.Markup(self._get_css_for_preview(styles, wizard_with_logo.id))
                 ir_ui_view = wizard_with_logo.env['ir.ui.view']
-                wizard.preview = ir_ui_view._render_template('web.report_invoice_wizard_preview', {'company': wizard_with_logo, 'preview_css': preview_css})
+                wizard.preview = ir_ui_view._render('web.report_invoice_wizard_preview', {'company': wizard_with_logo, 'preview_css': preview_css})
             else:
                 wizard.preview = False
 
@@ -256,7 +256,7 @@ class BaseDocumentLayout(models.TransientModel):
         if not template_style:
             return b''
 
-        company_styles = template_style._render({
+        company_styles = self.env['ir.ui.view']._render(template_style.id, {
             'company_ids': self,
         })
 

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -806,7 +806,7 @@ class ResCompany(models.Model):
         # One bundle for everyone, so this method
         # necessarily updates the style for every company at once
         company_ids = self.sudo().search([])
-        company_styles = template_style._render({
+        company_styles = self.env['ir.ui.view']._render(template_style.id, {
             'company_ids': company_ids,
         })
         return base64.b64encode(company_styles.encode())

--- a/addons/web_editor/models/ir_qweb.py
+++ b/addons/web_editor/models/ir_qweb.py
@@ -76,7 +76,7 @@ class IrQWeb(models.AbstractModel):
         el.set('t-call', key)
         el.set('t-options', f"{{'snippet-key': {key!r}}}")
         View = self.env['ir.ui.view'].sudo()
-        view_id = View.get_view_id(key)
+        view_id = View._get_view_id(key)
         name = View.browse(view_id).name
         thumbnail = el.attrib.pop('t-thumbnail', "oe-thumbnail")
         div = '<div name="%s" data-oe-type="snippet" data-oe-thumbnail="%s" data-oe-snippet-id="%s" data-oe-keywords="%s">' % (

--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -18,15 +18,16 @@ EDITING_ATTRIBUTES = ['data-oe-model', 'data-oe-id', 'data-oe-field', 'data-oe-x
 class IrUiView(models.Model):
     _inherit = 'ir.ui.view'
 
-    def _render(self, values=None, engine='ir.qweb', minimal_qcontext=False, options=None):
+    def _render(self, view_ref, values=None, engine='ir.qweb', minimal_qcontext=False, options=None):
         if values and values.get('editable'):
+            view = self._get_view(view_ref)
             try:
-                self.check_access_rights('write')
-                self.check_access_rule('write')
+                view.check_access_rights('write')
+                view.check_access_rule('write')
             except AccessError:
                 values['editable'] = False
 
-        return super(IrUiView, self)._render(values=values, engine=engine, minimal_qcontext=minimal_qcontext, options=options)
+        return super(IrUiView, self)._render(view_ref=view_ref, values=values, engine=engine, minimal_qcontext=minimal_qcontext, options=options)
 
     #------------------------------------------------------
     # Save from html

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -204,9 +204,9 @@ class Website(Home):
                     'locs': islice(locs, 0, LOC_PER_SITEMAP),
                     'url_root': request.httprequest.url_root[:-1],
                 }
-                urls = View._render_template('website.sitemap_locs', values)
+                urls = View._render('website.sitemap_locs', values)
                 if urls.strip():
-                    content = View._render_template('website.sitemap_xml', {'content': urls})
+                    content = View._render('website.sitemap_xml', {'content': urls})
                     pages += 1
                     last_sitemap = create_sitemap('/sitemap-%d-%d.xml' % (current_website.id, pages), content)
                 else:
@@ -225,7 +225,7 @@ class Website(Home):
                 pages_with_website = ["%d-%d" % (current_website.id, p) for p in range(1, pages + 1)]
 
                 # Sitemaps must be split in several smaller files with a sitemap index
-                content = View._render_template('website.sitemap_index_xml', {
+                content = View._render('website.sitemap_index_xml', {
                     'pages': pages_with_website,
                     'url_root': request.httprequest.url_root,
                 })
@@ -425,7 +425,7 @@ class Website(Home):
                         if pattern:
                             parts = re.split(f'({pattern})', value, flags=re.IGNORECASE)
                             if len(parts) > 1:
-                                value = request.env['ir.ui.view'].sudo()._render_template(
+                                value = request.env['ir.ui.view']._render(
                                     "website.search_text_with_highlight",
                                     {'parts': parts}
                                 )

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -397,7 +397,7 @@ class Http(models.AbstractModel):
     @classmethod
     def _get_error_html(cls, env, code, values):
         if code in ('page_404', 'protected_403'):
-            return code.split('_')[1], env['ir.ui.view']._render_template('website.%s' % code, values)
+            return code.split('_')[1], env['ir.ui.view']._render('website.%s' % code, values)
         return super(Http, cls)._get_error_html(env, code, values)
 
     def binary_content(self, xmlid=None, model='ir.attachment', id=None, field='datas',

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -349,7 +349,7 @@ class View(models.Model):
 
     @api.model
     @tools.ormcache_context('self.env.uid', 'self.env.su', 'xml_id', keys=('website_id',))
-    def get_view_id(self, xml_id):
+    def _get_view_id(self, xml_id):
         """If a website_id is in the context and the given xml_id is not an int
         then try to get the id of the specific view for that website, but
         fallback to the id of the generic view if there is no specific.
@@ -370,7 +370,7 @@ class View(models.Model):
                 _logger.warning("Could not find view object with xml_id '%s'", xml_id)
                 raise ValueError('View %r in website %r not found' % (xml_id, self._context['website_id']))
             return view.id
-        return super(View, self.sudo()).get_view_id(xml_id)
+        return super(View, self.sudo())._get_view_id(xml_id)
 
     def _handle_visibility(self, do_raise=True):
         """ Check the visibility set on the main view and raise 403 if you should not have access.

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1028,7 +1028,7 @@ class Website(models.Model):
             In case of website context, return the most specific one.
 
             If no website_id is in the context, it will return the generic view,
-            instead of a random one like `get_view_id`.
+            instead of a random one like `_get_view_id`.
 
             Look also for archived views, no matter the context.
 
@@ -1089,7 +1089,7 @@ class Website(models.Model):
         else:
             if '.' not in template:
                 template = 'website.%s' % template
-            view_id = View.get_view_id(template)
+            view_id = View._get_view_id(template)
         if not view_id:
             raise NotFound
         return View.sudo().browse(view_id)

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -28,7 +28,7 @@ class Menu(models.Model):
         for menu in self:
             if menu.is_mega_menu:
                 if not menu.mega_menu_content:
-                    menu.mega_menu_content = self.env['ir.ui.view']._render_template('website.s_mega_menu_odoo_menu')
+                    menu.mega_menu_content = self.env['ir.ui.view']._render('website.s_mega_menu_odoo_menu')
             else:
                 menu.mega_menu_content = False
                 menu.mega_menu_classes = False

--- a/addons/website/models/website_snippet_filter.py
+++ b/addons/website/models/website_snippet_filter.py
@@ -71,8 +71,8 @@ class WebsiteSnippetFilter(models.Model):
         is_sample = with_sample and not records
         if is_sample:
             records = self._prepare_sample(limit)
-        View = self.env['ir.ui.view'].sudo().with_context(inherit_branding=False)
-        content = View._render_template(template_key, dict(
+        View = self.env['ir.ui.view'].with_context(inherit_branding=False)
+        content = View._render(template_key, dict(
             records=records,
             is_sample=is_sample,
         ))

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -582,8 +582,8 @@ class TestCowViewSaving(TestViewSavingCommon):
         main_view.with_context(website_id=1).write({'arch': '<body>SPECIFIC<div>Z</div></body>'})
         self.assertEqual(total_views + 3 + 3, View.search_count([]), "It should have duplicated the Main View tree as a specific tree and then removed the specific view from the generic tree as no more needed")
 
-        generic_view = View.with_context(website_id=None).get_view_id('website.main_view')
-        specific_view = View.with_context(website_id=1).get_view_id('website.main_view')
+        generic_view = View.with_context(website_id=None)._get_view_id('website.main_view')
+        specific_view = View.with_context(website_id=1)._get_view_id('website.main_view')
         generic_view_arch = View.browse(generic_view).with_context(load_all_views=True).get_combined_arch()
         specific_view_arch = View.browse(specific_view).with_context(load_all_views=True, website_id=1).get_combined_arch()
         self.assertEqual(generic_view_arch, '<body>GENERIC<div>VIEW<span>C</span></div></body>')

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -211,7 +211,7 @@ class TestViewSaving(TestViewSavingCommon):
         )
         self.assertIn(
             replacement,
-            view._render(),
+            self.env['ir.ui.view']._render(view.id),
             'inline script should not be escaped when rendering'
         )
         # common text nodes should be be escaped client side
@@ -220,7 +220,7 @@ class TestViewSaving(TestViewSavingCommon):
         self.assertIn(replacement, view.arch, 'common text node should not be escaped server side')
         self.assertIn(
             replacement,
-            str(view._render()).replace(u'&', u'&amp;'),
+            str(self.env['ir.ui.view']._render(view.id)).replace(u'&', u'&amp;'),
             'text node characters wrongly unescaped when rendering'
         )
 

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -243,7 +243,7 @@ class WebsiteEventController(http.Controller):
                     "email": visitor.email,
                     "phone": visitor.mobile,
                 }
-        return request.env['ir.ui.view']._render_template("website_event.registration_attendee_details", {
+        return request.env['ir.ui.view']._render("website_event.registration_attendee_details", {
             'tickets': tickets,
             'event': event,
             'availability_check': availability_check,

--- a/addons/website_forum/controllers/main.py
+++ b/addons/website_forum/controllers/main.py
@@ -536,7 +536,7 @@ class WebsiteForum(WebsiteProfile):
         if not post.can_moderate:
             raise AccessError(_('%d karma required to mark a post as offensive.', post.forum_id.karma_moderate))
         values = self._prepare_mark_as_offensive_values(post, **kwargs)
-        return request.env['ir.ui.view']._render_template('website_forum.mark_as_offensive', values)
+        return request.env['ir.ui.view']._render('website_forum.mark_as_offensive', values)
 
     @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/ask_for_mark_as_offensive', type='http', auth="user", methods=['GET'], website=True)
     def post_http_ask_for_mark_as_offensive(self, forum, post, **kwargs):

--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -187,7 +187,7 @@ class Forum(models.Model):
 
     def _set_default_faq(self):
         for forum in self:
-            forum.faq = self.env['ir.ui.view']._render_template('website_forum.faq_accordion', {"forum": forum})
+            forum.faq = self.env['ir.ui.view']._render('website_forum.faq_accordion', {"forum": forum})
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -584,14 +584,14 @@ class WebsiteSale(http.Controller):
         if not display:
             return values
 
-        values['website_sale.cart_lines'] = request.env['ir.ui.view']._render_template(
+        values['website_sale.cart_lines'] = request.env['ir.ui.view']._render(
             "website_sale.cart_lines", {
                 'website_sale_order': order,
                 'date': fields.Date.today(),
                 'suggested_products': order._cart_accessories()
             }
         )
-        values['website_sale.short_cart_summary'] = request.env['ir.ui.view']._render_template(
+        values['website_sale.short_cart_summary'] = request.env['ir.ui.view']._render(
             "website_sale.short_cart_summary", {
                 'website_sale_order': order,
             }
@@ -1035,7 +1035,7 @@ class WebsiteSale(http.Controller):
 
         return {
             'recall': order.get_portal_last_transaction().state == 'pending',
-            'message': request.env['ir.ui.view']._render_template("website_sale.payment_confirmation_status", {
+            'message': request.env['ir.ui.view']._render("website_sale.payment_confirmation_status", {
                 'order': order
             })
         }

--- a/addons/website_sale/controllers/variant.py
+++ b/addons/website_sale/controllers/variant.py
@@ -18,7 +18,7 @@ class WebsiteSaleVariantController(VariantController):
         if request.website.google_analytics_key:
             combination['product_tracking_info'] = request.env['product.template'].get_google_analytics_data(combination)
 
-        carousel_view = request.env['ir.ui.view']._render_template('website_sale.shop_product_carousel', values={
+        carousel_view = request.env['ir.ui.view']._render('website_sale.shop_product_carousel', values={
             'product': request.env['product.template'].browse(combination['product_template_id']),
             'product_variant': request.env['product.product'].browse(combination['product_id']),
         })

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -458,7 +458,7 @@ class ProductTemplate(models.Model):
             if with_image:
                 data['image_url'] = '/web/image/product.template/%s/image_128' % data['id']
             if with_category and product.public_categ_ids:
-                data['category'] = self.env['ir.ui.view'].sudo()._render_template(
+                data['category'] = self.env['ir.ui.view']._render(
                     "website_sale.product_category_extra_link",
                     {'categories': product.public_categ_ids, 'slug': slug}
                 )

--- a/addons/website_sale_comparison/controllers/main.py
+++ b/addons/website_sale_comparison/controllers/main.py
@@ -32,7 +32,7 @@ class WebsiteSaleProductComparison(WebsiteSale):
         products = products.with_context(pricelist=pricelist.id, display_default_code=False)
         for product in products:
             ret[product.id] = {
-                'render': request.env['ir.ui.view']._render_template(
+                'render': request.env['ir.ui.view']._render(
                     "website_sale_comparison.product_product",
                     {'product': product, 'website': website}
                 ),

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -642,7 +642,7 @@ class IrActionsReport(models.Model):
                 website = request.website
                 context = dict(context, translatable=context.get('lang') != request.env['ir.http']._get_default_lang().code)
 
-        view_obj = self.env['ir.ui.view'].sudo().with_context(context)
+        view_obj = self.env['ir.ui.view'].with_context(context)
         values.update(
             time=time,
             context_timestamp=lambda t: fields.Datetime.context_timestamp(self.with_context(tz=user.tz), t),
@@ -651,7 +651,7 @@ class IrActionsReport(models.Model):
             website=website,
             web_base_url=self.env['ir.config_parameter'].sudo().get_param('web.base.url', default=''),
         )
-        return view_obj._render_template(template, values).encode()
+        return view_obj._render(template, values).encode()
 
     def _post_pdf(self, save_in_attachment, pdf_content=None, res_ids=None):
         '''Merge the existing attachments by adding one by one the content of the attachments

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -368,7 +368,7 @@ class IrActionsReport(models.Model):
         layout = self.env.ref('web.minimal_layout', False)
         if not layout:
             return {}
-        layout = self.env['ir.ui.view'].browse(self.env['ir.ui.view'].get_view_id('web.minimal_layout'))
+        layout = self.env['ir.ui.view'].browse(self.env['ir.ui.view']._get_view_id('web.minimal_layout'))
         base_url = IrConfig.get_param('report.url') or layout.get_base_url()
 
         root = lxml.html.fromstring(html)

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -348,7 +348,7 @@ class IrActionsReport(models.Model):
 
         return command_args
 
-    def _prepare_html(self, html):
+    def _prepare_html(self, html, report_model=False):
         '''Divide and recreate the header/footer html by merging all found in html.
         The bodies are extracted and added to a list. Then, extract the specific_paperformat_args.
         The idea is to put all headers/footers together. Then, we will use a javascript trick
@@ -404,7 +404,7 @@ class IrActionsReport(models.Model):
                 'base_url': base_url
             })
             bodies.append(body)
-            if node.get('data-oe-model') == self.model:
+            if node.get('data-oe-model') == report_model:
                 res_ids.append(int(node.get('data-oe-id', 0)))
             else:
                 res_ids.append(None)
@@ -872,7 +872,7 @@ class IrActionsReport(models.Model):
 
         html = self.with_context(context)._render_qweb_html(report_ref, res_ids, data=data)[0]
 
-        bodies, html_ids, header, footer, specific_paperformat_args = report_sudo.with_context(context)._prepare_html(html)
+        bodies, html_ids, header, footer, specific_paperformat_args = self.with_context(context)._prepare_html(html, report_model=report_sudo.model)
 
         if report_sudo.attachment and set(res_ids) != set(html_ids):
             raise UserError(_("The report's template '%s' is wrong, please contact your administrator. \n\n"

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -697,7 +697,7 @@ class IrQWeb(models.AbstractModel):
         :rtype: Optional[Tuple[Union[etree, str], Optional[str, int]]]
         """
         lang = options.get('lang') or get_lang(self.env).code
-        view_id = self.env['ir.ui.view'].get_view_id(ref)
+        view_id = self.env['ir.ui.view']._get_view_id(ref)
         template = self.env['ir.ui.view'].with_context(lang=lang).sudo()._read_template(view_id)
 
         # QWeb's ``_read_template`` will check if one of the first children of
@@ -705,7 +705,7 @@ class IrQWeb(models.AbstractModel):
         # to consider it has found it. As it'll never be the case when working
         # with view ids or children view or children primary views, force it here.
         def is_child_view(view_ref):
-            view_id = self.env['ir.ui.view'].get_view_id(view_ref)
+            view_id = self.env['ir.ui.view']._get_view_id(view_ref)
             view = self.env['ir.ui.view'].sudo().browse(view_id)
             return view.inherit_id is not None
 

--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -763,4 +763,4 @@ class QwebView(models.AbstractModel):
             _logger.warning("%s.%s must be a 'ir.ui.view', got %r.", record, field_name, view._name)
             return ''
 
-        return view._render(options.get('values', {}), engine='ir.qweb')
+        return self.env['ir.ui.view']._render(view.id, options.get('values', {}), engine='ir.qweb')

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1970,12 +1970,9 @@ actual arch.
 
     @api.model
     def render_public_asset(self, template, values=None):
-        template = self.sudo().browse(self._get_view_id(template))
-        template._check_view_access()
-        return template.sudo()._render(values, engine="ir.qweb")
-
-    def _render_template(self, template, values=None, engine='ir.qweb'):
-        return self._get_view(template)._render(values, engine)
+        view = self._get_view(template).sudo()
+        view._check_view_access()
+        return self._render(template, values, engine="ir.qweb")
 
     @api.model
     def _render(self, view_ref, values=None, engine='ir.qweb', minimal_qcontext=False, options=None):

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1852,20 +1852,28 @@ actual arch.
         return etree.tostring(arch_tree, encoding='unicode')
 
     @api.model
-    def get_view_id(self, template):
+    def _get_view_id(self, template):
         """ Return the view ID corresponding to ``template``, which may be a
         view ID or an XML ID. Note that this method may be overridden for other
         kinds of template values.
-
-        This method could return the ID of something that is not a view (when
-        using fallback to `_xmlid_to_res_id`).
         """
         if isinstance(template, int):
             return template
         if '.' not in template:
             raise ValueError('Invalid template id: %r' % template)
         view = self.sudo().search([('key', '=', template)], limit=1)
-        return view and view.id or self.env['ir.model.data']._xmlid_to_res_id(template, raise_if_not_found=True)
+        if view:
+            return view.id
+        res_id, res_model = self.env['ir.model.data']._xmlid_to_res_model_res_id(template, raise_if_not_found=True)
+        assert res_model == self._name
+        return res_id
+
+    @api.model
+    def _get_view(self, view_ref):
+        """ Return the view corresponding to ``view_ref``, which may be a
+        view ID or an XML ID.
+        """
+        return self.browse(self._get_view_id(view_ref))
 
     def clear_cache(self):
         """ Deprecated, use `clear_caches` instead. """
@@ -1961,12 +1969,12 @@ actual arch.
 
     @api.model
     def render_public_asset(self, template, values=None):
-        template = self.sudo().browse(self.get_view_id(template))
+        template = self.sudo().browse(self._get_view_id(template))
         template._check_view_access()
         return template.sudo()._render(values, engine="ir.qweb")
 
     def _render_template(self, template, values=None, engine='ir.qweb'):
-        return self.browse(self.get_view_id(template))._render(values, engine)
+        return self.browse(self._get_view_id(template))._render(values, engine)
 
     def _render(self, values=None, engine='ir.qweb', minimal_qcontext=False, options=None):
         assert isinstance(self.id, int)

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -94,7 +94,7 @@ class TestQWebTField(TransactionCase):
                 </t>
             """
         })
-        rendered = view._render({'malicious': '1</script><script>alert("pwned")</script><script>'})
+        rendered = self.env['ir.ui.view']._render(view.id, {'malicious': '1</script><script>alert("pwned")</script><script>'})
         self.assertIn('alert', rendered, "%r doesn't seem to be rendered" % rendered)
         doc = etree.fromstring(rendered)
         self.assertEqual(len(doc.xpath('//script')), 1)
@@ -1313,7 +1313,7 @@ class TestQWebBasic(TransactionCase):
             """
         })
 
-        result = view1._render({})
+        result = self.env['ir.ui.view']._render(view1.id, {})
         self.assertEqual(etree.fromstring(result), etree.fromstring("""
             <div>
                 <table>
@@ -1352,10 +1352,10 @@ class TestQWebBasic(TransactionCase):
         })
 
         with self.assertRaises(QWebException):
-            view1._render()
+            self.env['ir.ui.view']._render(view1.id)
 
         try:
-            view1._render()
+            self.env['ir.ui.view']._render(view1.id)
         except QWebException as e:
             error = str(e)
             self.assertIn("The varname 'a-2' can only contain alphanumeric characters and underscores", error)
@@ -1375,10 +1375,10 @@ class TestQWebBasic(TransactionCase):
         })
 
         with self.assertRaises(QWebException):
-            view1._render()
+            self.env['ir.ui.view']._render(view1.id)
 
         try:
-            view1._render()
+            self.env['ir.ui.view']._render(view1.id)
         except QWebException as e:
             error = str(e)
             self.assertIn('External ID not found in the system: base.dummy', error)
@@ -1420,7 +1420,7 @@ class TestQWebBasic(TransactionCase):
             """ % other_lang
         })
 
-        rendered = view2.with_context(lang=current_lang)._render().strip()
+        rendered = self.env['ir.ui.view'].with_context(lang=current_lang)._render(view2.id).strip()
         self.assertEqual(rendered, '9/000/000*00')
 
     def test_render_barcode(self):
@@ -1435,16 +1435,16 @@ class TestQWebBasic(TransactionCase):
         })
 
         view.arch = """<div t-field="partner.barcode" t-options="{'widget': 'barcode', 'width': 100, 'height': 30}"/>"""
-        rendered = view._render(values={'partner': partner}).strip()
+        rendered = self.env['ir.ui.view']._render(view.id, values={'partner': partner}).strip()
         self.assertRegex(rendered, r'<div><img alt="Barcode test" src="data:image/png;base64,\S+"></div>')
 
         partner.barcode = '4012345678901'
         view.arch = """<div t-field="partner.barcode" t-options="{'widget': 'barcode', 'symbology': 'EAN13', 'width': 100, 'height': 30, 'img_style': 'width:100%;', 'img_alt': 'Barcode'}"/>"""
-        ean_rendered = view._render(values={'partner': partner}).strip()
+        ean_rendered = self.env['ir.ui.view']._render(view.id, values={'partner': partner}).strip()
         self.assertRegex(ean_rendered, r'<div><img style="width:100%;" alt="Barcode" src="data:image/png;base64,\S+"></div>')
 
         view.arch = """<div t-field="partner.barcode" t-options="{'widget': 'barcode', 'symbology': 'auto', 'width': 100, 'height': 30, 'img_style': 'width:100%;', 'img_alt': 'Barcode'}"/>"""
-        auto_rendered = view._render(values={'partner': partner}).strip()
+        auto_rendered = self.env['ir.ui.view']._render(view.id, values={'partner': partner}).strip()
         self.assertRegex(auto_rendered, r'<div><img style="width:100%;" alt="Barcode" src="data:image/png;base64,\S+"></div>')
 
     def test_render_comment_tail(self):
@@ -1467,7 +1467,7 @@ class TestQWebBasic(TransactionCase):
         })
         emptyline = '\n                '
         expected = markupsafe.Markup('Text 1' + emptyline + emptyline + 'Text 2' + emptyline + 'ok')
-        self.assertEqual(view1._render().strip(), expected)
+        self.assertEqual(self.env['ir.ui.view']._render(view1.id).strip(), expected)
 
     def test_void_element(self):
         view = self.env['ir.ui.view'].create({

--- a/odoo/addons/test_assetsbundle/controllers/main.py
+++ b/odoo/addons/test_assetsbundle/controllers/main.py
@@ -8,4 +8,4 @@ class TestAssetsBundleController(Controller):
     @route('/test_assetsbundle/js', type='http', auth='user')
     def bundle(self):
         env = request.env(user=SUPERUSER_ID)
-        return env['ir.ui.view']._render_template('test_assetsbundle.template1')
+        return env['ir.ui.view']._render('test_assetsbundle.template1')

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -937,7 +937,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'target': 'test_assetsbundle/static/src/js/test_jsfile1.js',
             'path': 'http://external.link/external.js',
         })
-        rendered = view._render()
+        rendered = self.env['ir.ui.view']._render(view.id)
         html_tree = lxml.etree.fromstring(rendered)
         scripts = html_tree.findall('script')
         self.assertEqual(len(scripts), 2)

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -598,7 +598,7 @@ class TestJavascriptAssetsBundle(FileTouchable):
                          "there should be an css assets bundle created in /rtl if user's lang direction is rtl and debug=assets")
 
     def test_20_external_lib_assets(self):
-        html = self.env['ir.ui.view']._render_template('test_assetsbundle.template2')
+        html = self.env['ir.ui.view']._render('test_assetsbundle.template2')
         attachments = self.env['ir.attachment'].search([('url', '=like', '/web/assets/%-%/test_assetsbundle.bundle4.%')])
         self.assertEqual(len(attachments), 2)
 
@@ -631,7 +631,7 @@ class TestJavascriptAssetsBundle(FileTouchable):
 </html>""" % format_data))
 
     def test_21_external_lib_assets_debug_mode(self):
-        html = self.env['ir.ui.view']._render_template('test_assetsbundle.template2', {"debug": "assets"})
+        html = self.env['ir.ui.view']._render('test_assetsbundle.template2', {"debug": "assets"})
         attachments = self.env['ir.attachment'].search([('url', '=like', '%/test_assetsbundle.bundle4.js')])
         self.assertEqual(len(attachments), 1)
 
@@ -825,7 +825,7 @@ class TestAssetsManifest(AddonManifestPatched):
 
     def test_01_globmanifest(self):
         view = self.make_asset_view('test_assetsbundle.manifest1')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest1.min.js')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -847,7 +847,7 @@ class TestAssetsManifest(AddonManifestPatched):
 
     def test_02_globmanifest_no_duplicates(self):
         view = self.make_asset_view('test_assetsbundle.manifest2')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest2.min.js')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -869,7 +869,7 @@ class TestAssetsManifest(AddonManifestPatched):
 
     def test_03_globmanifest_file_before(self):
         view = self.make_asset_view('test_assetsbundle.manifest3')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest3.min.js')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -896,7 +896,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'bundle': 'test_assetsbundle.manifest4',
             'path': 'test_assetsbundle/static/src/js/test_jsfile1.js',
         })
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest4.min.js')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -917,7 +917,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'bundle': 'test_assetsbundle.irasset1',
             'path': 'test_assetsbundle/static/src/js/test_jsfile1.js',
         })
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.irasset1.min.js')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -968,7 +968,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'path': 'test_assetsbundle/static/src/js/test_jsfile1.js',
             'target': 'test_assetsbundle/static/src/js/test_jsfile3.js',
         })
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest4')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -997,7 +997,7 @@ class TestAssetsManifest(AddonManifestPatched):
         })
         # asset is now: js_file1 ; js_file2 ; js_file3
         # because js_file is replaced by 1 and 2
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest4')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1022,7 +1022,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'directive': 'remove',
             'path': 'test_assetsbundle/static/src/js/test_jsfile2.js',
         })
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest5')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1054,7 +1054,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'path': 'test_assetsbundle/static/src/js/test_doesntexist.js',
         })
         with self.assertRaises(Exception) as cm:
-            view._render()
+            self.env['ir.ui.view']._render(view.id)
         self.assertTrue(
             "['test_assetsbundle/static/src/js/test_doesntexist.js'] not found" in str(cm.exception)
         )
@@ -1067,7 +1067,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'directive': 'remove',
             'path': 'test_assetsbundle/static/src/**/*',
         })
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest2.js')], order='create_date DESC', limit=1)
         # indeed everything in the bundle matches the glob, so there is no attachment
         self.assertFalse(attach)
@@ -1080,7 +1080,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'bundle': 'test_assetsbundle.manifest4',
             'path': 'test_assetsbundle/static/src/js/test_jsfile1.js',
         })
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest4')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1102,7 +1102,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'bundle': 'test_assetsbundle.irasset_include1',
             'path': 'test_assetsbundle.manifest6',
         })
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.irasset_include1')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1115,7 +1115,7 @@ class TestAssetsManifest(AddonManifestPatched):
 
     def test_12_include2(self):
         view = self.make_asset_view('test_assetsbundle.manifest6')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest6')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1142,7 +1142,7 @@ class TestAssetsManifest(AddonManifestPatched):
         })
 
         with self.assertRaises(QWebException) as cm:
-            view._render()
+            self.env['ir.ui.view']._render(view.id)
         error = str(cm.exception.__cause__)
         self.assertTrue(error)
         self.assertFalse(isinstance(error, RecursionError))
@@ -1181,7 +1181,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'bundle': 'test_assetsbundle.irasset_include3',
             'path': 'test_assetsbundle/static/src/js/test_jsfile1.js',
         })
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.irasset_include1')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1205,7 +1205,7 @@ class TestAssetsManifest(AddonManifestPatched):
             }
         }
         view = self.make_asset_view('test_other.mockmanifest1')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_other.mockmanifest1')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1229,7 +1229,7 @@ class TestAssetsManifest(AddonManifestPatched):
             }
         }
         view = self.make_asset_view('test_assetsbundle.manifest4')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest4')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1256,7 +1256,7 @@ class TestAssetsManifest(AddonManifestPatched):
             }
         }
         view = self.make_asset_view('test_assetsbundle.manifest4')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest4')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1283,7 +1283,7 @@ class TestAssetsManifest(AddonManifestPatched):
             }
         }
         view = self.make_asset_view('test_assetsbundle.manifest4')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest4')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1308,7 +1308,7 @@ class TestAssetsManifest(AddonManifestPatched):
             }
         }
         view = self.make_asset_view('test_assetsbundle.manifest4')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest4')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1332,7 +1332,7 @@ class TestAssetsManifest(AddonManifestPatched):
             }
         }
         view = self.make_asset_view('test_assetsbundle.manifest4')
-        rendered = view._render()
+        rendered = self.env['ir.ui.view']._render(view.id)
         html_tree = lxml.etree.fromstring(rendered)
         scripts = html_tree.findall('script')
         self.assertEqual(len(scripts), 2)
@@ -1373,7 +1373,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'media': 'print',
         })
 
-        rendered = view._render()
+        rendered = self.env['ir.ui.view']._render(view.id)
         html_tree = lxml.etree.fromstring(rendered)
         stylesheets = html_tree.findall('link')
         self.assertEqual(len(stylesheets), 2)
@@ -1399,7 +1399,7 @@ class TestAssetsManifest(AddonManifestPatched):
             't-css': 'true',
         })
 
-        rendered = view._render()
+        rendered = self.env['ir.ui.view']._render(view.id)
         html_tree = lxml.etree.fromstring(rendered)
         stylesheets = html_tree.findall('link')
         self.assertEqual(len(stylesheets), 2)
@@ -1431,7 +1431,7 @@ class TestAssetsManifest(AddonManifestPatched):
             }
         }
         view = self.make_asset_view('test_assetsbundle.bundle4')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.bundle4')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1461,7 +1461,7 @@ class TestAssetsManifest(AddonManifestPatched):
             }
         }
         view = self.make_asset_view('test_assetsbundle.bundle4')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.bundle4')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1495,7 +1495,7 @@ class TestAssetsManifest(AddonManifestPatched):
             }
         }
         view = self.make_asset_view('test_assetsbundle.bundle4')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.bundle4')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1525,7 +1525,7 @@ class TestAssetsManifest(AddonManifestPatched):
             }
         }
         view = self.make_asset_view('test_assetsbundle.bundle4')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.bundle4')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1554,7 +1554,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'directive': 'before',
         })
         view = self.make_asset_view('test_assetsbundle.bundle4')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.bundle4')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1583,7 +1583,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'directive': 'after',
         })
         view = self.make_asset_view('test_assetsbundle.bundle4')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.bundle4')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1622,7 +1622,7 @@ class TestAssetsManifest(AddonManifestPatched):
             't-js': 'true',
             't-css': 'true',
         })
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.bundle4')], order='create_date DESC', limit=2)
         attach_css = None
         attach_js = None
@@ -1680,7 +1680,7 @@ class TestAssetsManifest(AddonManifestPatched):
         })
         view = self.make_asset_view('test_assetsbundle.wrong_path')
         with self.assertRaises(Exception) as cm:
-            view._render()
+            self.env['ir.ui.view']._render(view.id)
         self.assertTrue(
             "test_assetsbundle/static/src/js/doesnt_exist.js not found" in str(cm.exception)
         )
@@ -1694,7 +1694,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'directive': 'after',
         })
         view = self.make_asset_view('test_assetsbundle.manifest4')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest4')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1723,7 +1723,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'directive': 'before',
         })
         view = self.make_asset_view('test_assetsbundle.manifest4')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest4')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         self.assertStringEqual(
@@ -1756,7 +1756,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'path': '/test_assetsbundle/%s' % path_to_dummy,
         })
         view = self.make_asset_view('test_assetsbundle.irassetsec')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.irassetsec')], order='create_date DESC', limit=1)
         self.assertFalse(attach.exists())
 
@@ -1789,7 +1789,7 @@ class TestAssetsManifest(AddonManifestPatched):
         })
         view = self.make_asset_view('test_assetsbundle.irassetsec')
         with self.assertRaises(QWebException) as cm:
-            view._render()
+            self.env['ir.ui.view']._render(view.id)
 
         self.assertTrue('Unallowed to fetch files from addon notinstalled_module' in str(cm.exception))
 
@@ -1811,7 +1811,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'path': '/test_assetsbundle/__manifest__.py',
         })
         view = self.make_asset_view('test_assetsbundle.irassetsec')
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.irassetsec')], order='create_date DESC', limit=1)
         self.assertFalse(attach.exists())
 
@@ -1857,7 +1857,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'path': 'test_assetsbundle/my_style_attach.scss',
         })
         view = self.make_asset_view('test_assetsbundle.irasset_custom_attach', {'t-css': True})
-        view._render()
+        self.env['ir.ui.view']._render(view.id)
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.irasset_custom_attach')], order='create_date DESC', limit=1)
         content = attach.raw.decode()
         # The scss should be compiled

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1243,7 +1243,7 @@ class Response(werkzeug.wrappers.Response):
         """
         env = request.env(user=self.uid or request.uid or odoo.SUPERUSER_ID)
         self.qcontext['request'] = request
-        return env["ir.ui.view"]._render_template(self.template, self.qcontext)
+        return env["ir.ui.view"]._render(self.template, self.qcontext)
 
     def flatten(self):
         """ Forces the rendering of the response's template, sets the result


### PR DESCRIPTION
The render API was confusing as mixing the access to the report/view and the rendering env.
```py
# before
>>> self.env['ir.ui.view'].browse(42)._render({'obj': value})
>>> self.env['ir.ui.view']._render_template('base.my_view, {'obj': value})
>>> self.env.ref('base.my_action_report')._render_qweb_pdf(res_ids=self.ids)
```
```py
# after
>>> self.env['ir.ui.view']._render(42, {'obj': value})
>>> self.env['ir.ui.view']._render('base.my_view', {'obj': value})
>>> self.env['ir.actions.report']._render_qweb_pdf('base.my_action_report', res_ids=self.ids)
```

This will allow to call the report methods with any user and no longer need to use `with_user(1)` to render reports as public user