### PR TITLE
[FIX] web_editor: hide inactive modal behind fullscreen editor

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.backend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.backend.scss
@@ -56,7 +56,7 @@
         bottom: 0 !important;
         width: 100% !important;
         min-height: 100% !important;
-        z-index: 1001 !important;
+        z-index: $zindex-modal-backdrop + 1 !important;
         border: 0;
     }
     > :not(.modal):not(.modal-backdrop) {


### PR DESCRIPTION
`.modal.o_inactive_modal` (in modal.scss) had a z-index that was superior to that of a fullscreen editor. As a result we could end up with the editor being partially hidden by a modal.

task-2741872

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
