### PR TITLE
[FIX] account_edi_proxy_client, l10n_it_edi_sdicoop: timeouts and con…

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -8,6 +8,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.fernet import Fernet
+from psycopg2 import OperationalError
 import requests
 import uuid
 import base64
@@ -98,6 +99,8 @@ class AccountEdiProxyClientUser(models.Model):
             error_code = proxy_error['code']
             if error_code == 'refresh_token_expired':
                 self._renew_token()
+                if not self.env.context.get('test_skip_commit'):
+                    self.env.cr.commit() # We do not want to lose it if in the _make_request below something goes wrong
                 return self._make_request(url, params)
             if error_code == 'no_such_user':
                 # This error is also raised if the user didn't exchange data and someone else claimed the edi_identificaiton.
@@ -166,13 +169,19 @@ class AccountEdiProxyClientUser(models.Model):
         that multiple database use the same credentials. When receiving an error for an expired refresh_token,
         This method makes a request to get a new refresh token.
         '''
+        try:
+            with self.env.cr.savepoint(flush=False):
+                self.env.cr.execute('SELECT * FROM account_edi_proxy_client_user WHERE id IN %s FOR UPDATE NOWAIT', [tuple(self.ids)])
+        except OperationalError as e:
+            if e.pgcode == '55P03':
+                return
+            raise e
         response = self._make_request(self._get_server_url() + '/iap/account_edi/1/renew_token')
         if 'error' in response:
             # can happen if the database was duplicated and the refresh_token was refreshed by the other database.
             # we don't want two database to be able to query the proxy with the same user
             # because it could lead to not inconsistent data.
             _logger.error(response['error'])
-            raise UserError('Proxy error, please contact Odoo (code: 3)')
         self.refresh_token = response['refresh_token']
 
     def _decrypt_data(self, data, symmetric_key):


### PR DESCRIPTION
…currency

- Sometimes the refresh_token is not saved in the db because the code
after it fails (timeout).  We also want to avoid 2 processes
trying to renew the token at the same time (=> avoid desynchronization
of the refresh_token)

So, we added a locking mechanism and do a commit after we refresh the
token.

- If we have very big invoices to receive, they do not get imported into
the database.  At the moment we risk timeouts.

Our solution is to do a lot of intermediary commits and we link it
to a temporary account_move before doing the import logic and maybe
putting it into the definitive one.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
