### PR TITLE
[FIX] account: customer_rank/supplier_rank no copy

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -437,8 +437,8 @@ class ResPartner(models.Model):
     invoice_warn_msg = fields.Text('Message for Invoice')
     # Computed fields to order the partners as suppliers/customers according to the
     # amount of their generated incoming/outgoing account moves
-    supplier_rank = fields.Integer(default=0)
-    customer_rank = fields.Integer(default=0)
+    supplier_rank = fields.Integer(default=0, copy=False)
+    customer_rank = fields.Integer(default=0, copy=False)
 
     def _get_name_search_order_by_fields(self):
         res = super()._get_name_search_order_by_fields()


### PR DESCRIPTION
If partner is copied, it will copy customer_rank/supplier_rank and it
will be treated as such even though such partner has no references to
invoices for example.

Backport of https://github.com/odoo/odoo/commit/c0161736db4f2415e6a44674d872bf8aa2972287
