### PR TITLE
[IMP] mail: channel_type cannot be changed

### DIFF
--- a/addons/mail/tests/test_mail_channel.py
+++ b/addons/mail/tests/test_mail_channel.py
@@ -237,20 +237,18 @@ class TestChannelInternals(MailCommon):
         self.assertEqual(new_msg.partner_ids, self.env['res.partner'])
         self.assertEqual(new_msg.notified_partner_ids, self.env['res.partner'])
 
+    @users('employee')
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     def test_channel_recipients_chat(self):
         """ Posting a message on a chat should not send emails """
-        self.test_channel.write({
-            'channel_type': 'chat',
-        })
-        self.test_channel.add_members((self.partner_employee | self.partner_admin | self.test_partner).ids)
+        channel_info = self.env['mail.channel'].with_user(self.user_admin).channel_get((self.partner_employee | self.user_admin.partner_id).ids)
+        chat = self.env['mail.channel'].with_user(self.user_admin).browse(channel_info['id'])
         with self.mock_mail_gateway():
             with self.with_user('employee'):
-                channel = self.env['mail.channel'].browse(self.test_channel.ids)
-                new_msg = channel.message_post(body="Test", message_type='comment', subtype_xmlid='mail.mt_comment')
+                new_msg = chat.message_post(body="Test", message_type='comment', subtype_xmlid='mail.mt_comment')
         self.assertNotSentEmail()
-        self.assertEqual(new_msg.model, self.test_channel._name)
-        self.assertEqual(new_msg.res_id, self.test_channel.id)
+        self.assertEqual(new_msg.model, chat._name)
+        self.assertEqual(new_msg.res_id, chat.id)
         self.assertEqual(new_msg.partner_ids, self.env['res.partner'])
         self.assertEqual(new_msg.notified_partner_ids, self.env['res.partner'])
 
@@ -333,23 +331,21 @@ class TestChannelInternals(MailCommon):
     @users('employee')
     def test_channel_info_seen(self):
         """ In case of concurrent channel_seen RPC, ensure the oldest call has no effect. """
-        channel = self.env['mail.channel'].browse(self.test_channel.id)
-        channel.write({'channel_type': 'chat'})
-        channel.add_members(self.env.user.partner_id.ids)
+        channel_info = self.env['mail.channel'].with_user(self.user_admin).channel_get((self.partner_employee | self.user_admin.partner_id).ids)
+        chat = self.env['mail.channel'].with_user(self.user_admin).browse(channel_info['id'])
+        msg_1 = self._add_messages(chat, 'Body1', author=self.user_employee.partner_id)
+        msg_2 = self._add_messages(chat, 'Body2', author=self.user_employee.partner_id)
 
-        msg_1 = self._add_messages(self.test_channel, 'Body1', author=self.user_employee.partner_id)
-        msg_2 = self._add_messages(self.test_channel, 'Body2', author=self.user_employee.partner_id)
-
-        self.test_channel._channel_seen(msg_2.id)
+        chat._channel_seen(msg_2.id)
         self.assertEqual(
-            channel.channel_info()[0]['seen_partners_info'][0]['seen_message_id'],
+            chat.channel_info()[0]['seen_partners_info'][0]['seen_message_id'],
             msg_2.id,
             "Last message id should have been updated"
         )
 
-        self.test_channel._channel_seen(msg_1.id)
+        chat._channel_seen(msg_1.id)
         self.assertEqual(
-            channel.channel_info()[0]['seen_partners_info'][0]['seen_message_id'],
+            chat.channel_info()[0]['seen_partners_info'][0]['seen_message_id'],
             msg_2.id,
             "Last message id should stay the same after mark channel as seen with an older message"
         )
@@ -448,19 +444,20 @@ class TestChannelInternals(MailCommon):
         self.assertEqual(messages_1, messages_2)
 
     def test_channel_should_generate_correct_default_avatar(self):
-        channel = self.env['mail.channel'].create({'name': '', 'uuid': 'test-uuid'})
-        bgcolor = html_escape('hsl(288, 51%, 45%)')  # depends on uuid
-        expceted_avatar_channel = (channel_avatar.replace('fill="#875a7b"', f'fill="{bgcolor}"')).encode()
-        expected_avatar_group = (group_avatar.replace('fill="#875a7b"', f'fill="{bgcolor}"')).encode()
+        test_channel = self.env['mail.channel'].browse(self.env['mail.channel'].channel_create(name='Channel')['id'])
+        test_channel.uuid = 'channel-uuid'
+        test_group = self.env['mail.channel'].browse(self.env['mail.channel'].create_group(partners_to=self.user_employee.partner_id.ids)['id'])
+        test_group.uuid = 'group-uuid'
+        bgcolor_channel = html_escape('hsl(316, 61%, 45%)')  # depends on uuid
+        bgcolor_group = html_escape('hsl(17, 60%, 45%)')  # depends on uuid
+        expceted_avatar_channel = (channel_avatar.replace('fill="#875a7b"', f'fill="{bgcolor_channel}"')).encode()
+        expected_avatar_group = (group_avatar.replace('fill="#875a7b"', f'fill="{bgcolor_group}"')).encode()
 
-        channel.channel_type = 'group'
-        self.assertEqual(base64.b64decode(channel.avatar_128), expected_avatar_group)
+        self.assertEqual(base64.b64decode(test_channel.avatar_128), expceted_avatar_channel)
+        self.assertEqual(base64.b64decode(test_group.avatar_128), expected_avatar_group)
 
-        channel.channel_type = 'channel'
-        self.assertEqual(base64.b64decode(channel.avatar_128), expceted_avatar_channel)
-
-        channel.image_128 = base64.b64encode(("<svg/>").encode())
-        self.assertEqual(channel.avatar_128, channel.image_128)
+        test_channel.image_128 = base64.b64encode(("<svg/>").encode())
+        self.assertEqual(test_channel.avatar_128, test_channel.image_128)
 
     def test_channel_write_should_send_notification_if_image_128_changed(self):
         channel = self.env['mail.channel'].create({'name': '', 'uuid': 'test-uuid'})


### PR DESCRIPTION
Get prevention when transforming the channel type.
There will be an UserError raised when the user tries to change the channel_type.

task-2774330

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
