### PR TITLE
[FIX] {mrp_,}account,sale_{stock,mrp}: display lots in invoice

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3134,6 +3134,16 @@ class AccountMoveLine(models.Model):
             vals = {'price_unit': 0.0}
         return vals
 
+    def _get_invoiced_qty_per_product(self):
+        qties = defaultdict(float)
+        for aml in self:
+            qty = aml.product_uom_id._compute_quantity(aml.quantity, aml.product_id.uom_id)
+            if aml.move_id.type == 'out_invoice':
+                qties[aml.product_id] += qty
+            elif aml.move_id.type == 'out_refund':
+                qties[aml.product_id] -= qty
+        return qties
+
     # -------------------------------------------------------------------------
     # ONCHANGE METHODS
     # -------------------------------------------------------------------------

--- a/addons/mrp_account/models/__init__.py
+++ b/addons/mrp_account/models/__init__.py
@@ -3,3 +3,4 @@
 from . import mrp_workcenter
 from . import mrp_production
 from . import product
+from . import account_move

--- a/addons/mrp_account/models/account_move.py
+++ b/addons/mrp_account/models/account_move.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+from collections import defaultdict
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def _get_invoiced_qty_per_product(self):
+        # Replace the kit-type products with their components
+        qties = defaultdict(float)
+        res = super()._get_invoiced_qty_per_product()
+        for product, qty in res.items():
+            bom_kit = self.env['mrp.bom']._bom_find(product=product, company_id=self.company_id[:1].id, bom_type='phantom')
+            if bom_kit:
+                invoiced_qty = product.uom_id._compute_quantity(qty, bom_kit.product_uom_id, round=False)
+                factor = invoiced_qty / bom_kit.product_qty
+                dummy, bom_sub_lines = bom_kit.explode(product, factor)
+                for bom_line, bom_line_data in bom_sub_lines:
+                    qties[bom_line.product_id] += bom_line.product_uom_id._compute_quantity(bom_line_data['qty'], bom_line.product_id.uom_id)
+            else:
+                qties[product] += qty
+        return qties

--- a/addons/sale_mrp/tests/__init__.py
+++ b/addons/sale_mrp/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_sale_mrp_kit_bom
 from . import test_sale_mrp_lead_time
 from . import test_sale_mrp_procurement
 from . import test_multistep_manufacturing
+from . import test_sale_mrp_report

--- a/addons/sale_mrp/tests/test_sale_mrp_report.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_report.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import common
+
+from odoo.tools import html2plaintext
+
+@common.tagged('post_install', '-at_install')
+class TestSaleMrpInvoices(common.SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product_by_lot = cls.env['product.product'].create({
+            'name': 'Product By Lot',
+            'type': 'product',
+            'tracking': 'lot',
+        })
+        cls.warehouse = cls.env['stock.warehouse'].search([('company_id', '=', cls.env.company.id)], limit=1)
+        cls.stock_location = cls.warehouse.lot_stock_id
+        cls.lot = cls.env['stock.production.lot'].create({
+            'name': 'LOT0001',
+            'product_id': cls.product_by_lot.id,
+            'company_id': cls.env.company.id,
+        })
+        cls.env['stock.quant']._update_available_quantity(cls.product_by_lot, cls.stock_location, 10, lot_id=cls.lot)
+
+        cls.tracked_kit = cls.env['product.product'].create({
+            'name': 'Simple Kit',
+            'type': 'consu',
+        })
+        cls.env['mrp.bom'].create({
+            'product_tmpl_id': cls.tracked_kit.product_tmpl_id.id,
+            'type': 'phantom',
+            'bom_line_ids': [(0, 0, {
+                'product_id': cls.product_by_lot.id,
+                'product_qty': 1,
+            })]
+        })
+        cls.partner = cls.env.ref('base.res_partner_1')
+
+    def test_deliver_and_invoice_tracked_components(self):
+        """
+        Suppose the lots are printed on the invoices.
+        The user sells a kit that has one tracked component.
+        The lot of the delivered component should be on the invoice.
+        """
+        display_lots = self.env.ref('sale_stock.group_lot_on_invoice')
+        display_uom = self.env.ref('uom.group_uom')
+        self.env.user.write({'groups_id': [(4, display_lots.id), (4, display_uom.id)]})
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [
+                (0, 0, {'name': self.tracked_kit.name, 'product_id': self.tracked_kit.id, 'product_uom_qty': 1}),
+            ],
+        })
+        so.action_confirm()
+
+        action = so.picking_ids.button_validate()
+        wizard = self.env[action['res_model']].browse(action['res_id'])
+        wizard.process()
+
+        invoice = so._create_invoices()
+        invoice.action_post()
+
+        report = self.env['ir.actions.report']._get_report_from_name('account.report_invoice_with_payments')
+        html = report.render_qweb_html(invoice.ids)[0]
+        text = html2plaintext(html)
+        self.assertRegex(text, r'Product By Lot\n1.000\nUnits\nLOT0001', "There should be a line that specifies 1 x LOT0001")

--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -4,7 +4,8 @@
 from collections import defaultdict
 
 from odoo import fields, models
-from odoo.tools import float_is_zero
+from odoo.tools import float_is_zero, float_compare
+from odoo.tools.misc import formatLang
 
 
 class AccountMove(models.Model):
@@ -25,86 +26,62 @@ class AccountMove(models.Model):
     def _get_invoiced_lot_values(self):
         """ Get and prepare data to show a table of invoiced lot on the invoice's report. """
         self.ensure_one()
-
-        if self.state == 'draft':
+        if self.state == 'draft' or not self.invoice_date or self.type not in ('out_invoice', 'out_refund'):
             return []
 
-        sale_lines = self.invoice_line_ids.sale_line_ids
-        sale_orders = sale_lines.order_id
-        stock_move_lines = sale_lines.move_ids.filtered(lambda r: r.state == 'done').move_line_ids
+        current_invoice_amls = self.invoice_line_ids.filtered(lambda aml: not aml.display_type and aml.product_id and aml.quantity)
+        all_invoices_amls = current_invoice_amls.sale_line_ids.invoice_lines.filtered(lambda aml: aml.move_id.state == 'posted').sorted(lambda aml: (aml.date, aml.move_name, aml.id))
+        index = all_invoices_amls.ids.index(current_invoice_amls[:1].id) if current_invoice_amls[:1] in all_invoices_amls else 0
+        previous_amls = all_invoices_amls[:index]
 
-        # Get the other customer invoices and refunds.
-        ordered_invoice_ids = sale_orders.mapped('invoice_ids')\
-            .filtered(lambda i: i.state not in ['draft', 'cancel'])\
-            .sorted(lambda i: (i.invoice_date, i.id))
+        previous_qties_invoiced = previous_amls._get_invoiced_qty_per_product()
+        invoiced_qties = current_invoice_amls._get_invoiced_qty_per_product()
+        invoiced_products = invoiced_qties.keys()
 
-        # Get the position of self in other customer invoices and refunds.
-        self_index = None
-        i = 0
-        for invoice in ordered_invoice_ids:
-            if invoice.id == self.id:
-                self_index = i
-                break
-            i += 1
-
-        # Get the previous invoices if any.
-        previous_invoices = ordered_invoice_ids[:self_index]
-
-        # Get the incoming and outgoing sml between self.invoice_date and the previous invoice (if any) of the related product.
-        write_dates = [wd for wd in self.invoice_line_ids.mapped('write_date') if wd]
-        self_datetime = max(write_dates) if write_dates else None
-        last_invoice_datetime = dict()
-        for product in self.invoice_line_ids.product_id:
-            last_invoice = previous_invoices.filtered(lambda inv: product in inv.invoice_line_ids.product_id)
-            last_invoice = last_invoice[-1] if len(last_invoice) else None
-            last_write_dates = last_invoice and [wd for wd in last_invoice.invoice_line_ids.mapped('write_date') if wd]
-            last_invoice_datetime[product] = max(last_write_dates) if last_write_dates else None
-
-        def _filter_incoming_sml(ml):
-            if ml.state == 'done' and ml.location_id.usage == 'customer' and ml.lot_id:
-                last_date = last_invoice_datetime.get(ml.product_id)
-                if last_date:
-                    return last_date <= ml.date <= self_datetime
-                else:
-                    return ml.date <= self_datetime
-            return False
-
-        def _filter_outgoing_sml(ml):
-            if ml.state == 'done' and ml.location_dest_id.usage == 'customer' and ml.lot_id:
-                last_date = last_invoice_datetime.get(ml.product_id)
-                if last_date:
-                    return last_date <= ml.date <= self_datetime
-                else:
-                    return ml.date <= self_datetime
-            return False
-
-        incoming_sml = stock_move_lines.filtered(_filter_incoming_sml)
-        outgoing_sml = stock_move_lines.filtered(_filter_outgoing_sml)
-
-        # Prepare and return lot_values
-        qties_per_lot = defaultdict(lambda: 0)
-        if self.type == 'out_refund':
-            for ml in outgoing_sml:
-                qties_per_lot[ml.lot_id] -= ml.product_uom_id._compute_quantity(ml.qty_done, ml.product_id.uom_id)
-            for ml in incoming_sml:
-                qties_per_lot[ml.lot_id] += ml.product_uom_id._compute_quantity(ml.qty_done, ml.product_id.uom_id)
-        else:
-            for ml in outgoing_sml:
-                qties_per_lot[ml.lot_id] += ml.product_uom_id._compute_quantity(ml.qty_done, ml.product_id.uom_id)
-            for ml in incoming_sml:
-                qties_per_lot[ml.lot_id] -= ml.product_uom_id._compute_quantity(ml.qty_done, ml.product_id.uom_id)
-        lot_values = []
-        for lot_id, qty in qties_per_lot.items():
-            if float_is_zero(qty, precision_rounding=lot_id.product_id.uom_id.rounding):
+        qties_per_lot = defaultdict(float)
+        previous_qties_delivered = defaultdict(float)
+        stock_move_lines = current_invoice_amls.sale_line_ids.move_ids.move_line_ids.filtered(lambda sml: sml.state == 'done' and sml.lot_id).sorted(lambda sml: (sml.date, sml.id))
+        for sml in stock_move_lines:
+            if sml.product_id not in invoiced_products:
                 continue
+            product = sml.product_id
+            product_uom = product.uom_id
+            qty_done = sml.product_uom_id._compute_quantity(sml.qty_done, product_uom)
+
+            if sml.location_id.usage == 'customer':
+                returned_qty = min(qties_per_lot[sml.lot_id], qty_done)
+                qties_per_lot[sml.lot_id] -= returned_qty
+                qty_done = returned_qty - qty_done
+
+            previous_qty_invoiced = previous_qties_invoiced[product]
+            previous_qty_delivered = previous_qties_delivered[product]
+            # If we return more than currently delivered (i.e., qty_done < 0), we remove the surplus
+            # from the previously delivered (and qty_done becomes zero). If it's a delivery, we first
+            # try to reach the previous_qty_invoiced
+            if float_compare(qty_done, 0, precision_rounding=product_uom.rounding) < 0 or \
+                    float_compare(previous_qty_delivered, previous_qty_invoiced, precision_rounding=product_uom.rounding) < 0:
+                previously_done = qty_done if sml.location_id.usage == 'customer' else min(previous_qty_invoiced - previous_qty_delivered, qty_done)
+                previous_qties_delivered[product] += previously_done
+                qty_done -= previously_done
+
+            qties_per_lot[sml.lot_id] += qty_done
+
+        lot_values = []
+        for lot, qty in qties_per_lot.items():
+            if float_is_zero(invoiced_qties[lot.product_id], precision_rounding=lot.product_uom_id.rounding) \
+                    or float_compare(qty, 0, precision_rounding=lot.product_uom_id.rounding) <= 0:
+                continue
+            invoiced_lot_qty = min(qty, invoiced_qties[lot.product_id])
+            invoiced_qties[lot.product_id] -= invoiced_lot_qty
             lot_values.append({
-                'product_name': lot_id.product_id.display_name,
-                'quantity': qty,
-                'uom_name': lot_id.product_uom_id.name,
-                'lot_name': lot_id.name,
+                'product_name': lot.product_id.display_name,
+                'quantity': formatLang(self.env, invoiced_lot_qty, dp='Product Unit of Measure'),
+                'uom_name': lot.product_uom_id.name,
+                'lot_name': lot.name,
                 # The lot id is needed by localizations to inherit the method and add custom fields on the invoice's report.
-                'lot_id': lot_id.id
+                'lot_id': lot.id,
             })
+
         return lot_values
 
 

--- a/addons/sale_stock/tests/__init__.py
+++ b/addons/sale_stock/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_anglosaxon_account
 from . import test_sale_stock
 from . import test_sale_stock_lead_time
 from . import test_sale_order_dates
+from . import test_report

--- a/addons/sale_stock/tests/test_report.py
+++ b/addons/sale_stock/tests/test_report.py
@@ -1,0 +1,283 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged, Form
+from odoo.addons.sale.tests.test_sale_common import TestSale
+
+from odoo.tools import html2plaintext
+
+
+@tagged('post_install', '-at_install')
+class TestSaleStockInvoices(TestSale):
+
+    def setUp(self):
+        super(TestSaleStockInvoices, self).setUp()
+
+        self.product_by_lot = self.env['product.product'].create({
+            'name': 'Product By Lot',
+            'type': 'product',
+            'tracking': 'lot',
+        })
+        self.product_by_usn = self.env['product.product'].create({
+            'name': 'Product By USN',
+            'type': 'product',
+            'tracking': 'serial',
+        })
+        self.warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        self.stock_location = self.warehouse.lot_stock_id
+        lot = self.env['stock.production.lot'].create({
+            'name': 'LOT0001',
+            'product_id': self.product_by_lot.id,
+            'company_id': self.env.company.id,
+        })
+        usn01 = self.env['stock.production.lot'].create({
+            'name': 'USN0001',
+            'product_id': self.product_by_usn.id,
+            'company_id': self.env.company.id,
+        })
+        usn02 = self.env['stock.production.lot'].create({
+            'name': 'USN0002',
+            'product_id': self.product_by_usn.id,
+            'company_id': self.env.company.id,
+        })
+        self.env['stock.quant']._update_available_quantity(self.product_by_lot, self.stock_location, 10, lot_id=lot)
+        self.env['stock.quant']._update_available_quantity(self.product_by_usn, self.stock_location, 1, lot_id=usn01)
+        self.env['stock.quant']._update_available_quantity(self.product_by_usn, self.stock_location, 1, lot_id=usn02)
+
+    def test_invoice_less_than_delivered(self):
+        """
+        Suppose the lots are printed on the invoices.
+        A user invoice a tracked product with a smaller quantity than delivered.
+        On the invoice, the quantity of the used lot should be the invoiced one.
+        """
+        display_lots = self.env.ref('sale_stock.group_lot_on_invoice')
+        display_uom = self.env.ref('uom.group_uom')
+        self.env.user.write({'groups_id': [(4, display_lots.id), (4, display_uom.id)]})
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [
+                (0, 0, {'name': self.product_by_lot.name, 'product_id': self.product_by_lot.id, 'product_uom_qty': 5}),
+            ],
+        })
+        so.action_confirm()
+
+        picking = so.picking_ids
+        picking.move_lines.quantity_done = 5
+        picking.button_validate()
+
+        invoice = so._create_invoices()
+        with Form(invoice) as form:
+            with form.invoice_line_ids.edit(0) as line:
+                line.quantity = 2
+        invoice.action_post()
+
+        report = self.env['ir.actions.report']._get_report_from_name('account.report_invoice_with_payments')
+        html = report.render_qweb_html(invoice.ids)[0]
+        text = html2plaintext(html)
+        self.assertRegex(text, r'Product By Lot\n2.000\nUnits\nLOT0001', "There should be a line that specifies 2 x LOT0001")
+
+    def test_invoice_before_delivery(self):
+        """
+        Suppose the lots are printed on the invoices.
+        The user sells a tracked product, its invoicing policy is "Ordered quantities"
+        A user invoice a tracked product with a smaller quantity than delivered.
+        On the invoice, the quantity of the used lot should be the invoiced one.
+        """
+        display_lots = self.env.ref('sale_stock.group_lot_on_invoice')
+        display_uom = self.env.ref('uom.group_uom')
+        self.env.user.write({'groups_id': [(4, display_lots.id), (4, display_uom.id)]})
+
+        self.product_by_lot.invoice_policy = "order"
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [
+                (0, 0, {'name': self.product_by_lot.name, 'product_id': self.product_by_lot.id, 'product_uom_qty': 4}),
+            ],
+        })
+        so.action_confirm()
+
+        invoice = so._create_invoices()
+        invoice.action_post()
+
+        picking = so.picking_ids
+        picking.move_lines.quantity_done = 4
+        picking.button_validate()
+
+        report = self.env['ir.actions.report']._get_report_from_name('account.report_invoice_with_payments')
+        html = report.render_qweb_html(invoice.ids)[0]
+        text = html2plaintext(html)
+        self.assertRegex(text, r'Product By Lot\n4.000\nUnits\nLOT0001', "There should be a line that specifies 4 x LOT0001")
+
+    def test_backorder_and_several_invoices(self):
+        """
+        Suppose the lots are printed on the invoices.
+        The user sells 2 tracked-by-usn products, he delivers 1 product and invoices it
+        Then, he delivers the other one and invoices it too. Each invoice should have the
+        correct USN
+        """
+        report = self.env['ir.actions.report']._get_report_from_name('account.report_invoice_with_payments')
+        display_lots = self.env.ref('sale_stock.group_lot_on_invoice')
+        display_uom = self.env.ref('uom.group_uom')
+        self.env.user.write({'groups_id': [(4, display_lots.id), (4, display_uom.id)]})
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [
+                (0, 0, {'name': self.product_by_usn.name, 'product_id': self.product_by_usn.id, 'product_uom_qty': 2}),
+            ],
+        })
+        so.action_confirm()
+
+        picking = so.picking_ids
+        picking.move_lines.move_line_ids[0].qty_done = 1
+        picking.button_validate()
+        action = picking.button_validate()
+        wizard = self.env[action['res_model']].browse(action['res_id'])
+        wizard.process()
+
+        invoice01 = so._create_invoices()
+        with Form(invoice01) as form:
+            with form.invoice_line_ids.edit(0) as line:
+                line.quantity = 1
+        invoice01.action_post()
+
+        backorder = picking.backorder_ids
+        backorder.move_lines.move_line_ids.qty_done = 1
+        backorder.button_validate()
+
+        html = report.render_qweb_html(invoice01.ids)[0]
+        text = html2plaintext(html)
+        self.assertRegex(text, r'Product By USN\n1.000\nUnits\nUSN0001', "There should be a line that specifies 1 x USN0001")
+        self.assertNotIn('USN0002', text)
+
+        invoice02 = so._create_invoices()
+        invoice02.post()
+        html = report.render_qweb_html(invoice02.ids)[0]
+        text = html2plaintext(html)
+        self.assertRegex(text, r'Product By USN\n1.000\nUnits\nUSN0002', "There should be a line that specifies 1 x USN0002")
+        self.assertNotIn('USN0001', text)
+
+        # Posting the second invoice shouldn't change the result of the first one
+        html = report.render_qweb_html(invoice01.ids)[0]
+        text = html2plaintext(html)
+        self.assertRegex(text, r'Product By USN\n1.000\nUnits\nUSN0001', "There should still be a line that specifies 1 x USN0001")
+        self.assertNotIn('USN0002', text)
+
+        # Resetting and posting again the first invoice shouldn't change the results
+        invoice01.button_draft()
+        invoice01.post()
+        html = report.render_qweb_html(invoice01.ids)[0]
+        text = html2plaintext(html)
+        self.assertRegex(text, r'Product By USN\n1.000\nUnits\nUSN0001', "There should still be a line that specifies 1 x USN0001")
+        self.assertNotIn('USN0002', text)
+        html = report.render_qweb_html(invoice02.ids)[0]
+        text = html2plaintext(html)
+        self.assertRegex(text, r'Product By USN\n1.000\nUnits\nUSN0002', "There should be a line that specifies 1 x USN0002")
+        self.assertNotIn('USN0001', text)
+
+    def test_invoice_with_several_returns(self):
+        """
+        Mix of returns and partial invoice
+        - Product P tracked by lot
+        - SO with 10 x P
+        - Deliver 10 x Lot01
+        - Return 10 x Lot01
+        - Deliver 03 x Lot02
+        - Invoice 02 x P
+        - Deliver 05 x Lot02 + 02 x Lot03
+        - Invoice 08 x P
+        """
+        report = self.env['ir.actions.report']._get_report_from_name('account.report_invoice_with_payments')
+        display_lots = self.env.ref('sale_stock.group_lot_on_invoice')
+        display_uom = self.env.ref('uom.group_uom')
+        self.env.user.write({'groups_id': [(4, display_lots.id), (4, display_uom.id)]})
+
+        lot01 = self.env['stock.production.lot'].search([('name', '=', 'LOT0001')])
+        lot02, lot03 = self.env['stock.production.lot'].create([{
+            'name': name,
+            'product_id': self.product_by_lot.id,
+            'company_id': self.env.company.id,
+        } for name in ['LOT0002', 'LOT0003']])
+        self.env['stock.quant']._update_available_quantity(self.product_by_lot, self.stock_location, 8, lot_id=lot02)
+        self.env['stock.quant']._update_available_quantity(self.product_by_lot, self.stock_location, 2, lot_id=lot03)
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [
+                (0, 0, {'name': self.product_by_lot.name, 'product_id': self.product_by_lot.id, 'product_uom_qty': 10}),
+            ],
+        })
+        so.action_confirm()
+
+        # Deliver 10 x LOT0001
+        delivery01 = so.picking_ids
+        delivery01.move_lines.quantity_done = 10
+        delivery01.button_validate()
+        self.assertEqual(delivery01.move_line_ids.lot_id.name, 'LOT0001')
+
+        # Return delivery01 (-> 10 x LOT0001)
+        return_form = Form(self.env['stock.return.picking'].with_context(active_ids=[delivery01.id], active_id=delivery01.id, active_model='stock.picking'))
+        return_wizard = return_form.save()
+        action = return_wizard.create_returns()
+        pick_return = self.env['stock.picking'].browse(action['res_id'])
+
+        move_form = Form(pick_return.move_lines, view='stock.view_stock_move_nosuggest_operations')
+        with move_form.move_line_nosuggest_ids.new() as line:
+            line.lot_id = lot01
+            line.qty_done = 10
+        move_form.save()
+        pick_return.button_validate()
+
+        # Return pick_return
+        return_form = Form(self.env['stock.return.picking'].with_context(active_ids=[pick_return.id], active_id=pick_return.id, active_model='stock.picking'))
+        return_wizard = return_form.save()
+        action = return_wizard.create_returns()
+        delivery02 = self.env['stock.picking'].browse(action['res_id'])
+
+        # Deliver 3 x LOT0002
+        delivery02.do_unreserve()
+        move_form = Form(delivery02.move_lines, view='stock.view_stock_move_nosuggest_operations')
+        with move_form.move_line_nosuggest_ids.new() as line:
+            line.lot_id = lot02
+            line.qty_done = 3
+        move_form.save()
+        action = delivery02.button_validate()
+        wizard = self.env[action['res_model']].browse(action['res_id'])
+        wizard.process()
+
+        # Invoice 2 x P
+        invoice01 = so._create_invoices()
+        with Form(invoice01) as form:
+            with form.invoice_line_ids.edit(0) as line:
+                line.quantity = 2
+        invoice01.action_post()
+
+        html = report.render_qweb_html(invoice01.ids)[0]
+        text = html2plaintext(html)
+        self.assertRegex(text, r'Product By Lot\n2.000\nUnits\nLOT0002', "There should be a line that specifies 2 x LOT0002")
+        self.assertNotIn('LOT0001', text)
+
+        # Deliver 5 x LOT0002 + 2 x LOT0003
+        delivery03 = delivery02.backorder_ids
+        delivery03.do_unreserve()
+        move_form = Form(delivery03.move_lines, view='stock.view_stock_move_nosuggest_operations')
+        with move_form.move_line_nosuggest_ids.new() as line:
+            line.lot_id = lot02
+            line.qty_done = 5
+        with move_form.move_line_nosuggest_ids.new() as line:
+            line.lot_id = lot03
+            line.qty_done = 2
+        move_form.save()
+        delivery03.button_validate()
+
+        # Invoice 8 x P
+        invoice02 = so._create_invoices()
+        invoice02.action_post()
+
+        html = report.render_qweb_html(invoice02.ids)[0]
+        text = html2plaintext(html)
+        self.assertRegex(text, r'Product By Lot\n6.000\nUnits\nLOT0002', "There should be a line that specifies 6 x LOT0002")
+        self.assertRegex(text, r'Product By Lot\n2.000\nUnits\nLOT0003', "There should be a line that specifies 2 x LOT0003")
+        self.assertNotIn('LOT0001', text)


### PR DESCRIPTION
When invoicing a tracked product, the lots/SN delivered (or the related
quantities) are not always the correct ones displayed on the printed
invoice

To reproduce the issues:
1. In Settings, enable "Display Lots & Serial Numbers on Invoices"
2. Create a product P:
    - Storable
    - Tracked by lot
3. Update its quantity > 5 with lot L

Use case 01:

4. Create and confirm a SO with 5 x P
5. Process the delivery
6. Create an invoice
7. Edit the invoice line:
    - Quantity: 1
8. Post and print the invoice
Error: The quantity related to lot L is 5, it should be 1

Use case 02:

4. Edit P:
    - Invoicing Policy: Ordered quantities
5. Create and confirm a SO with 1 x P
6. Create and post the invoice
7. Process the delivery
8. Print the invoice
Error: There isn't any information about delivered lot L

Use case 03:

4. Create and confirm a SO with 3 x P
5. Deliver 1 x P (with backorder)
6. Invoice 1 x P + Post the invoice (-> INV01)
7. Deliver 2 x P
8. Reset, post INV01 again and print it
Error: The quantity related to L is 3, it should be 1. Moreover, if the
user then invoices the 2 others P, posts and prints this second invoice,
it won't contain any information about L

OPW-2730270
closes #81444