### PR TITLE
[FIX] project: fix various bugs in project app

### DIFF
--- a/addons/project/static/src/js/widgets/project_name_with_subtask_count_widget.js
+++ b/addons/project/static/src/js/widgets/project_name_with_subtask_count_widget.js
@@ -18,7 +18,7 @@ export const FieldNameWithSubTaskCount = FieldChar.extend({
 
     _render: function () {
         let result = this._super.apply(this, arguments);
-        if (this.recordData.child_text) {
+        if (this.recordData.allow_subtasks && this.recordData.child_text) {
             this.$el.append($('<span>')
                     .addClass("text-muted ml-2")
                     .text(this.recordData.child_text)

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -371,17 +371,14 @@
                                     <field name="privacy_visibility" widget="radio"/>
                                 </group>
                                 <group>
-                                    <div name="alias_def" colspan="2" attrs="{'invisible': [('alias_domain', '=', False)]}">
+                                    <div name="alias_def" colspan="2" class="pb-2" attrs="{'invisible': [('alias_domain', '=', False)]}">
                                         <!-- Always display the whole alias in edit mode. It depends in read only -->
                                         <field name="alias_enabled" invisible="1"/>
-                                        <span class="oe_read_only" attrs="{'invisible': [('alias_name', '!=', False)]}">Create tasks by sending an email to </span>
-                                        <span class="font-weight-bold oe_read_only" attrs="{'invisible': [('alias_name', '=', False)]}">Create tasks by sending an email to </span>
-                                        <span class="font-weight-bold oe_edit_only">Create tasks by sending an email to </span>
-                                            <field name="alias_value" class="oe_read_only d-inline" readonly="1" widget="email" attrs="{'invisible':  [('alias_name', '=', False)]}" />
-                                            <span class="oe_edit_only">
-                                                <field name="alias_name" class="oe_inline"/>@
-                                                <field name="alias_domain" class="oe_inline" readonly="1"/>
-                                            </span>
+                                        <label for="alias_name" class="font-weight-bold o_form_label" string="Create tasks by sending an email to"/>
+                                        <field name="alias_value" class="oe_read_only d-inline" readonly="1" widget="email" attrs="{'invisible':  [('alias_name', '=', False)]}" />
+                                        <span class="oe_edit_only">
+                                            <field name="alias_name" class="oe_inline"/>@<field name="alias_domain" class="oe_inline" readonly="1"/>
+                                        </span>
                                     </div>
                                     <!-- the alias contact must appear when the user start typing and it must disappear
                                         when the string is deleted. -->

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -18,7 +18,7 @@
                <search string="Tasks">
                     <field name="name" string="Task"/>
                     <field name="tag_ids"/>
-                    <field name="user_ids" context="{'active_test': False}"/>
+                    <field name="user_ids" filter_domain="[('user_ids', 'ilike', self), ('user_ids.active', 'in', [True, False])]"/>
                     <field string="Project" name="display_project_id"/>
                     <field name="stage_id"/>
                     <field name="partner_id" operator="child_of"/>


### PR DESCRIPTION
Before this PR,
1) in kanban view of task sub-task count of task is visible when the sub-task
feature is disabled from the setting.
2) in project form view alias_name field label color and padding are different
then other fields.
3) in task search view quick search on user_ids returns active and non-active
tasks of the user.

After this PR,
1) sub-task count of the task will not be visible in the kanban view of the task
when the sub-task feature is disabled from the setting.
2) alias_name field label color and padding will be the same as other fields'
label color and padding.
3) remove active_test false from the context of user_ids' quick search so it
should only return active tasks of the user.

task-2758779

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
