### PR TITLE
[FIX] sale: button are executed with active_test = False

### DIFF
--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -735,7 +735,7 @@
             <field name="arch" type="xml">
                 <search string="Search Sales Order">
                     <field name="name" string="Order" filter_domain="['|', '|', ('name', 'ilike', self), ('client_order_ref', 'ilike', self), ('partner_id', 'child_of', self)]"/>
-                    <field name="partner_id" operator="child_of" context="{'active_test': False}"/>
+                    <field name="partner_id" operator="child_of"/>
                     <field name="user_id"/>
                     <field name="team_id" string="Sales Team"/>
                     <field name="order_line" string="Product" filter_domain="[('order_line.product_id', 'ilike', self)]"/>


### PR DESCRIPTION
Partial Rev of https://github.com/odoo/odoo/pull/83669/commits/75979217d23a47e8484f95e3ee4721e501edfd10

Open a contact
Click on sale
Create an order
Click Confirm

--> Issue : active_test = False is in the context

Note : I think it is an issue of ORM
@odony @nle-odoo @rco-odoo 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
