### PR TITLE
[FIX] hr_holidays: remove unused domain to avoid domain attribute in view override domain attribute in field

### DIFF
--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -52,7 +52,7 @@
                         <group name="allocation_validation" string="Allocation Requests">
                             <field name="allocation_type" widget="radio" force_save="1"/>
                             <field name="allocation_validation_type" string="Approval" widget="radio" attrs="{'invisible': [('allocation_type', '!=', 'fixed_allocation')]}"/>
-                            <field name="responsible_id" domain="[('share', '=', False)]"
+                            <field name="responsible_id"
                                 attrs="{
                                 'invisible': [('leave_validation_type', 'in', ['no_validation', 'manager']), '|', ('allocation_type', '=', 'no'), ('allocation_validation_type', '=', 'manager')],
                                 'required': ['|', ('leave_validation_type', 'in', ['hr', 'both']), '&amp;', ('allocation_type', 'in', ['fixed_allocation', 'fixed']), ('allocation_validation_type', 'in', ['hr', 'both'])]}"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Remove attribute domain [('share', '=', False)] in view because there is attribute domain ('groups_id', 'in', self.env.ref('hr_holidays.group_hr_holidays_user').id) in field

To avoid domain attribute in view override domain attribute in field to only allow time off users to be time off type responsible

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
