### PR TITLE
[FIX] mail: prevent empty popover in the rtc call participant card

### DIFF
--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
@@ -80,7 +80,7 @@
                         <t t-if="!callParticipantCard.rtcSession.isOwnSession">
                             <Popover>
                                 <i class="o_RtcCallParticipantCard_volumeMenuAnchor" t-on-click="callParticipantCard.onClickVolumeAnchor" t-ref="volumeMenuAnchor"/>
-                                <t t-set="opened">
+                                <t t-set-slot="opened">
                                     <input type="range" min="0.0" max="1" step="0.01" t-att-value="callParticipantCard.rtcSession.volume" t-on-change="callParticipantCard.onChangeVolume"/>
                                 </t>
                             </Popover>


### PR DESCRIPTION
Before this commit, the popover containing the volume bar of the rtc
call participant card was rendered empty. This was because the `t-set`
was used instead of `t-set-slot`. This commit fixes this issue.

related to: https://github.com/odoo/odoo/commit/edd79ff560cf321ebd0488e4917abb7424fea1bb

