### PR TITLE
[IMP] hr_holidays: multi company in global leaves/stress days

### DIFF
--- a/addons/hr_contract/models/resource.py
+++ b/addons/hr_contract/models/resource.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import datetime
 
-from odoo import fields, models
+from odoo import Command, fields, models
 from odoo.osv.expression import AND
 
 
@@ -19,13 +19,13 @@ class ResourceCalendar(models.Model):
         """
         from_date = from_date or fields.Datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
         domain = [
-            ('calendar_id', 'in', self.ids),
+            ('calendar_ids', 'in', self.ids),
             ('date_from', '>=', from_date),
         ]
         domain = AND([domain, [('resource_id', 'in', resources.ids)]]) if resources else domain
 
         self.env['resource.calendar.leaves'].search(domain).write({
-            'calendar_id': other_calendar.id,
+            'calendar_ids': [[Command.SET, False, [other_calendar.id]]],
         })
 
     def _compute_contracts_count(self):

--- a/addons/hr_contract/tests/test_calendar_sync.py
+++ b/addons/hr_contract/tests/test_calendar_sync.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.fields import Datetime, Date
 from odoo.addons.hr_contract.tests.common import TestContractCommon
 
@@ -40,7 +41,7 @@ class TestContractCalendars(TestContractCommon):
                 'date_from': start,
                 'date_to': end,
                 'resource_id': resource.id if resource else None,
-                'calendar_id': self.employee.resource_calendar_id.id,
+                'calendar_ids': [[Command.SET, False, [self.employee.resource_calendar_id.id]]],
                 'time_type': 'leave',
             })
 
@@ -59,11 +60,11 @@ class TestContractCalendars(TestContractCommon):
 
         self.calendar_richard.transfer_leaves_to(self.calendar_35h, resources=self.employee.resource_id, from_date=Date.to_date('2015-11-21'))
 
-        self.assertEqual(leave1.calendar_id, self.calendar_richard, "It should stay in Richard's calendar")
-        self.assertEqual(leave3.calendar_id, self.calendar_richard, "Global leave should stay in original calendar")
-        self.assertEqual(leave2.calendar_id, self.calendar_35h, "It should be transfered to the other calendar")
+        self.assertEqual(leave1.calendar_ids, self.calendar_richard, "It should stay in Richard's calendar")
+        self.assertEqual(leave3.calendar_ids, self.calendar_richard, "Global leave should stay in original calendar")
+        self.assertEqual(leave2.calendar_ids, self.calendar_35h, "It should be transfered to the other calendar")
 
         # Transfer global leaves
         self.calendar_richard.transfer_leaves_to(self.calendar_35h, resources=None, from_date=Date.to_date('2015-11-21'))
 
-        self.assertEqual(leave3.calendar_id, self.calendar_35h, "Global leave should be transfered")
+        self.assertEqual(leave3.calendar_ids, self.calendar_35h, "Global leave should be transfered")

--- a/addons/hr_holidays/data/hr_holidays_demo.xml
+++ b/addons/hr_holidays/data/hr_holidays_demo.xml
@@ -442,7 +442,7 @@
     <record id="resource_public_time_off_1" model="resource.calendar.leaves">
         <field name="name">Public Time Off</field>
         <field name="company_id" ref="base.main_company"/>
-        <field name="calendar_id" ref="resource.resource_calendar_std"/>
+        <field name="calendar_ids" eval="[[6, False, [ref('resource.resource_calendar_std')]]]"/>
         <field name="date_from" eval="(datetime.today() + relativedelta(days=+8)).strftime('%Y-%m-%d 07:00:00')"></field>
         <field name="date_to" eval="(datetime.today() + relativedelta(days=+8)).strftime('%Y-%m-%d 16:00:00')"></field>
     </record>

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -544,8 +544,8 @@ class HolidaysRequest(models.Model):
                 ('start_date', '<=', date_to.date()),
                 ('end_date', '>=', date_from.date()),
                 '|',
-                    ('resource_calendar_id', '=', False),
-                    ('resource_calendar_id', 'in', resource_calendar_id.ids),
+                    ('resource_calendar_ids', '=', False),
+                    ('resource_calendar_ids', 'in', resource_calendar_id.ids),
             ])
 
             for leave in self:
@@ -553,8 +553,8 @@ class HolidaysRequest(models.Model):
                     ('start_date', '<=', leave.date_to.date()),
                     ('end_date', '>=', leave.date_from.date()),
                     '|',
-                        ('resource_calendar_id', '=', False),
-                        ('resource_calendar_id', '=', (leave.employee_id.resource_calendar_id or self.env.company.resource_calendar_id).id)
+                        ('resource_calendar_ids', '=', False),
+                        ('resource_calendar_ids', '=', (leave.employee_id.resource_calendar_id or self.env.company.resource_calendar_id).id)
                 ]
 
                 if leave.holiday_status_id.company_id:
@@ -1099,7 +1099,7 @@ class HolidaysRequest(models.Model):
             'holiday_id': leave.id,
             'date_to': leave.date_to,
             'resource_id': leave.employee_id.resource_id.id,
-            'calendar_id': leave.employee_id.resource_calendar_id.id,
+            'calendar_ids': [[Command.SET, False, [leave.employee_id.resource_calendar_id.id]]],
             'time_type': leave.holiday_status_id.time_type,
         } for leave in self]
 

--- a/addons/hr_holidays/models/hr_leave_stress_day.py
+++ b/addons/hr_holidays/models/hr_leave_stress_day.py
@@ -11,16 +11,38 @@ class StressDay(models.Model):
     _order = 'start_date desc, end_date desc'
 
     name = fields.Char(required=True)
-    company_id = fields.Many2one('res.company', default=lambda self: self.env.company, required=True)
+    company_id = fields.Many2one('res.company', default=lambda self: self.env.company)
     start_date = fields.Date(required=True)
     end_date = fields.Date(required=True)
     color = fields.Integer(default=lambda dummy: randint(1, 11))
-    resource_calendar_id = fields.Many2one('resource.calendar', 'Working Hours',
-        default=lambda self: self.env.company.resource_calendar_id.id, domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
+    resource_calendar_ids = fields.Many2many('resource.calendar',
+                                             string="Working Hours",
+                                             default=lambda self: self.env.company.resource_calendar_id.ids,
+                                             domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
 
     _sql_constraints = [
         ('date_from_after_day_to', 'CHECK(start_date <= end_date)', 'The start date must be anterior than the end date.')
     ]
+
+    def _get_resource_calendar_ids(self, vals, company_id):
+        if vals['resource_calendar_ids'][0][0] == fields.Command.SET and not vals['resource_calendar_ids'][0][2]:
+            resource_calendars = self.env['resource.calendar'].search_read([('company_id', '=', company_id)], ['id'])
+            return [r['id'] for r in resource_calendars]
+        return vals['resource_calendar_ids'][0][2]
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get('resource_calendar_ids'):
+                vals['resource_calendar_ids'][0][2] = self._get_resource_calendar_ids(vals, self.env.company.id)
+        stress_days = super().create(vals_list)
+        return stress_days
+
+    def write(self, values):
+        if values.get('resource_calendar_ids'):
+            values['resource_calendar_ids'][0][2] = self._get_resource_calendar_ids(values, self.company_id.id)
+        res = super().write(values)
+        return res
 
     @api.model
     def get_stress_days(self, start_date, end_date, resource_calendar_id=None):
@@ -30,8 +52,8 @@ class StressDay(models.Model):
             ('start_date', '>=', start_date),
             ('end_date', '<=', end_date),
             '|',
-                ('resource_calendar_id', '=', False),
-                ('resource_calendar_id', '=', resource_calendar_id.id),
+                ('resource_calendar_ids', '=', False),
+                ('resource_calendar_ids', 'in', resource_calendar_id.ids),
         ])
 
         for stress_day in stress_days:

--- a/addons/hr_holidays/tests/test_global_leaves.py
+++ b/addons/hr_holidays/tests/test_global_leaves.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import date
+from odoo import Command
 from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
 from odoo.exceptions import ValidationError
 
@@ -55,7 +56,7 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
             'name': 'Global Leave',
             'date_from': date(2022, 3, 8),
             'date_to': date(2022, 3, 8),
-            'calendar_id': cls.calendar_1.id,
+            'calendar_ids': [[Command.SET, False, [cls.calendar_1.id]]],
         })
 
     def test_leave_on_global_leave(self):
@@ -64,7 +65,7 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
                 'name': 'Wrong Leave',
                 'date_from': date(2022, 3, 7),
                 'date_to': date(2022, 3, 7),
-                'calendar_id': self.calendar_1.id,
+                'calendar_ids': [[Command.SET, False, [self.calendar_1.id]]],
             })
 
         with self.assertRaises(ValidationError):
@@ -79,7 +80,7 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
                 'name': 'Correct Leave',
                 'date_from': date(2022, 3, 8),
                 'date_to': date(2022, 3, 8),
-                'calendar_id': self.calendar_2.id,
+                'calendar_ids': [[Command.SET, False, [self.calendar_2.id]]],
             })
 
         with self.assertRaises(ValidationError):
@@ -94,5 +95,5 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
                 'name': 'Wrong Leave',
                 'date_from': date(2022, 3, 8),
                 'date_to': date(2022, 3, 8),
-                'calendar_id': self.calendar_1.id,
+                'calendar_ids': [[Command.SET, False, [self.calendar_1.id]]],
             })

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -380,7 +380,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                 (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
                 (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'})
             ],
-            'global_leave_ids': [(0, 0, {
+            'leave_ids': [(0, 0, {
                 'name': 'Christmas Leave',
                 'date_from': fields.Datetime.from_string('2019-12-25 00:00:00'),
                 'date_to': fields.Datetime.from_string('2019-12-26 23:59:59'),

--- a/addons/hr_holidays/tests/test_stress_days.py
+++ b/addons/hr_holidays/tests/test_stress_days.py
@@ -4,7 +4,7 @@
 from datetime import datetime
 from freezegun import freeze_time
 
-from odoo import tests
+from odoo import Command, tests
 from odoo.tests import new_test_user
 from odoo.tests.common import Form, TransactionCase
 from odoo.exceptions import ValidationError
@@ -53,7 +53,7 @@ class TestHrLeaveStressDays(TransactionCase):
             'start_date': datetime(2021, 11, 2),
             'end_date': datetime(2021, 11, 2),
             'color': 1,
-            'resource_calendar_id': cls.default_calendar.id,
+            'resource_calendar_ids': [[Command.SET, False, [cls.default_calendar.id]]],
         })
         cls.stress_week = cls.env['hr.leave.stress.day'].create({
             'name': 'Super Event End Of Week',
@@ -61,7 +61,7 @@ class TestHrLeaveStressDays(TransactionCase):
             'start_date': datetime(2021, 11, 8),
             'end_date': datetime(2021, 11, 12),
             'color': 2,
-            'resource_calendar_id': cls.default_calendar.id,
+            'resource_calendar_ids': [[Command.SET, False, [cls.default_calendar.id]]],
         })
 
     @freeze_time('2021-10-15')

--- a/addons/hr_holidays/views/hr_leave_stress_day_views.xml
+++ b/addons/hr_holidays/views/hr_leave_stress_day_views.xml
@@ -30,11 +30,11 @@
         <field name="arch" type="xml">
             <tree editable="bottom">
                 <field name="name"/>
-                <field name="company_id" groups="base.group_multi_company" optional="hide"/>
+                <field name="company_id" groups="base.group_multi_company" optional="hide" readonly="1"/>
                 <field name="start_date"/>
                 <field name="end_date"/>
                 <field name="color" widget="color_picker" width="1"/>
-                <field name="resource_calendar_id" optional="hide"/>
+                <field name="resource_calendar_ids" optional="hide" widget="many2many_tags"/>
             </tree>
         </field>
     </record>
@@ -59,5 +59,16 @@
         <field name="view_mode">tree,form</field>
         <field name="search_view_id" ref="hr_leave_stress_day_view_search"/>
         <field name="context">{'search_default_filter_date': True}</field>
+    </record>
+
+    <record model="ir.actions.server" id="action_stress_day_duplicate">
+        <field name="name">Duplicate</field>
+        <field name="model_id" ref="model_hr_leave_stress_day"/>
+        <field name="binding_model_id" ref="model_hr_leave_stress_day" />
+        <field name="state">code</field>
+        <field name="code">
+            if records:
+                records.copy()
+        </field>
     </record>
 </odoo>

--- a/addons/hr_holidays/views/resource_views.xml
+++ b/addons/hr_holidays/views/resource_views.xml
@@ -39,7 +39,7 @@
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//field[@name='date_to']" position="after">
-                <xpath expr="//field[@name='calendar_id']" position="move"/>
+                <xpath expr="//field[@name='calendar_ids']" position="move"/>
             </xpath>
         </field>
     </record>
@@ -86,5 +86,16 @@
         <field name="view_id" ref="resource_calendar_leaves_tree_inherit"/>
         <field name="context">{
             'search_default_filter_date': True}</field>
+    </record>
+
+    <record model="ir.actions.server" id="action_resource_calendar_leaves_duplicate">
+        <field name="name">Duplicate</field>
+        <field name="model_id" ref="model_resource_calendar_leaves"/>
+        <field name="binding_model_id" ref="model_resource_calendar_leaves" />
+        <field name="state">code</field>
+        <field name="code">
+            if records:
+                records.copy()
+        </field>
     </record>
 </odoo>

--- a/addons/hr_work_entry_contract/models/hr_contract.py
+++ b/addons/hr_work_entry_contract/models/hr_contract.py
@@ -55,7 +55,9 @@ class HrContract(models.Model):
     def _get_leave_domain(self, start_dt, end_dt):
         return [
             ('time_type', '=', 'leave'),
-            ('calendar_id', 'in', [False] + self.resource_calendar_id.ids),
+            '|',
+            ('calendar_ids', '=', False),
+            ('calendar_ids', 'in', self.resource_calendar_id.ids),
             ('resource_id', 'in', [False] + self.employee_id.resource_id.ids),
             ('date_from', '<=', end_dt),
             ('date_to', '>=', start_dt),
@@ -105,7 +107,7 @@ class HrContract(models.Model):
             for leave in itertools.chain(leaves_by_resource[False], leaves_by_resource[resource.id]):
                 for resource in resources_list:
                     # Global time off is not for this calendar, can happen with multiple calendars in self
-                    if resource and leave.calendar_id != calendar and not leave.resource_id:
+                    if resource and calendar not in leave.calendar_ids and not leave.resource_id:
                         continue
                     tz = tz if tz else pytz.timezone((resource or contract).tz)
                     if (tz, start_dt) in tz_dates:

--- a/addons/hr_work_entry_contract/tests/test_global_time_off.py
+++ b/addons/hr_work_entry_contract/tests/test_global_time_off.py
@@ -5,6 +5,7 @@ from .common import TestWorkEntryBase
 
 from datetime import datetime
 
+from odoo import Command
 from odoo.tests import tagged
 
 @tagged('-at_install', 'post_install')
@@ -21,7 +22,7 @@ class TestGlobalTimeOff(TestWorkEntryBase):
         leave = self.env['resource.calendar.leaves'].create({
             'date_from': start,
             'date_to': end,
-            'calendar_id': other_calendar.id,
+            'calendar_ids': [[Command.SET, False, [other_calendar.id]]],
             'work_entry_type_id': self.work_entry_type_leave.id,
         })
         contract = self.richard_emp.contract_ids
@@ -33,6 +34,6 @@ class TestGlobalTimeOff(TestWorkEntryBase):
         work_entries.unlink()
         contract.date_generated_from = start
         contract.date_generated_to = start
-        leave.calendar_id = contract.resource_calendar_id
+        leave.calendar_ids = [[Command.SET, False, [contract.resource_calendar_id.id]]]
         work_entries = contract._generate_work_entries(start, end)
         self.assertEqual(work_entries.work_entry_type_id, leave.work_entry_type_id)

--- a/addons/hr_work_entry_holidays/models/hr_contract.py
+++ b/addons/hr_work_entry_holidays/models/hr_contract.py
@@ -72,7 +72,7 @@ class HrContract(models.Model):
         # Complete override, compare over holiday_id.employee_id instead of calendar_id
         return [
             ('time_type', '=', 'leave'),
-            '|', ('calendar_id', 'in', [False] + self.resource_calendar_id.ids),
+            '|', '|', ('calendar_ids', '=', False), ('calendar_ids', 'in', self.resource_calendar_id.ids),
                  ('holiday_id.employee_id', 'in', self.employee_id.ids), # see https://github.com/odoo/enterprise/pull/15091
             ('resource_id', 'in', [False] + self.employee_id.resource_id.ids),
             ('date_from', '<=', end_dt),

--- a/addons/hr_work_entry_holidays/models/hr_leave.py
+++ b/addons/hr_work_entry_holidays/models/hr_leave.py
@@ -4,7 +4,7 @@
 from collections import defaultdict
 from datetime import datetime, date
 
-from odoo import api, fields, models, _
+from odoo import api, Command, fields, models, _
 from odoo.exceptions import ValidationError
 
 
@@ -41,7 +41,7 @@ class HrLeave(models.Model):
                     'time_type': leave.holiday_status_id.time_type,
                     'date_from': max(leave.date_from, datetime.combine(contract.date_start, datetime.min.time())),
                     'date_to': min(leave.date_to, datetime.combine(contract.date_end or date.max, datetime.max.time())),
-                    'calendar_id': contract.resource_calendar_id.id,
+                    'calendar_ids': [[Command.SET, False, [contract.resource_calendar_id.id]]],
                 }]
 
         return resource_leaves | self.env['resource.calendar.leaves'].create(resource_leave_values)

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -31,7 +31,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
         self.richard_emp.generate_work_entries(date(2018, 1, 1), date(2018, 1, 2))
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=92, admin=93):
+        with self.assertQueryCount(__system__=94, admin=95):
             leave.action_validate()
         leave.action_refuse()
 

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1278,7 +1278,7 @@ class MrpProduction(models.Model):
             # Create leave on chosen workcenter calendar
             leave = self.env['resource.calendar.leaves'].create({
                 'name': workorder.display_name,
-                'calendar_id': best_workcenter.resource_calendar_id.id,
+                'calendar_ids': [[Command.SET, False, [best_workcenter.resource_calendar_id.id]]],
                 'date_from': best_start_date,
                 'date_to': best_finished_date,
                 'resource_id': best_workcenter.resource_id.id,

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -6,7 +6,7 @@ from dateutil.relativedelta import relativedelta
 from collections import defaultdict
 import json
 
-from odoo import api, fields, models, _, SUPERUSER_ID
+from odoo import api, Command, fields, models, _, SUPERUSER_ID
 from odoo.exceptions import UserError
 from odoo.tools import float_compare, float_round, format_datetime
 
@@ -578,7 +578,7 @@ class MrpWorkorder(models.Model):
         if not self.leave_id:
             leave = self.env['resource.calendar.leaves'].create({
                 'name': self.display_name,
-                'calendar_id': self.workcenter_id.resource_calendar_id.id,
+                'calendar_ids': [[Command.SET, False, [self.workcenter_id.resource_calendar_id.id]]],
                 'date_from': start_date,
                 'date_to': start_date + relativedelta(minutes=self.duration_expected),
                 'resource_id': self.workcenter_id.resource_id.id,

--- a/addons/project_timesheet_holidays/models/hr_employee.py
+++ b/addons/project_timesheet_holidays/models/hr_employee.py
@@ -20,16 +20,16 @@ class Employee(models.Model):
         today = fields.Datetime.today()
         lines_vals = []
         for employee in employees:
-            global_leaves = employee.resource_calendar_id.global_leave_ids.filtered(lambda l: l.date_from >= today)
+            global_leaves = employee.resource_calendar_id.leave_ids.filtered(lambda l: l.date_from >= today)
             work_hours_data = global_leaves._work_time_per_day()
 
             for global_time_off in global_leaves:
-                for index, (day_date, work_hours_count) in enumerate(work_hours_data[global_time_off.id]):
+                for index, (day_date, work_hours_count) in enumerate(work_hours_data[global_time_off.id][employee.resource_calendar_id.id]):
                     lines_vals.append(
                         global_time_off._timesheet_prepare_line_values(
                             index,
                             employee,
-                            work_hours_data[global_time_off.id],
+                            work_hours_data[global_time_off.id][employee.resource_calendar_id.id],
                             day_date,
                             work_hours_count
                         )

--- a/addons/project_timesheet_holidays/tests/test_timesheet_global_time_off.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_global_time_off.py
@@ -64,7 +64,7 @@ class TestTimesheetGlobalTimeOff(common.TransactionCase):
 
         global_time_off = self.env['resource.calendar.leaves'].create({
             'name': 'Test',
-            'calendar_id': self.test_company.resource_calendar_id.id,
+            'calendar_ids': [[Command.SET, False, [self.test_company.resource_calendar_id.id]]],
             'date_from': leave_start_datetime,
             'date_to': leave_end_datetime,
         })
@@ -97,7 +97,7 @@ class TestTimesheetGlobalTimeOff(common.TransactionCase):
 
         self.env['resource.calendar.leaves'].create({
             'name': 'Test',
-            'calendar_id': self.part_time_calendar.id,
+            'calendar_ids': [[Command.SET, False, [self.part_time_calendar.id]]],
             'date_from': leave_start_datetime,
             'date_to': leave_end_datetime,
         })

--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 
-from odoo import fields, SUPERUSER_ID
+from odoo import Command, fields, SUPERUSER_ID
 
 from odoo.tests import common, new_test_user
 from odoo.addons.hr_timesheet.tests.test_timesheet import TestCommonTimesheet
@@ -166,7 +166,7 @@ class TestTimesheetHolidays(TestCommonTimesheet):
         # Create a public holiday
         self.env['resource.calendar.leaves'].create({
             'name': 'Test',
-            'calendar_id': self.employee_working_calendar.id,
+            'calendar_ids': [[Command.SET, False, [self.employee_working_calendar.id]]],
             'date_from': datetime(2022, 1, 26, 7, 0, 0, 0),  # This is Wednesday and India Independence
             'date_to': datetime(2022, 1, 26, 18, 0, 0, 0),
         })

--- a/addons/resource/views/resource_views.xml
+++ b/addons/resource/views/resource_views.xml
@@ -97,7 +97,7 @@
                 <field name="name"/>
                 <field name="resource_id"/>
                 <field name="company_id" groups="base.group_multi_company"/>
-                <field name="calendar_id"/>
+                <field name="calendar_ids"/>
                 <filter name="filter_date" date="date_from" default_period="this_year" string="Period"/>
                 <group expand="0" string="Group By">
                     <filter string="Resource" name="resource" domain="[]" context="{'group_by':'resource_id'}"/>
@@ -129,8 +129,8 @@
                 <group>
                     <group name="leave_details">
                         <field name="name" string="Reason"/>
-                        <field name="calendar_id"/>
-                        <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company" attrs="{'invisible':[('calendar_id','=',False)]}"/>
+                        <field name="calendar_ids"/>
+                        <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company" attrs="{'invisible':[('calendar_ids','=',False)]}"/>
                         <field name="resource_id"/>
                     </group>
                     <group name="leave_dates">
@@ -152,7 +152,7 @@
                 <field name="name" string="Reason"/>
                 <field name="resource_id" />
                 <field name="company_id" groups="base.group_multi_company"/>
-                <field name="calendar_id"/>
+                <field name="calendar_ids" widget="many2many_tags"/>
                 <field name="date_from" />
                 <field name="date_to" />
             </tree>

--- a/addons/test_resource/tests/test_resource.py
+++ b/addons/test_resource/tests/test_resource.py
@@ -4,7 +4,7 @@
 from datetime import date, datetime
 from pytz import timezone, utc
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.exceptions import ValidationError
 from odoo.addons.resource.models.resource import Intervals, sum_intervals
 from odoo.addons.test_resource.tests.common import TestResourceCommon
@@ -102,7 +102,7 @@ class TestErrors(TestResourceCommon):
             self.env['resource.calendar.leaves'].create({
                 'name': 'error cannot return in the past',
                 'resource_id': False,
-                'calendar_id': self.calendar_jean.id,
+                'calendar_ids': [[Command.SET, False, [self.calendar_jean.id]]],
                 'date_from': datetime_str(2018, 4, 3, 20, 0, 0, tzinfo=self.jean.tz),
                 'date_to': datetime_str(2018, 4, 3, 0, 0, 0, tzinfo=self.jean.tz),
             })
@@ -111,7 +111,7 @@ class TestErrors(TestResourceCommon):
             self.env['resource.calendar.leaves'].create({
                 'name': 'error caused by timezones',
                 'resource_id': False,
-                'calendar_id': self.calendar_jean.id,
+                'calendar_ids': [[Command.SET, False, [self.calendar_jean.id]]],
                 'date_from': datetime_str(2018, 4, 3, 10, 0, 0, tzinfo='UTC'),
                 'date_to': datetime_str(2018, 4, 3, 12, 0, 0, tzinfo='Etc/GMT-6')
             })
@@ -125,14 +125,14 @@ class TestCalendar(TestResourceCommon):
         self.env['resource.calendar.leaves'].create({
             'name': 'Global Leave',
             'resource_id': False,
-            'calendar_id': self.calendar_jean.id,
+            'calendar_ids': [[Command.SET, False, [self.calendar_jean.id]]],
             'date_from': datetime_str(2018, 4, 3, 0, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 3, 23, 59, 59, tzinfo=self.jean.tz),
         })
 
         self.env['resource.calendar.leaves'].create({
             'name': 'leave for Jean',
-            'calendar_id': self.calendar_jean.id,
+            'calendar_ids': [[Command.SET, False, [self.calendar_jean.id]]],
             'resource_id': self.jean.resource_id.id,
             'date_from': datetime_str(2018, 4, 5, 0, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 5, 23, 59, 59, tzinfo=self.jean.tz),
@@ -154,7 +154,7 @@ class TestCalendar(TestResourceCommon):
         # leave of size 0
         self.env['resource.calendar.leaves'].create({
             'name': 'zero_length',
-            'calendar_id': self.calendar_patel.id,
+            'calendar_ids': [[Command.SET, False, [self.calendar_patel.id]]],
             'resource_id': False,
             'date_from': datetime_str(2018, 4, 3, 0, 0, 0, tzinfo=self.patel.tz),
             'date_to': datetime_str(2018, 4, 3, 0, 0, 0, tzinfo=self.patel.tz),
@@ -169,7 +169,7 @@ class TestCalendar(TestResourceCommon):
         # leave of medium size
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'zero_length',
-            'calendar_id': self.calendar_patel.id,
+            'calendar_ids': [[Command.SET, False, [self.calendar_patel.id]]],
             'resource_id': False,
             'date_from': datetime_str(2018, 4, 3, 9, 0, 0, tzinfo=self.patel.tz),
             'date_to': datetime_str(2018, 4, 3, 12, 0, 0, tzinfo=self.patel.tz),
@@ -186,7 +186,7 @@ class TestCalendar(TestResourceCommon):
         # leave of very small size
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'zero_length',
-            'calendar_id': self.calendar_patel.id,
+            'calendar_ids': [[Command.SET, False, [self.calendar_patel.id]]],
             'resource_id': False,
             'date_from': datetime_str(2018, 4, 3, 0, 0, 0, tzinfo=self.patel.tz),
             'date_to': datetime_str(2018, 4, 3, 0, 0, 10, tzinfo=self.patel.tz),
@@ -204,7 +204,7 @@ class TestCalendar(TestResourceCommon):
         # Should equal to a leave between 2018/04/03 10:00:00 and 2018/04/04 10:00:00
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'no timezone',
-            'calendar_id': self.calendar_patel.id,
+            'calendar_ids': [[Command.SET, False, [self.calendar_patel.id]]],
             'resource_id': False,
             'date_from': datetime_str(2018, 4, 3, 4, 0, 0),
             'date_to': datetime_str(2018, 4, 4, 4, 0, 0),
@@ -248,7 +248,7 @@ class TestCalendar(TestResourceCommon):
         # 2 weeks calendar week 2, leave during a day where he doesn't work this week
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'Leave Jules week 2',
-            'calendar_id': self.calendar_jules.id,
+            'calendar_ids': [[Command.SET, False, [self.calendar_jules.id]]],
             'resource_id': False,
             'date_from': datetime_str(2018, 4, 11, 4, 0, 0, tzinfo=self.jules.tz),
             'date_to': datetime_str(2018, 4, 13, 4, 0, 0, tzinfo=self.jules.tz),
@@ -265,7 +265,7 @@ class TestCalendar(TestResourceCommon):
         # 2 weeks calendar week 2, leave during a day where he works this week
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'Leave Jules week 2',
-            'calendar_id': self.calendar_jules.id,
+            'calendar_ids': [[Command.SET, False, [self.calendar_jules.id]]],
             'resource_id': False,
             'date_from': datetime_str(2018, 4, 9, 0, 0, 0, tzinfo=self.jules.tz),
             'date_to': datetime_str(2018, 4, 9, 23, 59, 0, tzinfo=self.jules.tz),
@@ -319,7 +319,7 @@ class TestCalendar(TestResourceCommon):
     def test_plan_hours(self):
         self.env['resource.calendar.leaves'].create({
             'name': 'global',
-            'calendar_id': self.calendar_jean.id,
+            'calendar_ids': [[Command.SET, False, [self.calendar_jean.id]]],
             'resource_id': False,
             'date_from': datetime_str(2018, 4, 11, 0, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 11, 23, 59, 59, tzinfo=self.jean.tz),
@@ -355,7 +355,7 @@ class TestCalendar(TestResourceCommon):
     def test_plan_days(self):
         self.env['resource.calendar.leaves'].create({
             'name': 'global',
-            'calendar_id': self.calendar_jean.id,
+            'calendar_ids': [[Command.SET, False, [self.calendar_jean.id]]],
             'resource_id': False,
             'date_from': datetime_str(2018, 4, 11, 0, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 11, 23, 59, 59, tzinfo=self.jean.tz),
@@ -626,7 +626,7 @@ class TestResMixin(TestResourceCommon):
         # half days
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'half',
-            'calendar_id': self.calendar_jean.id,
+            'calendar_ids': [[Command.SET, False, [self.calendar_jean.id]]],
             'resource_id': self.jean.resource_id.id,
             'date_from': datetime_str(2018, 4, 2, 10, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 2, 14, 0, 0, tzinfo=self.jean.tz),
@@ -651,7 +651,7 @@ class TestResMixin(TestResourceCommon):
         # leave size 0
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'zero',
-            'calendar_id': self.calendar_jean.id,
+            'calendar_ids': [[Command.SET, False, [self.calendar_jean.id]]],
             'resource_id': False,
             'date_from': datetime_str(2018, 4, 2, 10, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 2, 10, 0, 0, tzinfo=self.jean.tz),
@@ -668,7 +668,7 @@ class TestResMixin(TestResourceCommon):
         # leave very small size
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'small',
-            'calendar_id': self.calendar_jean.id,
+            'calendar_ids': [[Command.SET, False, [self.calendar_jean.id]]],
             'resource_id': False,
             'date_from': datetime_str(2018, 4, 2, 10, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 2, 10, 0, 1, tzinfo=self.jean.tz),
@@ -685,7 +685,7 @@ class TestResMixin(TestResourceCommon):
         # Jean takes a leave
         self.env['resource.calendar.leaves'].create({
             'name': 'Jean is visiting India',
-            'calendar_id': self.jean.resource_calendar_id.id,
+            'calendar_ids': [[Command.SET, False, [self.jean.resource_calendar_id.id]]],
             'resource_id': self.jean.resource_id.id,
             'date_from': datetime_str(2018, 4, 10, 8, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 10, 16, 0, 0, tzinfo=self.jean.tz),
@@ -694,7 +694,7 @@ class TestResMixin(TestResourceCommon):
         # John takes a leave for Jean
         self.env['resource.calendar.leaves'].create({
             'name': 'Jean is comming in USA',
-            'calendar_id': self.jean.resource_calendar_id.id,
+            'calendar_ids': [[Command.SET, False, [self.jean.resource_calendar_id.id]]],
             'resource_id': self.jean.resource_id.id,
             'date_from': datetime_str(2018, 4, 12, 8, 0, 0, tzinfo=self.john.tz),
             'date_to': datetime_str(2018, 4, 12, 16, 0, 0, tzinfo=self.john.tz),
@@ -730,7 +730,7 @@ class TestResMixin(TestResourceCommon):
         # Gives 3 hours (3/8 of a day)
         self.env['resource.calendar.leaves'].create({
             'name': 'John is sick',
-            'calendar_id': self.john.resource_calendar_id.id,
+            'calendar_ids': [[Command.SET, False, [self.john.resource_calendar_id.id]]],
             'resource_id': self.john.resource_id.id,
             'date_from': datetime_str(2018, 4, 10, 0, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 10, 20, 0, 0, tzinfo=self.jean.tz),
@@ -740,7 +740,7 @@ class TestResMixin(TestResourceCommon):
         # Gives all day (12 hours)
         self.env['resource.calendar.leaves'].create({
             'name': 'John goes to holywood',
-            'calendar_id': self.john.resource_calendar_id.id,
+            'calendar_ids': [[Command.SET, False, [self.john.resource_calendar_id.id]]],
             'resource_id': self.john.resource_id.id,
             'date_from': datetime_str(2018, 4, 13, 7, 0, 0, tzinfo=self.john.tz),
             'date_to': datetime_str(2018, 4, 13, 18, 0, 0, tzinfo=self.john.tz),
@@ -757,7 +757,7 @@ class TestResMixin(TestResourceCommon):
         # half days
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'half',
-            'calendar_id': self.calendar_jean.id,
+            'calendar_ids': [[Command.SET, False, [self.calendar_jean.id]]],
             'resource_id': self.jean.resource_id.id,
             'date_from': datetime_str(2018, 4, 2, 10, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 2, 14, 0, 0, tzinfo=self.jean.tz),
@@ -774,7 +774,7 @@ class TestResMixin(TestResourceCommon):
         # leave size 0
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'zero',
-            'calendar_id': self.calendar_jean.id,
+            'calendar_ids': [[Command.SET, False, [self.calendar_jean.id]]],
             'resource_id': False,
             'date_from': datetime_str(2018, 4, 2, 10, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 2, 10, 0, 0, tzinfo=self.jean.tz),
@@ -791,7 +791,7 @@ class TestResMixin(TestResourceCommon):
         # leave very small size
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'small',
-            'calendar_id': self.calendar_jean.id,
+            'calendar_ids': [[Command.SET, False, [self.calendar_jean.id]]],
             'resource_id': False,
             'date_from': datetime_str(2018, 4, 2, 10, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 2, 10, 0, 1, tzinfo=self.jean.tz),
@@ -809,7 +809,7 @@ class TestResMixin(TestResourceCommon):
     def test_list_leaves(self):
         jean_leave = self.env['resource.calendar.leaves'].create({
             'name': "Jean's son is sick",
-            'calendar_id': self.jean.resource_calendar_id.id,
+            'calendar_ids': [[Command.SET, False, [self.jean.resource_calendar_id.id]]],
             'resource_id': False,
             'date_from': datetime_str(2018, 4, 10, 0, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 10, 23, 59, 59, tzinfo=self.jean.tz),
@@ -824,7 +824,7 @@ class TestResMixin(TestResourceCommon):
         # half days
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'half',
-            'calendar_id': self.jean.resource_calendar_id.id,
+            'calendar_ids': [[Command.SET, False, [self.jean.resource_calendar_id.id]]],
             'resource_id': self.jean.resource_id.id,
             'date_from': datetime_str(2018, 4, 2, 10, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 2, 14, 0, 0, tzinfo=self.jean.tz),
@@ -841,7 +841,7 @@ class TestResMixin(TestResourceCommon):
         # very small size
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'small',
-            'calendar_id': self.jean.resource_calendar_id.id,
+            'calendar_ids': [[Command.SET, False, [self.jean.resource_calendar_id.id]]],
             'resource_id': self.jean.resource_id.id,
             'date_from': datetime_str(2018, 4, 2, 10, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 2, 10, 0, 1, tzinfo=self.jean.tz),
@@ -861,7 +861,7 @@ class TestResMixin(TestResourceCommon):
         # size 0
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'zero',
-            'calendar_id': self.jean.resource_calendar_id.id,
+            'calendar_ids': [[Command.SET, False, [self.jean.resource_calendar_id.id]]],
             'resource_id': self.jean.resource_id.id,
             'date_from': datetime_str(2018, 4, 2, 10, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 2, 10, 0, 0, tzinfo=self.jean.tz),
@@ -901,7 +901,7 @@ class TestResMixin(TestResourceCommon):
         # half days
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'small',
-            'calendar_id': self.jean.resource_calendar_id.id,
+            'calendar_ids': [[Command.SET, False, [self.jean.resource_calendar_id.id]]],
             'resource_id': self.jean.resource_id.id,
             'date_from': datetime_str(2018, 4, 2, 10, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 2, 14, 0, 0, tzinfo=self.jean.tz),
@@ -924,7 +924,7 @@ class TestResMixin(TestResourceCommon):
         # very small size
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'small',
-            'calendar_id': self.jean.resource_calendar_id.id,
+            'calendar_ids': [[Command.SET, False, [self.jean.resource_calendar_id.id]]],
             'resource_id': self.jean.resource_id.id,
             'date_from': datetime_str(2018, 4, 2, 10, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 2, 10, 0, 1, tzinfo=self.jean.tz),
@@ -943,7 +943,7 @@ class TestResMixin(TestResourceCommon):
         # size 0
         leave = self.env['resource.calendar.leaves'].create({
             'name': 'zero',
-            'calendar_id': self.jean.resource_calendar_id.id,
+            'calendar_ids': [[Command.SET, False, [self.jean.resource_calendar_id.id]]],
             'resource_id': self.jean.resource_id.id,
             'date_from': datetime_str(2018, 4, 2, 10, 0, 0, tzinfo=self.jean.tz),
             'date_to': datetime_str(2018, 4, 2, 10, 0, 0, tzinfo=self.jean.tz),
@@ -1070,7 +1070,7 @@ class TestTimezones(TestResourceCommon):
     def test_leave_data(self):
         self.env['resource.calendar.leaves'].create({
             'name': '',
-            'calendar_id': self.jean.resource_calendar_id.id,
+            'calendar_ids': [[Command.SET, False, [self.jean.resource_calendar_id.id]]],
             'resource_id': self.jean.resource_id.id,
             'date_from': datetime_str(2018, 4, 9, 8, 0, 0, tzinfo=self.tz2),
             'date_to': datetime_str(2018, 4, 9, 14, 0, 0, tzinfo=self.tz2),
@@ -1100,7 +1100,7 @@ class TestTimezones(TestResourceCommon):
     def test_leaves(self):
         leave = self.env['resource.calendar.leaves'].create({
             'name': '',
-            'calendar_id': self.jean.resource_calendar_id.id,
+            'calendar_ids': [[Command.SET, False, [self.jean.resource_calendar_id.id]]],
             'resource_id': self.jean.resource_id.id,
             'date_from': datetime_str(2018, 4, 9, 8, 0, 0, tzinfo=self.tz2),
             'date_to': datetime_str(2018, 4, 9, 14, 0, 0, tzinfo=self.tz2),


### PR DESCRIPTION
At the moment, you can't create a global leave or stress day for another company
than the one you're currently logged in, even if you have multiple companies
selected in your session.

This commit allow for global leaves and stress days to:
- edit the company field
- If the company field is empty, the global leave/stress day is visibile in every company
- If a compnay is set, the global leave/stress day is only visibile for that company
- In the acion menu, add a duplication option

task-2719715

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
