### PR TITLE
[FIX] mrp: find child/source MO

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -282,15 +282,17 @@ class MrpProduction(models.Model):
                     product_domain += [('id', 'in', production.bom_id.product_tmpl_id.product_variant_ids.ids)]
             production.allowed_product_ids = self.env['product.product'].search(product_domain)
 
-    @api.depends('procurement_group_id.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids')
+    @api.depends('procurement_group_id.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids',
+                 'procurement_group_id.stock_move_ids.move_orig_ids.created_production_id.procurement_group_id.mrp_production_ids')
     def _compute_mrp_production_child_count(self):
         for production in self:
-            production.mrp_production_child_count = len(production.procurement_group_id.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids - production)
+            production.mrp_production_child_count = len(production._get_children())
 
-    @api.depends('move_dest_ids.group_id.mrp_production_ids')
+    @api.depends('procurement_group_id.mrp_production_ids.move_dest_ids.group_id.mrp_production_ids',
+                 'procurement_group_id.stock_move_ids.move_dest_ids.group_id.mrp_production_ids')
     def _compute_mrp_production_source_count(self):
         for production in self:
-            production.mrp_production_source_count = len(production.procurement_group_id.mrp_production_ids.move_dest_ids.group_id.mrp_production_ids - production)
+            production.mrp_production_source_count = len(production._get_sources())
 
     @api.depends('procurement_group_id.mrp_production_ids')
     def _compute_mrp_production_backorder(self):
@@ -1051,9 +1053,21 @@ class MrpProduction(models.Model):
 
         self.workorder_ids.filtered(lambda w: w.state not in ['done', 'cancel'])._action_confirm()
 
+    def _get_children(self):
+        self.ensure_one()
+        procurement_moves = self.procurement_group_id.stock_move_ids
+        child_moves = procurement_moves.move_orig_ids
+        return (procurement_moves | child_moves).created_production_id.procurement_group_id.mrp_production_ids - self
+
+    def _get_sources(self):
+        self.ensure_one()
+        dest_moves = self.procurement_group_id.mrp_production_ids.move_dest_ids
+        parent_moves = self.procurement_group_id.stock_move_ids.move_dest_ids
+        return (dest_moves | parent_moves).group_id.mrp_production_ids - self
+
     def action_view_mrp_production_childs(self):
         self.ensure_one()
-        mrp_production_ids = self.procurement_group_id.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids.ids
+        mrp_production_ids = self._get_children()
         action = {
             'res_model': 'mrp.production',
             'type': 'ir.actions.act_window',
@@ -1073,7 +1087,7 @@ class MrpProduction(models.Model):
 
     def action_view_mrp_production_sources(self):
         self.ensure_one()
-        mrp_production_ids = self.procurement_group_id.mrp_production_ids.move_dest_ids.group_id.mrp_production_ids.ids
+        mrp_production_ids = self._get_sources()
         action = {
             'res_model': 'mrp.production',
             'type': 'ir.actions.act_window',

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -421,6 +421,16 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         self.assertEqual(len(picking.move_lines), 1)
         picking.product_id = self.complex_product
 
+        # MOs are correctly linked to each other
+        self.assertEqual(production.mrp_production_child_count, 1)
+        self.assertEqual(production.mrp_production_source_count, 0)
+        self.assertEqual(subproduction.mrp_production_child_count, 0)
+        self.assertEqual(subproduction.mrp_production_source_count, 1)
+        child_action = production.action_view_mrp_production_childs()
+        source_action = subproduction.action_view_mrp_production_sources()
+        self.assertEqual(child_action.get('res_id'), subproduction)
+        self.assertEqual(source_action.get('res_id'), production)
+
     def test_3_steps_and_byproduct(self):
         """ Suppose a warehouse with Manufacture option set to '3 setps' and a product P01 with a reordering rule.
         Suppose P01 has a BoM and this BoM mentions that when some P01 are produced, some P02 are produced too.


### PR DESCRIPTION
When a MO is generated in order to supply another one, the smart buttons
"Source MO"/"Child MO" are still invisible.

To reproduce the issue:
1. In Settings, enable "Multi-Step Routes"
2. Enable MTO route
3. Edit the warehouse: 3-steps manufacturing
4. Create 3 stored products Super, Sub and Compo:
    - Sub has two routes: MTO and Manufacture
5. Create two BoMs:
    - For 1 x Super:
        - 1 x Sub
    - For 1 x Sub:
        - 1 x Compo
6. Create and confirm a MO with 1 x Super

Error: On confirmation, a second MO is created to produce one Sub, which
is correct. However, neither the first MO nor the generated one has a
link with the other one (through the smart button "Source MO"/"Child
MO")

When confirming the MO, a SM is created to bring one Sub to the
pre-production location. Thanks to MTO route, this will generate another
SM that brings one Sub from post-production to stock location (this will
lead to the creation of the second MO). However, the other SM (1 x Sub
from Post to Stock) doesn't have the same procurement group. This is the
reason why it is not found by the `_compute` methods.

OPW-2730830