### PR TITLE
[IMP] mail: show rtc candidate types

### DIFF
--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.js
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.js
@@ -39,10 +39,10 @@ export class RtcCallParticipantCard extends Component {
      * @param {Event} ev
      */
     async _onContextMenu(ev) {
+        ev.preventDefault();
         if (!this._volumeMenuAnchorRef || !this._volumeMenuAnchorRef.el) {
             return;
         }
-        ev.preventDefault();
         this._volumeMenuAnchorRef.el.click();
     }
 }

--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.scss
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.scss
@@ -163,3 +163,7 @@
     border-radius: 50%;
     background-color: gray('900');
 }
+
+.o_RtcCallParticipantCard_volumeMenuAnchor_separator {
+    background-color: $border-color;
+}

--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
@@ -81,7 +81,14 @@
                             <Popover>
                                 <i class="o_RtcCallParticipantCard_volumeMenuAnchor" t-on-click="callParticipantCard.onClickVolumeAnchor" t-ref="volumeMenuAnchor"/>
                                 <t t-set-slot="opened">
-                                    <input type="range" min="0.0" max="1" step="0.01" t-att-value="callParticipantCard.rtcSession.volume" t-on-change="callParticipantCard.onChangeVolume"/>
+                                    <div class="d-flex flex-column">
+                                        <input type="range" min="0.0" max="1" step="0.01" t-att-value="callParticipantCard.rtcSession.volume" t-on-change="callParticipantCard.onChangeVolume"/>
+                                        <t t-if="callParticipantCard.hasConnectionInfo">
+                                            <hr class="o_RtcCallParticipantCard_volumeMenuAnchor_separator w-100"/>
+                                            <div t-esc="callParticipantCard.inboundConnectionTypeText"/>
+                                            <div t-esc="callParticipantCard.outboundConnectionTypeText"/>
+                                        </t>
+                                    </div>
                                 </t>
                             </Popover>
                         </t>

--- a/addons/mail/static/src/models/rtc.js
+++ b/addons/mail/static/src/models/rtc.js
@@ -1114,6 +1114,9 @@ registerModel({
                 connectionState,
             });
             switch (connectionState) {
+                case "connected":
+                    rtcSession.updateConnectionTypes();
+                    break;
                 case "closed":
                     this._removePeer(rtcSession.id);
                     break;
@@ -1292,6 +1295,19 @@ registerModel({
          */
         pingInterval: attr({
             compute: '_computePingInterval',
+        }),
+        /**
+         * The protocols for each RTC ICE candidate types.
+         */
+        protocolsByCandidateTypes: attr({
+            default: {
+                'host': "HOST",
+                'srflx': "STUN",
+                'prflx': "STUN",
+                'relay': "TURN",
+            },
+            readonly: true,
+            required: true,
         }),
         /**
          *  timeoutId for the push to talk release delay.

--- a/addons/mail/static/src/models/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session.js
@@ -26,6 +26,8 @@ registerModel({
                 broadcastTimeout: clear(),
                 connectionRecoveryTimeout: clear(),
                 isTalking: clear(),
+                localCandidateType: clear(),
+                remoteCandidateType: clear(),
             });
         },
         /**
@@ -148,6 +150,33 @@ registerModel({
             this.messaging.browser.clearTimeout(this.broadcastTimeout);
             this.update({
                 broadcastTimeout: this.messaging.browser.setTimeout(this._onBroadcastTimeout, 3000),
+            });
+        },
+        /**
+         * Updates the rtcSession with information on the type of candidate used
+         * to establish the connections.
+         *
+         * @private
+         */
+        async updateConnectionTypes() {
+            if (!this.rtcPeerConnection) {
+                return;
+            }
+            const stats = await this.rtcPeerConnection.peerConnection.getStats();
+            for (const { localCandidateId, remoteCandidateId, state, type } of stats.values()) {
+                if (type === 'candidate-pair' && state === 'succeeded' && localCandidateId) {
+                    const localCandidate = stats.get(localCandidateId);
+                    const remoteCandidate = stats.get(remoteCandidateId);
+                    this.update({
+                        localCandidateType: localCandidate ? localCandidate.candidateType : clear(),
+                        remoteCandidateType: remoteCandidate ? remoteCandidate.candidateType : clear(),
+                    });
+                    return;
+                }
+            }
+            this.update({
+                localCandidateType: clear(),
+                remoteCandidateType: clear(),
             });
         },
         /**
@@ -394,6 +423,10 @@ registerModel({
             default: false,
         }),
         /**
+         * RTCIceCandidate.type String
+         */
+        localCandidateType: attr(),
+        /**
          * Name of the session, based on the partner name if set.
          */
         name: attr({
@@ -415,6 +448,10 @@ registerModel({
         peerToken: attr({
             compute: '_computePeerToken',
         }),
+        /**
+         * RTCIceCandidate.type String
+         */
+        remoteCandidateType: attr(),
         /**
          * If set, this session is the session of the current user and is in the active RTC call.
          * This information is distinct from this.isOwnSession as there can be other


### PR DESCRIPTION
This commit adds a way to see the candidateType of the inbound and
outbound peer connections. This information allows for example to
determine whether the peer connection is being relayed (using a TURN).

task-2766401