### PR TITLE
[FIX] web: Many 2 One external link was invisible

### DIFF
--- a/addons/web/static/src/legacy/scss/form_view.scss
+++ b/addons/web/static/src/legacy/scss/form_view.scss
@@ -595,7 +595,7 @@ $o-form-label-margin-right: 0px;
         }
 
         @include media-breakpoint-up(sm) {
-            :not(.o_row):not(.o_data_cell) > .o_field_widget,
+            :not(.o_row):not(.o_data_cell) > .o_field_widget > * >,
             .o_row > .o_field_widget:last-child { // Note: this does not take care
                                                 // of an invisible last-child but
                                                 // it does not really matter


### PR DESCRIPTION
Current behavior:
If you activate the packaging options of the inventory tab. The external link of the packaging type in the inventory tab of a product is invisible.

Steps to reproduce:
- Have inventory module installed
- Activate the packaging options
- Go on a product page and then go in the inventory tab
- Add a line in the packaging tree view
- There should be an exteral link next to the packaging type after you selected one
- The external link is invisible

opw-2749832
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
