### PR TITLE
[IMP] mail: update notification_type to match server's default

### DIFF
--- a/addons/mail/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_tests.js
@@ -379,7 +379,7 @@ QUnit.test('sidebar: inbox with counter', async function (assert) {
     assert.expect(2);
 
     // notification expected to be counted at init_messaging
-    this.data['mail.notification'].records.push({ res_partner_id: this.data.currentPartnerId });
+    this.data['mail.notification'].records.push({  notification_type: 'inbox', res_partner_id: this.data.currentPartnerId });
     await this.start();
     assert.strictEqual(
         document.querySelectorAll(`
@@ -529,6 +529,7 @@ QUnit.test('sidebar: channel rendering with needaction counter', async function 
     // expected needaction notification
     this.data['mail.notification'].records.push({
         mail_message_id: 100, // id of related message
+        notification_type: 'inbox',
         res_partner_id: this.data.currentPartnerId, // must be for current partner
     });
     await this.start();
@@ -2346,11 +2347,13 @@ QUnit.test('inbox: mark all messages as read', async function (assert) {
         // notification to have first message in inbox
         {
             mail_message_id: 100, // id of related message
+            notification_type: 'inbox',
             res_partner_id: this.data.currentPartnerId, // must be for current partner
         },
         // notification to have second message in inbox
         {
             mail_message_id: 101, // id of related message
+            notification_type: 'inbox',
             res_partner_id: this.data.currentPartnerId, // must be for current partner
         }
     );
@@ -3209,6 +3212,7 @@ QUnit.test('reply to message from inbox (message linked to document)', async fun
     // notification to have message in Inbox
     this.data['mail.notification'].records.push({
         mail_message_id: 100, // id of related message
+        notification_type: 'inbox',
         res_partner_id: this.data.currentPartnerId, // must be for current partner
     });
     await this.start({
@@ -3347,11 +3351,13 @@ QUnit.test('messages marked as read move to "History" mailbox', async function (
         // notification to have first message in inbox
         {
             mail_message_id: 100, // id of related message
+            notification_type: 'inbox',
             res_partner_id: this.data.currentPartnerId, // must be for current partner
         },
         // notification to have second message in inbox
         {
             mail_message_id: 101, // id of related message
+            notification_type: 'inbox',
             res_partner_id: this.data.currentPartnerId, // must be for current partner
         }
     );
@@ -3466,10 +3472,12 @@ QUnit.test('mark a single message as read should only move this message to "Hist
     this.data['mail.notification'].records.push(
         {
             mail_message_id: 1,
+            notification_type: 'inbox',
             res_partner_id: this.data.currentPartnerId,
         },
         {
             mail_message_id: 2,
+            notification_type: 'inbox',
             res_partner_id: this.data.currentPartnerId,
         }
     );
@@ -3589,6 +3597,7 @@ QUnit.test('all messages in "Inbox" in "History" after marked all as read', asyn
         // notification to have message in Inbox
         this.data['mail.notification'].records.push({
             mail_message_id: id, // id of related message
+            notification_type: 'inbox',
             res_partner_id: this.data.currentPartnerId, // must be for current partner
         });
 

--- a/addons/mail/static/src/components/discuss_sidebar_category/tests/discuss_sidebar_category_tests.js
+++ b/addons/mail/static/src/components/discuss_sidebar_category/tests/discuss_sidebar_category_tests.js
@@ -62,9 +62,11 @@ QUnit.test('channel - counter: should not have a counter if the category is unfo
     });
     this.data['mail.notification'].records.push({
         mail_message_id: 100,
+        notification_type: 'inbox',
         res_partner_id: this.data.currentPartnerId,
     }, {
         mail_message_id: 200,
+        notification_type: 'inbox',
         res_partner_id: this.data.currentPartnerId,
     });
     await this.start();
@@ -113,9 +115,11 @@ QUnit.test('channel - counter: should have correct value of needaction threads i
     });
     this.data['mail.notification'].records.push({
         mail_message_id: 100,
+        notification_type: 'inbox',
         res_partner_id: this.data.currentPartnerId,
     }, {
         mail_message_id: 200,
+        notification_type: 'inbox',
         res_partner_id: this.data.currentPartnerId,
     });
     this.data['res.users.settings'].records.push({

--- a/addons/mail/static/src/components/messaging_menu/tests/messaging_menu_tests.js
+++ b/addons/mail/static/src/components/messaging_menu/tests/messaging_menu_tests.js
@@ -266,6 +266,7 @@ QUnit.test('counter is taking into account failure notification', async function
     this.data['mail.notification'].records.push({
         mail_message_id: 11, // id of the related message
         notification_status: 'exception', // necessary value to have a failure
+        notification_type: 'email',
     });
     const { createMessagingMenuComponent } = await this.start();
     await createMessagingMenuComponent();

--- a/addons/mail/static/tests/helpers/mock_models.js
+++ b/addons/mail/static/tests/helpers/mock_models.js
@@ -171,7 +171,7 @@ export class MockModels {
                     is_read: { string: "Is Read", type: 'boolean', default: false },
                     mail_message_id: { string: "Message", type: 'many2one', relation: 'mail.message' },
                     notification_status: { string: "Notification Status", type: 'selection', selection: [['ready', 'Ready to Send'], ['sent', 'Sent'], ['bounce', 'Bounced'], ['exception', 'Exception'], ['canceled', 'Canceled']], default: 'ready' },
-                    notification_type: { string: "Notification Type", type: 'selection', selection: [['email', 'Handle by Emails'], ['inbox', 'Handle in Odoo']], default: 'email' },
+                    notification_type: { string: "Notification Type", type: 'selection', selection: [['email', 'Handle by Emails'], ['inbox', 'Handle in Odoo']], default: 'inbox' },
                     res_partner_id: { string: "Needaction Recipient", type: 'many2one', relation: 'res.partner' },
                 },
                 records: [],


### PR DESCRIPTION
This PR prepares the ground for the main PR introducing the use of the server side model definitions during tests. The `notification_type` field had a different default value than the one use on the server.The tests adaptation was an useless diff in the main PR thus the removal in an other one.

task-2767820