### PR TITLE
[IMP] survey: copy conditional questions when duplicating a survey

### DIFF
--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -140,7 +140,7 @@ class SurveyQuestion(models.Model):
 
     # Conditional display
     is_conditional = fields.Boolean(
-        string='Conditional Display', copy=False, help="""If checked, this question will be displayed only 
+        string='Conditional Display', copy=True, help="""If checked, this question will be displayed only
         if the specified conditional answer have been selected in a previous question""")
     triggering_question_id = fields.Many2one(
         'survey.question', string="Triggering Question", copy=False, compute="_compute_triggering_question_id",

--- a/addons/survey/tests/test_survey.py
+++ b/addons/survey/tests/test_survey.py
@@ -159,3 +159,64 @@ class TestSurveyInternals(common.TestSurveyCommon):
 
         for question in questions:
             self._assert_skipped_question(question, survey_user)
+
+    @users('survey_manager')
+    def test_copy_conditional_question_settings(self):
+        """ Create a survey with conditional layout, clone it and verify that the cloned survey has the same conditional
+        layout as the original survey.
+        The test also check that the cloned survey doesn't reference the original survey.
+        """
+        def get_question_by_title(survey, title):
+            return survey.question_ids.filtered(lambda q: q.title == title)[0]
+
+        # Create the survey questions (! texts of the questions must be unique as they are used to query them)
+        q_is_vegetarian_text = 'Are you vegetarian ?'
+        q_is_vegetarian = self._add_question(
+            self.page_0, q_is_vegetarian_text, 'multiple_choice', survey_id=self.survey.id,
+            sequence=100, labels=[{'value': 'Yes'}, {'value': 'No'}])
+        q_food_vegetarian_text = 'Choose your green meal'
+        self._add_question(self.page_0, q_food_vegetarian_text, 'multiple_choice',
+                           is_conditional=True, sequence=101,
+                           triggering_question_id=q_is_vegetarian.id,
+                           triggering_answer_id=q_is_vegetarian.suggested_answer_ids[0].id,
+                           survey_id=self.survey.id,
+                           labels=[{'value': 'Vegetarian pizza'}, {'value': 'Vegetarian burger'}])
+        q_food_not_vegetarian_text = 'Choose your meal'
+        self._add_question(self.page_0, q_food_not_vegetarian_text, 'multiple_choice',
+                           is_conditional=True, sequence=102,
+                           triggering_question_id=q_is_vegetarian.id,
+                           triggering_answer_id=q_is_vegetarian.suggested_answer_ids[1].id,
+                           survey_id=self.survey.id,
+                           labels=[{'value': 'Steak with french fries'}, {'value': 'Fish'}])
+
+        # Clone the survey
+        survey_clone = self.survey.copy()
+
+        # Verify the conditional layout and that the cloned survey doesn't reference the original survey
+        q_is_vegetarian_cloned = get_question_by_title(survey_clone, q_is_vegetarian_text)
+        q_food_vegetarian_cloned = get_question_by_title(survey_clone, q_food_vegetarian_text)
+        q_food_not_vegetarian_cloned = get_question_by_title(survey_clone, q_food_not_vegetarian_text)
+
+        self.assertFalse(q_is_vegetarian_cloned.is_conditional)
+
+        # Vegetarian choice
+        self.assertTrue(q_food_vegetarian_cloned)
+        # Correct conditional layout
+        self.assertEqual(q_food_vegetarian_cloned.triggering_question_id.id, q_is_vegetarian_cloned.id)
+        self.assertEqual(q_food_vegetarian_cloned.triggering_answer_id.id,
+                         q_is_vegetarian_cloned.suggested_answer_ids[0].id)
+        # Doesn't reference the original survey
+        self.assertNotEqual(q_food_vegetarian_cloned.triggering_question_id.id, q_is_vegetarian.id)
+        self.assertNotEqual(q_food_vegetarian_cloned.triggering_answer_id.id,
+                            q_is_vegetarian.suggested_answer_ids[0].id)
+
+        # Not vegetarian choice
+        self.assertTrue(q_food_not_vegetarian_cloned.is_conditional)
+        # Correct conditional layout
+        self.assertEqual(q_food_not_vegetarian_cloned.triggering_question_id.id, q_is_vegetarian_cloned.id)
+        self.assertEqual(q_food_not_vegetarian_cloned.triggering_answer_id.id,
+                         q_is_vegetarian_cloned.suggested_answer_ids[1].id)
+        # Doesn't reference the original survey
+        self.assertNotEqual(q_food_not_vegetarian_cloned.triggering_question_id.id, q_is_vegetarian.id)
+        self.assertNotEqual(q_food_not_vegetarian_cloned.triggering_answer_id.id,
+                            q_is_vegetarian.suggested_answer_ids[1].id)


### PR DESCRIPTION
…tion

Allow users to easily duplicate complex surveys that contain questions
displayed based on previous answers.
Currently, when duplicating a survey, the conditional settings are not copied
and the user has to re-do the entire mapping manually.

The implementation adds a post-process that recreates the orginal conditional
display mapping on the new copy of the questions.

Task-2766473

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
