### PR TITLE
[FIX] web_editor: mass_mailing infinite scroll & block sent to bottom

### DIFF
--- a/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
@@ -282,6 +282,9 @@ body.editor_enable.o_basic_theme.o_in_iframe {
         color: #999999;
         margin: 5px;
         height: auto;
+        width: -moz-available;          /* WebKit-based browsers will ignore this. */
+        width: -webkit-fill-available;  /* Mozilla-based browsers will ignore this. */
+        width: stretch;
 
         &:before {
             content: attr(data-editor-message);

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2396,7 +2396,7 @@ var SnippetsMenu = Widget.extend({
 
         let dragAndDropResolve;
         let $scrollingElement = $().getScrollingElement(this.ownerDocument);
-        if (!$scrollingElement[0]) {
+        if (!$scrollingElement[0] || $scrollingElement.find('body.o_in_iframe')) {
             $scrollingElement = $(this.ownerDocument).find('.o_editable');
         }
 


### PR DESCRIPTION
The empty editor message was overflowing its container when in a modal, so a part of it was hidden and there was a scrollbar. This fixes it by setting its width to the available space.

When opening mass_mailing in a dialog (eg, in marketing automation),
dragging a snippet to the bottom of the page (without dropping) caused
an infinitely growing scrollbar on the document element.

Note: this revealed that in that particular context the auto scroll to
snippet feature is broken and while dragging we have an extra scrollbar,
on the editable area. In order to fix that, we need to be able to
identify from within the iframe the case where mass_mailing
self-resizes. This involves changing the view to add an option which
will set a class on the document element. This is not acceptable in
stable and will therefore be fixed in master instead.

task-2742664

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
