### PR TITLE
[FIX] base: unique module name declared twice

### DIFF
--- a/odoo/addons/base/data/base_data.sql
+++ b/odoo/addons/base/data/base_data.sql
@@ -67,7 +67,6 @@ CREATE TABLE ir_module_module (
     to_buy boolean default False,
     primary key(id)
 );
-ALTER TABLE ir_module_module add constraint name_uniq unique (name);
 
 CREATE TABLE ir_module_module_dependency (
     id serial NOT NULL,


### PR DESCRIPTION
before this commit, there was 2 unique indexes on module name
after this commit, only 1 unique index remains (the one declared in base_data.sql)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
