### PR TITLE
[IMP] website, website_blog, test_website: test also perf real use case

### DIFF
--- a/addons/test_website/tests/test_performance.py
+++ b/addons/test_website/tests/test_performance.py
@@ -8,3 +8,4 @@ class TestPerformance(UtilPerf):
     def test_10_perf_sql_website_controller_minimalist(self):
         url = '/empty_controller_test'
         self.assertEqual(self._get_url_hot_query(url), 3)
+        self.assertEqual(self._get_url_hot_query(url, cache=False), 3)

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -18,8 +18,10 @@ EXTRA_REQUEST = 5
 
 
 class UtilPerf(HttpCase):
-    def _get_url_hot_query(self, url):
-        url += ('?' not in url and '?' or '') + '&nocache'
+    def _get_url_hot_query(self, url, cache=True):
+        url += ('?' not in url and '?' or '')
+        if not cache:
+            url += '&nocache'
 
         # ensure worker is in hot state
         self.url_open(url)
@@ -35,12 +37,22 @@ class TestStandardPerformance(UtilPerf):
         self.authenticate('demo', 'demo')
         url = '/web/image/res.users/2/image_256'
         self.assertEqual(self._get_url_hot_query(url), 6)
+        self.assertEqual(self._get_url_hot_query(url, cache=False), 6)
+
+    def test_11_perf_sql_img_controller(self):
+        self.authenticate('demo', 'demo')
+        self.env['res.users'].sudo().browse(2).website_published = True
+        url = '/web/image/res.users/2/image_256'
+        self.assertEqual(self._get_url_hot_query(url), 6)
+        self.assertEqual(self._get_url_hot_query(url, cache=False), 6)
 
     def test_20_perf_sql_img_controller_bis(self):
         url = '/web/image/website/1/favicon'
         self.assertEqual(self._get_url_hot_query(url), 4)
+        self.assertEqual(self._get_url_hot_query(url, cache=False), 4)
         self.authenticate('portal', 'portal')
         self.assertEqual(self._get_url_hot_query(url), 4)
+        self.assertEqual(self._get_url_hot_query(url, cache=False), 4)
 
 
 class TestWebsitePerformance(UtilPerf):
@@ -77,25 +89,31 @@ class TestWebsitePerformance(UtilPerf):
 
     def test_10_perf_sql_queries_page(self):
         # standard untracked website.page
-        self.assertEqual(self._get_url_hot_query(self.page.url), 11)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 8)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 11)
         self.menu.unlink()
-        self.assertEqual(self._get_url_hot_query(self.page.url), 13)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 10)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 13)
 
     def test_15_perf_sql_queries_page(self):
         # standard tracked website.page
         self.page.track = True
-        self.assertEqual(self._get_url_hot_query(self.page.url), 19)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 16)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 19)
         self.menu.unlink()
-        self.assertEqual(self._get_url_hot_query(self.page.url), 21)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 18)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 21)
 
     def test_20_perf_sql_queries_homepage(self):
         # homepage "/" has its own controller
-        self.assertEqual(self._get_url_hot_query('/'), 18)
+        self.assertEqual(self._get_url_hot_query('/'), 17)
+        self.assertEqual(self._get_url_hot_query('/', cache=False), 18)
 
     def test_30_perf_sql_queries_page_no_layout(self):
         # website.page with no call to layout templates
         self.page.arch = '<div>I am a blank page</div>'
-        self.assertEqual(self._get_url_hot_query(self.page.url), 9)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 8)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 9)
 
     def test_40_perf_sql_queries_page_multi_level_menu(self):
         # menu structure should not impact SQL requests
@@ -113,10 +131,12 @@ class TestWebsitePerformance(UtilPerf):
         menu_bb.parent_id = menu_b
         menu_aa.parent_id = menu_a
 
-        self.assertEqual(self._get_url_hot_query(self.page.url), 11)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 8)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 11)
 
     def test_50_perf_sql_web_assets(self):
         # assets route /web/assets/..
         self.url_open('/')  # create assets attachments
         assets_url = self.env['ir.attachment'].search([('url', '=like', '/web/assets/%/web.assets_common%.js')], limit=1).url
         self.assertEqual(self._get_url_hot_query(assets_url), 2)
+        self.assertEqual(self._get_url_hot_query(assets_url, cache=False), 2)

--- a/addons/website_blog/tests/test_performance.py
+++ b/addons/website_blog/tests/test_performance.py
@@ -13,7 +13,8 @@ class TestBlogPerformance(UtilPerf):
             self.env['website'].search([]).channel_id = False
 
     def test_10_perf_sql_blog_standard_data(self):
-        self.assertEqual(self._get_url_hot_query('/blog'), 26)
+        self.assertEqual(self._get_url_hot_query('/blog'), 27)
+        self.assertEqual(self._get_url_hot_query('/blog', cache=False), 26)
 
     def test_20_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']
@@ -25,8 +26,10 @@ class TestBlogPerformance(UtilPerf):
         for blog_post in blog_posts:
             blog_post.tag_ids += blog_tags
             blog_tags = blog_tags[:-1]
-        self.assertEqual(self._get_url_hot_query('/blog'), 26)
-        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url), 29)
+        self.assertEqual(self._get_url_hot_query('/blog'), 27)
+        self.assertEqual(self._get_url_hot_query('/blog', cache=False), 26)
+        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url), 30)
+        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 29)
 
     def test_30_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']
@@ -39,4 +42,6 @@ class TestBlogPerformance(UtilPerf):
             blog_post.write({'tag_ids': [[6, 0, random.choices(blog_tags.ids, k=random.randint(0, len(blog_tags)))]]})
 
         self.assertLessEqual(self._get_url_hot_query('/blog'), 28)
-        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url), 31)
+        self.assertLessEqual(self._get_url_hot_query('/blog', cache=False), 28)
+        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url), 32)
+        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 31)


### PR DESCRIPTION
The `nocache` URL param was introduced with [1] which allows to bypass
the cache when serving a page.
Bypassing that cache, despite not being the most common flow, was done
in the perf tests since that commit. Ultimately, it was not testing
real use cases anymore (despite still being useful as it would still
prevent perf killer feature to be merged).

This commit ensure the perf tests are also tested with cache.

[1]: https://github.com/odoo/odoo/commit/cbf8d3b3047c94a2ff7fb197bbae92a402e0b58b

task-2774979
