### PR TITLE
[FIX] Ignore referrals when usging LDAP auth

### DIFF
--- a/addons/auth_ldap/models/res_company_ldap.py
+++ b/addons/auth_ldap/models/res_company_ldap.py
@@ -74,6 +74,8 @@ class CompanyLDAP(models.Model):
         uri = 'ldap://%s:%d' % (conf['ldap_server'], conf['ldap_server_port'])
 
         connection = ldap.initialize(uri)
+        connection.set_option(ldap.OPT_REFERRALS, 0)
+
         if conf['ldap_tls']:
             connection.start_tls_s()
         return connection


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Related issue: 2724800

When using LDAP auth with an AD server, referral chasing needs to be
deactivated, otherwise the requests might hang.

Current behavior before PR:
Referral chasing is enabled, and in the case highlighted in the related issue, users can't log in using ldap.

Desired behavior after PR is merged:
Referral chasing is disabled, and user can log in using ldap.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
