### PR TITLE
[FIX] account,point_of_sale: fixed tax computation with 100% discount

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -1507,6 +1507,8 @@ class AccountTax(models.Model):
             if base_amount:
                 return math.copysign(quantity, base_amount) * self.amount
             else:
+                if self.price_include:
+                    return 0.0
                 return quantity * self.amount
 
         price_include = self._context.get('force_price_include', self.price_include)
@@ -1740,7 +1742,7 @@ class AccountTax(models.Model):
                     elif tax.amount_type == 'division':
                         incl_division_amount += tax.amount * sum_repartition_factor
                     elif tax.amount_type == 'fixed':
-                        incl_fixed_amount += quantity * tax.amount * sum_repartition_factor
+                        incl_fixed_amount += quantity * tax.amount * sum_repartition_factor if base else 0.0
                     else:
                         # tax.amount_type == other (python)
                         tax_amount = tax._compute_amount(base, sign * price_unit, abs(quantity), product, partner) * sum_repartition_factor

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1328,7 +1328,7 @@ exports.PosModel = Backbone.Model.extend({
                 else if(tax.amount_type === 'division')
                     incl_division_amount += tax.amount;
                 else if(tax.amount_type === 'fixed')
-                    incl_fixed_amount += Math.abs(quantity) * tax.amount
+                    incl_fixed_amount += base === 0.0 ? 0.0 : Math.abs(quantity) * tax.amount
                 else{
                     var tax_amount = self._compute_all(tax, base, quantity);
                     incl_fixed_amount += tax_amount;


### PR DESCRIPTION
1. Have a fixed price tax [FTAX] (i.e. 10$), price included affecting
base of subsequent taxes
2. Have a percent tax [PTAX] (i.e. 15%), price included
3.1 Sell a product (147$) having [FTAX] and [PTAX] in a SO and set 100% discount

The following amounts will compute:
Untaxed Amount  $ 10.00
Fixed Tax:  $ -10.00
Tax 15%:    $ -3.00
Total   $ -3.00

3.2 Sell a product (147$) having [PTAX] and [FTAX] in a SO and set 100% discount

The following amounts will compute:
Untaxed Amount  $ 8.70
Fixed Tax:  $ -10.00
Tax 15%:    $ -1.30
Total   $ -2.60

In POS with the same configuration (taxes need to be applied on the
product record) the total to pay will be 0 but journal entries will
still be generated with positive amounts

After this commit the use of 100% discount with fixed taxes should be
more consistent:

With 100% discount and included fixed taxes the tax amount will be 0, so
no amount will be used as base for subsequent taxes

Untaxed Amount  $ 0.0
Fixed Tax:  $ 0.0
Tax 15%:    $ 0.0
Total   $ 0.0

With 100% discount and not included fixed taxes the tax amount will be
the fixed tax and could be used as base for subsequent taxes

Untaxed Amount  $ 0.0
Fixed Tax:  $ 10.0
Tax 15%:    $ 0.0 (1.5 if FTAX is affecting next tax)
Total   $ 10.0 (11.5)

opw-2637512

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
