### PR TITLE
[FIX] uom: keep the current factor instead of setting it to 0

### DIFF
--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -35,7 +35,7 @@ class UoMCategory(models.Model):
             else:
                 new_reference = self.uom_ids.filtered(lambda o: o.uom_type == 'reference' and o._origin.uom_type != 'reference')
             if new_reference:
-                other_uoms = self.uom_ids - new_reference
+                other_uoms = self.uom_ids.filtered(lambda u: u._origin.id) - new_reference
                 for uom in other_uoms:
                     uom.factor = uom._origin.factor / (new_reference._origin.factor or 1)
                     if uom.factor > 1:


### PR DESCRIPTION
Steps to reproduce the bug:
- Create new UOM categories
- Add a new reference UOM
- Add another line, for example:
    - type: “Smaller than the reference”
    - Ratio: 4
- Click outside the line

Problem:
The type is changed to “Bigger” and the ratio is reset to 0,
because we are trying to change the type and the factor based on the value of the current uom factor,
but as this factor has not yet been calculated in `set_ratio` the changes will be distorted.

This part of the code in the onchange is useful when for example we already have a UOM category saved,
and we change the reference, in this case all the UOM will have to be calculated again

Solution:
Don't change the factor and the type in the onchange if it's a new line

opw-2754303




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
