### PR TITLE
[FIX] mass_mailing: empty alert message on the mailing form view

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -367,7 +367,7 @@
                     <xpath expr="//div[hasclass('alert-info')]" position="move"/>
                 </field>
                 <xpath expr="//div[hasclass('alert-info')]" position="attributes">
-                    <attribute name="attrs">{'invisible': ['|',('state', '=', 'draft'),'&amp;','&amp;',('state', '!=', 'in_queue'),('scheduled', '=', 0),('failed', '=', 0)]}</attribute>
+                    <attribute name="attrs">{'invisible': ['|',('state', '=', 'draft'),'&amp;',('state', '!=', 'in_queue'),('failed', '=', 0)]}</attribute>
                 </xpath>
                 <xpath expr="//div[hasclass('alert-info')]/div[hasclass('o_mails_canceled')]" position="replace"/>
                 <xpath expr="//div[hasclass('alert-info')]/div[hasclass('o_mails_sent')]" position="replace"/>


### PR DESCRIPTION
Bug
===
When sending a mailing (with a valid outgoing mail server), during the
"sending" stage, the blue alert div is visible but empty.

The reason for that the scheduled count is visible only when the
mailing is in the "in queue" state, so we adapt the condition on the
alert.

Task-2746886