### PR TITLE
[FIX] web_editor: fix cover when there is modal inside a snippet

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -222,7 +222,7 @@ var SnippetEditor = Widget.extend({
             return;
         }
 
-        const $modal = this.$target.find('.modal');
+        const $modal = this.$target.find('.modal:visible');
         const $target = $modal.length ? $modal : this.$target;
         const targetEl = $target[0];
 


### PR DESCRIPTION
[FIX] web_editor: fix cover when there is modal inside a snippet
Since this commit [1], we considered that if a snippet contained a
modal, it is that the overlay had to cover the modal itself.

But that is not correct, because in some cases a snippet can contain
closed modals (e.g. the course page in the website slides module
contains modals).

After this commit, we avoid applying an overlay on a modal that is not
open.

[1]: https://github.com/odoo/odoo/commit/bc055e7822b9b2e7f8f9608e335456a71d7896a1

task-2710582

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
