### PR TITLE
[FIX] l10n_ar: Doc prefix in Shared Sequences 

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -227,6 +227,14 @@ class AccountMove(models.Model):
                 return self._get_formatted_sequence()
         return super()._get_starting_sequence()
 
+    def _get_last_sequence(self, relaxed=False):
+        """ If use share sequences we need to recompute the sequence to add the proper document code prefix """
+        res = super()._get_last_sequence(relaxed=relaxed)
+        if res and self.journal_id.l10n_ar_share_sequences and self.l10n_latam_document_type_id.doc_code_prefix not in res:
+            res = self._get_formatted_sequence(number=self._l10n_ar_get_document_number_parts(
+                res.split()[-1], self.l10n_latam_document_type_id.code)['invoice_number'])
+        return res
+
     def _get_last_sequence_domain(self, relaxed=False):
         where_string, param = super(AccountMove, self)._get_last_sequence_domain(relaxed)
         if self.company_id.country_id.code == "AR" and self.l10n_latam_use_documents:


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Before this change, we have the errors that the credit notes of pre-printed sales journals mark as unified book were wrongly named using the wrong doc prefix code

### Current behavior before PR:

This can be checked in the demo credit notes already generated on pre-printed journals have a wrong doc prefix, They have `FA-` and should be `NC-`
![image](https://user-images.githubusercontent.com/7593953/154771075-12f10c4a-19a3-4d5b-a520-60e51081521a.png)

### Desired behavior after PR is merged:

The pre-printed sales journal with unified book option moves are properly named, for all invoices and refunds.

![image](https://user-images.githubusercontent.com/7593953/155195114-766b3448-a078-47ad-a114-a9e83399d4d2.png)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
